### PR TITLE
Add text styling with font family and weight support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Guido is a GPU-accelerated GUI library for building Wayland layer shell applicat
 - **HiDPI Support** - Automatic scaling for high-resolution displays
 - **Image Widget** - Display raster images (PNG, JPEG, WebP) and SVGs with GPU texture caching
 - **Scrollable Containers** - Vertical/horizontal scrolling with customizable scrollbars and momentum
+- **Text Styling** - Font family (sans-serif, serif, monospace, custom) and weight (thin to black) support
 
 ## Quick Start
 
@@ -106,6 +107,7 @@ cargo run --example component_example
 - **children_example** - Dynamic lists with keyed reconciliation
 - **image_example** - Raster and SVG images with content fit modes
 - **scroll_example** - Scrollable containers with custom scrollbar styling
+- **text_styling_example** - Font families and weights for text styling
 
 ## Documentation
 

--- a/book/src/building-ui/text-input.md
+++ b/book/src/building-ui/text-input.md
@@ -46,6 +46,34 @@ text_input(value)
     .font_size(16.0)
 ```
 
+### Font Family
+
+```rust
+// Predefined families
+text_input(value)
+    .font_family(FontFamily::Monospace)
+
+// Shorthand for monospace
+text_input(value)
+    .mono()
+
+// Custom font
+text_input(value)
+    .font_family(FontFamily::Name("JetBrains Mono".into()))
+```
+
+### Font Weight
+
+```rust
+// Using constants
+text_input(value)
+    .font_weight(FontWeight::BOLD)
+
+// Shorthand for bold
+text_input(value)
+    .bold()
+```
+
 ## Password Mode
 
 Hide text input for sensitive data like passwords:
@@ -233,6 +261,10 @@ impl TextInput {
     pub fn cursor_color(self, color: impl IntoMaybeDyn<Color>) -> Self;
     pub fn selection_color(self, color: impl IntoMaybeDyn<Color>) -> Self;
     pub fn font_size(self, size: impl IntoMaybeDyn<f32>) -> Self;
+    pub fn font_family(self, family: impl IntoMaybeDyn<FontFamily>) -> Self;
+    pub fn font_weight(self, weight: impl IntoMaybeDyn<FontWeight>) -> Self;
+    pub fn bold(self) -> Self;      // Shorthand for FontWeight::BOLD
+    pub fn mono(self) -> Self;      // Shorthand for FontFamily::Monospace
     pub fn password(self, enabled: bool) -> Self;
     pub fn mask_char(self, c: char) -> Self;
     pub fn on_change<F: Fn(&str) + 'static>(self, callback: F) -> Self;

--- a/book/src/building-ui/text.md
+++ b/book/src/building-ui/text.md
@@ -24,17 +24,62 @@ text("Colored text").color(Color::rgb(0.9, 0.3, 0.3))
 text("White text").color(Color::WHITE)
 ```
 
+### Font Family
+
+Set the font family using predefined families or custom font names:
+
+```rust
+// Predefined font families
+text("Sans-serif text").font_family(FontFamily::SansSerif)
+text("Serif text").font_family(FontFamily::Serif)
+text("Monospace text").font_family(FontFamily::Monospace)
+
+// Shorthand for monospace
+text("Code example").mono()
+
+// Custom font by name (if available on system)
+text("Custom font").font_family(FontFamily::Name("Inter".into()))
+```
+
+Available font families:
+- `FontFamily::SansSerif` - Default sans-serif font
+- `FontFamily::Serif` - Serif font
+- `FontFamily::Monospace` - Monospace/fixed-width font
+- `FontFamily::Cursive` - Cursive font
+- `FontFamily::Fantasy` - Fantasy/decorative font
+- `FontFamily::Name(String)` - Custom font by name
+
 ### Font Weight
 
+Set the font weight using predefined constants or numeric values (100-900):
+
 ```rust
+// Using constants
+text("Thin text").font_weight(FontWeight::THIN)
+text("Light text").font_weight(FontWeight::LIGHT)
+text("Normal text").font_weight(FontWeight::NORMAL)
+text("Medium text").font_weight(FontWeight::MEDIUM)
+text("Semi-bold text").font_weight(FontWeight::SEMI_BOLD)
+text("Bold text").font_weight(FontWeight::BOLD)
+text("Black text").font_weight(FontWeight::BLACK)
+
+// Shorthand for bold
 text("Bold text").bold()
+
+// Custom numeric weight
+text("Custom weight").font_weight(FontWeight(550))
 ```
 
-### Font Style
-
-```rust
-text("Italic text").italic()
-```
+Available weight constants:
+- `FontWeight::THIN` (100)
+- `FontWeight::EXTRA_LIGHT` (200)
+- `FontWeight::LIGHT` (300)
+- `FontWeight::NORMAL` (400)
+- `FontWeight::MEDIUM` (500)
+- `FontWeight::SEMI_BOLD` (600)
+- `FontWeight::BOLD` (700)
+- `FontWeight::EXTRA_BOLD` (800)
+- `FontWeight::BLACK` (900)
 
 ### Text Wrapping
 
@@ -70,6 +115,7 @@ Chain style methods:
 text("Styled Text")
     .font_size(18.0)
     .color(Color::WHITE)
+    .font_family(FontFamily::Serif)
     .bold()
     .nowrap()
 ```
@@ -117,6 +163,15 @@ text("Subtitle or caption")
     .color(Color::rgb(0.6, 0.6, 0.65))
 ```
 
+### Code/Monospace Text
+
+```rust
+text("let x = 42;")
+    .mono()
+    .font_size(13.0)
+    .color(Color::rgb(0.6, 0.9, 0.6))
+```
+
 ### Labels
 
 ```rust
@@ -125,6 +180,18 @@ text("LABEL")
     .bold()
     .color(Color::rgb(0.5, 0.5, 0.55))
 ```
+
+## App-Level Default Font
+
+Set a default font family for the entire application:
+
+```rust
+App::new()
+    .default_font_family(FontFamily::Name("Inter".into()))
+    .add_surface(config, || view)
+```
+
+All text widgets will use this font family unless they explicitly override it.
 
 ## Complete Example
 
@@ -135,34 +202,42 @@ fn article_card(title: &str, author: &str, preview: &str) -> Container {
         .background(Color::rgb(0.12, 0.12, 0.16))
         .corner_radius(8.0)
         .layout(Flex::column().spacing(8.0))
-        .children([
-            // Title
+        .child(
+            // Title - bold serif
             text(title)
                 .font_size(18.0)
+                .font_family(FontFamily::Serif)
                 .bold()
-                .color(Color::WHITE),
-            // Author
+                .color(Color::WHITE)
+        )
+        .child(
+            // Author - light weight
             text(format!("By {}", author))
                 .font_size(12.0)
-                .color(Color::rgb(0.5, 0.5, 0.6)),
+                .font_weight(FontWeight::LIGHT)
+                .color(Color::rgb(0.5, 0.5, 0.6))
+        )
+        .child(
             // Preview text
             text(preview)
                 .font_size(14.0)
-                .color(Color::rgb(0.7, 0.7, 0.75)),
-        ])
+                .color(Color::rgb(0.7, 0.7, 0.75))
+        )
 }
 ```
 
 ## API Reference
 
 ```rust
-text(content: impl Into<String>) -> Text
+text(content: impl IntoMaybeDyn<String>) -> Text
 
 impl Text {
-    pub fn font_size(self, size: f32) -> Self;
+    pub fn font_size(self, size: impl IntoMaybeDyn<f32>) -> Self;
     pub fn color(self, color: impl IntoMaybeDyn<Color>) -> Self;
-    pub fn bold(self) -> Self;
-    pub fn italic(self) -> Self;
+    pub fn font_family(self, family: impl IntoMaybeDyn<FontFamily>) -> Self;
+    pub fn font_weight(self, weight: impl IntoMaybeDyn<FontWeight>) -> Self;
+    pub fn bold(self) -> Self;      // Shorthand for FontWeight::BOLD
+    pub fn mono(self) -> Self;      // Shorthand for FontFamily::Monospace
     pub fn nowrap(self) -> Self;
 }
 ```

--- a/examples/text_styling_example.rs
+++ b/examples/text_styling_example.rs
@@ -1,0 +1,194 @@
+//! Text Styling Example
+//!
+//! Demonstrates text styling with font family and font weight options.
+//! Run with: cargo run --example text_styling_example
+
+use guido::prelude::*;
+
+fn main() {
+    // Set an app-level default font (widgets will use this unless overridden)
+    // Note: The actual font availability depends on the system
+    let (app, _) = App::new()
+        .default_font_family(FontFamily::SansSerif)
+        .add_surface(
+            SurfaceConfig::new()
+                .width(600)
+                .height(600)
+                .anchor(Anchor::TOP | Anchor::LEFT)
+                .background_color(Color::rgb(0.08, 0.08, 0.12)),
+            || {
+                container()
+                    .background(Color::rgb(0.08, 0.08, 0.12))
+                    .padding(24.0)
+                    .layout(Flex::column().spacing(20.0))
+                    .child(
+                        // Title
+                        text("Text Styling Demo")
+                            .font_size(28.0)
+                            .bold()
+                            .color(Color::rgb(0.9, 0.9, 0.95)),
+                    )
+                    .child(create_font_family_section())
+                    .child(create_font_weight_section())
+                    .child(create_combined_section())
+                    .child(create_text_input_section())
+            },
+        );
+    app.run();
+}
+
+/// Section demonstrating different font families
+fn create_font_family_section() -> Container {
+    container()
+        .layout(Flex::column().spacing(8.0))
+        .child(
+            text("Font Families:")
+                .font_size(16.0)
+                .bold()
+                .color(Color::rgb(0.7, 0.7, 0.8)),
+        )
+        .child(
+            container()
+                .padding(12.0)
+                .background(Color::rgb(0.12, 0.12, 0.18))
+                .corner_radius(8.0)
+                .layout(Flex::column().spacing(8.0))
+                .child(
+                    text("Sans-Serif (default)")
+                        .font_family(FontFamily::SansSerif)
+                        .color(Color::WHITE),
+                )
+                .child(
+                    text("Serif font family")
+                        .font_family(FontFamily::Serif)
+                        .color(Color::WHITE),
+                )
+                .child(
+                    text("Monospace font family")
+                        .font_family(FontFamily::Monospace)
+                        .color(Color::WHITE),
+                )
+                .child(
+                    text("Using .mono() shorthand")
+                        .mono()
+                        .color(Color::rgb(0.6, 0.9, 0.6)),
+                ),
+        )
+}
+
+/// Section demonstrating different font weights
+fn create_font_weight_section() -> Container {
+    container()
+        .layout(Flex::column().spacing(8.0))
+        .child(
+            text("Font Weights:")
+                .font_size(16.0)
+                .bold()
+                .color(Color::rgb(0.7, 0.7, 0.8)),
+        )
+        .child(
+            container()
+                .padding(12.0)
+                .background(Color::rgb(0.12, 0.12, 0.18))
+                .corner_radius(8.0)
+                .layout(Flex::column().spacing(8.0))
+                .child(
+                    text("Thin (100)")
+                        .font_weight(FontWeight::THIN)
+                        .color(Color::WHITE),
+                )
+                .child(
+                    text("Light (300)")
+                        .font_weight(FontWeight::LIGHT)
+                        .color(Color::WHITE),
+                )
+                .child(
+                    text("Normal (400)")
+                        .font_weight(FontWeight::NORMAL)
+                        .color(Color::WHITE),
+                )
+                .child(
+                    text("Medium (500)")
+                        .font_weight(FontWeight::MEDIUM)
+                        .color(Color::WHITE),
+                )
+                .child(
+                    text("Semi-Bold (600)")
+                        .font_weight(FontWeight::SEMI_BOLD)
+                        .color(Color::WHITE),
+                )
+                .child(
+                    text("Bold (700)")
+                        .font_weight(FontWeight::BOLD)
+                        .color(Color::WHITE),
+                )
+                .child(
+                    text("Using .bold() shorthand")
+                        .bold()
+                        .color(Color::rgb(0.9, 0.7, 0.4)),
+                ),
+        )
+}
+
+/// Section demonstrating combined font family and weight
+fn create_combined_section() -> Container {
+    container()
+        .layout(Flex::column().spacing(8.0))
+        .child(
+            text("Combined Styling:")
+                .font_size(16.0)
+                .bold()
+                .color(Color::rgb(0.7, 0.7, 0.8)),
+        )
+        .child(
+            container()
+                .padding(12.0)
+                .background(Color::rgb(0.12, 0.12, 0.18))
+                .corner_radius(8.0)
+                .layout(Flex::column().spacing(8.0))
+                .child(
+                    text("Bold Monospace")
+                        .mono()
+                        .bold()
+                        .color(Color::rgb(0.4, 0.8, 1.0)),
+                )
+                .child(
+                    text("Light Serif")
+                        .font_family(FontFamily::Serif)
+                        .font_weight(FontWeight::LIGHT)
+                        .color(Color::rgb(0.9, 0.8, 0.7)),
+                )
+                .child(
+                    text("Bold Serif")
+                        .font_family(FontFamily::Serif)
+                        .bold()
+                        .color(Color::rgb(1.0, 0.9, 0.8)),
+                ),
+        )
+}
+
+/// Section demonstrating text input with styling
+fn create_text_input_section() -> Container {
+    let input_value = create_signal("Type here...".to_string());
+
+    container()
+        .layout(Flex::column().spacing(8.0))
+        .child(
+            text("Styled Text Input:")
+                .font_size(16.0)
+                .bold()
+                .color(Color::rgb(0.7, 0.7, 0.8)),
+        )
+        .child(
+            container()
+                .padding(12.0)
+                .background(Color::rgb(0.15, 0.15, 0.2))
+                .corner_radius(8.0)
+                .child(
+                    text_input(input_value)
+                        .mono()
+                        .font_size(16.0)
+                        .text_color(Color::rgb(0.4, 1.0, 0.6)),
+                ),
+        )
+}

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -17,11 +17,15 @@ use self::text::TextRenderState;
 use self::text_texture::{QUALITY_MULTIPLIER, TextTextureRenderer};
 use crate::transform::Transform;
 use crate::transform_origin::TransformOrigin;
+use crate::widgets::font::{FontFamily, FontWeight};
 use crate::widgets::image::{ContentFit, ImageSource};
 use crate::widgets::{Color, Rect};
 
 pub use context::{GpuContext, SurfaceState};
-pub use text_measurer::{char_index_from_x, measure_text, measure_text_to_char};
+pub use text_measurer::{
+    char_index_from_x, char_index_from_x_styled, measure_text, measure_text_styled,
+    measure_text_to_char, measure_text_to_char_styled,
+};
 
 /// A text entry for rendering, containing all information needed to render text.
 #[derive(Debug, Clone)]
@@ -34,6 +38,10 @@ pub struct TextEntry {
     pub color: Color,
     /// The font size in logical pixels
     pub font_size: f32,
+    /// The font family
+    pub font_family: FontFamily,
+    /// The font weight
+    pub font_weight: FontWeight,
     /// Optional clip rectangle to constrain text rendering
     pub clip_rect: Option<Rect>,
     /// Transform to apply to this text
@@ -889,7 +897,28 @@ impl PaintContext {
         self.push_rounded_rect(shape);
     }
 
+    /// Draw text with default font (SansSerif, normal weight).
     pub fn draw_text(&mut self, text: &str, rect: Rect, color: Color, font_size: f32) {
+        self.draw_text_styled(
+            text,
+            rect,
+            color,
+            font_size,
+            FontFamily::default(),
+            FontWeight::NORMAL,
+        );
+    }
+
+    /// Draw text with specified font family and weight.
+    pub fn draw_text_styled(
+        &mut self,
+        text: &str,
+        rect: Rect,
+        color: Color,
+        font_size: f32,
+        font_family: FontFamily,
+        font_weight: FontWeight,
+    ) {
         // Get intersected clip rect (intersection of all clips in stack) for text clipping
         let clip_rect = self.intersected_clip_rect();
         // Get current transform from the stack
@@ -900,6 +929,8 @@ impl PaintContext {
             rect,
             color,
             font_size,
+            font_family,
+            font_weight,
             clip_rect,
             transform,
             transform_origin,

--- a/src/renderer/text.rs
+++ b/src/renderer/text.rs
@@ -1,12 +1,13 @@
 use std::collections::HashSet;
 
 use glyphon::{
-    Attrs, Buffer, Cache, Color as GlyphonColor, Family, FontSystem, Metrics, Resolution, Shaping,
+    Attrs, Buffer, Cache, Color as GlyphonColor, FontSystem, Metrics, Resolution, Shaping,
     SwashCache, TextArea, TextAtlas, TextBounds, TextRenderer, Viewport,
 };
 use wgpu::{Device, MultisampleState, Queue};
 
 use super::TextEntry;
+use crate::widgets::font::FontWeight;
 
 pub struct TextRenderState {
     font_system: FontSystem,
@@ -108,10 +109,18 @@ impl TextRenderState {
                 Some((entry.rect.width.max(200.0)) * scale_factor),
                 Some((entry.rect.height.max(50.0)) * scale_factor),
             );
+            // Use entry's font properties, defaulting to NORMAL weight if default (0)
+            let weight = if entry.font_weight == FontWeight::default() {
+                FontWeight::NORMAL
+            } else {
+                entry.font_weight
+            };
             buffer.set_text(
                 &mut self.font_system,
                 &entry.text,
-                &Attrs::new().family(Family::SansSerif),
+                &Attrs::new()
+                    .family(entry.font_family.to_cosmic())
+                    .weight(weight.to_cosmic()),
                 Shaping::Advanced,
                 None,
             );

--- a/src/renderer/text_texture.rs
+++ b/src/renderer/text_texture.rs
@@ -8,7 +8,7 @@
 use std::sync::Arc;
 
 use glyphon::{
-    Attrs, Buffer, Cache, Color as GlyphonColor, Family, FontSystem, Metrics, Resolution, Shaping,
+    Attrs, Buffer, Cache, Color as GlyphonColor, FontSystem, Metrics, Resolution, Shaping,
     SwashCache, TextArea, TextAtlas, TextBounds, TextRenderer, Viewport,
 };
 use wgpu::{
@@ -17,6 +17,7 @@ use wgpu::{
 };
 
 use super::TextEntry;
+use crate::widgets::font::FontWeight;
 
 /// Quality multiplier for supersampling text textures.
 /// Renders text at higher resolution for better quality when displayed.
@@ -108,10 +109,18 @@ impl TextTextureRenderer {
             Some(buffer_width),
             Some(buffer_height),
         );
+        // Use entry's font properties, defaulting to NORMAL weight if default (0)
+        let weight = if entry.font_weight == FontWeight::default() {
+            FontWeight::NORMAL
+        } else {
+            entry.font_weight
+        };
         buffer.set_text(
             &mut self.font_system,
             &entry.text,
-            &Attrs::new().family(Family::SansSerif),
+            &Attrs::new()
+                .family(entry.font_family.to_cosmic())
+                .weight(weight.to_cosmic()),
             Shaping::Advanced,
             None,
         );

--- a/src/widgets/font.rs
+++ b/src/widgets/font.rs
@@ -1,0 +1,102 @@
+//! Font family and weight types for text styling.
+//!
+//! These types allow configuring font family and weight on text widgets.
+
+use cosmic_text::{Family, Weight};
+
+/// Font family specification.
+///
+/// # Examples
+///
+/// ```ignore
+/// text("Hello").font_family(FontFamily::Monospace)
+/// text("Hello").font_family(FontFamily::Name("Inter".into()))
+/// ```
+#[derive(Debug, Clone, PartialEq, Default)]
+pub enum FontFamily {
+    /// Sans-serif font (default system sans-serif)
+    #[default]
+    SansSerif,
+    /// Serif font (default system serif)
+    Serif,
+    /// Monospace font (default system monospace)
+    Monospace,
+    /// Cursive font
+    Cursive,
+    /// Fantasy font
+    Fantasy,
+    /// Custom font by name
+    Name(String),
+}
+
+impl FontFamily {
+    /// Convert to cosmic-text Family type for rendering.
+    pub fn to_cosmic(&self) -> Family<'_> {
+        match self {
+            FontFamily::SansSerif => Family::SansSerif,
+            FontFamily::Serif => Family::Serif,
+            FontFamily::Monospace => Family::Monospace,
+            FontFamily::Cursive => Family::Cursive,
+            FontFamily::Fantasy => Family::Fantasy,
+            FontFamily::Name(name) => Family::Name(name),
+        }
+    }
+}
+
+/// Font weight on a 100-900 scale, matching CSS font-weight values.
+///
+/// # Examples
+///
+/// ```ignore
+/// text("Hello").font_weight(FontWeight::BOLD)
+/// text("Hello").font_weight(FontWeight(600))
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct FontWeight(pub u16);
+
+impl FontWeight {
+    /// Thin weight (100)
+    pub const THIN: Self = Self(100);
+    /// Extra-light weight (200)
+    pub const EXTRA_LIGHT: Self = Self(200);
+    /// Light weight (300)
+    pub const LIGHT: Self = Self(300);
+    /// Normal/regular weight (400) - default
+    pub const NORMAL: Self = Self(400);
+    /// Medium weight (500)
+    pub const MEDIUM: Self = Self(500);
+    /// Semi-bold weight (600)
+    pub const SEMI_BOLD: Self = Self(600);
+    /// Bold weight (700)
+    pub const BOLD: Self = Self(700);
+    /// Extra-bold weight (800)
+    pub const EXTRA_BOLD: Self = Self(800);
+    /// Black/heavy weight (900)
+    pub const BLACK: Self = Self(900);
+
+    /// Convert to cosmic-text Weight type for rendering.
+    pub fn to_cosmic(self) -> Weight {
+        Weight(self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn font_family_default() {
+        assert_eq!(FontFamily::default(), FontFamily::SansSerif);
+    }
+
+    #[test]
+    fn font_weight_default() {
+        assert_eq!(FontWeight::default(), FontWeight(0));
+    }
+
+    #[test]
+    fn font_weight_constants() {
+        assert_eq!(FontWeight::NORMAL.0, 400);
+        assert_eq!(FontWeight::BOLD.0, 700);
+    }
+}

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -1,5 +1,6 @@
 pub mod children;
 pub mod container;
+pub mod font;
 pub mod image;
 pub mod into_child;
 pub mod scroll;
@@ -33,6 +34,7 @@ pub(crate) use impl_dirty_flags;
 
 pub use children::ChildrenSource;
 pub use container::{Border, Container, GradientDirection, LinearGradient, Overflow, container};
+pub use font::{FontFamily, FontWeight};
 pub use image::{ContentFit, Image, ImageSource, image};
 pub use into_child::{DynamicChildren, IntoChild, IntoChildren, StaticChildren};
 pub use scroll::{ScrollAxis, ScrollbarBuilder, ScrollbarConfig, ScrollbarVisibility};
@@ -68,6 +70,18 @@ impl IntoMaybeDyn<Transform> for Transform {
 
 impl IntoMaybeDyn<TransformOrigin> for TransformOrigin {
     fn into_maybe_dyn(self) -> MaybeDyn<TransformOrigin> {
+        MaybeDyn::Static(self)
+    }
+}
+
+impl IntoMaybeDyn<FontFamily> for FontFamily {
+    fn into_maybe_dyn(self) -> MaybeDyn<FontFamily> {
+        MaybeDyn::Static(self)
+    }
+}
+
+impl IntoMaybeDyn<FontWeight> for FontWeight {
+    fn into_maybe_dyn(self) -> MaybeDyn<FontWeight> {
         MaybeDyn::Static(self)
     }
 }


### PR DESCRIPTION
## Summary

- Add `FontFamily` enum for setting text font (SansSerif, Serif, Monospace, Cursive, Fantasy, custom names)
- Add `FontWeight` struct with CSS-compatible values (100-900) and constants (THIN, LIGHT, NORMAL, BOLD, etc.)
- Add `.font_family()`, `.font_weight()`, `.bold()`, and `.mono()` methods to Text widget
- Add same font styling API to TextInput widget
- Add `App::default_font_family()` for app-wide default font
- Update renderer to pass font properties through text pipeline

## Test plan

- [x] Build passes: `cargo build`
- [x] Clippy passes: `cargo clippy --all-targets --all-features -- -D warnings`
- [x] Format passes: `cargo fmt --all -- --check`
- [x] Tests pass: `cargo test`
- [x] Visual verification via `cargo run --example text_styling_example`
- [x] Screenshot confirms font families and weights render correctly
- [x] Book builds: `mdbook build book`