### PR TITLE
refactor: simplify lib.rs and refactor surface management

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Guido is a reactive Rust GUI library using wgpu for rendering Wayland layer shell widgets (status bars, panels, etc.). The library emphasizes composition from minimal primitives, reactive properties, and GPU-accelerated rendering with animations.
 
+**Note: Backward compatibility is NOT a concern for this project.** Feel free to remove legacy code, refactor APIs, and make breaking changes when it improves the codebase. The library is under active development and not yet stable.
+
 ## Documentation
 
 ### Developer Reference (`docs/`)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,11 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 
 use layout::Constraints;
+
+// PaintContext capacity constants to avoid magic numbers
+const PAINT_CTX_SHAPES: usize = 32;
+const PAINT_CTX_TEXTS: usize = 16;
+const PAINT_CTX_OVERLAYS: usize = 8;
 use platform::{WaylandWindowWrapper, create_wayland_app};
 use reactive::{
     clear_animation_flag, init_wakeup, set_system_clipboard, take_clipboard_change,
@@ -284,7 +289,11 @@ impl App {
                     id: def.id,
                     config: def.config,
                     widget,
-                    paint_ctx: renderer::PaintContext::with_capacity(32, 16, 8),
+                    paint_ctx: renderer::PaintContext::with_capacity(
+                        PAINT_CTX_SHAPES,
+                        PAINT_CTX_TEXTS,
+                        PAINT_CTX_OVERLAYS,
+                    ),
                     wgpu_surface: Some(wgpu_surface),
                     previous_scale_factor: wayland_surface.scale_factor,
                 },
@@ -376,7 +385,11 @@ impl App {
                                 id,
                                 config,
                                 widget,
-                                paint_ctx: renderer::PaintContext::with_capacity(32, 16, 8),
+                                paint_ctx: renderer::PaintContext::with_capacity(
+                                    PAINT_CTX_SHAPES,
+                                    PAINT_CTX_TEXTS,
+                                    PAINT_CTX_OVERLAYS,
+                                ),
                                 wgpu_surface: None, // Will be created after configure
                                 previous_scale_factor: 1.0,
                             },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,17 +192,7 @@ impl App {
 
         // Create surfaces from add_surface() calls
         for def in &self.surface_definitions {
-            wayland_state.create_surface_with_id(
-                &qh,
-                def.id,
-                def.config.width,
-                def.config.height,
-                def.config.anchor,
-                def.config.layer,
-                &def.config.namespace,
-                def.config.exclusive_zone,
-                def.config.keyboard_interactivity,
-            );
+            wayland_state.create_surface_with_id(&qh, def.id, &def.config);
         }
 
         // Wait for all surfaces to configure
@@ -322,17 +312,7 @@ impl App {
                         log::info!("Creating dynamic surface {:?}", id);
 
                         // Create Wayland surface
-                        wayland_state.create_surface_with_id(
-                            &qh,
-                            id,
-                            config.width,
-                            config.height,
-                            config.anchor,
-                            config.layer,
-                            &config.namespace,
-                            config.exclusive_zone,
-                            config.keyboard_interactivity,
-                        );
+                        wayland_state.create_surface_with_id(&qh, id, &config);
 
                         // Create the widget and managed surface (GPU init happens later)
                         let widget = widget_fn();

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -107,18 +107,8 @@ pub struct WaylandState {
     pub seat_state: SeatState,
     pub layer_shell: LayerShell,
 
-    // Legacy single-surface fields (for backward compatibility)
-    pub layer_surface: Option<LayerSurface>,
-    pub surface: Option<wl_surface::WlSurface>,
-    pub configured: bool,
-    pub width: u32,
-    pub height: u32,
-    pub scale_factor: f32,
+    /// Whether the application should exit
     pub exit: bool,
-
-    // Initialization tracking for event-driven startup
-    pub scale_factor_received: bool,
-    pub first_frame_presented: bool,
 
     // Multi-surface tracking
     /// All surfaces indexed by SurfaceId
@@ -152,9 +142,6 @@ pub struct WaylandState {
     pending_clipboard_read: Option<ReadPipe>,
     clipboard_source: Option<CopyPasteSource>,
     selection_offer: Option<SelectionOffer>,
-
-    // Pending events to be processed by the main loop (legacy single-surface)
-    pub pending_events: Vec<Event>,
 }
 
 pub fn create_wayland_app() -> (
@@ -192,15 +179,7 @@ pub fn create_wayland_app() -> (
         output_state,
         seat_state,
         layer_shell,
-        layer_surface: None,
-        surface: None,
-        configured: false,
-        width: 0,
-        height: 0,
-        scale_factor: 1.0,
         exit: false,
-        scale_factor_received: false,
-        first_frame_presented: false,
         surfaces: HashMap::new(),
         surface_lookup: HashMap::new(),
         current_pointer_surface: None,
@@ -220,60 +199,13 @@ pub fn create_wayland_app() -> (
         pending_clipboard_read: None,
         clipboard_source: None,
         selection_offer: None,
-        pending_events: Vec::new(),
     };
 
     (connection, event_queue, state, qh)
 }
 
 impl WaylandState {
-    /// Create a layer surface (legacy single-surface API).
-    pub fn create_layer_surface(
-        &mut self,
-        qh: &QueueHandle<Self>,
-        width: u32,
-        height: u32,
-        anchor: Anchor,
-        layer: Layer,
-        namespace: &str,
-    ) {
-        let surface = self.compositor_state.create_surface(qh);
-        let layer_surface = self.layer_shell.create_layer_surface(
-            qh,
-            surface.clone(),
-            layer,
-            Some(namespace.to_string()),
-            None,
-        );
-
-        layer_surface.set_anchor(anchor);
-
-        // When anchored to both edges on an axis, set that dimension to 0
-        // to let the compositor stretch the surface to fill
-        let use_width = if anchor.contains(Anchor::LEFT) && anchor.contains(Anchor::RIGHT) {
-            0 // Let compositor decide
-        } else {
-            width
-        };
-        let use_height = if anchor.contains(Anchor::TOP) && anchor.contains(Anchor::BOTTOM) {
-            0 // Let compositor decide
-        } else {
-            height
-        };
-
-        layer_surface.set_size(use_width, use_height);
-        layer_surface.set_keyboard_interactivity(KeyboardInteractivity::OnDemand);
-        layer_surface.set_exclusive_zone(height as i32);
-
-        surface.commit();
-
-        self.surface = Some(surface);
-        self.layer_surface = Some(layer_surface);
-        self.width = width;
-        self.height = height;
-    }
-
-    /// Create a layer surface with a specific SurfaceId (multi-surface API).
+    /// Create a layer surface with a specific SurfaceId.
     pub fn create_surface_with_id(
         &mut self,
         qh: &QueueHandle<Self>,
@@ -457,11 +389,6 @@ impl WaylandState {
         self.surfaces
             .values()
             .any(|s| !s.first_frame_presented || !s.scale_factor_received)
-    }
-
-    /// Take all pending events (drains the queue)
-    pub fn take_events(&mut self) -> Vec<Event> {
-        std::mem::take(&mut self.pending_events)
     }
 
     /// Set clipboard content (copy)
@@ -672,19 +599,12 @@ impl CompositorHandler for WaylandState {
         new_factor: i32,
     ) {
         // Find which surface this is for
-        let surface_id = self.surface_lookup.get(&surface.id()).copied();
-
-        if let Some(id) = surface_id {
-            if let Some(surface_state) = self.surfaces.get_mut(&id) {
-                log::info!("Surface {:?} scale factor changed to: {}", id, new_factor);
-                surface_state.scale_factor = new_factor as f32;
-                surface_state.scale_factor_received = true;
-            }
-        } else {
-            // Legacy single-surface mode
-            log::info!("Scale factor changed to: {}", new_factor);
-            self.scale_factor = new_factor as f32;
-            self.scale_factor_received = true;
+        if let Some(id) = self.surface_lookup.get(&surface.id()).copied()
+            && let Some(surface_state) = self.surfaces.get_mut(&id)
+        {
+            log::info!("Surface {:?} scale factor changed to: {}", id, new_factor);
+            surface_state.scale_factor = new_factor as f32;
+            surface_state.scale_factor_received = true;
         }
 
         // Set the buffer scale on the surface for proper HiDPI rendering
@@ -726,26 +646,15 @@ impl CompositorHandler for WaylandState {
         _time: u32,
     ) {
         // Find which surface this is for
-        let surface_id = self.surface_lookup.get(&surface.id()).copied();
-
-        if let Some(id) = surface_id {
-            if let Some(surface_state) = self.surfaces.get_mut(&id)
-                && !surface_state.first_frame_presented
-            {
-                log::info!(
-                    "Surface {:?} first frame presented by compositor - initialization complete",
-                    id
-                );
-                surface_state.first_frame_presented = true;
-            }
-        } else {
-            // Legacy single-surface mode
-            if !self.first_frame_presented {
-                log::info!(
-                    "First frame presented by compositor - initialization complete, switching to on-demand rendering"
-                );
-                self.first_frame_presented = true;
-            }
+        if let Some(id) = self.surface_lookup.get(&surface.id()).copied()
+            && let Some(surface_state) = self.surfaces.get_mut(&id)
+            && !surface_state.first_frame_presented
+        {
+            log::info!(
+                "Surface {:?} first frame presented by compositor - initialization complete",
+                id
+            );
+            surface_state.first_frame_presented = true;
         }
     }
 }
@@ -797,9 +706,6 @@ impl LayerShellHandler for WaylandState {
             if self.surfaces.is_empty() {
                 self.exit = true;
             }
-        } else {
-            // Legacy single-surface mode
-            self.exit = true;
         }
     }
 
@@ -818,45 +724,29 @@ impl LayerShellHandler for WaylandState {
             .find(|(_, state)| &state.layer_surface == layer)
             .map(|(id, _)| *id);
 
-        if let Some(id) = surface_id {
-            if let Some(surface_state) = self.surfaces.get_mut(&id) {
-                log::info!(
-                    "Surface {:?} configure: requested size {:?}, current {}x{}",
-                    id,
-                    configure.new_size,
-                    surface_state.width,
-                    surface_state.height
-                );
-                if configure.new_size.0 > 0 {
-                    surface_state.width = configure.new_size.0;
-                }
-                if configure.new_size.1 > 0 {
-                    surface_state.height = configure.new_size.1;
-                }
-                log::info!(
-                    "Surface {:?} using size: {}x{}",
-                    id,
-                    surface_state.width,
-                    surface_state.height
-                );
-                surface_state.configured = true;
-            }
-        } else {
-            // Legacy single-surface mode
+        if let Some(id) = surface_id
+            && let Some(surface_state) = self.surfaces.get_mut(&id)
+        {
             log::info!(
-                "Layer shell configure: requested size {:?}, current {}x{}",
+                "Surface {:?} configure: requested size {:?}, current {}x{}",
+                id,
                 configure.new_size,
-                self.width,
-                self.height
+                surface_state.width,
+                surface_state.height
             );
             if configure.new_size.0 > 0 {
-                self.width = configure.new_size.0;
+                surface_state.width = configure.new_size.0;
             }
             if configure.new_size.1 > 0 {
-                self.height = configure.new_size.1;
+                surface_state.height = configure.new_size.1;
             }
-            log::info!("Layer shell using size: {}x{}", self.width, self.height);
-            self.configured = true;
+            log::info!(
+                "Surface {:?} using size: {}x{}",
+                id,
+                surface_state.width,
+                surface_state.height
+            );
+            surface_state.configured = true;
         }
     }
 }
@@ -942,20 +832,9 @@ impl PointerHandler for WaylandState {
             // Try to find the surface ID for this event's wl_surface
             let surface_id = self.surface_lookup.get(&event.surface.id()).copied();
 
-            // Check if this event is for our legacy single surface (backward compatibility)
-            let is_legacy_surface = self
-                .surface
-                .as_ref()
-                .map(|s| s == &event.surface)
-                .unwrap_or(false);
-
-            // Determine which event queue to push to
+            // Get the target event queue for this surface
             let target_events: Option<&mut Vec<Event>> = if let Some(id) = surface_id {
-                // Multi-surface mode: push to the specific surface's event queue
                 self.surfaces.get_mut(&id).map(|s| &mut s.pending_events)
-            } else if is_legacy_surface {
-                // Legacy single-surface mode: push to the global pending_events
-                Some(&mut self.pending_events)
             } else if !matches!(event.kind, PointerEventKind::Leave { .. }) {
                 // Not our surface and not a leave event, skip
                 continue;
@@ -989,12 +868,10 @@ impl PointerHandler for WaylandState {
                         self.pointer_over_surface = false;
 
                         // Send leave event to the surface that had focus
-                        if let Some(id) = self.current_pointer_surface {
-                            if let Some(surface_state) = self.surfaces.get_mut(&id) {
-                                surface_state.pending_events.push(Event::MouseLeave);
-                            }
-                        } else if is_legacy_surface {
-                            self.pending_events.push(Event::MouseLeave);
+                        if let Some(id) = self.current_pointer_surface
+                            && let Some(surface_state) = self.surfaces.get_mut(&id)
+                        {
+                            surface_state.pending_events.push(Event::MouseLeave);
                         }
 
                         self.current_pointer_surface = None;
@@ -1113,12 +990,10 @@ impl KeyboardHandler for WaylandState {
         self.current_keyboard_surface = surface_id;
 
         // Route event to correct surface
-        if let Some(id) = surface_id {
-            if let Some(surface_state) = self.surfaces.get_mut(&id) {
-                surface_state.pending_events.push(Event::FocusIn);
-            }
-        } else {
-            self.pending_events.push(Event::FocusIn);
+        if let Some(id) = surface_id
+            && let Some(surface_state) = self.surfaces.get_mut(&id)
+        {
+            surface_state.pending_events.push(Event::FocusIn);
         }
     }
 
@@ -1134,12 +1009,10 @@ impl KeyboardHandler for WaylandState {
 
         // Route event to correct surface
         let surface_id = self.surface_lookup.get(&surface.id()).copied();
-        if let Some(id) = surface_id {
-            if let Some(surface_state) = self.surfaces.get_mut(&id) {
-                surface_state.pending_events.push(Event::FocusOut);
-            }
-        } else {
-            self.pending_events.push(Event::FocusOut);
+        if let Some(id) = surface_id
+            && let Some(surface_state) = self.surfaces.get_mut(&id)
+        {
+            surface_state.pending_events.push(Event::FocusOut);
         }
 
         self.current_keyboard_surface = None;
@@ -1167,9 +1040,7 @@ impl KeyboardHandler for WaylandState {
                 && let Some(surface_state) = self.surfaces.get_mut(&id)
             {
                 surface_state.pending_events.push(key_event);
-                return;
             }
-            self.pending_events.push(key_event);
         }
     }
 
@@ -1192,9 +1063,7 @@ impl KeyboardHandler for WaylandState {
                 && let Some(surface_state) = self.surfaces.get_mut(&id)
             {
                 surface_state.pending_events.push(key_event);
-                return;
             }
-            self.pending_events.push(key_event);
         }
     }
 
@@ -1236,9 +1105,7 @@ impl KeyboardHandler for WaylandState {
                 && let Some(surface_state) = self.surfaces.get_mut(&id)
             {
                 surface_state.pending_events.push(key_event);
-                return;
             }
-            self.pending_events.push(key_event);
         }
     }
 }

--- a/src/surface_manager.rs
+++ b/src/surface_manager.rs
@@ -1,0 +1,207 @@
+//! Surface lifecycle management for Guido applications.
+//!
+//! This module provides types for managing the lifecycle of surfaces,
+//! including GPU initialization and widget layout.
+
+use std::collections::HashMap;
+
+use smithay_client_toolkit::reexports::client::Connection;
+
+use crate::layout::Constraints;
+use crate::platform::{WaylandState, WaylandWindowWrapper};
+use crate::renderer::{GpuContext, PaintContext, SurfaceState};
+use crate::surface::{SurfaceConfig, SurfaceId};
+use crate::widgets::Widget;
+
+// PaintContext capacity constants
+const PAINT_CTX_SHAPES: usize = 32;
+const PAINT_CTX_TEXTS: usize = 16;
+const PAINT_CTX_OVERLAYS: usize = 8;
+
+/// A surface with unified GPU lifecycle management.
+///
+/// This combines the widget tree, GPU surface state, and configuration
+/// into a single struct that manages the surface's entire lifecycle.
+pub struct ManagedSurface {
+    /// The unique identifier for this surface
+    pub id: SurfaceId,
+    /// Configuration for the surface
+    pub config: SurfaceConfig,
+    /// The root widget for this surface
+    pub widget: Box<dyn Widget>,
+    /// Paint context for rendering
+    pub paint_ctx: PaintContext,
+    /// The wgpu surface state (None until GPU init)
+    pub wgpu_surface: Option<SurfaceState>,
+    /// Previous scale factor for detecting changes
+    pub previous_scale_factor: f32,
+}
+
+impl ManagedSurface {
+    /// Create a new managed surface (wgpu_surface is None until GPU init).
+    pub fn new(id: SurfaceId, config: SurfaceConfig, widget: Box<dyn Widget>) -> Self {
+        Self {
+            id,
+            config,
+            widget,
+            paint_ctx: PaintContext::with_capacity(
+                PAINT_CTX_SHAPES,
+                PAINT_CTX_TEXTS,
+                PAINT_CTX_OVERLAYS,
+            ),
+            wgpu_surface: None,
+            previous_scale_factor: 1.0,
+        }
+    }
+
+    /// Initialize GPU surface. Returns true if successful.
+    pub fn init_gpu(
+        &mut self,
+        gpu_context: &GpuContext,
+        connection: &Connection,
+        wl_surface: &smithay_client_toolkit::reexports::client::protocol::wl_surface::WlSurface,
+        width: u32,
+        height: u32,
+        scale_factor: f32,
+    ) -> bool {
+        if self.wgpu_surface.is_some() {
+            return true; // Already initialized
+        }
+
+        let window_handle = WaylandWindowWrapper::new(connection, wl_surface);
+        let initial_scale = scale_factor.max(1.0) as u32;
+        let physical_width = width * initial_scale;
+        let physical_height = height * initial_scale;
+
+        log::info!(
+            "Creating wgpu surface for {:?}: logical {}x{}, physical {}x{}, scale {}",
+            self.id,
+            width,
+            height,
+            physical_width,
+            physical_height,
+            initial_scale
+        );
+
+        let wgpu_surface =
+            gpu_context.create_surface(window_handle, physical_width, physical_height);
+        self.wgpu_surface = Some(wgpu_surface);
+        self.previous_scale_factor = scale_factor;
+
+        // Perform initial layout
+        self.layout_widget(width as f32, height as f32);
+
+        true
+    }
+
+    /// Check if GPU is initialized.
+    pub fn is_gpu_ready(&self) -> bool {
+        self.wgpu_surface.is_some()
+    }
+
+    /// Perform widget layout with the given dimensions.
+    pub fn layout_widget(&mut self, width: f32, height: f32) {
+        let constraints = Constraints::new(0.0, 0.0, width, height);
+        self.widget.layout(constraints);
+        self.widget.set_origin(0.0, 0.0);
+    }
+}
+
+/// Manages all surfaces in the application.
+pub struct SurfaceManager {
+    surfaces: HashMap<SurfaceId, ManagedSurface>,
+}
+
+impl SurfaceManager {
+    /// Create a new empty surface manager.
+    pub fn new() -> Self {
+        Self {
+            surfaces: HashMap::new(),
+        }
+    }
+
+    /// Add a surface.
+    pub fn add(&mut self, surface: ManagedSurface) {
+        self.surfaces.insert(surface.id, surface);
+    }
+
+    /// Remove a surface by ID.
+    pub fn remove(&mut self, id: SurfaceId) -> Option<ManagedSurface> {
+        self.surfaces.remove(&id)
+    }
+
+    /// Get a surface by ID.
+    #[allow(dead_code)]
+    pub fn get(&self, id: SurfaceId) -> Option<&ManagedSurface> {
+        self.surfaces.get(&id)
+    }
+
+    /// Get a mutable surface by ID.
+    pub fn get_mut(&mut self, id: SurfaceId) -> Option<&mut ManagedSurface> {
+        self.surfaces.get_mut(&id)
+    }
+
+    /// Iterate over all surface IDs.
+    pub fn ids(&self) -> impl Iterator<Item = SurfaceId> + '_ {
+        self.surfaces.keys().copied()
+    }
+
+    /// Iterate over all surfaces.
+    #[allow(dead_code)]
+    pub fn iter(&self) -> impl Iterator<Item = (&SurfaceId, &ManagedSurface)> {
+        self.surfaces.iter()
+    }
+
+    /// Iterate over all surfaces mutably.
+    #[allow(dead_code)]
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = (&SurfaceId, &mut ManagedSurface)> {
+        self.surfaces.iter_mut()
+    }
+
+    /// Check if empty.
+    pub fn is_empty(&self) -> bool {
+        self.surfaces.is_empty()
+    }
+
+    /// Initialize GPU for surfaces that need it.
+    ///
+    /// This iterates over all surfaces and initializes GPU for any
+    /// that are configured in Wayland but don't yet have a wgpu surface.
+    pub fn init_pending_gpu(
+        &mut self,
+        gpu_context: &GpuContext,
+        connection: &Connection,
+        wayland_state: &WaylandState,
+    ) {
+        for (id, surface) in self.surfaces.iter_mut() {
+            if surface.is_gpu_ready() {
+                continue;
+            }
+
+            // Get wayland surface state
+            let Some(wayland_surface) = wayland_state.get_surface(*id) else {
+                continue;
+            };
+
+            // Skip if not configured yet
+            if !wayland_surface.configured {
+                continue;
+            }
+
+            surface.init_gpu(
+                gpu_context,
+                connection,
+                &wayland_surface.wl_surface,
+                wayland_surface.width,
+                wayland_surface.height,
+                wayland_surface.scale_factor,
+            );
+        }
+    }
+}
+
+impl Default for SurfaceManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}


### PR DESCRIPTION
## Summary

This PR refactors the surface management code in `lib.rs` to improve readability and maintainability:

- **Extract PaintContext capacity constants** - Replace magic numbers (32, 16, 8) with named constants
- **Create `surface_manager.rs` module** - Introduce `ManagedSurface` and `SurfaceManager` types that unify surface lifecycle management
- **Simplify `create_surface_with_id`** - Reduce from 10 arguments to 3 by accepting `&SurfaceConfig`
- **Extract helper functions** - Move command processing and per-surface rendering into dedicated functions
- **Clean up main loop** - Main loop is now more readable and focused on orchestration
- **Remove legacy single-surface code** - Remove unused fields, methods, and fallbacks from `WaylandState`

### Changes

| File | Changes |
|------|---------|
| `src/lib.rs` | Extract helpers, use SurfaceManager, clean main loop, remove SurfaceEntry |
| `src/surface_manager.rs` | New file with ManagedSurface and SurfaceManager |
| `src/platform/wayland.rs` | Simplify create_surface_with_id, remove legacy code |
| `CLAUDE.md` | Note that backward compatibility is not a concern |

### Legacy code removed from WaylandState

- Fields: `layer_surface`, `surface`, `configured`, `width`, `height`, `scale_factor`, `scale_factor_received`, `first_frame_presented`, `pending_events`
- Methods: `create_layer_surface()`, `take_events()`
- Event handler fallbacks for single-surface mode

## Test plan

- [x] `cargo clippy` passes
- [x] `cargo fmt` passes
- [x] `cargo test` passes
- [ ] Manual testing with `cargo run --example status_bar`
- [ ] Manual testing with `cargo run --example reactive_example`