### PR TITLE
Fix text scaling in transform animations

### DIFF
--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -12,7 +12,7 @@ use wgpu::{BufferUsages, Device, Queue, RenderPipeline};
 
 use self::primitives::{ClipRegion, Gradient, RoundedRect, TexturedQuad, Transformable, Vertex};
 use self::text::TextRenderState;
-use self::text_texture::TextTextureRenderer;
+use self::text_texture::{TextTextureRenderer, QUALITY_MULTIPLIER};
 use crate::transform::Transform;
 use crate::transform_origin::TransformOrigin;
 use crate::widgets::{Color, Rect};
@@ -265,10 +265,11 @@ impl Renderer {
                     ],
                 });
 
-                // Calculate display rect - the texture was rendered at an effective scale,
-                // so we need to display it at the correct logical size
-                let display_width = tex.width as f32 / tex.render_scale * self.scale_factor;
-                let display_height = tex.height as f32 / tex.render_scale * self.scale_factor;
+                // Calculate display rect - divide only by QUALITY_MULTIPLIER to preserve transform_scale.
+                // The texture was rendered at: original_size * scale_factor * transform_scale * QUALITY_MULTIPLIER
+                // We want display size: original_size * scale_factor * transform_scale
+                let display_width = tex.width as f32 / QUALITY_MULTIPLIER;
+                let display_height = tex.height as f32 / QUALITY_MULTIPLIER;
 
                 // Get the scale factor from the transform (we pre-scaled the text for this)
                 let transform_scale = tex.entry.transform.extract_scale();

--- a/src/renderer/text_texture.rs
+++ b/src/renderer/text_texture.rs
@@ -18,6 +18,11 @@ use wgpu::{
 
 use super::TextEntry;
 
+/// Quality multiplier for supersampling text textures.
+/// Renders text at higher resolution for better quality when displayed.
+/// 2.0 provides good quality without excessive memory usage.
+pub const QUALITY_MULTIPLIER: f32 = 2.0;
+
 /// A rendered text texture ready for display as a transformed quad.
 pub struct TextTexture {
     /// The GPU texture containing the rendered text
@@ -78,11 +83,6 @@ impl TextTextureRenderer {
         entry: &TextEntry,
         scale_factor: f32,
     ) -> TextTexture {
-        // Quality multiplier for supersampling - renders text at higher resolution
-        // for better quality when displayed. 2.0 provides good quality without
-        // excessive memory usage.
-        const QUALITY_MULTIPLIER: f32 = 2.0;
-
         // Extract the scale from the transform for crisp rendering
         let transform_scale = entry.transform.extract_scale().max(1.0);
 


### PR DESCRIPTION
## Summary
- Fix text not scaling with container when scale transform is applied
- Expose `QUALITY_MULTIPLIER` constant at module level in `text_texture.rs`
- Update display dimension calculation in `mod.rs` to only divide by `QUALITY_MULTIPLIER`, preserving the transform scale

## Test plan
- [x] Run `cargo build` - compiles successfully
- [x] Run `cargo clippy` and `cargo fmt` - no warnings/errors
- [x] Run `cargo run --example transform_example` and click on Scale box - text now scales with container