### PR TITLE
Fix publish workflow: commit before publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,11 +37,6 @@ jobs:
       - name: Set version
         run: cargo release version ${{ steps.version.outputs.version }} --execute --no-confirm
 
-      - name: Publish workspace
-        run: cargo release publish --execute --no-confirm
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
-
       - name: Commit version bump
         run: |
           git config user.name "github-actions[bot]"
@@ -49,3 +44,8 @@ jobs:
           git add -A
           git commit -m "chore: bump version to ${{ steps.version.outputs.version }}"
           git push origin HEAD:main
+
+      - name: Publish workspace
+        run: cargo release publish --execute --no-confirm
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}


### PR DESCRIPTION
## Summary

- Move the version bump commit **before** the publish step

## Problem

`cargo release publish` refuses to publish with uncommitted changes:
```
error: uncommitted changes detected, please resolve before release:
  Cargo.lock (Status(WT_MODIFIED))
  Cargo.toml (Status(WT_MODIFIED))
```

The `cargo release version` command modifies Cargo.toml and Cargo.lock, which must be committed before `cargo release publish` will run.

## Test plan

- [ ] Merge and create a new release (e.g., v0.1.2)
- [ ] Verify workflow completes successfully