### PR TITLE
Drop redundant Wayland dependencies and update to Rust 2024 edition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -690,8 +690,6 @@ version = "0.1.0"
 dependencies = [
  "bitflags 2.10.0",
  "bytemuck",
- "calloop",
- "calloop-wayland-source",
  "cosmic-text 0.16.0",
  "env_logger",
  "glyphon",
@@ -705,9 +703,6 @@ dependencies = [
  "smallvec",
  "smithay-client-toolkit",
  "wayland-backend",
- "wayland-client",
- "wayland-protocols",
- "wayland-protocols-wlr",
  "wgpu",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "guido-macros"]
 [package]
 name = "guido"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 description = "A reactive Rust GUI library using wgpu for Wayland layer shell widgets"
 license = "MIT"
 
@@ -15,16 +15,11 @@ bytemuck = { version = "1.24", features = ["derive"] }
 glyphon = "0.10"
 cosmic-text = "0.16"
 smithay-client-toolkit = { version = "0.20", default-features = false, features = ["calloop", "xkbcommon"] }
-wayland-protocols = { version = "0.32", features = ["client", "staging"] }
-wayland-protocols-wlr = { version = "0.3", features = ["client"] }
-wayland-client = "0.31"
 wayland-backend = { version = "0.3", features = ["client_system"] }
 raw-window-handle = "0.6"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "webp"] }
 resvg = "0.45"
 pollster = "0.4"
-calloop = "0.14"
-calloop-wayland-source = "0.4"
 log = "0.4"
 env_logger = "0.11"
 bitflags = "2.4"

--- a/examples/component_example.rs
+++ b/examples/component_example.rs
@@ -14,7 +14,7 @@ pub struct Button {
 }
 
 impl Button {
-    fn render(&self) -> impl Widget {
+    fn render(&self) -> impl Widget + use<> {
         container()
             .padding(self.padding.get())
             .background(self.background.clone())
@@ -38,7 +38,7 @@ pub struct Card {
 }
 
 impl Card {
-    fn render(&self) -> impl Widget {
+    fn render(&self) -> impl Widget + use<> {
         container()
             .padding(16.0)
             .background(self.background.get())

--- a/examples/reactive_example.rs
+++ b/examples/reactive_example.rs
@@ -19,9 +19,11 @@ fn main() {
 
     // Spawn a background thread that increments count every 2 seconds
     // No need to clone signals anymore - they implement Copy!
-    thread::spawn(move || loop {
-        thread::sleep(Duration::from_secs(2));
-        count.update(|c| *c += 1);
+    thread::spawn(move || {
+        loop {
+            thread::sleep(Duration::from_secs(2));
+            count.update(|c| *c += 1);
+        }
     });
 
     // Build the reactive UI with event handlers

--- a/guido-macros/Cargo.toml
+++ b/guido-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "guido-macros"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 proc-macro = true

--- a/guido-macros/src/lib.rs
+++ b/guido-macros/src/lib.rs
@@ -1,6 +1,6 @@
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, Fields, ItemStruct, Meta, Type};
+use syn::{Fields, ItemStruct, Meta, Type, parse_macro_input};
 
 /// Attribute macro to create a reusable component with builder pattern that automatically implements Widget
 ///
@@ -75,10 +75,10 @@ pub fn component(_attr: TokenStream, input: TokenStream) -> TokenStream {
 
             if tokens_str.contains("default") {
                 // Extract default value between quotes
-                if let Some(start) = tokens_str.find('"') {
-                    if let Some(end) = tokens_str[start + 1..].find('"') {
-                        default_value = Some(tokens_str[start + 1..start + 1 + end].to_string());
-                    }
+                if let Some(start) = tokens_str.find('"')
+                    && let Some(end) = tokens_str[start + 1..].find('"')
+                {
+                    default_value = Some(tokens_str[start + 1..start + 1 + end].to_string());
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ pub mod renderer;
 pub use guido_macros::component;
 
 use layout::Constraints;
-use platform::{create_wayland_app, Anchor, Layer, WaylandWindowWrapper};
+use platform::{Anchor, Layer, WaylandWindowWrapper, create_wayland_app};
 use reactive::{
     clear_animation_flag, init_wakeup, set_system_clipboard, take_clipboard_change,
     take_cursor_change, take_frame_request, with_app_state, with_app_state_mut,
@@ -22,33 +22,33 @@ use reactive::{
 use renderer::{GpuContext, Renderer};
 use widgets::{Color, Widget};
 
-// Calloop imports for event-driven main loop
-use calloop::ping::make_ping;
-use calloop::EventLoop;
-use calloop_wayland_source::WaylandSource;
+// Calloop imports for event-driven main loop (via smithay-client-toolkit re-exports)
+use smithay_client_toolkit::reexports::calloop::EventLoop;
+use smithay_client_toolkit::reexports::calloop::ping::make_ping;
+use smithay_client_toolkit::reexports::calloop_wayland_source::WaylandSource;
 
 pub mod prelude {
     pub use crate::animation::{SpringConfig, TimingFunction, Transition};
     pub use crate::layout::{
-        at_least, at_most, Axis, Constraints, CrossAxisAlignment, Flex, Length, MainAxisAlignment,
-        Overlay, Size,
+        Axis, Constraints, CrossAxisAlignment, Flex, Length, MainAxisAlignment, Overlay, Size,
+        at_least, at_most,
     };
     pub use crate::platform::{Anchor, Layer};
     pub use crate::reactive::{
-        batch, create_computed, create_effect, create_signal, set_cursor, Computed, CursorIcon,
-        Effect, IntoMaybeDyn, MaybeDyn, ReadSignal, Signal, WriteSignal,
+        Computed, CursorIcon, Effect, IntoMaybeDyn, MaybeDyn, ReadSignal, Signal, WriteSignal,
+        batch, create_computed, create_effect, create_signal, set_cursor,
     };
     pub use crate::renderer::primitives::Shadow;
-    pub use crate::renderer::{measure_text, PaintContext};
+    pub use crate::renderer::{PaintContext, measure_text};
     pub use crate::transform::Transform;
     pub use crate::transform_origin::{HorizontalAnchor, TransformOrigin, VerticalAnchor};
     pub use crate::widgets::{
-        container, image, text, text_input, Border, Color, Container, ContentFit, Event,
-        EventResponse, GradientDirection, Image, ImageSource, IntoChildren, Key, LinearGradient,
-        Modifiers, MouseButton, Overflow, Padding, Rect, ScrollAxis, ScrollSource,
-        ScrollbarBuilder, ScrollbarVisibility, Selection, StateStyle, Text, TextInput, Widget,
+        Border, Color, Container, ContentFit, Event, EventResponse, GradientDirection, Image,
+        ImageSource, IntoChildren, Key, LinearGradient, Modifiers, MouseButton, Overflow, Padding,
+        Rect, ScrollAxis, ScrollSource, ScrollbarBuilder, ScrollbarVisibility, Selection,
+        StateStyle, Text, TextInput, Widget, container, image, text, text_input,
     };
-    pub use crate::{component, App, AppConfig};
+    pub use crate::{App, AppConfig, component};
 }
 
 pub struct AppConfig {
@@ -303,10 +303,10 @@ impl App {
                     }
                 )
             });
-            if has_paste_event {
-                if let Some(text) = wayland_state.read_external_clipboard(&connection) {
-                    set_system_clipboard(text);
-                }
+            if has_paste_event
+                && let Some(text) = wayland_state.read_external_clipboard(&connection)
+            {
+                set_system_clipboard(text);
             }
 
             // Dispatch input events to widgets

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -1,5 +1,5 @@
 pub mod wayland;
 
-pub use wayland::{create_wayland_app, WaylandState, WaylandWindowWrapper};
+pub use wayland::{WaylandState, WaylandWindowWrapper, create_wayland_app};
 
 pub use smithay_client_toolkit::shell::wlr_layer::{Anchor, Layer};

--- a/src/reactive/computed.rs
+++ b/src/reactive/computed.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use super::effect::Effect;
-use super::signal::{create_signal, Signal};
+use super::signal::{Signal, create_signal};
 
 struct ComputedInner<T> {
     signal: Signal<T>,

--- a/src/reactive/effect.rs
+++ b/src/reactive/effect.rs
@@ -1,4 +1,4 @@
-use super::runtime::{with_runtime, EffectId};
+use super::runtime::{EffectId, with_runtime};
 
 pub struct Effect {
     id: EffectId,

--- a/src/reactive/invalidation.rs
+++ b/src/reactive/invalidation.rs
@@ -1,10 +1,10 @@
 use std::cell::RefCell;
 use std::collections::HashSet;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::OnceLock;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 use bitflags::bitflags;
-use calloop::ping::Ping;
+use smithay_client_toolkit::reexports::calloop::ping::Ping;
 
 bitflags! {
     /// Flags indicating what aspects of rendering need to be updated

--- a/src/reactive/mod.rs
+++ b/src/reactive/mod.rs
@@ -14,14 +14,15 @@ pub use clipboard::{
     request_clipboard_read, set_system_clipboard, take_clipboard_change,
     take_clipboard_read_request,
 };
-pub use computed::{create_computed, Computed};
-pub use cursor::{get_current_cursor, set_cursor, take_cursor_change, CursorIcon};
-pub use effect::{create_effect, Effect};
+pub use computed::{Computed, create_computed};
+pub use cursor::{CursorIcon, get_current_cursor, set_cursor, take_cursor_change};
+pub use effect::{Effect, create_effect};
 pub use focus::{clear_focus, focused_widget, has_focus, release_focus, request_focus};
 pub use invalidation::{
-    clear_animation_flag, init_wakeup, request_animation_frame, request_frame, request_layout,
-    request_paint, take_frame_request, with_app_state, with_app_state_mut, ChangeFlags, WidgetId,
+    ChangeFlags, WidgetId, clear_animation_flag, init_wakeup, request_animation_frame,
+    request_frame, request_layout, request_paint, take_frame_request, with_app_state,
+    with_app_state_mut,
 };
 pub use maybe_dyn::{IntoMaybeDyn, MaybeDyn};
 pub use runtime::batch;
-pub use signal::{create_signal, ReadSignal, Signal, WriteSignal};
+pub use signal::{ReadSignal, Signal, WriteSignal, create_signal};

--- a/src/reactive/signal.rs
+++ b/src/reactive/signal.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 
 use super::invalidation::request_frame;
-use super::runtime::{try_with_runtime, SignalId};
+use super::runtime::{SignalId, try_with_runtime};
 use super::storage::{
     create_signal_value, get_signal_value, set_signal_value, update_signal_value, with_signal_value,
 };

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -14,7 +14,7 @@ use wgpu::{BufferUsages, Device, Queue, RenderPipeline};
 use self::image_texture::ImageTextureRenderer;
 use self::primitives::{ClipRegion, Gradient, RoundedRect, TexturedQuad, Transformable, Vertex};
 use self::text::TextRenderState;
-use self::text_texture::{TextTextureRenderer, QUALITY_MULTIPLIER};
+use self::text_texture::{QUALITY_MULTIPLIER, TextTextureRenderer};
 use crate::transform::Transform;
 use crate::transform_origin::TransformOrigin;
 use crate::widgets::image::{ContentFit, ImageSource};

--- a/src/widgets/container/scrollable.rs
+++ b/src/widgets/container/scrollable.rs
@@ -9,8 +9,8 @@ use crate::transform_origin::TransformOrigin;
 use crate::widgets::scroll::{ScrollAxis, ScrollbarAxis, ScrollbarVisibility};
 use crate::widgets::widget::{Event, EventResponse, MouseButton, ScrollSource, Widget};
 
-use super::animations::AnimationState;
 use super::Container;
+use super::animations::AnimationState;
 
 impl Container {
     /// Initialize scrollbar containers if scrolling is enabled and they don't exist yet
@@ -141,7 +141,7 @@ impl Container {
             ),
         };
 
-        if let Some(ref mut anim) = scale_anim {
+        if let Some(anim) = scale_anim {
             anim.animate_to(target_scale);
             if anim.is_animating() {
                 anim.advance();
@@ -152,7 +152,7 @@ impl Container {
         let current_scale = scale_anim.as_ref().map(|a| *a.current()).unwrap_or(1.0);
 
         // Layout and position track container
-        if let Some(ref mut track) = track_container {
+        if let Some(track) = track_container {
             let track_constraints = Constraints {
                 min_width: track_rect.width,
                 min_height: track_rect.height,
@@ -178,7 +178,7 @@ impl Container {
         }
 
         // Layout and position handle container
-        if let Some(ref mut handle) = handle_container {
+        if let Some(handle) = handle_container {
             let handle_constraints = Constraints {
                 min_width: handle_rect.width,
                 min_height: handle_rect.height,
@@ -244,23 +244,19 @@ impl Container {
                 // Check vertical scrollbar
                 if self.scroll_axis.allows_vertical()
                     && self.scroll_state.needs_vertical_scrollbar()
-                {
-                    if let Some(response) =
+                    && let Some(response) =
                         self.handle_scrollbar_click(ScrollbarAxis::Vertical, *x, *y, event)
-                    {
-                        return Some(response);
-                    }
+                {
+                    return Some(response);
                 }
 
                 // Check horizontal scrollbar
                 if self.scroll_axis.allows_horizontal()
                     && self.scroll_state.needs_horizontal_scrollbar()
-                {
-                    if let Some(response) =
+                    && let Some(response) =
                         self.handle_scrollbar_click(ScrollbarAxis::Horizontal, *x, *y, event)
-                    {
-                        return Some(response);
-                    }
+                {
+                    return Some(response);
                 }
             }
 
@@ -379,7 +375,7 @@ impl Container {
                 ScrollbarAxis::Vertical => &mut self.v_scrollbar_handle,
                 ScrollbarAxis::Horizontal => &mut self.h_scrollbar_handle,
             };
-            if let Some(ref mut handle) = handle_container {
+            if let Some(handle) = handle_container {
                 handle.event(event);
             }
 
@@ -512,7 +508,7 @@ impl Container {
             ScrollbarAxis::Vertical => &mut self.v_scrollbar_handle,
             ScrollbarAxis::Horizontal => &mut self.h_scrollbar_handle,
         };
-        if let Some(ref mut handle) = handle_container {
+        if let Some(handle) = handle_container {
             handle.event(event);
         }
 

--- a/src/widgets/into_child.rs
+++ b/src/widgets/into_child.rs
@@ -1,5 +1,5 @@
-use super::children::{ChildrenSource, DynItem};
 use super::Widget;
+use super::children::{ChildrenSource, DynItem};
 
 /// Marker type for static child (widget value)
 pub struct StaticChild;

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -32,13 +32,13 @@ macro_rules! impl_dirty_flags {
 pub(crate) use impl_dirty_flags;
 
 pub use children::ChildrenSource;
-pub use container::{container, Border, Container, GradientDirection, LinearGradient, Overflow};
-pub use image::{image, ContentFit, Image, ImageSource};
+pub use container::{Border, Container, GradientDirection, LinearGradient, Overflow, container};
+pub use image::{ContentFit, Image, ImageSource, image};
 pub use into_child::{DynamicChildren, IntoChild, IntoChildren, StaticChildren};
 pub use scroll::{ScrollAxis, ScrollbarBuilder, ScrollbarConfig, ScrollbarVisibility};
 pub use state_layer::{BackgroundOverride, RippleConfig, StateStyle};
-pub use text::{text, Text};
-pub use text_input::{text_input, Selection, TextInput};
+pub use text::{Text, text};
+pub use text_input::{Selection, TextInput, text_input};
 pub use widget::{
     Color, Event, EventResponse, Key, Modifiers, MouseButton, Padding, Rect, ScrollSource, Widget,
 };

--- a/src/widgets/text.rs
+++ b/src/widgets/text.rs
@@ -1,6 +1,6 @@
 use crate::layout::{Constraints, Size};
 use crate::reactive::{ChangeFlags, IntoMaybeDyn, MaybeDyn, WidgetId};
-use crate::renderer::{measure_text, PaintContext};
+use crate::renderer::{PaintContext, measure_text};
 
 use super::impl_dirty_flags;
 use super::widget::{Color, EventResponse, Rect, Widget};

--- a/src/widgets/text_input.rs
+++ b/src/widgets/text_input.rs
@@ -13,10 +13,10 @@ use std::time::{Duration, Instant};
 
 use crate::layout::{Constraints, Size};
 use crate::reactive::{
-    clipboard_copy, clipboard_paste, has_focus, release_focus, request_animation_frame,
-    request_focus, set_cursor, ChangeFlags, CursorIcon, IntoMaybeDyn, MaybeDyn, Signal, WidgetId,
+    ChangeFlags, CursorIcon, IntoMaybeDyn, MaybeDyn, Signal, WidgetId, clipboard_copy,
+    clipboard_paste, has_focus, release_focus, request_animation_frame, request_focus, set_cursor,
 };
-use crate::renderer::{char_index_from_x, measure_text, PaintContext};
+use crate::renderer::{PaintContext, char_index_from_x, measure_text};
 
 use super::impl_dirty_flags;
 use super::widget::{Color, Event, EventResponse, Key, Modifiers, MouseButton, Rect, Widget};
@@ -89,10 +89,10 @@ impl History {
         let since_last = now.duration_since(self.last_edit_time);
 
         // Don't push if it's the same as the last entry
-        if let Some(last) = self.undo_stack.back() {
-            if last.text == entry.text {
-                return;
-            }
+        if let Some(last) = self.undo_stack.back()
+            && last.text == entry.text
+        {
+            return;
         }
 
         // Coalesce similar edits within the time window
@@ -1090,10 +1090,10 @@ impl Widget for TextInput {
             }
             Event::KeyUp { key, .. } => {
                 // Stop repeating when key is released
-                if let Some((pressed_key, _)) = self.pressed_key {
-                    if pressed_key == *key {
-                        self.pressed_key = None;
-                    }
+                if let Some((pressed_key, _)) = self.pressed_key
+                    && pressed_key == *key
+                {
+                    self.pressed_key = None;
                 }
             }
             Event::FocusOut => {


### PR DESCRIPTION
## Summary

- Drop 5 redundant Wayland dependencies by using smithay-client-toolkit's re-exports
- Update to Rust 2024 edition with all necessary code changes

## Dependency Changes

| Dependency | Version | Replacement |
|------------|---------|-------------|
| `calloop` | 0.14 | `smithay_client_toolkit::reexports::calloop` |
| `calloop-wayland-source` | 0.4 | `smithay_client_toolkit::reexports::calloop_wayland_source` |
| `wayland-client` | 0.31 | `smithay_client_toolkit::reexports::client` |
| `wayland-protocols` | 0.32 | `smithay_client_toolkit::reexports::protocols` |
| `wayland-protocols-wlr` | 0.3 | `smithay_client_toolkit::reexports::protocols_wlr` |

Kept `wayland-backend` (0.3) as it's required for `ObjectId::as_ptr()` and `Backend::display_ptr()` to get raw pointers for wgpu's raw-window-handle.

## Rust 2024 Edition Changes

- Remove explicit `ref mut` in pattern matching (implicit borrowing rules)
- Collapse nested if-let statements using let-chains (RFC 3498)
- Use `impl Widget + use<>` syntax for component render methods to explicitly not capture `&self` lifetime (RFC 3498 lifetime capture rules)
- Apply cargo fmt formatting changes

## Test plan

- [x] `cargo check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test` passes (109 tests)
- [x] All examples build and run correctly