### PR TITLE
Fix publish workflow: use cargo-release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,10 +21,6 @@ jobs:
           VERSION=${GITHUB_REF_NAME#v}
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-      - name: Update Cargo.toml version
-        run: |
-          sed -i 's/^version = ".*"/version = "${{ steps.version.outputs.version }}"/' Cargo.toml
-
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
@@ -33,19 +29,23 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libwayland-dev libxkbcommon-dev
 
-      - name: Publish guido-macros
-        run: cargo publish -p guido-macros --token ${{ secrets.CRATES_IO_TOKEN }}
+      - name: Install cargo-release
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-release
 
-      - name: Wait for crates.io index
-        run: sleep 30
+      - name: Set version
+        run: cargo release version ${{ steps.version.outputs.version }} --execute --no-confirm
 
-      - name: Publish guido
-        run: cargo publish -p guido --token ${{ secrets.CRATES_IO_TOKEN }}
+      - name: Publish workspace
+        run: cargo release publish --execute --no-confirm
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
 
       - name: Commit version bump
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add Cargo.toml
+          git add -A
           git commit -m "chore: bump version to ${{ steps.version.outputs.version }}"
           git push origin HEAD:main

--- a/guido-macros/Cargo.toml
+++ b/guido-macros/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "guido-macros"
 description = "Macro for guido"
+readme = "../README.md"
 version.workspace = true
 edition.workspace = true
 authors.workspace = true


### PR DESCRIPTION
## Summary

- Replace fragile sed-based version updates with `cargo-release`
- Uses `cargo release version` to update all workspace versions correctly
- Uses `cargo release publish` to publish crates in dependency order

## Problem

The current publish workflow has issues:
1. Only updates `[workspace.package] version`, not the dependency version in `[workspace.dependencies]`
2. Manual sed commands are fragile
3. Manual sleep for crates.io index may not be sufficient

## Solution

Use `cargo-release` which handles workspace publishing correctly:
- Publishes crates in dependency order
- Manages all version updates automatically (both workspace package version and dependencies)
- Handles waiting for crates.io index automatically
- Uses `CARGO_REGISTRY_TOKEN` env var (standard convention)

## Test plan

- [ ] Create a test release (e.g., v0.1.1)
- [ ] Check workflow logs for successful publish of both crates
- [ ] Verify on crates.io that guido depends on correct guido-macros version
- [ ] Verify committed Cargo.toml has updated versions in both locations