### PR TITLE
Add automatic ownership for dynamic children

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,7 @@ cargo test
 - `MaybeDyn<T>`: Enum allowing widget properties to accept either static values or reactive signals/closures
 - `Computed<T>`: Derived values that automatically update when dependencies change
 - `Effect`: Side effects that re-run when tracked signals change
+- `Owner`: Ownership system for automatic resource cleanup (signals, effects, custom callbacks)
 - Runtime uses thread-local storage for automatic dependency tracking on the main thread
 - Background threads can update signal values; effects only run on main thread
 

--- a/book/src/advanced/dynamic-children.md
+++ b/book/src/advanced/dynamic-children.md
@@ -1,6 +1,6 @@
 # Dynamic Children
 
-Learn the different ways to add children to containers, from static to fully reactive.
+Learn the different ways to add children to containers, from static to fully reactive with automatic resource cleanup.
 
 ![Children Example](../images/children_example.png)
 
@@ -22,47 +22,49 @@ container().children([
 ])
 ```
 
-### Conditional Child (Static)
+## Dynamic Children with Keyed Reconciliation
+
+For lists that change based on signals, use the keyed children API:
 
 ```rust
-let show_extra = true;  // Evaluated once at creation
+let items = create_signal(vec![1u64, 2, 3]);
 
-container()
-    .child(text("Always shown"))
-    .maybe_child(if show_extra {
-        Some(text("Conditionally shown"))
-    } else {
-        None
+container().children(move || {
+    items.get().into_iter().map(|id| {
+        // Return (key, closure) - closure creates the widget
+        (id, move || {
+            container()
+                .padding(8.0)
+                .background(Color::rgb(0.2, 0.2, 0.3))
+                .child(text(format!("Item {}", id)))
+        })
     })
+})
 ```
 
-> **Note:** `maybe_child` evaluates the condition once. For reactive conditions, use dynamic children.
+### The Closure Pattern
 
-## Dynamic Children
-
-For lists that change based on signals:
+The key insight is returning `(key, || widget)` instead of `(key, widget)`:
 
 ```rust
-let items = create_signal(vec!["A", "B", "C"]);
+// The closure ensures:
+// 1. Widget is only created for NEW keys (not every frame)
+// 2. Signals/effects inside are automatically owned
+// 3. Cleanup runs when the child is removed
 
-container()
-    .children_dyn(
-        move || items.get(),           // Data source
-        |item| item.to_string(),       // Key function (for reconciliation)
-        |item| text(*item),            // View function
-    )
+(item.id, move || create_item_widget(item))
 ```
 
 ### How Keys Work
 
-The key function identifies each item for efficient updates:
+The key identifies each item for efficient updates:
 
 ```rust
 // Good: Unique, stable identifier
-|item| item.id.to_string()
+(item.id, move || widget)
 
-// Bad: Index (changes when items reorder)
-|index, _| index.to_string()
+// Bad: Index changes when items reorder
+(index as u64, move || widget)
 ```
 
 With proper keys:
@@ -70,7 +72,71 @@ With proper keys:
 - **Insertions** only create new widgets
 - **Deletions** only remove specific widgets
 
-## Reactive List Example
+## Automatic Ownership & Cleanup
+
+Signals and effects created inside the child closure are **automatically owned** and cleaned up when the child is removed:
+
+```rust
+container().children(move || {
+    items.get().into_iter().map(|id| (id, move || {
+        // This signal is OWNED by this child
+        let local_count = create_signal(0);
+
+        // This effect is also owned
+        create_effect(move || {
+            println!("Count: {}", local_count.get());
+        });
+
+        // Register cleanup for non-reactive resources
+        on_cleanup(move || {
+            println!("Child {} removed!", id);
+        });
+
+        container()
+            .on_click(move || local_count.update(|c| *c += 1))
+            .child(text(move || local_count.get().to_string()))
+    }))
+})
+```
+
+When a child is removed:
+1. The widget is dropped
+2. `on_cleanup` callbacks run
+3. Effects are disposed
+4. Signals are disposed
+
+### Extracting Widget Creation
+
+You can extract the widget creation into a function:
+
+```rust
+fn create_item_widget(id: u64, name: String) -> impl Widget {
+    // Everything here is automatically owned!
+    let hover = create_signal(false);
+
+    on_cleanup(move || {
+        log::info!("Item {} cleaned up", id);
+    });
+
+    container()
+        .padding(8.0)
+        .background(move || {
+            if hover.get() { Color::rgb(0.3, 0.3, 0.4) }
+            else { Color::rgb(0.2, 0.2, 0.3) }
+        })
+        .on_hover(move |h| hover.set(h))
+        .child(text(name).color(Color::WHITE))
+}
+
+// Use it with the closure wrapper
+container().children(move || {
+    items.get().into_iter().map(|item| {
+        (item.id, move || create_item_widget(item.id, item.name.clone()))
+    })
+})
+```
+
+## Complete Example
 
 ```rust
 #[derive(Clone)]
@@ -79,123 +145,71 @@ struct Item {
     name: String,
 }
 
-let items = create_signal(vec![
-    Item { id: 1, name: "First".into() },
-    Item { id: 2, name: "Second".into() },
-]);
-
-container()
-    .layout(Flex::column().spacing(8.0))
-    .children_dyn(
-        move || items.get(),
-        |item| item.id.to_string(),
-        |item| {
-            container()
-                .padding(8.0)
-                .background(Color::rgb(0.2, 0.2, 0.3))
-                .corner_radius(4.0)
-                .child(text(item.name.clone()).color(Color::WHITE))
-        }
-    )
-```
-
-### Adding Items
-
-```rust
-items.update(|list| {
-    list.push(Item {
-        id: list.len() as u64 + 1,
-        name: "New Item".into(),
-    });
-});
-```
-
-### Removing Items
-
-```rust
-items.update(|list| {
-    list.retain(|item| item.id != id_to_remove);
-});
-```
-
-### Reordering
-
-```rust
-items.update(|list| {
-    list.reverse();  // Keys ensure state preservation
-});
-```
-
-## Mixing Static and Dynamic
-
-Combine static and dynamic children:
-
-```rust
-container()
-    .layout(Flex::column().spacing(8.0))
-    // Static header
-    .child(text("Items:").font_size(18.0).color(Color::WHITE))
-    // Dynamic list
-    .children_dyn(
-        move || items.get(),
-        |item| item.id.to_string(),
-        |item| item_view(item),
-    )
-    // Static footer
-    .child(text("End of list").color(Color::rgb(0.6, 0.6, 0.7)))
-```
-
-## Complete Example
-
-```rust
 fn dynamic_list_demo() -> impl Widget {
     let items = create_signal(vec![
-        Item { id: 1, name: "Item 1".into() },
-        Item { id: 2, name: "Item 2".into() },
-        Item { id: 3, name: "Item 3".into() },
+        Item { id: 1, name: "First".into() },
+        Item { id: 2, name: "Second".into() },
+        Item { id: 3, name: "Third".into() },
     ]);
+    let next_id = create_signal(4u64);
 
     container()
         .padding(16.0)
         .layout(Flex::column().spacing(12.0))
-        .children([
+        .child(
             // Control buttons
             container()
                 .layout(Flex::row().spacing(8.0))
                 .children([
                     button("Add", move || {
+                        let id = next_id.get();
+                        next_id.set(id + 1);
                         items.update(|list| {
-                            let id = list.len() as u64 + 1;
                             list.push(Item { id, name: format!("Item {}", id) });
                         });
                     }),
-                    button("Remove", move || {
+                    button("Remove Last", move || {
                         items.update(|list| { list.pop(); });
                     }),
                     button("Reverse", move || {
                         items.update(|list| { list.reverse(); });
                     }),
-                ]),
-
-            // Dynamic list
+                ])
+        )
+        .child(
+            // Dynamic list with automatic cleanup
             container()
                 .layout(Flex::column().spacing(4.0))
-                .children_dyn(
-                    move || items.get(),
-                    |item| item.id.to_string(),
-                    |item| {
-                        container()
-                            .padding(8.0)
-                            .background(Color::rgb(0.2, 0.2, 0.3))
-                            .corner_radius(4.0)
-                            .hover_state(|s| s.lighter(0.1))
-                            .child(text(item.name.clone()).color(Color::WHITE))
-                    }
-                ),
-        ])
+                .children(move || {
+                    items.get().into_iter().map(|item| {
+                        let id = item.id;
+                        let name = item.name.clone();
+                        (id, move || {
+                            // Local state for this item
+                            let clicks = create_signal(0);
+
+                            on_cleanup(move || {
+                                log::info!("Item {} removed", id);
+                            });
+
+                            container()
+                                .padding(8.0)
+                                .background(Color::rgb(0.2, 0.2, 0.3))
+                                .corner_radius(4.0)
+                                .hover_state(|s| s.lighter(0.1))
+                                .pressed_state(|s| s.ripple())
+                                .on_click(move || clicks.update(|c| *c += 1))
+                                .child(
+                                    text(move || format!("{} (clicks: {})", name, clicks.get()))
+                                        .color(Color::WHITE)
+                                )
+                        })
+                    })
+                })
+        )
 }
 
-fn button(label: &str, on_click: impl Fn() + 'static) -> Container {
+fn button(label: &str, on_click: impl Fn() + Send + Sync + 'static) -> Container {
     container()
         .padding(8.0)
         .background(Color::rgb(0.3, 0.3, 0.4))
@@ -205,6 +219,25 @@ fn button(label: &str, on_click: impl Fn() + 'static) -> Container {
         .on_click(on_click)
         .child(text(label).color(Color::WHITE))
 }
+```
+
+## Mixing Static and Dynamic
+
+Combine static and dynamic children freely:
+
+```rust
+container()
+    .layout(Flex::column().spacing(8.0))
+    // Static header
+    .child(text("Items:").font_size(18.0).color(Color::WHITE))
+    // Dynamic list
+    .children(move || {
+        items.get().into_iter().map(|item| {
+            (item.id, move || item_view(item.clone()))
+        })
+    })
+    // Static footer
+    .child(text("End of list").color(Color::rgb(0.6, 0.6, 0.7)))
 ```
 
 ## API Reference
@@ -220,22 +253,15 @@ impl Container {
         children: impl IntoIterator<Item = W>
     ) -> Self;
 
-    // Conditional static child
-    pub fn maybe_child<W: Widget + 'static>(
-        self,
-        child: Option<W>
-    ) -> Self;
-
-    // Reactive list
-    pub fn children_dyn<T, K, V>(
-        self,
-        items: impl Fn() -> Vec<T> + 'static,
-        key_fn: impl Fn(&T) -> K + 'static,
-        view_fn: impl Fn(&T) -> V + 'static,
-    ) -> Self
+    // Dynamic keyed children with automatic ownership
+    pub fn children<F, I, G, W>(self, children: F) -> Self
     where
-        T: Clone + 'static,
-        K: Hash + Eq + 'static,
-        V: Widget + 'static;
+        F: Fn() -> I + Send + Sync + 'static,
+        I: IntoIterator<Item = (u64, G)>,
+        G: FnOnce() -> W + 'static,
+        W: Widget + 'static;
 }
+
+// Cleanup registration (use inside dynamic child closures)
+pub fn on_cleanup(f: impl FnOnce() + 'static);
 ```

--- a/examples/children_example.rs
+++ b/examples/children_example.rs
@@ -219,7 +219,8 @@ fn main() {
                                 .children(move || {
                                     items.get().into_iter().map(|item| {
                                         // Key by ID - preserves widget state on reorder!
-                                        (item.id, container()
+                                        // Return (key, closure) - closure runs in owner scope
+                                        (item.id, move || container()
                                             .padding(8.0)
                                             .background(item.color)
                                             .corner_radius(4.0)
@@ -414,7 +415,8 @@ fn main() {
                                         let mut hasher = DefaultHasher::new();
                                         content.hash(&mut hasher);
                                         let key = hasher.finish();
-                                        (key, container()
+                                        // Return (key, closure) - closure runs in owner scope
+                                        (key, move || container()
                                             .padding(8.0)
                                             .background(Color::rgb(0.5, 0.3, 0.5))
                                             .corner_radius(4.0)

--- a/examples/effect_cleanup_test.rs
+++ b/examples/effect_cleanup_test.rs
@@ -36,8 +36,8 @@
 //! Watch the console for logging output.
 
 use guido::prelude::*;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::thread;
 use std::time::Duration;
 

--- a/examples/effect_cleanup_test.rs
+++ b/examples/effect_cleanup_test.rs
@@ -1,0 +1,221 @@
+//! Test example to verify that signals and effects are properly cleaned up
+//! when children are dynamically added/removed using automatic ownership.
+//!
+//! This example demonstrates:
+//! 1. Dynamic children with add/remove buttons
+//! 2. Each child returns (key, closure) where the closure calls a function
+//!    that creates signals, effects, and cleanup callbacks
+//! 3. When children are removed:
+//!    - The `OwnedWidget` wrapper is dropped
+//!    - This automatically calls `dispose_owner()`
+//!    - All signals and effects are cleaned up
+//!    - The `on_cleanup` callback stops the background thread
+//!
+//! Key API pattern:
+//! ```ignore
+//! fn create_child(id: u64) -> impl Widget {
+//!     let signal = create_signal(0);  // OWNED!
+//!     on_cleanup(|| println!("Cleaned up"));
+//!     container().child(text(move || signal.get().to_string()))
+//! }
+//!
+//! .children(move || {
+//!     items.get().into_iter().map(|id| (id, move || create_child(id)))
+//! })
+//! ```
+//!
+//! Expected console output:
+//! - "[Child N Effect] Signal value: X" - from the effect
+//! - "[Child N Thread] Tick #X" - from the background thread
+//! - When removed, you should see:
+//!   - "[Child N Cleanup] Stopping thread..."
+//!   - "[Child N Thread] STOPPED"
+//!   - The effect logs should STOP (effect was disposed)
+//!
+//! To run: cargo run --example effect_cleanup_test
+//! Watch the console for logging output.
+
+use guido::prelude::*;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+// Global counter for unique child IDs
+static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+
+/// Creates a child widget with its own signal, effect, and background thread.
+///
+/// Everything created inside this function is automatically owned by the
+/// child's owner scope because it's called from within the `.children()`
+/// closure wrapper.
+fn create_child_widget(id: u64) -> impl Widget {
+    // Create a signal for this child's tick count - AUTOMATICALLY OWNED!
+    let tick_signal = create_signal(0i32);
+
+    // Flag to stop the background thread
+    let running = Arc::new(AtomicBool::new(true));
+    let running_for_cleanup = running.clone();
+
+    log::info!(
+        "[Child {}] Created - signal and effect automatically owned",
+        id
+    );
+
+    // Create an effect that tracks the tick signal
+    // This effect will be disposed when the child is removed
+    create_effect(move || {
+        let value = tick_signal.get();
+        log::info!("[Child {} Effect] Signal value: {}", id, value);
+    });
+
+    // Register cleanup callback - runs when the child is removed
+    on_cleanup(move || {
+        log::info!("[Child {} Cleanup] Stopping thread...", id);
+        running_for_cleanup.store(false, Ordering::SeqCst);
+    });
+
+    // Spawn a background thread for this child
+    let running_clone = running.clone();
+    thread::spawn(move || {
+        let mut count = 0;
+        while running_clone.load(Ordering::SeqCst) {
+            thread::sleep(Duration::from_secs(2));
+            if running_clone.load(Ordering::SeqCst) {
+                count += 1;
+                log::info!("[Child {} Thread] Tick #{}", id, count);
+                // Update the signal from background thread
+                tick_signal.set(count);
+            }
+        }
+        log::info!("[Child {} Thread] STOPPED", id);
+    });
+
+    // Return the widget
+    container()
+        .layout(Flex::row().spacing(8.0))
+        .padding(12.0)
+        .background(Color::rgb(0.2, 0.2, 0.3))
+        .corner_radius(8.0)
+        .child(text(format!("Child {}", id)).color(Color::WHITE))
+        .child(
+            text(move || format!("Ticks: {}", tick_signal.get())).color(Color::rgb(0.6, 0.8, 1.0)),
+        )
+}
+
+fn main() {
+    let _ = env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
+        .try_init();
+
+    log::info!("=== Effect Cleanup Test (Automatic Ownership) ===");
+    log::info!("This test verifies automatic cleanup via dynamic children ownership.");
+    log::info!("Child creation is extracted into a function - signals are still owned!");
+    log::info!("When a child is removed, its OwnedWidget drops and calls dispose_owner().\n");
+
+    // Signal holding the list of child IDs
+    let children_ids = create_signal(Vec::<u64>::new());
+
+    let view = container()
+        .layout(Flex::column().spacing(12.0))
+        .padding(16.0)
+        .child(
+            // Title and instructions
+            container()
+                .layout(Flex::column().spacing(4.0))
+                .child(text("Effect Cleanup Test (Automatic Ownership)").color(Color::WHITE))
+                .child(
+                    text("Watch the console: each child logs every 2 seconds.")
+                        .color(Color::rgb(0.7, 0.7, 0.7)),
+                )
+                .child(
+                    text("When removed, on_cleanup runs and effect logs STOP.")
+                        .color(Color::rgb(0.7, 0.7, 0.7)),
+                ),
+        )
+        .child(
+            // Control buttons
+            container()
+                .layout(Flex::row().spacing(8.0))
+                .child(
+                    container()
+                        .padding(10.0)
+                        .background(Color::rgb(0.2, 0.5, 0.3))
+                        .corner_radius(6.0)
+                        .hover_state(|s| s.lighter(0.1))
+                        .pressed_state(|s| s.ripple())
+                        .on_click(move || {
+                            let id = NEXT_ID.fetch_add(1, Ordering::SeqCst);
+                            log::info!("[Child {}] Adding to list", id);
+                            children_ids.update(|list| list.push(id));
+                        })
+                        .child(text("Add Child").color(Color::WHITE)),
+                )
+                .child(
+                    container()
+                        .padding(10.0)
+                        .background(Color::rgb(0.5, 0.2, 0.2))
+                        .corner_radius(6.0)
+                        .hover_state(|s| s.lighter(0.1))
+                        .pressed_state(|s| s.ripple())
+                        .on_click(move || {
+                            children_ids.update(|list| {
+                                if let Some(id) = list.pop() {
+                                    log::info!(
+                                        "[Child {}] Removing from list (automatic cleanup will happen)",
+                                        id
+                                    );
+                                }
+                            });
+                        })
+                        .child(text("Remove Last").color(Color::WHITE)),
+                )
+                .child(
+                    container()
+                        .padding(10.0)
+                        .background(Color::rgb(0.5, 0.3, 0.2))
+                        .corner_radius(6.0)
+                        .hover_state(|s| s.lighter(0.1))
+                        .pressed_state(|s| s.ripple())
+                        .on_click(move || {
+                            children_ids.update(|list| {
+                                log::info!(
+                                    "Removing all {} children (automatic cleanup for each)",
+                                    list.len()
+                                );
+                                list.clear();
+                            });
+                        })
+                        .child(text("Remove All").color(Color::WHITE)),
+                ),
+        )
+        .child(
+            // Status display
+            text(move || {
+                let count = children_ids.get().len();
+                format!("Active children: {}", count)
+            })
+            .color(Color::WHITE),
+        )
+        .child(
+            // Children container with dynamic children
+            // The closure wrapper ensures create_child_widget runs inside owner scope
+            container()
+                .layout(Flex::column().spacing(8.0))
+                .children(move || {
+                    children_ids
+                        .get()
+                        .into_iter()
+                        .map(|id| (id, move || create_child_widget(id)))
+                }),
+        );
+
+    let (app, _) = App::new().add_surface(
+        SurfaceConfig::new()
+            .width(500)
+            .height(400)
+            .anchor(Anchor::TOP | Anchor::LEFT)
+            .background_color(Color::rgb(0.1, 0.1, 0.15)),
+        move || view,
+    );
+    app.run();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ pub mod prelude {
     pub use crate::platform::{Anchor, KeyboardInteractivity, Layer};
     pub use crate::reactive::{
         Computed, CursorIcon, Effect, IntoMaybeDyn, MaybeDyn, ReadSignal, Signal, WriteSignal,
-        batch, create_computed, create_effect, create_signal, set_cursor,
+        batch, create_computed, create_effect, create_signal, on_cleanup, set_cursor,
     };
     pub use crate::renderer::primitives::Shadow;
     pub use crate::renderer::{PaintContext, measure_text};

--- a/src/reactive/effect.rs
+++ b/src/reactive/effect.rs
@@ -21,6 +21,13 @@ impl Effect {
 
         Self { id }
     }
+
+    /// Get the effect's ID.
+    /// Used internally for testing the ownership system.
+    #[cfg(test)]
+    pub(crate) fn id(&self) -> EffectId {
+        self.id
+    }
 }
 
 impl Drop for Effect {

--- a/src/reactive/mod.rs
+++ b/src/reactive/mod.rs
@@ -5,6 +5,7 @@ pub mod effect;
 pub mod focus;
 pub mod invalidation;
 pub mod maybe_dyn;
+pub mod owner;
 pub mod runtime;
 pub mod signal;
 pub mod storage;
@@ -24,5 +25,16 @@ pub use invalidation::{
     with_app_state_mut,
 };
 pub use maybe_dyn::{IntoMaybeDyn, MaybeDyn};
+// Only on_cleanup is public API - with_owner, dispose_owner, and OwnerId are
+// internal and automatically used by the dynamic children system
+pub use owner::on_cleanup;
+pub(crate) use owner::{OwnerId, dispose_owner, with_owner};
+
+/// Internal module for macro support. NOT PART OF PUBLIC API.
+/// Do not use directly - these are re-exported for proc macros only.
+#[doc(hidden)]
+pub mod __internal {
+    pub use super::owner::{OwnerId, dispose_owner, with_owner};
+}
 pub use runtime::batch;
 pub use signal::{ReadSignal, Signal, WriteSignal, create_signal};

--- a/src/reactive/owner.rs
+++ b/src/reactive/owner.rs
@@ -1,0 +1,386 @@
+//! Reactive ownership system for automatic resource cleanup.
+//!
+//! This module implements a reactive owner pattern (similar to Leptos/SolidJS/Dioxus)
+//! where signals and effects belong to an owner, and when the owner is disposed,
+//! all owned resources are automatically cleaned up.
+//!
+//! # Overview
+//!
+//! - Every signal and effect can belong to an owner
+//! - Owners form a tree structure (child owners are disposed before parents)
+//! - When an owner is disposed, all owned signals, effects, and cleanup callbacks are cleaned up
+//! - `on_cleanup` allows registering custom cleanup logic (timers, connections, etc.)
+//!
+//! # Example
+//!
+//! ```ignore
+//! // Create a scope with automatic cleanup
+//! let (result, owner_id) = with_owner(|| {
+//!     let signal = create_signal(42);
+//!     let effect = create_effect(move || {
+//!         println!("Signal: {}", signal.get());
+//!     });
+//!
+//!     // Register custom cleanup
+//!     on_cleanup(|| {
+//!         println!("Cleaning up!");
+//!     });
+//!
+//!     signal
+//! });
+//!
+//! // Later, dispose everything in that scope
+//! dispose_owner(owner_id);
+//! // All signals, effects, and cleanup callbacks are now disposed
+//! ```
+
+use std::cell::RefCell;
+
+use super::runtime::{EffectId, SignalId, with_runtime};
+use super::storage::dispose_signal;
+
+/// Unique identifier for an owner in the owner arena.
+pub type OwnerId = usize;
+
+/// An owner that manages the lifecycle of reactive primitives.
+struct Owner {
+    #[allow(dead_code)]
+    id: OwnerId,
+    #[allow(dead_code)]
+    parent: Option<OwnerId>,
+    signals: Vec<SignalId>,
+    effects: Vec<EffectId>,
+    cleanups: Vec<Box<dyn FnOnce()>>,
+    children: Vec<OwnerId>,
+}
+
+impl Owner {
+    fn new(id: OwnerId, parent: Option<OwnerId>) -> Self {
+        Self {
+            id,
+            parent,
+            signals: Vec::new(),
+            effects: Vec::new(),
+            cleanups: Vec::new(),
+            children: Vec::new(),
+        }
+    }
+}
+
+/// Arena-based storage for owners.
+struct OwnerArena {
+    owners: Vec<Option<Owner>>,
+    next_id: OwnerId,
+}
+
+impl OwnerArena {
+    fn new() -> Self {
+        Self {
+            owners: Vec::new(),
+            next_id: 0,
+        }
+    }
+
+    fn allocate(&mut self, parent: Option<OwnerId>) -> OwnerId {
+        let id = self.next_id;
+        self.next_id += 1;
+        let owner = Owner::new(id, parent);
+        self.owners.push(Some(owner));
+        id
+    }
+
+    #[allow(dead_code)]
+    fn get(&self, id: OwnerId) -> Option<&Owner> {
+        self.owners.get(id).and_then(|o| o.as_ref())
+    }
+
+    fn get_mut(&mut self, id: OwnerId) -> Option<&mut Owner> {
+        self.owners.get_mut(id).and_then(|o| o.as_mut())
+    }
+
+    fn take(&mut self, id: OwnerId) -> Option<Owner> {
+        self.owners.get_mut(id).and_then(|o| o.take())
+    }
+}
+
+thread_local! {
+    static CURRENT_OWNER: RefCell<Option<OwnerId>> = const { RefCell::new(None) };
+    static OWNERS: RefCell<OwnerArena> = RefCell::new(OwnerArena::new());
+}
+
+/// Execute a closure within a new owner scope.
+///
+/// All signals and effects created within the closure will be registered
+/// with this owner and automatically cleaned up when the owner is disposed.
+///
+/// Returns a tuple of the closure's return value and the owner ID.
+///
+/// This is used internally by the dynamic children system to automatically
+/// manage reactive resource lifetimes. User code should use `on_cleanup`
+/// inside dynamic children closures to register custom cleanup logic.
+///
+/// **Note:** This function is not part of the public API and may change.
+/// Use `on_cleanup` for registering cleanup callbacks in user code.
+pub fn with_owner<T>(f: impl FnOnce() -> T) -> (T, OwnerId) {
+    // Get current owner as parent
+    let parent = CURRENT_OWNER.with(|current| *current.borrow());
+
+    // Allocate new owner
+    let owner_id = OWNERS.with(|owners| {
+        let mut owners = owners.borrow_mut();
+        let id = owners.allocate(parent);
+
+        // Register as child of parent
+        if let Some(parent_id) = parent
+            && let Some(parent_owner) = owners.get_mut(parent_id)
+        {
+            parent_owner.children.push(id);
+        }
+
+        id
+    });
+
+    // Set as current owner
+    let prev_owner = CURRENT_OWNER.with(|current| {
+        let prev = *current.borrow();
+        *current.borrow_mut() = Some(owner_id);
+        prev
+    });
+
+    // Execute the closure
+    let result = f();
+
+    // Restore previous owner
+    CURRENT_OWNER.with(|current| {
+        *current.borrow_mut() = prev_owner;
+    });
+
+    (result, owner_id)
+}
+
+/// Get the current owner ID, if any.
+///
+/// Returns `None` if not currently inside an owner scope.
+pub fn current_owner() -> Option<OwnerId> {
+    CURRENT_OWNER.with(|current| *current.borrow())
+}
+
+/// Dispose an owner and all its resources.
+///
+/// This will:
+/// 1. Recursively dispose all child owners (depth-first)
+/// 2. Run all cleanup callbacks in reverse order
+/// 3. Dispose all effects
+/// 4. Dispose all signals
+///
+/// After disposal, any attempt to access the disposed signals will panic
+/// with a clear error message.
+///
+/// **Note:** This function is not part of the public API and may change.
+/// Cleanup is automatic when using dynamic children or components.
+pub fn dispose_owner(id: OwnerId) {
+    // Take the owner out of the arena
+    let owner = OWNERS.with(|owners| owners.borrow_mut().take(id));
+
+    let Some(owner) = owner else {
+        return; // Already disposed
+    };
+
+    // Dispose children first (depth-first)
+    for child_id in owner.children {
+        dispose_owner(child_id);
+    }
+
+    // Run cleanup callbacks in reverse order (LIFO)
+    for cleanup in owner.cleanups.into_iter().rev() {
+        cleanup();
+    }
+
+    // Dispose effects
+    for effect_id in owner.effects {
+        with_runtime(|rt| rt.dispose_effect(effect_id));
+    }
+
+    // Dispose signals
+    for signal_id in owner.signals {
+        dispose_signal(signal_id);
+    }
+}
+
+/// Register a cleanup callback to run when the current owner is disposed.
+///
+/// This is useful for cleaning up non-reactive resources like timers,
+/// event listeners, or external connections.
+///
+/// Cleanup callbacks are run in reverse order (LIFO) - the last registered
+/// callback runs first.
+///
+/// # Panics
+///
+/// This function will silently do nothing if called outside an owner scope.
+///
+/// # Example
+///
+/// ```ignore
+/// with_owner(|| {
+///     // Start a timer
+///     let timer_id = start_timer();
+///
+///     // Register cleanup to stop the timer
+///     on_cleanup(move || {
+///         stop_timer(timer_id);
+///     });
+/// });
+/// ```
+pub fn on_cleanup(f: impl FnOnce() + 'static) {
+    if let Some(owner_id) = current_owner() {
+        OWNERS.with(|owners| {
+            if let Some(owner) = owners.borrow_mut().get_mut(owner_id) {
+                owner.cleanups.push(Box::new(f));
+            }
+        });
+    }
+}
+
+/// Register a signal with the current owner.
+///
+/// This is called internally by `create_signal` to register newly created
+/// signals for automatic cleanup.
+pub(crate) fn register_signal(id: SignalId) {
+    if let Some(owner_id) = current_owner() {
+        OWNERS.with(|owners| {
+            if let Some(owner) = owners.borrow_mut().get_mut(owner_id) {
+                owner.signals.push(id);
+            }
+        });
+    }
+}
+
+/// Register an effect with the current owner.
+///
+/// This is called internally by `create_effect` to register newly created
+/// effects for automatic cleanup.
+pub(crate) fn register_effect(id: EffectId) {
+    if let Some(owner_id) = current_owner() {
+        OWNERS.with(|owners| {
+            if let Some(owner) = owners.borrow_mut().get_mut(owner_id) {
+                owner.effects.push(id);
+            }
+        });
+    }
+}
+
+/// Check if an effect is owned by any owner.
+///
+/// This is used by Effect's Drop impl to determine if it should dispose
+/// the effect or let the owner handle it.
+pub(crate) fn effect_has_owner(id: EffectId) -> bool {
+    OWNERS.with(|owners| {
+        let owners = owners.borrow();
+        for owner in owners.owners.iter().flatten() {
+            if owner.effects.contains(&id) {
+                return true;
+            }
+        }
+        false
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_with_owner_basic() {
+        let (value, owner_id) = with_owner(|| 42);
+        assert_eq!(value, 42);
+        assert!(owner_id < 100); // Just check it's a reasonable ID
+    }
+
+    #[test]
+    fn test_current_owner_inside_scope() {
+        let ((inner_owner, outer_owner), _outer_id) = with_owner(|| {
+            let outer = current_owner();
+            let (inner, _inner_id) = with_owner(current_owner);
+            (inner, outer)
+        });
+
+        // Both should be Some
+        assert!(inner_owner.is_some());
+        assert!(outer_owner.is_some());
+
+        // They should be different
+        assert_ne!(inner_owner, outer_owner);
+    }
+
+    #[test]
+    fn test_current_owner_outside_scope() {
+        // Outside any scope, should be None
+        assert!(current_owner().is_none());
+    }
+
+    #[test]
+    fn test_nested_owners() {
+        let cleanup_order = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+
+        let order = cleanup_order.clone();
+        let (_, outer_id) = with_owner(|| {
+            let order_inner = order.clone();
+            on_cleanup(move || {
+                order_inner.lock().unwrap().push("outer");
+            });
+
+            let order_nested = order.clone();
+            with_owner(|| {
+                on_cleanup(move || {
+                    order_nested.lock().unwrap().push("inner");
+                });
+            });
+        });
+
+        // Dispose the outer owner
+        dispose_owner(outer_id);
+
+        // Children should be disposed first
+        let order = cleanup_order.lock().unwrap();
+        assert_eq!(*order, vec!["inner", "outer"]);
+    }
+
+    #[test]
+    fn test_on_cleanup_reverse_order() {
+        let cleanup_order = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+
+        let order = cleanup_order.clone();
+        let (_, owner_id) = with_owner(|| {
+            let order1 = order.clone();
+            on_cleanup(move || {
+                order1.lock().unwrap().push("first");
+            });
+
+            let order2 = order.clone();
+            on_cleanup(move || {
+                order2.lock().unwrap().push("second");
+            });
+
+            let order3 = order.clone();
+            on_cleanup(move || {
+                order3.lock().unwrap().push("third");
+            });
+        });
+
+        dispose_owner(owner_id);
+
+        // Should be reverse order (LIFO)
+        let order = cleanup_order.lock().unwrap();
+        assert_eq!(*order, vec!["third", "second", "first"]);
+    }
+
+    #[test]
+    fn test_dispose_owner_twice_is_safe() {
+        let (_, owner_id) = with_owner(|| {});
+
+        // Should not panic
+        dispose_owner(owner_id);
+        dispose_owner(owner_id);
+    }
+}

--- a/src/reactive/signal.rs
+++ b/src/reactive/signal.rs
@@ -1,6 +1,7 @@
 use std::marker::PhantomData;
 
 use super::invalidation::request_frame;
+use super::owner::register_signal;
 use super::runtime::{SignalId, try_with_runtime};
 use super::storage::{
     create_signal_value, get_signal_value, set_signal_value, update_signal_value, with_signal_value,
@@ -189,6 +190,8 @@ pub fn create_signal<T: Clone + PartialEq + Send + Sync + 'static>(value: T) -> 
     let id = create_signal_value(value);
     // Register with thread-local runtime for subscriber tracking
     try_with_runtime(|rt| rt.register_signal(id));
+    // Register with current owner for automatic cleanup
+    register_signal(id);
     Signal {
         id,
         _marker: PhantomData,

--- a/src/reactive/storage.rs
+++ b/src/reactive/storage.rs
@@ -63,22 +63,59 @@ pub fn dispose_signal(id: SignalId) {
 /// Get a signal's value (clones it)
 pub fn get_signal_value<T: Clone + Send + Sync + 'static>(id: SignalId) -> T {
     let arc = with_storage_read(|storage| {
-        storage.values[id].clone().expect(
-            "Signal was disposed - cannot read after owner cleanup. \
-             This usually means the signal's owner was disposed while you still hold a reference to the signal.",
-        )
+        storage
+            .values
+            .get(id)
+            .unwrap_or_else(|| {
+                panic!(
+                    "Invalid signal ID {}: out of bounds (max ID is {})",
+                    id,
+                    storage.values.len().saturating_sub(1)
+                )
+            })
+            .clone()
+            .unwrap_or_else(|| {
+                panic!(
+                    "Signal {} was disposed - cannot read after owner cleanup. \
+                     This usually means the signal's owner was disposed while you still hold a reference to the signal.",
+                    id
+                )
+            })
     });
     let guard = arc.read().unwrap();
-    guard.downcast_ref::<T>().expect("Type mismatch").clone()
+    guard
+        .downcast_ref::<T>()
+        .unwrap_or_else(|| {
+            panic!(
+                "Signal {} type mismatch: stored type does not match requested type {}",
+                id,
+                std::any::type_name::<T>()
+            )
+        })
+        .clone()
 }
 
 /// Set a signal's value
 pub fn set_signal_value<T: Send + Sync + 'static>(id: SignalId, value: T) {
     let arc = with_storage_read(|storage| {
-        storage.values[id].clone().expect(
-            "Signal was disposed - cannot write after owner cleanup. \
-             This usually means the signal's owner was disposed while you still hold a reference to the signal.",
-        )
+        storage
+            .values
+            .get(id)
+            .unwrap_or_else(|| {
+                panic!(
+                    "Invalid signal ID {}: out of bounds (max ID is {})",
+                    id,
+                    storage.values.len().saturating_sub(1)
+                )
+            })
+            .clone()
+            .unwrap_or_else(|| {
+                panic!(
+                    "Signal {} was disposed - cannot write after owner cleanup. \
+                     This usually means the signal's owner was disposed while you still hold a reference to the signal.",
+                    id
+                )
+            })
     });
     let mut guard = arc.write().unwrap();
     *guard = Box::new(value);
@@ -87,24 +124,64 @@ pub fn set_signal_value<T: Send + Sync + 'static>(id: SignalId, value: T) {
 /// Update a signal's value with a closure
 pub fn update_signal_value<T: Clone + Send + Sync + 'static>(id: SignalId, f: impl FnOnce(&mut T)) {
     let arc = with_storage_read(|storage| {
-        storage.values[id].clone().expect(
-            "Signal was disposed - cannot update after owner cleanup. \
-             This usually means the signal's owner was disposed while you still hold a reference to the signal.",
-        )
+        storage
+            .values
+            .get(id)
+            .unwrap_or_else(|| {
+                panic!(
+                    "Invalid signal ID {}: out of bounds (max ID is {})",
+                    id,
+                    storage.values.len().saturating_sub(1)
+                )
+            })
+            .clone()
+            .unwrap_or_else(|| {
+                panic!(
+                    "Signal {} was disposed - cannot update after owner cleanup. \
+                     This usually means the signal's owner was disposed while you still hold a reference to the signal.",
+                    id
+                )
+            })
     });
     let mut guard = arc.write().unwrap();
-    let value = guard.downcast_mut::<T>().expect("Type mismatch");
+    let value = guard.downcast_mut::<T>().unwrap_or_else(|| {
+        panic!(
+            "Signal {} type mismatch: stored type does not match requested type {}",
+            id,
+            std::any::type_name::<T>()
+        )
+    });
     f(value);
 }
 
 /// Borrow a signal's value for reading
 pub fn with_signal_value<T: Send + Sync + 'static, R>(id: SignalId, f: impl FnOnce(&T) -> R) -> R {
     let arc = with_storage_read(|storage| {
-        storage.values[id].clone().expect(
-            "Signal was disposed - cannot borrow after owner cleanup. \
-             This usually means the signal's owner was disposed while you still hold a reference to the signal.",
-        )
+        storage
+            .values
+            .get(id)
+            .unwrap_or_else(|| {
+                panic!(
+                    "Invalid signal ID {}: out of bounds (max ID is {})",
+                    id,
+                    storage.values.len().saturating_sub(1)
+                )
+            })
+            .clone()
+            .unwrap_or_else(|| {
+                panic!(
+                    "Signal {} was disposed - cannot borrow after owner cleanup. \
+                     This usually means the signal's owner was disposed while you still hold a reference to the signal.",
+                    id
+                )
+            })
     });
     let guard = arc.read().unwrap();
-    f(guard.downcast_ref::<T>().expect("Type mismatch"))
+    f(guard.downcast_ref::<T>().unwrap_or_else(|| {
+        panic!(
+            "Signal {} type mismatch: stored type does not match requested type {}",
+            id,
+            std::any::type_name::<T>()
+        )
+    }))
 }


### PR DESCRIPTION
## Summary

- Integrates the reactive ownership system with dynamic children for automatic resource cleanup
- Signals, effects, and cleanup callbacks created inside dynamic child closures are automatically disposed when the child is removed
- Uses lazy widget creation to avoid recreating widgets every frame

## Key Changes

- **Owner system** (`src/reactive/owner.rs`): Manages reactive resource lifecycles with `with_owner`, `dispose_owner`, and `on_cleanup`
- **Lazy DynItem**: Widget closures are only called for NEW keys during reconciliation
- **OwnedWidget wrapper**: Calls `dispose_owner` on `Drop` for automatic cleanup
- **API change**: Dynamic children now use closure syntax: `(key, || widget)` instead of `(key, widget)`
- **Internal API**: `with_owner`/`dispose_owner` are internal; only `on_cleanup` is public

## Usage

```rust
container().children(move || {
    items.get().into_iter().map(|id| (id, move || {
        let signal = create_signal(0);  // Automatically owned!
        on_cleanup(|| log::info!("Child removed"));
        create_child_widget(signal)
    }))
})
```

Or extract into a function:
```rust
fn create_child(id: u64) -> impl Widget {
    let signal = create_signal(0);  // Owned!
    on_cleanup(|| cleanup());
    container().child(text(move || signal.get().to_string()))
}

.children(move || items.iter().map(|id| (*id, move || create_child(*id))))
```

## Test plan

- [x] Run `cargo clippy` - passes
- [x] Run `cargo test` - passes  
- [x] Run `cargo run --example effect_cleanup_test` - verify child creation/cleanup in console logs
- [x] Run `cargo run --example children_example` - verify keyed reconciliation still works
- [ ] Update mdbook documentation