### PR TITLE
Fix container not rendering without children or padding

### DIFF
--- a/src/widgets/container.rs
+++ b/src/widgets/container.rs
@@ -908,7 +908,10 @@ impl Widget for Container {
                 .is_some_and(|a| a.is_animating());
 
         // Downgrade to paint-only if only visuals changed (but not during layout-affecting animations)
+        // Don't downgrade on first layout (when bounds are uninitialized)
+        let bounds_initialized = self.bounds.width > 0.0 || self.bounds.height > 0.0;
         if self.needs_layout()
+            && bounds_initialized
             && !padding_changed
             && !child_needs_layout
             && !has_size_animations


### PR DESCRIPTION
## Summary
- Fix bug where containers with `width`, `height`, and `background` but no children would not render
- The layout optimization was incorrectly downgrading `NEEDS_LAYOUT` to `NEEDS_PAINT` on the first frame
- This caused `bounds` to remain at `(0, 0, 0, 0)`, resulting in nothing being drawn

## Test plan
- [x] Verified container with only `width`/`height`/`background` now renders correctly
- [x] Verified nested containers without children render correctly
- [x] Ran `cargo clippy` and `cargo fmt` - no issues