### PR TITLE
fix: ripple effect parent transform propagation

### DIFF
--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -130,20 +130,27 @@ impl Renderer {
 
     /// Scale a clip region for HiDPI rendering
     fn scale_clip(&self, clip: &Option<ClipRegion>) -> Option<ClipRegion> {
-        clip.as_ref().map(|c| ClipRegion {
-            rect: Rect::new(
-                c.rect.x * self.scale_factor,
-                c.rect.y * self.scale_factor,
-                c.rect.width * self.scale_factor,
-                c.rect.height * self.scale_factor,
-            ),
-            radius: c.radius * self.scale_factor,
-            curvature: c.curvature,
-            // Scale transform origin for HiDPI, keep transform as-is
-            transform: c.transform,
-            transform_origin: c
-                .transform_origin
-                .map(|(x, y)| (x * self.scale_factor, y * self.scale_factor)),
+        clip.as_ref().map(|c| {
+            // Scale transform's translation components for HiDPI
+            let scaled_transform = c.transform.map(|mut t| {
+                t.scale_translation(self.scale_factor);
+                t
+            });
+            ClipRegion {
+                rect: Rect::new(
+                    c.rect.x * self.scale_factor,
+                    c.rect.y * self.scale_factor,
+                    c.rect.width * self.scale_factor,
+                    c.rect.height * self.scale_factor,
+                ),
+                radius: c.radius * self.scale_factor,
+                curvature: c.curvature,
+                // Scale both transform translation and origin for HiDPI
+                transform: scaled_transform,
+                transform_origin: c
+                    .transform_origin
+                    .map(|(x, y)| (x * self.scale_factor, y * self.scale_factor)),
+            }
         })
     }
 

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -220,6 +220,15 @@ impl Transform {
         self.data[7] *= factor;
     }
 
+    /// Returns a copy of this transform with translation removed (tx=0, ty=0).
+    /// Preserves rotation and scale.
+    pub fn without_translation(&self) -> Self {
+        let mut result = *self;
+        result.data[3] = 0.0; // tx
+        result.data[7] = 0.0; // ty
+        result
+    }
+
     /// Extract the X and Y scale components from the transform matrix.
     ///
     /// For transforms that contain rotation and/or scale:
@@ -342,6 +351,29 @@ impl Transform {
                 1.0,
             ],
         }
+    }
+
+    /// Extract the rotation angle in radians from this transform.
+    ///
+    /// This extracts the rotation angle even when the transform also contains
+    /// scale and translation. Returns 0 for degenerate transforms.
+    pub fn extract_rotation_angle(&self) -> f32 {
+        let (sx, sy) = self.extract_scale_components();
+
+        // Avoid division by zero for degenerate transforms
+        if sx < 1e-10 || sy < 1e-10 {
+            return 0.0;
+        }
+
+        let a = self.data[0];
+        let c = self.data[4];
+
+        // For a rotation matrix:
+        // | cos(θ)  -sin(θ) |
+        // | sin(θ)   cos(θ) |
+        // After removing scale: a/sx = cos(θ), c/sy = sin(θ)
+        // So: θ = atan2(sin(θ), cos(θ)) = atan2(c/sy, a/sx)
+        (c / sy).atan2(a / sx)
     }
 }
 

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -1344,6 +1344,18 @@ impl Widget for Container {
             self.paint_scrollbar_containers(ctx);
         }
 
+        // Capture the composed transform (all parents + this container) BEFORE popping.
+        // This is needed for ripple to properly clip to the transformed container bounds.
+        let composed_transform_for_ripple = if has_transform {
+            // We have our own transform, so composed transform includes it
+            Some(ctx.current_transform_with_origin())
+        } else if !ctx.current_transform().is_identity() {
+            // Even if this container has no transform, parents might
+            Some(ctx.current_transform_with_origin())
+        } else {
+            None
+        };
+
         // Pop transform BEFORE drawing ripple
         if has_transform {
             ctx.pop_transform();
@@ -1369,18 +1381,29 @@ impl Widget for Container {
                 ripple_config.color.a * self.ripple.opacity,
             );
 
-            let (clip_bounds, clip_transform) = if has_transform {
-                (self.bounds, Some((transform, transform_origin)))
-            } else {
-                (self.bounds, None)
-            };
+            // Use the COMPOSED transform (all parents + this container) for clipping.
+            // This ensures nested transforms are properly applied to the ripple clip region.
+            let clip_transform =
+                composed_transform_for_ripple.map(|(composed_transform, origin)| {
+                    // Convert origin from absolute coordinates to TransformOrigin
+                    // The origin from current_transform_with_origin() is already resolved,
+                    // so we convert to pixel offset from bounds.
+                    let transform_origin = if let Some((ox, oy)) = origin {
+                        // Convert absolute coords to offset from bounds
+                        TransformOrigin::px(ox - self.bounds.x, oy - self.bounds.y)
+                    } else {
+                        // Default to container center if no origin specified
+                        TransformOrigin::CENTER
+                    };
+                    (composed_transform, transform_origin)
+                });
 
             ctx.draw_overlay_circle_clipped_with_transform(
                 screen_cx,
                 screen_cy,
                 current_radius,
                 ripple_color,
-                clip_bounds,
+                self.bounds,
                 corner_radius,
                 corner_curvature,
                 clip_transform,


### PR DESCRIPTION
## Summary

- Fix ripple effect not properly inheriting parent transforms on nested containers
- Fix ripple clip position on translated containers (HiDPI scaling issue)
- Add `without_translation()` and `extract_rotation_angle()` methods to Transform

## Problem

The ripple effect on transformed containers had several issues:

1. **Nested transforms**: Child container's ripple didn't include parent's rotation/scale
2. **Translation**: Ripple clip appeared at original layout position instead of translated visual position (HiDPI scaling bug)

## Solution

1. **Use composed transform**: Capture the full transform stack (all parents + this container) before popping, and use it for ripple clipping

2. **Separate shape vs clip transforms**: 
   - Shape: Apply only rotation+scale (ripple center is already in screen space)
   - Clip: Apply full transform for proper inverse-transform in shader

3. **Fix HiDPI scaling**: Scale the clip transform's translation components in `scale_clip()`, matching how other coordinates are already scaled

## Test plan

- [x] Run `cargo run --example transform_events_test`
- [x] Click on "Translate" box - ripple should clip to translated position
- [x] Click on "Rotate" box - ripple should clip to rotated bounds
- [x] Click on "Nested" box (parent rotated) - ripple should clip correctly
- [x] Click on "Nest+Rot" box (parent scaled, child rotated) - ripple should clip correctly
- [x] All tests pass (`cargo test`)