### PR TITLE
Revert: ripple effect parent transform propagation (#50)

### DIFF
--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -130,27 +130,15 @@ impl Renderer {
 
     /// Scale a clip region for HiDPI rendering
     fn scale_clip(&self, clip: &Option<ClipRegion>) -> Option<ClipRegion> {
-        clip.as_ref().map(|c| {
-            // Scale transform's translation components for HiDPI
-            let scaled_transform = c.transform.map(|mut t| {
-                t.scale_translation(self.scale_factor);
-                t
-            });
-            ClipRegion {
-                rect: Rect::new(
-                    c.rect.x * self.scale_factor,
-                    c.rect.y * self.scale_factor,
-                    c.rect.width * self.scale_factor,
-                    c.rect.height * self.scale_factor,
-                ),
-                radius: c.radius * self.scale_factor,
-                curvature: c.curvature,
-                // Scale both transform translation and origin for HiDPI
-                transform: scaled_transform,
-                transform_origin: c
-                    .transform_origin
-                    .map(|(x, y)| (x * self.scale_factor, y * self.scale_factor)),
-            }
+        clip.as_ref().map(|c| ClipRegion {
+            rect: Rect::new(
+                c.rect.x * self.scale_factor,
+                c.rect.y * self.scale_factor,
+                c.rect.width * self.scale_factor,
+                c.rect.height * self.scale_factor,
+            ),
+            radius: c.radius * self.scale_factor,
+            curvature: c.curvature,
         })
     }
 
@@ -405,8 +393,6 @@ impl Renderer {
                             ),
                             radius: 0.0,
                             curvature: 1.0,
-                            transform: None,
-                            transform_origin: None,
                         }
                     } else {
                         // No scaling needed for rotated transforms or scale = 1.0
@@ -414,8 +400,6 @@ impl Renderer {
                             rect: hidpi_rect,
                             radius: 0.0,
                             curvature: 1.0,
-                            transform: None,
-                            transform_origin: None,
                         }
                     }
                 });
@@ -609,8 +593,6 @@ impl Renderer {
                     ),
                     radius: 0.0, // Images typically have square clip regions
                     curvature: 1.0,
-                    transform: None,
-                    transform_origin: None,
                 });
 
                 // Create the textured quad with UV coordinates and clip
@@ -1045,8 +1027,6 @@ impl PaintContext {
                 rect: *rect,
                 radius: *radius,
                 curvature: *curvature,
-                transform: None,
-                transform_origin: None,
             })
     }
 
@@ -1090,7 +1070,7 @@ impl PaintContext {
     }
 
     /// Get the current transform with its custom origin (if any)
-    pub fn current_transform_with_origin(&self) -> (Transform, Option<(f32, f32)>) {
+    fn current_transform_with_origin(&self) -> (Transform, Option<(f32, f32)>) {
         self.transform_stack
             .last()
             .cloned()
@@ -1159,16 +1139,14 @@ impl PaintContext {
             rect: clip_rect,
             radius: clip_radius,
             curvature: clip_curvature,
-            transform: None,
-            transform_origin: None,
         });
         self.apply_current_transform(&mut shape);
         self.overlay_shapes.push(Shape::RoundedRect(shape));
     }
 
     /// Draw a circle as an overlay with a clip region that can have its own transform.
-    /// Used for ripple effects on transformed containers - the ripple center is in local
-    /// coordinates and both shape and clip need the same transform applied.
+    /// Used for ripple effects on transformed containers - the ripple uses screen coordinates
+    /// but the clip region needs to match the transformed container bounds.
     #[allow(clippy::too_many_arguments)]
     pub fn draw_overlay_circle_clipped_with_transform(
         &mut self,
@@ -1184,35 +1162,20 @@ impl PaintContext {
         let rect = Rect::new(cx - radius, cy - radius, radius * 2.0, radius * 2.0);
         let mut shape = RoundedRect::new(rect, color, radius);
 
-        // Shape and clip use DIFFERENT transforms:
-        // - Shape: rotation+scale only (ripple center is already in screen space)
-        // - Clip: full transform (inverse-transforms screen positions to local space)
+        // Set explicit clip for this shape
+        shape.clip = Some(ClipRegion {
+            rect: clip_rect,
+            radius: clip_radius,
+            curvature: clip_curvature,
+        });
+
+        // Apply transform to both shape and clip if provided
+        // This makes the ripple appear at the correct screen position
+        // while clipping to the transformed container bounds
         if let Some((transform, origin)) = clip_transform {
             let (origin_x, origin_y) = origin.resolve(clip_rect);
-
-            // For the SHAPE: Apply only rotation+scale, NOT translation.
-            // The ripple center (cx, cy) is already in screen space where the user clicked.
-            let shape_transform = transform.without_translation();
-            shape.transform = shape_transform;
+            shape.transform = transform;
             shape.transform_origin = Some((origin_x, origin_y));
-
-            // For the CLIP: Use full transform for inverse-transform in shader.
-            // This correctly maps screen positions back to layout space for clipping.
-            shape.clip = Some(ClipRegion {
-                rect: clip_rect,
-                radius: clip_radius,
-                curvature: clip_curvature,
-                transform: Some(transform),
-                transform_origin: Some((origin_x, origin_y)),
-            });
-        } else {
-            shape.clip = Some(ClipRegion {
-                rect: clip_rect,
-                radius: clip_radius,
-                curvature: clip_curvature,
-                transform: None,
-                transform_origin: None,
-            });
         }
 
         self.overlay_shapes.push(Shape::RoundedRect(shape));

--- a/src/renderer/primitives.rs
+++ b/src/renderer/primitives.rs
@@ -96,15 +96,14 @@ pub struct Vertex {
     pub shadow_spread: f32,
     /// Shadow color RGBA
     pub shadow_color: [f32; 4],
-    /// Transform matrix row 0 (2D affine: [a, b, 0, tx])
+    /// Transform matrix row 0
     pub transform_row0: [f32; 4],
-    /// Transform matrix row 1 (2D affine: [c, d, 0, ty])
+    /// Transform matrix row 1
     pub transform_row1: [f32; 4],
-    /// Inverse transform for clip region (row 0): [a, b, 0, tx]
-    /// Used to transform screen_pos back to clip-local space for proper rotated clipping
-    pub clip_inv_transform_row0: [f32; 4],
-    /// Inverse transform for clip region (row 1): [c, d, 0, ty]
-    pub clip_inv_transform_row1: [f32; 4],
+    /// Transform matrix row 2
+    pub transform_row2: [f32; 4],
+    /// Transform matrix row 3
+    pub transform_row3: [f32; 4],
     /// Local position (untransformed) for SDF evaluation in fragment shader
     pub local_pos: [f32; 2],
     /// Clip rectangle in NDC: [min_x, min_y, max_x, max_y] - (0,0,0,0) means no clip
@@ -178,25 +177,25 @@ impl Vertex {
                     shader_location: 9,
                     format: wgpu::VertexFormat::Float32x4,
                 },
-                // transform_row0 (2D affine)
+                // transform_row0
                 wgpu::VertexAttribute {
                     offset: std::mem::size_of::<[f32; 28]>() as wgpu::BufferAddress,
                     shader_location: 10,
                     format: wgpu::VertexFormat::Float32x4,
                 },
-                // transform_row1 (2D affine)
+                // transform_row1
                 wgpu::VertexAttribute {
                     offset: std::mem::size_of::<[f32; 32]>() as wgpu::BufferAddress,
                     shader_location: 11,
                     format: wgpu::VertexFormat::Float32x4,
                 },
-                // clip_inv_transform_row0
+                // transform_row2
                 wgpu::VertexAttribute {
                     offset: std::mem::size_of::<[f32; 36]>() as wgpu::BufferAddress,
                     shader_location: 12,
                     format: wgpu::VertexFormat::Float32x4,
                 },
-                // clip_inv_transform_row1
+                // transform_row3
                 wgpu::VertexAttribute {
                     offset: std::mem::size_of::<[f32; 40]>() as wgpu::BufferAddress,
                     shader_location: 13,
@@ -336,7 +335,6 @@ impl Vertex {
             transform,
             [0.0, 0.0, 0.0, 0.0], // No clip
             0.0,                  // No clip radius
-            None,                 // No clip inverse transform
         )
     }
 
@@ -358,17 +356,8 @@ impl Vertex {
         transform: Transform,
         clip_rect: [f32; 4],
         clip_radius: f32,
-        clip_inv_transform: Option<Transform>,
     ) -> Self {
         let rows = transform.rows();
-        // Extract the 2D affine inverse transform rows (only need first 2 rows for 2D)
-        let (clip_inv_row0, clip_inv_row1) = if let Some(inv) = clip_inv_transform {
-            let inv_rows = inv.rows();
-            (inv_rows[0], inv_rows[1])
-        } else {
-            // Identity: no inverse transform needed
-            ([1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0])
-        };
         Self {
             position,
             color,
@@ -382,21 +371,22 @@ impl Vertex {
             shadow_blur,
             shadow_spread,
             shadow_color,
-            // Only store first 2 rows of transform (2D affine)
             transform_row0: rows[0],
             transform_row1: rows[1],
-            clip_inv_transform_row0: clip_inv_row0,
-            clip_inv_transform_row1: clip_inv_row1,
+            transform_row2: rows[2],
+            transform_row3: rows[3],
             local_pos,
             clip_rect,
         }
     }
 
-    /// Set the transform on an existing vertex (only 2D affine components)
+    /// Set the transform on an existing vertex
     pub fn set_transform(&mut self, transform: Transform) {
         let rows = transform.rows();
         self.transform_row0 = rows[0];
         self.transform_row1 = rows[1];
+        self.transform_row2 = rows[2];
+        self.transform_row3 = rows[3];
     }
 }
 
@@ -492,11 +482,6 @@ pub struct ClipRegion {
     pub radius: f32,
     /// Superellipse curvature K-value (default 1.0 = circle)
     pub curvature: f32,
-    /// Optional transform for the clip region (for rotated/scaled clips)
-    /// This allows clipping to transformed container bounds without transforming the shape itself
-    pub transform: Option<Transform>,
-    /// Transform origin for the clip, if transform is set
-    pub transform_origin: Option<(f32, f32)>,
 }
 
 impl Default for RoundedRect {
@@ -770,37 +755,21 @@ impl RoundedRect {
         };
 
         // Compute clip region in NDC if present
-        let (clip_rect_ndc, clip_radius_ndc, clip_inv_transform) = if let Some(ref clip) = self.clip
-        {
-            // Use clip's transform origin if set, otherwise use shape's origin or clip center
+        // Apply the same scale transform to clip region so it matches the scaled shape
+        let (clip_rect_ndc, clip_radius_ndc) = if let Some(ref clip) = self.clip {
+            // Use transform_origin if set, otherwise clip center
             let clip_center_x = clip.rect.x + clip.rect.width / 2.0;
             let clip_center_y = clip.rect.y + clip.rect.height / 2.0;
-            let (clip_origin_x, clip_origin_y) = clip
+            let (clip_origin_x, clip_origin_y) = self
                 .transform_origin
-                .or(self.transform_origin)
                 .unwrap_or((clip_center_x, clip_center_y));
 
-            // Determine which transform affects the clip region:
-            // - If clip has its own transform, use that (for ripples on transformed containers)
-            // - Otherwise, use the shape's transform (for clipped shapes that are transformed)
-            let clip_transform = clip.transform.unwrap_or(self.transform);
-
-            // Extract scale and translation from clip transform
-            let (clip_scale_x, clip_scale_y) = clip_transform.extract_scale_components();
-            let clip_rotation_only = clip_transform.without_scale();
-
-            // Get translation from the transform
-            let clip_tx = clip_transform.tx();
-            let clip_ty = clip_transform.ty();
-
-            // Scale the clip rect around the transform origin, then apply translation
-            // Translation is applied directly to the clip rect position so the clip
-            // follows the transformed shape without needing shader inverse transform magic.
+            // Scale the clip rect around the transform origin (same as shape scaling)
             let scaled_clip = Rect::new(
-                clip_origin_x + (clip.rect.x - clip_origin_x) * clip_scale_x + clip_tx,
-                clip_origin_y + (clip.rect.y - clip_origin_y) * clip_scale_y + clip_ty,
-                clip.rect.width * clip_scale_x,
-                clip.rect.height * clip_scale_y,
+                clip_origin_x + (clip.rect.x - clip_origin_x) * scale_x,
+                clip_origin_y + (clip.rect.y - clip_origin_y) * scale_y,
+                clip.rect.width * scale_x,
+                clip.rect.height * scale_y,
             );
 
             let clip_x1 = to_ndc_x(scaled_clip.x);
@@ -816,33 +785,12 @@ impl RoundedRect {
             // Use height-based NDC for uniform clip radius (aspect-corrected in shader)
             let clip_r_ndc = (clip_radius / screen_height) * 2.0;
 
-            // Compute inverse transform for clip region if there's rotation.
-            // Translation is already applied to clip rect above, so we only need
-            // inverse for rotation (to map screen positions back to rotated clip space).
-            let clip_inv = if clip_rotation_only.has_rotation() {
-                // Build the NDC transform for the clip's rotation only (no translation)
-                // Translation was already applied to the clip rect geometry above.
-                let rotation_for_clip =
-                    Transform::rotate(clip_rotation_only.extract_rotation_angle());
-                let clip_ndc_transform = transform_to_ndc(
-                    &rotation_for_clip,
-                    Some((clip_origin_x + clip_tx, clip_origin_y + clip_ty)),
-                    ((clip_x1 + clip_x2) / 2.0, (clip_y1 + clip_y2) / 2.0),
-                    screen_width,
-                    screen_height,
-                );
-                Some(clip_ndc_transform.inverse())
-            } else {
-                None
-            };
-
             (
                 [clip_x1, clip_y2, clip_x2, clip_y1], // min_x, min_y, max_x, max_y
                 clip_r_ndc,
-                clip_inv,
             )
         } else {
-            ([0.0, 0.0, 0.0, 0.0], 0.0, None)
+            ([0.0, 0.0, 0.0, 0.0], 0.0)
         };
 
         // Simple quad - SDF rendering handles the shape in fragment shader
@@ -864,7 +812,6 @@ impl RoundedRect {
                 centered_transform,
                 clip_rect_ndc,
                 clip_radius_ndc,
-                clip_inv_transform,
             ),
             Vertex::with_transform_and_clip(
                 [quad_x2, quad_y1],
@@ -882,7 +829,6 @@ impl RoundedRect {
                 centered_transform,
                 clip_rect_ndc,
                 clip_radius_ndc,
-                clip_inv_transform,
             ),
             Vertex::with_transform_and_clip(
                 [quad_x2, quad_y2],
@@ -900,7 +846,6 @@ impl RoundedRect {
                 centered_transform,
                 clip_rect_ndc,
                 clip_radius_ndc,
-                clip_inv_transform,
             ),
             Vertex::with_transform_and_clip(
                 [quad_x1, quad_y2],
@@ -918,7 +863,6 @@ impl RoundedRect {
                 centered_transform,
                 clip_rect_ndc,
                 clip_radius_ndc,
-                clip_inv_transform,
             ),
         ];
 

--- a/src/renderer/shader.wgsl
+++ b/src/renderer/shader.wgsl
@@ -14,12 +14,12 @@ struct VertexInput {
     @location(7) shadow_offset: vec2<f32>,  // shadow offset in NDC (x, y)
     @location(8) shadow_params: vec2<f32>,  // x = blur, y = spread
     @location(9) shadow_color: vec4<f32>,
-    @location(10) transform_row0: vec4<f32>,  // 2D affine row 0: [a, b, 0, tx]
-    @location(11) transform_row1: vec4<f32>,  // 2D affine row 1: [c, d, 0, ty]
-    @location(12) clip_inv_row0: vec4<f32>,   // inverse transform for clip (row 0)
-    @location(13) clip_inv_row1: vec4<f32>,   // inverse transform for clip (row 1)
-    @location(14) local_pos: vec2<f32>,       // untransformed position for SDF
-    @location(15) clip_rect: vec4<f32>,       // clip region: min_x, min_y, max_x, max_y in NDC
+    @location(10) transform_row0: vec4<f32>,
+    @location(11) transform_row1: vec4<f32>,
+    @location(12) transform_row2: vec4<f32>,
+    @location(13) transform_row3: vec4<f32>,
+    @location(14) local_pos: vec2<f32>,  // untransformed position for SDF
+    @location(15) clip_rect: vec4<f32>,  // clip region: min_x, min_y, max_x, max_y in NDC
 }
 
 struct VertexOutput {
@@ -34,25 +34,22 @@ struct VertexOutput {
     @location(7) shadow_offset: vec2<f32>,
     @location(8) shadow_params: vec2<f32>,  // x = blur, y = spread
     @location(9) shadow_color: vec4<f32>,
-    @location(10) clip_rect: vec4<f32>,  // clip region in NDC (local space)
+    @location(10) clip_rect: vec4<f32>,  // clip region in NDC (screen space)
     @location(11) clip_radius: f32,  // clip corner radius (uniform, height-based NDC)
     @location(12) screen_pos: vec2<f32>,  // transformed position for clipping (screen space)
-    @location(13) clip_inv_row0: vec4<f32>,  // inverse clip transform (row 0)
-    @location(14) clip_inv_row1: vec4<f32>,  // inverse clip transform (row 1)
 }
 
 @vertex
 fn vs_main(in: VertexInput) -> VertexOutput {
     var out: VertexOutput;
 
-    // Build transform matrix from 2 row vectors (2D affine transform)
-    // Rows 2 and 3 are identity: [0, 0, 1, 0] and [0, 0, 0, 1]
+    // Build transform matrix from row vectors
     // WGSL mat4x4 constructor takes columns, so we transpose by extracting columns from rows
     let transform = mat4x4<f32>(
-        vec4<f32>(in.transform_row0.x, in.transform_row1.x, 0.0, 0.0),
-        vec4<f32>(in.transform_row0.y, in.transform_row1.y, 0.0, 0.0),
-        vec4<f32>(in.transform_row0.z, in.transform_row1.z, 1.0, 0.0),
-        vec4<f32>(in.transform_row0.w, in.transform_row1.w, 0.0, 1.0)
+        vec4<f32>(in.transform_row0.x, in.transform_row1.x, in.transform_row2.x, in.transform_row3.x),
+        vec4<f32>(in.transform_row0.y, in.transform_row1.y, in.transform_row2.y, in.transform_row3.y),
+        vec4<f32>(in.transform_row0.z, in.transform_row1.z, in.transform_row2.z, in.transform_row3.z),
+        vec4<f32>(in.transform_row0.w, in.transform_row1.w, in.transform_row2.w, in.transform_row3.w)
     );
 
     // Transform position for screen placement
@@ -77,9 +74,6 @@ fn vs_main(in: VertexInput) -> VertexOutput {
     out.clip_radius = in.shape_curvature.y;
     // Pass transformed position for screen-space clipping
     out.screen_pos = transformed.xy;
-    // Pass clip inverse transform for rotated clipping
-    out.clip_inv_row0 = in.clip_inv_row0;
-    out.clip_inv_row1 = in.clip_inv_row1;
 
     return out;
 }
@@ -316,43 +310,25 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     }
 
     // Apply clip region if defined (clip_rect width > 0)
-    // clip_rect is in local (untransformed) space, so we need to transform
-    // screen_pos back to local space using the inverse clip transform.
+    // Use screen_pos (transformed) for clipping since clip_rect is in screen space
     let clip_width = in.clip_rect.z - in.clip_rect.x;
     let clip_height = in.clip_rect.w - in.clip_rect.y;
     if (clip_width > 0.0 && clip_height > 0.0) {
-        // Transform screen_pos back to clip-local space using inverse transform.
-        // This handles rotated/transformed containers correctly.
-        // The inverse transform is a 2D affine transform stored in two rows:
-        // | a  b  0  tx |  -> row0 = [a, b, 0, tx]
-        // | c  d  0  ty |  -> row1 = [c, d, 0, ty]
-        let inv_a = in.clip_inv_row0.x;
-        let inv_b = in.clip_inv_row0.y;
-        let inv_tx = in.clip_inv_row0.w;
-        let inv_c = in.clip_inv_row1.x;
-        let inv_d = in.clip_inv_row1.y;
-        let inv_ty = in.clip_inv_row1.w;
-
-        // Apply inverse transform to get local position for clip testing
-        let local_clip_x = inv_a * in.screen_pos.x + inv_b * in.screen_pos.y + inv_tx;
-        let local_clip_y = inv_c * in.screen_pos.x + inv_d * in.screen_pos.y + inv_ty;
-        let local_clip_pos = vec2<f32>(local_clip_x, local_clip_y);
-
-        // Scale local position and clip region for aspect ratio
-        let scaled_local_clip_pos = vec2<f32>(local_clip_pos.x * aspect, local_clip_pos.y);
+        // Scale screen position and clip region for aspect ratio
+        let scaled_screen_pos = vec2<f32>(in.screen_pos.x * aspect, in.screen_pos.y);
         let scaled_clip_rect = vec4<f32>(
             in.clip_rect.x * aspect,
             in.clip_rect.y,
             in.clip_rect.z * aspect,
             in.clip_rect.w
         );
-        // clip_radius is height-based NDC, which is already in "uniform" units
-        // (the same units that y coordinates use after aspect scaling).
-        // No additional scaling needed - both components should be equal for circular corners.
+        // clip_radius is uniform (height-based NDC), which matches scaled space
+        // In scaled space, x coords are scaled by aspect, so distances match y
+        // Therefore we use clip_radius directly for both dimensions
         let scaled_clip_radius = vec2<f32>(in.clip_radius, in.clip_radius);
 
         // Compute clip SDF (use K=1.0 for circular corners)
-        let clip_dist = rounded_rect_sdf(scaled_local_clip_pos, scaled_clip_rect, scaled_clip_radius, 1.0);
+        let clip_dist = rounded_rect_sdf(scaled_screen_pos, scaled_clip_rect, scaled_clip_radius, 1.0);
         let clip_aa = fwidth(clip_dist);
         let clip_alpha = 1.0 - smoothstep(-clip_aa, clip_aa, clip_dist);
 

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -220,15 +220,6 @@ impl Transform {
         self.data[7] *= factor;
     }
 
-    /// Returns a copy of this transform with translation removed (tx=0, ty=0).
-    /// Preserves rotation and scale.
-    pub fn without_translation(&self) -> Self {
-        let mut result = *self;
-        result.data[3] = 0.0; // tx
-        result.data[7] = 0.0; // ty
-        result
-    }
-
     /// Extract the X and Y scale components from the transform matrix.
     ///
     /// For transforms that contain rotation and/or scale:
@@ -351,29 +342,6 @@ impl Transform {
                 1.0,
             ],
         }
-    }
-
-    /// Extract the rotation angle in radians from this transform.
-    ///
-    /// This extracts the rotation angle even when the transform also contains
-    /// scale and translation. Returns 0 for degenerate transforms.
-    pub fn extract_rotation_angle(&self) -> f32 {
-        let (sx, sy) = self.extract_scale_components();
-
-        // Avoid division by zero for degenerate transforms
-        if sx < 1e-10 || sy < 1e-10 {
-            return 0.0;
-        }
-
-        let a = self.data[0];
-        let c = self.data[4];
-
-        // For a rotation matrix:
-        // | cos(θ)  -sin(θ) |
-        // | sin(θ)   cos(θ) |
-        // After removing scale: a/sx = cos(θ), c/sy = sin(θ)
-        // So: θ = atan2(sin(θ), cos(θ)) = atan2(c/sy, a/sx)
-        (c / sy).atan2(a / sx)
     }
 }
 


### PR DESCRIPTION
## Summary
- Reverts PR #50 (c817d5f) due to a regression

## Context
PR #50 introduced a bad regression that needs to be reverted.

## Changes reverted
- Transform's `without_translation()` method
- Composed transform for ripple clipping
- Split shape vs clip transforms in `draw_overlay_circle_clipped_with_transform()`
- HiDPI scaling for clip transform translation