### PR TITLE
docs: update documentation for PRs #42-#47

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ cargo run --example component_example
 - **children_example** - Dynamic lists with keyed reconciliation
 - **image_example** - Raster and SVG images with content fit modes
 - **scroll_example** - Scrollable containers with custom scrollbar styling
+- **scroll_mixed_content** - Scrolling with text, text input, and images combined
 - **text_styling_example** - Font families and weights for text styling
 - **service_example** - Background services with automatic cleanup
 

--- a/book/src/getting-started/examples.md
+++ b/book/src/getting-started/examples.md
@@ -230,6 +230,70 @@ cargo run --example scroll_example
 - Hidden scrollbars
 - Kinetic/momentum scrolling
 
+---
+
+### scroll_mixed_content
+
+Advanced scrollable container with mixed content types.
+
+```bash
+cargo run --example scroll_mixed_content
+```
+
+**Features demonstrated:**
+- Text widgets inside scrollable containers
+- Text input widgets with form fields
+- Raster and SVG images in scrollable content
+- Interactive elements with hover states and ripples
+- Vertical and horizontal scrolling together
+- Scrollbar customization with different styles
+
+---
+
+### multi_surface
+
+Multiple surfaces with shared reactive state.
+
+```bash
+cargo run --example multi_surface
+```
+
+**Features demonstrated:**
+- Creating multiple layer shell surfaces
+- Shared reactive signals between surfaces
+- Independent surface configuration
+
+---
+
+### surface_properties_example
+
+Dynamic surface property modification at runtime.
+
+```bash
+cargo run --example surface_properties_example
+```
+
+**Features demonstrated:**
+- Changing layer at runtime
+- Modifying keyboard interactivity
+- Adjusting anchor and size dynamically
+
+---
+
+### text_input_example
+
+Text input widgets with editing capabilities.
+
+```bash
+cargo run --example text_input_example
+```
+
+**Features demonstrated:**
+- Single and multiline text input
+- Cursor and selection styling
+- Placeholder text
+- Focus states
+
 ## Exploring the Code
 
 Each example's source code is in the `examples/` directory. Reading through them is a great way to learn Guido patterns:


### PR DESCRIPTION
## Summary

Updates documentation to reflect changes from PRs #42-#47:

- **Widget Trait**: Added `advance_animations()` and `is_relayout_boundary()` methods
- **Rendering Pipeline**: Updated to include animation advancement phase before layout
- **Performance Section**: Replaced "Future: Relayout Boundaries" with current implementation details
- **New sections**: Paint-only scrolling, layout caching, text measurement caching
- **Examples**: Added `scroll_mixed_content` and other missing examples

## Files Changed

| File | Changes |
|------|---------|
| `docs/ARCHITECTURE.md` | Update Widget trait, Performance section, Rendering pipeline |
| `README.md` | Add `scroll_mixed_content` to examples list |
| `book/src/getting-started/examples.md` | Add multiple missing examples |
| `book/src/architecture/rendering.md` | Update dirty tracking, add animation phase, paint-only scroll |

## Test plan

- [x] `mdbook build book` completes without errors
- [x] `cargo clippy` passes
- [x] `cargo fmt --check` passes