### PR TITLE
Refactor: code cleanup and deduplication

### DIFF
--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -953,6 +953,20 @@ impl PaintContext {
         self.overlay_shapes.push(Shape::RoundedRect(shape));
     }
 
+    /// Draw a shape with all its configured properties.
+    ///
+    /// This is the unified entry point for drawing pre-configured shapes.
+    /// Use with RoundedRect builder methods for ergonomic shape creation:
+    ///
+    /// ```ignore
+    /// ctx.draw_shape(RoundedRect::new(rect, color, radius)
+    ///     .curvature(2.0)
+    ///     .border(1.0, Color::WHITE));
+    /// ```
+    pub fn draw_shape(&mut self, shape: RoundedRect) {
+        self.push_rounded_rect(shape);
+    }
+
     /// Draw a circle as an overlay (rendered after text).
     /// The circle is drawn centered at (cx, cy) with the given radius.
     pub fn draw_overlay_circle(&mut self, cx: f32, cy: f32, radius: f32, color: Color) {

--- a/src/renderer/primitives.rs
+++ b/src/renderer/primitives.rs
@@ -513,33 +513,15 @@ impl RoundedRect {
     }
 
     pub fn with_clip(rect: Rect, color: Color, radius: f32, clip: ClipRegion) -> Self {
-        Self {
-            rect,
-            color,
-            radius,
-            clip: Some(clip),
-            ..Default::default()
-        }
+        Self::new(rect, color, radius).clip_region(clip)
     }
 
     pub fn with_gradient(rect: Rect, gradient: Gradient, radius: f32) -> Self {
-        Self {
-            rect,
-            color: gradient.start_color, // fallback
-            radius,
-            gradient: Some(gradient),
-            ..Default::default()
-        }
+        Self::new(rect, gradient.start_color, radius).gradient(gradient)
     }
 
     pub fn with_curvature(rect: Rect, color: Color, radius: f32, curvature: f32) -> Self {
-        Self {
-            rect,
-            color,
-            radius,
-            curvature,
-            ..Default::default()
-        }
+        Self::new(rect, color, radius).curvature(curvature)
     }
 
     /// Create a rounded rect with a border
@@ -550,25 +532,12 @@ impl RoundedRect {
         border_width: f32,
         border_color: Color,
     ) -> Self {
-        Self {
-            rect,
-            color: fill_color,
-            radius,
-            border_width,
-            border_color,
-            ..Default::default()
-        }
+        Self::new(rect, fill_color, radius).border(border_width, border_color)
     }
 
     /// Create a border-only rounded rect (transparent fill)
     pub fn border_only(rect: Rect, radius: f32, border_width: f32, border_color: Color) -> Self {
-        Self {
-            rect,
-            radius,
-            border_width,
-            border_color,
-            ..Default::default()
-        }
+        Self::new(rect, Color::TRANSPARENT, radius).border(border_width, border_color)
     }
 
     /// Create a border-only rounded rect with custom curvature
@@ -579,14 +548,7 @@ impl RoundedRect {
         border_color: Color,
         curvature: f32,
     ) -> Self {
-        Self {
-            rect,
-            radius,
-            curvature,
-            border_width,
-            border_color,
-            ..Default::default()
-        }
+        Self::border_only(rect, radius, border_width, border_color).curvature(curvature)
     }
 
     // Builder methods for chainable configuration

--- a/src/renderer/primitives.rs
+++ b/src/renderer/primitives.rs
@@ -589,6 +589,40 @@ impl RoundedRect {
         }
     }
 
+    // Builder methods for chainable configuration
+
+    /// Set the superellipse curvature (K-value).
+    /// K=1 is circular (default), K=2 is squircle, K=0 is bevel, K=-1 is scoop.
+    pub fn curvature(mut self, curvature: f32) -> Self {
+        self.curvature = curvature;
+        self
+    }
+
+    /// Set a linear gradient (overrides solid color).
+    pub fn gradient(mut self, gradient: Gradient) -> Self {
+        self.gradient = Some(gradient);
+        self
+    }
+
+    /// Set a border with width and color.
+    pub fn border(mut self, width: f32, color: Color) -> Self {
+        self.border_width = width;
+        self.border_color = color;
+        self
+    }
+
+    /// Set a clip region for this shape.
+    pub fn clip_region(mut self, clip: ClipRegion) -> Self {
+        self.clip = Some(clip);
+        self
+    }
+
+    /// Set the shadow configuration.
+    pub fn shadow(mut self, shadow: Shadow) -> Self {
+        self.shadow = shadow;
+        self
+    }
+
     /// Calculate safe progress value, avoiding division by zero
     #[inline]
     fn safe_progress(value: f32, start: f32, end: f32) -> f32 {

--- a/src/widgets/image.rs
+++ b/src/widgets/image.rs
@@ -10,6 +10,7 @@ use crate::layout::{Constraints, Size};
 use crate::reactive::{ChangeFlags, IntoMaybeDyn, MaybeDyn, WidgetId};
 use crate::renderer::PaintContext;
 
+use super::impl_dirty_flags;
 use super::widget::{EventResponse, Rect, Widget};
 
 /// Source for an image - can be a file path or in-memory bytes.
@@ -278,21 +279,7 @@ impl Widget for Image {
         self.widget_id
     }
 
-    fn mark_dirty(&mut self, flags: ChangeFlags) {
-        self.dirty_flags |= flags;
-    }
-
-    fn needs_layout(&self) -> bool {
-        self.dirty_flags.contains(ChangeFlags::NEEDS_LAYOUT)
-    }
-
-    fn needs_paint(&self) -> bool {
-        self.dirty_flags.contains(ChangeFlags::NEEDS_PAINT)
-    }
-
-    fn clear_dirty(&mut self) {
-        self.dirty_flags = ChangeFlags::empty();
-    }
+    impl_dirty_flags!();
 }
 
 /// Create an image widget from a source.

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -6,6 +6,29 @@ pub mod state_layer;
 pub mod text;
 pub mod widget;
 
+/// Macro to implement common dirty flag methods for simple widgets.
+///
+/// Container keeps its custom implementation because it recurses to children.
+macro_rules! impl_dirty_flags {
+    () => {
+        fn mark_dirty(&mut self, flags: crate::reactive::ChangeFlags) {
+            self.dirty_flags |= flags;
+        }
+        fn needs_layout(&self) -> bool {
+            self.dirty_flags
+                .contains(crate::reactive::ChangeFlags::NEEDS_LAYOUT)
+        }
+        fn needs_paint(&self) -> bool {
+            self.dirty_flags
+                .contains(crate::reactive::ChangeFlags::NEEDS_PAINT)
+        }
+        fn clear_dirty(&mut self) {
+            self.dirty_flags = crate::reactive::ChangeFlags::empty();
+        }
+    };
+}
+pub(crate) use impl_dirty_flags;
+
 pub use children::ChildrenSource;
 pub use container::{container, Border, Container, GradientDirection, LinearGradient, Overflow};
 pub use image::{image, ContentFit, Image, ImageSource};

--- a/src/widgets/text.rs
+++ b/src/widgets/text.rs
@@ -2,6 +2,7 @@ use crate::layout::{Constraints, Size};
 use crate::reactive::{ChangeFlags, IntoMaybeDyn, MaybeDyn, WidgetId};
 use crate::renderer::{measure_text, PaintContext};
 
+use super::impl_dirty_flags;
 use super::widget::{Color, EventResponse, Rect, Widget};
 
 pub struct Text {
@@ -109,21 +110,7 @@ impl Widget for Text {
         self.widget_id
     }
 
-    fn mark_dirty(&mut self, flags: ChangeFlags) {
-        self.dirty_flags |= flags;
-    }
-
-    fn needs_layout(&self) -> bool {
-        self.dirty_flags.contains(ChangeFlags::NEEDS_LAYOUT)
-    }
-
-    fn needs_paint(&self) -> bool {
-        self.dirty_flags.contains(ChangeFlags::NEEDS_PAINT)
-    }
-
-    fn clear_dirty(&mut self) {
-        self.dirty_flags = ChangeFlags::empty();
-    }
+    impl_dirty_flags!();
 }
 
 /// Create a text widget


### PR DESCRIPTION
## Summary

Address code duplication and simplification opportunities in both the new image widget code and pre-existing patterns.

### Changes

1. **Widget Dirty State Macro** - Extract common dirty flag implementations into `impl_dirty_flags!` macro. Text and Image widgets now use the macro, reducing ~24 lines of duplicated code.

2. **Fix Weak Byte Hash** - Improve image byte hashing to sample first/middle/last 256 bytes (or entire content for small images) for better collision resistance.

3. **Extract GPU Texture Upload Helper** - Create `upload_rgba_texture()` helper to consolidate duplicate texture creation and upload code between raster and SVG rendering.

4. **RoundedRect Builder Methods** - Add chainable builder methods (`curvature()`, `gradient()`, `border()`, `clip_region()`, `shadow()`) for more ergonomic shape configuration.

5. **Unified `draw_shape` Method** - Add unified entry point to PaintContext for drawing pre-configured shapes.

6. **Simplify Factory Methods** - Refactor existing factory methods to use builder pattern internally.

### Impact

- ~100 lines of code reduction
- Improved maintainability
- Better API ergonomics for shape configuration

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` (80 tests pass)
- [x] `cargo build --release`