### PR TITLE
Add elevation with SDF-based shadow casting

### DIFF
--- a/examples/elevation_example.rs
+++ b/examples/elevation_example.rs
@@ -1,0 +1,126 @@
+//! Example demonstrating elevation with shadow casting.
+//!
+//! This example showcases different elevation levels that cast shadows:
+//! - Level 0: No shadow
+//! - Level 1-5: Progressively larger and softer shadows
+//!
+//! Higher elevation values create the illusion of depth by casting
+//! shadows below the container.
+
+use guido::prelude::*;
+
+fn main() {
+    let view = guido::column![
+        // Row 1: Basic elevation levels
+        row![
+            container()
+                .padding(16.0)
+                .background(Color::WHITE)
+                .corner_radius(8.0)
+                .elevation(0.0)
+                .child(text("Level 0\n(No shadow)").color(Color::rgb(0.2, 0.2, 0.2))),
+            container()
+                .padding(16.0)
+                .background(Color::WHITE)
+                .corner_radius(8.0)
+                .elevation(1.0)
+                .child(text("Level 1").color(Color::rgb(0.2, 0.2, 0.2))),
+            container()
+                .padding(16.0)
+                .background(Color::WHITE)
+                .corner_radius(8.0)
+                .elevation(2.0)
+                .child(text("Level 2").color(Color::rgb(0.2, 0.2, 0.2))),
+            container()
+                .padding(16.0)
+                .background(Color::WHITE)
+                .corner_radius(8.0)
+                .elevation(3.0)
+                .child(text("Level 3").color(Color::rgb(0.2, 0.2, 0.2))),
+        ]
+        .spacing(16.0),
+        // Row 2: Higher elevation levels
+        row![
+            container()
+                .padding(16.0)
+                .background(Color::WHITE)
+                .corner_radius(8.0)
+                .elevation(4.0)
+                .child(text("Level 4").color(Color::rgb(0.2, 0.2, 0.2))),
+            container()
+                .padding(16.0)
+                .background(Color::WHITE)
+                .corner_radius(8.0)
+                .elevation(5.0)
+                .child(text("Level 5").color(Color::rgb(0.2, 0.2, 0.2))),
+            container()
+                .padding(16.0)
+                .background(Color::WHITE)
+                .corner_radius(8.0)
+                .elevation(7.0)
+                .child(text("Level 7").color(Color::rgb(0.2, 0.2, 0.2))),
+            container()
+                .padding(16.0)
+                .background(Color::WHITE)
+                .corner_radius(8.0)
+                .elevation(10.0)
+                .child(text("Level 10").color(Color::rgb(0.2, 0.2, 0.2))),
+        ]
+        .spacing(16.0),
+        // Row 3: Colored cards with elevation
+        row![
+            container()
+                .padding(16.0)
+                .background(Color::rgb(0.9, 0.7, 0.7))
+                .corner_radius(12.0)
+                .elevation(2.0)
+                .child(text("Card 1").color(Color::rgb(0.3, 0.1, 0.1))),
+            container()
+                .padding(16.0)
+                .background(Color::rgb(0.7, 0.9, 0.7))
+                .corner_radius(12.0)
+                .elevation(3.0)
+                .child(text("Card 2").color(Color::rgb(0.1, 0.3, 0.1))),
+            container()
+                .padding(16.0)
+                .background(Color::rgb(0.7, 0.7, 0.9))
+                .corner_radius(12.0)
+                .elevation(4.0)
+                .child(text("Card 3").color(Color::rgb(0.1, 0.1, 0.3))),
+        ]
+        .spacing(16.0),
+        // Row 4: Squircle with elevation
+        row![
+            container()
+                .padding(16.0)
+                .background(Color::rgb(0.95, 0.95, 0.95))
+                .corner_radius(16.0)
+                .squircle()
+                .elevation(2.0)
+                .child(text("Squircle\nElevation 2").color(Color::rgb(0.2, 0.2, 0.2))),
+            container()
+                .padding(16.0)
+                .background(Color::rgb(0.95, 0.95, 0.95))
+                .corner_radius(16.0)
+                .squircle()
+                .elevation(4.0)
+                .child(text("Squircle\nElevation 4").color(Color::rgb(0.2, 0.2, 0.2))),
+            container()
+                .padding(16.0)
+                .background(Color::rgb(0.95, 0.95, 0.95))
+                .corner_radius(16.0)
+                .squircle()
+                .elevation(6.0)
+                .child(text("Squircle\nElevation 6").color(Color::rgb(0.2, 0.2, 0.2))),
+        ]
+        .spacing(16.0),
+    ]
+    .spacing(16.0);
+
+    // Run the app
+    App::new()
+        .width(600)
+        .height(280)
+        .background_color(Color::rgb(0.85, 0.85, 0.9))
+        .run(view);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub mod prelude {
         batch, create_computed, create_effect, create_signal, Computed, Effect, IntoMaybeDyn,
         MaybeDyn, ReadSignal, Signal, WriteSignal,
     };
+    pub use crate::renderer::primitives::Shadow;
     pub use crate::renderer::PaintContext;
     pub use crate::widgets::{
         column, container, row, text, Border, Color, Column, Container, CrossAxisAlignment, Event,

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -122,6 +122,16 @@ impl Renderer {
                     scaled_rect.curvature = rect.curvature; // Preserve curvature (doesn't scale)
                     scaled_rect.border_width = rect.border_width * self.scale_factor;
                     scaled_rect.border_color = rect.border_color;
+                    // Scale shadow parameters
+                    scaled_rect.shadow = primitives::Shadow {
+                        offset: (
+                            rect.shadow.offset.0 * self.scale_factor,
+                            rect.shadow.offset.1 * self.scale_factor,
+                        ),
+                        blur: rect.shadow.blur * self.scale_factor,
+                        spread: rect.shadow.spread * self.scale_factor,
+                        color: rect.shadow.color,
+                    };
                     scaled_rect.to_vertices(self.screen_width, self.screen_height)
                 }
                 Shape::Circle(circle) => {
@@ -181,6 +191,16 @@ impl Renderer {
                     scaled_rect.curvature = rect.curvature; // Preserve curvature (doesn't scale)
                     scaled_rect.border_width = rect.border_width * self.scale_factor;
                     scaled_rect.border_color = rect.border_color;
+                    // Scale shadow parameters
+                    scaled_rect.shadow = primitives::Shadow {
+                        offset: (
+                            rect.shadow.offset.0 * self.scale_factor,
+                            rect.shadow.offset.1 * self.scale_factor,
+                        ),
+                        blur: rect.shadow.blur * self.scale_factor,
+                        spread: rect.shadow.spread * self.scale_factor,
+                        color: rect.shadow.color,
+                    };
                     scaled_rect.to_vertices(self.screen_width, self.screen_height)
                 }
                 Shape::Circle(circle) => {
@@ -497,6 +517,33 @@ impl PaintContext {
         self.shapes.push(Shape::Circle(Circle::with_clip(
             center_x, center_y, radius, color, clip,
         )));
+    }
+
+    /// Draw a rounded rectangle with a shadow
+    pub fn draw_rounded_rect_with_shadow(
+        &mut self,
+        rect: Rect,
+        color: Color,
+        radius: f32,
+        shadow: primitives::Shadow,
+    ) {
+        let mut rounded_rect = RoundedRect::new(rect, color, radius);
+        rounded_rect.shadow = shadow;
+        self.shapes.push(Shape::RoundedRect(rounded_rect));
+    }
+
+    /// Draw a rounded rectangle with a shadow and custom curvature
+    pub fn draw_rounded_rect_with_shadow_and_curvature(
+        &mut self,
+        rect: Rect,
+        color: Color,
+        radius: f32,
+        curvature: f32,
+        shadow: primitives::Shadow,
+    ) {
+        let mut rounded_rect = RoundedRect::with_curvature(rect, color, radius, curvature);
+        rounded_rect.shadow = shadow;
+        self.shapes.push(Shape::RoundedRect(rounded_rect));
     }
 
     pub fn draw_text(&mut self, text: &str, rect: Rect, color: Color, font_size: f32) {


### PR DESCRIPTION
## Summary

Implements Material Design-inspired elevation system with GPU-accelerated shadow rendering for the Container widget.

## Features

- **Shadow struct**: Configurable offset, blur, spread, and color parameters
- **Elevation property**: Simple `.elevation(level)` API on Container widget
- **SDF-based rendering**: Resolution-independent shadows rendered in fragment shader
- **Smooth fadeout**: CSS-like shadow behavior with gradual transparency
- **HiDPI support**: Automatic shadow scaling for high-DPI displays
- **Material Design compliance**: Shadow parameters match Material Design elevation spec

## Implementation Details

### Renderer Changes
- Extended `Vertex` struct with shadow attributes (offset, blur, spread, color)
- Updated vertex buffer layout to include shadow data (locations 7-9)
- Modified fragment shader to compute shadow SDF with smooth falloff
- Smart quad expansion (3x blur radius) for complete shadow fadeout

### Shadow Struct
- `Shadow::new(offset, blur, spread, color)` - Full control
- `Shadow::simple(offset, blur, color)` - No spread
- `Shadow::none()` - No shadow

### Container Widget
- Added `elevation(level)` method with automatic shadow mapping
- Elevation levels 1-5 use Material Design specifications
- Higher levels scale gradually (max offset 12px, blur 24px, alpha 0.25)
- Preserves existing widget properties (borders, gradients, curvature)

### Shader Algorithm
- Computes shadow SDF offset from shape position
- Applies spread expansion to shadow shape
- Smooth alpha falloff using `smoothstep(-blur, 2×blur, distance)`
- Composites shadow behind shape for proper layering

## Example Usage

```rust
// Simple elevation
container()
    .background(Color::WHITE)
    .corner_radius(8.0)
    .elevation(3.0)
    .child(text("Card"))

// Custom shadow
container()
    .background(Color::WHITE)
    .corner_radius(12.0)
    .squircle()
    .elevation(5.0)
    .child(text("Elevated Squircle"))
```

## Visual Examples

Run the elevation example to see shadows at different levels:
```bash
cargo run --example elevation_example
```

The example demonstrates:
- Levels 0-10 with progressive shadow intensity
- Colored cards with elevation
- Squircle corners with shadows
- Proper shadow stacking (later elements paint on top)

## Technical Notes

- Shadows render in DOM order (like CSS `box-shadow`)
- Quad bounds expand directionally based on shadow offset and blur
- No performance impact when elevation is 0 (no shadow)
- Works with all corner curvature styles (circle, squircle, bevel, scoop)
- Gradients currently render without shadows (limitation noted)

## Files Modified

- `src/renderer/primitives.rs` - Vertex struct, Shadow type, RoundedRect updates
- `src/renderer/pipeline.rs` - Shader with shadow computation
- `src/renderer/mod.rs` - Shadow drawing methods
- `src/widgets/container.rs` - Elevation property and mapping
- `src/lib.rs` - Export Shadow in prelude
- `examples/elevation_example.rs` - Comprehensive demonstration

## Test Plan

- [x] `cargo build` - No errors
- [x] `cargo clippy` - No new warnings
- [x] `cargo test` - All tests pass
- [x] Visual verification with elevation_example
- [x] HiDPI scaling verified
- [x] Shadow smoothness at all elevation levels