### PR TITLE
Add TextInput widget with full editing support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1557,12 +1557,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0512da38f5e2b31201a93524adb8d3136276fa4fe4aafab4e1f727a82b534cc0"
 dependencies = [
  "bitflags 2.10.0",
+ "bytemuck",
  "calloop",
  "calloop-wayland-source",
  "cursor-icon",
  "libc",
  "log",
  "memmap2",
+ "pkg-config",
  "rustix",
  "thiserror",
  "wayland-backend",
@@ -1574,6 +1576,7 @@ dependencies = [
  "wayland-protocols-misc",
  "wayland-protocols-wlr",
  "wayland-scanner",
+ "xkbcommon",
  "xkeysym",
 ]
 
@@ -2330,10 +2333,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec9e4a500ca8864c5b47b8b482a73d62e4237670e5b5f1d6b9e3cae50f28f2b"
 
 [[package]]
+name = "xkbcommon"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d66ca9352cbd4eecbbc40871d8a11b4ac8107cfc528a6e14d7c19c69d0e1ac9"
+dependencies = [
+ "libc",
+ "memmap2",
+ "xkeysym",
+]
+
+[[package]]
 name = "xkeysym"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "xml-rs"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -697,6 +697,7 @@ dependencies = [
  "glyphon",
  "guido-macros",
  "image",
+ "libc",
  "log",
  "pollster",
  "raw-window-handle",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -706,6 +706,7 @@ dependencies = [
  "smithay-client-toolkit",
  "wayland-backend",
  "wayland-client",
+ "wayland-protocols",
  "wayland-protocols-wlr",
  "wgpu",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ wgpu = { version = "28.0", features = ["fragile-send-sync-non-atomic-wasm"] }
 bytemuck = { version = "1.24", features = ["derive"] }
 glyphon = "0.10"
 cosmic-text = "0.16"
-smithay-client-toolkit = { version = "0.20", default-features = false, features = ["calloop"] }
+smithay-client-toolkit = { version = "0.20", default-features = false, features = ["calloop", "xkbcommon"] }
 wayland-protocols-wlr = { version = "0.3", features = ["client"] }
 wayland-client = "0.31"
 wayland-backend = { version = "0.3", features = ["client_system"] }
@@ -47,3 +47,7 @@ path = "examples/showcase.rs"
 [[example]]
 name = "image_example"
 path = "examples/image_example.rs"
+
+[[example]]
+name = "text_input_example"
+path = "examples/text_input_example.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ bytemuck = { version = "1.24", features = ["derive"] }
 glyphon = "0.10"
 cosmic-text = "0.16"
 smithay-client-toolkit = { version = "0.20", default-features = false, features = ["calloop", "xkbcommon"] }
+wayland-protocols = { version = "0.32", features = ["client", "staging"] }
 wayland-protocols-wlr = { version = "0.3", features = ["client"] }
 wayland-client = "0.31"
 wayland-backend = { version = "0.3", features = ["client_system"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ log = "0.4"
 env_logger = "0.11"
 bitflags = "2.4"
 smallvec = "1.13"
+libc = "0.2"
 
 [dev-dependencies]
 env_logger = "0.11"

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -25,6 +25,7 @@
     - [Borders & Corners](building-ui/borders.md)
     - [Elevation & Shadows](building-ui/elevation.md)
     - [Text](building-ui/text.md)
+    - [Text Input](building-ui/text-input.md)
     - [Images](building-ui/images.md)
 
 # Interactivity

--- a/book/src/building-ui/text-input.md
+++ b/book/src/building-ui/text-input.md
@@ -1,0 +1,237 @@
+# Text Input
+
+The TextInput widget provides single-line text editing with support for selection, clipboard operations, undo/redo, and password masking.
+
+## Basic Usage
+
+```rust
+let username = create_signal(String::new());
+
+text_input(username)
+```
+
+The widget automatically syncs with the signal, updating when the signal changes and notifying via callbacks when the user edits.
+
+## Styling
+
+### Text Color
+
+```rust
+text_input(value)
+    .text_color(Color::WHITE)
+```
+
+### Cursor Color
+
+```rust
+text_input(value)
+    .cursor_color(Color::rgb(0.4, 0.8, 1.0))
+```
+
+### Selection Color
+
+```rust
+text_input(value)
+    .selection_color(Color::rgba(0.4, 0.6, 1.0, 0.4))
+```
+
+### Font Size
+
+```rust
+text_input(value)
+    .font_size(16.0)
+```
+
+## Password Mode
+
+Hide text input for sensitive data like passwords:
+
+```rust
+text_input(password)
+    .password(true)
+```
+
+By default, characters are masked with `•`. Customize the mask character:
+
+```rust
+text_input(password)
+    .password(true)
+    .mask_char('*')
+```
+
+## Callbacks
+
+### On Change
+
+Called whenever the text content changes:
+
+```rust
+text_input(value)
+    .on_change(|new_text| {
+        println!("Text changed: {}", new_text);
+    })
+```
+
+### On Submit
+
+Called when the user presses Enter:
+
+```rust
+text_input(value)
+    .on_submit(|text| {
+        println!("Submitted: {}", text);
+    })
+```
+
+## Keyboard Shortcuts
+
+The TextInput widget supports standard text editing shortcuts:
+
+| Shortcut | Action |
+|----------|--------|
+| `Ctrl+A` | Select all |
+| `Ctrl+C` | Copy selection |
+| `Ctrl+X` | Cut selection |
+| `Ctrl+V` | Paste |
+| `Ctrl+Z` | Undo |
+| `Ctrl+Shift+Z` or `Ctrl+Y` | Redo |
+| `Left/Right` | Move cursor |
+| `Ctrl+Left/Right` | Move by word |
+| `Shift+Left/Right` | Extend selection |
+| `Home/End` | Move to start/end |
+| `Backspace` | Delete before cursor |
+| `Delete` | Delete after cursor |
+
+## Styling with Container
+
+TextInput handles text editing but not visual styling like backgrounds and borders. Wrap it in a Container for full styling:
+
+```rust
+container()
+    .padding(Padding::horizontal(12.0).vertical(8.0))
+    .background(Color::rgb(0.15, 0.15, 0.2))
+    .border(1.0, Color::rgb(0.3, 0.3, 0.4))
+    .corner_radius(4.0)
+    .child(
+        text_input(value)
+            .text_color(Color::WHITE)
+            .font_size(14.0)
+    )
+```
+
+### With Focus State
+
+Add visual feedback when the input is focused:
+
+```rust
+container()
+    .padding(Padding::horizontal(12.0).vertical(8.0))
+    .background(Color::rgb(0.15, 0.15, 0.2))
+    .border(1.0, Color::rgb(0.3, 0.3, 0.4))
+    .corner_radius(4.0)
+    .focused_state(|s| s.border_color(Color::rgb(0.4, 0.6, 1.0)))
+    .child(
+        text_input(value)
+            .text_color(Color::WHITE)
+    )
+```
+
+## Complete Example
+
+A login form with username and password fields:
+
+```rust
+fn login_form() -> Container {
+    let username = create_signal(String::new());
+    let password = create_signal(String::new());
+
+    container()
+        .padding(24.0)
+        .background(Color::rgb(0.1, 0.1, 0.15))
+        .corner_radius(12.0)
+        .layout(Flex::column().spacing(16.0))
+        .children([
+            // Username field
+            container()
+                .layout(Flex::column().spacing(4.0))
+                .children([
+                    text("Username")
+                        .font_size(12.0)
+                        .color(Color::rgb(0.6, 0.6, 0.7)),
+                    container()
+                        .padding(Padding::horizontal(12.0).vertical(8.0))
+                        .background(Color::rgb(0.15, 0.15, 0.2))
+                        .border(1.0, Color::rgb(0.3, 0.3, 0.4))
+                        .corner_radius(4.0)
+                        .focused_state(|s| s.border_color(Color::rgb(0.4, 0.6, 1.0)))
+                        .child(
+                            text_input(username)
+                                .text_color(Color::WHITE)
+                                .font_size(14.0)
+                        ),
+                ]),
+            // Password field
+            container()
+                .layout(Flex::column().spacing(4.0))
+                .children([
+                    text("Password")
+                        .font_size(12.0)
+                        .color(Color::rgb(0.6, 0.6, 0.7)),
+                    container()
+                        .padding(Padding::horizontal(12.0).vertical(8.0))
+                        .background(Color::rgb(0.15, 0.15, 0.2))
+                        .border(1.0, Color::rgb(0.3, 0.3, 0.4))
+                        .corner_radius(4.0)
+                        .focused_state(|s| s.border_color(Color::rgb(0.4, 0.6, 1.0)))
+                        .child(
+                            text_input(password)
+                                .password(true)
+                                .text_color(Color::WHITE)
+                                .font_size(14.0)
+                        ),
+                ]),
+            // Submit button
+            container()
+                .padding(Padding::horizontal(16.0).vertical(10.0))
+                .background(Color::rgb(0.3, 0.5, 0.9))
+                .corner_radius(6.0)
+                .hover_state(|s| s.lighter(0.1))
+                .pressed_state(|s| s.darker(0.1))
+                .on_click(move || {
+                    println!("Login: {} / {}", username.get(), password.get());
+                })
+                .child(
+                    text("Sign In")
+                        .color(Color::WHITE)
+                        .font_size(14.0)
+                        .bold()
+                ),
+        ])
+}
+```
+
+## Features
+
+- **Selection**: Click and drag to select text, or use Shift+Arrow keys
+- **Clipboard**: Full copy/cut/paste support via Ctrl+C/X/V
+- **Undo/Redo**: History with intelligent coalescing of rapid edits
+- **Scrolling**: Long text scrolls horizontally to keep cursor visible
+- **Cursor Blinking**: Standard blinking cursor when focused
+- **Key Repeat**: Hold keys for continuous input
+
+## API Reference
+
+```rust
+text_input(value: impl IntoMaybeDyn<String>) -> TextInput
+
+impl TextInput {
+    pub fn text_color(self, color: impl IntoMaybeDyn<Color>) -> Self;
+    pub fn cursor_color(self, color: impl IntoMaybeDyn<Color>) -> Self;
+    pub fn selection_color(self, color: impl IntoMaybeDyn<Color>) -> Self;
+    pub fn font_size(self, size: impl IntoMaybeDyn<f32>) -> Self;
+    pub fn password(self, enabled: bool) -> Self;
+    pub fn mask_char(self, c: char) -> Self;
+    pub fn on_change<F: Fn(&str) + 'static>(self, callback: F) -> Self;
+    pub fn on_submit<F: Fn(&str) + 'static>(self, callback: F) -> Self;
+}
+```

--- a/book/src/building-ui/text-input.md
+++ b/book/src/building-ui/text-input.md
@@ -10,7 +10,11 @@ let username = create_signal(String::new());
 text_input(username)
 ```
 
-The widget automatically syncs with the signal, updating when the signal changes and notifying via callbacks when the user edits.
+TextInput uses **two-way binding** with signals:
+- When the user types, the signal is automatically updated
+- When the signal changes programmatically, the input reflects the new value
+
+No manual synchronization is needed - just pass a `Signal<String>` and the binding works automatically.
 
 ## Styling
 
@@ -222,7 +226,7 @@ fn login_form() -> Container {
 ## API Reference
 
 ```rust
-text_input(value: impl IntoMaybeDyn<String>) -> TextInput
+text_input(signal: Signal<String>) -> TextInput
 
 impl TextInput {
     pub fn text_color(self, color: impl IntoMaybeDyn<Color>) -> Self;
@@ -235,3 +239,5 @@ impl TextInput {
     pub fn on_submit<F: Fn(&str) + 'static>(self, callback: F) -> Self;
 }
 ```
+
+**Note:** The `on_change` callback is optional and is called *in addition* to the automatic signal update. Use it for side effects like validation or logging, not for updating the signal (that happens automatically).

--- a/book/src/concepts/widgets.md
+++ b/book/src/concepts/widgets.md
@@ -52,6 +52,20 @@ text("Hello, World!")
 
 See [Text](../building-ui/text.md) for styling options.
 
+### TextInput
+
+Single-line text editing with selection, clipboard, and undo/redo:
+
+```rust
+let username = create_signal(String::new());
+
+text_input(username)
+    .text_color(Color::WHITE)
+    .on_submit(|text| println!("Submitted: {}", text))
+```
+
+See [Text Input](../building-ui/text-input.md) for details.
+
 ## Composition
 
 Guido UIs are built through composition - nesting widgets inside containers:

--- a/docs/STATE_LAYER.md
+++ b/docs/STATE_LAYER.md
@@ -1,12 +1,13 @@
 # State Layer API
 
-The state layer system provides declarative style overrides based on widget interaction state (hover, pressed). This enables rich visual feedback without manual signal management.
+The state layer system provides declarative style overrides based on widget interaction state (hover, pressed, focused). This enables rich visual feedback without manual signal management.
 
 ## Overview
 
 State layers allow containers to define how they should look when:
 - **Hovered**: Mouse cursor is over the widget
 - **Pressed**: Mouse button is held down on the widget
+- **Focused**: Any child widget has keyboard focus (e.g., text input)
 
 Style changes are defined declaratively using builder methods, and the framework handles all state transitions, animations, and rendering automatically.
 
@@ -21,6 +22,18 @@ container()
     .hover_state(|s| s.lighter(0.1))      // Lighten on hover
     .pressed_state(|s| s.ripple())         // Ripple on press
     .child(text("Click me"))
+```
+
+### Focused State for Input Containers
+
+The `focused_state` is applied when any child widget has keyboard focus. This is particularly useful for styling input containers:
+
+```rust
+container()
+    .border(1.0, Color::rgb(0.3, 0.3, 0.4))
+    .corner_radius(6.0)
+    .focused_state(|s| s.border(2.0, Color::rgb(0.4, 0.8, 1.0)))  // Highlight when focused
+    .child(text_input(value))
 ```
 
 ## State Style Methods

--- a/examples/text_input_example.rs
+++ b/examples/text_input_example.rs
@@ -19,9 +19,7 @@ fn main() {
         .layout(Flex::column().spacing(16.0))
         .child(
             // Title
-            text("Text Input Demo")
-                .color(Color::WHITE)
-                .font_size(20.0),
+            text("Text Input Demo").color(Color::WHITE).font_size(20.0),
         )
         .child(
             // Username section
@@ -34,6 +32,7 @@ fn main() {
                 )
                 .child(
                     container()
+                        .width(at_least(300.0))
                         .padding(8.0)
                         .background(Color::rgb(0.18, 0.18, 0.24))
                         .border(1.0, Color::rgb(0.3, 0.3, 0.4))
@@ -59,6 +58,7 @@ fn main() {
                 )
                 .child(
                     container()
+                        .width(at_least(300.0))
                         .padding(8.0)
                         .background(Color::rgb(0.18, 0.18, 0.24))
                         .border(1.0, Color::rgb(0.3, 0.3, 0.4))

--- a/examples/text_input_example.rs
+++ b/examples/text_input_example.rs
@@ -5,6 +5,8 @@
 //! - Password field with masking
 //! - Real-time display of input values
 //! - Submit handling with Enter key
+//! - Focused state styling on input containers
+//! - Clipboard support (Ctrl+C/V/X)
 
 use guido::prelude::*;
 
@@ -37,6 +39,8 @@ fn main() {
                         .background(Color::rgb(0.18, 0.18, 0.24))
                         .border(1.0, Color::rgb(0.3, 0.3, 0.4))
                         .corner_radius(6.0)
+                        // Highlight border when text input is focused
+                        .focused_state(|s| s.border(2.0, Color::rgb(0.4, 0.8, 1.0)))
                         .child(
                             text_input(username)
                                 .text_color(Color::WHITE)
@@ -63,6 +67,8 @@ fn main() {
                         .background(Color::rgb(0.18, 0.18, 0.24))
                         .border(1.0, Color::rgb(0.3, 0.3, 0.4))
                         .corner_radius(6.0)
+                        // Highlight border when text input is focused
+                        .focused_state(|s| s.border(2.0, Color::rgb(0.4, 0.8, 1.0)))
                         .child(
                             text_input(password)
                                 .text_color(Color::WHITE)
@@ -158,6 +164,11 @@ fn main() {
                 )
                 .child(
                     text("• Enter to submit (in password field)")
+                        .color(Color::rgb(0.5, 0.5, 0.6))
+                        .font_size(11.0),
+                )
+                .child(
+                    text("• Ctrl+C/X/V to copy/cut/paste")
                         .color(Color::rgb(0.5, 0.5, 0.6))
                         .font_size(11.0),
                 ),

--- a/examples/text_input_example.rs
+++ b/examples/text_input_example.rs
@@ -47,8 +47,7 @@ fn main() {
                                 .text_color(Color::WHITE)
                                 .cursor_color(Color::rgb(0.4, 0.8, 1.0))
                                 .selection_color(Color::rgba(0.4, 0.6, 1.0, 0.4))
-                                .font_size(14.0)
-                                .on_change(move |text| username.set(text.to_string())),
+                                .font_size(14.0),
                         ),
                 ),
         )
@@ -77,7 +76,6 @@ fn main() {
                                 .selection_color(Color::rgba(0.4, 0.6, 1.0, 0.4))
                                 .font_size(14.0)
                                 .password(true)
-                                .on_change(move |text| password.set(text.to_string()))
                                 .on_submit(move |_| {
                                     let msg = format!("Login attempt: {}", username.get());
                                     submitted.set(msg);

--- a/examples/text_input_example.rs
+++ b/examples/text_input_example.rs
@@ -7,6 +7,7 @@
 //! - Submit handling with Enter key
 //! - Focused state styling on input containers
 //! - Clipboard support (Ctrl+C/V/X)
+//! - Undo/redo history (Ctrl+Z/Y)
 
 use guido::prelude::*;
 
@@ -169,6 +170,11 @@ fn main() {
                 )
                 .child(
                     text("• Ctrl+C/X/V to copy/cut/paste")
+                        .color(Color::rgb(0.5, 0.5, 0.6))
+                        .font_size(11.0),
+                )
+                .child(
+                    text("• Ctrl+Z to undo, Ctrl+Y to redo")
                         .color(Color::rgb(0.5, 0.5, 0.6))
                         .font_size(11.0),
                 ),

--- a/examples/text_input_example.rs
+++ b/examples/text_input_example.rs
@@ -1,0 +1,174 @@
+//! Text Input Example
+//!
+//! Demonstrates the TextInput widget with:
+//! - Basic text input
+//! - Password field with masking
+//! - Real-time display of input values
+//! - Submit handling with Enter key
+
+use guido::prelude::*;
+
+fn main() {
+    let username = create_signal(String::new());
+    let password = create_signal(String::new());
+    let submitted = create_signal(String::new());
+
+    let view = container()
+        .background(Color::rgb(0.12, 0.12, 0.18))
+        .padding(24.0)
+        .layout(Flex::column().spacing(16.0))
+        .child(
+            // Title
+            text("Text Input Demo")
+                .color(Color::WHITE)
+                .font_size(20.0),
+        )
+        .child(
+            // Username section
+            container()
+                .layout(Flex::column().spacing(4.0))
+                .child(
+                    text("Username")
+                        .color(Color::rgb(0.7, 0.7, 0.8))
+                        .font_size(12.0),
+                )
+                .child(
+                    container()
+                        .padding(8.0)
+                        .background(Color::rgb(0.18, 0.18, 0.24))
+                        .border(1.0, Color::rgb(0.3, 0.3, 0.4))
+                        .corner_radius(6.0)
+                        .child(
+                            text_input(username)
+                                .text_color(Color::WHITE)
+                                .cursor_color(Color::rgb(0.4, 0.8, 1.0))
+                                .selection_color(Color::rgba(0.4, 0.6, 1.0, 0.4))
+                                .font_size(14.0)
+                                .on_change(move |text| username.set(text.to_string())),
+                        ),
+                ),
+        )
+        .child(
+            // Password section
+            container()
+                .layout(Flex::column().spacing(4.0))
+                .child(
+                    text("Password")
+                        .color(Color::rgb(0.7, 0.7, 0.8))
+                        .font_size(12.0),
+                )
+                .child(
+                    container()
+                        .padding(8.0)
+                        .background(Color::rgb(0.18, 0.18, 0.24))
+                        .border(1.0, Color::rgb(0.3, 0.3, 0.4))
+                        .corner_radius(6.0)
+                        .child(
+                            text_input(password)
+                                .text_color(Color::WHITE)
+                                .cursor_color(Color::rgb(0.4, 0.8, 1.0))
+                                .selection_color(Color::rgba(0.4, 0.6, 1.0, 0.4))
+                                .font_size(14.0)
+                                .password(true)
+                                .on_change(move |text| password.set(text.to_string()))
+                                .on_submit(move |_| {
+                                    let msg = format!("Login attempt: {}", username.get());
+                                    submitted.set(msg);
+                                }),
+                        ),
+                ),
+        )
+        .child(
+            // Current values display
+            container()
+                .padding(12.0)
+                .background(Color::rgb(0.15, 0.15, 0.2))
+                .corner_radius(6.0)
+                .layout(Flex::column().spacing(8.0))
+                .child(
+                    text("Current Values:")
+                        .color(Color::rgb(0.6, 0.6, 0.7))
+                        .font_size(12.0),
+                )
+                .child(
+                    text(move || format!("Username: {}", username.get()))
+                        .color(Color::rgb(0.8, 0.8, 0.9))
+                        .font_size(13.0),
+                )
+                .child(
+                    text(move || format!("Password: {} chars", password.get().len()))
+                        .color(Color::rgb(0.8, 0.8, 0.9))
+                        .font_size(13.0),
+                ),
+        )
+        .child(
+            // Submit status
+            text(move || {
+                let msg = submitted.get();
+                if msg.is_empty() {
+                    "Press Enter in password field to submit".to_string()
+                } else {
+                    msg
+                }
+            })
+            .color(Color::rgb(0.5, 0.8, 0.5))
+            .font_size(13.0),
+        )
+        .child(
+            // Instructions
+            container()
+                .padding(12.0)
+                .background(Color::rgb(0.1, 0.1, 0.14))
+                .corner_radius(6.0)
+                .layout(Flex::column().spacing(4.0))
+                .child(
+                    text("Keyboard shortcuts:")
+                        .color(Color::rgb(0.5, 0.5, 0.6))
+                        .font_size(11.0),
+                )
+                .child(
+                    text("• Click to focus and position cursor")
+                        .color(Color::rgb(0.5, 0.5, 0.6))
+                        .font_size(11.0),
+                )
+                .child(
+                    text("• Arrow keys to move cursor")
+                        .color(Color::rgb(0.5, 0.5, 0.6))
+                        .font_size(11.0),
+                )
+                .child(
+                    text("• Shift+Arrow to select text")
+                        .color(Color::rgb(0.5, 0.5, 0.6))
+                        .font_size(11.0),
+                )
+                .child(
+                    text("• Ctrl+A to select all")
+                        .color(Color::rgb(0.5, 0.5, 0.6))
+                        .font_size(11.0),
+                )
+                .child(
+                    text("• Ctrl+Arrow for word jump")
+                        .color(Color::rgb(0.5, 0.5, 0.6))
+                        .font_size(11.0),
+                )
+                .child(
+                    text("• Home/End to go to start/end")
+                        .color(Color::rgb(0.5, 0.5, 0.6))
+                        .font_size(11.0),
+                )
+                .child(
+                    text("• Enter to submit (in password field)")
+                        .color(Color::rgb(0.5, 0.5, 0.6))
+                        .font_size(11.0),
+                ),
+        );
+
+    App::new()
+        .width(400)
+        .height(500)
+        .anchor(Anchor::TOP | Anchor::LEFT)
+        .layer(Layer::Top)
+        .namespace("text-input-example")
+        .background_color(Color::rgb(0.12, 0.12, 0.18))
+        .run(view);
+}

--- a/examples/text_input_transform_test.rs
+++ b/examples/text_input_transform_test.rs
@@ -40,7 +40,7 @@ fn main() {
                         .border(1.0, Color::rgb(0.3, 0.8, 0.3))
                         .corner_radius(6.0)
                         .child(
-                            text_input(input1)
+                            text_input_signal(input1)
                                 .text_color(Color::WHITE)
                                 .cursor_color(Color::rgb(0.4, 0.8, 1.0))
                                 .font_size(14.0),
@@ -65,7 +65,7 @@ fn main() {
                         .corner_radius(6.0)
                         .rotate(15.0)
                         .child(
-                            text_input(input2)
+                            text_input_signal(input2)
                                 .text_color(Color::WHITE)
                                 .cursor_color(Color::rgb(0.4, 0.8, 1.0))
                                 .font_size(14.0),
@@ -90,7 +90,7 @@ fn main() {
                         .corner_radius(6.0)
                         .scale(1.2)
                         .child(
-                            text_input(input3)
+                            text_input_signal(input3)
                                 .text_color(Color::WHITE)
                                 .cursor_color(Color::rgb(0.4, 0.8, 1.0))
                                 .font_size(14.0),
@@ -115,7 +115,7 @@ fn main() {
                         .corner_radius(6.0)
                         .translate(50.0, 10.0)
                         .child(
-                            text_input(input4)
+                            text_input_signal(input4)
                                 .text_color(Color::WHITE)
                                 .cursor_color(Color::rgb(0.4, 0.8, 1.0))
                                 .font_size(14.0),
@@ -144,7 +144,7 @@ fn main() {
                                 .then(&Transform::scale(0.9)),
                         )
                         .child(
-                            text_input(input5)
+                            text_input_signal(input5)
                                 .text_color(Color::WHITE)
                                 .cursor_color(Color::rgb(0.4, 0.8, 1.0))
                                 .font_size(14.0),

--- a/examples/text_input_transform_test.rs
+++ b/examples/text_input_transform_test.rs
@@ -1,0 +1,169 @@
+//! Test TextInput widget with transforms
+//!
+//! Tests that text input works correctly when inside transformed containers:
+//! - Click-to-position cursor works with rotation, scale, and translation
+//! - Selection works correctly
+//! - Visual rendering is correct
+
+use guido::prelude::*;
+
+fn main() {
+    let input1 = create_signal(String::from("Normal input"));
+    let input2 = create_signal(String::from("Rotated 15°"));
+    let input3 = create_signal(String::from("Scaled 1.2x"));
+    let input4 = create_signal(String::from("Translated"));
+    let input5 = create_signal(String::from("All transforms"));
+
+    let view = container()
+        .background(Color::rgb(0.1, 0.1, 0.15))
+        .padding(32.0)
+        .layout(Flex::column().spacing(32.0))
+        .child(
+            text("TextInput Transform Test")
+                .color(Color::WHITE)
+                .font_size(18.0),
+        )
+        // 1. Normal (no transform) - baseline
+        .child(
+            container()
+                .layout(Flex::column().spacing(4.0))
+                .child(
+                    text("No transform (baseline)")
+                        .color(Color::rgb(0.6, 0.6, 0.7))
+                        .font_size(12.0),
+                )
+                .child(
+                    container()
+                        .width(at_least(300.0))
+                        .padding(8.0)
+                        .background(Color::rgb(0.18, 0.18, 0.24))
+                        .border(1.0, Color::rgb(0.3, 0.8, 0.3))
+                        .corner_radius(6.0)
+                        .child(
+                            text_input(input1)
+                                .text_color(Color::WHITE)
+                                .cursor_color(Color::rgb(0.4, 0.8, 1.0))
+                                .font_size(14.0),
+                        ),
+                ),
+        )
+        // 2. Rotated container
+        .child(
+            container()
+                .layout(Flex::column().spacing(4.0))
+                .child(
+                    text("Rotated 15°")
+                        .color(Color::rgb(0.6, 0.6, 0.7))
+                        .font_size(12.0),
+                )
+                .child(
+                    container()
+                        .width(at_least(300.0))
+                        .padding(8.0)
+                        .background(Color::rgb(0.18, 0.18, 0.24))
+                        .border(1.0, Color::rgb(0.8, 0.5, 0.3))
+                        .corner_radius(6.0)
+                        .rotate(15.0)
+                        .child(
+                            text_input(input2)
+                                .text_color(Color::WHITE)
+                                .cursor_color(Color::rgb(0.4, 0.8, 1.0))
+                                .font_size(14.0),
+                        ),
+                ),
+        )
+        // 3. Scaled container
+        .child(
+            container()
+                .layout(Flex::column().spacing(4.0))
+                .child(
+                    text("Scaled 1.2x")
+                        .color(Color::rgb(0.6, 0.6, 0.7))
+                        .font_size(12.0),
+                )
+                .child(
+                    container()
+                        .width(at_least(250.0))
+                        .padding(8.0)
+                        .background(Color::rgb(0.18, 0.18, 0.24))
+                        .border(1.0, Color::rgb(0.3, 0.5, 0.8))
+                        .corner_radius(6.0)
+                        .scale(1.2)
+                        .child(
+                            text_input(input3)
+                                .text_color(Color::WHITE)
+                                .cursor_color(Color::rgb(0.4, 0.8, 1.0))
+                                .font_size(14.0),
+                        ),
+                ),
+        )
+        // 4. Translated container
+        .child(
+            container()
+                .layout(Flex::column().spacing(4.0))
+                .child(
+                    text("Translated (50, 10)")
+                        .color(Color::rgb(0.6, 0.6, 0.7))
+                        .font_size(12.0),
+                )
+                .child(
+                    container()
+                        .width(at_least(300.0))
+                        .padding(8.0)
+                        .background(Color::rgb(0.18, 0.18, 0.24))
+                        .border(1.0, Color::rgb(0.8, 0.8, 0.3))
+                        .corner_radius(6.0)
+                        .translate(50.0, 10.0)
+                        .child(
+                            text_input(input4)
+                                .text_color(Color::WHITE)
+                                .cursor_color(Color::rgb(0.4, 0.8, 1.0))
+                                .font_size(14.0),
+                        ),
+                ),
+        )
+        // 5. All transforms combined: translate + rotate + scale
+        .child(
+            container()
+                .layout(Flex::column().spacing(4.0))
+                .child(
+                    text("Translate(20,5) + Rotate(-10°) + Scale(0.9)")
+                        .color(Color::rgb(0.6, 0.6, 0.7))
+                        .font_size(12.0),
+                )
+                .child(
+                    container()
+                        .width(at_least(300.0))
+                        .padding(8.0)
+                        .background(Color::rgb(0.18, 0.18, 0.24))
+                        .border(1.0, Color::rgb(0.8, 0.3, 0.8))
+                        .corner_radius(6.0)
+                        .transform(
+                            Transform::translate(20.0, 5.0)
+                                .then(&Transform::rotate_degrees(-10.0))
+                                .then(&Transform::scale(0.9)),
+                        )
+                        .child(
+                            text_input(input5)
+                                .text_color(Color::WHITE)
+                                .cursor_color(Color::rgb(0.4, 0.8, 1.0))
+                                .font_size(14.0),
+                        ),
+                ),
+        )
+        // Instructions
+        .child(
+            text("Click in each input to test cursor positioning")
+                .color(Color::rgb(0.5, 0.5, 0.6))
+                .font_size(11.0),
+        );
+
+    App::new()
+        .width(550)
+        .height(680)
+        .anchor(Anchor::TOP | Anchor::LEFT)
+        .layer(Layer::Top)
+        .namespace("text-input-transform-test")
+        .background_color(Color::rgb(0.1, 0.1, 0.15))
+        .run(view);
+}

--- a/examples/text_input_transform_test.rs
+++ b/examples/text_input_transform_test.rs
@@ -40,7 +40,7 @@ fn main() {
                         .border(1.0, Color::rgb(0.3, 0.8, 0.3))
                         .corner_radius(6.0)
                         .child(
-                            text_input_signal(input1)
+                            text_input(input1)
                                 .text_color(Color::WHITE)
                                 .cursor_color(Color::rgb(0.4, 0.8, 1.0))
                                 .font_size(14.0),
@@ -65,7 +65,7 @@ fn main() {
                         .corner_radius(6.0)
                         .rotate(15.0)
                         .child(
-                            text_input_signal(input2)
+                            text_input(input2)
                                 .text_color(Color::WHITE)
                                 .cursor_color(Color::rgb(0.4, 0.8, 1.0))
                                 .font_size(14.0),
@@ -90,7 +90,7 @@ fn main() {
                         .corner_radius(6.0)
                         .scale(1.2)
                         .child(
-                            text_input_signal(input3)
+                            text_input(input3)
                                 .text_color(Color::WHITE)
                                 .cursor_color(Color::rgb(0.4, 0.8, 1.0))
                                 .font_size(14.0),
@@ -115,7 +115,7 @@ fn main() {
                         .corner_radius(6.0)
                         .translate(50.0, 10.0)
                         .child(
-                            text_input_signal(input4)
+                            text_input(input4)
                                 .text_color(Color::WHITE)
                                 .cursor_color(Color::rgb(0.4, 0.8, 1.0))
                                 .font_size(14.0),
@@ -144,7 +144,7 @@ fn main() {
                                 .then(&Transform::scale(0.9)),
                         )
                         .child(
-                            text_input_signal(input5)
+                            text_input(input5)
                                 .text_color(Color::WHITE)
                                 .cursor_color(Color::rgb(0.4, 0.8, 1.0))
                                 .font_size(14.0),

--- a/src/layout/flex_layout.rs
+++ b/src/layout/flex_layout.rs
@@ -17,12 +17,16 @@ pub struct Flex {
 
 impl Flex {
     /// Create a new flex layout with the given direction
+    ///
+    /// Default alignments match CSS Flexbox:
+    /// - `main_axis_alignment`: `Start` (CSS `justify-content: flex-start`)
+    /// - `cross_axis_alignment`: `Stretch` (CSS `align-items: stretch`)
     pub fn new(direction: Axis) -> Self {
         Self {
             direction: MaybeDyn::Static(direction),
             spacing: MaybeDyn::Static(0.0),
             main_axis_alignment: MaybeDyn::Static(MainAxisAlignment::Start),
-            cross_axis_alignment: MaybeDyn::Static(CrossAxisAlignment::Center),
+            cross_axis_alignment: MaybeDyn::Static(CrossAxisAlignment::Stretch),
             child_sizes: SmallVec::new(),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,9 +43,9 @@ pub mod prelude {
     pub use crate::transform::Transform;
     pub use crate::transform_origin::{HorizontalAnchor, TransformOrigin, VerticalAnchor};
     pub use crate::widgets::{
-        container, image, text, text_input, Border, Color, Container, ContentFit, Event,
-        EventResponse, GradientDirection, Image, ImageSource, IntoChildren, Key, LinearGradient,
-        Modifiers, MouseButton, Overflow, Padding, Rect, ScrollAxis, ScrollSource,
+        container, image, text, text_input, text_input_signal, Border, Color, Container,
+        ContentFit, Event, EventResponse, GradientDirection, Image, ImageSource, IntoChildren, Key,
+        LinearGradient, Modifiers, MouseButton, Overflow, Padding, Rect, ScrollAxis, ScrollSource,
         ScrollbarBuilder, ScrollbarVisibility, Selection, StateStyle, Text, TextInput, Widget,
     };
     pub use crate::{component, App, AppConfig};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,8 @@ pub use guido_macros::component;
 use layout::Constraints;
 use platform::{create_wayland_app, Anchor, Layer, WaylandWindowWrapper};
 use reactive::{
-    clear_animation_flag, init_wakeup, take_frame_request, with_app_state, with_app_state_mut,
+    clear_animation_flag, init_wakeup, take_clipboard_change, take_frame_request, with_app_state,
+    with_app_state_mut,
 };
 use renderer::{GpuContext, Renderer};
 use widgets::{Color, Widget};
@@ -290,6 +291,11 @@ impl App {
             // Dispatch input events to widgets
             for event in wayland_state.take_events() {
                 root.event(&event);
+            }
+
+            // Sync clipboard to Wayland if it changed
+            if let Some(text) = take_clipboard_change() {
+                wayland_state.set_clipboard(text, &qh);
             }
 
             // Calculate physical pixel dimensions (for HiDPI)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,10 +42,10 @@ pub mod prelude {
     pub use crate::transform::Transform;
     pub use crate::transform_origin::{HorizontalAnchor, TransformOrigin, VerticalAnchor};
     pub use crate::widgets::{
-        container, image, text, Border, Color, Container, ContentFit, Event, EventResponse,
-        GradientDirection, Image, ImageSource, IntoChildren, LinearGradient, MouseButton, Overflow,
-        Padding, Rect, ScrollAxis, ScrollSource, ScrollbarBuilder, ScrollbarVisibility, StateStyle,
-        Text, Widget,
+        container, image, text, text_input, Border, Color, Container, ContentFit, Event,
+        EventResponse, GradientDirection, Image, ImageSource, IntoChildren, Key, LinearGradient,
+        Modifiers, MouseButton, Overflow, Padding, Rect, ScrollAxis, ScrollSource,
+        ScrollbarBuilder, ScrollbarVisibility, Selection, StateStyle, Text, TextInput, Widget,
     };
     pub use crate::{component, App, AppConfig};
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ use layout::Constraints;
 use platform::{create_wayland_app, Anchor, Layer, WaylandWindowWrapper};
 use reactive::{
     clear_animation_flag, init_wakeup, set_system_clipboard, take_clipboard_change,
-    take_frame_request, with_app_state, with_app_state_mut,
+    take_cursor_change, take_frame_request, with_app_state, with_app_state_mut,
 };
 use renderer::{GpuContext, Renderer};
 use widgets::{Color, Widget};
@@ -35,8 +35,8 @@ pub mod prelude {
     };
     pub use crate::platform::{Anchor, Layer};
     pub use crate::reactive::{
-        batch, create_computed, create_effect, create_signal, Computed, Effect, IntoMaybeDyn,
-        MaybeDyn, ReadSignal, Signal, WriteSignal,
+        batch, create_computed, create_effect, create_signal, set_cursor, Computed, CursorIcon,
+        Effect, IntoMaybeDyn, MaybeDyn, ReadSignal, Signal, WriteSignal,
     };
     pub use crate::renderer::primitives::Shadow;
     pub use crate::renderer::{measure_text, PaintContext};
@@ -317,6 +317,11 @@ impl App {
             // Sync clipboard to Wayland if it changed (copy operations)
             if let Some(text) = take_clipboard_change() {
                 wayland_state.set_clipboard(text, &qh);
+            }
+
+            // Sync cursor to Wayland if it changed
+            if let Some(cursor) = take_cursor_change() {
+                wayland_state.set_cursor(cursor, &qh);
             }
 
             // Calculate physical pixel dimensions (for HiDPI)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,12 +292,19 @@ impl App {
             let events = wayland_state.take_events();
 
             // Sync external clipboard before keyboard event dispatch (for paste operations)
-            // Only read if there are keyboard events (potential Ctrl+V)
-            let has_keyboard_events = events
-                .iter()
-                .any(|e| matches!(e, widgets::Event::KeyDown { .. }));
-            if has_keyboard_events {
-                if let Some(text) = wayland_state.read_external_clipboard() {
+            // Only read if Ctrl+V is pressed (actual paste operation)
+            let has_paste_event = events.iter().any(|e| {
+                matches!(
+                    e,
+                    widgets::Event::KeyDown {
+                        key: widgets::Key::Char('v'),
+                        modifiers: widgets::Modifiers { ctrl: true, .. },
+                        ..
+                    }
+                )
+            });
+            if has_paste_event {
+                if let Some(text) = wayland_state.read_external_clipboard(&connection) {
                     set_system_clipboard(text);
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,9 +43,9 @@ pub mod prelude {
     pub use crate::transform::Transform;
     pub use crate::transform_origin::{HorizontalAnchor, TransformOrigin, VerticalAnchor};
     pub use crate::widgets::{
-        container, image, text, text_input, text_input_signal, Border, Color, Container,
-        ContentFit, Event, EventResponse, GradientDirection, Image, ImageSource, IntoChildren, Key,
-        LinearGradient, Modifiers, MouseButton, Overflow, Padding, Rect, ScrollAxis, ScrollSource,
+        container, image, text, text_input, Border, Color, Container, ContentFit, Event,
+        EventResponse, GradientDirection, Image, ImageSource, IntoChildren, Key, LinearGradient,
+        Modifiers, MouseButton, Overflow, Padding, Rect, ScrollAxis, ScrollSource,
         ScrollbarBuilder, ScrollbarVisibility, Selection, StateStyle, Text, TextInput, Widget,
     };
     pub use crate::{component, App, AppConfig};

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -720,6 +720,7 @@ fn keysym_to_key(keysym: Keysym, utf8: Option<&str>) -> Option<Key> {
         Keysym::Down => return Some(Key::Down),
         Keysym::Home => return Some(Key::Home),
         Keysym::End => return Some(Key::End),
+        Keysym::space => return Some(Key::Char(' ')),
         _ => {}
     }
 

--- a/src/reactive/clipboard.rs
+++ b/src/reactive/clipboard.rs
@@ -1,0 +1,99 @@
+//! Clipboard support for text copy/paste operations.
+//!
+//! This module provides a thread-local clipboard buffer for internal clipboard operations.
+//! It also coordinates with the Wayland clipboard for system-wide clipboard support.
+
+use std::cell::RefCell;
+
+thread_local! {
+    /// Internal clipboard buffer
+    static CLIPBOARD: RefCell<Option<String>> = const { RefCell::new(None) };
+
+    /// Flag indicating clipboard was changed and needs to be synced to Wayland
+    static CLIPBOARD_CHANGED: RefCell<bool> = const { RefCell::new(false) };
+
+    /// Pending clipboard read request (for async clipboard reading from Wayland)
+    static CLIPBOARD_READ_REQUESTED: RefCell<bool> = const { RefCell::new(false) };
+
+    /// System clipboard contents (from Wayland selection offer)
+    static SYSTEM_CLIPBOARD: RefCell<Option<String>> = const { RefCell::new(None) };
+}
+
+/// Copy text to the clipboard
+pub fn clipboard_copy(text: &str) {
+    CLIPBOARD.with(|c| {
+        *c.borrow_mut() = Some(text.to_string());
+    });
+    CLIPBOARD_CHANGED.with(|changed| {
+        *changed.borrow_mut() = true;
+    });
+}
+
+/// Take pending clipboard change (returns text if clipboard was changed since last call)
+pub fn take_clipboard_change() -> Option<String> {
+    let changed = CLIPBOARD_CHANGED.with(|c| {
+        let was_changed = *c.borrow();
+        *c.borrow_mut() = false;
+        was_changed
+    });
+
+    if changed {
+        CLIPBOARD.with(|c| c.borrow().clone())
+    } else {
+        None
+    }
+}
+
+/// Paste text from the clipboard
+/// Returns the clipboard contents if available
+pub fn clipboard_paste() -> Option<String> {
+    // First try system clipboard, fall back to internal
+    SYSTEM_CLIPBOARD.with(|sc| {
+        if let Some(text) = sc.borrow().as_ref() {
+            return Some(text.clone());
+        }
+        CLIPBOARD.with(|c| c.borrow().clone())
+    })
+}
+
+/// Check if clipboard has content
+pub fn clipboard_has_content() -> bool {
+    SYSTEM_CLIPBOARD.with(|sc| {
+        if sc.borrow().is_some() {
+            return true;
+        }
+        CLIPBOARD.with(|c| c.borrow().is_some())
+    })
+}
+
+/// Set system clipboard contents (called from Wayland event handling)
+pub fn set_system_clipboard(text: String) {
+    SYSTEM_CLIPBOARD.with(|sc| {
+        *sc.borrow_mut() = Some(text);
+    });
+}
+
+/// Clear system clipboard (called when selection is lost)
+pub fn clear_system_clipboard() {
+    SYSTEM_CLIPBOARD.with(|sc| {
+        *sc.borrow_mut() = None;
+    });
+}
+
+/// Request reading from system clipboard
+pub fn request_clipboard_read() {
+    CLIPBOARD_READ_REQUESTED.with(|r| {
+        *r.borrow_mut() = true;
+    });
+}
+
+/// Check and clear clipboard read request
+pub fn take_clipboard_read_request() -> bool {
+    CLIPBOARD_READ_REQUESTED.with(|r| {
+        let requested = *r.borrow();
+        if requested {
+            *r.borrow_mut() = false;
+        }
+        requested
+    })
+}

--- a/src/reactive/cursor.rs
+++ b/src/reactive/cursor.rs
@@ -1,0 +1,88 @@
+//! Cursor management for changing the mouse cursor appearance.
+//!
+//! Widgets can request a cursor change by calling `set_cursor(CursorIcon::Text)`.
+//! The main event loop will pick up cursor changes and apply them via Wayland.
+
+use std::cell::RefCell;
+
+/// Standard cursor icons that can be displayed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CursorIcon {
+    /// The default arrow cursor.
+    #[default]
+    Default,
+    /// Text selection cursor (I-beam).
+    Text,
+    /// Pointer/hand cursor for clickable elements.
+    Pointer,
+    /// Crosshair cursor.
+    Crosshair,
+    /// Move/drag cursor.
+    Move,
+    /// Not allowed cursor.
+    NotAllowed,
+    /// Grab cursor (open hand).
+    Grab,
+    /// Grabbing cursor (closed hand).
+    Grabbing,
+    /// Resize cursors for window edges.
+    ResizeNorth,
+    ResizeSouth,
+    ResizeEast,
+    ResizeWest,
+    ResizeNorthEast,
+    ResizeNorthWest,
+    ResizeSouthEast,
+    ResizeSouthWest,
+    /// Column resize cursor.
+    ColResize,
+    /// Row resize cursor.
+    RowResize,
+    /// Wait/loading cursor.
+    Wait,
+    /// Progress cursor (arrow with spinner).
+    Progress,
+}
+
+thread_local! {
+    /// Current requested cursor
+    static CURRENT_CURSOR: RefCell<CursorIcon> = const { RefCell::new(CursorIcon::Default) };
+
+    /// Flag indicating cursor was changed and needs to be synced to Wayland
+    static CURSOR_CHANGED: RefCell<bool> = const { RefCell::new(false) };
+}
+
+/// Set the cursor to display.
+/// This should be called by widgets when they want to change the cursor appearance.
+pub fn set_cursor(cursor: CursorIcon) {
+    CURRENT_CURSOR.with(|c| {
+        let current = *c.borrow();
+        if current != cursor {
+            *c.borrow_mut() = cursor;
+            CURSOR_CHANGED.with(|changed| {
+                *changed.borrow_mut() = true;
+            });
+        }
+    });
+}
+
+/// Take pending cursor change (returns cursor if it was changed since last call).
+/// Called by the main event loop to sync cursor to Wayland.
+pub fn take_cursor_change() -> Option<CursorIcon> {
+    let changed = CURSOR_CHANGED.with(|c| {
+        let was_changed = *c.borrow();
+        *c.borrow_mut() = false;
+        was_changed
+    });
+
+    if changed {
+        Some(CURRENT_CURSOR.with(|c| *c.borrow()))
+    } else {
+        None
+    }
+}
+
+/// Get the current cursor without clearing the change flag.
+pub fn get_current_cursor() -> CursorIcon {
+    CURRENT_CURSOR.with(|c| *c.borrow())
+}

--- a/src/reactive/focus.rs
+++ b/src/reactive/focus.rs
@@ -1,0 +1,49 @@
+//! Focus management system for keyboard input routing.
+//!
+//! This module provides a centralized way to track which widget has keyboard focus.
+//! Only one widget can have focus at a time.
+
+use std::cell::RefCell;
+
+use super::WidgetId;
+
+thread_local! {
+    /// The currently focused widget ID, if any
+    static FOCUSED_WIDGET: RefCell<Option<WidgetId>> = const { RefCell::new(None) };
+}
+
+/// Request keyboard focus for a widget.
+/// If another widget has focus, it will lose focus.
+pub fn request_focus(id: WidgetId) {
+    FOCUSED_WIDGET.with(|cell| {
+        *cell.borrow_mut() = Some(id);
+    });
+}
+
+/// Release keyboard focus from a widget.
+/// Only releases if the given widget currently has focus.
+pub fn release_focus(id: WidgetId) {
+    FOCUSED_WIDGET.with(|cell| {
+        let mut focused = cell.borrow_mut();
+        if *focused == Some(id) {
+            *focused = None;
+        }
+    });
+}
+
+/// Check if a specific widget has keyboard focus.
+pub fn has_focus(id: WidgetId) -> bool {
+    FOCUSED_WIDGET.with(|cell| *cell.borrow() == Some(id))
+}
+
+/// Get the ID of the currently focused widget, if any.
+pub fn focused_widget() -> Option<WidgetId> {
+    FOCUSED_WIDGET.with(|cell| *cell.borrow())
+}
+
+/// Clear all focus (no widget will have focus).
+pub fn clear_focus() {
+    FOCUSED_WIDGET.with(|cell| {
+        *cell.borrow_mut() = None;
+    });
+}

--- a/src/reactive/mod.rs
+++ b/src/reactive/mod.rs
@@ -1,5 +1,6 @@
 pub mod clipboard;
 pub mod computed;
+pub mod cursor;
 pub mod effect;
 pub mod focus;
 pub mod invalidation;
@@ -14,6 +15,7 @@ pub use clipboard::{
     take_clipboard_read_request,
 };
 pub use computed::{create_computed, Computed};
+pub use cursor::{get_current_cursor, set_cursor, take_cursor_change, CursorIcon};
 pub use effect::{create_effect, Effect};
 pub use focus::{clear_focus, focused_widget, has_focus, release_focus, request_focus};
 pub use invalidation::{

--- a/src/reactive/mod.rs
+++ b/src/reactive/mod.rs
@@ -1,5 +1,6 @@
 pub mod computed;
 pub mod effect;
+pub mod focus;
 pub mod invalidation;
 pub mod maybe_dyn;
 pub mod runtime;
@@ -8,6 +9,7 @@ pub mod storage;
 
 pub use computed::{create_computed, Computed};
 pub use effect::{create_effect, Effect};
+pub use focus::{clear_focus, focused_widget, has_focus, release_focus, request_focus};
 pub use invalidation::{
     clear_animation_flag, init_wakeup, request_animation_frame, request_frame, request_layout,
     request_paint, take_frame_request, with_app_state, with_app_state_mut, ChangeFlags, WidgetId,

--- a/src/reactive/mod.rs
+++ b/src/reactive/mod.rs
@@ -1,3 +1,4 @@
+pub mod clipboard;
 pub mod computed;
 pub mod effect;
 pub mod focus;
@@ -7,6 +8,11 @@ pub mod runtime;
 pub mod signal;
 pub mod storage;
 
+pub use clipboard::{
+    clear_system_clipboard, clipboard_copy, clipboard_has_content, clipboard_paste,
+    request_clipboard_read, set_system_clipboard, take_clipboard_change,
+    take_clipboard_read_request,
+};
 pub use computed::{create_computed, Computed};
 pub use effect::{create_effect, Effect};
 pub use focus::{clear_focus, focused_widget, has_focus, release_focus, request_focus};

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -21,7 +21,7 @@ use crate::widgets::image::{ContentFit, ImageSource};
 use crate::widgets::{Color, Rect};
 
 pub use context::{GpuContext, SurfaceState};
-pub use text_measurer::measure_text;
+pub use text_measurer::{char_index_from_x, measure_text, measure_text_to_char};
 
 /// A text entry for rendering, containing all information needed to render text.
 #[derive(Debug, Clone)]

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -320,7 +320,7 @@ impl Renderer {
                 // The texture has padding added around the text content (see text_texture.rs).
                 // The padding is 4.0 * effective_scale, where effective_scale = scale_factor * transform_scale * QUALITY_MULTIPLIER.
                 // After dividing by QUALITY_MULTIPLIER for display, the padding becomes:
-                let display_padding = 4.0 * self.scale_factor * transform_scale.max(1.0);
+                let display_padding = 4.0 * self.scale_factor * transform_scale;
 
                 // Position the display_rect by scaling the original rect's top-left from the transform origin.
                 // Subtract the display padding so that the text content (not the texture edge) aligns

--- a/src/renderer/text.rs
+++ b/src/renderer/text.rs
@@ -145,12 +145,13 @@ impl TextRenderState {
                 let scaled_top = (entry.rect.y + ty) * scale_factor;
 
                 // Use clip rect if provided, otherwise use full screen
+                // Apply translation offset to clip bounds to match text position
                 let bounds = if let Some(clip_rect) = &entry.clip_rect {
                     TextBounds {
-                        left: (clip_rect.x * scale_factor) as i32,
-                        top: (clip_rect.y * scale_factor) as i32,
-                        right: ((clip_rect.x + clip_rect.width) * scale_factor) as i32,
-                        bottom: ((clip_rect.y + clip_rect.height) * scale_factor) as i32,
+                        left: ((clip_rect.x + tx) * scale_factor) as i32,
+                        top: ((clip_rect.y + ty) * scale_factor) as i32,
+                        right: ((clip_rect.x + clip_rect.width + tx) * scale_factor) as i32,
+                        bottom: ((clip_rect.y + clip_rect.height + ty) * scale_factor) as i32,
                     }
                 } else {
                     TextBounds {

--- a/src/renderer/text_measurer.rs
+++ b/src/renderer/text_measurer.rs
@@ -41,6 +41,66 @@ impl TextMeasurer {
 
         Size::new(width, height)
     }
+
+    /// Measure text width up to a specific character index.
+    /// This is useful for cursor positioning in text input widgets.
+    pub fn measure_to_char(&mut self, text: &str, font_size: f32, char_index: usize) -> f32 {
+        if char_index == 0 || text.is_empty() {
+            return 0.0;
+        }
+
+        // Get the byte position for the character index
+        let byte_pos = text
+            .char_indices()
+            .nth(char_index)
+            .map(|(i, _)| i)
+            .unwrap_or(text.len());
+
+        let prefix = &text[..byte_pos];
+        self.measure(prefix, font_size, None).width
+    }
+
+    /// Find the character index from an x-coordinate.
+    /// This is useful for click-to-position in text input widgets.
+    pub fn char_from_x(&mut self, text: &str, font_size: f32, x: f32) -> usize {
+        if text.is_empty() || x <= 0.0 {
+            return 0;
+        }
+
+        let total_width = self.measure(text, font_size, None).width;
+        if x >= total_width {
+            return text.chars().count();
+        }
+
+        // Binary search for the character position
+        let char_count = text.chars().count();
+        let mut best_index = 0;
+        let mut best_distance = x.abs();
+
+        for i in 0..=char_count {
+            let width = self.measure_to_char(text, font_size, i);
+            let distance = (width - x).abs();
+
+            if distance < best_distance {
+                best_distance = distance;
+                best_index = i;
+            }
+
+            // Early exit if we've passed the target
+            if width > x && i > 0 {
+                // Check if we're closer to this character or the previous one
+                let prev_width = self.measure_to_char(text, font_size, i - 1);
+                let mid = (prev_width + width) / 2.0;
+                if x < mid {
+                    return i - 1;
+                } else {
+                    return i;
+                }
+            }
+        }
+
+        best_index
+    }
 }
 
 thread_local! {
@@ -50,4 +110,14 @@ thread_local! {
 /// Measure text dimensions using the font system
 pub fn measure_text(text: &str, font_size: f32, max_width: Option<f32>) -> Size {
     TEXT_MEASURER.with_borrow_mut(|m| m.measure(text, font_size, max_width))
+}
+
+/// Measure text width up to a specific character index (for cursor positioning)
+pub fn measure_text_to_char(text: &str, font_size: f32, char_index: usize) -> f32 {
+    TEXT_MEASURER.with_borrow_mut(|m| m.measure_to_char(text, font_size, char_index))
+}
+
+/// Find the character index from an x-coordinate (for click-to-position)
+pub fn char_index_from_x(text: &str, font_size: f32, x: f32) -> usize {
+    TEXT_MEASURER.with_borrow_mut(|m| m.char_from_x(text, font_size, x))
 }

--- a/src/renderer/text_texture.rs
+++ b/src/renderer/text_texture.rs
@@ -84,7 +84,8 @@ impl TextTextureRenderer {
         scale_factor: f32,
     ) -> TextTexture {
         // Extract the scale from the transform for crisp rendering
-        let transform_scale = entry.transform.extract_scale().max(1.0);
+        // Use actual scale (not clamped) so text size matches cursor/selection positioning
+        let transform_scale = entry.transform.extract_scale();
 
         // Calculate the effective scale for text rendering (includes quality multiplier)
         let effective_scale = scale_factor * transform_scale * QUALITY_MULTIPLIER;

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -1477,6 +1477,8 @@ impl Widget for Container {
                     }
                 }
             }
+            // Keyboard and focus events are handled by focused widgets, not containers
+            Event::KeyDown { .. } | Event::KeyUp { .. } | Event::FocusIn | Event::FocusOut => {}
         }
 
         EventResponse::Ignored

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -13,7 +13,9 @@ use std::sync::Arc;
 use crate::advance_anim;
 use crate::animation::Transition;
 use crate::layout::{Constraints, Flex, Layout, Length, Size};
-use crate::reactive::{request_animation_frame, ChangeFlags, IntoMaybeDyn, MaybeDyn, WidgetId};
+use crate::reactive::{
+    focused_widget, request_animation_frame, ChangeFlags, IntoMaybeDyn, MaybeDyn, WidgetId,
+};
 use crate::renderer::primitives::{GradientDir, Shadow};
 use crate::renderer::PaintContext;
 use crate::transform::Transform;
@@ -159,9 +161,10 @@ pub struct Container {
     pub(super) border_color_anim: Option<AnimationState<Color>>,
     pub(super) transform_anim: Option<AnimationState<Transform>>,
 
-    // State layer styles (hover/pressed overrides)
+    // State layer styles (hover/pressed/focused overrides)
     pub(super) hover_state: Option<StateStyle>,
     pub(super) pressed_state: Option<StateStyle>,
+    pub(super) focused_state: Option<StateStyle>,
 
     // Scroll configuration
     pub(super) scroll_axis: ScrollAxis,
@@ -224,6 +227,7 @@ impl Container {
             transform_anim: None,
             hover_state: None,
             pressed_state: None,
+            focused_state: None,
             scroll_axis: ScrollAxis::None,
             scrollbar_visibility: ScrollbarVisibility::Always,
             scrollbar_config: ScrollbarConfig::default(),
@@ -586,7 +590,49 @@ impl Container {
         self
     }
 
+    /// Set style overrides for when any child widget has focus.
+    ///
+    /// This is useful for styling input containers when their child text input is focused.
+    ///
+    /// # Example
+    /// ```ignore
+    /// container()
+    ///     .border(1.0, Color::rgb(0.3, 0.3, 0.4))
+    ///     .focused_state(|s| s.border(2.0, Color::rgb(0.4, 0.8, 1.0)))
+    ///     .child(text_input(value))
+    /// ```
+    pub fn focused_state<F>(mut self, f: F) -> Self
+    where
+        F: FnOnce(StateStyle) -> StateStyle,
+    {
+        self.focused_state = Some(f(StateStyle::new()));
+        self
+    }
+
+    /// Check if any child widget has focus
+    fn has_child_focus(&self) -> bool {
+        if let Some(focused_id) = focused_widget() {
+            return self.widget_has_focus(focused_id);
+        }
+        false
+    }
+
+    /// Recursively check if this widget or any child matches the focused widget ID
+    fn widget_has_focus(&self, focused_id: WidgetId) -> bool {
+        for child in self.children_source.get() {
+            if child.id() == focused_id {
+                return true;
+            }
+            // Recursively check nested containers/widgets
+            if child.has_focus_descendant(focused_id) {
+                return true;
+            }
+        }
+        false
+    }
+
     // State layer resolution helper
+    // Priority: pressed > focused > hovered
     fn resolve_state_value<T: Clone>(
         &self,
         base: T,
@@ -594,6 +640,14 @@ impl Container {
     ) -> T {
         if self.is_pressed {
             if let Some(ref state) = self.pressed_state {
+                if let Some(value) = extractor(state) {
+                    return value;
+                }
+            }
+        }
+        // Check focused state
+        if self.focused_state.is_some() && self.has_child_focus() {
+            if let Some(ref state) = self.focused_state {
                 if let Some(value) = extractor(state) {
                     return value;
                 }
@@ -1542,6 +1596,10 @@ impl Widget for Container {
         for child in self.children_source.get_mut() {
             child.clear_dirty();
         }
+    }
+
+    fn has_focus_descendant(&self, id: WidgetId) -> bool {
+        self.widget_has_focus(id)
     }
 }
 

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -1224,14 +1224,11 @@ impl Widget for Container {
         let transform_origin = self.transform_origin.get();
 
         // Push transform if not identity
+        // Always resolve the transform origin so child elements (like text) know where to center
         let has_transform = !transform.is_identity();
         if has_transform {
-            if transform_origin.is_center() {
-                ctx.push_transform(transform);
-            } else {
-                let (origin_x, origin_y) = transform_origin.resolve(self.bounds);
-                ctx.push_transform_with_origin(transform, origin_x, origin_y);
-            }
+            let (origin_x, origin_y) = transform_origin.resolve(self.bounds);
+            ctx.push_transform_with_origin(transform, origin_x, origin_y);
         }
 
         // Draw background

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -38,7 +38,7 @@ pub use into_child::{DynamicChildren, IntoChild, IntoChildren, StaticChildren};
 pub use scroll::{ScrollAxis, ScrollbarBuilder, ScrollbarConfig, ScrollbarVisibility};
 pub use state_layer::{BackgroundOverride, RippleConfig, StateStyle};
 pub use text::{text, Text};
-pub use text_input::{text_input, text_input_signal, Selection, TextInput};
+pub use text_input::{text_input, Selection, TextInput};
 pub use widget::{
     Color, Event, EventResponse, Key, Modifiers, MouseButton, Padding, Rect, ScrollSource, Widget,
 };

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -5,6 +5,7 @@ pub mod into_child;
 pub mod scroll;
 pub mod state_layer;
 pub mod text;
+pub mod text_input;
 pub mod widget;
 
 /// Macro to implement common dirty flag methods for simple widgets.
@@ -37,7 +38,10 @@ pub use into_child::{DynamicChildren, IntoChild, IntoChildren, StaticChildren};
 pub use scroll::{ScrollAxis, ScrollbarBuilder, ScrollbarConfig, ScrollbarVisibility};
 pub use state_layer::{BackgroundOverride, RippleConfig, StateStyle};
 pub use text::{text, Text};
-pub use widget::{Color, Event, EventResponse, MouseButton, Padding, Rect, ScrollSource, Widget};
+pub use text_input::{text_input, Selection, TextInput};
+pub use widget::{
+    Color, Event, EventResponse, Key, Modifiers, MouseButton, Padding, Rect, ScrollSource, Widget,
+};
 
 // IntoMaybeDyn implementations for widget types
 use crate::reactive::{IntoMaybeDyn, MaybeDyn};

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -38,7 +38,7 @@ pub use into_child::{DynamicChildren, IntoChild, IntoChildren, StaticChildren};
 pub use scroll::{ScrollAxis, ScrollbarBuilder, ScrollbarConfig, ScrollbarVisibility};
 pub use state_layer::{BackgroundOverride, RippleConfig, StateStyle};
 pub use text::{text, Text};
-pub use text_input::{text_input, Selection, TextInput};
+pub use text_input::{text_input, text_input_signal, Selection, TextInput};
 pub use widget::{
     Color, Event, EventResponse, Key, Modifiers, MouseButton, Padding, Rect, ScrollSource, Widget,
 };

--- a/src/widgets/text_input.rs
+++ b/src/widgets/text_input.rs
@@ -14,7 +14,7 @@ use std::time::{Duration, Instant};
 use crate::layout::{Constraints, Size};
 use crate::reactive::{
     clipboard_copy, clipboard_paste, has_focus, release_focus, request_animation_frame,
-    request_focus, ChangeFlags, IntoMaybeDyn, MaybeDyn, WidgetId,
+    request_focus, ChangeFlags, IntoMaybeDyn, MaybeDyn, Signal, WidgetId,
 };
 use crate::renderer::{char_index_from_x, measure_text, measure_text_to_char, PaintContext};
 
@@ -203,6 +203,8 @@ pub struct TextInput {
 
     // Content (actual value, never masked)
     value: MaybeDyn<String>,
+    /// Signal for two-way binding (write-back when text changes)
+    value_signal: Option<Signal<String>>,
     cached_value: String,
     cached_display_text: String,
     display_text_dirty: bool,
@@ -255,6 +257,41 @@ impl TextInput {
             widget_id: WidgetId::next(),
             dirty_flags: ChangeFlags::NEEDS_LAYOUT | ChangeFlags::NEEDS_PAINT,
             value,
+            value_signal: None,
+            cached_value,
+            cached_display_text: String::new(),
+            display_text_dirty: true,
+            text_color: MaybeDyn::Static(Color::WHITE),
+            cursor_color: MaybeDyn::Static(Color::rgb(0.4, 0.8, 1.0)),
+            selection_color: MaybeDyn::Static(Color::rgba(0.4, 0.6, 1.0, 0.4)),
+            font_size: MaybeDyn::Static(14.0),
+            cached_font_size: 14.0,
+            is_password: false,
+            mask_char: '•',
+            selection: Selection::new(0),
+            cursor_visible: true,
+            last_cursor_toggle: Instant::now(),
+            pressed_key: None,
+            key_press_time: Instant::now(),
+            last_repeat_time: Instant::now(),
+            is_dragging: false,
+            history: History::new(),
+            scroll_offset: 0.0,
+            bounds: Rect::new(0.0, 0.0, 0.0, 0.0),
+            on_change: None,
+            on_submit: None,
+        }
+    }
+
+    /// Create a TextInput with a Signal for two-way binding.
+    /// Changes made in the TextInput will be written back to the signal.
+    pub fn from_signal(signal: Signal<String>) -> Self {
+        let cached_value = signal.get();
+        Self {
+            widget_id: WidgetId::next(),
+            dirty_flags: ChangeFlags::NEEDS_LAYOUT | ChangeFlags::NEEDS_PAINT,
+            value: MaybeDyn::Dynamic(std::sync::Arc::new(move || signal.get())),
+            value_signal: Some(signal),
             cached_value,
             cached_display_text: String::new(),
             display_text_dirty: true,
@@ -706,8 +743,13 @@ impl TextInput {
         }
     }
 
-    /// Notify change callback
+    /// Notify change callback and sync to signal
     fn notify_change(&self) {
+        // Update the signal for two-way binding
+        if let Some(ref signal) = self.value_signal {
+            signal.set(self.cached_value.clone());
+        }
+        // Call the on_change callback
         if let Some(ref callback) = self.on_change {
             callback(&self.cached_value);
         }
@@ -990,13 +1032,26 @@ impl Widget for TextInput {
     impl_dirty_flags!();
 }
 
-/// Create a text input widget
+/// Create a text input widget (one-way binding)
 ///
 /// Accepts static strings, closures, or signals:
 /// ```ignore
-/// text_input(username)  // reactive signal
 /// text_input("default value")  // static initial value
+/// text_input(move || some_signal.get())  // reactive closure
 /// ```
+///
+/// Note: For two-way binding with a signal, use [`text_input_signal`] instead.
 pub fn text_input(value: impl IntoMaybeDyn<String>) -> TextInput {
     TextInput::new(value)
+}
+
+/// Create a text input widget with two-way signal binding
+///
+/// Changes made in the text input will be written back to the signal.
+/// ```ignore
+/// let username = create_signal(String::new());
+/// text_input_signal(username)  // two-way binding
+/// ```
+pub fn text_input_signal(signal: Signal<String>) -> TextInput {
+    TextInput::from_signal(signal)
 }

--- a/src/widgets/text_input.rs
+++ b/src/widgets/text_input.rs
@@ -481,14 +481,19 @@ impl Widget for TextInput {
         let display = self.display_text();
         let measured = measure_text(&display, self.cached_font_size, None);
 
-        // Use measured width but ensure minimum height for empty text
+        // Ensure minimum height for empty text
         let height = measured.height.max(self.cached_font_size * 1.2);
 
+        // Text inputs should fill available width (like HTML input elements)
+        // Use max_width if available, otherwise fall back to measured width
+        let width = if constraints.max_width.is_finite() && constraints.max_width > 0.0 {
+            constraints.max_width
+        } else {
+            measured.width.max(100.0) // Minimum 100px if unconstrained
+        };
+
         let size = Size::new(
-            measured
-                .width
-                .max(constraints.min_width)
-                .min(constraints.max_width),
+            width.max(constraints.min_width).min(constraints.max_width),
             height
                 .max(constraints.min_height)
                 .min(constraints.max_height),

--- a/src/widgets/text_input.rs
+++ b/src/widgets/text_input.rs
@@ -1,0 +1,624 @@
+//! TextInput widget for single-line text editing.
+//!
+//! The TextInput widget handles:
+//! - Text display and editing
+//! - Cursor blinking and positioning
+//! - Text selection with mouse and keyboard
+//! - Password masking mode
+//!
+//! Styling (background, borders, etc.) should be handled by wrapping in a Container.
+
+use std::time::{Duration, Instant};
+
+use crate::layout::{Constraints, Size};
+use crate::reactive::{
+    has_focus, release_focus, request_animation_frame, request_focus, ChangeFlags, IntoMaybeDyn,
+    MaybeDyn, WidgetId,
+};
+use crate::renderer::{char_index_from_x, measure_text, measure_text_to_char, PaintContext};
+
+use super::impl_dirty_flags;
+use super::widget::{Color, Event, EventResponse, Key, MouseButton, Rect, Widget};
+
+/// Cursor blink interval in milliseconds
+const CURSOR_BLINK_MS: u64 = 530;
+
+/// Type alias for text input callbacks
+type TextCallback = Box<dyn Fn(&str)>;
+
+/// Selection state tracking anchor and cursor positions
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Selection {
+    /// Where selection started (anchor point)
+    pub anchor: usize,
+    /// Current cursor position
+    pub cursor: usize,
+}
+
+impl Selection {
+    /// Create a new selection with cursor at given position (no selection)
+    pub fn new(pos: usize) -> Self {
+        Self {
+            anchor: pos,
+            cursor: pos,
+        }
+    }
+
+    /// Check if there is an active selection (anchor != cursor)
+    pub fn has_selection(&self) -> bool {
+        self.anchor != self.cursor
+    }
+
+    /// Get the start and end of the selection (min, max)
+    pub fn range(&self) -> (usize, usize) {
+        if self.anchor <= self.cursor {
+            (self.anchor, self.cursor)
+        } else {
+            (self.cursor, self.anchor)
+        }
+    }
+
+    /// Collapse selection to cursor position
+    pub fn collapse(&mut self) {
+        self.anchor = self.cursor;
+    }
+}
+
+pub struct TextInput {
+    widget_id: WidgetId,
+    dirty_flags: ChangeFlags,
+
+    // Content (actual value, never masked)
+    value: MaybeDyn<String>,
+    cached_value: String,
+
+    // Styling
+    text_color: MaybeDyn<Color>,
+    cursor_color: MaybeDyn<Color>,
+    selection_color: MaybeDyn<Color>,
+    font_size: MaybeDyn<f32>,
+    cached_font_size: f32,
+
+    // Password mode
+    is_password: bool,
+    mask_char: char,
+
+    // Selection state
+    selection: Selection,
+
+    // Cursor blinking
+    cursor_visible: bool,
+    last_cursor_toggle: Instant,
+
+    // Mouse drag selection
+    is_dragging: bool,
+
+    // Layout
+    bounds: Rect,
+
+    // Callbacks
+    on_change: Option<TextCallback>,
+    on_submit: Option<TextCallback>,
+}
+
+impl TextInput {
+    pub fn new(value: impl IntoMaybeDyn<String>) -> Self {
+        let value = value.into_maybe_dyn();
+        let cached_value = value.get();
+        Self {
+            widget_id: WidgetId::next(),
+            dirty_flags: ChangeFlags::NEEDS_LAYOUT | ChangeFlags::NEEDS_PAINT,
+            value,
+            cached_value,
+            text_color: MaybeDyn::Static(Color::WHITE),
+            cursor_color: MaybeDyn::Static(Color::rgb(0.4, 0.8, 1.0)),
+            selection_color: MaybeDyn::Static(Color::rgba(0.4, 0.6, 1.0, 0.4)),
+            font_size: MaybeDyn::Static(14.0),
+            cached_font_size: 14.0,
+            is_password: false,
+            mask_char: '•',
+            selection: Selection::new(0),
+            cursor_visible: true,
+            last_cursor_toggle: Instant::now(),
+            is_dragging: false,
+            bounds: Rect::new(0.0, 0.0, 0.0, 0.0),
+            on_change: None,
+            on_submit: None,
+        }
+    }
+
+    /// Set the text color
+    pub fn text_color(mut self, color: impl IntoMaybeDyn<Color>) -> Self {
+        self.text_color = color.into_maybe_dyn();
+        self
+    }
+
+    /// Set the cursor color
+    pub fn cursor_color(mut self, color: impl IntoMaybeDyn<Color>) -> Self {
+        self.cursor_color = color.into_maybe_dyn();
+        self
+    }
+
+    /// Set the selection highlight color
+    pub fn selection_color(mut self, color: impl IntoMaybeDyn<Color>) -> Self {
+        self.selection_color = color.into_maybe_dyn();
+        self
+    }
+
+    /// Set the font size
+    pub fn font_size(mut self, size: impl IntoMaybeDyn<f32>) -> Self {
+        self.font_size = size.into_maybe_dyn();
+        self
+    }
+
+    /// Enable password mode (masks text with bullet characters)
+    pub fn password(mut self, enabled: bool) -> Self {
+        self.is_password = enabled;
+        self
+    }
+
+    /// Set custom mask character for password mode (default: '•')
+    pub fn mask_char(mut self, c: char) -> Self {
+        self.mask_char = c;
+        self
+    }
+
+    /// Set callback for text changes
+    pub fn on_change<F: Fn(&str) + 'static>(mut self, callback: F) -> Self {
+        self.on_change = Some(Box::new(callback));
+        self
+    }
+
+    /// Set callback for submit (Enter key)
+    pub fn on_submit<F: Fn(&str) + 'static>(mut self, callback: F) -> Self {
+        self.on_submit = Some(Box::new(callback));
+        self
+    }
+
+    /// Get the display text (masked if password mode)
+    fn display_text(&self) -> String {
+        if self.is_password {
+            self.mask_char
+                .to_string()
+                .repeat(self.cached_value.chars().count())
+        } else {
+            self.cached_value.clone()
+        }
+    }
+
+    /// Refresh cached values and return true if changed
+    fn refresh(&mut self) -> bool {
+        let new_value = self.value.get();
+        let new_font_size = self.font_size.get();
+
+        let value_changed = new_value != self.cached_value;
+        let font_changed = (new_font_size - self.cached_font_size).abs() > f32::EPSILON;
+
+        if value_changed {
+            self.cached_value = new_value;
+            // Clamp selection to valid range
+            let char_count = self.cached_value.chars().count();
+            self.selection.cursor = self.selection.cursor.min(char_count);
+            self.selection.anchor = self.selection.anchor.min(char_count);
+        }
+        if font_changed {
+            self.cached_font_size = new_font_size;
+        }
+
+        value_changed || font_changed
+    }
+
+    /// Update cursor blink state
+    fn update_cursor_blink(&mut self) {
+        if has_focus(self.widget_id) {
+            let now = Instant::now();
+            if now.duration_since(self.last_cursor_toggle) >= Duration::from_millis(CURSOR_BLINK_MS)
+            {
+                self.cursor_visible = !self.cursor_visible;
+                self.last_cursor_toggle = now;
+            }
+            // Keep requesting frames for blinking
+            request_animation_frame();
+        }
+    }
+
+    /// Reset cursor to visible (called on input)
+    fn reset_cursor_blink(&mut self) {
+        self.cursor_visible = true;
+        self.last_cursor_toggle = Instant::now();
+    }
+
+    /// Get character index from x coordinate relative to text start
+    fn char_index_at_x(&self, x: f32) -> usize {
+        let display = self.display_text();
+        let text_x = self.bounds.x;
+        let relative_x = x - text_x;
+        char_index_from_x(&display, self.cached_font_size, relative_x)
+    }
+
+    /// Insert text at cursor, replacing any selection
+    fn insert_text(&mut self, text: &str) {
+        let (start, end) = self.selection.range();
+
+        // Convert character indices to byte indices
+        let byte_start = self
+            .cached_value
+            .char_indices()
+            .nth(start)
+            .map(|(i, _)| i)
+            .unwrap_or(self.cached_value.len());
+        let byte_end = self
+            .cached_value
+            .char_indices()
+            .nth(end)
+            .map(|(i, _)| i)
+            .unwrap_or(self.cached_value.len());
+
+        // Replace selection with new text
+        let mut new_value = String::with_capacity(self.cached_value.len() + text.len());
+        new_value.push_str(&self.cached_value[..byte_start]);
+        new_value.push_str(text);
+        new_value.push_str(&self.cached_value[byte_end..]);
+
+        self.cached_value = new_value;
+        self.selection = Selection::new(start + text.chars().count());
+
+        self.notify_change();
+        self.reset_cursor_blink();
+    }
+
+    /// Delete selected text or character before/after cursor
+    fn delete(&mut self, forward: bool) {
+        if self.selection.has_selection() {
+            // Delete selection
+            let (start, end) = self.selection.range();
+            self.delete_range(start, end);
+            self.selection = Selection::new(start);
+        } else if forward {
+            // Delete character after cursor
+            let char_count = self.cached_value.chars().count();
+            if self.selection.cursor < char_count {
+                self.delete_range(self.selection.cursor, self.selection.cursor + 1);
+            }
+        } else {
+            // Delete character before cursor (backspace)
+            if self.selection.cursor > 0 {
+                self.delete_range(self.selection.cursor - 1, self.selection.cursor);
+                self.selection = Selection::new(self.selection.cursor - 1);
+            }
+        }
+        self.reset_cursor_blink();
+    }
+
+    /// Delete a range of characters
+    fn delete_range(&mut self, start: usize, end: usize) {
+        let byte_start = self
+            .cached_value
+            .char_indices()
+            .nth(start)
+            .map(|(i, _)| i)
+            .unwrap_or(self.cached_value.len());
+        let byte_end = self
+            .cached_value
+            .char_indices()
+            .nth(end)
+            .map(|(i, _)| i)
+            .unwrap_or(self.cached_value.len());
+
+        let mut new_value = String::with_capacity(self.cached_value.len());
+        new_value.push_str(&self.cached_value[..byte_start]);
+        new_value.push_str(&self.cached_value[byte_end..]);
+
+        self.cached_value = new_value;
+        self.notify_change();
+    }
+
+    /// Move cursor left/right, optionally extending selection
+    fn move_cursor(&mut self, direction: i32, extend_selection: bool, word: bool) {
+        let char_count = self.cached_value.chars().count();
+        let new_pos = if word {
+            self.find_word_boundary(self.selection.cursor, direction)
+        } else if direction < 0 {
+            self.selection.cursor.saturating_sub(1)
+        } else {
+            (self.selection.cursor + 1).min(char_count)
+        };
+
+        self.selection.cursor = new_pos;
+        if !extend_selection {
+            self.selection.collapse();
+        }
+        self.reset_cursor_blink();
+    }
+
+    /// Find word boundary in given direction
+    fn find_word_boundary(&self, start: usize, direction: i32) -> usize {
+        let chars: Vec<char> = self.cached_value.chars().collect();
+        let len = chars.len();
+
+        if direction < 0 {
+            // Move left
+            if start == 0 {
+                return 0;
+            }
+            let mut pos = start - 1;
+            // Skip whitespace
+            while pos > 0 && chars[pos].is_whitespace() {
+                pos -= 1;
+            }
+            // Skip word characters
+            while pos > 0 && !chars[pos - 1].is_whitespace() {
+                pos -= 1;
+            }
+            pos
+        } else {
+            // Move right
+            if start >= len {
+                return len;
+            }
+            let mut pos = start;
+            // Skip word characters
+            while pos < len && !chars[pos].is_whitespace() {
+                pos += 1;
+            }
+            // Skip whitespace
+            while pos < len && chars[pos].is_whitespace() {
+                pos += 1;
+            }
+            pos
+        }
+    }
+
+    /// Move cursor to start/end
+    fn move_to_edge(&mut self, to_start: bool, extend_selection: bool) {
+        self.selection.cursor = if to_start {
+            0
+        } else {
+            self.cached_value.chars().count()
+        };
+        if !extend_selection {
+            self.selection.collapse();
+        }
+        self.reset_cursor_blink();
+    }
+
+    /// Select all text
+    fn select_all(&mut self) {
+        self.selection.anchor = 0;
+        self.selection.cursor = self.cached_value.chars().count();
+        self.reset_cursor_blink();
+    }
+
+    /// Notify change callback
+    fn notify_change(&self) {
+        if let Some(ref callback) = self.on_change {
+            callback(&self.cached_value);
+        }
+    }
+
+    /// Handle key down event
+    fn handle_key(&mut self, key: &Key, ctrl: bool, shift: bool) -> EventResponse {
+        match key {
+            Key::Backspace => {
+                self.delete(false);
+                EventResponse::Handled
+            }
+            Key::Delete => {
+                self.delete(true);
+                EventResponse::Handled
+            }
+            Key::Enter => {
+                if let Some(ref callback) = self.on_submit {
+                    callback(&self.cached_value);
+                }
+                EventResponse::Handled
+            }
+            Key::Left => {
+                if !shift && self.selection.has_selection() {
+                    // Collapse to start of selection
+                    let (start, _) = self.selection.range();
+                    self.selection = Selection::new(start);
+                    self.reset_cursor_blink();
+                } else {
+                    self.move_cursor(-1, shift, ctrl);
+                }
+                EventResponse::Handled
+            }
+            Key::Right => {
+                if !shift && self.selection.has_selection() {
+                    // Collapse to end of selection
+                    let (_, end) = self.selection.range();
+                    self.selection = Selection::new(end);
+                    self.reset_cursor_blink();
+                } else {
+                    self.move_cursor(1, shift, ctrl);
+                }
+                EventResponse::Handled
+            }
+            Key::Home => {
+                self.move_to_edge(true, shift);
+                EventResponse::Handled
+            }
+            Key::End => {
+                self.move_to_edge(false, shift);
+                EventResponse::Handled
+            }
+            Key::Char(c) => {
+                if ctrl {
+                    match c.to_ascii_lowercase() {
+                        'a' => {
+                            self.select_all();
+                            EventResponse::Handled
+                        }
+                        // Note: Clipboard operations (Ctrl+C/V/X) require Wayland data device
+                        // protocol which is not implemented yet
+                        _ => EventResponse::Ignored,
+                    }
+                } else if !c.is_control() {
+                    self.insert_text(&c.to_string());
+                    EventResponse::Handled
+                } else {
+                    EventResponse::Ignored
+                }
+            }
+            _ => EventResponse::Ignored,
+        }
+    }
+}
+
+impl Widget for TextInput {
+    fn layout(&mut self, constraints: Constraints) -> Size {
+        let content_changed = self.refresh();
+
+        // Update cursor blink if focused
+        self.update_cursor_blink();
+
+        // Skip re-measurement if nothing changed and we don't need layout
+        if !content_changed && !self.needs_layout() && self.bounds.width > 0.0 {
+            return Size::new(self.bounds.width, self.bounds.height);
+        }
+
+        let display = self.display_text();
+        let measured = measure_text(&display, self.cached_font_size, None);
+
+        // Use measured width but ensure minimum height for empty text
+        let height = measured.height.max(self.cached_font_size * 1.2);
+
+        let size = Size::new(
+            measured
+                .width
+                .max(constraints.min_width)
+                .min(constraints.max_width),
+            height
+                .max(constraints.min_height)
+                .min(constraints.max_height),
+        );
+
+        self.bounds.width = size.width;
+        self.bounds.height = size.height;
+
+        size
+    }
+
+    fn paint(&self, ctx: &mut PaintContext) {
+        let display = self.display_text();
+        let text_color = self.text_color.get();
+        let is_focused = has_focus(self.widget_id);
+
+        // Draw selection highlight if focused and has selection
+        if is_focused && self.selection.has_selection() {
+            let (start, end) = self.selection.range();
+            let start_x = measure_text_to_char(&display, self.cached_font_size, start);
+            let end_x = measure_text_to_char(&display, self.cached_font_size, end);
+
+            let selection_rect = Rect::new(
+                self.bounds.x + start_x,
+                self.bounds.y,
+                end_x - start_x,
+                self.bounds.height,
+            );
+            ctx.draw_rect(selection_rect, self.selection_color.get());
+        }
+
+        // Draw text
+        ctx.draw_text(&display, self.bounds, text_color, self.cached_font_size);
+
+        // Draw cursor if focused and visible
+        if is_focused && self.cursor_visible {
+            let cursor_x =
+                measure_text_to_char(&display, self.cached_font_size, self.selection.cursor);
+            let cursor_rect = Rect::new(
+                self.bounds.x + cursor_x,
+                self.bounds.y,
+                1.5, // cursor width
+                self.bounds.height,
+            );
+            ctx.draw_rect(cursor_rect, self.cursor_color.get());
+        }
+    }
+
+    fn event(&mut self, event: &Event) -> EventResponse {
+        match event {
+            Event::MouseDown { x, y, button } => {
+                if self.bounds.contains(*x, *y) && *button == MouseButton::Left {
+                    // Request focus
+                    request_focus(self.widget_id);
+                    request_animation_frame();
+
+                    // Set cursor position
+                    let char_index = self.char_index_at_x(*x);
+                    self.selection = Selection::new(char_index);
+                    self.is_dragging = true;
+                    self.reset_cursor_blink();
+
+                    return EventResponse::Handled;
+                }
+            }
+            Event::MouseMove { x, y } => {
+                if self.is_dragging {
+                    // Extend selection while dragging
+                    let char_index = self.char_index_at_x(*x);
+                    self.selection.cursor = char_index;
+                    request_animation_frame();
+                    return EventResponse::Handled;
+                }
+                // Check if we're over the text input for cursor styling (future)
+                if self.bounds.contains(*x, *y) {
+                    // Could set cursor to text cursor here
+                }
+            }
+            Event::MouseUp { button, .. } => {
+                if *button == MouseButton::Left && self.is_dragging {
+                    self.is_dragging = false;
+                    return EventResponse::Handled;
+                }
+            }
+            Event::KeyDown { key, modifiers } => {
+                if has_focus(self.widget_id) {
+                    let response = self.handle_key(key, modifiers.ctrl, modifiers.shift);
+                    if response == EventResponse::Handled {
+                        request_animation_frame();
+                    }
+                    return response;
+                }
+            }
+            Event::FocusOut => {
+                if has_focus(self.widget_id) {
+                    release_focus(self.widget_id);
+                    self.cursor_visible = false;
+                    self.is_dragging = false;
+                    request_animation_frame();
+                }
+            }
+            _ => {}
+        }
+
+        EventResponse::Ignored
+    }
+
+    fn set_origin(&mut self, x: f32, y: f32) {
+        self.bounds.x = x;
+        self.bounds.y = y;
+    }
+
+    fn bounds(&self) -> Rect {
+        self.bounds
+    }
+
+    fn id(&self) -> WidgetId {
+        self.widget_id
+    }
+
+    impl_dirty_flags!();
+}
+
+/// Create a text input widget
+///
+/// Accepts static strings, closures, or signals:
+/// ```ignore
+/// text_input(username)  // reactive signal
+/// text_input("default value")  // static initial value
+/// ```
+pub fn text_input(value: impl IntoMaybeDyn<String>) -> TextInput {
+    TextInput::new(value)
+}

--- a/src/widgets/text_input.rs
+++ b/src/widgets/text_input.rs
@@ -822,10 +822,12 @@ impl Widget for TextInput {
         }
 
         // Draw text with scroll offset
+        // Use a very large width to prevent word wrapping - the clip rect handles clipping
+        let text_width = measure_text(&display, self.cached_font_size, None).width;
         let text_bounds = Rect::new(
             self.bounds.x - self.scroll_offset,
             self.bounds.y,
-            self.bounds.width + self.scroll_offset * 2.0, // Allow text to extend
+            text_width.max(self.bounds.width), // Use actual text width to prevent wrapping
             self.bounds.height,
         );
         ctx.draw_text(&display, text_bounds, text_color, self.cached_font_size);

--- a/src/widgets/widget.rs
+++ b/src/widgets/widget.rs
@@ -402,6 +402,13 @@ pub trait Widget {
 
     /// Clear dirty flags after processing
     fn clear_dirty(&mut self);
+
+    /// Check if this widget has a descendant with the given ID.
+    /// Used by containers to check if a child has focus.
+    /// Default implementation returns false (leaf widgets have no children).
+    fn has_focus_descendant(&self, _id: WidgetId) -> bool {
+        false
+    }
 }
 
 #[cfg(test)]

--- a/src/widgets/widget.rs
+++ b/src/widgets/widget.rs
@@ -220,6 +220,44 @@ pub enum ScrollSource {
     Continuous,
 }
 
+/// Keyboard modifier state
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Modifiers {
+    pub ctrl: bool,
+    pub alt: bool,
+    pub shift: bool,
+    pub logo: bool,
+}
+
+/// Named keys for special keyboard keys
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Key {
+    /// Backspace key
+    Backspace,
+    /// Delete key
+    Delete,
+    /// Enter/Return key
+    Enter,
+    /// Tab key
+    Tab,
+    /// Escape key
+    Escape,
+    /// Left arrow
+    Left,
+    /// Right arrow
+    Right,
+    /// Up arrow
+    Up,
+    /// Down arrow
+    Down,
+    /// Home key
+    Home,
+    /// End key
+    End,
+    /// Character input (includes A-Z for Ctrl+A shortcuts)
+    Char(char),
+}
+
 #[derive(Debug, Clone)]
 pub enum Event {
     /// Mouse/pointer moved
@@ -245,6 +283,24 @@ pub enum Event {
         /// Source of the scroll event
         source: ScrollSource,
     },
+    /// Key pressed
+    KeyDown {
+        /// The key that was pressed
+        key: Key,
+        /// Current modifier state
+        modifiers: Modifiers,
+    },
+    /// Key released
+    KeyUp {
+        /// The key that was released
+        key: Key,
+        /// Current modifier state
+        modifiers: Modifiers,
+    },
+    /// Widget gained keyboard focus
+    FocusIn,
+    /// Widget lost keyboard focus
+    FocusOut,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -262,7 +318,11 @@ impl Event {
             Event::MouseUp { x, y, .. } => Some((*x, *y)),
             Event::MouseEnter { x, y } => Some((*x, *y)),
             Event::Scroll { x, y, .. } => Some((*x, *y)),
-            Event::MouseLeave => None,
+            Event::MouseLeave
+            | Event::KeyDown { .. }
+            | Event::KeyUp { .. }
+            | Event::FocusIn
+            | Event::FocusOut => None,
         }
     }
 
@@ -294,6 +354,17 @@ impl Event {
                 source: *source,
             },
             Event::MouseLeave => Event::MouseLeave,
+            // Keyboard/focus events don't have coordinates
+            Event::KeyDown { key, modifiers } => Event::KeyDown {
+                key: *key,
+                modifiers: *modifiers,
+            },
+            Event::KeyUp { key, modifiers } => Event::KeyUp {
+                key: *key,
+                modifiers: *modifiers,
+            },
+            Event::FocusIn => Event::FocusIn,
+            Event::FocusOut => Event::FocusOut,
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add a full-featured TextInput widget for single-line text editing
- Support for text selection, clipboard operations, undo/redo, and password masking
- Performance optimizations including VecDeque for history, display text caching, and binary search for click positioning
- History coalescing to merge rapid edits within 500ms window
- Comprehensive mdbook documentation

## Changes

### TextInput Widget Features
- Text display and editing with cursor blinking
- Mouse and keyboard selection support
- Clipboard operations (Ctrl+C/V/X)
- Undo/redo with intelligent coalescing (Ctrl+Z/Y)
- Password masking mode
- Horizontal scrolling for overflow text
- Key repeat for held keys

### Performance Improvements
- VecDeque for O(1) history removal at front
- Display text caching to avoid repeated string allocation
- Binary search for click-to-cursor positioning (O(log n))
- Character-to-byte index helpers to eliminate duplication

### Documentation
- Added `book/src/building-ui/text-input.md` with comprehensive documentation
- Updated `SUMMARY.md` and `widgets.md` to reference TextInput

## Test plan
- [x] `cargo fmt --all` - Code formatted
- [x] `cargo clippy --all-targets --all-features -- -D warnings` - No warnings
- [x] `cargo test` - All 109 tests pass
- [x] `mdbook build book` - Documentation builds successfully
- [ ] Manual testing with `cargo run --example status_bar`