### PR TITLE
Add CSS-style transform_origin for widget transforms

### DIFF
--- a/examples/transform_example.rs
+++ b/examples/transform_example.rs
@@ -5,6 +5,7 @@
 //! - Reactive transforms that change based on signals
 //! - Animated transforms with spring physics
 //! - Nested transforms (parent-child composition)
+//! - Custom transform origins (pivot points for rotation/scale)
 
 use guido::prelude::*;
 
@@ -116,6 +117,68 @@ fn main() {
                         )
                         .child(text("Both").color(Color::WHITE).font_size(10.0).nowrap()),
                 ),
+            // 6. Rotation around top-left corner (transform origin)
+            container()
+                .width(60.0)
+                .height(60.0)
+                .background(Color::rgb(0.8, 0.5, 0.7))
+                .corner_radius(8.0)
+                .rotate(45.0)
+                .transform_origin(TransformOrigin::TOP_LEFT)
+                .child(
+                    container()
+                        .layout(
+                            Flex::column()
+                                .main_axis_alignment(MainAxisAlignment::Center)
+                                .cross_axis_alignment(CrossAxisAlignment::Center),
+                        )
+                        .child(text("TL").color(Color::WHITE).font_size(12.0)),
+                ),
+            // 7. Scale from bottom-right corner (transform origin)
+            container()
+                .width(60.0)
+                .height(60.0)
+                .background(Color::rgb(0.5, 0.7, 0.8))
+                .corner_radius(8.0)
+                .scale(0.8)
+                .transform_origin(TransformOrigin::BOTTOM_RIGHT)
+                .child(
+                    container()
+                        .layout(
+                            Flex::column()
+                                .main_axis_alignment(MainAxisAlignment::Center)
+                                .cross_axis_alignment(CrossAxisAlignment::Center),
+                        )
+                        .child(text("BR").color(Color::WHITE).font_size(12.0)),
+                ),
+            // 8. Interactive: click to cycle through origins
+            {
+                let origin_index = create_signal(0usize);
+                container()
+                    .width(60.0)
+                    .height(60.0)
+                    .background(Color::rgb(0.7, 0.8, 0.5))
+                    .corner_radius(8.0)
+                    .rotate(30.0)
+                    .transform_origin(move || match origin_index.get() % 5 {
+                        0 => TransformOrigin::CENTER,
+                        1 => TransformOrigin::TOP_LEFT,
+                        2 => TransformOrigin::TOP_RIGHT,
+                        3 => TransformOrigin::BOTTOM_LEFT,
+                        _ => TransformOrigin::BOTTOM_RIGHT,
+                    })
+                    .ripple()
+                    .on_click(move || origin_index.update(|i| *i += 1))
+                    .child(
+                        container()
+                            .layout(
+                                Flex::column()
+                                    .main_axis_alignment(MainAxisAlignment::Center)
+                                    .cross_axis_alignment(CrossAxisAlignment::Center),
+                            )
+                            .child(text("Cycle").color(Color::WHITE).font_size(10.0).nowrap()),
+                    )
+            },
         ]);
 
     // Run the app with taller height to see transforms

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod animation;
 pub mod layout;
 pub mod reactive;
 pub mod transform;
+pub mod transform_origin;
 pub mod widgets;
 
 // These modules are public for advanced use cases
@@ -38,6 +39,7 @@ pub mod prelude {
     pub use crate::renderer::primitives::Shadow;
     pub use crate::renderer::{measure_text, PaintContext};
     pub use crate::transform::Transform;
+    pub use crate::transform_origin::{HorizontalAnchor, TransformOrigin, VerticalAnchor};
     pub use crate::widgets::{
         container, text, Border, Color, Container, Event, EventResponse, GradientDirection,
         IntoChildren, LinearGradient, MouseButton, Overflow, Padding, Rect, ScrollSource, Text,

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -89,6 +89,7 @@ impl Renderer {
                     color: rect.shadow.color,
                 };
                 scaled_rect.transform = rect.transform;
+                scaled_rect.transform_is_centered = rect.transform_is_centered;
                 scaled_rect.to_vertices(self.screen_width, self.screen_height)
             }
             Shape::Circle(circle) => {
@@ -110,6 +111,7 @@ impl Renderer {
                 );
                 scaled_circle.clip = scaled_clip;
                 scaled_circle.transform = circle.transform;
+                scaled_circle.transform_is_centered = circle.transform_is_centered;
                 scaled_circle.to_vertices(self.screen_width, self.screen_height)
             }
         }
@@ -306,21 +308,27 @@ pub struct PaintContext {
     /// Each entry is (clip_rect, corner_radius, curvature)
     clip_stack: Vec<(Rect, f32, f32)>,
     /// Transform stack for composing parent→child transformations
-    transform_stack: Vec<Transform>,
+    /// Each entry is (transform, is_centered) where is_centered indicates
+    /// the transform has already been centered around a custom origin
+    transform_stack: Vec<(Transform, bool)>,
 }
 
 impl PaintContext {
     pub fn draw_rect(&mut self, rect: Rect, color: Color) {
         let mut shape = RoundedRect::new(rect, color, 0.0);
         shape.clip = self.current_clip();
-        shape.transform = self.current_transform();
+        let (transform, is_centered) = self.current_transform_with_flag();
+        shape.transform = transform;
+        shape.transform_is_centered = is_centered;
         self.shapes.push(Shape::RoundedRect(shape));
     }
 
     pub fn draw_rounded_rect(&mut self, rect: Rect, color: Color, radius: f32) {
         let mut shape = RoundedRect::new(rect, color, radius);
         shape.clip = self.current_clip();
-        shape.transform = self.current_transform();
+        let (transform, is_centered) = self.current_transform_with_flag();
+        shape.transform = transform;
+        shape.transform_is_centered = is_centered;
         self.shapes.push(Shape::RoundedRect(shape));
     }
 
@@ -334,7 +342,9 @@ impl PaintContext {
     ) {
         let mut shape = RoundedRect::with_curvature(rect, color, radius, curvature);
         shape.clip = self.current_clip();
-        shape.transform = self.current_transform();
+        let (transform, is_centered) = self.current_transform_with_flag();
+        shape.transform = transform;
+        shape.transform_is_centered = is_centered;
         self.shapes.push(Shape::RoundedRect(shape));
     }
 
@@ -354,7 +364,9 @@ impl PaintContext {
         };
         let mut shape = RoundedRect::with_gradient(rect, gradient, radius);
         shape.clip = self.current_clip();
-        shape.transform = self.current_transform();
+        let (transform, is_centered) = self.current_transform_with_flag();
+        shape.transform = transform;
+        shape.transform_is_centered = is_centered;
         self.shapes.push(Shape::RoundedRect(shape));
     }
 
@@ -376,7 +388,9 @@ impl PaintContext {
         let mut shape = RoundedRect::with_gradient(rect, gradient, radius);
         shape.curvature = curvature;
         shape.clip = self.current_clip();
-        shape.transform = self.current_transform();
+        let (transform, is_centered) = self.current_transform_with_flag();
+        shape.transform = transform;
+        shape.transform_is_centered = is_centered;
         self.shapes.push(Shape::RoundedRect(shape));
     }
 
@@ -391,7 +405,9 @@ impl PaintContext {
     ) {
         let mut shape = RoundedRect::border_only(rect, corner_radius, border_width, color);
         shape.clip = self.current_clip();
-        shape.transform = self.current_transform();
+        let (transform, is_centered) = self.current_transform_with_flag();
+        shape.transform = transform;
+        shape.transform_is_centered = is_centered;
         self.shapes.push(Shape::RoundedRect(shape));
     }
 
@@ -413,7 +429,9 @@ impl PaintContext {
             curvature,
         );
         shape.clip = self.current_clip();
-        shape.transform = self.current_transform();
+        let (transform, is_centered) = self.current_transform_with_flag();
+        shape.transform = transform;
+        shape.transform_is_centered = is_centered;
         self.shapes.push(Shape::RoundedRect(shape));
     }
 
@@ -429,7 +447,9 @@ impl PaintContext {
         let mut shape =
             RoundedRect::with_border(rect, fill_color, radius, border_width, border_color);
         shape.clip = self.current_clip();
-        shape.transform = self.current_transform();
+        let (transform, is_centered) = self.current_transform_with_flag();
+        shape.transform = transform;
+        shape.transform_is_centered = is_centered;
         self.shapes.push(Shape::RoundedRect(shape));
     }
 
@@ -447,7 +467,9 @@ impl PaintContext {
             RoundedRect::with_border(rect, fill_color, radius, border_width, border_color);
         shape.curvature = curvature;
         shape.clip = self.current_clip();
-        shape.transform = self.current_transform();
+        let (transform, is_centered) = self.current_transform_with_flag();
+        shape.transform = transform;
+        shape.transform_is_centered = is_centered;
         self.shapes.push(Shape::RoundedRect(shape));
     }
 
@@ -455,7 +477,9 @@ impl PaintContext {
     pub fn draw_circle(&mut self, center_x: f32, center_y: f32, radius: f32, color: Color) {
         let mut shape = Circle::new(center_x, center_y, radius, color);
         shape.clip = self.current_clip();
-        shape.transform = self.current_transform();
+        let (transform, is_centered) = self.current_transform_with_flag();
+        shape.transform = transform;
+        shape.transform_is_centered = is_centered;
         self.shapes.push(Shape::Circle(shape));
     }
 
@@ -475,7 +499,9 @@ impl PaintContext {
             curvature: 2.0, // Default to circular clipping
         };
         let mut shape = Circle::with_clip(center_x, center_y, radius, color, clip);
-        shape.transform = self.current_transform();
+        let (transform, is_centered) = self.current_transform_with_flag();
+        shape.transform = transform;
+        shape.transform_is_centered = is_centered;
         self.shapes.push(Shape::Circle(shape));
     }
 
@@ -489,7 +515,9 @@ impl PaintContext {
     ) {
         let mut rounded_rect = RoundedRect::new(rect, color, radius);
         rounded_rect.shadow = shadow;
-        rounded_rect.transform = self.current_transform();
+        let (transform, is_centered) = self.current_transform_with_flag();
+        rounded_rect.transform = transform;
+        rounded_rect.transform_is_centered = is_centered;
         self.shapes.push(Shape::RoundedRect(rounded_rect));
     }
 
@@ -505,7 +533,9 @@ impl PaintContext {
         let mut shape = RoundedRect::with_curvature(rect, color, radius, curvature);
         shape.shadow = shadow;
         shape.clip = self.current_clip();
-        shape.transform = self.current_transform();
+        let (transform, is_centered) = self.current_transform_with_flag();
+        shape.transform = transform;
+        shape.transform_is_centered = is_centered;
         self.shapes.push(Shape::RoundedRect(shape));
     }
 
@@ -519,7 +549,9 @@ impl PaintContext {
     /// Draw a circle as an overlay (rendered on top of text)
     pub fn draw_overlay_circle(&mut self, center_x: f32, center_y: f32, radius: f32, color: Color) {
         let mut shape = Circle::new(center_x, center_y, radius, color);
-        shape.transform = self.current_transform();
+        let (transform, is_centered) = self.current_transform_with_flag();
+        shape.transform = transform;
+        shape.transform_is_centered = is_centered;
         self.overlay_shapes.push(Shape::Circle(shape));
     }
 
@@ -539,7 +571,9 @@ impl PaintContext {
             curvature: 2.0, // Default to circular clipping
         };
         let mut shape = Circle::with_clip(center_x, center_y, radius, color, clip);
-        shape.transform = self.current_transform();
+        let (transform, is_centered) = self.current_transform_with_flag();
+        shape.transform = transform;
+        shape.transform_is_centered = is_centered;
         self.overlay_shapes.push(Shape::Circle(shape));
     }
 
@@ -561,7 +595,9 @@ impl PaintContext {
             curvature: clip_curvature,
         };
         let mut shape = Circle::with_clip(center_x, center_y, radius, color, clip);
-        shape.transform = self.current_transform();
+        let (transform, is_centered) = self.current_transform_with_flag();
+        shape.transform = transform;
+        shape.transform_is_centered = is_centered;
         self.overlay_shapes.push(Shape::Circle(shape));
     }
 
@@ -590,12 +626,23 @@ impl PaintContext {
     /// Push a transform onto the stack
     /// This transform is composed with the current transform
     pub fn push_transform(&mut self, transform: Transform) {
-        let composed = if let Some(current) = self.transform_stack.last() {
-            current.then(&transform)
+        let (composed, _) = if let Some((current, _)) = self.transform_stack.last() {
+            (current.then(&transform), false)
         } else {
-            transform
+            (transform, false)
         };
-        self.transform_stack.push(composed);
+        self.transform_stack.push((composed, false));
+    }
+
+    /// Push a pre-centered transform onto the stack
+    /// Use this when the transform has already been centered around a custom origin point
+    pub fn push_centered_transform(&mut self, transform: Transform) {
+        let (composed, _) = if let Some((current, _)) = self.transform_stack.last() {
+            (current.then(&transform), true)
+        } else {
+            (transform, true)
+        };
+        self.transform_stack.push((composed, true));
     }
 
     /// Pop a transform from the stack
@@ -607,7 +654,15 @@ impl PaintContext {
     pub fn current_transform(&self) -> Transform {
         self.transform_stack
             .last()
-            .copied()
+            .map(|(t, _)| *t)
             .unwrap_or(Transform::IDENTITY)
+    }
+
+    /// Get the current transform with its centered flag
+    fn current_transform_with_flag(&self) -> (Transform, bool) {
+        self.transform_stack
+            .last()
+            .copied()
+            .unwrap_or((Transform::IDENTITY, false))
     }
 }

--- a/src/renderer/primitives.rs
+++ b/src/renderer/primitives.rs
@@ -353,6 +353,8 @@ pub struct RoundedRect {
     pub shadow: Shadow,
     /// Transform matrix for this shape
     pub transform: Transform,
+    /// If true, the transform is already centered and should not be auto-centered
+    pub transform_is_centered: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -376,6 +378,7 @@ impl RoundedRect {
             border_color: Color::TRANSPARENT,
             shadow: Shadow::none(),
             transform: Transform::IDENTITY,
+            transform_is_centered: false,
         }
     }
 
@@ -391,6 +394,7 @@ impl RoundedRect {
             border_color: Color::TRANSPARENT,
             shadow: Shadow::none(),
             transform: Transform::IDENTITY,
+            transform_is_centered: false,
         }
     }
 
@@ -406,6 +410,7 @@ impl RoundedRect {
             border_color: Color::TRANSPARENT,
             shadow: Shadow::none(),
             transform: Transform::IDENTITY,
+            transform_is_centered: false,
         }
     }
 
@@ -421,6 +426,7 @@ impl RoundedRect {
             border_color: Color::TRANSPARENT,
             shadow: Shadow::none(),
             transform: Transform::IDENTITY,
+            transform_is_centered: false,
         }
     }
 
@@ -443,6 +449,7 @@ impl RoundedRect {
             border_color,
             shadow: Shadow::none(),
             transform: Transform::IDENTITY,
+            transform_is_centered: false,
         }
     }
 
@@ -459,6 +466,7 @@ impl RoundedRect {
             border_color,
             shadow: Shadow::none(),
             transform: Transform::IDENTITY,
+            transform_is_centered: false,
         }
     }
 
@@ -481,6 +489,7 @@ impl RoundedRect {
             border_color,
             shadow: Shadow::none(),
             transform: Transform::IDENTITY,
+            transform_is_centered: false,
         }
     }
 
@@ -595,10 +604,15 @@ impl RoundedRect {
                 ],
             };
 
-            // Center the transform around the shape's center in NDC
-            let center_x = (x1 + x2) / 2.0;
-            let center_y = (y1 + y2) / 2.0;
-            ndc_transform.center_at(center_x, center_y)
+            // If transform is already centered (from Container with custom transform_origin),
+            // use it directly. Otherwise, center around the shape's center in NDC.
+            if self.transform_is_centered {
+                ndc_transform
+            } else {
+                let center_x = (x1 + x2) / 2.0;
+                let center_y = (y1 + y2) / 2.0;
+                ndc_transform.center_at(center_x, center_y)
+            }
         } else {
             Transform::IDENTITY
         };
@@ -748,6 +762,8 @@ pub struct Circle {
     pub clip: Option<ClipRegion>,
     /// Transform matrix for this shape
     pub transform: Transform,
+    /// If true, the transform is already centered and should not be auto-centered
+    pub transform_is_centered: bool,
 }
 
 impl Circle {
@@ -759,6 +775,7 @@ impl Circle {
             color,
             clip: None,
             transform: Transform::IDENTITY,
+            transform_is_centered: false,
         }
     }
 
@@ -776,6 +793,7 @@ impl Circle {
             color,
             clip: Some(clip),
             transform: Transform::IDENTITY,
+            transform_is_centered: false,
         }
     }
 
@@ -792,8 +810,14 @@ impl Circle {
         let r_ndc_y = (self.radius / screen_height) * 2.0;
 
         // Compute centered transform in NDC space (circle is already centered at cx, cy)
+        // If transform is already centered (from Container with custom transform_origin),
+        // use it directly.
         let centered_transform = if !self.transform.is_identity() {
-            self.transform.center_at(cx, cy)
+            if self.transform_is_centered {
+                self.transform
+            } else {
+                self.transform.center_at(cx, cy)
+            }
         } else {
             Transform::IDENTITY
         };

--- a/src/renderer/primitives.rs
+++ b/src/renderer/primitives.rs
@@ -766,6 +766,28 @@ pub struct Circle {
     pub transform_is_centered: bool,
 }
 
+/// Trait for shapes that can have transforms applied.
+///
+/// This allows PaintContext to apply transforms uniformly to all shape types.
+pub trait Transformable {
+    /// Set the transform matrix and whether it's already centered
+    fn set_transform(&mut self, transform: Transform, is_centered: bool);
+}
+
+impl Transformable for RoundedRect {
+    fn set_transform(&mut self, transform: Transform, is_centered: bool) {
+        self.transform = transform;
+        self.transform_is_centered = is_centered;
+    }
+}
+
+impl Transformable for Circle {
+    fn set_transform(&mut self, transform: Transform, is_centered: bool) {
+        self.transform = transform;
+        self.transform_is_centered = is_centered;
+    }
+}
+
 impl Circle {
     pub fn new(center_x: f32, center_y: f32, radius: f32, color: Color) -> Self {
         Self {

--- a/src/transform_origin.rs
+++ b/src/transform_origin.rs
@@ -1,0 +1,304 @@
+use crate::widgets::Rect;
+
+/// Horizontal anchor position for transform origin
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum HorizontalAnchor {
+    /// Anchor at the left edge (0%)
+    Left,
+    /// Anchor at the center (50%)
+    Center,
+    /// Anchor at the right edge (100%)
+    Right,
+    /// Anchor at a percentage from the left (0-100)
+    Percent(f32),
+    /// Anchor at a fixed pixel offset from the left
+    Px(f32),
+}
+
+/// Vertical anchor position for transform origin
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum VerticalAnchor {
+    /// Anchor at the top edge (0%)
+    Top,
+    /// Anchor at the center (50%)
+    Center,
+    /// Anchor at the bottom edge (100%)
+    Bottom,
+    /// Anchor at a percentage from the top (0-100)
+    Percent(f32),
+    /// Anchor at a fixed pixel offset from the top
+    Px(f32),
+}
+
+/// Specifies the pivot point for transforms, similar to CSS `transform-origin`.
+///
+/// The origin is the point around which rotations and scales are applied.
+/// By default, transforms are centered on the widget (50%, 50%).
+///
+/// # Example
+/// ```ignore
+/// // Rotate around the top-left corner
+/// container()
+///     .rotate(45.0)
+///     .transform_origin(TransformOrigin::TOP_LEFT)
+///
+/// // Scale from the bottom-right corner
+/// container()
+///     .scale(1.5)
+///     .transform_origin(TransformOrigin::BOTTOM_RIGHT)
+///
+/// // Use percentage-based origin (25% from left, 75% from top)
+/// container()
+///     .rotate(30.0)
+///     .transform_origin(TransformOrigin::percent(25.0, 75.0))
+///
+/// // Use pixel-based offset (10px from left, 20px from top)
+/// container()
+///     .scale(2.0)
+///     .transform_origin(TransformOrigin::px(10.0, 20.0))
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct TransformOrigin {
+    /// Horizontal position of the origin
+    pub horizontal: HorizontalAnchor,
+    /// Vertical position of the origin
+    pub vertical: VerticalAnchor,
+}
+
+impl TransformOrigin {
+    /// Center of the widget (50%, 50%) - the default
+    pub const CENTER: Self = Self {
+        horizontal: HorizontalAnchor::Center,
+        vertical: VerticalAnchor::Center,
+    };
+
+    /// Top-left corner (0%, 0%)
+    pub const TOP_LEFT: Self = Self {
+        horizontal: HorizontalAnchor::Left,
+        vertical: VerticalAnchor::Top,
+    };
+
+    /// Top center (50%, 0%)
+    pub const TOP: Self = Self {
+        horizontal: HorizontalAnchor::Center,
+        vertical: VerticalAnchor::Top,
+    };
+
+    /// Top-right corner (100%, 0%)
+    pub const TOP_RIGHT: Self = Self {
+        horizontal: HorizontalAnchor::Right,
+        vertical: VerticalAnchor::Top,
+    };
+
+    /// Center left (0%, 50%)
+    pub const LEFT: Self = Self {
+        horizontal: HorizontalAnchor::Left,
+        vertical: VerticalAnchor::Center,
+    };
+
+    /// Center right (100%, 50%)
+    pub const RIGHT: Self = Self {
+        horizontal: HorizontalAnchor::Right,
+        vertical: VerticalAnchor::Center,
+    };
+
+    /// Bottom-left corner (0%, 100%)
+    pub const BOTTOM_LEFT: Self = Self {
+        horizontal: HorizontalAnchor::Left,
+        vertical: VerticalAnchor::Bottom,
+    };
+
+    /// Bottom center (50%, 100%)
+    pub const BOTTOM: Self = Self {
+        horizontal: HorizontalAnchor::Center,
+        vertical: VerticalAnchor::Bottom,
+    };
+
+    /// Bottom-right corner (100%, 100%)
+    pub const BOTTOM_RIGHT: Self = Self {
+        horizontal: HorizontalAnchor::Right,
+        vertical: VerticalAnchor::Bottom,
+    };
+
+    /// Create a new transform origin with explicit anchors
+    pub fn new(horizontal: HorizontalAnchor, vertical: VerticalAnchor) -> Self {
+        Self {
+            horizontal,
+            vertical,
+        }
+    }
+
+    /// Create a transform origin from percentages (0-100 scale)
+    ///
+    /// # Example
+    /// ```ignore
+    /// // 25% from left, 75% from top
+    /// TransformOrigin::percent(25.0, 75.0)
+    /// ```
+    pub fn percent(x_percent: f32, y_percent: f32) -> Self {
+        Self {
+            horizontal: HorizontalAnchor::Percent(x_percent),
+            vertical: VerticalAnchor::Percent(y_percent),
+        }
+    }
+
+    /// Create a transform origin from pixel offsets from the top-left corner
+    ///
+    /// # Example
+    /// ```ignore
+    /// // 10px from left, 20px from top
+    /// TransformOrigin::px(10.0, 20.0)
+    /// ```
+    pub fn px(x: f32, y: f32) -> Self {
+        Self {
+            horizontal: HorizontalAnchor::Px(x),
+            vertical: VerticalAnchor::Px(y),
+        }
+    }
+
+    /// Resolve the transform origin to absolute coordinates within the given bounds.
+    ///
+    /// Returns `(x, y)` coordinates in the same coordinate system as the bounds.
+    pub fn resolve(&self, bounds: Rect) -> (f32, f32) {
+        let x = match self.horizontal {
+            HorizontalAnchor::Left => bounds.x,
+            HorizontalAnchor::Center => bounds.x + bounds.width / 2.0,
+            HorizontalAnchor::Right => bounds.x + bounds.width,
+            HorizontalAnchor::Percent(p) => bounds.x + bounds.width * (p / 100.0),
+            HorizontalAnchor::Px(px) => bounds.x + px,
+        };
+
+        let y = match self.vertical {
+            VerticalAnchor::Top => bounds.y,
+            VerticalAnchor::Center => bounds.y + bounds.height / 2.0,
+            VerticalAnchor::Bottom => bounds.y + bounds.height,
+            VerticalAnchor::Percent(p) => bounds.y + bounds.height * (p / 100.0),
+            VerticalAnchor::Px(px) => bounds.y + px,
+        };
+
+        (x, y)
+    }
+
+    /// Check if this is the center origin (default)
+    pub fn is_center(&self) -> bool {
+        matches!(
+            self,
+            Self {
+                horizontal: HorizontalAnchor::Center,
+                vertical: VerticalAnchor::Center
+            }
+        )
+    }
+}
+
+impl Default for TransformOrigin {
+    fn default() -> Self {
+        Self::CENTER
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn approx_eq(a: f32, b: f32) -> bool {
+        (a - b).abs() < 1e-5
+    }
+
+    #[test]
+    fn test_constants() {
+        let bounds = Rect::new(100.0, 50.0, 200.0, 100.0);
+
+        // CENTER: (200, 100)
+        let (x, y) = TransformOrigin::CENTER.resolve(bounds);
+        assert!(approx_eq(x, 200.0));
+        assert!(approx_eq(y, 100.0));
+
+        // TOP_LEFT: (100, 50)
+        let (x, y) = TransformOrigin::TOP_LEFT.resolve(bounds);
+        assert!(approx_eq(x, 100.0));
+        assert!(approx_eq(y, 50.0));
+
+        // TOP: (200, 50)
+        let (x, y) = TransformOrigin::TOP.resolve(bounds);
+        assert!(approx_eq(x, 200.0));
+        assert!(approx_eq(y, 50.0));
+
+        // TOP_RIGHT: (300, 50)
+        let (x, y) = TransformOrigin::TOP_RIGHT.resolve(bounds);
+        assert!(approx_eq(x, 300.0));
+        assert!(approx_eq(y, 50.0));
+
+        // LEFT: (100, 100)
+        let (x, y) = TransformOrigin::LEFT.resolve(bounds);
+        assert!(approx_eq(x, 100.0));
+        assert!(approx_eq(y, 100.0));
+
+        // RIGHT: (300, 100)
+        let (x, y) = TransformOrigin::RIGHT.resolve(bounds);
+        assert!(approx_eq(x, 300.0));
+        assert!(approx_eq(y, 100.0));
+
+        // BOTTOM_LEFT: (100, 150)
+        let (x, y) = TransformOrigin::BOTTOM_LEFT.resolve(bounds);
+        assert!(approx_eq(x, 100.0));
+        assert!(approx_eq(y, 150.0));
+
+        // BOTTOM: (200, 150)
+        let (x, y) = TransformOrigin::BOTTOM.resolve(bounds);
+        assert!(approx_eq(x, 200.0));
+        assert!(approx_eq(y, 150.0));
+
+        // BOTTOM_RIGHT: (300, 150)
+        let (x, y) = TransformOrigin::BOTTOM_RIGHT.resolve(bounds);
+        assert!(approx_eq(x, 300.0));
+        assert!(approx_eq(y, 150.0));
+    }
+
+    #[test]
+    fn test_percent() {
+        let bounds = Rect::new(0.0, 0.0, 100.0, 200.0);
+
+        // 25%, 75%
+        let origin = TransformOrigin::percent(25.0, 75.0);
+        let (x, y) = origin.resolve(bounds);
+        assert!(approx_eq(x, 25.0));
+        assert!(approx_eq(y, 150.0));
+
+        // 0%, 0% should be same as TOP_LEFT
+        let origin = TransformOrigin::percent(0.0, 0.0);
+        let (x, y) = origin.resolve(bounds);
+        assert!(approx_eq(x, 0.0));
+        assert!(approx_eq(y, 0.0));
+
+        // 100%, 100% should be same as BOTTOM_RIGHT
+        let origin = TransformOrigin::percent(100.0, 100.0);
+        let (x, y) = origin.resolve(bounds);
+        assert!(approx_eq(x, 100.0));
+        assert!(approx_eq(y, 200.0));
+    }
+
+    #[test]
+    fn test_px() {
+        let bounds = Rect::new(50.0, 100.0, 200.0, 300.0);
+
+        // 10px, 20px from bounds origin
+        let origin = TransformOrigin::px(10.0, 20.0);
+        let (x, y) = origin.resolve(bounds);
+        assert!(approx_eq(x, 60.0)); // 50 + 10
+        assert!(approx_eq(y, 120.0)); // 100 + 20
+    }
+
+    #[test]
+    fn test_is_center() {
+        assert!(TransformOrigin::CENTER.is_center());
+        assert!(TransformOrigin::default().is_center());
+        assert!(!TransformOrigin::TOP_LEFT.is_center());
+        assert!(!TransformOrigin::percent(50.0, 50.0).is_center());
+    }
+
+    #[test]
+    fn test_default() {
+        assert_eq!(TransformOrigin::default(), TransformOrigin::CENTER);
+    }
+}

--- a/src/transform_origin.rs
+++ b/src/transform_origin.rs
@@ -179,7 +179,13 @@ impl TransformOrigin {
         (x, y)
     }
 
-    /// Check if this is the center origin (default)
+    /// Check if this is the center origin using the CENTER constant.
+    ///
+    /// Note: This checks the enum variant, not the resolved position.
+    /// `TransformOrigin::percent(50.0, 50.0).is_center()` returns `false`
+    /// even though it resolves to the same point as `CENTER`.
+    /// This is intentional for performance - it enables a fast path
+    /// when using the default center origin.
     pub fn is_center(&self) -> bool {
         matches!(
             self,

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -13,6 +13,7 @@ pub use widget::{Color, Event, EventResponse, MouseButton, Padding, Rect, Scroll
 // IntoMaybeDyn implementations for widget types
 use crate::reactive::{IntoMaybeDyn, MaybeDyn};
 use crate::transform::Transform;
+use crate::transform_origin::TransformOrigin;
 
 impl IntoMaybeDyn<Color> for Color {
     fn into_maybe_dyn(self) -> MaybeDyn<Color> {
@@ -28,6 +29,12 @@ impl IntoMaybeDyn<Padding> for Padding {
 
 impl IntoMaybeDyn<Transform> for Transform {
     fn into_maybe_dyn(self) -> MaybeDyn<Transform> {
+        MaybeDyn::Static(self)
+    }
+}
+
+impl IntoMaybeDyn<TransformOrigin> for TransformOrigin {
+    fn into_maybe_dyn(self) -> MaybeDyn<TransformOrigin> {
         MaybeDyn::Static(self)
     }
 }


### PR DESCRIPTION
## Summary

- Add CSS-style `transform_origin` property to specify the pivot point for transforms on Container widgets
- Similar to CSS `transform-origin` property, allows rotating/scaling around any point instead of just the center
- Supports static values, reactive signals, and closures

## API

```rust
// Predefined constants
container()
    .rotate(45.0)
    .transform_origin(TransformOrigin::TOP_LEFT)

container()
    .scale(1.5)
    .transform_origin(TransformOrigin::BOTTOM_RIGHT)

// Percentage-based (25% from left, 75% from top)
container()
    .rotate(30.0)
    .transform_origin(TransformOrigin::percent(25.0, 75.0))

// Pixel-based (10px from left, 20px from top)
container()
    .scale(2.0)
    .transform_origin(TransformOrigin::px(10.0, 20.0))

// Reactive
container()
    .rotate(30.0)
    .transform_origin(move || if condition.get() {
        TransformOrigin::CENTER
    } else {
        TransformOrigin::TOP_LEFT
    })
```

## Implementation Details

- New `TransformOrigin` type with `HorizontalAnchor` and `VerticalAnchor` enums
- Constants: `CENTER` (default), `TOP_LEFT`, `TOP`, `TOP_RIGHT`, `LEFT`, `RIGHT`, `BOTTOM_LEFT`, `BOTTOM`, `BOTTOM_RIGHT`
- Container pre-centers transforms using the specified origin before passing to renderer
- `PaintContext` tracks whether transforms are pre-centered to avoid double-centering
- Primitives have `transform_is_centered` flag to skip auto-centering when needed

## Test plan

- [x] Run `cargo clippy` - passes
- [x] Run `cargo fmt` - formatted
- [x] Run `cargo test` - all 80 tests pass
- [x] Run `cargo run --example transform_example` - visual verification
  - Box 6 (TL): Rotates around top-left corner
  - Box 7 (BR): Scales toward bottom-right corner
  - Box 8 (Cycle): Clicking cycles through different origins