### PR TITLE
feat: add layout stats and unify reactive subscription system

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,10 @@ documentation.workspace = true
 homepage.workspace = true
 license.workspace = true
 
+[features]
+default = []
+layout-stats = []
+
 [dependencies]
 guido-macros = { workspace = true }
 wgpu = { version = "28.0", features = ["fragile-send-sync-non-atomic-wasm"] }
@@ -67,3 +71,7 @@ path = "examples/image_example.rs"
 [[example]]
 name = "text_input_example"
 path = "examples/text_input_example.rs"
+
+[[example]]
+name = "layout_stats_test"
+path = "examples/layout_stats_test.rs"

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ cargo run --example component_example
 - **scroll_mixed_content** - Scrolling with text, text input, and images combined
 - **text_styling_example** - Font families and weights for text styling
 - **service_example** - Background services with automatic cleanup
+- **layout_stats_test** - Layout performance debugging (requires `--features layout-stats`)
 
 ## Documentation
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -246,12 +246,30 @@ doesn't run again - instead, a scroll transform is applied during the paint phas
 significantly reduces CPU overhead for scrolling.
 
 ### Layout Caching
-The layout system caches results and uses reactive version tracking to detect signal changes.
-Layout only recalculates when constraints change, animations are active, or reactive state updates.
+The layout system caches results and uses per-widget layout subscribers to track signal dependencies.
+During layout, any signal reads are recorded as dependencies. When those signals change, only the
+affected widgets are marked dirty for re-layout - not the entire tree.
+
+Layout only recalculates when:
+- Constraints change
+- Animations are active
+- A tracked signal dependency changes (widget is marked dirty)
 
 ### Text Measurement Caching
 Text measurement results are cached to avoid redundant computation when text content
 hasn't changed.
+
+### Layout Stats (Debug Feature)
+Enable the `layout-stats` feature to get real-time statistics about layout performance:
+```bash
+cargo run --example your_example --features layout-stats
+```
+
+This prints per-second statistics showing:
+- Total layout calls and skip rate
+- Breakdown of reasons layouts were executed (constraints, animations, reactive changes)
+
+The feature has zero overhead when disabled (code is completely compiled out).
 
 ## Key Files
 

--- a/examples/layout_stats_test.rs
+++ b/examples/layout_stats_test.rs
@@ -1,0 +1,65 @@
+//! Minimal test for layout stats - static UI with animation.
+//! Tests layout skipping during animation frames.
+//!
+//! Run with:
+//! ```bash
+//! cargo run --example layout_stats_test --features layout-stats
+//! ```
+//!
+//! The rotating container triggers continuous rendering,
+//! but the static children should have their layouts skipped.
+
+use guido::prelude::*;
+
+fn main() {
+    // Signal to drive rotation animation
+    let rotation = create_signal(0.0f32);
+
+    // Continuously update rotation to force frame rendering
+    let _ = create_service::<(), _>(move |_rx, ctx| {
+        while ctx.is_running() {
+            rotation.update(|r| *r += 1.0);
+            std::thread::sleep(std::time::Duration::from_millis(16)); // ~60fps
+        }
+    });
+
+    let view = container()
+        .width(400.0)
+        .height(200.0)
+        .padding(16.0)
+        .background(Color::rgb(0.1, 0.1, 0.15))
+        .layout(Flex::column().spacing(8.0))
+        // Animated container (will re-layout due to transform animation)
+        .child(
+            container()
+                .padding(8.0)
+                .background(Color::rgb(0.2, 0.2, 0.3))
+                .transform(move || Transform::rotate_degrees(rotation.get()))
+                .child(text("Rotating").color(Color::WHITE)),
+        )
+        // Static containers (should have layout skipped after first frame)
+        .child(
+            container()
+                .padding(8.0)
+                .background(Color::rgb(0.2, 0.3, 0.2))
+                .child(text("Static text 1").color(Color::WHITE)),
+        )
+        .child(
+            container()
+                .padding(8.0)
+                .background(Color::rgb(0.3, 0.2, 0.2))
+                .child(text("Static text 2").color(Color::WHITE)),
+        );
+
+    let (app, _) = App::new().add_surface(
+        SurfaceConfig::new()
+            .width(400)
+            .height(200)
+            .anchor(Anchor::TOP | Anchor::LEFT)
+            .layer(Layer::Top)
+            .namespace("layout-stats-test")
+            .background_color(Color::rgb(0.08, 0.08, 0.12)),
+        move || view,
+    );
+    app.run();
+}

--- a/src/layout_stats.rs
+++ b/src/layout_stats.rs
@@ -1,0 +1,168 @@
+//! Layout statistics tracking for debugging and performance analysis.
+//!
+//! Enable layout stats by compiling with the `layout-stats` feature:
+//! ```bash
+//! cargo run --example scroll_mixed_content --features layout-stats
+//! ```
+//!
+//! Stats are printed every second when enabled, showing:
+//! - Total layout calls
+//! - Layouts skipped (cache hit)
+//! - Layouts executed (cache miss)
+//! - Skip rate percentage
+//! - Breakdown of why layouts were executed
+
+/// Reasons why a layout was executed (can be multiple).
+#[derive(Default, Clone, Copy)]
+pub struct LayoutReasons {
+    pub constraints_changed: bool,
+    pub padding_changed: bool,
+    pub size_animations: bool,
+    pub layout_animations: bool,
+    pub reactive_changed: bool,
+}
+
+#[cfg(feature = "layout-stats")]
+mod inner {
+    use super::LayoutReasons;
+    use std::cell::RefCell;
+    use std::time::Instant;
+
+    thread_local! {
+        static STATS: RefCell<LayoutStats> = RefCell::new(LayoutStats::new());
+    }
+
+    struct LayoutStats {
+        /// Total layout() calls
+        total_calls: u64,
+        /// Layouts that were skipped (cache hit)
+        skipped: u64,
+        /// Layouts that were executed (cache miss)
+        executed: u64,
+        /// Primary (first) reason - mutually exclusive
+        primary_constraints: u64,
+        primary_padding: u64,
+        primary_size_anim: u64,
+        primary_layout_anim: u64,
+        primary_reactive: u64,
+        /// Last time stats were printed
+        last_print: Instant,
+        /// Frame counter
+        frames: u64,
+    }
+
+    impl LayoutStats {
+        fn new() -> Self {
+            Self {
+                total_calls: 0,
+                skipped: 0,
+                executed: 0,
+                primary_constraints: 0,
+                primary_padding: 0,
+                primary_size_anim: 0,
+                primary_layout_anim: 0,
+                primary_reactive: 0,
+                last_print: Instant::now(),
+                frames: 0,
+            }
+        }
+
+        fn reset(&mut self) {
+            self.total_calls = 0;
+            self.skipped = 0;
+            self.executed = 0;
+            self.primary_constraints = 0;
+            self.primary_padding = 0;
+            self.primary_size_anim = 0;
+            self.primary_layout_anim = 0;
+            self.primary_reactive = 0;
+            self.frames = 0;
+            self.last_print = Instant::now();
+        }
+    }
+
+    /// Record a layout call that was skipped (cache hit).
+    #[inline]
+    pub fn record_layout_skipped() {
+        STATS.with(|s| {
+            let mut stats = s.borrow_mut();
+            stats.total_calls += 1;
+            stats.skipped += 1;
+        });
+    }
+
+    /// Record a layout call that was executed (cache miss) with reasons.
+    /// Tracks the primary (first) reason.
+    #[inline]
+    pub fn record_layout_executed_with_reasons(reasons: LayoutReasons) {
+        STATS.with(|s| {
+            let mut stats = s.borrow_mut();
+            stats.total_calls += 1;
+            stats.executed += 1;
+
+            // Track primary (first) reason - order matches evaluation in Container::layout
+            if reasons.constraints_changed {
+                stats.primary_constraints += 1;
+            } else if reasons.padding_changed {
+                stats.primary_padding += 1;
+            } else if reasons.size_animations {
+                stats.primary_size_anim += 1;
+            } else if reasons.layout_animations {
+                stats.primary_layout_anim += 1;
+            } else if reasons.reactive_changed {
+                stats.primary_reactive += 1;
+            }
+        });
+    }
+
+    /// Called at the end of each frame to potentially print stats.
+    /// Prints stats every second when enabled.
+    pub fn end_frame() {
+        STATS.with(|s| {
+            let mut stats = s.borrow_mut();
+            stats.frames += 1;
+
+            let elapsed = stats.last_print.elapsed();
+            if elapsed.as_secs() >= 1 {
+                let skip_rate = if stats.total_calls > 0 {
+                    (stats.skipped as f64 / stats.total_calls as f64) * 100.0
+                } else {
+                    0.0
+                };
+
+                eprintln!(
+                    "[Layout Stats] frames={} calls={} skipped={} executed={} skip_rate={:.1}%",
+                    stats.frames, stats.total_calls, stats.skipped, stats.executed, skip_rate
+                );
+                if stats.executed > 0 {
+                    eprintln!(
+                        "  primary: constraints={} padding={} size_anim={} layout_anim={} reactive={}",
+                        stats.primary_constraints,
+                        stats.primary_padding,
+                        stats.primary_size_anim,
+                        stats.primary_layout_anim,
+                        stats.primary_reactive
+                    );
+                }
+
+                stats.reset();
+            }
+        });
+    }
+}
+
+#[cfg(feature = "layout-stats")]
+pub use inner::*;
+
+// No-op implementations when feature is disabled - these get completely inlined away
+#[cfg(not(feature = "layout-stats"))]
+#[inline(always)]
+pub fn record_layout_skipped() {}
+
+#[cfg(not(feature = "layout-stats"))]
+#[inline(always)]
+pub fn record_layout_executed_with_reasons(_reasons: LayoutReasons) {}
+
+#[cfg(not(feature = "layout-stats"))]
+#[inline(always)]
+pub fn end_frame() {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod animation;
 pub mod image_metadata;
 pub mod layout;
+pub mod layout_stats;
 pub mod reactive;
 pub mod surface;
 mod surface_manager;
@@ -319,6 +320,9 @@ fn render_surface(
             state.clear_layout_flag();
             state.clear_paint_flag();
         });
+
+        // Track layout stats (when compiled with --features layout-stats)
+        layout_stats::end_frame();
 
         // Commit surface
         wl_surface.commit();

--- a/src/reactive/mod.rs
+++ b/src/reactive/mod.rs
@@ -21,10 +21,11 @@ pub use cursor::{CursorIcon, get_current_cursor, set_cursor, take_cursor_change}
 pub use effect::{Effect, create_effect};
 pub use focus::{clear_focus, focused_widget, has_focus, release_focus, request_focus};
 pub use invalidation::{
-    ChangeFlags, WidgetId, add_layout_root, clear_animation_flag, get_reactive_version,
-    get_widget_parent, init_wakeup, remove_widget_from_tree, request_animation_frame,
-    request_frame, request_layout, request_paint, set_widget_parent, take_frame_request,
-    take_layout_roots, with_app_state, with_app_state_mut,
+    ChangeFlags, WidgetId, add_layout_root, clear_animation_flag, finish_layout_tracking,
+    get_needs_layout_flag, get_widget_parent, init_wakeup, register_relayout_boundary,
+    remove_widget_from_tree, request_animation_frame, request_frame, request_layout, request_paint,
+    set_needs_layout_flag, set_widget_parent, start_layout_tracking, take_frame_request,
+    take_layout_roots, unregister_relayout_boundary, with_app_state, with_app_state_mut,
 };
 pub use maybe_dyn::{IntoMaybeDyn, MaybeDyn};
 // Only on_cleanup is public API - with_owner, dispose_owner, and OwnerId are

--- a/src/widgets/text.rs
+++ b/src/widgets/text.rs
@@ -1,6 +1,9 @@
 use crate::default_font_family;
 use crate::layout::{Constraints, Size};
-use crate::reactive::{IntoMaybeDyn, MaybeDyn, WidgetId};
+use crate::reactive::{
+    IntoMaybeDyn, MaybeDyn, WidgetId, finish_layout_tracking, register_relayout_boundary,
+    start_layout_tracking,
+};
 use crate::renderer::{PaintContext, measure_text_styled};
 
 use super::font::{FontFamily, FontWeight};
@@ -121,7 +124,14 @@ impl Text {
 
 impl Widget for Text {
     fn layout(&mut self, constraints: Constraints) -> Size {
+        // Start layout tracking for dependency registration
+        start_layout_tracking(self.widget_id);
+
+        // Text widgets are never relayout boundaries
+        register_relayout_boundary(self.widget_id, false);
+
         // Refresh cached values from reactive properties
+        // This reads signals and registers layout dependencies
         self.refresh();
 
         // Determine the effective max_width for measurement
@@ -156,6 +166,9 @@ impl Widget for Text {
 
         self.bounds.width = size.width;
         self.bounds.height = size.height;
+
+        // Finish layout tracking
+        finish_layout_tracking();
 
         size
     }

--- a/src/widgets/text_input.rs
+++ b/src/widgets/text_input.rs
@@ -15,7 +15,8 @@ use crate::default_font_family;
 use crate::layout::{Constraints, Size};
 use crate::reactive::{
     CursorIcon, IntoMaybeDyn, MaybeDyn, Signal, WidgetId, clipboard_copy, clipboard_paste,
-    has_focus, release_focus, request_animation_frame, request_focus, set_cursor,
+    finish_layout_tracking, has_focus, register_relayout_boundary, release_focus,
+    request_animation_frame, request_focus, set_cursor, start_layout_tracking,
 };
 use crate::renderer::{PaintContext, char_index_from_x_styled, measure_text_styled};
 
@@ -994,7 +995,14 @@ impl TextInput {
 
 impl Widget for TextInput {
     fn layout(&mut self, constraints: Constraints) -> Size {
+        // Start layout tracking for dependency registration
+        start_layout_tracking(self.widget_id);
+
+        // Text inputs are never relayout boundaries
+        register_relayout_boundary(self.widget_id, false);
+
         // Refresh cached values from reactive properties
+        // This reads signals and registers layout dependencies
         self.refresh();
 
         // Update cursor blink if focused
@@ -1026,6 +1034,9 @@ impl Widget for TextInput {
 
         self.bounds.width = size.width;
         self.bounds.height = size.height;
+
+        // Finish layout tracking
+        finish_layout_tracking();
 
         size
     }


### PR DESCRIPTION
## Summary

- Add layout stats tracking (enabled via `--features layout-stats`)
  - Track layout calls, skips, and reasons for execution
  - Report skip rate percentages for performance analysis
  - Zero overhead when feature is disabled (code compiled out)

- Unify reactive subscription system by removing global reactive version
  - Remove `GLOBAL_REACTIVE_VERSION`, `bump_reactive_version()`, `get_reactive_version()`
  - Remove `last_version` field from `SegmentType::Dynamic` in children.rs
  - Dynamic children now rely solely on per-widget layout subscribers

- Add per-widget layout tracking infrastructure
  - `start_layout_tracking()` / `finish_layout_tracking()` for dependency tracking
  - `record_layout_read()` called from `Signal::get()` during layout
  - `notify_layout_subscribers()` marks dependent widgets dirty when signals change
  - `mark_needs_layout()` bubbles up through parent chain to relayout boundaries

The unified approach is more efficient because `reconcile()` is only called when the Container is marked dirty by its actual signal dependencies, rather than on any global signal change.

## Test plan

- [x] `cargo test` passes
- [x] `cargo clippy --all-features` clean
- [x] `cargo run --example reactive_example` works
- [x] `cargo run --example layout_stats_test --features layout-stats` shows stats
- [x] Updated docs/ARCHITECTURE.md
- [x] Updated README.md examples list