### PR TITLE
Add text transform support for rotated/scaled containers

### DIFF
--- a/examples/text_transform_example.rs
+++ b/examples/text_transform_example.rs
@@ -1,0 +1,289 @@
+//! Example demonstrating text transform support.
+//!
+//! This example shows text following parent container transforms:
+//! - Text with rotation
+//! - Text with scale
+//! - Text with translation
+//! - Combined transformations (rotation + scale + translation)
+//! - Custom transform origin
+//! - Nested transforms with text
+//! - Animated text rotation
+
+use guido::prelude::*;
+use std::f32::consts::PI;
+
+fn main() {
+    // Animated rotation angle
+    let angle = create_signal(0.0_f32);
+
+    // Animation effect - the signal is Copy so we can use it directly
+    create_effect(move || {
+        let current = angle.get();
+        // This will be updated by the on_update callback
+        let _ = current;
+    });
+
+    let view = container()
+        .layout(
+            Flex::column()
+                .spacing(20.0)
+                .main_axis_alignment(MainAxisAlignment::Center)
+                .cross_axis_alignment(CrossAxisAlignment::Center),
+        )
+        .padding(30.0)
+        .children([
+            // Title
+            container().child(
+                text("Text Transform Demo")
+                    .font_size(24.0)
+                    .color(Color::WHITE),
+            ),
+            // Row 1: Basic transforms (rotation, scale, translation)
+            container()
+                .layout(
+                    Flex::row()
+                        .spacing(30.0)
+                        .main_axis_alignment(MainAxisAlignment::Center)
+                        .cross_axis_alignment(CrossAxisAlignment::Center),
+                )
+                .children([
+                    // Rotation
+                    container()
+                        .width(110.0)
+                        .height(70.0)
+                        .background(Color::rgba(0.3, 0.5, 0.8, 0.8))
+                        .corner_radius(8.0)
+                        .layout(
+                            Flex::column()
+                                .main_axis_alignment(MainAxisAlignment::Center)
+                                .cross_axis_alignment(CrossAxisAlignment::Center),
+                        )
+                        .rotate(15.0)
+                        .child(text("Rotate 15°").font_size(13.0).color(Color::WHITE)),
+                    // Scale
+                    container()
+                        .width(110.0)
+                        .height(70.0)
+                        .background(Color::rgba(0.8, 0.5, 0.3, 0.8))
+                        .corner_radius(8.0)
+                        .layout(
+                            Flex::column()
+                                .main_axis_alignment(MainAxisAlignment::Center)
+                                .cross_axis_alignment(CrossAxisAlignment::Center),
+                        )
+                        .scale(1.2)
+                        .child(text("Scale 1.2x").font_size(13.0).color(Color::WHITE)),
+                    // Translation
+                    container()
+                        .width(110.0)
+                        .height(70.0)
+                        .background(Color::rgba(0.5, 0.8, 0.3, 0.8))
+                        .corner_radius(8.0)
+                        .layout(
+                            Flex::column()
+                                .main_axis_alignment(MainAxisAlignment::Center)
+                                .cross_axis_alignment(CrossAxisAlignment::Center),
+                        )
+                        .translate(10.0, -10.0)
+                        .child(text("Translate").font_size(13.0).color(Color::WHITE)),
+                    // Rotation + Scale
+                    container()
+                        .width(110.0)
+                        .height(70.0)
+                        .background(Color::rgba(0.8, 0.3, 0.8, 0.8))
+                        .corner_radius(8.0)
+                        .layout(
+                            Flex::column()
+                                .main_axis_alignment(MainAxisAlignment::Center)
+                                .cross_axis_alignment(CrossAxisAlignment::Center),
+                        )
+                        .rotate(-20.0)
+                        .scale(0.9)
+                        .child(text("Rot + Scale").font_size(13.0).color(Color::WHITE)),
+                ]),
+            // Row 2: Combined transforms and custom origin
+            container()
+                .layout(
+                    Flex::row()
+                        .spacing(30.0)
+                        .main_axis_alignment(MainAxisAlignment::Center)
+                        .cross_axis_alignment(CrossAxisAlignment::Center),
+                )
+                .children([
+                    // All three: rotation + scale + translation
+                    container()
+                        .width(130.0)
+                        .height(80.0)
+                        .background(Color::rgba(0.3, 0.7, 0.7, 0.8))
+                        .corner_radius(8.0)
+                        .layout(
+                            Flex::column()
+                                .main_axis_alignment(MainAxisAlignment::Center)
+                                .cross_axis_alignment(CrossAxisAlignment::Center),
+                        )
+                        .rotate(10.0)
+                        .scale(1.1)
+                        .translate(5.0, 5.0)
+                        .child(text("All Combined").font_size(13.0).color(Color::WHITE)),
+                    // Custom origin: top-left
+                    container()
+                        .width(130.0)
+                        .height(80.0)
+                        .background(Color::rgba(0.7, 0.5, 0.2, 0.8))
+                        .corner_radius(8.0)
+                        .layout(
+                            Flex::column()
+                                .main_axis_alignment(MainAxisAlignment::Center)
+                                .cross_axis_alignment(CrossAxisAlignment::Center),
+                        )
+                        .transform_origin(TransformOrigin::TOP_LEFT)
+                        .rotate(15.0)
+                        .child(text("Origin: Top-Left").font_size(12.0).color(Color::WHITE)),
+                    // Custom origin: bottom-right
+                    container()
+                        .width(130.0)
+                        .height(80.0)
+                        .background(Color::rgba(0.2, 0.5, 0.7, 0.8))
+                        .corner_radius(8.0)
+                        .layout(
+                            Flex::column()
+                                .main_axis_alignment(MainAxisAlignment::Center)
+                                .cross_axis_alignment(CrossAxisAlignment::Center),
+                        )
+                        .transform_origin(TransformOrigin::BOTTOM_RIGHT)
+                        .rotate(15.0)
+                        .child(text("Origin: Bot-Right").font_size(12.0).color(Color::WHITE)),
+                    // Custom origin with scale
+                    container()
+                        .width(130.0)
+                        .height(80.0)
+                        .background(Color::rgba(0.7, 0.3, 0.5, 0.8))
+                        .corner_radius(8.0)
+                        .layout(
+                            Flex::column()
+                                .main_axis_alignment(MainAxisAlignment::Center)
+                                .cross_axis_alignment(CrossAxisAlignment::Center),
+                        )
+                        .transform_origin(TransformOrigin::TOP_RIGHT)
+                        .scale(1.15)
+                        .rotate(-10.0)
+                        .child(text("Origin + Scale").font_size(12.0).color(Color::WHITE)),
+                ]),
+            // Row 3: Nested transforms
+            container()
+                .layout(
+                    Flex::row()
+                        .spacing(30.0)
+                        .main_axis_alignment(MainAxisAlignment::Center)
+                        .cross_axis_alignment(CrossAxisAlignment::Center),
+                )
+                .children([
+                    // Nested: parent rotated, child has text
+                    container()
+                        .width(130.0)
+                        .height(90.0)
+                        .background(Color::rgba(0.6, 0.3, 0.6, 0.5))
+                        .corner_radius(12.0)
+                        .layout(
+                            Flex::column()
+                                .main_axis_alignment(MainAxisAlignment::Center)
+                                .cross_axis_alignment(CrossAxisAlignment::Center),
+                        )
+                        .rotate(20.0)
+                        .child(
+                            container()
+                                .width(90.0)
+                                .height(50.0)
+                                .background(Color::rgba(0.8, 0.6, 0.8, 0.9))
+                                .corner_radius(6.0)
+                                .layout(
+                                    Flex::column()
+                                        .main_axis_alignment(MainAxisAlignment::Center)
+                                        .cross_axis_alignment(CrossAxisAlignment::Center),
+                                )
+                                .child(text("Nested").font_size(14.0).color(Color::WHITE)),
+                        ),
+                    // Double nested with additional rotation
+                    container()
+                        .width(130.0)
+                        .height(90.0)
+                        .background(Color::rgba(0.3, 0.6, 0.6, 0.5))
+                        .corner_radius(12.0)
+                        .layout(
+                            Flex::column()
+                                .main_axis_alignment(MainAxisAlignment::Center)
+                                .cross_axis_alignment(CrossAxisAlignment::Center),
+                        )
+                        .rotate(15.0)
+                        .child(
+                            container()
+                                .width(90.0)
+                                .height(50.0)
+                                .background(Color::rgba(0.5, 0.8, 0.8, 0.9))
+                                .corner_radius(6.0)
+                                .layout(
+                                    Flex::column()
+                                        .main_axis_alignment(MainAxisAlignment::Center)
+                                        .cross_axis_alignment(CrossAxisAlignment::Center),
+                                )
+                                .rotate(15.0)
+                                .child(text("30° Total").font_size(13.0).color(Color::rgb(0.1, 0.1, 0.1))),
+                        ),
+                    // Nested with scale + translation
+                    container()
+                        .width(130.0)
+                        .height(90.0)
+                        .background(Color::rgba(0.6, 0.6, 0.3, 0.5))
+                        .corner_radius(12.0)
+                        .layout(
+                            Flex::column()
+                                .main_axis_alignment(MainAxisAlignment::Center)
+                                .cross_axis_alignment(CrossAxisAlignment::Center),
+                        )
+                        .scale(1.1)
+                        .translate(5.0, 0.0)
+                        .child(
+                            container()
+                                .width(90.0)
+                                .height(50.0)
+                                .background(Color::rgba(0.8, 0.8, 0.5, 0.9))
+                                .corner_radius(6.0)
+                                .layout(
+                                    Flex::column()
+                                        .main_axis_alignment(MainAxisAlignment::Center)
+                                        .cross_axis_alignment(CrossAxisAlignment::Center),
+                                )
+                                .rotate(-10.0)
+                                .child(text("Scale+Trans").font_size(12.0).color(Color::rgb(0.1, 0.1, 0.1))),
+                        ),
+                    // Animated rotating text
+                    container()
+                        .width(110.0)
+                        .height(70.0)
+                        .background(Color::rgba(0.8, 0.3, 0.5, 0.8))
+                        .corner_radius(8.0)
+                        .layout(
+                            Flex::column()
+                                .main_axis_alignment(MainAxisAlignment::Center)
+                                .cross_axis_alignment(CrossAxisAlignment::Center),
+                        )
+                        .rotate(move || angle.get())
+                        .child(text("Spinning!").font_size(14.0).color(Color::WHITE)),
+                ]),
+        ]);
+
+    // Track time for animation
+    let start_time = std::time::Instant::now();
+
+    App::new()
+        .width(900)
+        .height(450)
+        .background_color(Color::rgb(0.1, 0.1, 0.15))
+        .on_update(move || {
+            // Update animation angle (full rotation every 4 seconds)
+            let elapsed = start_time.elapsed().as_secs_f32();
+            let new_angle = (elapsed * PI / 2.0).to_degrees() % 360.0;
+            angle.set(new_angle);
+        })
+        .run(view);
+}

--- a/examples/text_transform_example.rs
+++ b/examples/text_transform_example.rs
@@ -152,7 +152,11 @@ fn main() {
                         )
                         .transform_origin(TransformOrigin::BOTTOM_RIGHT)
                         .rotate(15.0)
-                        .child(text("Origin: Bot-Right").font_size(12.0).color(Color::WHITE)),
+                        .child(
+                            text("Origin: Bot-Right")
+                                .font_size(12.0)
+                                .color(Color::WHITE),
+                        ),
                     // Custom origin with scale
                     container()
                         .width(130.0)
@@ -227,7 +231,11 @@ fn main() {
                                         .cross_axis_alignment(CrossAxisAlignment::Center),
                                 )
                                 .rotate(15.0)
-                                .child(text("30° Total").font_size(13.0).color(Color::rgb(0.1, 0.1, 0.1))),
+                                .child(
+                                    text("30° Total")
+                                        .font_size(13.0)
+                                        .color(Color::rgb(0.1, 0.1, 0.1)),
+                                ),
                         ),
                     // Nested with scale + translation
                     container()
@@ -254,7 +262,11 @@ fn main() {
                                         .cross_axis_alignment(CrossAxisAlignment::Center),
                                 )
                                 .rotate(-10.0)
-                                .child(text("Scale+Trans").font_size(12.0).color(Color::rgb(0.1, 0.1, 0.1))),
+                                .child(
+                                    text("Scale+Trans")
+                                        .font_size(12.0)
+                                        .color(Color::rgb(0.1, 0.1, 0.1)),
+                                ),
                         ),
                     // Animated rotating text
                     container()

--- a/examples/transform_origin_test.rs
+++ b/examples/transform_origin_test.rs
@@ -1,0 +1,197 @@
+//! Test example for transform_origin with shapes only (no text).
+//!
+//! This helps isolate transform_origin behavior from text rendering issues.
+
+use guido::prelude::*;
+
+fn main() {
+    let angle = create_signal(0.0_f32);
+
+    let view = container()
+        .layout(
+            Flex::column()
+                .spacing(40.0)
+                .main_axis_alignment(MainAxisAlignment::Center)
+                .cross_axis_alignment(CrossAxisAlignment::Center),
+        )
+        .padding(40.0)
+        .children([
+            // Row 1: Different origins with same rotation
+            container()
+                .layout(
+                    Flex::row()
+                        .spacing(80.0)
+                        .main_axis_alignment(MainAxisAlignment::Center)
+                        .cross_axis_alignment(CrossAxisAlignment::Center),
+                )
+                .children([
+                    // Default origin (center)
+                    container()
+                        .width(100.0)
+                        .height(80.0)
+                        .background(Color::rgba(0.3, 0.5, 0.8, 0.8))
+                        .corner_radius(8.0)
+                        .rotate(20.0),
+                    // Top-left origin
+                    container()
+                        .width(100.0)
+                        .height(80.0)
+                        .background(Color::rgba(0.8, 0.5, 0.3, 0.8))
+                        .corner_radius(8.0)
+                        .transform_origin(TransformOrigin::TOP_LEFT)
+                        .rotate(20.0),
+                    // Top-right origin
+                    container()
+                        .width(100.0)
+                        .height(80.0)
+                        .background(Color::rgba(0.5, 0.8, 0.3, 0.8))
+                        .corner_radius(8.0)
+                        .transform_origin(TransformOrigin::TOP_RIGHT)
+                        .rotate(20.0),
+                    // Bottom-left origin
+                    container()
+                        .width(100.0)
+                        .height(80.0)
+                        .background(Color::rgba(0.8, 0.3, 0.8, 0.8))
+                        .corner_radius(8.0)
+                        .transform_origin(TransformOrigin::BOTTOM_LEFT)
+                        .rotate(20.0),
+                    // Bottom-right origin
+                    container()
+                        .width(100.0)
+                        .height(80.0)
+                        .background(Color::rgba(0.3, 0.8, 0.8, 0.8))
+                        .corner_radius(8.0)
+                        .transform_origin(TransformOrigin::BOTTOM_RIGHT)
+                        .rotate(20.0),
+                ]),
+            // Row 2: Scale with different origins
+            container()
+                .layout(
+                    Flex::row()
+                        .spacing(80.0)
+                        .main_axis_alignment(MainAxisAlignment::Center)
+                        .cross_axis_alignment(CrossAxisAlignment::Center),
+                )
+                .children([
+                    // Default origin (center) - scale
+                    container()
+                        .width(80.0)
+                        .height(60.0)
+                        .background(Color::rgba(0.6, 0.3, 0.3, 0.8))
+                        .corner_radius(6.0)
+                        .scale(1.3),
+                    // Top-left origin - scale
+                    container()
+                        .width(80.0)
+                        .height(60.0)
+                        .background(Color::rgba(0.3, 0.6, 0.3, 0.8))
+                        .corner_radius(6.0)
+                        .transform_origin(TransformOrigin::TOP_LEFT)
+                        .scale(1.3),
+                    // Bottom-right origin - scale
+                    container()
+                        .width(80.0)
+                        .height(60.0)
+                        .background(Color::rgba(0.3, 0.3, 0.6, 0.8))
+                        .corner_radius(6.0)
+                        .transform_origin(TransformOrigin::BOTTOM_RIGHT)
+                        .scale(1.3),
+                ]),
+            // Row 3: Animated rotation with different origins
+            container()
+                .layout(
+                    Flex::row()
+                        .spacing(80.0)
+                        .main_axis_alignment(MainAxisAlignment::Center)
+                        .cross_axis_alignment(CrossAxisAlignment::Center),
+                )
+                .children([
+                    // Center origin - animated
+                    container()
+                        .width(80.0)
+                        .height(60.0)
+                        .background(Color::rgba(0.7, 0.5, 0.2, 0.8))
+                        .corner_radius(6.0)
+                        .rotate(move || angle.get()),
+                    // Top-left origin - animated
+                    container()
+                        .width(80.0)
+                        .height(60.0)
+                        .background(Color::rgba(0.2, 0.5, 0.7, 0.8))
+                        .corner_radius(6.0)
+                        .transform_origin(TransformOrigin::TOP_LEFT)
+                        .rotate(move || angle.get()),
+                    // Custom origin (25%, 75%) - animated
+                    container()
+                        .width(80.0)
+                        .height(60.0)
+                        .background(Color::rgba(0.5, 0.7, 0.2, 0.8))
+                        .corner_radius(6.0)
+                        .transform_origin(TransformOrigin::percent(25.0, 75.0))
+                        .rotate(move || angle.get()),
+                ]),
+            // Row 4: Nested containers with different origins
+            container()
+                .layout(
+                    Flex::row()
+                        .spacing(80.0)
+                        .main_axis_alignment(MainAxisAlignment::Center)
+                        .cross_axis_alignment(CrossAxisAlignment::Center),
+                )
+                .children([
+                    // Parent rotated at center, child inside
+                    container()
+                        .width(120.0)
+                        .height(100.0)
+                        .background(Color::rgba(0.4, 0.4, 0.6, 0.5))
+                        .corner_radius(10.0)
+                        .layout(
+                            Flex::column()
+                                .main_axis_alignment(MainAxisAlignment::Center)
+                                .cross_axis_alignment(CrossAxisAlignment::Center),
+                        )
+                        .rotate(15.0)
+                        .child(
+                            container()
+                                .width(60.0)
+                                .height(40.0)
+                                .background(Color::rgba(0.6, 0.6, 0.8, 0.9))
+                                .corner_radius(4.0),
+                        ),
+                    // Parent rotated at top-left, child inside
+                    container()
+                        .width(120.0)
+                        .height(100.0)
+                        .background(Color::rgba(0.6, 0.4, 0.4, 0.5))
+                        .corner_radius(10.0)
+                        .layout(
+                            Flex::column()
+                                .main_axis_alignment(MainAxisAlignment::Center)
+                                .cross_axis_alignment(CrossAxisAlignment::Center),
+                        )
+                        .transform_origin(TransformOrigin::TOP_LEFT)
+                        .rotate(15.0)
+                        .child(
+                            container()
+                                .width(60.0)
+                                .height(40.0)
+                                .background(Color::rgba(0.8, 0.6, 0.6, 0.9))
+                                .corner_radius(4.0),
+                        ),
+                ]),
+        ]);
+
+    let start_time = std::time::Instant::now();
+
+    App::new()
+        .width(900)
+        .height(550)
+        .background_color(Color::rgb(0.1, 0.1, 0.15))
+        .on_update(move || {
+            let elapsed = start_time.elapsed().as_secs_f32();
+            let new_angle = (elapsed * 45.0) % 360.0; // 45 degrees per second
+            angle.set(new_angle);
+        })
+        .run(view);
+}

--- a/src/renderer/pipeline.rs
+++ b/src/renderer/pipeline.rs
@@ -1,8 +1,9 @@
 use wgpu::{Device, RenderPipeline, TextureFormat};
 
-use super::primitives::Vertex;
+use super::primitives::{TexturedVertex, Vertex};
 
 const SHADER_SOURCE: &str = include_str!("shader.wgsl");
+const TEXTURE_SHADER_SOURCE: &str = include_str!("texture_shader.wgsl");
 
 pub fn create_render_pipeline(device: &Device, format: TextureFormat) -> RenderPipeline {
     let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
@@ -49,4 +50,84 @@ pub fn create_render_pipeline(device: &Device, format: TextureFormat) -> RenderP
         multiview_mask: None,
         cache: None,
     })
+}
+
+/// Create the texture pipeline for rendering textured quads (transformed text).
+///
+/// Returns the pipeline and the bind group layout needed to create texture bind groups.
+pub fn create_texture_pipeline(
+    device: &Device,
+    format: TextureFormat,
+) -> (RenderPipeline, wgpu::BindGroupLayout) {
+    let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+        label: Some("Guido Texture Shader"),
+        source: wgpu::ShaderSource::Wgsl(TEXTURE_SHADER_SOURCE.into()),
+    });
+
+    // Create bind group layout for texture + sampler
+    let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+        label: Some("Texture Bind Group Layout"),
+        entries: &[
+            // Texture
+            wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Texture {
+                    multisampled: false,
+                    view_dimension: wgpu::TextureViewDimension::D2,
+                    sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                },
+                count: None,
+            },
+            // Sampler
+            wgpu::BindGroupLayoutEntry {
+                binding: 1,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                count: None,
+            },
+        ],
+    });
+
+    let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+        label: Some("Guido Texture Pipeline Layout"),
+        bind_group_layouts: &[&bind_group_layout],
+        immediate_size: 0,
+    });
+
+    let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+        label: Some("Guido Texture Render Pipeline"),
+        layout: Some(&pipeline_layout),
+        vertex: wgpu::VertexState {
+            module: &shader,
+            entry_point: Some("vs_main"),
+            buffers: &[TexturedVertex::desc()],
+            compilation_options: wgpu::PipelineCompilationOptions::default(),
+        },
+        fragment: Some(wgpu::FragmentState {
+            module: &shader,
+            entry_point: Some("fs_main"),
+            targets: &[Some(wgpu::ColorTargetState {
+                format,
+                blend: Some(wgpu::BlendState::ALPHA_BLENDING),
+                write_mask: wgpu::ColorWrites::ALL,
+            })],
+            compilation_options: wgpu::PipelineCompilationOptions::default(),
+        }),
+        primitive: wgpu::PrimitiveState {
+            topology: wgpu::PrimitiveTopology::TriangleList,
+            strip_index_format: None,
+            front_face: wgpu::FrontFace::Ccw,
+            cull_mode: None,
+            polygon_mode: wgpu::PolygonMode::Fill,
+            unclipped_depth: false,
+            conservative: false,
+        },
+        depth_stencil: None,
+        multisample: wgpu::MultisampleState::default(),
+        multiview_mask: None,
+        cache: None,
+    });
+
+    (pipeline, bind_group_layout)
 }

--- a/src/renderer/text.rs
+++ b/src/renderer/text.rs
@@ -4,7 +4,7 @@ use glyphon::{
 };
 use wgpu::{Device, MultisampleState, Queue};
 
-use crate::widgets::{Color, Rect};
+use super::TextEntry;
 
 pub struct TextRenderState {
     font_system: FontSystem,
@@ -38,20 +38,31 @@ impl TextRenderState {
         }
     }
 
+    /// Prepare non-transformed text for rendering directly to screen.
+    /// Returns a list of indices of texts that have transforms and need special handling.
     pub fn prepare_text(
         &mut self,
         device: &Device,
         queue: &Queue,
-        texts: &[(String, Rect, Color, f32, Option<Rect>)],
+        texts: &[TextEntry],
         screen_width: u32,
         screen_height: u32,
         scale_factor: f32,
-    ) {
+    ) -> Vec<usize> {
         self.buffers.clear();
 
-        for (text, rect, _color, font_size, _clip) in texts {
+        // Collect indices of texts that have non-trivial transforms
+        let mut transformed_indices = Vec::new();
+
+        for (idx, entry) in texts.iter().enumerate() {
+            // Check if text has a transform that affects rendering
+            if entry.transform.has_rotation_or_scale() {
+                transformed_indices.push(idx);
+                continue; // Skip transformed text in direct rendering
+            }
+
             // Scale the font size for HiDPI rendering
-            let scaled_font_size = *font_size * scale_factor;
+            let scaled_font_size = entry.font_size * scale_factor;
 
             let mut buffer = Buffer::new(
                 &mut self.font_system,
@@ -60,12 +71,12 @@ impl TextRenderState {
             // Give more space for the text buffer, scaled
             buffer.set_size(
                 &mut self.font_system,
-                Some((rect.width.max(200.0)) * scale_factor),
-                Some((rect.height.max(50.0)) * scale_factor),
+                Some((entry.rect.width.max(200.0)) * scale_factor),
+                Some((entry.rect.height.max(50.0)) * scale_factor),
             );
             buffer.set_text(
                 &mut self.font_system,
-                text,
+                &entry.text,
                 &Attrs::new().family(Family::SansSerif),
                 Shaping::Advanced,
                 None,
@@ -74,16 +85,31 @@ impl TextRenderState {
             self.buffers.push(buffer);
         }
 
-        let text_areas: Vec<TextArea> = texts
+        // Filter to only non-transformed texts for TextArea creation
+        let non_transformed_texts: Vec<_> = texts
+            .iter()
+            .enumerate()
+            .filter(|(idx, _)| !transformed_indices.contains(idx))
+            .map(|(_, entry)| entry)
+            .collect();
+
+        let text_areas: Vec<TextArea> = non_transformed_texts
             .iter()
             .zip(self.buffers.iter())
-            .map(|((_text, rect, color, _, clip), buffer)| {
+            .map(|(entry, buffer)| {
+                // Apply translation from transform (if any) to position
+                let (tx, ty) = if entry.transform.is_identity() {
+                    (0.0, 0.0)
+                } else {
+                    (entry.transform.tx(), entry.transform.ty())
+                };
+
                 // Scale positions for HiDPI rendering
-                let scaled_left = rect.x * scale_factor;
-                let scaled_top = rect.y * scale_factor;
+                let scaled_left = (entry.rect.x + tx) * scale_factor;
+                let scaled_top = (entry.rect.y + ty) * scale_factor;
 
                 // Use clip rect if provided, otherwise use full screen
-                let bounds = if let Some(clip_rect) = clip {
+                let bounds = if let Some(clip_rect) = &entry.clip_rect {
                     TextBounds {
                         left: (clip_rect.x * scale_factor) as i32,
                         top: (clip_rect.y * scale_factor) as i32,
@@ -106,10 +132,10 @@ impl TextRenderState {
                     scale: 1.0, // Buffer is already scaled, no additional scaling needed
                     bounds,
                     default_color: GlyphonColor::rgba(
-                        (color.r * 255.0) as u8,
-                        (color.g * 255.0) as u8,
-                        (color.b * 255.0) as u8,
-                        (color.a * 255.0) as u8,
+                        (entry.color.r * 255.0) as u8,
+                        (entry.color.g * 255.0) as u8,
+                        (entry.color.b * 255.0) as u8,
+                        (entry.color.a * 255.0) as u8,
                     ),
                     custom_glyphs: &[],
                 }
@@ -138,6 +164,8 @@ impl TextRenderState {
         if let Err(e) = result {
             log::error!("Text prepare failed: {:?}", e);
         }
+
+        transformed_indices
     }
 
     pub fn render<'a>(&'a self, pass: &mut wgpu::RenderPass<'a>, _device: &Device) {

--- a/src/renderer/text.rs
+++ b/src/renderer/text.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use glyphon::{
     Attrs, Buffer, Cache, Color as GlyphonColor, Family, FontSystem, Metrics, Resolution, Shaping,
     SwashCache, TextArea, TextAtlas, TextBounds, TextRenderer, Viewport,
@@ -86,10 +88,12 @@ impl TextRenderState {
         }
 
         // Filter to only non-transformed texts for TextArea creation
+        // Use HashSet for O(1) lookup instead of Vec::contains which is O(n)
+        let transformed_set: HashSet<_> = transformed_indices.iter().copied().collect();
         let non_transformed_texts: Vec<_> = texts
             .iter()
             .enumerate()
-            .filter(|(idx, _)| !transformed_indices.contains(idx))
+            .filter(|(idx, _)| !transformed_set.contains(idx))
             .map(|(_, entry)| entry)
             .collect();
 

--- a/src/renderer/text_texture.rs
+++ b/src/renderer/text_texture.rs
@@ -1,0 +1,229 @@
+//! Text-to-texture rendering for transformed text.
+//!
+//! This module renders text to offscreen textures, which can then be
+//! displayed as transformed quads. This allows text to follow parent
+//! container transforms (rotation, scale, etc.) while maintaining
+//! crisp rendering quality.
+
+use std::sync::Arc;
+
+use glyphon::{
+    Attrs, Buffer, Cache, Color as GlyphonColor, Family, FontSystem, Metrics, Resolution, Shaping,
+    SwashCache, TextArea, TextAtlas, TextBounds, TextRenderer, Viewport,
+};
+use wgpu::{
+    Device, Extent3d, MultisampleState, Queue, Texture, TextureDescriptor, TextureDimension,
+    TextureFormat, TextureUsages, TextureView,
+};
+
+use super::TextEntry;
+
+/// A rendered text texture ready for display as a transformed quad.
+pub struct TextTexture {
+    /// The GPU texture containing the rendered text
+    pub texture: Texture,
+    /// View for sampling the texture
+    pub view: TextureView,
+    /// The original text entry this was rendered from
+    pub entry: TextEntry,
+    /// Width of the texture in pixels
+    pub width: u32,
+    /// Height of the texture in pixels
+    pub height: u32,
+    /// The scale factor used when rendering (for crisp text)
+    pub render_scale: f32,
+}
+
+/// Renders text to offscreen textures for transform support.
+pub struct TextTextureRenderer {
+    font_system: FontSystem,
+    swash_cache: SwashCache,
+    #[allow(dead_code)] // Required for atlas and viewport lifetime
+    cache: Cache,
+    atlas: TextAtlas,
+    text_renderer: TextRenderer,
+    viewport: Viewport,
+    format: TextureFormat,
+}
+
+impl TextTextureRenderer {
+    pub fn new(device: &Device, queue: &Queue, format: TextureFormat) -> Self {
+        let font_system = FontSystem::new();
+        let swash_cache = SwashCache::new();
+        let cache = Cache::new(device);
+        let mut atlas = TextAtlas::new(device, queue, &cache, format);
+        let text_renderer =
+            TextRenderer::new(&mut atlas, device, MultisampleState::default(), None);
+        let viewport = Viewport::new(device, &cache);
+
+        Self {
+            font_system,
+            swash_cache,
+            cache,
+            atlas,
+            text_renderer,
+            viewport,
+            format,
+        }
+    }
+
+    /// Render a text entry to an offscreen texture.
+    ///
+    /// The text is rendered at `font_size * transform_scale * scale_factor * quality_multiplier`
+    /// for crisp quality when the texture is displayed with the transform applied.
+    pub fn render_to_texture(
+        &mut self,
+        device: &Arc<Device>,
+        queue: &Arc<Queue>,
+        entry: &TextEntry,
+        scale_factor: f32,
+    ) -> TextTexture {
+        // Quality multiplier for supersampling - renders text at higher resolution
+        // for better quality when displayed. 2.0 provides good quality without
+        // excessive memory usage.
+        const QUALITY_MULTIPLIER: f32 = 2.0;
+
+        // Extract the scale from the transform for crisp rendering
+        let transform_scale = entry.transform.extract_scale().max(1.0);
+
+        // Calculate the effective scale for text rendering (includes quality multiplier)
+        let effective_scale = scale_factor * transform_scale * QUALITY_MULTIPLIER;
+
+        // Scale font size for crisp rendering at the transformed size
+        let scaled_font_size = entry.font_size * effective_scale;
+
+        // Create a buffer for text measurement and rendering
+        let mut buffer = Buffer::new(
+            &mut self.font_system,
+            Metrics::new(scaled_font_size, scaled_font_size * 1.2),
+        );
+
+        // Set buffer size to match the entry rect (no arbitrary minimums that would offset text)
+        let buffer_width = entry.rect.width * effective_scale;
+        let buffer_height = entry.rect.height * effective_scale;
+
+        buffer.set_size(
+            &mut self.font_system,
+            Some(buffer_width),
+            Some(buffer_height),
+        );
+        buffer.set_text(
+            &mut self.font_system,
+            &entry.text,
+            &Attrs::new().family(Family::SansSerif),
+            Shaping::Advanced,
+            None,
+        );
+        buffer.shape_until_scroll(&mut self.font_system, true);
+
+        // Use the original rect dimensions for the texture size to preserve layout centering.
+        // The text will be rendered at top-left (with padding), matching glyphon's behavior.
+        let padding = 4.0 * effective_scale;
+        let tex_width = ((buffer_width + padding * 2.0).ceil() as u32).max(1);
+        let tex_height = ((buffer_height + padding * 2.0).ceil() as u32).max(1);
+
+        // Create the offscreen texture
+        let texture = device.create_texture(&TextureDescriptor {
+            label: Some("Text Texture"),
+            size: Extent3d {
+                width: tex_width,
+                height: tex_height,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: TextureDimension::D2,
+            format: self.format,
+            usage: TextureUsages::RENDER_ATTACHMENT | TextureUsages::TEXTURE_BINDING,
+            view_formats: &[],
+        });
+
+        let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+
+        // Update viewport for this texture size
+        self.viewport.update(
+            queue,
+            Resolution {
+                width: tex_width,
+                height: tex_height,
+            },
+        );
+
+        // Create text area for rendering
+        let text_area = TextArea {
+            buffer: &buffer,
+            left: padding,
+            top: padding,
+            scale: 1.0,
+            bounds: TextBounds {
+                left: 0,
+                top: 0,
+                right: tex_width as i32,
+                bottom: tex_height as i32,
+            },
+            default_color: GlyphonColor::rgba(
+                (entry.color.r * 255.0) as u8,
+                (entry.color.g * 255.0) as u8,
+                (entry.color.b * 255.0) as u8,
+                (entry.color.a * 255.0) as u8,
+            ),
+            custom_glyphs: &[],
+        };
+
+        // Prepare text for rendering
+        let result = self.text_renderer.prepare(
+            device,
+            queue,
+            &mut self.font_system,
+            &mut self.atlas,
+            &self.viewport,
+            vec![text_area],
+            &mut self.swash_cache,
+        );
+
+        if let Err(e) = result {
+            log::error!("Text texture prepare failed: {:?}", e);
+        }
+
+        // Create encoder and render to texture
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("Text Texture Encoder"),
+        });
+
+        {
+            let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("Text Texture Render Pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &view,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        // Clear to transparent
+                        load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                        store: wgpu::StoreOp::Store,
+                    },
+                    depth_slice: None,
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+                multiview_mask: None,
+            });
+
+            // Render the text
+            self.text_renderer
+                .render(&self.atlas, &self.viewport, &mut render_pass)
+                .expect("Failed to render text to texture");
+        }
+
+        queue.submit(std::iter::once(encoder.finish()));
+
+        TextTexture {
+            texture,
+            view,
+            entry: entry.clone(),
+            width: tex_width,
+            height: tex_height,
+            render_scale: effective_scale,
+        }
+    }
+}

--- a/src/renderer/texture_shader.wgsl
+++ b/src/renderer/texture_shader.wgsl
@@ -1,0 +1,52 @@
+// Guido Texture Shader - Renders textured quads with transforms
+//
+// Used for displaying text textures that have been rendered to offscreen
+// textures, allowing text to follow parent container transforms.
+
+struct VertexInput {
+    @location(0) position: vec2<f32>,
+    @location(1) tex_coords: vec2<f32>,
+    @location(2) transform_row0: vec4<f32>,
+    @location(3) transform_row1: vec4<f32>,
+    @location(4) transform_row2: vec4<f32>,
+    @location(5) transform_row3: vec4<f32>,
+}
+
+struct VertexOutput {
+    @builtin(position) clip_position: vec4<f32>,
+    @location(0) tex_coords: vec2<f32>,
+}
+
+@vertex
+fn vs_main(in: VertexInput) -> VertexOutput {
+    var out: VertexOutput;
+
+    // Build transform matrix from row vectors
+    let transform = mat4x4<f32>(
+        vec4<f32>(in.transform_row0.x, in.transform_row1.x, in.transform_row2.x, in.transform_row3.x),
+        vec4<f32>(in.transform_row0.y, in.transform_row1.y, in.transform_row2.y, in.transform_row3.y),
+        vec4<f32>(in.transform_row0.z, in.transform_row1.z, in.transform_row2.z, in.transform_row3.z),
+        vec4<f32>(in.transform_row0.w, in.transform_row1.w, in.transform_row2.w, in.transform_row3.w)
+    );
+
+    // Transform position
+    let transformed = transform * vec4<f32>(in.position, 0.0, 1.0);
+    out.clip_position = vec4<f32>(transformed.xy, 0.0, 1.0);
+
+    // Pass through texture coordinates
+    out.tex_coords = in.tex_coords;
+
+    return out;
+}
+
+@group(0) @binding(0)
+var t_texture: texture_2d<f32>;
+@group(0) @binding(1)
+var s_sampler: sampler;
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    // Sample the texture with the interpolated UV coordinates
+    let color = textureSample(t_texture, s_sampler, in.tex_coords);
+    return color;
+}

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -220,29 +220,28 @@ impl Transform {
         self.data[7] *= factor;
     }
 
+    /// Extract the X and Y scale components from the transform matrix.
+    ///
+    /// For transforms that contain rotation and/or scale:
+    /// - sx = sqrt(a² + b²)
+    /// - sy = sqrt(c² + d²)
+    ///
+    /// This is a private helper used by `extract_scale()`, `without_scale()`, and `rotation_only()`.
+    fn extract_scale_components(&self) -> (f32, f32) {
+        let a = self.data[0];
+        let b = self.data[1];
+        let c = self.data[4];
+        let d = self.data[5];
+        ((a * a + b * b).sqrt(), (c * c + d * d).sqrt())
+    }
+
     /// Extract the uniform scale factor from this transform.
     ///
     /// For transforms that contain rotation and/or scale, this returns the
     /// average scale factor. For pure scale transforms, returns the exact scale.
     /// For transforms with non-uniform scaling, returns the geometric mean.
     pub fn extract_scale(&self) -> f32 {
-        // Matrix layout:
-        // | a  b  0  tx |  where for rotation+scale:
-        // | c  d  0  ty |  a = sx * cos(θ), b = sx * (-sin(θ))
-        // | 0  0  1  0  |  c = sy * sin(θ), d = sy * cos(θ)
-        // | 0  0  0  1  |
-        //
-        // Scale factors can be extracted as:
-        // sx = sqrt(a² + b²)
-        // sy = sqrt(c² + d²)
-        let a = self.data[0];
-        let b = self.data[1];
-        let c = self.data[4];
-        let d = self.data[5];
-
-        let sx = (a * a + b * b).sqrt();
-        let sy = (c * c + d * d).sqrt();
-
+        let (sx, sy) = self.extract_scale_components();
         // Return geometric mean for uniform scale approximation
         (sx * sy).sqrt()
     }
@@ -252,20 +251,19 @@ impl Transform {
     /// This preserves rotation and translation but normalizes scale to 1.0.
     /// Useful for render-to-texture workflows where text is pre-scaled.
     pub fn without_scale(&self) -> Transform {
-        let a = self.data[0];
-        let b = self.data[1];
-        let c = self.data[4];
-        let d = self.data[5];
+        let (sx, sy) = self.extract_scale_components();
         let tx = self.data[3];
         let ty = self.data[7];
-
-        let sx = (a * a + b * b).sqrt();
-        let sy = (c * c + d * d).sqrt();
 
         // Avoid division by zero
         if sx < 1e-10 || sy < 1e-10 {
             return Transform::translate(tx, ty);
         }
+
+        let a = self.data[0];
+        let b = self.data[1];
+        let c = self.data[4];
+        let d = self.data[5];
 
         // Normalize the rotation component
         Transform {
@@ -311,18 +309,17 @@ impl Transform {
     /// This is useful when you need to apply the same rotation to a different
     /// object at a different position (like text inside a transformed container).
     pub fn rotation_only(&self) -> Transform {
-        let a = self.data[0];
-        let b = self.data[1];
-        let c = self.data[4];
-        let d = self.data[5];
-
-        let sx = (a * a + b * b).sqrt();
-        let sy = (c * c + d * d).sqrt();
+        let (sx, sy) = self.extract_scale_components();
 
         // Avoid division by zero
         if sx < 1e-10 || sy < 1e-10 {
             return Transform::IDENTITY;
         }
+
+        let a = self.data[0];
+        let b = self.data[1];
+        let c = self.data[4];
+        let d = self.data[5];
 
         // Extract normalized rotation (no translation)
         Transform {

--- a/src/widgets/container.rs
+++ b/src/widgets/container.rs
@@ -552,9 +552,12 @@ impl Container {
     /// Multiple transform calls are composed (e.g., `.rotate(30).scale(1.5)` applies both)
     pub fn rotate(mut self, degrees: impl IntoMaybeDyn<f32>) -> Self {
         let degrees = degrees.into_maybe_dyn();
-        let prev_transform = std::mem::replace(&mut self.transform, MaybeDyn::Static(Transform::IDENTITY));
+        let prev_transform =
+            std::mem::replace(&mut self.transform, MaybeDyn::Static(Transform::IDENTITY));
         self.transform = MaybeDyn::Dynamic(std::sync::Arc::new(move || {
-            prev_transform.get().then(&Transform::rotate_degrees(degrees.get()))
+            prev_transform
+                .get()
+                .then(&Transform::rotate_degrees(degrees.get()))
         }));
         self
     }
@@ -564,7 +567,8 @@ impl Container {
     /// Multiple transform calls are composed (e.g., `.rotate(30).scale(1.5)` applies both)
     pub fn scale(mut self, s: impl IntoMaybeDyn<f32>) -> Self {
         let s = s.into_maybe_dyn();
-        let prev_transform = std::mem::replace(&mut self.transform, MaybeDyn::Static(Transform::IDENTITY));
+        let prev_transform =
+            std::mem::replace(&mut self.transform, MaybeDyn::Static(Transform::IDENTITY));
         self.transform = MaybeDyn::Dynamic(std::sync::Arc::new(move || {
             prev_transform.get().then(&Transform::scale(s.get()))
         }));
@@ -576,9 +580,12 @@ impl Container {
     pub fn scale_xy(mut self, sx: impl IntoMaybeDyn<f32>, sy: impl IntoMaybeDyn<f32>) -> Self {
         let sx = sx.into_maybe_dyn();
         let sy = sy.into_maybe_dyn();
-        let prev_transform = std::mem::replace(&mut self.transform, MaybeDyn::Static(Transform::IDENTITY));
+        let prev_transform =
+            std::mem::replace(&mut self.transform, MaybeDyn::Static(Transform::IDENTITY));
         self.transform = MaybeDyn::Dynamic(std::sync::Arc::new(move || {
-            prev_transform.get().then(&Transform::scale_xy(sx.get(), sy.get()))
+            prev_transform
+                .get()
+                .then(&Transform::scale_xy(sx.get(), sy.get()))
         }));
         self
     }
@@ -588,9 +595,12 @@ impl Container {
     pub fn translate(mut self, x: impl IntoMaybeDyn<f32>, y: impl IntoMaybeDyn<f32>) -> Self {
         let x = x.into_maybe_dyn();
         let y = y.into_maybe_dyn();
-        let prev_transform = std::mem::replace(&mut self.transform, MaybeDyn::Static(Transform::IDENTITY));
+        let prev_transform =
+            std::mem::replace(&mut self.transform, MaybeDyn::Static(Transform::IDENTITY));
         self.transform = MaybeDyn::Dynamic(std::sync::Arc::new(move || {
-            prev_transform.get().then(&Transform::translate(x.get(), y.get()))
+            prev_transform
+                .get()
+                .then(&Transform::translate(x.get(), y.get()))
         }));
         self
     }
@@ -1188,18 +1198,15 @@ impl Widget for Container {
         let transform_origin = self.transform_origin.get();
 
         // Push transform if not identity
-        // If we have a custom transform origin (not center), pre-center the transform
-        // around that origin point and mark it as centered
         let has_transform = !transform.is_identity();
         if has_transform {
             if transform_origin.is_center() {
                 // Default behavior: let the primitives auto-center around their bounds
                 ctx.push_transform(transform);
             } else {
-                // Custom origin: pre-center the transform around the origin point
+                // Custom origin: pass the origin point to let primitives center in NDC space
                 let (origin_x, origin_y) = transform_origin.resolve(self.bounds);
-                let centered_transform = transform.center_at(origin_x, origin_y);
-                ctx.push_centered_transform(centered_transform);
+                ctx.push_transform_with_origin(transform, origin_x, origin_y);
             }
         }
 

--- a/src/widgets/container.rs
+++ b/src/widgets/container.rs
@@ -549,38 +549,48 @@ impl Container {
     /// Rotate this container by the given angle in degrees
     /// Rotation is applied around the center of the widget bounds
     /// Note: Rotation may appear stretched on non-square aspect ratios
+    /// Multiple transform calls are composed (e.g., `.rotate(30).scale(1.5)` applies both)
     pub fn rotate(mut self, degrees: impl IntoMaybeDyn<f32>) -> Self {
         let degrees = degrees.into_maybe_dyn();
+        let prev_transform = std::mem::replace(&mut self.transform, MaybeDyn::Static(Transform::IDENTITY));
         self.transform = MaybeDyn::Dynamic(std::sync::Arc::new(move || {
-            Transform::rotate_degrees(degrees.get())
+            prev_transform.get().then(&Transform::rotate_degrees(degrees.get()))
         }));
         self
     }
 
     /// Scale this container uniformly
     /// Scaling is applied around the center of the widget bounds
+    /// Multiple transform calls are composed (e.g., `.rotate(30).scale(1.5)` applies both)
     pub fn scale(mut self, s: impl IntoMaybeDyn<f32>) -> Self {
         let s = s.into_maybe_dyn();
-        self.transform = MaybeDyn::Dynamic(std::sync::Arc::new(move || Transform::scale(s.get())));
+        let prev_transform = std::mem::replace(&mut self.transform, MaybeDyn::Static(Transform::IDENTITY));
+        self.transform = MaybeDyn::Dynamic(std::sync::Arc::new(move || {
+            prev_transform.get().then(&Transform::scale(s.get()))
+        }));
         self
     }
 
     /// Scale this container non-uniformly
+    /// Multiple transform calls are composed (e.g., `.rotate(30).scale_xy(1.5, 2.0)` applies both)
     pub fn scale_xy(mut self, sx: impl IntoMaybeDyn<f32>, sy: impl IntoMaybeDyn<f32>) -> Self {
         let sx = sx.into_maybe_dyn();
         let sy = sy.into_maybe_dyn();
+        let prev_transform = std::mem::replace(&mut self.transform, MaybeDyn::Static(Transform::IDENTITY));
         self.transform = MaybeDyn::Dynamic(std::sync::Arc::new(move || {
-            Transform::scale_xy(sx.get(), sy.get())
+            prev_transform.get().then(&Transform::scale_xy(sx.get(), sy.get()))
         }));
         self
     }
 
     /// Translate (move) this container by the given offset
+    /// Multiple transform calls are composed (e.g., `.rotate(30).translate(10, 20)` applies both)
     pub fn translate(mut self, x: impl IntoMaybeDyn<f32>, y: impl IntoMaybeDyn<f32>) -> Self {
         let x = x.into_maybe_dyn();
         let y = y.into_maybe_dyn();
+        let prev_transform = std::mem::replace(&mut self.transform, MaybeDyn::Static(Transform::IDENTITY));
         self.transform = MaybeDyn::Dynamic(std::sync::Arc::new(move || {
-            Transform::translate(x.get(), y.get())
+            prev_transform.get().then(&Transform::translate(x.get(), y.get()))
         }));
         self
     }


### PR DESCRIPTION
## Summary

- Adds support for text inside transformed containers (rotation, scale, translation, custom transform_origin)
- Implements render-to-texture approach for crisp text quality at any scale
- Text now properly follows parent container transforms

## Implementation Details

**Render-to-Texture Pipeline:**
- Text is rendered to an offscreen texture at scaled resolution for crisp quality
- Texture is then displayed as a transformed quad using the shape transform pipeline
- Quality multiplier (2x) provides supersampling for smooth text edges

**Key Changes:**
- `src/renderer/text_texture.rs` - New module for rendering text to textures
- `src/renderer/texture_shader.wgsl` - New shader for textured quads
- `src/renderer/primitives.rs` - Added `TexturedQuad` primitive with transform support
- `src/renderer/pipeline.rs` - Added texture pipeline and sampler
- `src/transform.rs` - Added `extract_scale()`, `without_scale()`, `rotation_only()` methods
- `src/widgets/container.rs` - Transform origin now uses coordinate-based system

**Transform Origin:**
- Refactored from boolean flag to explicit coordinate-based system
- Supports CSS-style origins: TOP_LEFT, CENTER, BOTTOM_RIGHT, etc.
- Custom percentage-based origins via `TransformOrigin::new(x_pct, y_pct)`

## Test plan

- [x] Run `cargo run --example text_transform_example` to verify text transforms
- [x] Run `cargo run --example transform_origin_test` to verify shape transforms with custom origins
- [x] Run existing examples to verify no regression
- [x] `cargo clippy` passes
- [x] `cargo test` passes