### PR TITLE
perf: add text measurement caching

### DIFF
--- a/src/widgets/font.rs
+++ b/src/widgets/font.rs
@@ -12,7 +12,7 @@ use cosmic_text::{Family, Weight};
 /// text("Hello").font_family(FontFamily::Monospace)
 /// text("Hello").font_family(FontFamily::Name("Inter".into()))
 /// ```
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
 pub enum FontFamily {
     /// Sans-serif font (default system sans-serif)
     #[default]
@@ -51,7 +51,7 @@ impl FontFamily {
 /// text("Hello").font_weight(FontWeight::BOLD)
 /// text("Hello").font_weight(FontWeight(600))
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub struct FontWeight(pub u16);
 
 impl FontWeight {


### PR DESCRIPTION
## Summary

- Add measurement cache to `TextMeasurer` for improved text shaping performance
- Refactor `TextInput` widget to align with the patterns established in the `Text` widget refactor:
  - Remove return value from `refresh()` - just update cached values and dirty flags
  - Remove redundant `content_changed` check in `layout()` - `measurements_dirty` already tracks this
  - Use `cached_text_width` instead of calling `measure_text_styled()` again in `layout()`

## Test plan

- [x] `cargo check && cargo clippy && cargo test` pass
- [x] Run `cargo run --example reactive_example` - text input works correctly
- [x] Verified typing, cursor movement, selection work as expected