### PR TITLE
Add reusable component declaration system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -639,6 +639,7 @@ dependencies = [
  "cosmic-text 0.16.0",
  "env_logger",
  "glyphon",
+ "guido-macros",
  "image",
  "log",
  "pollster",
@@ -648,6 +649,15 @@ dependencies = [
  "wayland-client",
  "wayland-protocols-wlr",
  "wgpu",
+]
+
+[[package]]
+name = "guido-macros"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[workspace]
+members = [".", "guido-macros"]
+
 [package]
 name = "guido"
 version = "0.1.0"
@@ -6,6 +9,7 @@ description = "A reactive Rust GUI library using wgpu for Wayland layer shell wi
 license = "MIT"
 
 [dependencies]
+guido-macros = { path = "guido-macros" }
 wgpu = { version = "28.0", features = ["fragile-send-sync-non-atomic-wasm"] }
 bytemuck = { version = "1.24", features = ["derive"] }
 glyphon = "0.10"

--- a/examples/component_example.rs
+++ b/examples/component_example.rs
@@ -43,11 +43,7 @@ impl Card {
             .background(self.background.get())
             .corner_radius(8.0)
             .layout(Flex::column().spacing(8.0))
-            .child(
-                text(self.title.clone())
-                    .font_size(18.0)
-                    .color(Color::WHITE),
-            )
+            .child(text(self.title.clone()).font_size(18.0).color(Color::WHITE))
             .children_source(self.take_children())
     }
 }
@@ -114,33 +110,31 @@ fn main() {
                 .child(text("Cards can have multiple children.").color(Color::rgb(0.8, 0.8, 0.8))),
         )
         .child(
-            card()
-                .title("Styled Buttons")
-                .child(
-                    container()
-                        .layout(Flex::row().spacing(8.0))
-                        .child(
-                            button()
-                                .label("Primary")
-                                .background(Color::rgb(0.2, 0.4, 0.8))
-                                .padding(12.0)
-                                .on_click(|| println!("Primary clicked")),
-                        )
-                        .child(
-                            button()
-                                .label("Secondary")
-                                .background(Color::rgb(0.5, 0.5, 0.6))
-                                .padding(12.0)
-                                .on_click(|| println!("Secondary clicked")),
-                        )
-                        .child(
-                            button()
-                                .label("Danger")
-                                .background(Color::rgb(0.8, 0.2, 0.2))
-                                .padding(12.0)
-                                .on_click(|| println!("Danger clicked")),
-                        ),
-                ),
+            card().title("Styled Buttons").child(
+                container()
+                    .layout(Flex::row().spacing(8.0))
+                    .child(
+                        button()
+                            .label("Primary")
+                            .background(Color::rgb(0.2, 0.4, 0.8))
+                            .padding(12.0)
+                            .on_click(|| println!("Primary clicked")),
+                    )
+                    .child(
+                        button()
+                            .label("Secondary")
+                            .background(Color::rgb(0.5, 0.5, 0.6))
+                            .padding(12.0)
+                            .on_click(|| println!("Secondary clicked")),
+                    )
+                    .child(
+                        button()
+                            .label("Danger")
+                            .background(Color::rgb(0.8, 0.2, 0.2))
+                            .padding(12.0)
+                            .on_click(|| println!("Danger clicked")),
+                    ),
+            ),
         )
         .child(
             card()
@@ -160,22 +154,20 @@ fn main() {
                         .color(Color::rgb(0.8, 0.8, 0.8)),
                 )
                 .child(
-                    container()
-                        .layout(Flex::row().spacing(8.0))
-                        .child(
-                            button()
-                                .label(move || format!("Count is {}", count5.get()))
-                                .background(move || {
-                                    // Button color changes based on count
-                                    let c = count6.get();
-                                    if c % 2 == 0 {
-                                        Color::rgb(0.3, 0.5, 0.7)
-                                    } else {
-                                        Color::rgb(0.7, 0.5, 0.3)
-                                    }
-                                })
-                                .on_click(move || count7.update(|c| *c += 1)),
-                        ),
+                    container().layout(Flex::row().spacing(8.0)).child(
+                        button()
+                            .label(move || format!("Count is {}", count5.get()))
+                            .background(move || {
+                                // Button color changes based on count
+                                let c = count6.get();
+                                if c % 2 == 0 {
+                                    Color::rgb(0.3, 0.5, 0.7)
+                                } else {
+                                    Color::rgb(0.7, 0.5, 0.3)
+                                }
+                            })
+                            .on_click(move || count7.update(|c| *c += 1)),
+                    ),
                 ),
         );
 

--- a/examples/component_example.rs
+++ b/examples/component_example.rs
@@ -1,0 +1,190 @@
+use guido::prelude::*;
+
+/// A reusable Button component
+#[component]
+pub struct Button {
+    #[prop]
+    label: String,
+    #[prop(default = "Color::rgb(0.3, 0.3, 0.4)")]
+    background: Color,
+    #[prop(default = "8.0")]
+    padding: f32,
+    #[prop(callback)]
+    on_click: (),
+}
+
+impl Button {
+    fn render(&self) -> impl Widget {
+        container()
+            .padding(self.padding.get())
+            .background(self.background.clone())
+            .corner_radius(6.0)
+            .ripple()
+            .on_click_option(self.on_click.clone())
+            .child(text(self.label.clone()).color(Color::WHITE))
+    }
+}
+
+/// A reusable Card component with children
+#[component]
+pub struct Card {
+    #[prop]
+    title: String,
+    #[prop(default = "Color::rgb(0.18, 0.18, 0.22)")]
+    background: Color,
+    #[prop(children)]
+    children: (),
+}
+
+impl Card {
+    fn render(&self) -> impl Widget {
+        container()
+            .padding(16.0)
+            .background(self.background.get())
+            .corner_radius(8.0)
+            .layout(Flex::column().spacing(8.0))
+            .child(
+                text(self.title.clone())
+                    .font_size(18.0)
+                    .color(Color::WHITE),
+            )
+            .children_source(self.take_children())
+    }
+}
+
+fn main() {
+    let _ = env_logger::try_init();
+
+    // Create some reactive state
+    let count = create_signal(0);
+    let count1 = count.clone();
+    let count2 = count.clone();
+    let count3 = count.clone();
+    let count4 = count.clone();
+    let count5 = count.clone();
+    let count6 = count.clone();
+    let count7 = count.clone();
+
+    // Build UI using our custom components
+    let view = container()
+        .padding(16.0)
+        .background(Color::rgb(0.1, 0.1, 0.15))
+        .layout(Flex::column().spacing(12.0))
+        .child(
+            text("Component Example")
+                .font_size(24.0)
+                .color(Color::WHITE),
+        )
+        .child(
+            card()
+                .title("Counter")
+                .background(Color::rgb(0.15, 0.2, 0.25))
+                .child(
+                    text(move || format!("Count: {}", count.get()))
+                        .font_size(16.0)
+                        .color(Color::WHITE),
+                )
+                .child(
+                    container()
+                        .layout(Flex::row().spacing(8.0))
+                        .child(
+                            button()
+                                .label("Increment")
+                                .background(Color::rgb(0.2, 0.6, 0.3))
+                                .on_click(move || count1.update(|c| *c += 1)),
+                        )
+                        .child(
+                            button()
+                                .label("Decrement")
+                                .background(Color::rgb(0.6, 0.2, 0.2))
+                                .on_click(move || count2.update(|c| *c -= 1)),
+                        )
+                        .child(
+                            button()
+                                .label("Reset")
+                                .background(Color::rgb(0.4, 0.4, 0.5))
+                                .on_click(move || count3.set(0)),
+                        ),
+                ),
+        )
+        .child(
+            card()
+                .title("Static Content")
+                .child(text("This is a card with static content.").color(Color::rgb(0.8, 0.8, 0.8)))
+                .child(text("Cards can have multiple children.").color(Color::rgb(0.8, 0.8, 0.8))),
+        )
+        .child(
+            card()
+                .title("Styled Buttons")
+                .child(
+                    container()
+                        .layout(Flex::row().spacing(8.0))
+                        .child(
+                            button()
+                                .label("Primary")
+                                .background(Color::rgb(0.2, 0.4, 0.8))
+                                .padding(12.0)
+                                .on_click(|| println!("Primary clicked")),
+                        )
+                        .child(
+                            button()
+                                .label("Secondary")
+                                .background(Color::rgb(0.5, 0.5, 0.6))
+                                .padding(12.0)
+                                .on_click(|| println!("Secondary clicked")),
+                        )
+                        .child(
+                            button()
+                                .label("Danger")
+                                .background(Color::rgb(0.8, 0.2, 0.2))
+                                .padding(12.0)
+                                .on_click(|| println!("Danger clicked")),
+                        ),
+                ),
+        )
+        .child(
+            card()
+                .title("Reactive Props Example")
+                .background(move || {
+                    // Card background changes based on count
+                    if count4.get() > 5 {
+                        Color::rgb(0.2, 0.3, 0.2)
+                    } else if count4.get() < -5 {
+                        Color::rgb(0.3, 0.2, 0.2)
+                    } else {
+                        Color::rgb(0.18, 0.18, 0.22)
+                    }
+                })
+                .child(
+                    text("The card background changes color based on the count value.")
+                        .color(Color::rgb(0.8, 0.8, 0.8)),
+                )
+                .child(
+                    container()
+                        .layout(Flex::row().spacing(8.0))
+                        .child(
+                            button()
+                                .label(move || format!("Count is {}", count5.get()))
+                                .background(move || {
+                                    // Button color changes based on count
+                                    let c = count6.get();
+                                    if c % 2 == 0 {
+                                        Color::rgb(0.3, 0.5, 0.7)
+                                    } else {
+                                        Color::rgb(0.7, 0.5, 0.3)
+                                    }
+                                })
+                                .on_click(move || count7.update(|c| *c += 1)),
+                        ),
+                ),
+        );
+
+    App::new()
+        .width(600)
+        .height(500)
+        .anchor(Anchor::TOP | Anchor::LEFT)
+        .layer(Layer::Overlay)
+        .namespace("component-example")
+        .background_color(Color::rgb(0.1, 0.1, 0.15))
+        .run(view);
+}

--- a/guido-macros/Cargo.toml
+++ b/guido-macros/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "guido-macros"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = { version = "2.0", features = ["full"] }

--- a/guido-macros/src/lib.rs
+++ b/guido-macros/src/lib.rs
@@ -1,0 +1,308 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, Fields, ItemStruct, Meta, Type};
+
+/// Attribute macro to create a reusable component with builder pattern that automatically implements Widget
+///
+/// # Attributes on fields
+/// - `#[prop]` - Standard prop, generates builder method accepting `impl IntoMaybeDyn<T>`
+/// - `#[prop(default = "expr")]` - Prop with default value
+/// - `#[prop(callback)]` - Generates callback accepting `impl Fn() + Send + Sync + 'static`
+/// - `#[prop(children)]` - Marks field for children support
+///
+/// # Example
+/// ```ignore
+/// #[component]
+/// pub struct Button {
+///     #[prop]
+///     label: String,
+///     #[prop(callback)]
+///     on_click: (),
+/// }
+///
+/// impl Button {
+///     fn render(&self) -> impl Widget {
+///         container().child(text(self.label.clone()))
+///     }
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn component(_attr: TokenStream, input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as ItemStruct);
+
+    let struct_name = &input.ident;
+    let vis = &input.vis;
+
+    // Extract fields
+    let fields = match &input.fields {
+        Fields::Named(fields) => &fields.named,
+        _ => panic!("Component can only be used on structs with named fields"),
+    };
+
+    // Parse field information
+    let mut prop_fields = Vec::new();
+    let mut has_children = false;
+
+    for field in fields {
+        let field_name = field.ident.as_ref().unwrap();
+        let field_type = &field.ty;
+
+        // Skip if no #[prop] attribute
+        let prop_attr = field.attrs.iter().find(|attr| {
+            attr.path().is_ident("prop")
+        });
+
+        if prop_attr.is_none() {
+            continue;
+        }
+
+        let prop_attr = prop_attr.unwrap();
+
+        // Parse attribute arguments
+        let mut default_value: Option<String> = None;
+        let mut is_callback = false;
+        let mut is_children = false;
+
+        if let Meta::List(meta_list) = &prop_attr.meta {
+            let tokens_str = meta_list.tokens.to_string();
+
+            if tokens_str.contains("callback") {
+                is_callback = true;
+            }
+
+            if tokens_str.contains("children") {
+                is_children = true;
+                has_children = true;
+            }
+
+            if tokens_str.contains("default") {
+                // Extract default value between quotes
+                if let Some(start) = tokens_str.find('"') {
+                    if let Some(end) = tokens_str[start + 1..].find('"') {
+                        default_value = Some(tokens_str[start + 1..start + 1 + end].to_string());
+                    }
+                }
+            }
+        }
+
+        prop_fields.push(PropField {
+            name: field_name.clone(),
+            ty: field_type.clone(),
+            default_value,
+            is_callback,
+            is_children,
+        });
+    }
+
+    // Generate field definitions
+    let field_defs = prop_fields.iter().map(|field| {
+        let name = &field.name;
+        let ty = &field.ty;
+
+        if field.is_callback {
+            quote! {
+                #name: Option<std::sync::Arc<dyn Fn() + Send + Sync>>
+            }
+        } else if field.is_children {
+            quote! {
+                __children: std::cell::RefCell<::guido::widgets::ChildrenSource>
+            }
+        } else {
+            quote! {
+                #name: ::guido::reactive::MaybeDyn<#ty>
+            }
+        }
+    });
+
+    // Generate field initializers for new()
+    let field_inits = prop_fields.iter().map(|field| {
+        let name = &field.name;
+
+        if field.is_callback {
+            quote! {
+                #name: None
+            }
+        } else if field.is_children {
+            quote! {
+                __children: std::cell::RefCell::new(::guido::widgets::ChildrenSource::default())
+            }
+        } else if let Some(default) = &field.default_value {
+            let default_tokens: proc_macro2::TokenStream = default.parse().unwrap();
+            quote! {
+                #name: ::guido::reactive::MaybeDyn::Static(#default_tokens)
+            }
+        } else {
+            quote! {
+                #name: ::guido::reactive::MaybeDyn::Static(Default::default())
+            }
+        }
+    });
+
+    // Generate builder methods
+    let builder_methods = prop_fields.iter().map(|field| {
+        let name = &field.name;
+        let ty = &field.ty;
+
+        if field.is_callback {
+            quote! {
+                #vis fn #name<F: Fn() + Send + Sync + 'static>(mut self, f: F) -> Self {
+                    self.#name = Some(std::sync::Arc::new(f));
+                    self
+                }
+            }
+        } else if field.is_children {
+            // Don't generate a builder method for children - use child/children instead
+            quote! {}
+        } else {
+            quote! {
+                #vis fn #name(mut self, value: impl ::guido::reactive::IntoMaybeDyn<#ty>) -> Self {
+                    self.#name = value.into_maybe_dyn();
+                    self
+                }
+            }
+        }
+    });
+
+    // Generate children methods if needed
+    let children_methods = if has_children {
+        quote! {
+            #vis fn child(self, child: impl ::guido::widgets::IntoChild) -> Self {
+                child.add_to_container(&mut *self.__children.borrow_mut());
+                self
+            }
+
+            #vis fn children<I>(self, children: I) -> Self
+            where
+                I: ::guido::widgets::IntoChildren,
+            {
+                children.add_to_container(&mut *self.__children.borrow_mut());
+                self
+            }
+
+            /// Take the children source (consumes the children)
+            fn take_children(&self) -> ::guido::widgets::ChildrenSource {
+                std::mem::take(&mut *self.__children.borrow_mut())
+            }
+        }
+    } else {
+        quote! {}
+    };
+
+    // Create snake_case constructor name
+    let constructor_name = syn::Ident::new(
+        &to_snake_case(&struct_name.to_string()),
+        struct_name.span(),
+    );
+
+    let expanded = quote! {
+        #vis struct #struct_name {
+            #(#field_defs,)*
+            __inner: std::cell::RefCell<Option<Box<dyn ::guido::widgets::Widget>>>,
+        }
+
+        impl #struct_name {
+            #vis fn new() -> Self {
+                Self {
+                    #(#field_inits,)*
+                    __inner: std::cell::RefCell::new(None),
+                }
+            }
+
+            #(#builder_methods)*
+
+            #children_methods
+
+            fn ensure_built(&self) {
+                if self.__inner.borrow().is_none() {
+                    let widget = self.render();
+                    *self.__inner.borrow_mut() = Some(Box::new(widget));
+                }
+            }
+        }
+
+        impl ::guido::widgets::Widget for #struct_name {
+            fn layout(&mut self, constraints: ::guido::layout::Constraints) -> ::guido::layout::Size {
+                self.ensure_built();
+                self.__inner.borrow_mut().as_mut().unwrap().layout(constraints)
+            }
+
+            fn paint(&self, ctx: &mut ::guido::renderer::PaintContext) {
+                self.ensure_built();
+                self.__inner.borrow().as_ref().unwrap().paint(ctx)
+            }
+
+            fn event(&mut self, event: &::guido::widgets::Event) -> ::guido::widgets::EventResponse {
+                self.ensure_built();
+                self.__inner.borrow_mut().as_mut().unwrap().event(event)
+            }
+
+            fn set_origin(&mut self, x: f32, y: f32) {
+                self.ensure_built();
+                self.__inner.borrow_mut().as_mut().unwrap().set_origin(x, y)
+            }
+
+            fn bounds(&self) -> ::guido::widgets::Rect {
+                self.ensure_built();
+                self.__inner.borrow().as_ref().unwrap().bounds()
+            }
+
+            fn id(&self) -> ::guido::reactive::WidgetId {
+                self.ensure_built();
+                self.__inner.borrow().as_ref().unwrap().id()
+            }
+
+            fn mark_dirty(&mut self, flags: ::guido::reactive::ChangeFlags) {
+                self.ensure_built();
+                self.__inner.borrow_mut().as_mut().unwrap().mark_dirty(flags)
+            }
+
+            fn needs_layout(&self) -> bool {
+                self.__inner.borrow().as_ref().map_or(true, |w| w.needs_layout())
+            }
+
+            fn needs_paint(&self) -> bool {
+                self.__inner.borrow().as_ref().map_or(true, |w| w.needs_paint())
+            }
+
+            fn clear_dirty(&mut self) {
+                if let Some(w) = self.__inner.borrow_mut().as_mut() {
+                    w.clear_dirty()
+                }
+            }
+        }
+
+        #vis fn #constructor_name() -> #struct_name {
+            #struct_name::new()
+        }
+    };
+
+    TokenStream::from(expanded)
+}
+
+struct PropField {
+    name: syn::Ident,
+    ty: Type,
+    default_value: Option<String>,
+    is_callback: bool,
+    is_children: bool,
+}
+
+fn to_snake_case(s: &str) -> String {
+    let mut result = String::new();
+    let mut prev_is_lower = false;
+
+    for (i, c) in s.chars().enumerate() {
+        if c.is_uppercase() {
+            if i > 0 && prev_is_lower {
+                result.push('_');
+            }
+            result.push(c.to_lowercase().next().unwrap());
+            prev_is_lower = false;
+        } else {
+            result.push(c);
+            prev_is_lower = c.is_lowercase();
+        }
+    }
+
+    result
+}

--- a/guido-macros/src/lib.rs
+++ b/guido-macros/src/lib.rs
@@ -48,9 +48,7 @@ pub fn component(_attr: TokenStream, input: TokenStream) -> TokenStream {
         let field_type = &field.ty;
 
         // Skip if no #[prop] attribute
-        let prop_attr = field.attrs.iter().find(|attr| {
-            attr.path().is_ident("prop")
-        });
+        let prop_attr = field.attrs.iter().find(|attr| attr.path().is_ident("prop"));
 
         if prop_attr.is_none() {
             continue;
@@ -189,10 +187,8 @@ pub fn component(_attr: TokenStream, input: TokenStream) -> TokenStream {
     };
 
     // Create snake_case constructor name
-    let constructor_name = syn::Ident::new(
-        &to_snake_case(&struct_name.to_string()),
-        struct_name.span(),
-    );
+    let constructor_name =
+        syn::Ident::new(&to_snake_case(&struct_name.to_string()), struct_name.span());
 
     let expanded = quote! {
         #vis struct #struct_name {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,9 @@ pub mod widgets;
 pub mod platform;
 pub mod renderer;
 
+// Re-export macros
+pub use guido_macros::component;
+
 use layout::Constraints;
 use platform::{create_wayland_app, Anchor, Layer, WaylandWindowWrapper};
 use reactive::{
@@ -32,7 +35,7 @@ pub mod prelude {
         container, text, Border, Color, Container, Event, EventResponse, GradientDirection,
         IntoChildren, LinearGradient, MouseButton, Padding, Rect, ScrollSource, Text, Widget,
     };
-    pub use crate::{App, AppConfig};
+    pub use crate::{component, App, AppConfig};
 }
 
 pub struct AppConfig {
@@ -143,7 +146,7 @@ impl App {
     }
 
     pub fn run<W: Widget + 'static>(mut self, mut root: W) {
-        env_logger::init();
+        let _ = env_logger::try_init();
 
         let (connection, mut event_queue, mut wayland_state, qh) = create_wayland_app();
 

--- a/src/widgets/container.rs
+++ b/src/widgets/container.rs
@@ -197,6 +197,12 @@ impl Container {
         self
     }
 
+    /// Transfer children from another ChildrenSource (useful for components)
+    pub fn children_source(mut self, source: ChildrenSource) -> Self {
+        self.children_source = source;
+        self
+    }
+
     pub fn padding(mut self, value: impl IntoMaybeDyn<f32>) -> Self {
         let value = value.into_maybe_dyn();
         self.padding = MaybeDyn::Dynamic(std::sync::Arc::new(move || Padding::all(value.get())));
@@ -289,6 +295,12 @@ impl Container {
 
     pub fn on_click<F: Fn() + Send + Sync + 'static>(mut self, callback: F) -> Self {
         self.on_click = Some(Arc::new(callback));
+        self
+    }
+
+    /// Accept an optional click callback (useful for components)
+    pub fn on_click_option(mut self, callback: Option<ClickCallback>) -> Self {
+        self.on_click = callback;
         self
     }
 

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -4,8 +4,9 @@ pub mod into_child;
 pub mod text;
 pub mod widget;
 
+pub use children::ChildrenSource;
 pub use container::{container, Border, Container, GradientDirection, LinearGradient};
-pub use into_child::{DynamicChildren, IntoChildren, StaticChildren};
+pub use into_child::{DynamicChildren, IntoChild, IntoChildren, StaticChildren};
 pub use text::{text, Text};
 pub use widget::{Color, Event, EventResponse, MouseButton, Padding, Rect, ScrollSource, Widget};
 


### PR DESCRIPTION
## Summary

Implements a powerful component system that allows declaring reusable UI components with a fluent builder API and automatic `Widget` trait implementation.

## Features

### #[component] Attribute Macro
- Generates complete builder pattern automatically
- No `.build()` call needed - components auto-implement `Widget`
- Supports both static and reactive props via `MaybeDyn`

### Property Attributes
- **`#[prop]`** - Standard reactive props
- **`#[prop(default = "expr")]`** - Props with defaults
- **`#[prop(callback)]`** - Event callbacks
- **`#[prop(children)]`** - Child component support

### Full Reactive Support
Components accept reactive values seamlessly:
```rust
button()
    .label(move || format!("Count: {}", count.get()))
    .background(move || if count.get() % 2 == 0 { Color::BLUE } else { Color::RED })
```

## Implementation Details

### New Crate: `guido-macros`
- Proc-macro crate implementing the `#[component]` attribute
- Generates wrapper struct with `MaybeDyn` fields and `RefCell` for caching
- Lazy widget building via `ensure_built()` pattern
- Full `Widget` trait delegation to inner cached widget

### Container Enhancements
- `on_click_option()` - Accept optional callbacks from components
- `children_source()` - Transfer children from component sources

### Core Changes
- Export `ChildrenSource` and `IntoChild` from widgets module
- Changed `env_logger::init()` to `try_init()` to prevent re-initialization errors

## Example Usage

```rust
#[component]
pub struct Button {
    #[prop]
    label: String,
    #[prop(default = "Color::rgb(0.3, 0.3, 0.4)")]
    background: Color,
    #[prop(callback)]
    on_click: (),
}

impl Button {
    fn render(&self) -> impl Widget {
        container()
            .padding(8.0)
            .background(self.background.clone())
            .child(text(self.label.clone()))
    }
}

// Usage
button()
    .label("Click me")
    .background(Color::rgb(0.2, 0.6, 0.3))
    .on_click(|| println!("clicked"))
```

## Test Plan

- [x] Created `examples/component_example.rs` demonstrating:
  - Button component with static and reactive props
  - Card component with children support
  - Reactive counter with multiple components
  - Reactive color-changing backgrounds and labels
- [x] All clippy checks pass
- [x] Example runs successfully and renders correctly
- [x] Screenshot verification shows proper rendering

## Screenshots

![Component Example](https://github.com/user-attachments/assets/...)

Component example showing Button and Card components with reactive props.