### PR TITLE
refactor: scroll paint-only and remove per-widget dirty flags

### DIFF
--- a/examples/scroll_mixed_content.rs
+++ b/examples/scroll_mixed_content.rs
@@ -18,11 +18,7 @@ fn main() {
     fn form_field(label: &'static str, input_signal: Signal<String>) -> Container {
         container()
             .layout(Flex::column().spacing(4.0))
-            .child(
-                text(label)
-                    .color(Color::rgb(0.7, 0.7, 0.8))
-                    .font_size(12.0),
-            )
+            .child(text(label).color(Color::rgb(0.7, 0.7, 0.8)).font_size(12.0))
             .child(
                 container()
                     .padding(8.0)
@@ -56,11 +52,7 @@ fn main() {
                             .content_fit(ContentFit::Cover),
                     ),
             )
-            .child(
-                text(label)
-                    .font_size(11.0)
-                    .color(Color::rgb(0.6, 0.6, 0.7)),
-            )
+            .child(text(label).font_size(11.0).color(Color::rgb(0.6, 0.6, 0.7)))
     }
 
     // Main scrollable content
@@ -157,7 +149,9 @@ fn main() {
                                                     .corner_radius(6.0)
                                                     .hover_state(|s| s.lighter(0.05))
                                                     .pressed_state(|s| s.ripple())
-                                                    .child(text(item).color(Color::rgb(0.8, 0.8, 0.9)))
+                                                    .child(
+                                                        text(item).color(Color::rgb(0.8, 0.8, 0.9)),
+                                                    )
                                             })
                                             .collect::<Vec<_>>(),
                                         ),
@@ -195,13 +189,20 @@ fn main() {
                                                                 .layout(Flex::column().spacing(2.0))
                                                                 .child(
                                                                     text(format!("Activity {}", i))
-                                                                        .color(Color::rgb(0.8, 0.8, 0.9))
+                                                                        .color(Color::rgb(
+                                                                            0.8, 0.8, 0.9,
+                                                                        ))
                                                                         .font_size(13.0),
                                                                 )
                                                                 .child(
-                                                                    text(format!("{} hours ago", i * 2))
-                                                                        .color(Color::rgb(0.5, 0.5, 0.6))
-                                                                        .font_size(11.0),
+                                                                    text(format!(
+                                                                        "{} hours ago",
+                                                                        i * 2
+                                                                    ))
+                                                                    .color(Color::rgb(
+                                                                        0.5, 0.5, 0.6,
+                                                                    ))
+                                                                    .font_size(11.0),
                                                                 ),
                                                         )
                                                 })

--- a/examples/scroll_mixed_content.rs
+++ b/examples/scroll_mixed_content.rs
@@ -1,0 +1,357 @@
+//! Example demonstrating scrollable containers with mixed content.
+//!
+//! This example shows scrolling with:
+//! - Text widgets
+//! - Text input widgets
+//! - Image widgets (raster and SVG)
+//! - Interactive elements with hover states
+
+use guido::prelude::*;
+
+fn main() {
+    // Signals for text inputs
+    let name = create_signal(String::new());
+    let email = create_signal(String::new());
+    let bio = create_signal(String::new());
+
+    // Helper to create a form field
+    fn form_field(label: &'static str, input_signal: Signal<String>) -> Container {
+        container()
+            .layout(Flex::column().spacing(4.0))
+            .child(
+                text(label)
+                    .color(Color::rgb(0.7, 0.7, 0.8))
+                    .font_size(12.0),
+            )
+            .child(
+                container()
+                    .padding(8.0)
+                    .background(Color::rgb(0.18, 0.18, 0.24))
+                    .border(1.0, Color::rgb(0.3, 0.3, 0.4))
+                    .corner_radius(6.0)
+                    .focused_state(|s| s.border(2.0, Color::rgb(0.4, 0.8, 1.0)))
+                    .child(
+                        text_input(input_signal)
+                            .text_color(Color::WHITE)
+                            .cursor_color(Color::rgb(0.4, 0.8, 1.0))
+                            .selection_color(Color::rgba(0.4, 0.6, 1.0, 0.4))
+                            .font_size(14.0),
+                    ),
+            )
+    }
+
+    // Helper to create an image card
+    fn image_card(path: &'static str, label: &'static str) -> Container {
+        container()
+            .layout(Flex::column().spacing(8.0))
+            .child(
+                container()
+                    .background(Color::rgb(0.2, 0.2, 0.25))
+                    .corner_radius(8.0)
+                    .hover_state(|s| s.lighter(0.05))
+                    .child(
+                        image(path)
+                            .width(120.0)
+                            .height(90.0)
+                            .content_fit(ContentFit::Cover),
+                    ),
+            )
+            .child(
+                text(label)
+                    .font_size(11.0)
+                    .color(Color::rgb(0.6, 0.6, 0.7)),
+            )
+    }
+
+    // Main scrollable content
+    let view = container()
+        .padding(16.0)
+        .layout(Flex::row().spacing(16.0))
+        // Left panel: Vertical scroll with form and content
+        .child(
+            container()
+                .layout(Flex::column().spacing(8.0))
+                .child(
+                    text("User Profile")
+                        .color(Color::WHITE)
+                        .font_size(16.0)
+                        .font_weight(FontWeight::BOLD),
+                )
+                .child(
+                    container()
+                        .width(320.0)
+                        .height(400.0)
+                        .background(Color::rgb(0.12, 0.12, 0.18))
+                        .corner_radius(12.0)
+                        .scrollable(ScrollAxis::Vertical)
+                        .scrollbar(|sb| {
+                            sb.width(6.0)
+                                .handle_color(Color::rgb(0.4, 0.5, 0.6))
+                                .handle_hover_color(Color::rgb(0.5, 0.6, 0.7))
+                                .track_color(Color::rgba(0.3, 0.3, 0.4, 0.3))
+                        })
+                        .child(
+                            container()
+                                .layout(Flex::column().spacing(16.0))
+                                .padding(16.0)
+                                // Profile header with image
+                                .child(
+                                    container()
+                                        .layout(
+                                            Flex::row()
+                                                .spacing(16.0)
+                                                .cross_axis_alignment(CrossAxisAlignment::Center),
+                                        )
+                                        .child(
+                                            container()
+                                                .corner_radius(40.0)
+                                                .background(Color::rgb(0.25, 0.25, 0.3))
+                                                .child(
+                                                    image("examples/assets/photo.webp")
+                                                        .width(80.0)
+                                                        .height(80.0)
+                                                        .content_fit(ContentFit::Cover),
+                                                ),
+                                        )
+                                        .child(
+                                            container()
+                                                .layout(Flex::column().spacing(4.0))
+                                                .child(
+                                                    text("Edit Profile")
+                                                        .color(Color::WHITE)
+                                                        .font_size(18.0),
+                                                )
+                                                .child(
+                                                    text("Update your information")
+                                                        .color(Color::rgb(0.5, 0.5, 0.6))
+                                                        .font_size(12.0),
+                                                ),
+                                        ),
+                                )
+                                // Form fields
+                                .child(form_field("Name", name))
+                                .child(form_field("Email", email))
+                                .child(form_field("Bio", bio))
+                                // Additional info section
+                                .child(
+                                    container()
+                                        .layout(Flex::column().spacing(8.0))
+                                        .child(
+                                            text("Account Settings")
+                                                .color(Color::WHITE)
+                                                .font_size(14.0),
+                                        )
+                                        .children(
+                                            [
+                                                "Notifications",
+                                                "Privacy",
+                                                "Security",
+                                                "Appearance",
+                                                "Language",
+                                            ]
+                                            .into_iter()
+                                            .map(|item| {
+                                                container()
+                                                    .padding(12.0)
+                                                    .background(Color::rgb(0.18, 0.18, 0.24))
+                                                    .corner_radius(6.0)
+                                                    .hover_state(|s| s.lighter(0.05))
+                                                    .pressed_state(|s| s.ripple())
+                                                    .child(text(item).color(Color::rgb(0.8, 0.8, 0.9)))
+                                            })
+                                            .collect::<Vec<_>>(),
+                                        ),
+                                )
+                                // More content to ensure scroll
+                                .child(
+                                    container()
+                                        .layout(Flex::column().spacing(8.0))
+                                        .child(
+                                            text("Recent Activity")
+                                                .color(Color::WHITE)
+                                                .font_size(14.0),
+                                        )
+                                        .children(
+                                            (1..=8)
+                                                .map(|i| {
+                                                    container()
+                                                        .layout(Flex::row().spacing(8.0))
+                                                        .padding(8.0)
+                                                        .background(Color::rgb(0.15, 0.15, 0.2))
+                                                        .corner_radius(4.0)
+                                                        .child(
+                                                            container()
+                                                                .width(32.0)
+                                                                .height(32.0)
+                                                                .background(Color::rgb(
+                                                                    0.2 + (i as f32) * 0.02,
+                                                                    0.3,
+                                                                    0.4,
+                                                                ))
+                                                                .corner_radius(16.0),
+                                                        )
+                                                        .child(
+                                                            container()
+                                                                .layout(Flex::column().spacing(2.0))
+                                                                .child(
+                                                                    text(format!("Activity {}", i))
+                                                                        .color(Color::rgb(0.8, 0.8, 0.9))
+                                                                        .font_size(13.0),
+                                                                )
+                                                                .child(
+                                                                    text(format!("{} hours ago", i * 2))
+                                                                        .color(Color::rgb(0.5, 0.5, 0.6))
+                                                                        .font_size(11.0),
+                                                                ),
+                                                        )
+                                                })
+                                                .collect::<Vec<_>>(),
+                                        ),
+                                ),
+                        ),
+                ),
+        )
+        // Right panel: Horizontal scroll gallery
+        .child(
+            container()
+                .layout(Flex::column().spacing(8.0))
+                .child(
+                    text("Image Gallery")
+                        .color(Color::WHITE)
+                        .font_size(16.0)
+                        .font_weight(FontWeight::BOLD),
+                )
+                .child(
+                    container()
+                        .width(400.0)
+                        .height(160.0)
+                        .background(Color::rgb(0.12, 0.12, 0.18))
+                        .corner_radius(12.0)
+                        .scrollable(ScrollAxis::Horizontal)
+                        .scrollbar(|sb| {
+                            sb.width(6.0)
+                                .handle_color(Color::rgb(0.5, 0.6, 0.4))
+                                .handle_hover_color(Color::rgb(0.6, 0.7, 0.5))
+                                .track_color(Color::rgba(0.3, 0.4, 0.3, 0.3))
+                        })
+                        .child(
+                            container()
+                                .layout(Flex::row().spacing(12.0))
+                                .padding(12.0)
+                                .child(image_card("examples/assets/photo.webp", "Photo 1"))
+                                .child(image_card("examples/assets/photo.webp", "Photo 2"))
+                                .child(image_card("examples/assets/photo.webp", "Photo 3"))
+                                .child(image_card("examples/assets/photo.webp", "Photo 4"))
+                                .child(image_card("examples/assets/photo.webp", "Photo 5"))
+                                .child(image_card("examples/assets/photo.webp", "Photo 6")),
+                        ),
+                )
+                // SVG icons row
+                .child(
+                    text("Icons")
+                        .color(Color::WHITE)
+                        .font_size(16.0)
+                        .font_weight(FontWeight::BOLD),
+                )
+                .child(
+                    container()
+                        .width(400.0)
+                        .height(100.0)
+                        .background(Color::rgb(0.12, 0.12, 0.18))
+                        .corner_radius(12.0)
+                        .scrollable(ScrollAxis::Horizontal)
+                        .scrollbar(|sb| {
+                            sb.width(4.0)
+                                .handle_color(Color::rgb(0.6, 0.5, 0.7))
+                                .handle_hover_color(Color::rgb(0.7, 0.6, 0.8))
+                        })
+                        .child(
+                            container()
+                                .layout(Flex::row().spacing(16.0))
+                                .padding(12.0)
+                                .children(
+                                    (0..12)
+                                        .map(|i| {
+                                            container()
+                                                .layout(
+                                                    Flex::column()
+                                                        .spacing(4.0)
+                                                        .cross_axis_alignment(
+                                                            CrossAxisAlignment::Center,
+                                                        ),
+                                                )
+                                                .child(
+                                                    container()
+                                                        .width(48.0)
+                                                        .height(48.0)
+                                                        .background(Color::rgb(0.2, 0.2, 0.28))
+                                                        .corner_radius(8.0)
+                                                        .hover_state(|s| s.lighter(0.1))
+                                                        .pressed_state(|s| s.ripple())
+                                                        .layout(
+                                                            Flex::column()
+                                                                .main_axis_alignment(
+                                                                    MainAxisAlignment::Center,
+                                                                )
+                                                                .cross_axis_alignment(
+                                                                    CrossAxisAlignment::Center,
+                                                                ),
+                                                        )
+                                                        .child(
+                                                            image("examples/assets/logo.svg")
+                                                                .width(32.0)
+                                                                .height(24.0),
+                                                        ),
+                                                )
+                                                .child(
+                                                    text(format!("Icon {}", i + 1))
+                                                        .font_size(10.0)
+                                                        .color(Color::rgb(0.5, 0.5, 0.6)),
+                                                )
+                                        })
+                                        .collect::<Vec<_>>(),
+                                ),
+                        ),
+                )
+                // Current input values display
+                .child(
+                    container()
+                        .padding(12.0)
+                        .background(Color::rgb(0.12, 0.12, 0.18))
+                        .corner_radius(8.0)
+                        .layout(Flex::column().spacing(4.0))
+                        .child(
+                            text("Form Values:")
+                                .color(Color::rgb(0.5, 0.5, 0.6))
+                                .font_size(11.0),
+                        )
+                        .child(
+                            text(move || format!("Name: {}", name.get()))
+                                .color(Color::rgb(0.7, 0.7, 0.8))
+                                .font_size(12.0),
+                        )
+                        .child(
+                            text(move || format!("Email: {}", email.get()))
+                                .color(Color::rgb(0.7, 0.7, 0.8))
+                                .font_size(12.0),
+                        )
+                        .child(
+                            text(move || format!("Bio: {}", bio.get()))
+                                .color(Color::rgb(0.7, 0.7, 0.8))
+                                .font_size(12.0),
+                        ),
+                ),
+        );
+
+    let (app, _) = App::new().add_surface(
+        SurfaceConfig::new()
+            .width(780)
+            .height(500)
+            .anchor(Anchor::TOP | Anchor::LEFT)
+            .layer(Layer::Top)
+            .namespace("scroll-mixed-content")
+            .background_color(Color::rgb(0.08, 0.08, 0.12)),
+        move || view,
+    );
+    app.run();
+}

--- a/guido-macros/src/lib.rs
+++ b/guido-macros/src/lib.rs
@@ -261,25 +261,6 @@ pub fn component(_attr: TokenStream, input: TokenStream) -> TokenStream {
                 self.ensure_built();
                 self.__inner.borrow().as_ref().unwrap().id()
             }
-
-            fn mark_dirty(&mut self, flags: ::guido::reactive::ChangeFlags) {
-                self.ensure_built();
-                self.__inner.borrow_mut().as_mut().unwrap().mark_dirty(flags)
-            }
-
-            fn needs_layout(&self) -> bool {
-                self.__inner.borrow().as_ref().map_or(true, |w| w.needs_layout())
-            }
-
-            fn needs_paint(&self) -> bool {
-                self.__inner.borrow().as_ref().map_or(true, |w| w.needs_paint())
-            }
-
-            fn clear_dirty(&mut self) {
-                if let Some(w) = self.__inner.borrow_mut().as_mut() {
-                    w.clear_dirty()
-                }
-            }
         }
 
         #vis fn #constructor_name() -> #struct_name {

--- a/src/layout/flex_layout.rs
+++ b/src/layout/flex_layout.rs
@@ -148,12 +148,7 @@ impl Flex {
         let mut children_main = 0.0f32;
 
         for child in children.iter_mut() {
-            let size = if child.needs_layout() {
-                child.layout(child_constraints)
-            } else {
-                let bounds = child.bounds();
-                Size::new(bounds.width, bounds.height)
-            };
+            let size = child.layout(child_constraints);
             let main_size = size.main_axis(axis);
             let cross_size = size.cross_axis(axis);
             total_main += main_size;

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -974,7 +974,8 @@ impl PaintContext {
         } else {
             rect
         };
-        self.clip_stack.push((adjusted_rect, corner_radius, curvature));
+        self.clip_stack
+            .push((adjusted_rect, corner_radius, curvature));
     }
 
     /// Pop a clip region from the stack

--- a/src/renderer/text.rs
+++ b/src/renderer/text.rs
@@ -154,13 +154,14 @@ impl TextRenderState {
                 let scaled_top = (entry.rect.y + ty) * scale_factor;
 
                 // Use clip rect if provided, otherwise use full screen
-                // Apply translation offset to clip bounds to match text position
+                // Clip bounds stay in screen space - don't apply transform translation
+                // (text position is transformed, but clip region should remain fixed)
                 let bounds = if let Some(clip_rect) = &entry.clip_rect {
                     TextBounds {
-                        left: ((clip_rect.x + tx) * scale_factor) as i32,
-                        top: ((clip_rect.y + ty) * scale_factor) as i32,
-                        right: ((clip_rect.x + clip_rect.width + tx) * scale_factor) as i32,
-                        bottom: ((clip_rect.y + clip_rect.height + ty) * scale_factor) as i32,
+                        left: (clip_rect.x * scale_factor) as i32,
+                        top: (clip_rect.y * scale_factor) as i32,
+                        right: ((clip_rect.x + clip_rect.width) * scale_factor) as i32,
+                        bottom: ((clip_rect.y + clip_rect.height) * scale_factor) as i32,
                     }
                 } else {
                     TextBounds {

--- a/src/renderer/text.rs
+++ b/src/renderer/text.rs
@@ -78,10 +78,12 @@ impl TextRenderState {
                 let clip_bottom = clip.y + clip.height;
 
                 // Check if text is completely outside clip region
-                let outside = text_right <= clip.x
-                    || text_left >= clip_right
-                    || text_bottom <= clip.y
-                    || text_top >= clip_bottom;
+                // Use small epsilon to avoid floating point precision issues at boundaries
+                let epsilon = 0.1;
+                let outside = text_right < clip.x - epsilon
+                    || text_left > clip_right + epsilon
+                    || text_bottom < clip.y - epsilon
+                    || text_top > clip_bottom + epsilon;
 
                 if outside {
                     // Text is completely outside clip - skip it entirely

--- a/src/widgets/children.rs
+++ b/src/widgets/children.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::layout::{Constraints, Size};
-use crate::reactive::{ChangeFlags, OwnerId, WidgetId, dispose_owner, get_reactive_version};
+use crate::reactive::{OwnerId, WidgetId, dispose_owner, get_reactive_version};
 use crate::renderer::PaintContext;
 
 use super::Widget;
@@ -367,39 +367,11 @@ impl Widget for OwnedWidget {
         self.inner.id()
     }
 
-    fn mark_dirty(&mut self, flags: ChangeFlags) {
-        self.inner.mark_dirty(flags)
-    }
-
-    fn mark_dirty_recursive(&mut self, flags: ChangeFlags) {
-        self.inner.mark_dirty_recursive(flags)
-    }
-
-    fn needs_layout(&self) -> bool {
-        self.inner.needs_layout()
-    }
-
-    fn needs_paint(&self) -> bool {
-        self.inner.needs_paint()
-    }
-
-    fn clear_dirty(&mut self) {
-        self.inner.clear_dirty()
-    }
-
     fn has_focus_descendant(&self, id: WidgetId) -> bool {
         self.inner.has_focus_descendant(id)
     }
 
     fn is_relayout_boundary(&self) -> bool {
         self.inner.is_relayout_boundary()
-    }
-
-    fn mark_needs_layout(&mut self) {
-        self.inner.mark_needs_layout()
-    }
-
-    fn mark_needs_paint(&mut self) {
-        self.inner.mark_needs_paint()
     }
 }

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -14,8 +14,7 @@ use crate::advance_anim;
 use crate::animation::Transition;
 use crate::layout::{Constraints, Flex, Layout, Length, Size};
 use crate::reactive::{
-    ChangeFlags, IntoMaybeDyn, MaybeDyn, WidgetId, add_layout_root, focused_widget,
-    get_widget_parent, request_animation_frame, request_frame, set_widget_parent,
+    IntoMaybeDyn, MaybeDyn, WidgetId, focused_widget, request_animation_frame, set_widget_parent,
 };
 use crate::renderer::PaintContext;
 use crate::renderer::primitives::{GradientDir, Shadow};
@@ -114,7 +113,6 @@ pub enum Overflow {
 
 pub struct Container {
     pub(super) widget_id: WidgetId,
-    pub(super) dirty_flags: ChangeFlags,
 
     // Layout and children
     pub(super) layout: Box<dyn Layout>,
@@ -194,7 +192,6 @@ impl Container {
     pub fn new() -> Self {
         Self {
             widget_id: WidgetId::next(),
-            dirty_flags: ChangeFlags::NEEDS_LAYOUT | ChangeFlags::NEEDS_PAINT,
             layout: Box::new(Flex::column()),
             children_source: ChildrenSource::default(),
             padding: MaybeDyn::Static(Padding::default()),
@@ -707,14 +704,6 @@ impl Container {
         self.resolve_state_value(base, |state| state.elevation)
     }
 
-    /// Check if any child widget needs layout
-    fn any_child_needs_layout(&self) -> bool {
-        self.children_source
-            .get()
-            .iter()
-            .any(|child| child.needs_layout())
-    }
-
     /// Get current padding (animated or static)
     fn animated_padding(&self) -> Padding {
         get_animated_value(&self.padding_anim, || self.padding.get())
@@ -916,8 +905,6 @@ impl Widget for Container {
             || corner_curvature != self.cached_corner_curvature
             || elevation != self.cached_elevation;
 
-        let child_needs_layout = self.any_child_needs_layout();
-
         // Size animations require full layout recalculation
         let has_size_animations = self.width_anim.as_ref().is_some_and(|a| a.is_animating())
             || self.height_anim.as_ref().is_some_and(|a| a.is_animating());
@@ -929,27 +916,11 @@ impl Widget for Container {
                 .as_ref()
                 .is_some_and(|a| a.is_animating());
 
-        // Downgrade to paint-only if only visuals changed
-        let bounds_initialized = self.bounds.width > 0.0 || self.bounds.height > 0.0;
-        if self.needs_layout()
-            && bounds_initialized
-            && !padding_changed
-            && !child_needs_layout
-            && !has_size_animations
-            && !has_layout_animations
-            && visual_changed
-        {
-            self.dirty_flags = ChangeFlags::NEEDS_PAINT;
-        }
-
         let constraints_changed = self.last_constraints != Some(constraints);
 
-        let needs_layout = self.needs_layout()
-            || padding_changed
-            || child_needs_layout
-            || has_size_animations
-            || has_layout_animations
-            || constraints_changed;
+        // Layout is needed if constraints changed or any layout-affecting property animated
+        let needs_layout =
+            constraints_changed || padding_changed || has_size_animations || has_layout_animations;
 
         if !needs_layout {
             if visual_changed {
@@ -1043,8 +1014,6 @@ impl Widget for Container {
 
         // For scrollable containers, use unbounded constraints in scroll direction
         let scroll_axis = self.scroll_axis;
-        let scroll_offset_x = self.scroll_state.offset_x;
-        let scroll_offset_y = self.scroll_state.offset_y;
 
         let child_constraints = match scroll_axis {
             ScrollAxis::Vertical => Constraints {
@@ -1073,14 +1042,10 @@ impl Widget for Container {
             },
         };
 
-        let (child_origin_x, child_origin_y) = if scroll_axis != ScrollAxis::None {
-            (
-                self.bounds.x + padding.left - scroll_offset_x,
-                self.bounds.y + padding.top - scroll_offset_y,
-            )
-        } else {
-            (self.bounds.x + padding.left, self.bounds.y + padding.top)
-        };
+        // Children are positioned at their "unscrolled" positions.
+        // Scroll offset is applied as a transform in paint().
+        let (child_origin_x, child_origin_y) =
+            (self.bounds.x + padding.left, self.bounds.y + padding.top);
 
         // Reconcile and layout children
         let children = self.children_source.reconcile_and_get_mut();
@@ -1088,12 +1053,6 @@ impl Widget for Container {
         // Update parent tracking for all children
         for child in children.iter() {
             set_widget_parent(child.id(), self.widget_id);
-        }
-
-        if has_size_animations {
-            for child in children.iter_mut() {
-                child.mark_dirty_recursive(ChangeFlags::NEEDS_LAYOUT);
-            }
         }
 
         let content_size = if !children.is_empty() {
@@ -1310,9 +1269,21 @@ impl Widget for Container {
             ctx.push_clip(self.bounds, corner_radius, corner_curvature);
         }
 
+        // Apply scroll offset as a transform (paint-only, doesn't affect layout)
+        if is_scrollable {
+            let scroll_transform =
+                Transform::translate(-self.scroll_state.offset_x, -self.scroll_state.offset_y);
+            ctx.push_transform(scroll_transform);
+        }
+
         // Draw children
         for child in self.children_source.get() {
             child.paint(ctx);
+        }
+
+        // Pop scroll transform
+        if is_scrollable {
+            ctx.pop_transform();
         }
 
         if should_clip {
@@ -1557,14 +1528,9 @@ impl Widget for Container {
         let child_constraints = self.calc_child_constraints();
         let padding = self.padding.get();
 
-        let (child_origin_x, child_origin_y) = if self.scroll_axis != ScrollAxis::None {
-            (
-                x + padding.left - self.scroll_state.offset_x,
-                y + padding.top - self.scroll_state.offset_y,
-            )
-        } else {
-            (x + padding.left, y + padding.top)
-        };
+        // Children are positioned at their "unscrolled" positions.
+        // Scroll offset is applied as a transform in paint().
+        let (child_origin_x, child_origin_y) = (x + padding.left, y + padding.top);
 
         // Layout already reconciled children, just get them
         let children = self.children_source.get_mut();
@@ -1585,32 +1551,6 @@ impl Widget for Container {
         self.widget_id
     }
 
-    fn mark_dirty(&mut self, flags: ChangeFlags) {
-        self.dirty_flags |= flags;
-    }
-
-    fn mark_dirty_recursive(&mut self, flags: ChangeFlags) {
-        self.dirty_flags |= flags;
-        for child in self.children_source.get_mut() {
-            child.mark_dirty_recursive(flags);
-        }
-    }
-
-    fn needs_layout(&self) -> bool {
-        self.dirty_flags.contains(ChangeFlags::NEEDS_LAYOUT)
-    }
-
-    fn needs_paint(&self) -> bool {
-        self.dirty_flags.contains(ChangeFlags::NEEDS_PAINT)
-    }
-
-    fn clear_dirty(&mut self) {
-        self.dirty_flags = ChangeFlags::empty();
-        for child in self.children_source.get_mut() {
-            child.clear_dirty();
-        }
-    }
-
     fn has_focus_descendant(&self, id: WidgetId) -> bool {
         self.widget_has_focus(id)
     }
@@ -1623,39 +1563,6 @@ impl Widget for Container {
             .as_ref()
             .is_some_and(|h| h.get().exact.is_some());
         has_fixed_width && has_fixed_height
-    }
-
-    fn mark_needs_layout(&mut self) {
-        // If already dirty, parent was already notified
-        if self.dirty_flags.contains(ChangeFlags::NEEDS_LAYOUT) {
-            return;
-        }
-
-        self.dirty_flags |= ChangeFlags::NEEDS_LAYOUT | ChangeFlags::NEEDS_PAINT;
-
-        if self.is_relayout_boundary() {
-            // Stop here - add to layout roots
-            add_layout_root(self.widget_id);
-            request_frame();
-        } else if let Some(parent_id) = get_widget_parent(self.widget_id) {
-            // Bubble up to parent by requesting layout on parent widget
-            // Note: We can't directly call parent.mark_needs_layout() since we don't have
-            // a reference to it. Instead, we add ourselves to layout roots and request frame.
-            // The parent tracking is for future use when we can look up widgets by ID.
-            add_layout_root(self.widget_id);
-            request_frame();
-            // Mark the parent as needing layout too (global flag)
-            parent_id.request_layout();
-        } else {
-            // At root - add to layout roots
-            add_layout_root(self.widget_id);
-            request_frame();
-        }
-    }
-
-    fn mark_needs_paint(&mut self) {
-        self.dirty_flags |= ChangeFlags::NEEDS_PAINT;
-        request_frame();
     }
 }
 

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -890,6 +890,12 @@ impl Widget for Container {
             self.update_scrollbar_handle_positions();
         }
 
+        // Advance scrollbar scale animations (for hover expansion effect)
+        // Must be done here since scroll/hover is paint-only and layout may not run
+        if self.advance_scrollbar_scale_animations() {
+            any_animating = true;
+        }
+
         any_animating
     }
 

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -884,6 +884,12 @@ impl Widget for Container {
             any_animating = true;
         }
 
+        // Update scrollbar handle positions based on current scroll offset
+        // (scroll is paint-only, so layout may not run during scrolling)
+        if self.scroll_axis != ScrollAxis::None {
+            self.update_scrollbar_handle_positions();
+        }
+
         any_animating
     }
 

--- a/src/widgets/container/scrollable.rs
+++ b/src/widgets/container/scrollable.rs
@@ -221,14 +221,20 @@ impl Container {
 
         // Advance vertical scrollbar scale animation
         if self.scroll_axis.allows_vertical() && needs_vertical {
-            any_animating |=
-                self.advance_scrollbar_scale_axis(ScrollbarAxis::Vertical, scale_factor, needs_horizontal);
+            any_animating |= self.advance_scrollbar_scale_axis(
+                ScrollbarAxis::Vertical,
+                scale_factor,
+                needs_horizontal,
+            );
         }
 
         // Advance horizontal scrollbar scale animation
         if self.scroll_axis.allows_horizontal() && needs_horizontal {
-            any_animating |=
-                self.advance_scrollbar_scale_axis(ScrollbarAxis::Horizontal, scale_factor, needs_vertical);
+            any_animating |= self.advance_scrollbar_scale_axis(
+                ScrollbarAxis::Horizontal,
+                scale_factor,
+                needs_vertical,
+            );
         }
 
         any_animating

--- a/src/widgets/container/scrollable.rs
+++ b/src/widgets/container/scrollable.rs
@@ -204,6 +204,48 @@ impl Container {
         }
     }
 
+    /// Update scrollbar handle positions based on current scroll offset.
+    /// Called from advance_animations to ensure handles are positioned correctly
+    /// even when layout doesn't run (scroll is paint-only).
+    pub(super) fn update_scrollbar_handle_positions(&mut self) {
+        if self.scroll_axis == ScrollAxis::None
+            || self.scrollbar_visibility == ScrollbarVisibility::Hidden
+        {
+            return;
+        }
+
+        let needs_vertical = self.scroll_state.needs_vertical_scrollbar();
+        let needs_horizontal = self.scroll_state.needs_horizontal_scrollbar();
+
+        // Update vertical scrollbar handle position
+        if self.scroll_axis.allows_vertical()
+            && needs_vertical
+            && let Some(ref mut handle) = self.v_scrollbar_handle
+        {
+            let handle_rect = self.scroll_state.scrollbar_handle_rect(
+                ScrollbarAxis::Vertical,
+                self.bounds,
+                &self.scrollbar_config,
+                needs_horizontal,
+            );
+            handle.set_origin(handle_rect.x, handle_rect.y);
+        }
+
+        // Update horizontal scrollbar handle position
+        if self.scroll_axis.allows_horizontal()
+            && needs_horizontal
+            && let Some(ref mut handle) = self.h_scrollbar_handle
+        {
+            let handle_rect = self.scroll_state.scrollbar_handle_rect(
+                ScrollbarAxis::Horizontal,
+                self.bounds,
+                &self.scrollbar_config,
+                needs_vertical,
+            );
+            handle.set_origin(handle_rect.x, handle_rect.y);
+        }
+    }
+
     /// Paint scrollbar container widgets
     pub(super) fn paint_scrollbar_containers(&self, ctx: &mut PaintContext) {
         if self.scrollbar_visibility == ScrollbarVisibility::Hidden {

--- a/src/widgets/container/scrollable.rs
+++ b/src/widgets/container/scrollable.rs
@@ -204,6 +204,122 @@ impl Container {
         }
     }
 
+    /// Advance scrollbar scale animations and apply transforms.
+    /// Called from advance_animations since scroll is paint-only and layout
+    /// may not run during hover events.
+    pub(super) fn advance_scrollbar_scale_animations(&mut self) -> bool {
+        if self.scroll_axis == ScrollAxis::None
+            || self.scrollbar_visibility == ScrollbarVisibility::Hidden
+        {
+            return false;
+        }
+
+        let scale_factor = self.scrollbar_config.hover_width / self.scrollbar_config.width;
+        let needs_vertical = self.scroll_state.needs_vertical_scrollbar();
+        let needs_horizontal = self.scroll_state.needs_horizontal_scrollbar();
+        let mut any_animating = false;
+
+        // Advance vertical scrollbar scale animation
+        if self.scroll_axis.allows_vertical() && needs_vertical {
+            any_animating |=
+                self.advance_scrollbar_scale_axis(ScrollbarAxis::Vertical, scale_factor, needs_horizontal);
+        }
+
+        // Advance horizontal scrollbar scale animation
+        if self.scroll_axis.allows_horizontal() && needs_horizontal {
+            any_animating |=
+                self.advance_scrollbar_scale_axis(ScrollbarAxis::Horizontal, scale_factor, needs_vertical);
+        }
+
+        any_animating
+    }
+
+    fn advance_scrollbar_scale_axis(
+        &mut self,
+        axis: ScrollbarAxis,
+        scale_factor: f32,
+        needs_other_scrollbar: bool,
+    ) -> bool {
+        // Determine target scale based on hover state
+        let is_hovered = self.scroll_state.is_track_hovered(axis)
+            || self.scroll_state.is_handle_hovered(axis)
+            || self.scroll_state.is_dragging(axis);
+        let target_scale = if is_hovered { scale_factor } else { 1.0 };
+
+        let (scale_anim, track_container, handle_container) = match axis {
+            ScrollbarAxis::Vertical => (
+                &mut self.v_scrollbar_scale_anim,
+                &mut self.v_scrollbar_track,
+                &mut self.v_scrollbar_handle,
+            ),
+            ScrollbarAxis::Horizontal => (
+                &mut self.h_scrollbar_scale_anim,
+                &mut self.h_scrollbar_track,
+                &mut self.h_scrollbar_handle,
+            ),
+        };
+
+        // Advance the animation
+        let mut animating = false;
+        if let Some(anim) = scale_anim {
+            anim.animate_to(target_scale);
+            if anim.is_animating() {
+                anim.advance();
+                animating = true;
+            }
+        }
+
+        let current_scale = scale_anim.as_ref().map(|a| *a.current()).unwrap_or(1.0);
+
+        // Get track rect for transform origin
+        let track_rect = self.scroll_state.scrollbar_track_rect(
+            axis,
+            self.bounds,
+            &self.scrollbar_config,
+            needs_other_scrollbar,
+        );
+        let handle_rect = self.scroll_state.scrollbar_handle_rect(
+            axis,
+            self.bounds,
+            &self.scrollbar_config,
+            needs_other_scrollbar,
+        );
+
+        // Apply scale transform to track
+        if let Some(track) = track_container {
+            let (transform, origin) = match axis {
+                ScrollbarAxis::Vertical => (
+                    Transform::scale_xy(current_scale, 1.0),
+                    TransformOrigin::px(track_rect.width, track_rect.height / 2.0),
+                ),
+                ScrollbarAxis::Horizontal => (
+                    Transform::scale_xy(1.0, current_scale),
+                    TransformOrigin::px(track_rect.width / 2.0, track_rect.height),
+                ),
+            };
+            track.set_transform(transform);
+            track.set_transform_origin(origin);
+        }
+
+        // Apply scale transform to handle
+        if let Some(handle) = handle_container {
+            let (transform, origin) = match axis {
+                ScrollbarAxis::Vertical => (
+                    Transform::scale_xy(current_scale, 1.0),
+                    TransformOrigin::px(handle_rect.width, handle_rect.height / 2.0),
+                ),
+                ScrollbarAxis::Horizontal => (
+                    Transform::scale_xy(1.0, current_scale),
+                    TransformOrigin::px(handle_rect.width / 2.0, handle_rect.height),
+                ),
+            };
+            handle.set_transform(transform);
+            handle.set_transform_origin(origin);
+        }
+
+        animating
+    }
+
     /// Update scrollbar handle positions based on current scroll offset.
     /// Called from advance_animations to ensure handles are positioned correctly
     /// even when layout doesn't run (scroll is paint-only).

--- a/src/widgets/image.rs
+++ b/src/widgets/image.rs
@@ -7,10 +7,9 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::layout::{Constraints, Size};
-use crate::reactive::{ChangeFlags, IntoMaybeDyn, MaybeDyn, WidgetId};
+use crate::reactive::{IntoMaybeDyn, MaybeDyn, WidgetId};
 use crate::renderer::PaintContext;
 
-use super::impl_dirty_flags;
 use super::widget::{EventResponse, Rect, Widget};
 
 /// Source for an image - can be a file path or in-memory bytes.
@@ -109,7 +108,6 @@ pub enum ContentFit {
 /// Image widget for displaying raster and SVG images.
 pub struct Image {
     widget_id: WidgetId,
-    dirty_flags: ChangeFlags,
     source: MaybeDyn<ImageSource>,
     width: Option<MaybeDyn<f32>>,
     height: Option<MaybeDyn<f32>>,
@@ -126,7 +124,6 @@ impl Image {
     pub fn new(source: impl IntoMaybeDyn<ImageSource>) -> Self {
         Self {
             widget_id: WidgetId::next(),
-            dirty_flags: ChangeFlags::NEEDS_LAYOUT | ChangeFlags::NEEDS_PAINT,
             source: source.into_maybe_dyn(),
             width: None,
             height: None,
@@ -278,8 +275,6 @@ impl Widget for Image {
     fn id(&self) -> WidgetId {
         self.widget_id
     }
-
-    impl_dirty_flags!();
 }
 
 /// Create an image widget from a source.

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -9,29 +9,6 @@ pub mod text;
 pub mod text_input;
 pub mod widget;
 
-/// Macro to implement common dirty flag methods for simple widgets.
-///
-/// Container keeps its custom implementation because it recurses to children.
-macro_rules! impl_dirty_flags {
-    () => {
-        fn mark_dirty(&mut self, flags: crate::reactive::ChangeFlags) {
-            self.dirty_flags |= flags;
-        }
-        fn needs_layout(&self) -> bool {
-            self.dirty_flags
-                .contains(crate::reactive::ChangeFlags::NEEDS_LAYOUT)
-        }
-        fn needs_paint(&self) -> bool {
-            self.dirty_flags
-                .contains(crate::reactive::ChangeFlags::NEEDS_PAINT)
-        }
-        fn clear_dirty(&mut self) {
-            self.dirty_flags = crate::reactive::ChangeFlags::empty();
-        }
-    };
-}
-pub(crate) use impl_dirty_flags;
-
 pub use children::ChildrenSource;
 pub use container::{Border, Container, GradientDirection, LinearGradient, Overflow, container};
 pub use font::{FontFamily, FontWeight};

--- a/src/widgets/text.rs
+++ b/src/widgets/text.rs
@@ -1,15 +1,13 @@
 use crate::default_font_family;
 use crate::layout::{Constraints, Size};
-use crate::reactive::{ChangeFlags, IntoMaybeDyn, MaybeDyn, WidgetId};
+use crate::reactive::{IntoMaybeDyn, MaybeDyn, WidgetId};
 use crate::renderer::{PaintContext, measure_text_styled};
 
 use super::font::{FontFamily, FontWeight};
-use super::impl_dirty_flags;
 use super::widget::{Color, EventResponse, Rect, Widget};
 
 pub struct Text {
     widget_id: WidgetId,
-    dirty_flags: ChangeFlags,
     content: MaybeDyn<String>,
     color: MaybeDyn<Color>,
     font_size: MaybeDyn<f32>,
@@ -32,7 +30,6 @@ impl Text {
         let default_family = default_font_family();
         Self {
             widget_id: WidgetId::next(),
-            dirty_flags: ChangeFlags::NEEDS_LAYOUT | ChangeFlags::NEEDS_PAINT,
             content,
             color: MaybeDyn::Static(Color::WHITE),
             font_size: MaybeDyn::Static(14.0),
@@ -191,8 +188,6 @@ impl Widget for Text {
     fn id(&self) -> WidgetId {
         self.widget_id
     }
-
-    impl_dirty_flags!();
 }
 
 /// Create a text widget

--- a/src/widgets/text_input.rs
+++ b/src/widgets/text_input.rs
@@ -14,13 +14,12 @@ use std::time::{Duration, Instant};
 use crate::default_font_family;
 use crate::layout::{Constraints, Size};
 use crate::reactive::{
-    ChangeFlags, CursorIcon, IntoMaybeDyn, MaybeDyn, Signal, WidgetId, clipboard_copy,
-    clipboard_paste, has_focus, release_focus, request_animation_frame, request_focus, set_cursor,
+    CursorIcon, IntoMaybeDyn, MaybeDyn, Signal, WidgetId, clipboard_copy, clipboard_paste,
+    has_focus, release_focus, request_animation_frame, request_focus, set_cursor,
 };
 use crate::renderer::{PaintContext, char_index_from_x_styled, measure_text_styled};
 
 use super::font::{FontFamily, FontWeight};
-use super::impl_dirty_flags;
 use super::widget::{Color, Event, EventResponse, Key, Modifiers, MouseButton, Rect, Widget};
 
 /// Cursor blink interval in milliseconds
@@ -201,7 +200,6 @@ impl Selection {
 
 pub struct TextInput {
     widget_id: WidgetId,
-    dirty_flags: ChangeFlags,
 
     // Content (actual value, never masked)
     /// Signal for two-way binding
@@ -276,7 +274,6 @@ impl TextInput {
         let default_family = default_font_family();
         Self {
             widget_id: WidgetId::next(),
-            dirty_flags: ChangeFlags::NEEDS_LAYOUT | ChangeFlags::NEEDS_PAINT,
             value: signal,
             cached_value,
             cached_char_count,
@@ -1190,8 +1187,6 @@ impl Widget for TextInput {
     fn id(&self) -> WidgetId {
         self.widget_id
     }
-
-    impl_dirty_flags!();
 }
 
 /// Create a text input widget with two-way signal binding.

--- a/src/widgets/widget.rs
+++ b/src/widgets/widget.rs
@@ -1,5 +1,5 @@
 use crate::layout::{Constraints, Size};
-use crate::reactive::{ChangeFlags, WidgetId};
+use crate::reactive::WidgetId;
 use crate::renderer::PaintContext;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -391,25 +391,6 @@ pub trait Widget {
     /// Get the widget's unique identifier
     fn id(&self) -> WidgetId;
 
-    /// Mark this widget as needing layout and/or paint
-    fn mark_dirty(&mut self, flags: ChangeFlags);
-
-    /// Mark this widget and all descendants as needing layout and/or paint.
-    /// Default implementation just calls mark_dirty. Containers override this
-    /// to recursively mark children.
-    fn mark_dirty_recursive(&mut self, flags: ChangeFlags) {
-        self.mark_dirty(flags);
-    }
-
-    /// Check if this widget needs layout
-    fn needs_layout(&self) -> bool;
-
-    /// Check if this widget needs paint
-    fn needs_paint(&self) -> bool;
-
-    /// Clear dirty flags after processing
-    fn clear_dirty(&mut self);
-
     /// Check if this widget has a descendant with the given ID.
     /// Used by containers to check if a child has focus.
     /// Default implementation returns false (leaf widgets have no children).
@@ -423,21 +404,6 @@ pub trait Widget {
     /// Default returns false (most widgets are not boundaries).
     fn is_relayout_boundary(&self) -> bool {
         false
-    }
-
-    /// Mark this widget as needing layout.
-    /// Bubbles up to parent until hitting a relayout boundary.
-    /// Default implementation marks dirty and requests frame.
-    fn mark_needs_layout(&mut self) {
-        self.mark_dirty(ChangeFlags::NEEDS_LAYOUT | ChangeFlags::NEEDS_PAINT);
-        crate::reactive::request_frame();
-    }
-
-    /// Mark this widget as needing paint only (doesn't affect layout).
-    /// Default implementation marks paint dirty and requests frame.
-    fn mark_needs_paint(&mut self) {
-        self.mark_dirty(ChangeFlags::NEEDS_PAINT);
-        crate::reactive::request_frame();
     }
 }
 


### PR DESCRIPTION
## Summary

- Make scroll a paint-only operation using transforms instead of triggering layout
- Remove per-widget dirty flags in favor of reactive version tracking for detecting signal changes
- Fix regressions from the refactor: dynamic children not adding, scroll clipping issues, scrollbar hover animation

## Changes

### Paint-only scroll
- Scroll now applies a transform at paint time instead of triggering full re-layout
- Layout positions children in "unscrolled" space; scroll transform is applied during paint
- Scrollbar handle positions updated in `advance_animations` since layout may not run during scroll

### Reactive version tracking
- Added `last_reactive_version` field to Container to detect when signals (like dynamic children lists) change
- Layout early-return checks reactive version to ensure children are reconciled when signal data updates

### Shader clipping fixes
- Fixed shaders to use screen-space position (`screen_pos`) for clipping instead of untransformed `local_pos`
- Fixed text clip bounds to stay in screen space (not adjusted by scroll transform)
- Fixed clip intersection to preserve valid clip when intersection fails for off-screen scrollable content

### Scrollbar hover animation
- Moved scrollbar scale animation advancement from layout to `advance_animations`
- Hover expansion animation now works correctly since it's advanced during paint phase

## Test plan

- [ ] Run `cargo run --example children_example` - verify Add/Remove buttons work
- [ ] Run `cargo run --example scroll_example` - verify:
  - Smooth scrolling
  - Elements stay within container bounds
  - Scrollbar handle moves with scroll
  - Scrollbar expands on hover
- [ ] Run `cargo run --example reactive_example` - verify UI responds to interactions