### PR TITLE
Add dynamic layer shell surface property modification

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,8 +102,15 @@ cargo test
 **`platform/`** - Wayland layer shell integration
 - Uses smithay-client-toolkit for Wayland protocol handling
 - Supports layer shell positioning (top, bottom, overlay) and anchoring
+- Keyboard interactivity modes (None, OnDemand, Exclusive)
 - Event loop integration via calloop
-- Mouse and scroll event handling
+- Mouse, scroll, and keyboard event handling
+
+**`surface.rs`** - Multi-surface management
+- `SurfaceConfig`: Configuration for surfaces (size, anchor, layer, keyboard mode)
+- `SurfaceHandle`: Control handle for modifying surface properties at runtime
+- `spawn_surface()`: Create surfaces dynamically
+- `surface_handle()`: Get a handle for any surface by ID
 
 **`layout/`** - Constraint-based layout system
 - `Constraints`: min/max width/height bounds for sizing
@@ -198,14 +205,28 @@ let view = container()
 ### App Configuration
 
 ```rust
-App::new()
-    .width(1920)
-    .height(32)
-    .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
-    .layer(Layer::Top)
-    .namespace("my-app")
-    .background_color(Color::rgb(0.1, 0.1, 0.15))
-    .run(view);
+let (app, surface_id) = App::new().add_surface(
+    SurfaceConfig::new()
+        .height(32)
+        .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+        .layer(Layer::Top)
+        .keyboard_interactivity(KeyboardInteractivity::OnDemand)
+        .namespace("my-app")
+        .background_color(Color::rgb(0.1, 0.1, 0.15)),
+    move || view,
+);
+app.run();
+```
+
+### Dynamic Surface Properties
+
+Modify surface properties at runtime via `SurfaceHandle`:
+
+```rust
+// Get handle for a surface added via add_surface()
+let handle = surface_handle(surface_id);
+handle.set_layer(Layer::Overlay);
+handle.set_keyboard_interactivity(KeyboardInteractivity::Exclusive);
 ```
 
 ### Integrating Background Threads
@@ -308,7 +329,10 @@ This is a work-in-progress GUI library. Current implemented features:
 - Transform system (translate, rotate, scale) with animations
 - SDF-based rendering with superellipse corners and crisp borders
 - Mouse event handling with proper transform hit testing
+- Multi-surface support with shared reactive state
+- Dynamic surface property modification (layer, keyboard interactivity, anchor, size, margins)
+- Text input widget with full editing support
+- Image widget with raster and SVG support
 
 Planned features (see TODO.md):
-- Additional widgets (input text, images, toggles)
 - Relayout boundaries for performance optimization

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Guido is a GPU-accelerated GUI library for building Wayland layer shell applicat
 - **State Layer System** - Declarative hover/pressed style overrides with animations and Material-style ripple effects
 - **GPU Rendering** - Hardware-accelerated rendering via wgpu with SDF-based shapes
 - **Transform System** - Translate, rotate, and scale widgets with proper hit testing and animations
-- **Multi-Surface Apps** - Create multiple layer shell surfaces that share reactive state
+- **Multi-Surface Apps** - Create multiple layer shell surfaces that share reactive state, with dynamic property modification
 - **Superellipse Corners** - Configurable corner curvature from squircle (iOS-style) to bevel to scoop
 - **SDF Borders** - Crisp anti-aliased borders using signed distance field rendering
 - **Composable Widgets** - Build UIs from minimal primitives with pluggable Flex layout
@@ -41,36 +41,35 @@ use guido::prelude::*;
 fn main() {
     let count = create_signal(0);
 
-    App::new()
-        .add_surface(
-            SurfaceConfig::new()
-                .height(48)
-                .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
-                .layer(Layer::Top)
-                .background_color(Color::rgb(0.1, 0.1, 0.15)),
-            move || {
-                container()
-                    .height(fill())
-                    .layout(
-                        Flex::row()
-                            .spacing(16.0)
-                            .cross_axis_alignment(CrossAxisAlignment::Center),
-                    )
-                    .padding_xy(16.0, 0.0)
-                    .child(text(move || format!("Count: {}", count.get())).color(Color::WHITE))
-                    .child(
-                        container()
-                            .background(Color::rgb(0.3, 0.3, 0.4))
-                            .corner_radius(8.0)
-                            .padding(8.0)
-                            .hover_state(|s| s.lighter(0.1))
-                            .pressed_state(|s| s.ripple())
-                            .on_click(move || count.update(|c| *c += 1))
-                            .child(text("Click me").color(Color::WHITE)),
-                    )
-            },
-        )
-        .run();
+    let (app, _) = App::new().add_surface(
+        SurfaceConfig::new()
+            .height(48)
+            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+            .layer(Layer::Top)
+            .background_color(Color::rgb(0.1, 0.1, 0.15)),
+        move || {
+            container()
+                .height(fill())
+                .layout(
+                    Flex::row()
+                        .spacing(16.0)
+                        .cross_axis_alignment(CrossAxisAlignment::Center),
+                )
+                .padding_xy(16.0, 0.0)
+                .child(text(move || format!("Count: {}", count.get())).color(Color::WHITE))
+                .child(
+                    container()
+                        .background(Color::rgb(0.3, 0.3, 0.4))
+                        .corner_radius(8.0)
+                        .padding(8.0)
+                        .hover_state(|s| s.lighter(0.1))
+                        .pressed_state(|s| s.ripple())
+                        .on_click(move || count.update(|c| *c += 1))
+                        .child(text("Click me").color(Color::WHITE)),
+                )
+        },
+    );
+    app.run();
 }
 ```
 
@@ -98,6 +97,7 @@ cargo run --example component_example
 - **status_bar** - Basic status bar layout demonstration
 - **reactive_example** - Interactive features with signals and state layers
 - **multi_surface** - Multiple surfaces with shared reactive state
+- **surface_properties_example** - Dynamic surface property modification (layer, keyboard interactivity)
 - **state_layer_example** - Hover, pressed states, and ripple effects
 - **transform_example** - Rotation, scale, and animated transforms
 - **animation_example** - Spring and eased animations

--- a/book/src/advanced/wayland.md
+++ b/book/src/advanced/wayland.md
@@ -7,19 +7,21 @@ Guido uses the Wayland layer shell protocol for positioning widgets on the deskt
 Each surface is configured using `SurfaceConfig`:
 
 ```rust
-App::new()
-    .add_surface(
-        SurfaceConfig::new()
-            .width(1920)
-            .height(32)
-            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
-            .layer(Layer::Top)
-            .namespace("my-status-bar")
-            .background_color(Color::rgb(0.1, 0.1, 0.15)),
-        || view,
-    )
-    .run();
+let (app, _surface_id) = App::new().add_surface(
+    SurfaceConfig::new()
+        .width(1920)
+        .height(32)
+        .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+        .layer(Layer::Top)
+        .keyboard_interactivity(KeyboardInteractivity::OnDemand)
+        .namespace("my-status-bar")
+        .background_color(Color::rgb(0.1, 0.1, 0.15)),
+    || view,
+);
+app.run();
 ```
+
+Note: `add_surface()` returns `(App, SurfaceId)`. The `SurfaceId` can be used to get a `SurfaceHandle` for dynamic property modification.
 
 ## Layers
 
@@ -42,6 +44,26 @@ SurfaceConfig::new().layer(Layer::Top)
 - **Bottom**: Dock bars (below windows but above background)
 - **Top**: Status bars, panels (above windows)
 - **Overlay**: Notifications, lock screens
+
+## Keyboard Interactivity
+
+Control how the surface receives keyboard focus:
+
+```rust
+SurfaceConfig::new().keyboard_interactivity(KeyboardInteractivity::OnDemand)
+```
+
+| Mode | Description |
+|------|-------------|
+| `None` | Surface never receives keyboard focus |
+| `OnDemand` | Surface receives focus when clicked (default) |
+| `Exclusive` | Surface grabs keyboard focus exclusively |
+
+### Use Cases
+
+- **None**: Status bars that only respond to mouse
+- **OnDemand**: Panels with text input fields
+- **Exclusive**: Lock screens, app launchers, modal dialogs
 
 ## Anchoring
 
@@ -157,57 +179,56 @@ fn main() {
     // Shared reactive state
     let count = create_signal(0);
 
-    App::new()
-        // Top status bar
-        .add_surface(
-            SurfaceConfig::new()
-                .height(32)
-                .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
-                .layer(Layer::Top)
-                .namespace("status-bar")
-                .background_color(Color::rgb(0.1, 0.1, 0.15)),
-            move || {
-                container()
-                    .height(fill())
-                    .layout(
-                        Flex::row()
-                            .main_axis_alignment(MainAxisAlignment::SpaceBetween)
-                            .cross_axis_alignment(CrossAxisAlignment::Center)
-                    )
-                    .padding_xy(16.0, 0.0)
-                    .child(text("Status Bar"))
-                    .child(text(move || format!("Count: {}", count.get())))
-            },
-        )
-        // Bottom dock
-        .add_surface(
-            SurfaceConfig::new()
-                .height(48)
-                .anchor(Anchor::BOTTOM | Anchor::LEFT | Anchor::RIGHT)
-                .layer(Layer::Top)
-                .namespace("dock")
-                .background_color(Color::rgb(0.15, 0.15, 0.2)),
-            move || {
-                container()
-                    .height(fill())
-                    .layout(
-                        Flex::row()
-                            .spacing(16.0)
-                            .main_axis_alignment(MainAxisAlignment::Center)
-                            .cross_axis_alignment(CrossAxisAlignment::Center)
-                    )
-                    .child(
-                        container()
-                            .padding_xy(16.0, 8.0)
-                            .background(Color::rgb(0.3, 0.3, 0.4))
-                            .corner_radius(8.0)
-                            .hover_state(|s| s.lighter(0.1))
-                            .on_click(move || count.update(|c| *c += 1))
-                            .child(text("+").color(Color::WHITE))
-                    )
-            },
-        )
-        .run();
+    // Top status bar
+    let (app, _bar_id) = App::new().add_surface(
+        SurfaceConfig::new()
+            .height(32)
+            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+            .layer(Layer::Top)
+            .namespace("status-bar")
+            .background_color(Color::rgb(0.1, 0.1, 0.15)),
+        move || {
+            container()
+                .height(fill())
+                .layout(
+                    Flex::row()
+                        .main_axis_alignment(MainAxisAlignment::SpaceBetween)
+                        .cross_axis_alignment(CrossAxisAlignment::Center)
+                )
+                .padding_xy(16.0, 0.0)
+                .child(text("Status Bar"))
+                .child(text(move || format!("Count: {}", count.get())))
+        },
+    );
+    // Bottom dock
+    let (app, _dock_id) = app.add_surface(
+        SurfaceConfig::new()
+            .height(48)
+            .anchor(Anchor::BOTTOM | Anchor::LEFT | Anchor::RIGHT)
+            .layer(Layer::Top)
+            .namespace("dock")
+            .background_color(Color::rgb(0.15, 0.15, 0.2)),
+        move || {
+            container()
+                .height(fill())
+                .layout(
+                    Flex::row()
+                        .spacing(16.0)
+                        .main_axis_alignment(MainAxisAlignment::Center)
+                        .cross_axis_alignment(CrossAxisAlignment::Center)
+                )
+                .child(
+                    container()
+                        .padding_xy(16.0, 8.0)
+                        .background(Color::rgb(0.3, 0.3, 0.4))
+                        .corner_radius(8.0)
+                        .hover_state(|s| s.lighter(0.1))
+                        .on_click(move || count.update(|c| *c += 1))
+                        .child(text("+").color(Color::WHITE))
+                )
+        },
+    );
+    app.run();
 }
 ```
 
@@ -229,63 +250,99 @@ fn main() {
     let popup_handle: Rc<RefCell<Option<SurfaceHandle>>> = Rc::new(RefCell::new(None));
     let popup_clone = popup_handle.clone();
 
-    App::new()
-        .add_surface(
-            SurfaceConfig::new()
-                .height(32)
-                .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT),
-            move || {
-                container()
-                    .child(
-                        container()
-                            .padding(8.0)
-                            .hover_state(|s| s.lighter(0.1))
-                            .on_click({
-                                let popup_handle = popup_clone.clone();
-                                move || {
-                                    let mut handle = popup_handle.borrow_mut();
-                                    if let Some(h) = handle.take() {
-                                        // Close existing popup
-                                        h.close();
-                                    } else {
-                                        // Create new popup
-                                        let new_handle = spawn_surface(
-                                            SurfaceConfig::new()
-                                                .width(200)
-                                                .height(300)
-                                                .anchor(Anchor::TOP | Anchor::RIGHT)
-                                                .layer(Layer::Overlay),
-                                            || {
-                                                container()
-                                                    .padding(16.0)
-                                                    .child(text("Popup Content"))
-                                            }
-                                        );
-                                        *handle = Some(new_handle);
-                                    }
+    let (app, _) = App::new().add_surface(
+        SurfaceConfig::new()
+            .height(32)
+            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT),
+        move || {
+            container()
+                .child(
+                    container()
+                        .padding(8.0)
+                        .hover_state(|s| s.lighter(0.1))
+                        .on_click({
+                            let popup_handle = popup_clone.clone();
+                            move || {
+                                let mut handle = popup_handle.borrow_mut();
+                                if let Some(h) = handle.take() {
+                                    // Close existing popup
+                                    h.close();
+                                } else {
+                                    // Create new popup
+                                    let new_handle = spawn_surface(
+                                        SurfaceConfig::new()
+                                            .width(200)
+                                            .height(300)
+                                            .anchor(Anchor::TOP | Anchor::RIGHT)
+                                            .layer(Layer::Overlay)
+                                            .keyboard_interactivity(KeyboardInteractivity::Exclusive),
+                                        || {
+                                            container()
+                                                .padding(16.0)
+                                                .child(text("Popup Content"))
+                                        }
+                                    );
+                                    *handle = Some(new_handle);
                                 }
-                            })
-                            .child(text("Toggle Popup"))
-                    )
-            },
-        )
-        .run();
+                            }
+                        })
+                        .child(text("Toggle Popup"))
+                )
+        },
+    );
+    app.run();
 }
 ```
 
 ### SurfaceHandle API
 
+The `SurfaceHandle` allows controlling a surface after creation:
+
 ```rust
 impl SurfaceHandle {
-    /// Close the surface
+    /// Close and destroy the surface
     pub fn close(&self);
-
-    /// Check if still open
-    pub fn is_open(&self) -> bool;
 
     /// Get the surface ID
     pub fn id(&self) -> SurfaceId;
+
+    /// Change the layer (Background, Bottom, Top, Overlay)
+    pub fn set_layer(&self, layer: Layer);
+
+    /// Change keyboard interactivity mode
+    pub fn set_keyboard_interactivity(&self, mode: KeyboardInteractivity);
+
+    /// Change anchor edges
+    pub fn set_anchor(&self, anchor: Anchor);
+
+    /// Change surface size
+    pub fn set_size(&self, width: u32, height: u32);
+
+    /// Change exclusive zone
+    pub fn set_exclusive_zone(&self, zone: i32);
+
+    /// Change margins
+    pub fn set_margin(&self, top: i32, right: i32, bottom: i32, left: i32);
 }
+```
+
+### Getting a Handle for Existing Surfaces
+
+Use `surface_handle()` to get a handle for any surface by its ID:
+
+```rust
+// Store the ID when adding the surface
+let (app, status_bar_id) = App::new().add_surface(config, move || {
+    container()
+        .on_click(move || {
+            // Get handle and modify properties dynamically
+            let handle = surface_handle(status_bar_id);
+            handle.set_layer(Layer::Overlay);
+            handle.set_keyboard_interactivity(KeyboardInteractivity::Exclusive);
+        })
+        .child(text("Click to promote to overlay"))
+});
+app.run();
 ```
 
 ## Complete Examples
@@ -294,31 +351,30 @@ impl SurfaceHandle {
 
 ```rust
 fn main() {
-    App::new()
-        .add_surface(
-            SurfaceConfig::new()
-                .height(32)
-                .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
-                .layer(Layer::Top)
-                .exclusive_zone(32)
-                .namespace("status-bar")
-                .background_color(Color::rgb(0.1, 0.1, 0.15)),
-            || {
-                container()
-                    .height(fill())
-                    .layout(
-                        Flex::row()
-                            .main_axis_alignment(MainAxisAlignment::SpaceBetween)
-                            .cross_axis_alignment(CrossAxisAlignment::Center)
-                    )
-                    .children([
-                        left_section(),
-                        center_section(),
-                        right_section(),
-                    ])
-            },
-        )
-        .run();
+    let (app, _) = App::new().add_surface(
+        SurfaceConfig::new()
+            .height(32)
+            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+            .layer(Layer::Top)
+            .exclusive_zone(Some(32))
+            .namespace("status-bar")
+            .background_color(Color::rgb(0.1, 0.1, 0.15)),
+        || {
+            container()
+                .height(fill())
+                .layout(
+                    Flex::row()
+                        .main_axis_alignment(MainAxisAlignment::SpaceBetween)
+                        .cross_axis_alignment(CrossAxisAlignment::Center)
+                )
+                .children([
+                    left_section(),
+                    center_section(),
+                    right_section(),
+                ])
+        },
+    );
+    app.run();
 }
 ```
 
@@ -326,57 +382,56 @@ fn main() {
 
 ```rust
 fn main() {
-    App::new()
-        .add_surface(
-            SurfaceConfig::new()
-                .height(64)
-                .anchor(Anchor::BOTTOM | Anchor::LEFT | Anchor::RIGHT)
-                .layer(Layer::Top)
-                .exclusive_zone(64)
-                .namespace("dock")
-                .background_color(Color::rgba(0.1, 0.1, 0.15, 0.9)),
-            || {
-                container()
-                    .height(fill())
-                    .layout(
-                        Flex::row()
-                            .spacing(8.0)
-                            .main_axis_alignment(MainAxisAlignment::Center)
-                            .cross_axis_alignment(CrossAxisAlignment::Center)
-                    )
-                    .children([
-                        dock_icon("terminal"),
-                        dock_icon("browser"),
-                        dock_icon("files"),
-                    ])
-            },
-        )
-        .run();
+    let (app, _) = App::new().add_surface(
+        SurfaceConfig::new()
+            .height(64)
+            .anchor(Anchor::BOTTOM | Anchor::LEFT | Anchor::RIGHT)
+            .layer(Layer::Top)
+            .exclusive_zone(Some(64))
+            .namespace("dock")
+            .background_color(Color::rgba(0.1, 0.1, 0.15, 0.9)),
+        || {
+            container()
+                .height(fill())
+                .layout(
+                    Flex::row()
+                        .spacing(8.0)
+                        .main_axis_alignment(MainAxisAlignment::Center)
+                        .cross_axis_alignment(CrossAxisAlignment::Center)
+                )
+                .children([
+                    dock_icon("terminal"),
+                    dock_icon("browser"),
+                    dock_icon("files"),
+                ])
+        },
+    );
+    app.run();
 }
 ```
 
-### Floating Overlay
+### Floating Overlay with Keyboard Focus
 
 ```rust
 fn main() {
-    App::new()
-        .add_surface(
-            SurfaceConfig::new()
-                .width(300)
-                .height(100)
-                .anchor(Anchor::TOP | Anchor::RIGHT)
-                .layer(Layer::Overlay)
-                .namespace("notification")
-                .background_color(Color::TRANSPARENT),
-            || {
-                container()
-                    .padding(20.0)
-                    .background(Color::rgb(0.15, 0.15, 0.2))
-                    .corner_radius(12.0)
-                    .child(text("Notification").color(Color::WHITE))
-            },
-        )
-        .run();
+    let (app, _) = App::new().add_surface(
+        SurfaceConfig::new()
+            .width(300)
+            .height(100)
+            .anchor(Anchor::TOP | Anchor::RIGHT)
+            .layer(Layer::Overlay)
+            .keyboard_interactivity(KeyboardInteractivity::Exclusive)
+            .namespace("notification")
+            .background_color(Color::TRANSPARENT),
+        || {
+            container()
+                .padding(20.0)
+                .background(Color::rgb(0.15, 0.15, 0.2))
+                .corner_radius(12.0)
+                .child(text("Notification").color(Color::WHITE))
+        },
+    );
+    app.run();
 }
 ```
 
@@ -391,7 +446,8 @@ impl SurfaceConfig {
     pub fn height(self, height: u32) -> Self;
     pub fn anchor(self, anchor: Anchor) -> Self;
     pub fn layer(self, layer: Layer) -> Self;
-    pub fn exclusive_zone(self, zone: i32) -> Self;
+    pub fn keyboard_interactivity(self, mode: KeyboardInteractivity) -> Self;
+    pub fn exclusive_zone(self, zone: Option<i32>) -> Self;
     pub fn namespace(self, namespace: impl Into<String>) -> Self;
     pub fn background_color(self, color: Color) -> Self;
 }
@@ -402,7 +458,7 @@ impl SurfaceConfig {
 ```rust
 impl App {
     pub fn new() -> Self;
-    pub fn add_surface<W, F>(self, config: SurfaceConfig, widget_fn: F) -> Self
+    pub fn add_surface<W, F>(self, config: SurfaceConfig, widget_fn: F) -> (Self, SurfaceId)
     where
         W: Widget + 'static,
         F: FnOnce() -> W + 'static;
@@ -414,8 +470,27 @@ impl App {
 ### Dynamic Surface Creation
 
 ```rust
+/// Spawn a new surface at runtime
 pub fn spawn_surface<W, F>(config: SurfaceConfig, widget_fn: F) -> SurfaceHandle
 where
     W: Widget + 'static,
     F: FnOnce() -> W + Send + 'static;
+
+/// Get a handle for an existing surface by ID
+pub fn surface_handle(id: SurfaceId) -> SurfaceHandle;
+```
+
+### SurfaceHandle
+
+```rust
+impl SurfaceHandle {
+    pub fn id(&self) -> SurfaceId;
+    pub fn close(&self);
+    pub fn set_layer(&self, layer: Layer);
+    pub fn set_keyboard_interactivity(&self, mode: KeyboardInteractivity);
+    pub fn set_anchor(&self, anchor: Anchor);
+    pub fn set_size(&self, width: u32, height: u32);
+    pub fn set_exclusive_zone(&self, zone: i32);
+    pub fn set_margin(&self, top: i32, right: i32, bottom: i32, left: i32);
+}
 ```

--- a/book/src/getting-started/hello-world.md
+++ b/book/src/getting-started/hello-world.md
@@ -22,39 +22,38 @@ Replace `src/main.rs` with:
 use guido::prelude::*;
 
 fn main() {
-    App::new()
-        .add_surface(
-            SurfaceConfig::new()
-                .height(32)
-                .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
-                .background_color(Color::rgb(0.1, 0.1, 0.15)),
-            || {
-                container()
-                    .height(fill())
-                    .layout(
-                        Flex::row()
-                            .spacing(8.0)
-                            .main_axis_alignment(MainAxisAlignment::SpaceBetween)
-                            .cross_axis_alignment(CrossAxisAlignment::Center),
-                    )
-                    .child(
-                        container()
-                            .padding(8.0)
-                            .background(Color::rgb(0.2, 0.2, 0.3))
-                            .corner_radius(4.0)
-                            .child(text("Guido")),
-                    )
-                    .child(container().padding(8.0).child(text("Hello World!")))
-                    .child(
-                        container()
-                            .padding(8.0)
-                            .background(Color::rgb(0.3, 0.2, 0.2))
-                            .corner_radius(4.0)
-                            .child(text("Status Bar")),
-                    )
-            },
-        )
-        .run();
+    let (app, _) = App::new().add_surface(
+        SurfaceConfig::new()
+            .height(32)
+            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+            .background_color(Color::rgb(0.1, 0.1, 0.15)),
+        || {
+            container()
+                .height(fill())
+                .layout(
+                    Flex::row()
+                        .spacing(8.0)
+                        .main_axis_alignment(MainAxisAlignment::SpaceBetween)
+                        .cross_axis_alignment(CrossAxisAlignment::Center),
+                )
+                .child(
+                    container()
+                        .padding(8.0)
+                        .background(Color::rgb(0.2, 0.2, 0.3))
+                        .corner_radius(4.0)
+                        .child(text("Guido")),
+                )
+                .child(container().padding(8.0).child(text("Hello World!")))
+                .child(
+                    container()
+                        .padding(8.0)
+                        .background(Color::rgb(0.3, 0.2, 0.2))
+                        .corner_radius(4.0)
+                        .child(text("Status Bar")),
+                )
+        },
+    );
+    app.run();
 }
 ```
 
@@ -75,21 +74,22 @@ The prelude imports everything you need: widgets, colors, layout types, and reac
 ### Surface Configuration
 
 ```rust
-App::new()
-    .add_surface(
-        SurfaceConfig::new()
-            .height(32)
-            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
-            .background_color(Color::rgb(0.1, 0.1, 0.15)),
-        || { /* widget tree */ },
-    )
-    .run();
+let (app, _surface_id) = App::new().add_surface(
+    SurfaceConfig::new()
+        .height(32)
+        .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+        .background_color(Color::rgb(0.1, 0.1, 0.15)),
+    || { /* widget tree */ },
+);
+app.run();
 ```
 
 The `SurfaceConfig` defines how the window appears:
 - **Height** - 32 pixels tall
 - **Anchor** - Attached to top, left, and right edges (full width)
 - **Background color** - Dark background for the bar
+
+Note: `add_surface()` returns a tuple `(App, SurfaceId)`. The `SurfaceId` can be used later to get a `SurfaceHandle` for modifying surface properties dynamically.
 
 ### Building the View
 
@@ -150,42 +150,41 @@ use guido::prelude::*;
 fn main() {
     let count = create_signal(0);
 
-    App::new()
-        .add_surface(
-            SurfaceConfig::new()
-                .height(32)
-                .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
-                .background_color(Color::rgb(0.1, 0.1, 0.15)),
-            move || {
-                container()
-                    .height(fill())
-                    .layout(
-                        Flex::row()
-                            .spacing(8.0)
-                            .main_axis_alignment(MainAxisAlignment::SpaceBetween)
-                            .cross_axis_alignment(CrossAxisAlignment::Center),
-                    )
-                    .child(
-                        container()
-                            .padding(8.0)
-                            .background(Color::rgb(0.2, 0.2, 0.3))
-                            .corner_radius(4.0)
-                            .hover_state(|s| s.lighter(0.1))
-                            .pressed_state(|s| s.ripple())
-                            .on_click(move || count.update(|c| *c += 1))
-                            .child(text(move || format!("Clicks: {}", count.get()))),
-                    )
-                    .child(container().padding(8.0).child(text("Hello World!")))
-                    .child(
-                        container()
-                            .padding(8.0)
-                            .background(Color::rgb(0.3, 0.2, 0.2))
-                            .corner_radius(4.0)
-                            .child(text("Status Bar")),
-                    )
-            },
-        )
-        .run();
+    let (app, _) = App::new().add_surface(
+        SurfaceConfig::new()
+            .height(32)
+            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+            .background_color(Color::rgb(0.1, 0.1, 0.15)),
+        move || {
+            container()
+                .height(fill())
+                .layout(
+                    Flex::row()
+                        .spacing(8.0)
+                        .main_axis_alignment(MainAxisAlignment::SpaceBetween)
+                        .cross_axis_alignment(CrossAxisAlignment::Center),
+                )
+                .child(
+                    container()
+                        .padding(8.0)
+                        .background(Color::rgb(0.2, 0.2, 0.3))
+                        .corner_radius(4.0)
+                        .hover_state(|s| s.lighter(0.1))
+                        .pressed_state(|s| s.ripple())
+                        .on_click(move || count.update(|c| *c += 1))
+                        .child(text(move || format!("Clicks: {}", count.get()))),
+                )
+                .child(container().padding(8.0).child(text("Hello World!")))
+                .child(
+                    container()
+                        .padding(8.0)
+                        .background(Color::rgb(0.3, 0.2, 0.2))
+                        .corner_radius(4.0)
+                        .child(text("Status Bar")),
+                )
+        },
+    );
+    app.run();
 }
 ```
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -112,8 +112,29 @@ Layer shell protocol implementation for desktop widgets.
 - Smithay-client-toolkit for Wayland protocols
 - Layer shell positioning (Top, Bottom, Overlay, Background)
 - Anchor edges (TOP, BOTTOM, LEFT, RIGHT combinations)
+- Keyboard interactivity modes (None, OnDemand, Exclusive)
 - Exclusive zones for panels
 - Event loop via calloop
+- Dynamic surface property modification via `SurfaceHandle`
+
+### `surface.rs` - Surface Management
+
+Handles surface creation, configuration, and runtime modification.
+
+**Key Types:**
+- `SurfaceConfig` - Configuration for new surfaces (size, anchor, layer, keyboard mode)
+- `SurfaceId` - Unique identifier for each surface
+- `SurfaceHandle` - Control handle for modifying surface properties
+
+**Dynamic Properties:**
+Surfaces can be modified at runtime through `SurfaceHandle`:
+```rust
+let handle = surface_handle(surface_id);
+handle.set_layer(Layer::Overlay);
+handle.set_keyboard_interactivity(KeyboardInteractivity::Exclusive);
+handle.set_anchor(Anchor::TOP | Anchor::RIGHT);
+handle.set_size(400, 300);
+```
 
 ### `transform.rs` - 2D Transforms
 
@@ -212,6 +233,7 @@ Planned optimization to limit layout recalculation scope. See TODO.md for detail
 | File | Purpose |
 |------|---------|
 | `src/lib.rs` | App entry, main event loop |
+| `src/surface.rs` | Surface config, handles, dynamic properties |
 | `src/widgets/container.rs` | Container widget implementation |
 | `src/widgets/state_layer.rs` | State layer types and logic |
 | `src/renderer/mod.rs` | Main renderer, GPU setup |

--- a/examples/animation_example.rs
+++ b/examples/animation_example.rs
@@ -4,33 +4,32 @@ fn main() {
     // State signals for animations
     let expanded = create_signal(false);
 
-    App::new()
-        .add_surface(
-            SurfaceConfig::new()
-                .width(800)
-                .height(400)
-                .anchor(Anchor::TOP | Anchor::LEFT)
-                .background_color(Color::rgb(0.08, 0.08, 0.12)),
-            move || {
-                container()
-                    .background(Color::rgb(0.08, 0.08, 0.12))
-                    .padding(20.0)
-                    .layout(Flex::column().spacing(20.0))
-                    .children([
-                        // Row 1
-                        container().layout(Flex::row().spacing(20.0)).children([
-                            create_width_animation_card(expanded),
-                            create_color_animation_card(),
-                        ]),
-                        // Row 2
-                        container().layout(Flex::row().spacing(20.0)).children([
-                            create_combined_animation_card(),
-                            create_border_animation_card(),
-                        ]),
-                    ])
-            },
-        )
-        .run();
+    let (app, _) = App::new().add_surface(
+        SurfaceConfig::new()
+            .width(800)
+            .height(400)
+            .anchor(Anchor::TOP | Anchor::LEFT)
+            .background_color(Color::rgb(0.08, 0.08, 0.12)),
+        move || {
+            container()
+                .background(Color::rgb(0.08, 0.08, 0.12))
+                .padding(20.0)
+                .layout(Flex::column().spacing(20.0))
+                .children([
+                    // Row 1
+                    container().layout(Flex::row().spacing(20.0)).children([
+                        create_width_animation_card(expanded),
+                        create_color_animation_card(),
+                    ]),
+                    // Row 2
+                    container().layout(Flex::row().spacing(20.0)).children([
+                        create_combined_animation_card(),
+                        create_border_animation_card(),
+                    ]),
+                ])
+        },
+    );
+    app.run();
 }
 
 /// Card demonstrating width animation with spring physics

--- a/examples/children_example.rs
+++ b/examples/children_example.rs
@@ -427,14 +427,13 @@ fn main() {
         )
         );
 
-    App::new()
-        .add_surface(
-            SurfaceConfig::new()
-                .width(1800)
-                .height(450)
-                .anchor(Anchor::TOP | Anchor::LEFT)
-                .background_color(Color::rgb(0.1, 0.1, 0.15)),
-            move || view,
-        )
-        .run();
+    let (app, _) = App::new().add_surface(
+        SurfaceConfig::new()
+            .width(1800)
+            .height(450)
+            .anchor(Anchor::TOP | Anchor::LEFT)
+            .background_color(Color::rgb(0.1, 0.1, 0.15)),
+        move || view,
+    );
+    app.run();
 }

--- a/examples/component_example.rs
+++ b/examples/component_example.rs
@@ -56,131 +56,130 @@ fn main() {
     // No need to clone signals anymore - they implement Copy!
     let count = create_signal(0);
 
-    App::new()
-        .add_surface(
-            SurfaceConfig::new()
-                .width(600)
-                .height(500)
-                .anchor(Anchor::TOP | Anchor::LEFT)
-                .layer(Layer::Overlay)
-                .namespace("component-example")
-                .background_color(Color::rgb(0.1, 0.1, 0.15)),
-            move || {
-                container()
-                    .padding(16.0)
-                    .background(Color::rgb(0.1, 0.1, 0.15))
-                    .layout(Flex::column().spacing(12.0))
-                    .child(
-                        text("Component Example")
-                            .font_size(24.0)
-                            .color(Color::WHITE),
-                    )
-                    .child(
-                        card()
-                            .title("Counter")
-                            .background(Color::rgb(0.15, 0.2, 0.25))
-                            .child(
-                                text(move || format!("Count: {}", count.get()))
-                                    .font_size(16.0)
-                                    .color(Color::WHITE),
-                            )
-                            .child(
-                                container()
-                                    .layout(Flex::row().spacing(8.0))
-                                    .child(
-                                        button()
-                                            .label("Increment")
-                                            .background(Color::rgb(0.2, 0.6, 0.3))
-                                            .on_click(move || count.update(|c| *c += 1)),
-                                    )
-                                    .child(
-                                        button()
-                                            .label("Decrement")
-                                            .background(Color::rgb(0.6, 0.2, 0.2))
-                                            .on_click(move || count.update(|c| *c -= 1)),
-                                    )
-                                    .child(
-                                        button()
-                                            .label("Reset")
-                                            .background(Color::rgb(0.4, 0.4, 0.5))
-                                            .on_click(move || count.set(0)),
-                                    ),
-                            ),
-                    )
-                    .child(
-                        card()
-                            .title("Static Content")
-                            .child(
-                                text("This is a card with static content.")
-                                    .color(Color::rgb(0.8, 0.8, 0.8)),
-                            )
-                            .child(
-                                text("Cards can have multiple children.")
-                                    .color(Color::rgb(0.8, 0.8, 0.8)),
-                            ),
-                    )
-                    .child(
-                        card().title("Styled Buttons").child(
+    let (app, _) = App::new().add_surface(
+        SurfaceConfig::new()
+            .width(600)
+            .height(500)
+            .anchor(Anchor::TOP | Anchor::LEFT)
+            .layer(Layer::Overlay)
+            .namespace("component-example")
+            .background_color(Color::rgb(0.1, 0.1, 0.15)),
+        move || {
+            container()
+                .padding(16.0)
+                .background(Color::rgb(0.1, 0.1, 0.15))
+                .layout(Flex::column().spacing(12.0))
+                .child(
+                    text("Component Example")
+                        .font_size(24.0)
+                        .color(Color::WHITE),
+                )
+                .child(
+                    card()
+                        .title("Counter")
+                        .background(Color::rgb(0.15, 0.2, 0.25))
+                        .child(
+                            text(move || format!("Count: {}", count.get()))
+                                .font_size(16.0)
+                                .color(Color::WHITE),
+                        )
+                        .child(
                             container()
                                 .layout(Flex::row().spacing(8.0))
                                 .child(
                                     button()
-                                        .label("Primary")
-                                        .background(Color::rgb(0.2, 0.4, 0.8))
-                                        .padding(12.0)
-                                        .on_click(|| println!("Primary clicked")),
+                                        .label("Increment")
+                                        .background(Color::rgb(0.2, 0.6, 0.3))
+                                        .on_click(move || count.update(|c| *c += 1)),
                                 )
                                 .child(
                                     button()
-                                        .label("Secondary")
-                                        .background(Color::rgb(0.5, 0.5, 0.6))
-                                        .padding(12.0)
-                                        .on_click(|| println!("Secondary clicked")),
+                                        .label("Decrement")
+                                        .background(Color::rgb(0.6, 0.2, 0.2))
+                                        .on_click(move || count.update(|c| *c -= 1)),
                                 )
                                 .child(
                                     button()
-                                        .label("Danger")
-                                        .background(Color::rgb(0.8, 0.2, 0.2))
-                                        .padding(12.0)
-                                        .on_click(|| println!("Danger clicked")),
+                                        .label("Reset")
+                                        .background(Color::rgb(0.4, 0.4, 0.5))
+                                        .on_click(move || count.set(0)),
                                 ),
                         ),
-                    )
-                    .child(
-                        card()
-                            .title("Reactive Props Example")
-                            .background(move || {
-                                // Card background changes based on count
-                                if count.get() > 5 {
-                                    Color::rgb(0.2, 0.3, 0.2)
-                                } else if count.get() < -5 {
-                                    Color::rgb(0.3, 0.2, 0.2)
-                                } else {
-                                    Color::rgb(0.18, 0.18, 0.22)
-                                }
-                            })
+                )
+                .child(
+                    card()
+                        .title("Static Content")
+                        .child(
+                            text("This is a card with static content.")
+                                .color(Color::rgb(0.8, 0.8, 0.8)),
+                        )
+                        .child(
+                            text("Cards can have multiple children.")
+                                .color(Color::rgb(0.8, 0.8, 0.8)),
+                        ),
+                )
+                .child(
+                    card().title("Styled Buttons").child(
+                        container()
+                            .layout(Flex::row().spacing(8.0))
                             .child(
-                                text("The card background changes color based on the count value.")
-                                    .color(Color::rgb(0.8, 0.8, 0.8)),
+                                button()
+                                    .label("Primary")
+                                    .background(Color::rgb(0.2, 0.4, 0.8))
+                                    .padding(12.0)
+                                    .on_click(|| println!("Primary clicked")),
                             )
                             .child(
-                                container().layout(Flex::row().spacing(8.0)).child(
-                                    button()
-                                        .label(move || format!("Count is {}", count.get()))
-                                        .background(move || {
-                                            // Button color changes based on count
-                                            let c = count.get();
-                                            if c % 2 == 0 {
-                                                Color::rgb(0.3, 0.5, 0.7)
-                                            } else {
-                                                Color::rgb(0.7, 0.5, 0.3)
-                                            }
-                                        })
-                                        .on_click(move || count.update(|c| *c += 1)),
-                                ),
+                                button()
+                                    .label("Secondary")
+                                    .background(Color::rgb(0.5, 0.5, 0.6))
+                                    .padding(12.0)
+                                    .on_click(|| println!("Secondary clicked")),
+                            )
+                            .child(
+                                button()
+                                    .label("Danger")
+                                    .background(Color::rgb(0.8, 0.2, 0.2))
+                                    .padding(12.0)
+                                    .on_click(|| println!("Danger clicked")),
                             ),
-                    )
-            },
-        )
-        .run();
+                    ),
+                )
+                .child(
+                    card()
+                        .title("Reactive Props Example")
+                        .background(move || {
+                            // Card background changes based on count
+                            if count.get() > 5 {
+                                Color::rgb(0.2, 0.3, 0.2)
+                            } else if count.get() < -5 {
+                                Color::rgb(0.3, 0.2, 0.2)
+                            } else {
+                                Color::rgb(0.18, 0.18, 0.22)
+                            }
+                        })
+                        .child(
+                            text("The card background changes color based on the count value.")
+                                .color(Color::rgb(0.8, 0.8, 0.8)),
+                        )
+                        .child(
+                            container().layout(Flex::row().spacing(8.0)).child(
+                                button()
+                                    .label(move || format!("Count is {}", count.get()))
+                                    .background(move || {
+                                        // Button color changes based on count
+                                        let c = count.get();
+                                        if c % 2 == 0 {
+                                            Color::rgb(0.3, 0.5, 0.7)
+                                        } else {
+                                            Color::rgb(0.7, 0.5, 0.3)
+                                        }
+                                    })
+                                    .on_click(move || count.update(|c| *c += 1)),
+                            ),
+                        ),
+                )
+        },
+    );
+    app.run();
 }

--- a/examples/elevation_example.rs
+++ b/examples/elevation_example.rs
@@ -10,164 +10,159 @@
 use guido::prelude::*;
 
 fn main() {
-    App::new()
-        .add_surface(
-            SurfaceConfig::new()
-                .width(600)
-                .height(280)
-                .anchor(Anchor::TOP | Anchor::LEFT)
-                .background_color(Color::rgb(0.85, 0.85, 0.9)),
-            || {
-                container()
-                    .layout(Flex::column().spacing(16.0))
-                    .child(
-                        // Row 1: Basic elevation levels
-                        container()
-                            .layout(Flex::row().spacing(16.0))
-                            .child(
-                                container()
-                                    .padding(16.0)
-                                    .background(Color::WHITE)
-                                    .corner_radius(8.0)
-                                    .elevation(0.0)
-                                    .child(
-                                        text("Level 0\n(No shadow)")
-                                            .color(Color::rgb(0.2, 0.2, 0.2)),
-                                    ),
-                            )
-                            .child(
-                                container()
-                                    .padding(16.0)
-                                    .background(Color::WHITE)
-                                    .corner_radius(8.0)
-                                    .elevation(1.0)
-                                    .child(text("Level 1").color(Color::rgb(0.2, 0.2, 0.2))),
-                            )
-                            .child(
-                                container()
-                                    .padding(16.0)
-                                    .background(Color::WHITE)
-                                    .corner_radius(8.0)
-                                    .elevation(2.0)
-                                    .child(text("Level 2").color(Color::rgb(0.2, 0.2, 0.2))),
-                            )
-                            .child(
-                                container()
-                                    .padding(16.0)
-                                    .background(Color::WHITE)
-                                    .corner_radius(8.0)
-                                    .elevation(3.0)
-                                    .child(text("Level 3").color(Color::rgb(0.2, 0.2, 0.2))),
-                            ),
-                    )
-                    .child(
-                        // Row 2: Higher elevation levels
-                        container()
-                            .layout(Flex::row().spacing(16.0))
-                            .child(
-                                container()
-                                    .padding(16.0)
-                                    .background(Color::WHITE)
-                                    .corner_radius(8.0)
-                                    .elevation(4.0)
-                                    .child(text("Level 4").color(Color::rgb(0.2, 0.2, 0.2))),
-                            )
-                            .child(
-                                container()
-                                    .padding(16.0)
-                                    .background(Color::WHITE)
-                                    .corner_radius(8.0)
-                                    .elevation(5.0)
-                                    .child(text("Level 5").color(Color::rgb(0.2, 0.2, 0.2))),
-                            )
-                            .child(
-                                container()
-                                    .padding(16.0)
-                                    .background(Color::WHITE)
-                                    .corner_radius(8.0)
-                                    .elevation(7.0)
-                                    .child(text("Level 7").color(Color::rgb(0.2, 0.2, 0.2))),
-                            )
-                            .child(
-                                container()
-                                    .padding(16.0)
-                                    .background(Color::WHITE)
-                                    .corner_radius(8.0)
-                                    .elevation(10.0)
-                                    .child(text("Level 10").color(Color::rgb(0.2, 0.2, 0.2))),
-                            ),
-                    )
-                    .child(
-                        // Row 3: Colored cards with elevation
-                        container()
-                            .layout(Flex::row().spacing(16.0))
-                            .child(
-                                container()
-                                    .padding(16.0)
-                                    .background(Color::rgb(0.9, 0.7, 0.7))
-                                    .corner_radius(12.0)
-                                    .elevation(2.0)
-                                    .child(text("Card 1").color(Color::rgb(0.3, 0.1, 0.1))),
-                            )
-                            .child(
-                                container()
-                                    .padding(16.0)
-                                    .background(Color::rgb(0.7, 0.9, 0.7))
-                                    .corner_radius(12.0)
-                                    .elevation(3.0)
-                                    .child(text("Card 2").color(Color::rgb(0.1, 0.3, 0.1))),
-                            )
-                            .child(
-                                container()
-                                    .padding(16.0)
-                                    .background(Color::rgb(0.7, 0.7, 0.9))
-                                    .corner_radius(12.0)
-                                    .elevation(4.0)
-                                    .child(text("Card 3").color(Color::rgb(0.1, 0.1, 0.3))),
-                            ),
-                    )
-                    .child(
-                        // Row 4: Squircle with elevation
-                        container()
-                            .layout(Flex::row().spacing(16.0))
-                            .child(
-                                container()
-                                    .padding(16.0)
-                                    .background(Color::rgb(0.95, 0.95, 0.95))
-                                    .corner_radius(16.0)
-                                    .squircle()
-                                    .elevation(2.0)
-                                    .child(
-                                        text("Squircle\nElevation 2")
-                                            .color(Color::rgb(0.2, 0.2, 0.2)),
-                                    ),
-                            )
-                            .child(
-                                container()
-                                    .padding(16.0)
-                                    .background(Color::rgb(0.95, 0.95, 0.95))
-                                    .corner_radius(16.0)
-                                    .squircle()
-                                    .elevation(4.0)
-                                    .child(
-                                        text("Squircle\nElevation 4")
-                                            .color(Color::rgb(0.2, 0.2, 0.2)),
-                                    ),
-                            )
-                            .child(
-                                container()
-                                    .padding(16.0)
-                                    .background(Color::rgb(0.95, 0.95, 0.95))
-                                    .corner_radius(16.0)
-                                    .squircle()
-                                    .elevation(6.0)
-                                    .child(
-                                        text("Squircle\nElevation 6")
-                                            .color(Color::rgb(0.2, 0.2, 0.2)),
-                                    ),
-                            ),
-                    )
-            },
-        )
-        .run();
+    let (app, _) = App::new().add_surface(
+        SurfaceConfig::new()
+            .width(600)
+            .height(280)
+            .anchor(Anchor::TOP | Anchor::LEFT)
+            .background_color(Color::rgb(0.85, 0.85, 0.9)),
+        || {
+            container()
+                .layout(Flex::column().spacing(16.0))
+                .child(
+                    // Row 1: Basic elevation levels
+                    container()
+                        .layout(Flex::row().spacing(16.0))
+                        .child(
+                            container()
+                                .padding(16.0)
+                                .background(Color::WHITE)
+                                .corner_radius(8.0)
+                                .elevation(0.0)
+                                .child(
+                                    text("Level 0\n(No shadow)").color(Color::rgb(0.2, 0.2, 0.2)),
+                                ),
+                        )
+                        .child(
+                            container()
+                                .padding(16.0)
+                                .background(Color::WHITE)
+                                .corner_radius(8.0)
+                                .elevation(1.0)
+                                .child(text("Level 1").color(Color::rgb(0.2, 0.2, 0.2))),
+                        )
+                        .child(
+                            container()
+                                .padding(16.0)
+                                .background(Color::WHITE)
+                                .corner_radius(8.0)
+                                .elevation(2.0)
+                                .child(text("Level 2").color(Color::rgb(0.2, 0.2, 0.2))),
+                        )
+                        .child(
+                            container()
+                                .padding(16.0)
+                                .background(Color::WHITE)
+                                .corner_radius(8.0)
+                                .elevation(3.0)
+                                .child(text("Level 3").color(Color::rgb(0.2, 0.2, 0.2))),
+                        ),
+                )
+                .child(
+                    // Row 2: Higher elevation levels
+                    container()
+                        .layout(Flex::row().spacing(16.0))
+                        .child(
+                            container()
+                                .padding(16.0)
+                                .background(Color::WHITE)
+                                .corner_radius(8.0)
+                                .elevation(4.0)
+                                .child(text("Level 4").color(Color::rgb(0.2, 0.2, 0.2))),
+                        )
+                        .child(
+                            container()
+                                .padding(16.0)
+                                .background(Color::WHITE)
+                                .corner_radius(8.0)
+                                .elevation(5.0)
+                                .child(text("Level 5").color(Color::rgb(0.2, 0.2, 0.2))),
+                        )
+                        .child(
+                            container()
+                                .padding(16.0)
+                                .background(Color::WHITE)
+                                .corner_radius(8.0)
+                                .elevation(7.0)
+                                .child(text("Level 7").color(Color::rgb(0.2, 0.2, 0.2))),
+                        )
+                        .child(
+                            container()
+                                .padding(16.0)
+                                .background(Color::WHITE)
+                                .corner_radius(8.0)
+                                .elevation(10.0)
+                                .child(text("Level 10").color(Color::rgb(0.2, 0.2, 0.2))),
+                        ),
+                )
+                .child(
+                    // Row 3: Colored cards with elevation
+                    container()
+                        .layout(Flex::row().spacing(16.0))
+                        .child(
+                            container()
+                                .padding(16.0)
+                                .background(Color::rgb(0.9, 0.7, 0.7))
+                                .corner_radius(12.0)
+                                .elevation(2.0)
+                                .child(text("Card 1").color(Color::rgb(0.3, 0.1, 0.1))),
+                        )
+                        .child(
+                            container()
+                                .padding(16.0)
+                                .background(Color::rgb(0.7, 0.9, 0.7))
+                                .corner_radius(12.0)
+                                .elevation(3.0)
+                                .child(text("Card 2").color(Color::rgb(0.1, 0.3, 0.1))),
+                        )
+                        .child(
+                            container()
+                                .padding(16.0)
+                                .background(Color::rgb(0.7, 0.7, 0.9))
+                                .corner_radius(12.0)
+                                .elevation(4.0)
+                                .child(text("Card 3").color(Color::rgb(0.1, 0.1, 0.3))),
+                        ),
+                )
+                .child(
+                    // Row 4: Squircle with elevation
+                    container()
+                        .layout(Flex::row().spacing(16.0))
+                        .child(
+                            container()
+                                .padding(16.0)
+                                .background(Color::rgb(0.95, 0.95, 0.95))
+                                .corner_radius(16.0)
+                                .squircle()
+                                .elevation(2.0)
+                                .child(
+                                    text("Squircle\nElevation 2").color(Color::rgb(0.2, 0.2, 0.2)),
+                                ),
+                        )
+                        .child(
+                            container()
+                                .padding(16.0)
+                                .background(Color::rgb(0.95, 0.95, 0.95))
+                                .corner_radius(16.0)
+                                .squircle()
+                                .elevation(4.0)
+                                .child(
+                                    text("Squircle\nElevation 4").color(Color::rgb(0.2, 0.2, 0.2)),
+                                ),
+                        )
+                        .child(
+                            container()
+                                .padding(16.0)
+                                .background(Color::rgb(0.95, 0.95, 0.95))
+                                .corner_radius(16.0)
+                                .squircle()
+                                .elevation(6.0)
+                                .child(
+                                    text("Squircle\nElevation 6").color(Color::rgb(0.2, 0.2, 0.2)),
+                                ),
+                        ),
+                )
+        },
+    );
+    app.run();
 }

--- a/examples/flex_layout_test.rs
+++ b/examples/flex_layout_test.rs
@@ -9,60 +9,59 @@
 use guido::prelude::*;
 
 fn main() {
-    App::new()
-        .add_surface(
-            SurfaceConfig::new()
-                .width(1000)
-                .height(400)
-                .anchor(Anchor::TOP | Anchor::LEFT)
-                .background_color(Color::rgb(0.08, 0.08, 0.1)),
-            || {
-                container()
-                    .layout(Flex::column().spacing(8.0))
-                    .padding(8.0)
-                    // Row tests side by side
-                    .child(
-                        container()
-                            .layout(Flex::row().spacing(16.0))
-                            .child(
-                                container()
-                                    .layout(Flex::column().spacing(3.0))
-                                    .child(section_title("Row - MainAxisAlignment"))
-                                    .child(row_main_axis_tests()),
-                            )
-                            .child(
-                                container()
-                                    .layout(Flex::column().spacing(3.0))
-                                    .child(section_title("Row - CrossAxisAlignment"))
-                                    .child(row_cross_axis_tests()),
-                            )
-                            .child(
-                                container()
-                                    .layout(Flex::column().spacing(3.0))
-                                    .child(section_title("Center Test"))
-                                    .child(center_test()),
-                            ),
-                    )
-                    // Column tests side by side
-                    .child(
-                        container()
-                            .layout(Flex::row().spacing(16.0))
-                            .child(
-                                container()
-                                    .layout(Flex::column().spacing(3.0))
-                                    .child(section_title("Column - MainAxisAlignment"))
-                                    .child(column_main_axis_tests()),
-                            )
-                            .child(
-                                container()
-                                    .layout(Flex::column().spacing(3.0))
-                                    .child(section_title("Column - CrossAxisAlignment"))
-                                    .child(column_cross_axis_tests()),
-                            ),
-                    )
-            },
-        )
-        .run();
+    let (app, _) = App::new().add_surface(
+        SurfaceConfig::new()
+            .width(1000)
+            .height(400)
+            .anchor(Anchor::TOP | Anchor::LEFT)
+            .background_color(Color::rgb(0.08, 0.08, 0.1)),
+        || {
+            container()
+                .layout(Flex::column().spacing(8.0))
+                .padding(8.0)
+                // Row tests side by side
+                .child(
+                    container()
+                        .layout(Flex::row().spacing(16.0))
+                        .child(
+                            container()
+                                .layout(Flex::column().spacing(3.0))
+                                .child(section_title("Row - MainAxisAlignment"))
+                                .child(row_main_axis_tests()),
+                        )
+                        .child(
+                            container()
+                                .layout(Flex::column().spacing(3.0))
+                                .child(section_title("Row - CrossAxisAlignment"))
+                                .child(row_cross_axis_tests()),
+                        )
+                        .child(
+                            container()
+                                .layout(Flex::column().spacing(3.0))
+                                .child(section_title("Center Test"))
+                                .child(center_test()),
+                        ),
+                )
+                // Column tests side by side
+                .child(
+                    container()
+                        .layout(Flex::row().spacing(16.0))
+                        .child(
+                            container()
+                                .layout(Flex::column().spacing(3.0))
+                                .child(section_title("Column - MainAxisAlignment"))
+                                .child(column_main_axis_tests()),
+                        )
+                        .child(
+                            container()
+                                .layout(Flex::column().spacing(3.0))
+                                .child(section_title("Column - CrossAxisAlignment"))
+                                .child(column_cross_axis_tests()),
+                        ),
+                )
+        },
+    );
+    app.run();
 }
 
 fn section_title(title: &'static str) -> impl Widget {

--- a/examples/image_example.rs
+++ b/examples/image_example.rs
@@ -111,16 +111,15 @@ fn main() {
                 ),
         );
 
-    App::new()
-        .add_surface(
-            SurfaceConfig::new()
-                .width(820)
-                .height(400)
-                .anchor(Anchor::TOP | Anchor::LEFT)
-                .layer(Layer::Top)
-                .namespace("image-example")
-                .background_color(Color::rgb(0.1, 0.1, 0.15)),
-            || view,
-        )
-        .run();
+    let (app, _) = App::new().add_surface(
+        SurfaceConfig::new()
+            .width(820)
+            .height(400)
+            .anchor(Anchor::TOP | Anchor::LEFT)
+            .layer(Layer::Top)
+            .namespace("image-example")
+            .background_color(Color::rgb(0.1, 0.1, 0.15)),
+        || view,
+    );
+    app.run();
 }

--- a/examples/image_fit_none_test.rs
+++ b/examples/image_fit_none_test.rs
@@ -150,16 +150,15 @@ fn main() {
                 )),
         );
 
-    App::new()
-        .add_surface(
-            SurfaceConfig::new()
-                .width(900)
-                .height(700)
-                .anchor(Anchor::TOP | Anchor::LEFT)
-                .layer(Layer::Top)
-                .namespace("image-fit-none-test")
-                .background_color(Color::rgb(0.1, 0.1, 0.15)),
-            || view,
-        )
-        .run();
+    let (app, _) = App::new().add_surface(
+        SurfaceConfig::new()
+            .width(900)
+            .height(700)
+            .anchor(Anchor::TOP | Anchor::LEFT)
+            .layer(Layer::Top)
+            .namespace("image-fit-none-test")
+            .background_color(Color::rgb(0.1, 0.1, 0.15)),
+        || view,
+    );
+    app.run();
 }

--- a/examples/multi_surface.rs
+++ b/examples/multi_surface.rs
@@ -12,81 +12,80 @@ fn main() {
     // Shared signal that can be updated from any surface
     let count = create_signal(0);
 
-    App::new()
+    let (app, _bar_id) = App::new().add_surface(
         // Top status bar
-        .add_surface(
-            SurfaceConfig::new()
-                .height(32)
-                .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
-                .layer(Layer::Top)
-                .namespace("status-bar")
-                .background_color(Color::rgb(0.1, 0.1, 0.15)),
-            move || {
-                container()
-                    .height(fill())
-                    .layout(
-                        Flex::row()
-                            .spacing(8.0)
-                            .main_axis_alignment(MainAxisAlignment::SpaceBetween)
-                            .cross_axis_alignment(CrossAxisAlignment::Center),
-                    )
-                    .padding_xy(16.0, 0.0)
-                    .child(
-                        text("Multi-Surface Demo")
-                            .color(Color::WHITE)
-                            .font_size(14.0),
-                    )
-                    .child(
-                        text(move || format!("Count: {}", count.get()))
-                            .color(Color::WHITE)
-                            .font_size(14.0),
-                    )
-            },
-        )
-        // Bottom dock
-        .add_surface(
-            SurfaceConfig::new()
-                .height(48)
-                .anchor(Anchor::BOTTOM | Anchor::LEFT | Anchor::RIGHT)
-                .layer(Layer::Top)
-                .namespace("dock")
-                .background_color(Color::rgb(0.15, 0.15, 0.2)),
-            move || {
-                container()
-                    .height(fill())
-                    .layout(
-                        Flex::row()
-                            .spacing(16.0)
-                            .main_axis_alignment(MainAxisAlignment::Center)
-                            .cross_axis_alignment(CrossAxisAlignment::Center),
-                    )
-                    .children([
-                        container()
-                            .background(Color::rgb(0.3, 0.3, 0.4))
-                            .padding_xy(16.0, 8.0)
-                            .corner_radius(8.0)
-                            .hover_state(|s| s.lighter(0.1))
-                            .pressed_state(|s| s.ripple())
-                            .on_click(move || count.update(|c| *c += 1))
-                            .child(text("+").color(Color::WHITE).font_size(16.0)),
-                        container()
-                            .background(Color::rgb(0.3, 0.3, 0.4))
-                            .padding_xy(16.0, 8.0)
-                            .corner_radius(8.0)
-                            .hover_state(|s| s.lighter(0.1))
-                            .pressed_state(|s| s.ripple())
-                            .on_click(move || count.update(|c| *c -= 1))
-                            .child(text("-").color(Color::WHITE).font_size(16.0)),
-                        container()
-                            .background(Color::rgb(0.4, 0.2, 0.2))
-                            .padding_xy(16.0, 8.0)
-                            .corner_radius(8.0)
-                            .hover_state(|s| s.lighter(0.1))
-                            .pressed_state(|s| s.ripple())
-                            .on_click(move || count.set(0))
-                            .child(text("Reset").color(Color::WHITE).font_size(16.0)),
-                    ])
-            },
-        )
-        .run();
+        SurfaceConfig::new()
+            .height(32)
+            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+            .layer(Layer::Top)
+            .namespace("status-bar")
+            .background_color(Color::rgb(0.1, 0.1, 0.15)),
+        move || {
+            container()
+                .height(fill())
+                .layout(
+                    Flex::row()
+                        .spacing(8.0)
+                        .main_axis_alignment(MainAxisAlignment::SpaceBetween)
+                        .cross_axis_alignment(CrossAxisAlignment::Center),
+                )
+                .padding_xy(16.0, 0.0)
+                .child(
+                    text("Multi-Surface Demo")
+                        .color(Color::WHITE)
+                        .font_size(14.0),
+                )
+                .child(
+                    text(move || format!("Count: {}", count.get()))
+                        .color(Color::WHITE)
+                        .font_size(14.0),
+                )
+        },
+    );
+    // Bottom dock
+    let (app, _dock_id) = app.add_surface(
+        SurfaceConfig::new()
+            .height(48)
+            .anchor(Anchor::BOTTOM | Anchor::LEFT | Anchor::RIGHT)
+            .layer(Layer::Top)
+            .namespace("dock")
+            .background_color(Color::rgb(0.15, 0.15, 0.2)),
+        move || {
+            container()
+                .height(fill())
+                .layout(
+                    Flex::row()
+                        .spacing(16.0)
+                        .main_axis_alignment(MainAxisAlignment::Center)
+                        .cross_axis_alignment(CrossAxisAlignment::Center),
+                )
+                .children([
+                    container()
+                        .background(Color::rgb(0.3, 0.3, 0.4))
+                        .padding_xy(16.0, 8.0)
+                        .corner_radius(8.0)
+                        .hover_state(|s| s.lighter(0.1))
+                        .pressed_state(|s| s.ripple())
+                        .on_click(move || count.update(|c| *c += 1))
+                        .child(text("+").color(Color::WHITE).font_size(16.0)),
+                    container()
+                        .background(Color::rgb(0.3, 0.3, 0.4))
+                        .padding_xy(16.0, 8.0)
+                        .corner_radius(8.0)
+                        .hover_state(|s| s.lighter(0.1))
+                        .pressed_state(|s| s.ripple())
+                        .on_click(move || count.update(|c| *c -= 1))
+                        .child(text("-").color(Color::WHITE).font_size(16.0)),
+                    container()
+                        .background(Color::rgb(0.4, 0.2, 0.2))
+                        .padding_xy(16.0, 8.0)
+                        .corner_radius(8.0)
+                        .hover_state(|s| s.lighter(0.1))
+                        .pressed_state(|s| s.ripple())
+                        .on_click(move || count.set(0))
+                        .child(text("Reset").color(Color::WHITE).font_size(16.0)),
+                ])
+        },
+    );
+    app.run();
 }

--- a/examples/nested_transform_example.rs
+++ b/examples/nested_transform_example.rs
@@ -6,87 +6,86 @@
 use guido::prelude::*;
 
 fn main() {
-    App::new()
-        .add_surface(
-            SurfaceConfig::new()
-                .height(200)
-                .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
-                .background_color(Color::rgb(0.1, 0.1, 0.15)),
-            || {
-                container()
-                    .layout(
-                        Flex::row()
-                            .spacing(40.0)
-                            .main_axis_alignment(MainAxisAlignment::Center)
-                            .cross_axis_alignment(CrossAxisAlignment::Center),
-                    )
-                    .padding(20.0)
-                    .children([
-                        // Case 1: Parent rotated 30, child scaled 0.7
-                        // Expected: Inner box rotated 30deg AND smaller
-                        container()
-                            .width(100.0)
-                            .height(100.0)
-                            .background(Color::rgba(0.8, 0.3, 0.3, 0.5))
-                            .corner_radius(8.0)
-                            .rotate(30.0)
-                            .child(
-                                container()
-                                    .width(60.0)
-                                    .height(60.0)
-                                    .background(Color::rgb(0.3, 0.8, 0.3))
-                                    .corner_radius(4.0)
-                                    .scale(0.7),
-                            ),
-                        // Case 2: Both parent and child rotated 20deg each
-                        // Expected: Inner box rotated 40deg total
-                        container()
-                            .width(100.0)
-                            .height(100.0)
-                            .background(Color::rgba(0.3, 0.3, 0.8, 0.5))
-                            .corner_radius(8.0)
-                            .rotate(20.0)
-                            .child(
-                                container()
-                                    .width(60.0)
-                                    .height(60.0)
-                                    .background(Color::rgb(0.8, 0.8, 0.3))
-                                    .corner_radius(4.0)
-                                    .rotate(20.0),
-                            ),
-                        // Case 3: Parent scaled 1.3, child rotated 45deg
-                        // Expected: Inner box rotated AND the whole group larger
-                        container()
-                            .width(100.0)
-                            .height(100.0)
-                            .background(Color::rgba(0.8, 0.5, 0.2, 0.5))
-                            .corner_radius(8.0)
-                            .scale(1.3)
-                            .child(
-                                container()
-                                    .width(60.0)
-                                    .height(60.0)
-                                    .background(Color::rgb(0.5, 0.2, 0.8))
-                                    .corner_radius(4.0)
-                                    .rotate(45.0),
-                            ),
-                        // Case 4: Child with NO transform (inherits parent's rotation)
-                        // Expected: Inner box rotated same as parent (30deg)
-                        container()
-                            .width(100.0)
-                            .height(100.0)
-                            .background(Color::rgba(0.2, 0.7, 0.7, 0.5))
-                            .corner_radius(8.0)
-                            .rotate(30.0)
-                            .child(
-                                container()
-                                    .width(60.0)
-                                    .height(60.0)
-                                    .background(Color::rgb(0.7, 0.2, 0.7))
-                                    .corner_radius(4.0),
-                            ),
-                    ])
-            },
-        )
-        .run();
+    let (app, _) = App::new().add_surface(
+        SurfaceConfig::new()
+            .height(200)
+            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+            .background_color(Color::rgb(0.1, 0.1, 0.15)),
+        || {
+            container()
+                .layout(
+                    Flex::row()
+                        .spacing(40.0)
+                        .main_axis_alignment(MainAxisAlignment::Center)
+                        .cross_axis_alignment(CrossAxisAlignment::Center),
+                )
+                .padding(20.0)
+                .children([
+                    // Case 1: Parent rotated 30, child scaled 0.7
+                    // Expected: Inner box rotated 30deg AND smaller
+                    container()
+                        .width(100.0)
+                        .height(100.0)
+                        .background(Color::rgba(0.8, 0.3, 0.3, 0.5))
+                        .corner_radius(8.0)
+                        .rotate(30.0)
+                        .child(
+                            container()
+                                .width(60.0)
+                                .height(60.0)
+                                .background(Color::rgb(0.3, 0.8, 0.3))
+                                .corner_radius(4.0)
+                                .scale(0.7),
+                        ),
+                    // Case 2: Both parent and child rotated 20deg each
+                    // Expected: Inner box rotated 40deg total
+                    container()
+                        .width(100.0)
+                        .height(100.0)
+                        .background(Color::rgba(0.3, 0.3, 0.8, 0.5))
+                        .corner_radius(8.0)
+                        .rotate(20.0)
+                        .child(
+                            container()
+                                .width(60.0)
+                                .height(60.0)
+                                .background(Color::rgb(0.8, 0.8, 0.3))
+                                .corner_radius(4.0)
+                                .rotate(20.0),
+                        ),
+                    // Case 3: Parent scaled 1.3, child rotated 45deg
+                    // Expected: Inner box rotated AND the whole group larger
+                    container()
+                        .width(100.0)
+                        .height(100.0)
+                        .background(Color::rgba(0.8, 0.5, 0.2, 0.5))
+                        .corner_radius(8.0)
+                        .scale(1.3)
+                        .child(
+                            container()
+                                .width(60.0)
+                                .height(60.0)
+                                .background(Color::rgb(0.5, 0.2, 0.8))
+                                .corner_radius(4.0)
+                                .rotate(45.0),
+                        ),
+                    // Case 4: Child with NO transform (inherits parent's rotation)
+                    // Expected: Inner box rotated same as parent (30deg)
+                    container()
+                        .width(100.0)
+                        .height(100.0)
+                        .background(Color::rgba(0.2, 0.7, 0.7, 0.5))
+                        .corner_radius(8.0)
+                        .rotate(30.0)
+                        .child(
+                            container()
+                                .width(60.0)
+                                .height(60.0)
+                                .background(Color::rgb(0.7, 0.2, 0.7))
+                                .corner_radius(4.0),
+                        ),
+                ])
+        },
+    );
+    app.run();
 }

--- a/examples/reactive_example.rs
+++ b/examples/reactive_example.rs
@@ -27,74 +27,70 @@ fn main() {
     });
 
     // Run the app
-    App::new()
-        .add_surface(
-            SurfaceConfig::new()
-                .height(32)
-                .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
-                .background_color(Color::rgb(0.1, 0.1, 0.15)),
-            move || {
-                container()
-                    .layout(
-                        Flex::row()
-                            .spacing(8.0)
-                            .main_axis_alignment(MainAxisAlignment::SpaceBetween),
-                    )
-                    .child(
-                        // Clickable container with state layer - click to increment count
-                        container()
-                            .padding(8.0)
-                            .background(Color::rgb(0.2, 0.2, 0.3))
-                            .corner_radius(4.0)
-                            .hover_state(|s| s.lighter(0.1))
-                            .pressed_state(|s| s.ripple())
-                            .on_click(move || {
-                                count.update(|c| *c += 10);
-                            })
-                            .child(
-                                text(move || format!("Count: {} (click me!)", count.get()))
-                                    .color(Color::WHITE),
-                            ),
-                    )
-                    .child(
-                        // Scrollable container with hover state
-                        container()
-                            .padding(8.0)
-                            .background(Color::rgb(0.2, 0.3, 0.2))
-                            .corner_radius(4.0)
-                            .hover_state(|s| s.lighter(0.05))
-                            .on_scroll(move |_dx, dy, _source| {
-                                scroll_offset.update(|offset| {
-                                    *offset += dy;
-                                });
-                            })
-                            .child(
-                                text(move || format!("Scroll: {:.0}px", scroll_offset.get()))
-                                    .color(Color::WHITE),
-                            ),
-                    )
-                    .child(
-                        // Container with border and hover state
-                        container()
-                            .padding(8.0)
-                            .background(Color::rgb(0.15, 0.15, 0.2))
-                            .border(2.0, Color::rgb(0.4, 0.6, 0.8))
-                            .hover_state(|s| s.lighter(0.1))
-                            .child(text("With border").color(Color::WHITE)),
-                    )
-                    .child(
-                        // Container with gradient and hover state
-                        container()
-                            .padding(8.0)
-                            .gradient_horizontal(
-                                Color::rgb(0.3, 0.1, 0.4),
-                                Color::rgb(0.1, 0.3, 0.5),
-                            )
-                            .corner_radius(4.0)
-                            .hover_state(|s| s.lighter(0.1))
-                            .child(text("Gradient!").color(Color::WHITE)),
-                    )
-            },
-        )
-        .run();
+    let (app, _) = App::new().add_surface(
+        SurfaceConfig::new()
+            .height(32)
+            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+            .background_color(Color::rgb(0.1, 0.1, 0.15)),
+        move || {
+            container()
+                .layout(
+                    Flex::row()
+                        .spacing(8.0)
+                        .main_axis_alignment(MainAxisAlignment::SpaceBetween),
+                )
+                .child(
+                    // Clickable container with state layer - click to increment count
+                    container()
+                        .padding(8.0)
+                        .background(Color::rgb(0.2, 0.2, 0.3))
+                        .corner_radius(4.0)
+                        .hover_state(|s| s.lighter(0.1))
+                        .pressed_state(|s| s.ripple())
+                        .on_click(move || {
+                            count.update(|c| *c += 10);
+                        })
+                        .child(
+                            text(move || format!("Count: {} (click me!)", count.get()))
+                                .color(Color::WHITE),
+                        ),
+                )
+                .child(
+                    // Scrollable container with hover state
+                    container()
+                        .padding(8.0)
+                        .background(Color::rgb(0.2, 0.3, 0.2))
+                        .corner_radius(4.0)
+                        .hover_state(|s| s.lighter(0.05))
+                        .on_scroll(move |_dx, dy, _source| {
+                            scroll_offset.update(|offset| {
+                                *offset += dy;
+                            });
+                        })
+                        .child(
+                            text(move || format!("Scroll: {:.0}px", scroll_offset.get()))
+                                .color(Color::WHITE),
+                        ),
+                )
+                .child(
+                    // Container with border and hover state
+                    container()
+                        .padding(8.0)
+                        .background(Color::rgb(0.15, 0.15, 0.2))
+                        .border(2.0, Color::rgb(0.4, 0.6, 0.8))
+                        .hover_state(|s| s.lighter(0.1))
+                        .child(text("With border").color(Color::WHITE)),
+                )
+                .child(
+                    // Container with gradient and hover state
+                    container()
+                        .padding(8.0)
+                        .gradient_horizontal(Color::rgb(0.3, 0.1, 0.4), Color::rgb(0.1, 0.3, 0.5))
+                        .corner_radius(4.0)
+                        .hover_state(|s| s.lighter(0.1))
+                        .child(text("Gradient!").color(Color::WHITE)),
+                )
+        },
+    );
+    app.run();
 }

--- a/examples/rounded_hitbox_test.rs
+++ b/examples/rounded_hitbox_test.rs
@@ -9,55 +9,54 @@ use guido::prelude::*;
 fn main() {
     let click_count = create_signal(0);
 
-    App::new()
-        .add_surface(
-            SurfaceConfig::new()
-                .height(300)
-                .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
-                .background_color(Color::rgb(0.1, 0.1, 0.15)),
-            move || {
-                container()
-                    .layout(
-                        Flex::column()
-                            .spacing(30.0)
-                            .main_axis_alignment(MainAxisAlignment::Center)
-                            .cross_axis_alignment(CrossAxisAlignment::Center),
-                    )
-                    .padding(40.0)
-                    .children([
-                        // Row with different corner radii
-                        container()
-                            .layout(
-                                Flex::row()
-                                    .spacing(40.0)
-                                    .main_axis_alignment(MainAxisAlignment::Center),
-                            )
-                            .children([
-                                // No corner radius (control)
-                                make_box("r=0", 0.0, Color::rgb(0.5, 0.5, 0.5), click_count),
-                                // Small corner radius
-                                make_box("r=10", 10.0, Color::rgb(0.3, 0.8, 0.3), click_count),
-                                // Medium corner radius
-                                make_box("r=25", 25.0, Color::rgb(0.3, 0.3, 0.8), click_count),
-                                // Large corner radius (half of size = circle-ish)
-                                make_box("r=50", 50.0, Color::rgb(0.8, 0.3, 0.8), click_count),
-                            ]),
-                        // Instructions
-                        container().child(
-                            text("Hover over corners - should NOT highlight outside the rounded area")
-                                .font_size(14.0)
-                                .color(Color::rgb(0.7, 0.7, 0.7)),
-                        ),
-                        // Click counter display
-                        container().child(
-                            text(move || format!("Clicks: {}", click_count.get()))
-                                .font_size(20.0)
-                                .color(Color::WHITE),
-                        ),
-                    ])
-            },
-        )
-        .run();
+    let (app, _) = App::new().add_surface(
+        SurfaceConfig::new()
+            .height(300)
+            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+            .background_color(Color::rgb(0.1, 0.1, 0.15)),
+        move || {
+            container()
+                .layout(
+                    Flex::column()
+                        .spacing(30.0)
+                        .main_axis_alignment(MainAxisAlignment::Center)
+                        .cross_axis_alignment(CrossAxisAlignment::Center),
+                )
+                .padding(40.0)
+                .children([
+                    // Row with different corner radii
+                    container()
+                        .layout(
+                            Flex::row()
+                                .spacing(40.0)
+                                .main_axis_alignment(MainAxisAlignment::Center),
+                        )
+                        .children([
+                            // No corner radius (control)
+                            make_box("r=0", 0.0, Color::rgb(0.5, 0.5, 0.5), click_count),
+                            // Small corner radius
+                            make_box("r=10", 10.0, Color::rgb(0.3, 0.8, 0.3), click_count),
+                            // Medium corner radius
+                            make_box("r=25", 25.0, Color::rgb(0.3, 0.3, 0.8), click_count),
+                            // Large corner radius (half of size = circle-ish)
+                            make_box("r=50", 50.0, Color::rgb(0.8, 0.3, 0.8), click_count),
+                        ]),
+                    // Instructions
+                    container().child(
+                        text("Hover over corners - should NOT highlight outside the rounded area")
+                            .font_size(14.0)
+                            .color(Color::rgb(0.7, 0.7, 0.7)),
+                    ),
+                    // Click counter display
+                    container().child(
+                        text(move || format!("Clicks: {}", click_count.get()))
+                            .font_size(20.0)
+                            .color(Color::WHITE),
+                    ),
+                ])
+        },
+    );
+    app.run();
 }
 
 fn make_box(

--- a/examples/rounded_transform_test.rs
+++ b/examples/rounded_transform_test.rs
@@ -9,65 +9,62 @@ use guido::prelude::*;
 fn main() {
     let click_count = create_signal(0);
 
-    App::new()
-        .add_surface(
-            SurfaceConfig::new()
-                .height(280)
-                .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
-                .background_color(Color::rgb(0.1, 0.1, 0.15)),
-            move || {
-                container()
-                    .layout(
-                        Flex::column()
-                            .spacing(30.0)
-                            .main_axis_alignment(MainAxisAlignment::Center)
-                            .cross_axis_alignment(CrossAxisAlignment::Center),
-                    )
-                    .padding(40.0)
-                    .children([
-                        // Row with transforms
-                        container()
-                            .layout(
-                                Flex::row()
-                                    .spacing(50.0)
-                                    .main_axis_alignment(MainAxisAlignment::Center),
-                            )
-                            .children([
-                                // No transform (control)
-                                make_box("None", Color::rgb(0.5, 0.5, 0.5), click_count),
-                                // Translate
-                                make_box("Translate", Color::rgb(0.3, 0.8, 0.3), click_count)
-                                    .translate(15.0, 10.0),
-                                // Rotate
-                                make_box("Rotate", Color::rgb(0.3, 0.3, 0.8), click_count)
-                                    .rotate(20.0),
-                                // All 3 transforms (nested)
-                                container().translate(10.0, 15.0).child(
-                                    container().scale(1.15).child(
-                                        make_box("All 3", Color::rgb(0.8, 0.8, 0.3), click_count)
-                                            .rotate(25.0),
-                                    ),
+    let (app, _) = App::new().add_surface(
+        SurfaceConfig::new()
+            .height(280)
+            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+            .background_color(Color::rgb(0.1, 0.1, 0.15)),
+        move || {
+            container()
+                .layout(
+                    Flex::column()
+                        .spacing(30.0)
+                        .main_axis_alignment(MainAxisAlignment::Center)
+                        .cross_axis_alignment(CrossAxisAlignment::Center),
+                )
+                .padding(40.0)
+                .children([
+                    // Row with transforms
+                    container()
+                        .layout(
+                            Flex::row()
+                                .spacing(50.0)
+                                .main_axis_alignment(MainAxisAlignment::Center),
+                        )
+                        .children([
+                            // No transform (control)
+                            make_box("None", Color::rgb(0.5, 0.5, 0.5), click_count),
+                            // Translate
+                            make_box("Translate", Color::rgb(0.3, 0.8, 0.3), click_count)
+                                .translate(15.0, 10.0),
+                            // Rotate
+                            make_box("Rotate", Color::rgb(0.3, 0.3, 0.8), click_count).rotate(20.0),
+                            // All 3 transforms (nested)
+                            container().translate(10.0, 15.0).child(
+                                container().scale(1.15).child(
+                                    make_box("All 3", Color::rgb(0.8, 0.8, 0.3), click_count)
+                                        .rotate(25.0),
                                 ),
-                                // Scale
-                                make_box("Scale", Color::rgb(0.8, 0.3, 0.8), click_count)
-                                    .scale(1.2),
-                            ]),
-                        // Instructions
-                        container().child(
-                            text("Rectangular boxes with transforms. Hover and click to test.")
-                                .font_size(14.0)
-                                .color(Color::rgb(0.7, 0.7, 0.7)),
-                        ),
-                        // Click counter display
-                        container().child(
-                            text(move || format!("Clicks: {}", click_count.get()))
-                                .font_size(20.0)
-                                .color(Color::WHITE),
-                        ),
-                    ])
-            },
-        )
-        .run();
+                            ),
+                            // Scale
+                            make_box("Scale", Color::rgb(0.8, 0.3, 0.8), click_count).scale(1.2),
+                        ]),
+                    // Instructions
+                    container().child(
+                        text("Rectangular boxes with transforms. Hover and click to test.")
+                            .font_size(14.0)
+                            .color(Color::rgb(0.7, 0.7, 0.7)),
+                    ),
+                    // Click counter display
+                    container().child(
+                        text(move || format!("Clicks: {}", click_count.get()))
+                            .font_size(20.0)
+                            .color(Color::WHITE),
+                    ),
+                ])
+        },
+    );
+    app.run();
 }
 
 fn make_box(label: &'static str, base_color: Color, click_count: Signal<i32>) -> Container {

--- a/examples/scroll_example.rs
+++ b/examples/scroll_example.rs
@@ -173,14 +173,13 @@ fn main() {
         );
 
     // Run the app with a larger window for the demo
-    App::new()
-        .add_surface(
-            SurfaceConfig::new()
-                .width(900)
-                .height(300)
-                .anchor(Anchor::TOP | Anchor::LEFT)
-                .background_color(Color::rgb(0.1, 0.1, 0.15)),
-            move || view,
-        )
-        .run();
+    let (app, _) = App::new().add_surface(
+        SurfaceConfig::new()
+            .width(900)
+            .height(300)
+            .anchor(Anchor::TOP | Anchor::LEFT)
+            .background_color(Color::rgb(0.1, 0.1, 0.15)),
+        move || view,
+    );
+    app.run();
 }

--- a/examples/showcase.rs
+++ b/examples/showcase.rs
@@ -9,183 +9,182 @@
 use guido::prelude::*;
 
 fn main() {
-    App::new()
-        .add_surface(
-            SurfaceConfig::new()
-                .width(500)
-                .height(250)
-                .anchor(Anchor::TOP | Anchor::LEFT)
-                .background_color(Color::rgb(0.1, 0.1, 0.15)),
-            || {
-                container()
-                    .layout(Flex::column().spacing(12.0))
-                    .child(
-                        // Row 1: Different curvature values with solid colors
-                        container()
-                            .layout(Flex::row().spacing(8.0))
-                            .child(
-                                container()
-                                    .padding(12.0)
-                                    .background(Color::rgb(0.3, 0.2, 0.4))
-                                    .corner_radius(12.0)
-                                    .squircle() // K=2 → n=4
-                                    .child(text("Squircle\n(K=2)").color(Color::WHITE)),
-                            )
-                            .child(
-                                container()
-                                    .padding(12.0)
-                                    .background(Color::rgb(0.2, 0.3, 0.4))
-                                    .corner_radius(12.0)
-                                    // Default circular K=1 → n=2
-                                    .child(text("Circle\n(K=1)").color(Color::WHITE)),
-                            )
-                            .child(
-                                container()
-                                    .padding(12.0)
-                                    .background(Color::rgb(0.4, 0.3, 0.2))
-                                    .corner_radius(12.0)
-                                    .bevel() // K=0 → n=1
-                                    .child(text("Bevel\n(K=0)").color(Color::WHITE)),
-                            )
-                            .child(
-                                container()
-                                    .padding(12.0)
-                                    .background(Color::rgb(0.2, 0.4, 0.3))
-                                    .corner_radius(12.0)
-                                    .scoop() // K=-1 → n=0.5
-                                    .hover_state(|s| s.lighter(0.1))
-                                    .pressed_state(|s| s.ripple())
-                                    .child(text("Scoop\n(K=-1)").color(Color::WHITE)),
-                            ),
-                    )
-                    .child(
-                        // Row 2: With borders
-                        container()
-                            .layout(Flex::row().spacing(8.0))
-                            .child(
-                                container()
-                                    .padding(12.0)
-                                    .background(Color::rgb(0.15, 0.15, 0.2))
-                                    .corner_radius(12.0)
-                                    .border(2.0, Color::rgb(0.5, 0.3, 0.7))
-                                    .squircle()
-                                    .child(text("Squircle\nBorder").color(Color::WHITE)),
-                            )
-                            .child(
-                                container()
-                                    .padding(12.0)
-                                    .background(Color::rgb(0.15, 0.15, 0.2))
-                                    .corner_radius(12.0)
-                                    .border(2.0, Color::rgb(0.3, 0.5, 0.7))
-                                    .child(text("Circle\nBorder").color(Color::WHITE)),
-                            )
-                            .child(
-                                container()
-                                    .padding(12.0)
-                                    .background(Color::rgb(0.15, 0.15, 0.2))
-                                    .corner_radius(12.0)
-                                    .border(2.0, Color::rgb(0.7, 0.5, 0.3))
-                                    .bevel()
-                                    .child(text("Bevel\nBorder").color(Color::WHITE)),
-                            )
-                            .child(
-                                container()
-                                    .padding(12.0)
-                                    .background(Color::rgb(0.15, 0.15, 0.2))
-                                    .corner_radius(12.0)
-                                    .border(2.0, Color::rgb(0.3, 0.7, 0.5))
-                                    .scoop()
-                                    .hover_state(|s| s.lighter(0.1))
-                                    .pressed_state(|s| s.ripple())
-                                    .child(text("Scoop\nBorder").color(Color::WHITE)),
-                            ),
-                    )
-                    .child(
-                        // Row 3: With gradients
-                        container()
-                            .layout(Flex::row().spacing(8.0))
-                            .child(
-                                container()
-                                    .padding(12.0)
-                                    .gradient_horizontal(
-                                        Color::rgb(0.4, 0.2, 0.5),
-                                        Color::rgb(0.2, 0.4, 0.6),
-                                    )
-                                    .corner_radius(12.0)
-                                    .squircle()
-                                    .child(text("Squircle\nGradient").color(Color::WHITE)),
-                            )
-                            .child(
-                                container()
-                                    .padding(12.0)
-                                    .gradient_horizontal(
-                                        Color::rgb(0.2, 0.4, 0.5),
-                                        Color::rgb(0.4, 0.2, 0.6),
-                                    )
-                                    .corner_radius(12.0)
-                                    .child(text("Circle\nGradient").color(Color::WHITE)),
-                            )
-                            .child(
-                                container()
-                                    .padding(12.0)
-                                    .gradient_horizontal(
-                                        Color::rgb(0.5, 0.4, 0.2),
-                                        Color::rgb(0.6, 0.2, 0.4),
-                                    )
-                                    .corner_radius(12.0)
-                                    .bevel()
-                                    .child(text("Bevel\nGradient").color(Color::WHITE)),
-                            )
-                            .child(
-                                container()
-                                    .padding(12.0)
-                                    .gradient_horizontal(
-                                        Color::rgb(0.2, 0.5, 0.4),
-                                        Color::rgb(0.4, 0.6, 0.2),
-                                    )
-                                    .corner_radius(12.0)
-                                    .scoop()
-                                    .child(text("Scoop\nGradient").color(Color::WHITE)),
-                            ),
-                    )
-                    .child(
-                        // Row 4: Custom curvature values
-                        container()
-                            .layout(Flex::row().spacing(8.0))
-                            .child(
-                                container()
-                                    .padding(12.0)
-                                    .background(Color::rgb(0.3, 0.3, 0.4))
-                                    .corner_radius(12.0)
-                                    .corner_curvature(0.5) // K=0.5 → n=1.41
-                                    .child(text("K=0.5").color(Color::WHITE)),
-                            )
-                            .child(
-                                container()
-                                    .padding(12.0)
-                                    .background(Color::rgb(0.3, 0.4, 0.3))
-                                    .corner_radius(12.0)
-                                    .corner_curvature(1.5) // K=1.5 → n=2.83
-                                    .child(text("K=1.5").color(Color::WHITE)),
-                            )
-                            .child(
-                                container()
-                                    .padding(12.0)
-                                    .background(Color::rgb(0.4, 0.3, 0.3))
-                                    .corner_radius(12.0)
-                                    .corner_curvature(2.5) // K=2.5 → n=5.66
-                                    .child(text("K=2.5").color(Color::WHITE)),
-                            )
-                            .child(
-                                container()
-                                    .padding(12.0)
-                                    .background(Color::rgb(0.35, 0.3, 0.4))
-                                    .corner_radius(12.0)
-                                    .corner_curvature(-0.5) // K=-0.5 → n=0.707
-                                    .child(text("K=-0.5").color(Color::WHITE)),
-                            ),
-                    )
-            },
-        )
-        .run();
+    let (app, _) = App::new().add_surface(
+        SurfaceConfig::new()
+            .width(500)
+            .height(250)
+            .anchor(Anchor::TOP | Anchor::LEFT)
+            .background_color(Color::rgb(0.1, 0.1, 0.15)),
+        || {
+            container()
+                .layout(Flex::column().spacing(12.0))
+                .child(
+                    // Row 1: Different curvature values with solid colors
+                    container()
+                        .layout(Flex::row().spacing(8.0))
+                        .child(
+                            container()
+                                .padding(12.0)
+                                .background(Color::rgb(0.3, 0.2, 0.4))
+                                .corner_radius(12.0)
+                                .squircle() // K=2 → n=4
+                                .child(text("Squircle\n(K=2)").color(Color::WHITE)),
+                        )
+                        .child(
+                            container()
+                                .padding(12.0)
+                                .background(Color::rgb(0.2, 0.3, 0.4))
+                                .corner_radius(12.0)
+                                // Default circular K=1 → n=2
+                                .child(text("Circle\n(K=1)").color(Color::WHITE)),
+                        )
+                        .child(
+                            container()
+                                .padding(12.0)
+                                .background(Color::rgb(0.4, 0.3, 0.2))
+                                .corner_radius(12.0)
+                                .bevel() // K=0 → n=1
+                                .child(text("Bevel\n(K=0)").color(Color::WHITE)),
+                        )
+                        .child(
+                            container()
+                                .padding(12.0)
+                                .background(Color::rgb(0.2, 0.4, 0.3))
+                                .corner_radius(12.0)
+                                .scoop() // K=-1 → n=0.5
+                                .hover_state(|s| s.lighter(0.1))
+                                .pressed_state(|s| s.ripple())
+                                .child(text("Scoop\n(K=-1)").color(Color::WHITE)),
+                        ),
+                )
+                .child(
+                    // Row 2: With borders
+                    container()
+                        .layout(Flex::row().spacing(8.0))
+                        .child(
+                            container()
+                                .padding(12.0)
+                                .background(Color::rgb(0.15, 0.15, 0.2))
+                                .corner_radius(12.0)
+                                .border(2.0, Color::rgb(0.5, 0.3, 0.7))
+                                .squircle()
+                                .child(text("Squircle\nBorder").color(Color::WHITE)),
+                        )
+                        .child(
+                            container()
+                                .padding(12.0)
+                                .background(Color::rgb(0.15, 0.15, 0.2))
+                                .corner_radius(12.0)
+                                .border(2.0, Color::rgb(0.3, 0.5, 0.7))
+                                .child(text("Circle\nBorder").color(Color::WHITE)),
+                        )
+                        .child(
+                            container()
+                                .padding(12.0)
+                                .background(Color::rgb(0.15, 0.15, 0.2))
+                                .corner_radius(12.0)
+                                .border(2.0, Color::rgb(0.7, 0.5, 0.3))
+                                .bevel()
+                                .child(text("Bevel\nBorder").color(Color::WHITE)),
+                        )
+                        .child(
+                            container()
+                                .padding(12.0)
+                                .background(Color::rgb(0.15, 0.15, 0.2))
+                                .corner_radius(12.0)
+                                .border(2.0, Color::rgb(0.3, 0.7, 0.5))
+                                .scoop()
+                                .hover_state(|s| s.lighter(0.1))
+                                .pressed_state(|s| s.ripple())
+                                .child(text("Scoop\nBorder").color(Color::WHITE)),
+                        ),
+                )
+                .child(
+                    // Row 3: With gradients
+                    container()
+                        .layout(Flex::row().spacing(8.0))
+                        .child(
+                            container()
+                                .padding(12.0)
+                                .gradient_horizontal(
+                                    Color::rgb(0.4, 0.2, 0.5),
+                                    Color::rgb(0.2, 0.4, 0.6),
+                                )
+                                .corner_radius(12.0)
+                                .squircle()
+                                .child(text("Squircle\nGradient").color(Color::WHITE)),
+                        )
+                        .child(
+                            container()
+                                .padding(12.0)
+                                .gradient_horizontal(
+                                    Color::rgb(0.2, 0.4, 0.5),
+                                    Color::rgb(0.4, 0.2, 0.6),
+                                )
+                                .corner_radius(12.0)
+                                .child(text("Circle\nGradient").color(Color::WHITE)),
+                        )
+                        .child(
+                            container()
+                                .padding(12.0)
+                                .gradient_horizontal(
+                                    Color::rgb(0.5, 0.4, 0.2),
+                                    Color::rgb(0.6, 0.2, 0.4),
+                                )
+                                .corner_radius(12.0)
+                                .bevel()
+                                .child(text("Bevel\nGradient").color(Color::WHITE)),
+                        )
+                        .child(
+                            container()
+                                .padding(12.0)
+                                .gradient_horizontal(
+                                    Color::rgb(0.2, 0.5, 0.4),
+                                    Color::rgb(0.4, 0.6, 0.2),
+                                )
+                                .corner_radius(12.0)
+                                .scoop()
+                                .child(text("Scoop\nGradient").color(Color::WHITE)),
+                        ),
+                )
+                .child(
+                    // Row 4: Custom curvature values
+                    container()
+                        .layout(Flex::row().spacing(8.0))
+                        .child(
+                            container()
+                                .padding(12.0)
+                                .background(Color::rgb(0.3, 0.3, 0.4))
+                                .corner_radius(12.0)
+                                .corner_curvature(0.5) // K=0.5 → n=1.41
+                                .child(text("K=0.5").color(Color::WHITE)),
+                        )
+                        .child(
+                            container()
+                                .padding(12.0)
+                                .background(Color::rgb(0.3, 0.4, 0.3))
+                                .corner_radius(12.0)
+                                .corner_curvature(1.5) // K=1.5 → n=2.83
+                                .child(text("K=1.5").color(Color::WHITE)),
+                        )
+                        .child(
+                            container()
+                                .padding(12.0)
+                                .background(Color::rgb(0.4, 0.3, 0.3))
+                                .corner_radius(12.0)
+                                .corner_curvature(2.5) // K=2.5 → n=5.66
+                                .child(text("K=2.5").color(Color::WHITE)),
+                        )
+                        .child(
+                            container()
+                                .padding(12.0)
+                                .background(Color::rgb(0.35, 0.3, 0.4))
+                                .corner_radius(12.0)
+                                .corner_curvature(-0.5) // K=-0.5 → n=0.707
+                                .child(text("K=-0.5").color(Color::WHITE)),
+                        ),
+                )
+        },
+    );
+    app.run();
 }

--- a/examples/state_layer_example.rs
+++ b/examples/state_layer_example.rs
@@ -7,52 +7,51 @@
 use guido::prelude::*;
 
 fn main() {
-    App::new()
-        .add_surface(
-            SurfaceConfig::new()
-                .width(700)
-                .height(400)
-                .anchor(Anchor::TOP | Anchor::LEFT)
-                .background_color(Color::rgb(0.08, 0.08, 0.12)),
-            || {
-                container()
-                    .background(Color::rgb(0.08, 0.08, 0.12))
-                    .padding(24.0)
-                    .layout(Flex::column().spacing(16.0))
-                    .child(
-                        // Title section
-                        container().layout(Flex::column().spacing(8.0)).children([
-                            text("State Layer Demo")
-                                .font_size(24.0)
-                                .color(Color::rgb(0.9, 0.9, 0.95)),
-                            text("Hover and click the buttons to see state changes and ripple effects")
-                                .font_size(14.0)
-                                .color(Color::rgb(0.6, 0.6, 0.7)),
+    let (app, _) = App::new().add_surface(
+        SurfaceConfig::new()
+            .width(700)
+            .height(400)
+            .anchor(Anchor::TOP | Anchor::LEFT)
+            .background_color(Color::rgb(0.08, 0.08, 0.12)),
+        || {
+            container()
+                .background(Color::rgb(0.08, 0.08, 0.12))
+                .padding(24.0)
+                .layout(Flex::column().spacing(16.0))
+                .child(
+                    // Title section
+                    container().layout(Flex::column().spacing(8.0)).children([
+                        text("State Layer Demo")
+                            .font_size(24.0)
+                            .color(Color::rgb(0.9, 0.9, 0.95)),
+                        text("Hover and click the buttons to see state changes and ripple effects")
+                            .font_size(14.0)
+                            .color(Color::rgb(0.6, 0.6, 0.7)),
+                    ]),
+                )
+                .child(
+                    // Buttons container - two columns
+                    container().layout(Flex::row().spacing(16.0)).children([
+                        // Left column - basic effects
+                        container().layout(Flex::column().spacing(12.0)).children([
+                            create_lighter_button(),
+                            create_explicit_colors_button(),
+                            create_transform_button(),
+                            create_animated_button(),
+                            create_border_button(),
                         ]),
-                    )
-                    .child(
-                        // Buttons container - two columns
-                        container().layout(Flex::row().spacing(16.0)).children([
-                            // Left column - basic effects
-                            container().layout(Flex::column().spacing(12.0)).children([
-                                create_lighter_button(),
-                                create_explicit_colors_button(),
-                                create_transform_button(),
-                                create_animated_button(),
-                                create_border_button(),
-                            ]),
-                            // Right column - ripple effects
-                            container().layout(Flex::column().spacing(12.0)).children([
-                                create_ripple_button(),
-                                create_colored_ripple_button(),
-                                create_ripple_with_scale_button(),
-                                create_rotated_ripple_button(),
-                            ]),
+                        // Right column - ripple effects
+                        container().layout(Flex::column().spacing(12.0)).children([
+                            create_ripple_button(),
+                            create_colored_ripple_button(),
+                            create_ripple_with_scale_button(),
+                            create_rotated_ripple_button(),
                         ]),
-                    )
-            },
-        )
-        .run();
+                    ]),
+                )
+        },
+    );
+    app.run();
 }
 
 /// Button with lighter() hover effect

--- a/examples/status_bar.rs
+++ b/examples/status_bar.rs
@@ -1,35 +1,34 @@
 use guido::prelude::*;
 
 fn main() {
-    App::new()
-        .add_surface(
-            SurfaceConfig::new()
-                .height(32)
-                .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
-                .background_color(Color::rgb(0.1, 0.1, 0.15)),
-            || {
-                container()
-                    .layout(
-                        Flex::row()
-                            .spacing(8.0)
-                            .main_axis_alignment(MainAxisAlignment::SpaceBetween),
-                    )
-                    .child(
-                        container()
-                            .padding(8.0)
-                            .background(Color::rgb(0.2, 0.2, 0.3))
-                            .corner_radius(4.0)
-                            .child(text("Guido")),
-                    )
-                    .child(container().padding(8.0).child(text("Hello World!")))
-                    .child(
-                        container()
-                            .padding(8.0)
-                            .background(Color::rgb(0.3, 0.2, 0.2))
-                            .corner_radius(4.0)
-                            .child(text("Status Bar")),
-                    )
-            },
-        )
-        .run();
+    let (app, _) = App::new().add_surface(
+        SurfaceConfig::new()
+            .height(32)
+            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+            .background_color(Color::rgb(0.1, 0.1, 0.15)),
+        || {
+            container()
+                .layout(
+                    Flex::row()
+                        .spacing(8.0)
+                        .main_axis_alignment(MainAxisAlignment::SpaceBetween),
+                )
+                .child(
+                    container()
+                        .padding(8.0)
+                        .background(Color::rgb(0.2, 0.2, 0.3))
+                        .corner_radius(4.0)
+                        .child(text("Guido")),
+                )
+                .child(container().padding(8.0).child(text("Hello World!")))
+                .child(
+                    container()
+                        .padding(8.0)
+                        .background(Color::rgb(0.3, 0.2, 0.2))
+                        .corner_radius(4.0)
+                        .child(text("Status Bar")),
+                )
+        },
+    );
+    app.run();
 }

--- a/examples/surface_properties_example.rs
+++ b/examples/surface_properties_example.rs
@@ -1,0 +1,207 @@
+//! Example demonstrating dynamic surface property modification.
+//!
+//! This example shows how to:
+//! - Configure keyboard interactivity at surface creation
+//! - Get a handle for surfaces added via `add_surface()`
+//! - Dynamically modify surface properties (layer, keyboard interactivity, etc.)
+//!
+//! Click the buttons to change the surface's layer and keyboard mode.
+
+use guido::prelude::*;
+
+fn main() {
+    // Store the surface ID so we can get a handle to it later
+    let surface_id_signal = create_signal(None::<SurfaceId>);
+
+    // Track current layer and keyboard mode for display
+    let current_layer = create_signal("Top");
+    let current_keyboard = create_signal("OnDemand");
+
+    let (app, surface_id) = App::new().add_surface(
+        SurfaceConfig::new()
+            .width(500)
+            .height(300)
+            .anchor(Anchor::TOP | Anchor::LEFT)
+            .layer(Layer::Top)
+            .keyboard_interactivity(KeyboardInteractivity::OnDemand)
+            .namespace("surface-properties-example")
+            .background_color(Color::rgb(0.1, 0.1, 0.15)),
+        move || {
+            container()
+                .padding(24.0)
+                .layout(Flex::column().spacing(16.0))
+                .child(
+                    text("Surface Properties Demo")
+                        .font_size(20.0)
+                        .color(Color::WHITE),
+                )
+                // Current state display
+                .child(
+                    container()
+                        .padding(12.0)
+                        .background(Color::rgb(0.15, 0.15, 0.2))
+                        .corner_radius(8.0)
+                        .layout(Flex::column().spacing(8.0))
+                        .child(
+                            text(move || format!("Current Layer: {}", current_layer.get()))
+                                .color(Color::rgb(0.7, 0.9, 0.7))
+                                .font_size(14.0),
+                        )
+                        .child(
+                            text(move || {
+                                format!("Keyboard Interactivity: {}", current_keyboard.get())
+                            })
+                            .color(Color::rgb(0.7, 0.9, 0.7))
+                            .font_size(14.0),
+                        ),
+                )
+                // Layer controls
+                .child(
+                    container()
+                        .layout(Flex::column().spacing(8.0))
+                        .child(
+                            text("Change Layer:")
+                                .color(Color::rgb(0.6, 0.6, 0.7))
+                                .font_size(12.0),
+                        )
+                        .child(
+                            container()
+                                .layout(Flex::row().spacing(8.0))
+                                .child(layer_button(
+                                    "Background",
+                                    Layer::Background,
+                                    surface_id_signal,
+                                    current_layer,
+                                ))
+                                .child(layer_button(
+                                    "Bottom",
+                                    Layer::Bottom,
+                                    surface_id_signal,
+                                    current_layer,
+                                ))
+                                .child(layer_button(
+                                    "Top",
+                                    Layer::Top,
+                                    surface_id_signal,
+                                    current_layer,
+                                ))
+                                .child(layer_button(
+                                    "Overlay",
+                                    Layer::Overlay,
+                                    surface_id_signal,
+                                    current_layer,
+                                )),
+                        ),
+                )
+                // Keyboard interactivity controls
+                .child(
+                    container()
+                        .layout(Flex::column().spacing(8.0))
+                        .child(
+                            text("Change Keyboard Interactivity:")
+                                .color(Color::rgb(0.6, 0.6, 0.7))
+                                .font_size(12.0),
+                        )
+                        .child(
+                            container()
+                                .layout(Flex::row().spacing(8.0))
+                                .child(keyboard_button(
+                                    "None",
+                                    KeyboardInteractivity::None,
+                                    surface_id_signal,
+                                    current_keyboard,
+                                ))
+                                .child(keyboard_button(
+                                    "OnDemand",
+                                    KeyboardInteractivity::OnDemand,
+                                    surface_id_signal,
+                                    current_keyboard,
+                                ))
+                                .child(keyboard_button(
+                                    "Exclusive",
+                                    KeyboardInteractivity::Exclusive,
+                                    surface_id_signal,
+                                    current_keyboard,
+                                )),
+                        ),
+                )
+                // Instructions
+                .child(
+                    container()
+                        .padding(12.0)
+                        .background(Color::rgb(0.12, 0.12, 0.16))
+                        .corner_radius(6.0)
+                        .layout(Flex::column().spacing(4.0))
+                        .child(
+                            text("Tips:")
+                                .color(Color::rgb(0.5, 0.5, 0.6))
+                                .font_size(11.0),
+                        )
+                        .child(
+                            text("- Overlay layer appears above other windows")
+                                .color(Color::rgb(0.5, 0.5, 0.6))
+                                .font_size(11.0),
+                        )
+                        .child(
+                            text("- Background layer appears below the desktop")
+                                .color(Color::rgb(0.5, 0.5, 0.6))
+                                .font_size(11.0),
+                        )
+                        .child(
+                            text("- Exclusive keyboard grabs focus from other apps")
+                                .color(Color::rgb(0.5, 0.5, 0.6))
+                                .font_size(11.0),
+                        ),
+                )
+        },
+    );
+
+    // Store the surface ID so the buttons can access it
+    surface_id_signal.set(Some(surface_id));
+
+    app.run();
+}
+
+fn layer_button(
+    label: &'static str,
+    layer: Layer,
+    surface_id_signal: Signal<Option<SurfaceId>>,
+    current_layer: Signal<&'static str>,
+) -> Container {
+    container()
+        .padding_xy(12.0, 8.0)
+        .background(Color::rgb(0.25, 0.25, 0.35))
+        .corner_radius(6.0)
+        .hover_state(|s| s.lighter(0.1))
+        .pressed_state(|s| s.ripple())
+        .on_click(move || {
+            if let Some(id) = surface_id_signal.get() {
+                let handle = surface_handle(id);
+                handle.set_layer(layer);
+                current_layer.set(label);
+            }
+        })
+        .child(text(label).color(Color::WHITE).font_size(13.0))
+}
+
+fn keyboard_button(
+    label: &'static str,
+    mode: KeyboardInteractivity,
+    surface_id_signal: Signal<Option<SurfaceId>>,
+    current_keyboard: Signal<&'static str>,
+) -> Container {
+    container()
+        .padding_xy(12.0, 8.0)
+        .background(Color::rgb(0.25, 0.3, 0.35))
+        .corner_radius(6.0)
+        .hover_state(|s| s.lighter(0.1))
+        .pressed_state(|s| s.ripple())
+        .on_click(move || {
+            if let Some(id) = surface_id_signal.get() {
+                let handle = surface_handle(id);
+                handle.set_keyboard_interactivity(mode);
+                current_keyboard.set(label);
+            }
+        })
+        .child(text(label).color(Color::WHITE).font_size(13.0))
+}

--- a/examples/text_input_example.rs
+++ b/examples/text_input_example.rs
@@ -178,16 +178,15 @@ fn main() {
                 ),
         );
 
-    App::new()
-        .add_surface(
-            SurfaceConfig::new()
-                .width(400)
-                .height(500)
-                .anchor(Anchor::TOP | Anchor::LEFT)
-                .layer(Layer::Top)
-                .namespace("text-input-example")
-                .background_color(Color::rgb(0.12, 0.12, 0.18)),
-            move || view,
-        )
-        .run();
+    let (app, _) = App::new().add_surface(
+        SurfaceConfig::new()
+            .width(400)
+            .height(500)
+            .anchor(Anchor::TOP | Anchor::LEFT)
+            .layer(Layer::Top)
+            .namespace("text-input-example")
+            .background_color(Color::rgb(0.12, 0.12, 0.18)),
+        move || view,
+    );
+    app.run();
 }

--- a/examples/text_input_transform_test.rs
+++ b/examples/text_input_transform_test.rs
@@ -158,16 +158,15 @@ fn main() {
                 .font_size(11.0),
         );
 
-    App::new()
-        .add_surface(
-            SurfaceConfig::new()
-                .width(550)
-                .height(680)
-                .anchor(Anchor::TOP | Anchor::LEFT)
-                .layer(Layer::Top)
-                .namespace("text-input-transform-test")
-                .background_color(Color::rgb(0.1, 0.1, 0.15)),
-            move || view,
-        )
-        .run();
+    let (app, _) = App::new().add_surface(
+        SurfaceConfig::new()
+            .width(550)
+            .height(680)
+            .anchor(Anchor::TOP | Anchor::LEFT)
+            .layer(Layer::Top)
+            .namespace("text-input-transform-test")
+            .background_color(Color::rgb(0.1, 0.1, 0.15)),
+        move || view,
+    );
+    app.run();
 }

--- a/examples/text_transform_example.rs
+++ b/examples/text_transform_example.rs
@@ -287,20 +287,19 @@ fn main() {
     // Track time for animation
     let start_time = std::time::Instant::now();
 
-    App::new()
-        .add_surface(
-            SurfaceConfig::new()
-                .width(900)
-                .height(450)
-                .anchor(Anchor::TOP | Anchor::LEFT)
-                .background_color(Color::rgb(0.1, 0.1, 0.15)),
-            move || view,
-        )
-        .on_update(move || {
-            // Update animation angle (full rotation every 4 seconds)
-            let elapsed = start_time.elapsed().as_secs_f32();
-            let new_angle = (elapsed * PI / 2.0).to_degrees() % 360.0;
-            angle.set(new_angle);
-        })
-        .run();
+    let (app, _) = App::new().add_surface(
+        SurfaceConfig::new()
+            .width(900)
+            .height(450)
+            .anchor(Anchor::TOP | Anchor::LEFT)
+            .background_color(Color::rgb(0.1, 0.1, 0.15)),
+        move || view,
+    );
+    app.on_update(move || {
+        // Update animation angle (full rotation every 4 seconds)
+        let elapsed = start_time.elapsed().as_secs_f32();
+        let new_angle = (elapsed * PI / 2.0).to_degrees() % 360.0;
+        angle.set(new_angle);
+    })
+    .run();
 }

--- a/examples/transform_events_test.rs
+++ b/examples/transform_events_test.rs
@@ -13,100 +13,88 @@ use guido::prelude::*;
 fn main() {
     let click_count = create_signal(0);
 
-    App::new()
-        .add_surface(
-            SurfaceConfig::new()
-                .height(350)
-                .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
-                .background_color(Color::rgb(0.1, 0.1, 0.15)),
-            move || {
-                container()
-                    .layout(
-                        Flex::column()
-                            .spacing(20.0)
-                            .cross_axis_alignment(CrossAxisAlignment::Center),
-                    )
-                    .padding(20.0)
-                    .children([
-                        // Row 1: Basic transforms
-                        container()
-                            .layout(
-                                Flex::row()
-                                    .spacing(30.0)
-                                    .main_axis_alignment(MainAxisAlignment::Center),
-                            )
-                            .children([
-                                // No transform (control)
-                                make_box("None", Color::rgb(0.5, 0.5, 0.5), click_count),
-                                // Translation
-                                make_box("Translate", Color::rgb(0.3, 0.8, 0.3), click_count)
-                                    .translate(20.0, 10.0),
-                                // Rotation
-                                make_box("Rotate", Color::rgb(0.3, 0.3, 0.8), click_count)
-                                    .rotate(15.0),
-                                // Scale up
-                                make_box("Scale+", Color::rgb(0.8, 0.3, 0.8), click_count)
-                                    .scale(1.2),
-                                // Scale down
-                                make_box("Scale-", Color::rgb(0.8, 0.6, 0.3), click_count)
-                                    .scale(0.7),
-                            ]),
-                        // Row 2: Nested transforms
-                        container()
-                            .layout(
-                                Flex::row()
-                                    .spacing(50.0)
-                                    .main_axis_alignment(MainAxisAlignment::Center),
-                            )
-                            .children([
-                                // Nested: parent rotated, child clickable
-                                container()
-                                    .width(100.0)
-                                    .height(100.0)
-                                    .background(Color::rgba(0.8, 0.3, 0.3, 0.3))
-                                    .corner_radius(8.0)
-                                    .rotate(20.0)
-                                    .layout(
-                                        Flex::column()
-                                            .main_axis_alignment(MainAxisAlignment::Center)
-                                            .cross_axis_alignment(CrossAxisAlignment::Center),
-                                    )
-                                    .child(make_box(
-                                        "Nested",
-                                        Color::rgb(0.8, 0.8, 0.3),
-                                        click_count,
-                                    )),
-                                // Nested: parent scaled, child rotated and clickable
-                                container()
-                                    .width(100.0)
-                                    .height(100.0)
-                                    .background(Color::rgba(0.3, 0.8, 0.3, 0.3))
-                                    .corner_radius(8.0)
-                                    .scale(1.3)
-                                    .layout(
-                                        Flex::column()
-                                            .main_axis_alignment(MainAxisAlignment::Center)
-                                            .cross_axis_alignment(CrossAxisAlignment::Center),
-                                    )
-                                    .child(
-                                        make_box(
-                                            "Nest+Rot",
-                                            Color::rgb(0.3, 0.8, 0.8),
-                                            click_count,
-                                        )
+    let (app, _) = App::new().add_surface(
+        SurfaceConfig::new()
+            .height(350)
+            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+            .background_color(Color::rgb(0.1, 0.1, 0.15)),
+        move || {
+            container()
+                .layout(
+                    Flex::column()
+                        .spacing(20.0)
+                        .cross_axis_alignment(CrossAxisAlignment::Center),
+                )
+                .padding(20.0)
+                .children([
+                    // Row 1: Basic transforms
+                    container()
+                        .layout(
+                            Flex::row()
+                                .spacing(30.0)
+                                .main_axis_alignment(MainAxisAlignment::Center),
+                        )
+                        .children([
+                            // No transform (control)
+                            make_box("None", Color::rgb(0.5, 0.5, 0.5), click_count),
+                            // Translation
+                            make_box("Translate", Color::rgb(0.3, 0.8, 0.3), click_count)
+                                .translate(20.0, 10.0),
+                            // Rotation
+                            make_box("Rotate", Color::rgb(0.3, 0.3, 0.8), click_count).rotate(15.0),
+                            // Scale up
+                            make_box("Scale+", Color::rgb(0.8, 0.3, 0.8), click_count).scale(1.2),
+                            // Scale down
+                            make_box("Scale-", Color::rgb(0.8, 0.6, 0.3), click_count).scale(0.7),
+                        ]),
+                    // Row 2: Nested transforms
+                    container()
+                        .layout(
+                            Flex::row()
+                                .spacing(50.0)
+                                .main_axis_alignment(MainAxisAlignment::Center),
+                        )
+                        .children([
+                            // Nested: parent rotated, child clickable
+                            container()
+                                .width(100.0)
+                                .height(100.0)
+                                .background(Color::rgba(0.8, 0.3, 0.3, 0.3))
+                                .corner_radius(8.0)
+                                .rotate(20.0)
+                                .layout(
+                                    Flex::column()
+                                        .main_axis_alignment(MainAxisAlignment::Center)
+                                        .cross_axis_alignment(CrossAxisAlignment::Center),
+                                )
+                                .child(make_box("Nested", Color::rgb(0.8, 0.8, 0.3), click_count)),
+                            // Nested: parent scaled, child rotated and clickable
+                            container()
+                                .width(100.0)
+                                .height(100.0)
+                                .background(Color::rgba(0.3, 0.8, 0.3, 0.3))
+                                .corner_radius(8.0)
+                                .scale(1.3)
+                                .layout(
+                                    Flex::column()
+                                        .main_axis_alignment(MainAxisAlignment::Center)
+                                        .cross_axis_alignment(CrossAxisAlignment::Center),
+                                )
+                                .child(
+                                    make_box("Nest+Rot", Color::rgb(0.3, 0.8, 0.8), click_count)
                                         .rotate(30.0),
-                                    ),
-                            ]),
-                        // Click counter display
-                        container().child(
-                            text(move || format!("Clicks: {}", click_count.get()))
-                                .font_size(20.0)
-                                .color(Color::WHITE),
-                        ),
-                    ])
-            },
-        )
-        .run();
+                                ),
+                        ]),
+                    // Click counter display
+                    container().child(
+                        text(move || format!("Clicks: {}", click_count.get()))
+                            .font_size(20.0)
+                            .color(Color::WHITE),
+                    ),
+                ])
+        },
+    );
+    app.run();
 }
 
 fn make_box(label: &'static str, base_color: Color, click_count: Signal<i32>) -> Container {

--- a/examples/transform_example.rs
+++ b/examples/transform_example.rs
@@ -16,192 +16,182 @@ fn main() {
     let is_scaled = create_signal(false);
 
     // Run the app with taller height to see transforms
-    App::new()
-        .add_surface(
-            SurfaceConfig::new()
-                .height(120)
-                .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
-                .background_color(Color::rgb(0.1, 0.1, 0.15)),
-            move || {
-                container()
-                    .layout(
-                        Flex::row()
-                            .spacing(20.0)
-                            .main_axis_alignment(MainAxisAlignment::Center)
-                            .cross_axis_alignment(CrossAxisAlignment::Center),
-                    )
-                    .padding(16.0)
-                    .children([
-                        // 1. Static rotation (45 degrees)
-                        container()
-                            .width(60.0)
-                            .height(60.0)
-                            .background(Color::rgb(0.8, 0.3, 0.3))
-                            .corner_radius(8.0)
-                            .rotate(45.0)
-                            .child(
-                                container()
-                                    .layout(
-                                        Flex::column()
-                                            .main_axis_alignment(MainAxisAlignment::Center)
-                                            .cross_axis_alignment(CrossAxisAlignment::Center),
-                                    )
-                                    .child(text("45").color(Color::WHITE).font_size(12.0)),
-                            ),
-                        // 2. Click to rotate (increments by 45 degrees)
-                        container()
-                            .width(60.0)
-                            .height(60.0)
-                            .background(Color::rgb(0.3, 0.6, 0.8))
-                            .corner_radius(8.0)
-                            .rotate(rotation)
-                            .animate_transform(Transition::new(300.0, TimingFunction::EaseOut))
-                            .hover_state(|s| s.lighter(0.1))
-                            .pressed_state(|s| s.ripple())
-                            .on_click(move || {
-                                rotation.update(|r| *r += 45.0);
-                            })
-                            .child(
-                                container()
-                                    .layout(
-                                        Flex::column()
-                                            .main_axis_alignment(MainAxisAlignment::Center)
-                                            .cross_axis_alignment(CrossAxisAlignment::Center),
-                                    )
-                                    .child(
-                                        text("Click").color(Color::WHITE).font_size(10.0).nowrap(),
-                                    ),
-                            ),
-                        // 3. Click to toggle scale with spring animation
-                        container()
-                            .width(60.0)
-                            .height(60.0)
-                            .background(Color::rgb(0.3, 0.8, 0.4))
-                            .corner_radius(8.0)
-                            .scale(scale_factor)
-                            .animate_transform(Transition::spring(SpringConfig::BOUNCY))
-                            .hover_state(|s| s.lighter(0.1))
-                            .pressed_state(|s| s.ripple())
-                            .on_click(move || {
-                                is_scaled.update(|s| *s = !*s);
-                                let target = if is_scaled.get() { 1.3 } else { 1.0 };
-                                scale_factor.set(target);
-                            })
-                            .child(
-                                container()
-                                    .layout(
-                                        Flex::column()
-                                            .main_axis_alignment(MainAxisAlignment::Center)
-                                            .cross_axis_alignment(CrossAxisAlignment::Center),
-                                    )
-                                    .child(
-                                        text("Scale").color(Color::WHITE).font_size(10.0).nowrap(),
-                                    ),
-                            ),
-                        // 4. Static scale (smaller)
-                        container()
-                            .width(60.0)
-                            .height(60.0)
-                            .background(Color::rgb(0.6, 0.4, 0.8))
-                            .corner_radius(8.0)
-                            .scale(0.7)
-                            .child(
-                                container()
-                                    .layout(
-                                        Flex::column()
-                                            .main_axis_alignment(MainAxisAlignment::Center)
-                                            .cross_axis_alignment(CrossAxisAlignment::Center),
-                                    )
-                                    .child(text("0.7x").color(Color::WHITE).font_size(12.0)),
-                            ),
-                        // 5. Combined rotation + scale
-                        container()
-                            .width(60.0)
-                            .height(60.0)
-                            .background(Color::rgb(0.8, 0.6, 0.2))
-                            .corner_radius(8.0)
-                            .transform(Transform::rotate_degrees(30.0).then(&Transform::scale(0.8)))
-                            .child(
-                                container()
-                                    .layout(
-                                        Flex::column()
-                                            .main_axis_alignment(MainAxisAlignment::Center)
-                                            .cross_axis_alignment(CrossAxisAlignment::Center),
-                                    )
-                                    .child(
-                                        text("Both").color(Color::WHITE).font_size(10.0).nowrap(),
-                                    ),
-                            ),
-                        // 6. Rotation around top-left corner (transform origin)
-                        container()
-                            .width(60.0)
-                            .height(60.0)
-                            .background(Color::rgb(0.8, 0.5, 0.7))
-                            .corner_radius(8.0)
-                            .rotate(45.0)
-                            .transform_origin(TransformOrigin::TOP_LEFT)
-                            .child(
-                                container()
-                                    .layout(
-                                        Flex::column()
-                                            .main_axis_alignment(MainAxisAlignment::Center)
-                                            .cross_axis_alignment(CrossAxisAlignment::Center),
-                                    )
-                                    .child(text("TL").color(Color::WHITE).font_size(12.0)),
-                            ),
-                        // 7. Scale from bottom-right corner (transform origin)
-                        container()
-                            .width(60.0)
-                            .height(60.0)
-                            .background(Color::rgb(0.5, 0.7, 0.8))
-                            .corner_radius(8.0)
-                            .scale(0.8)
-                            .transform_origin(TransformOrigin::BOTTOM_RIGHT)
-                            .child(
-                                container()
-                                    .layout(
-                                        Flex::column()
-                                            .main_axis_alignment(MainAxisAlignment::Center)
-                                            .cross_axis_alignment(CrossAxisAlignment::Center),
-                                    )
-                                    .child(text("BR").color(Color::WHITE).font_size(12.0)),
-                            ),
-                        // 8. Interactive: click to cycle through origins
-                        {
-                            let origin_index = create_signal(0usize);
+    let (app, _) = App::new().add_surface(
+        SurfaceConfig::new()
+            .height(120)
+            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+            .background_color(Color::rgb(0.1, 0.1, 0.15)),
+        move || {
+            container()
+                .layout(
+                    Flex::row()
+                        .spacing(20.0)
+                        .main_axis_alignment(MainAxisAlignment::Center)
+                        .cross_axis_alignment(CrossAxisAlignment::Center),
+                )
+                .padding(16.0)
+                .children([
+                    // 1. Static rotation (45 degrees)
+                    container()
+                        .width(60.0)
+                        .height(60.0)
+                        .background(Color::rgb(0.8, 0.3, 0.3))
+                        .corner_radius(8.0)
+                        .rotate(45.0)
+                        .child(
                             container()
-                                .width(60.0)
-                                .height(60.0)
-                                .background(Color::rgb(0.7, 0.8, 0.5))
-                                .corner_radius(8.0)
-                                .rotate(30.0)
-                                .transform_origin(move || match origin_index.get() % 5 {
-                                    0 => TransformOrigin::CENTER,
-                                    1 => TransformOrigin::TOP_LEFT,
-                                    2 => TransformOrigin::TOP_RIGHT,
-                                    3 => TransformOrigin::BOTTOM_LEFT,
-                                    _ => TransformOrigin::BOTTOM_RIGHT,
-                                })
-                                .hover_state(|s| s.lighter(0.1))
-                                .pressed_state(|s| s.ripple())
-                                .on_click(move || origin_index.update(|i| *i += 1))
-                                .child(
-                                    container()
-                                        .layout(
-                                            Flex::column()
-                                                .main_axis_alignment(MainAxisAlignment::Center)
-                                                .cross_axis_alignment(CrossAxisAlignment::Center),
-                                        )
-                                        .child(
-                                            text("Cycle")
-                                                .color(Color::WHITE)
-                                                .font_size(10.0)
-                                                .nowrap(),
-                                        ),
+                                .layout(
+                                    Flex::column()
+                                        .main_axis_alignment(MainAxisAlignment::Center)
+                                        .cross_axis_alignment(CrossAxisAlignment::Center),
                                 )
-                        },
-                    ])
-            },
-        )
-        .run();
+                                .child(text("45").color(Color::WHITE).font_size(12.0)),
+                        ),
+                    // 2. Click to rotate (increments by 45 degrees)
+                    container()
+                        .width(60.0)
+                        .height(60.0)
+                        .background(Color::rgb(0.3, 0.6, 0.8))
+                        .corner_radius(8.0)
+                        .rotate(rotation)
+                        .animate_transform(Transition::new(300.0, TimingFunction::EaseOut))
+                        .hover_state(|s| s.lighter(0.1))
+                        .pressed_state(|s| s.ripple())
+                        .on_click(move || {
+                            rotation.update(|r| *r += 45.0);
+                        })
+                        .child(
+                            container()
+                                .layout(
+                                    Flex::column()
+                                        .main_axis_alignment(MainAxisAlignment::Center)
+                                        .cross_axis_alignment(CrossAxisAlignment::Center),
+                                )
+                                .child(text("Click").color(Color::WHITE).font_size(10.0).nowrap()),
+                        ),
+                    // 3. Click to toggle scale with spring animation
+                    container()
+                        .width(60.0)
+                        .height(60.0)
+                        .background(Color::rgb(0.3, 0.8, 0.4))
+                        .corner_radius(8.0)
+                        .scale(scale_factor)
+                        .animate_transform(Transition::spring(SpringConfig::BOUNCY))
+                        .hover_state(|s| s.lighter(0.1))
+                        .pressed_state(|s| s.ripple())
+                        .on_click(move || {
+                            is_scaled.update(|s| *s = !*s);
+                            let target = if is_scaled.get() { 1.3 } else { 1.0 };
+                            scale_factor.set(target);
+                        })
+                        .child(
+                            container()
+                                .layout(
+                                    Flex::column()
+                                        .main_axis_alignment(MainAxisAlignment::Center)
+                                        .cross_axis_alignment(CrossAxisAlignment::Center),
+                                )
+                                .child(text("Scale").color(Color::WHITE).font_size(10.0).nowrap()),
+                        ),
+                    // 4. Static scale (smaller)
+                    container()
+                        .width(60.0)
+                        .height(60.0)
+                        .background(Color::rgb(0.6, 0.4, 0.8))
+                        .corner_radius(8.0)
+                        .scale(0.7)
+                        .child(
+                            container()
+                                .layout(
+                                    Flex::column()
+                                        .main_axis_alignment(MainAxisAlignment::Center)
+                                        .cross_axis_alignment(CrossAxisAlignment::Center),
+                                )
+                                .child(text("0.7x").color(Color::WHITE).font_size(12.0)),
+                        ),
+                    // 5. Combined rotation + scale
+                    container()
+                        .width(60.0)
+                        .height(60.0)
+                        .background(Color::rgb(0.8, 0.6, 0.2))
+                        .corner_radius(8.0)
+                        .transform(Transform::rotate_degrees(30.0).then(&Transform::scale(0.8)))
+                        .child(
+                            container()
+                                .layout(
+                                    Flex::column()
+                                        .main_axis_alignment(MainAxisAlignment::Center)
+                                        .cross_axis_alignment(CrossAxisAlignment::Center),
+                                )
+                                .child(text("Both").color(Color::WHITE).font_size(10.0).nowrap()),
+                        ),
+                    // 6. Rotation around top-left corner (transform origin)
+                    container()
+                        .width(60.0)
+                        .height(60.0)
+                        .background(Color::rgb(0.8, 0.5, 0.7))
+                        .corner_radius(8.0)
+                        .rotate(45.0)
+                        .transform_origin(TransformOrigin::TOP_LEFT)
+                        .child(
+                            container()
+                                .layout(
+                                    Flex::column()
+                                        .main_axis_alignment(MainAxisAlignment::Center)
+                                        .cross_axis_alignment(CrossAxisAlignment::Center),
+                                )
+                                .child(text("TL").color(Color::WHITE).font_size(12.0)),
+                        ),
+                    // 7. Scale from bottom-right corner (transform origin)
+                    container()
+                        .width(60.0)
+                        .height(60.0)
+                        .background(Color::rgb(0.5, 0.7, 0.8))
+                        .corner_radius(8.0)
+                        .scale(0.8)
+                        .transform_origin(TransformOrigin::BOTTOM_RIGHT)
+                        .child(
+                            container()
+                                .layout(
+                                    Flex::column()
+                                        .main_axis_alignment(MainAxisAlignment::Center)
+                                        .cross_axis_alignment(CrossAxisAlignment::Center),
+                                )
+                                .child(text("BR").color(Color::WHITE).font_size(12.0)),
+                        ),
+                    // 8. Interactive: click to cycle through origins
+                    {
+                        let origin_index = create_signal(0usize);
+                        container()
+                            .width(60.0)
+                            .height(60.0)
+                            .background(Color::rgb(0.7, 0.8, 0.5))
+                            .corner_radius(8.0)
+                            .rotate(30.0)
+                            .transform_origin(move || match origin_index.get() % 5 {
+                                0 => TransformOrigin::CENTER,
+                                1 => TransformOrigin::TOP_LEFT,
+                                2 => TransformOrigin::TOP_RIGHT,
+                                3 => TransformOrigin::BOTTOM_LEFT,
+                                _ => TransformOrigin::BOTTOM_RIGHT,
+                            })
+                            .hover_state(|s| s.lighter(0.1))
+                            .pressed_state(|s| s.ripple())
+                            .on_click(move || origin_index.update(|i| *i += 1))
+                            .child(
+                                container()
+                                    .layout(
+                                        Flex::column()
+                                            .main_axis_alignment(MainAxisAlignment::Center)
+                                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                                    )
+                                    .child(
+                                        text("Cycle").color(Color::WHITE).font_size(10.0).nowrap(),
+                                    ),
+                            )
+                    },
+                ])
+        },
+    );
+    app.run();
 }

--- a/examples/transform_origin_test.rs
+++ b/examples/transform_origin_test.rs
@@ -8,194 +8,193 @@ fn main() {
     let angle = create_signal(0.0_f32);
     let start_time = std::time::Instant::now();
 
-    App::new()
-        .add_surface(
-            SurfaceConfig::new()
-                .width(900)
-                .height(550)
-                .anchor(Anchor::TOP | Anchor::LEFT)
-                .background_color(Color::rgb(0.1, 0.1, 0.15)),
-            move || {
-                container()
-                    .layout(
-                        Flex::column()
-                            .spacing(40.0)
-                            .main_axis_alignment(MainAxisAlignment::Center)
-                            .cross_axis_alignment(CrossAxisAlignment::Center),
-                    )
-                    .padding(40.0)
-                    .children([
-                        // Row 1: Different origins with same rotation
-                        container()
-                            .layout(
-                                Flex::row()
-                                    .spacing(80.0)
-                                    .main_axis_alignment(MainAxisAlignment::Center)
-                                    .cross_axis_alignment(CrossAxisAlignment::Center),
-                            )
-                            .children([
-                                // Default origin (center)
-                                container()
-                                    .width(100.0)
-                                    .height(80.0)
-                                    .background(Color::rgba(0.3, 0.5, 0.8, 0.8))
-                                    .corner_radius(8.0)
-                                    .rotate(20.0),
-                                // Top-left origin
-                                container()
-                                    .width(100.0)
-                                    .height(80.0)
-                                    .background(Color::rgba(0.8, 0.5, 0.3, 0.8))
-                                    .corner_radius(8.0)
-                                    .transform_origin(TransformOrigin::TOP_LEFT)
-                                    .rotate(20.0),
-                                // Top-right origin
-                                container()
-                                    .width(100.0)
-                                    .height(80.0)
-                                    .background(Color::rgba(0.5, 0.8, 0.3, 0.8))
-                                    .corner_radius(8.0)
-                                    .transform_origin(TransformOrigin::TOP_RIGHT)
-                                    .rotate(20.0),
-                                // Bottom-left origin
-                                container()
-                                    .width(100.0)
-                                    .height(80.0)
-                                    .background(Color::rgba(0.8, 0.3, 0.8, 0.8))
-                                    .corner_radius(8.0)
-                                    .transform_origin(TransformOrigin::BOTTOM_LEFT)
-                                    .rotate(20.0),
-                                // Bottom-right origin
-                                container()
-                                    .width(100.0)
-                                    .height(80.0)
-                                    .background(Color::rgba(0.3, 0.8, 0.8, 0.8))
-                                    .corner_radius(8.0)
-                                    .transform_origin(TransformOrigin::BOTTOM_RIGHT)
-                                    .rotate(20.0),
-                            ]),
-                        // Row 2: Scale with different origins
-                        container()
-                            .layout(
-                                Flex::row()
-                                    .spacing(80.0)
-                                    .main_axis_alignment(MainAxisAlignment::Center)
-                                    .cross_axis_alignment(CrossAxisAlignment::Center),
-                            )
-                            .children([
-                                // Default origin (center) - scale
-                                container()
-                                    .width(80.0)
-                                    .height(60.0)
-                                    .background(Color::rgba(0.6, 0.3, 0.3, 0.8))
-                                    .corner_radius(6.0)
-                                    .scale(1.3),
-                                // Top-left origin - scale
-                                container()
-                                    .width(80.0)
-                                    .height(60.0)
-                                    .background(Color::rgba(0.3, 0.6, 0.3, 0.8))
-                                    .corner_radius(6.0)
-                                    .transform_origin(TransformOrigin::TOP_LEFT)
-                                    .scale(1.3),
-                                // Bottom-right origin - scale
-                                container()
-                                    .width(80.0)
-                                    .height(60.0)
-                                    .background(Color::rgba(0.3, 0.3, 0.6, 0.8))
-                                    .corner_radius(6.0)
-                                    .transform_origin(TransformOrigin::BOTTOM_RIGHT)
-                                    .scale(1.3),
-                            ]),
-                        // Row 3: Animated rotation with different origins
-                        container()
-                            .layout(
-                                Flex::row()
-                                    .spacing(80.0)
-                                    .main_axis_alignment(MainAxisAlignment::Center)
-                                    .cross_axis_alignment(CrossAxisAlignment::Center),
-                            )
-                            .children([
-                                // Center origin - animated
-                                container()
-                                    .width(80.0)
-                                    .height(60.0)
-                                    .background(Color::rgba(0.7, 0.5, 0.2, 0.8))
-                                    .corner_radius(6.0)
-                                    .rotate(move || angle.get()),
-                                // Top-left origin - animated
-                                container()
-                                    .width(80.0)
-                                    .height(60.0)
-                                    .background(Color::rgba(0.2, 0.5, 0.7, 0.8))
-                                    .corner_radius(6.0)
-                                    .transform_origin(TransformOrigin::TOP_LEFT)
-                                    .rotate(move || angle.get()),
-                                // Custom origin (25%, 75%) - animated
-                                container()
-                                    .width(80.0)
-                                    .height(60.0)
-                                    .background(Color::rgba(0.5, 0.7, 0.2, 0.8))
-                                    .corner_radius(6.0)
-                                    .transform_origin(TransformOrigin::percent(25.0, 75.0))
-                                    .rotate(move || angle.get()),
-                            ]),
-                        // Row 4: Nested containers with different origins
-                        container()
-                            .layout(
-                                Flex::row()
-                                    .spacing(80.0)
-                                    .main_axis_alignment(MainAxisAlignment::Center)
-                                    .cross_axis_alignment(CrossAxisAlignment::Center),
-                            )
-                            .children([
-                                // Parent rotated at center, child inside
-                                container()
-                                    .width(120.0)
-                                    .height(100.0)
-                                    .background(Color::rgba(0.4, 0.4, 0.6, 0.5))
-                                    .corner_radius(10.0)
-                                    .layout(
-                                        Flex::column()
-                                            .main_axis_alignment(MainAxisAlignment::Center)
-                                            .cross_axis_alignment(CrossAxisAlignment::Center),
-                                    )
-                                    .rotate(15.0)
-                                    .child(
-                                        container()
-                                            .width(60.0)
-                                            .height(40.0)
-                                            .background(Color::rgba(0.6, 0.6, 0.8, 0.9))
-                                            .corner_radius(4.0),
-                                    ),
-                                // Parent rotated at top-left, child inside
-                                container()
-                                    .width(120.0)
-                                    .height(100.0)
-                                    .background(Color::rgba(0.6, 0.4, 0.4, 0.5))
-                                    .corner_radius(10.0)
-                                    .layout(
-                                        Flex::column()
-                                            .main_axis_alignment(MainAxisAlignment::Center)
-                                            .cross_axis_alignment(CrossAxisAlignment::Center),
-                                    )
-                                    .transform_origin(TransformOrigin::TOP_LEFT)
-                                    .rotate(15.0)
-                                    .child(
-                                        container()
-                                            .width(60.0)
-                                            .height(40.0)
-                                            .background(Color::rgba(0.8, 0.6, 0.6, 0.9))
-                                            .corner_radius(4.0),
-                                    ),
-                            ]),
-                    ])
-            },
-        )
-        .on_update(move || {
-            let elapsed = start_time.elapsed().as_secs_f32();
-            let new_angle = (elapsed * 45.0) % 360.0; // 45 degrees per second
-            angle.set(new_angle);
-        })
-        .run();
+    let (app, _) = App::new().add_surface(
+        SurfaceConfig::new()
+            .width(900)
+            .height(550)
+            .anchor(Anchor::TOP | Anchor::LEFT)
+            .background_color(Color::rgb(0.1, 0.1, 0.15)),
+        move || {
+            container()
+                .layout(
+                    Flex::column()
+                        .spacing(40.0)
+                        .main_axis_alignment(MainAxisAlignment::Center)
+                        .cross_axis_alignment(CrossAxisAlignment::Center),
+                )
+                .padding(40.0)
+                .children([
+                    // Row 1: Different origins with same rotation
+                    container()
+                        .layout(
+                            Flex::row()
+                                .spacing(80.0)
+                                .main_axis_alignment(MainAxisAlignment::Center)
+                                .cross_axis_alignment(CrossAxisAlignment::Center),
+                        )
+                        .children([
+                            // Default origin (center)
+                            container()
+                                .width(100.0)
+                                .height(80.0)
+                                .background(Color::rgba(0.3, 0.5, 0.8, 0.8))
+                                .corner_radius(8.0)
+                                .rotate(20.0),
+                            // Top-left origin
+                            container()
+                                .width(100.0)
+                                .height(80.0)
+                                .background(Color::rgba(0.8, 0.5, 0.3, 0.8))
+                                .corner_radius(8.0)
+                                .transform_origin(TransformOrigin::TOP_LEFT)
+                                .rotate(20.0),
+                            // Top-right origin
+                            container()
+                                .width(100.0)
+                                .height(80.0)
+                                .background(Color::rgba(0.5, 0.8, 0.3, 0.8))
+                                .corner_radius(8.0)
+                                .transform_origin(TransformOrigin::TOP_RIGHT)
+                                .rotate(20.0),
+                            // Bottom-left origin
+                            container()
+                                .width(100.0)
+                                .height(80.0)
+                                .background(Color::rgba(0.8, 0.3, 0.8, 0.8))
+                                .corner_radius(8.0)
+                                .transform_origin(TransformOrigin::BOTTOM_LEFT)
+                                .rotate(20.0),
+                            // Bottom-right origin
+                            container()
+                                .width(100.0)
+                                .height(80.0)
+                                .background(Color::rgba(0.3, 0.8, 0.8, 0.8))
+                                .corner_radius(8.0)
+                                .transform_origin(TransformOrigin::BOTTOM_RIGHT)
+                                .rotate(20.0),
+                        ]),
+                    // Row 2: Scale with different origins
+                    container()
+                        .layout(
+                            Flex::row()
+                                .spacing(80.0)
+                                .main_axis_alignment(MainAxisAlignment::Center)
+                                .cross_axis_alignment(CrossAxisAlignment::Center),
+                        )
+                        .children([
+                            // Default origin (center) - scale
+                            container()
+                                .width(80.0)
+                                .height(60.0)
+                                .background(Color::rgba(0.6, 0.3, 0.3, 0.8))
+                                .corner_radius(6.0)
+                                .scale(1.3),
+                            // Top-left origin - scale
+                            container()
+                                .width(80.0)
+                                .height(60.0)
+                                .background(Color::rgba(0.3, 0.6, 0.3, 0.8))
+                                .corner_radius(6.0)
+                                .transform_origin(TransformOrigin::TOP_LEFT)
+                                .scale(1.3),
+                            // Bottom-right origin - scale
+                            container()
+                                .width(80.0)
+                                .height(60.0)
+                                .background(Color::rgba(0.3, 0.3, 0.6, 0.8))
+                                .corner_radius(6.0)
+                                .transform_origin(TransformOrigin::BOTTOM_RIGHT)
+                                .scale(1.3),
+                        ]),
+                    // Row 3: Animated rotation with different origins
+                    container()
+                        .layout(
+                            Flex::row()
+                                .spacing(80.0)
+                                .main_axis_alignment(MainAxisAlignment::Center)
+                                .cross_axis_alignment(CrossAxisAlignment::Center),
+                        )
+                        .children([
+                            // Center origin - animated
+                            container()
+                                .width(80.0)
+                                .height(60.0)
+                                .background(Color::rgba(0.7, 0.5, 0.2, 0.8))
+                                .corner_radius(6.0)
+                                .rotate(move || angle.get()),
+                            // Top-left origin - animated
+                            container()
+                                .width(80.0)
+                                .height(60.0)
+                                .background(Color::rgba(0.2, 0.5, 0.7, 0.8))
+                                .corner_radius(6.0)
+                                .transform_origin(TransformOrigin::TOP_LEFT)
+                                .rotate(move || angle.get()),
+                            // Custom origin (25%, 75%) - animated
+                            container()
+                                .width(80.0)
+                                .height(60.0)
+                                .background(Color::rgba(0.5, 0.7, 0.2, 0.8))
+                                .corner_radius(6.0)
+                                .transform_origin(TransformOrigin::percent(25.0, 75.0))
+                                .rotate(move || angle.get()),
+                        ]),
+                    // Row 4: Nested containers with different origins
+                    container()
+                        .layout(
+                            Flex::row()
+                                .spacing(80.0)
+                                .main_axis_alignment(MainAxisAlignment::Center)
+                                .cross_axis_alignment(CrossAxisAlignment::Center),
+                        )
+                        .children([
+                            // Parent rotated at center, child inside
+                            container()
+                                .width(120.0)
+                                .height(100.0)
+                                .background(Color::rgba(0.4, 0.4, 0.6, 0.5))
+                                .corner_radius(10.0)
+                                .layout(
+                                    Flex::column()
+                                        .main_axis_alignment(MainAxisAlignment::Center)
+                                        .cross_axis_alignment(CrossAxisAlignment::Center),
+                                )
+                                .rotate(15.0)
+                                .child(
+                                    container()
+                                        .width(60.0)
+                                        .height(40.0)
+                                        .background(Color::rgba(0.6, 0.6, 0.8, 0.9))
+                                        .corner_radius(4.0),
+                                ),
+                            // Parent rotated at top-left, child inside
+                            container()
+                                .width(120.0)
+                                .height(100.0)
+                                .background(Color::rgba(0.6, 0.4, 0.4, 0.5))
+                                .corner_radius(10.0)
+                                .layout(
+                                    Flex::column()
+                                        .main_axis_alignment(MainAxisAlignment::Center)
+                                        .cross_axis_alignment(CrossAxisAlignment::Center),
+                                )
+                                .transform_origin(TransformOrigin::TOP_LEFT)
+                                .rotate(15.0)
+                                .child(
+                                    container()
+                                        .width(60.0)
+                                        .height(40.0)
+                                        .background(Color::rgba(0.8, 0.6, 0.6, 0.9))
+                                        .corner_radius(4.0),
+                                ),
+                        ]),
+                ])
+        },
+    );
+    app.on_update(move || {
+        let elapsed = start_time.elapsed().as_secs_f32();
+        let new_angle = (elapsed * 45.0) % 360.0; // 45 degrees per second
+        angle.set(new_angle);
+    })
+    .run();
 }

--- a/examples/transform_scale_test.rs
+++ b/examples/transform_scale_test.rs
@@ -3,47 +3,46 @@
 use guido::prelude::*;
 
 fn main() {
-    App::new()
-        .add_surface(
-            SurfaceConfig::new()
-                .height(150)
-                .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
-                .background_color(Color::rgb(0.15, 0.15, 0.2)),
-            || {
-                container()
-                    .layout(
-                        Flex::row()
-                            .spacing(40.0)
-                            .main_axis_alignment(MainAxisAlignment::Center)
-                            .cross_axis_alignment(CrossAxisAlignment::Center),
-                    )
-                    .padding(16.0)
-                    .children([
-                        // Normal box
-                        container()
-                            .width(60.0)
-                            .height(60.0)
-                            .padding(10.)
-                            .background(Color::rgb(0.8, 0.3, 0.3))
-                            .corner_radius(8.0),
-                        // Scaled up box (should be bigger)
-                        container()
-                            .width(60.0)
-                            .height(60.0)
-                            .padding(10.0)
-                            .background(Color::rgb(0.3, 0.8, 0.3))
-                            .corner_radius(8.0)
-                            .scale(1.5),
-                        // Scaled down box (should be smaller)
-                        container()
-                            .width(60.0)
-                            .height(60.0)
-                            .padding(10.0)
-                            .background(Color::rgb(0.3, 0.3, 0.8))
-                            .corner_radius(8.0)
-                            .scale(0.5),
-                    ])
-            },
-        )
-        .run();
+    let (app, _) = App::new().add_surface(
+        SurfaceConfig::new()
+            .height(150)
+            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+            .background_color(Color::rgb(0.15, 0.15, 0.2)),
+        || {
+            container()
+                .layout(
+                    Flex::row()
+                        .spacing(40.0)
+                        .main_axis_alignment(MainAxisAlignment::Center)
+                        .cross_axis_alignment(CrossAxisAlignment::Center),
+                )
+                .padding(16.0)
+                .children([
+                    // Normal box
+                    container()
+                        .width(60.0)
+                        .height(60.0)
+                        .padding(10.)
+                        .background(Color::rgb(0.8, 0.3, 0.3))
+                        .corner_radius(8.0),
+                    // Scaled up box (should be bigger)
+                    container()
+                        .width(60.0)
+                        .height(60.0)
+                        .padding(10.0)
+                        .background(Color::rgb(0.3, 0.8, 0.3))
+                        .corner_radius(8.0)
+                        .scale(1.5),
+                    // Scaled down box (should be smaller)
+                    container()
+                        .width(60.0)
+                        .height(60.0)
+                        .padding(10.0)
+                        .background(Color::rgb(0.3, 0.3, 0.8))
+                        .corner_radius(8.0)
+                        .scale(0.5),
+                ])
+        },
+    );
+    app.run();
 }

--- a/examples/transform_test.rs
+++ b/examples/transform_test.rs
@@ -3,31 +3,30 @@
 use guido::prelude::*;
 
 fn main() {
-    App::new()
-        .add_surface(
-            SurfaceConfig::new()
-                .height(300)
-                .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
-                .background_color(Color::rgb(0.1, 0.1, 0.15)),
-            || {
-                container()
-                    .layout(
-                        Flex::column()
-                            .main_axis_alignment(MainAxisAlignment::Center)
-                            .cross_axis_alignment(CrossAxisAlignment::Center),
-                    )
-                    .padding(16.0)
-                    .child(
-                        container()
-                            .width(200.0)
-                            .height(100.0)
-                            .padding(10.0)
-                            .background(Color::rgb(0.8, 0.3, 0.3))
-                            .corner_radius(8.0)
-                            .elevation(4.0) // Add shadow to test shadow rendering with rotation
-                            .rotate(45.0), // Should be clearly rotated
-                    )
-            },
-        )
-        .run();
+    let (app, _) = App::new().add_surface(
+        SurfaceConfig::new()
+            .height(300)
+            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+            .background_color(Color::rgb(0.1, 0.1, 0.15)),
+        || {
+            container()
+                .layout(
+                    Flex::column()
+                        .main_axis_alignment(MainAxisAlignment::Center)
+                        .cross_axis_alignment(CrossAxisAlignment::Center),
+                )
+                .padding(16.0)
+                .child(
+                    container()
+                        .width(200.0)
+                        .height(100.0)
+                        .padding(10.0)
+                        .background(Color::rgb(0.8, 0.3, 0.3))
+                        .corner_radius(8.0)
+                        .elevation(4.0) // Add shadow to test shadow rendering with rotation
+                        .rotate(45.0), // Should be clearly rotated
+                )
+        },
+    );
+    app.run();
 }

--- a/examples/transform_translate_test.rs
+++ b/examples/transform_translate_test.rs
@@ -3,39 +3,38 @@
 use guido::prelude::*;
 
 fn main() {
-    App::new()
-        .add_surface(
-            SurfaceConfig::new()
-                .height(200)
-                .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
-                .background_color(Color::rgb(0.1, 0.1, 0.15)),
-            || {
-                container()
-                    .layout(
-                        Flex::row()
-                            .spacing(20.0)
-                            .main_axis_alignment(MainAxisAlignment::Center)
-                            .cross_axis_alignment(CrossAxisAlignment::Center),
-                    )
-                    .padding(16.0)
-                    .children([
-                        // No transform
-                        container()
-                            .width(80.0)
-                            .height(80.0)
-                            .padding(10.0)
-                            .background(Color::rgb(0.8, 0.3, 0.3))
-                            .corner_radius(8.0),
-                        // With translation - should move right and down
-                        container()
-                            .width(80.0)
-                            .height(80.0)
-                            .padding(10.0)
-                            .background(Color::rgb(0.3, 0.8, 0.3))
-                            .corner_radius(8.0)
-                            .translate(100.0, 10.0), // Move 10px right, 10px down
-                    ])
-            },
-        )
-        .run();
+    let (app, _) = App::new().add_surface(
+        SurfaceConfig::new()
+            .height(200)
+            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+            .background_color(Color::rgb(0.1, 0.1, 0.15)),
+        || {
+            container()
+                .layout(
+                    Flex::row()
+                        .spacing(20.0)
+                        .main_axis_alignment(MainAxisAlignment::Center)
+                        .cross_axis_alignment(CrossAxisAlignment::Center),
+                )
+                .padding(16.0)
+                .children([
+                    // No transform
+                    container()
+                        .width(80.0)
+                        .height(80.0)
+                        .padding(10.0)
+                        .background(Color::rgb(0.8, 0.3, 0.3))
+                        .corner_radius(8.0),
+                    // With translation - should move right and down
+                    container()
+                        .width(80.0)
+                        .height(80.0)
+                        .padding(10.0)
+                        .background(Color::rgb(0.3, 0.8, 0.3))
+                        .corner_radius(8.0)
+                        .translate(100.0, 10.0), // Move 10px right, 10px down
+                ])
+        },
+    );
+    app.run();
 }

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -2,4 +2,4 @@ pub mod wayland;
 
 pub use wayland::{WaylandState, WaylandSurfaceState, WaylandWindowWrapper, create_wayland_app};
 
-pub use smithay_client_toolkit::shell::wlr_layer::{Anchor, Layer};
+pub use smithay_client_toolkit::shell::wlr_layer::{Anchor, KeyboardInteractivity, Layer};


### PR DESCRIPTION
## Summary

- Add ability to configure `KeyboardInteractivity` at surface creation (was hardcoded to `OnDemand`)
- Return `SurfaceId` from `add_surface()` to enable getting handles for startup surfaces
- Add `surface_handle(id)` function to get a handle for any surface by ID
- Extend `SurfaceHandle` with property modification methods:
  - `set_layer()` - Change surface layer (Background, Bottom, Top, Overlay)
  - `set_keyboard_interactivity()` - Change keyboard focus mode (None, OnDemand, Exclusive)
  - `set_anchor()` - Change anchor edges
  - `set_size()` - Change surface dimensions
  - `set_exclusive_zone()` - Change reserved screen space
  - `set_margin()` - Change surface margins

## API Changes

- `SurfaceConfig` gains `keyboard_interactivity` field and builder method
- `App::add_surface()` now returns `(Self, SurfaceId)` instead of `Self`
- New `surface_handle()` function exported in prelude
- `KeyboardInteractivity` re-exported in prelude

## Usage Examples

### Configure keyboard interactivity at creation:
```rust
spawn_surface(
    SurfaceConfig::new()
        .layer(Layer::Overlay)
        .keyboard_interactivity(KeyboardInteractivity::Exclusive),
    move || popup_widget()
);
```

### Modify startup surface dynamically:
```rust
let (app, status_bar_id) = App::new()
    .add_surface(config, move || {
        container()
            .on_click(move || {
                let handle = surface_handle(status_bar_id);
                handle.set_layer(Layer::Overlay);
            })
            .child(text("Click to promote to overlay"))
    });
app.run();
```

## Test plan

- [x] Run `cargo clippy` and `cargo fmt`
- [x] Build passes with `cargo build`
- [ ] Run `cargo run --example surface_properties_example` to test dynamic property changes
- [ ] Verify layer changes take effect (Overlay should appear above other windows)
- [ ] Verify keyboard interactivity changes work