### PR TITLE
Fix publish workflow: allow detached HEAD

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,6 +46,6 @@ jobs:
           git push origin HEAD:main
 
       - name: Publish workspace
-        run: cargo release publish --execute --no-confirm
+        run: cargo release publish --execute --no-confirm --allow-branch HEAD
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}


### PR DESCRIPTION
## Summary

- Add `--allow-branch HEAD` to `cargo release publish` command

## Problem

After pushing the version bump commit, the workflow is in a detached HEAD state. `cargo release publish` rejects this by default:

```
error: cannot release from branch `HEAD` as it doesn't match `*`, `!HEAD`
```

## Solution

Add `--allow-branch HEAD` flag to allow publishing from detached HEAD state.