### PR TITLE
Refactor scrollbars to use nested Container widgets

### DIFF
--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -1,8 +1,10 @@
 pub mod flex;
 pub mod flex_layout;
+pub mod overlay;
 
 pub use flex::{Constraints, Size};
 pub use flex_layout::Flex;
+pub use overlay::Overlay;
 
 use crate::reactive::{IntoMaybeDyn, MaybeDyn};
 use crate::widgets::Widget;

--- a/src/layout/overlay.rs
+++ b/src/layout/overlay.rs
@@ -1,0 +1,47 @@
+//! Overlay layout that stacks children on top of each other.
+
+use super::{Constraints, Layout, Size};
+use crate::widgets::Widget;
+
+/// Overlay layout that places all children at the same position,
+/// stacking them on top of each other. Later children appear on top.
+///
+/// The size of the overlay is determined by the largest child.
+pub struct Overlay;
+
+impl Overlay {
+    /// Create a new overlay layout
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for Overlay {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Layout for Overlay {
+    fn layout(
+        &mut self,
+        children: &mut [Box<dyn Widget>],
+        constraints: Constraints,
+        origin: (f32, f32),
+    ) -> Size {
+        let mut max_width: f32 = 0.0;
+        let mut max_height: f32 = 0.0;
+
+        // Layout all children at the same origin, giving them the full constraints
+        for child in children.iter_mut() {
+            let child_size = child.layout(constraints);
+            child.set_origin(origin.0, origin.1);
+
+            max_width = max_width.max(child_size.width);
+            max_height = max_height.max(child_size.height);
+        }
+
+        // Return the size of the largest child, constrained
+        constraints.constrain(Size::new(max_width, max_height))
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ pub mod prelude {
     pub use crate::animation::{SpringConfig, TimingFunction, Transition};
     pub use crate::layout::{
         at_least, at_most, Axis, Constraints, CrossAxisAlignment, Flex, Length, MainAxisAlignment,
-        Size,
+        Overlay, Size,
     };
     pub use crate::platform::{Anchor, Layer};
     pub use crate::reactive::{

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -226,8 +226,8 @@ impl Transform {
     /// - sx = sqrt(a² + b²)
     /// - sy = sqrt(c² + d²)
     ///
-    /// This is a private helper used by `extract_scale()`, `without_scale()`, and `rotation_only()`.
-    fn extract_scale_components(&self) -> (f32, f32) {
+    /// Returns `(scale_x, scale_y)` as a tuple.
+    pub fn extract_scale_components(&self) -> (f32, f32) {
         let a = self.data[0];
         let b = self.data[1];
         let c = self.data[4];

--- a/src/widgets/container.rs
+++ b/src/widgets/container.rs
@@ -1125,11 +1125,12 @@ impl Container {
 
         // Create vertical scrollbar containers if needed
         if self.scroll_axis.allows_vertical() && self.v_scrollbar_track.is_none() {
-            // Track container
+            // Track container with width animation to sync with handle
             let track = Container::new()
                 .background(track_color)
                 .corner_radius(track_corner_radius)
-                .corner_curvature(track_corner_curvature);
+                .corner_curvature(track_corner_curvature)
+                .animate_width(Transition::spring(SpringConfig::SNAPPY));
             self.v_scrollbar_track = Some(Box::new(track));
 
             // Handle container with hover state for color change and width animation
@@ -1145,11 +1146,12 @@ impl Container {
 
         // Create horizontal scrollbar containers if needed
         if self.scroll_axis.allows_horizontal() && self.h_scrollbar_track.is_none() {
-            // Track container
+            // Track container with height animation to sync with handle
             let track = Container::new()
                 .background(track_color)
                 .corner_radius(track_corner_radius)
-                .corner_curvature(track_corner_curvature);
+                .corner_curvature(track_corner_curvature)
+                .animate_height(Transition::spring(SpringConfig::SNAPPY));
             self.h_scrollbar_track = Some(Box::new(track));
 
             // Handle container with hover state for color change and height animation

--- a/src/widgets/scroll.rs
+++ b/src/widgets/scroll.rs
@@ -76,11 +76,11 @@ impl Default for ScrollbarConfig {
             hover_width: 10.0,
             margin: 2.0,
             track_color: Color::rgba(1.0, 1.0, 1.0, 0.05),
-            track_corner_radius: 3.0,
-            track_corner_curvature: 1.0, // Circular corners by default
+            track_corner_radius: 100.0, // Large value to ensure pill shape (clamped to half width)
+            track_corner_curvature: 1.0, // Circular corners (standard)
             handle_color: Color::rgba(1.0, 1.0, 1.0, 0.3),
-            handle_corner_radius: 3.0,
-            handle_corner_curvature: 1.0, // Circular corners by default
+            handle_corner_radius: 100.0, // Large value to ensure pill shape (clamped to half width)
+            handle_corner_curvature: 1.0, // Circular corners (standard)
             handle_hover_color: Color::rgba(1.0, 1.0, 1.0, 0.5),
             handle_pressed_color: Color::rgba(1.0, 1.0, 1.0, 0.6),
             min_handle_size: 20.0,


### PR DESCRIPTION
## Summary
- Refactor scrollbar rendering to use nested Container widgets instead of manual painting
- Add scale transform for hover expansion animation (non-uniform scaling)
- Add ripple effect on scrollbar handle press
- Use faster, bouncier spring animation for hover expansion
- Use pill-shaped scrollbars with circular corners

## Test plan
- Run `cargo run --example scroll_example`
- Verify scrollbar hover expansion animates with bounce
- Verify ripple appears when clicking scrollbar handle
- Verify scrollbar maintains pill shape when expanded