### PR TITLE
refactor: separate animation advancement from layout

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -294,6 +294,12 @@ fn render_surface(
         renderer.set_screen_size(physical_width as f32, physical_height as f32);
         renderer.set_scale_factor(scale_factor);
 
+        // Advance animations first (separate from layout)
+        let animations_active = surface.widget.advance_animations();
+        if animations_active {
+            reactive::request_animation_frame();
+        }
+
         // Re-layout (for reactive updates)
         let constraints = Constraints::new(0.0, 0.0, width as f32, height as f32);
         surface.widget.layout(constraints);

--- a/src/widgets/children.rs
+++ b/src/widgets/children.rs
@@ -170,6 +170,10 @@ impl ChildrenSource {
 struct DummyWidget;
 
 impl super::Widget for DummyWidget {
+    fn advance_animations(&mut self) -> bool {
+        false
+    }
+
     fn layout(&mut self, _constraints: crate::layout::Constraints) -> crate::layout::Size {
         crate::layout::Size::zero()
     }
@@ -332,6 +336,10 @@ impl Drop for OwnedWidget {
 }
 
 impl Widget for OwnedWidget {
+    fn advance_animations(&mut self) -> bool {
+        self.inner.advance_animations()
+    }
+
     fn layout(&mut self, constraints: Constraints) -> Size {
         self.inner.layout(constraints)
     }

--- a/src/widgets/widget.rs
+++ b/src/widgets/widget.rs
@@ -370,6 +370,13 @@ impl Event {
 }
 
 pub trait Widget {
+    /// Advance animations for this widget and children.
+    /// Returns true if any animations are still active and need another frame.
+    /// Called once per frame before layout.
+    fn advance_animations(&mut self) -> bool {
+        false
+    }
+
     fn layout(&mut self, constraints: Constraints) -> Size;
     fn paint(&self, ctx: &mut PaintContext);
     fn event(&mut self, event: &Event) -> EventResponse {


### PR DESCRIPTION
## Summary

- Add `advance_animations()` method to Widget trait with default implementation
- Move Container's animation logic from `layout()` to `advance_animations()`
- Call `advance_animations()` in main render loop before `layout()`
- Add constraint caching to Container for layout skip optimization
- Forward `advance_animations()` in `OwnedWidget` and `DummyWidget`

This is **PR #1** of the widget system refactoring plan to separate concerns:
1. **Animation advancement** - independent step, runs before layout/paint
2. **Dirty flag propagation** (future PR) - layout_dirty bubbles up with relayout boundaries
3. **Layout function** - pure layout with constraint caching, no animation logic
4. **Paint function** - pure drawing (already mostly clean)

## Test plan

- [x] `cargo check` and `cargo clippy` pass
- [x] `cargo test` passes (125 unit tests)
- [x] All examples build successfully
- [ ] Manual testing of animation examples to verify smooth animations
- [ ] Manual testing of reactive examples to verify reactivity works