### PR TITLE
fix: add --workspace flag to publish all workspace members

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,6 +46,6 @@ jobs:
           git push origin HEAD:main
 
       - name: Publish workspace
-        run: cargo release publish --execute --no-confirm --allow-branch HEAD
+        run: cargo release publish --workspace --execute --no-confirm --allow-branch HEAD
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}


### PR DESCRIPTION
## Summary
- Add `--workspace` flag to `cargo release publish` command to ensure all workspace members are published in dependency order

## Problem
The publish workflow was only publishing `guido`, not `guido-macros` first, causing dependency resolution to fail with:
```
failed to select a version for the requirement `guido-macros = "^0.1.3"`
candidate versions found which didn't match: 0.1.0
```

## Test plan
- [ ] Merge PR and create a new release (v0.1.4)
- [ ] Check workflow logs show both `guido-macros` and `guido` being published
- [ ] Verify both crates appear on crates.io with correct versions