### PR TITLE
chore: remove dead code and fix doc warnings

### DIFF
--- a/src/reactive/maybe_dyn.rs
+++ b/src/reactive/maybe_dyn.rs
@@ -42,7 +42,7 @@ impl<T: Clone + 'static> Clone for MaybeDyn<T> {
 unsafe impl<T: Send + Sync + 'static> Send for MaybeDyn<T> {}
 unsafe impl<T: Send + Sync + 'static> Sync for MaybeDyn<T> {}
 
-/// Trait for types that can be converted into MaybeDyn<T>
+/// Trait for types that can be converted into `MaybeDyn<T>`
 pub trait IntoMaybeDyn<T: Clone + 'static> {
     fn into_maybe_dyn(self) -> MaybeDyn<T>;
 }

--- a/src/reactive/mod.rs
+++ b/src/reactive/mod.rs
@@ -22,10 +22,11 @@ pub use effect::{Effect, create_effect};
 pub use focus::{clear_focus, focused_widget, has_focus, release_focus, request_focus};
 pub use invalidation::{
     ChangeFlags, WidgetId, add_layout_root, clear_animation_flag, finish_layout_tracking,
-    get_needs_layout_flag, get_widget_parent, init_wakeup, register_relayout_boundary,
-    remove_widget_from_tree, request_animation_frame, request_frame, request_layout, request_paint,
-    set_needs_layout_flag, set_widget_parent, start_layout_tracking, take_frame_request,
-    take_layout_roots, unregister_relayout_boundary, with_app_state, with_app_state_mut,
+    get_needs_layout_flag, get_widget_parent, init_wakeup, mark_needs_layout,
+    register_relayout_boundary, remove_widget_from_tree, request_animation_frame, request_frame,
+    request_layout, request_paint, set_needs_layout_flag, set_widget_parent, start_layout_tracking,
+    take_frame_request, take_layout_roots, unregister_relayout_boundary, with_app_state,
+    with_app_state_mut,
 };
 pub use maybe_dyn::{IntoMaybeDyn, MaybeDyn};
 // Only on_cleanup is public API - with_owner, dispose_owner, and OwnerId are

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -86,8 +86,6 @@ pub struct Renderer {
     screen_width: f32,
     screen_height: f32,
     scale_factor: f32,
-    #[allow(dead_code)] // May be used for dynamic pipeline creation
-    format: wgpu::TextureFormat,
 }
 
 impl Renderer {
@@ -124,7 +122,6 @@ impl Renderer {
             screen_width: 1.0,
             screen_height: 1.0,
             scale_factor: 1.0,
-            format,
         }
     }
 

--- a/src/renderer/text_measurer.rs
+++ b/src/renderer/text_measurer.rs
@@ -28,12 +28,6 @@ impl TextMeasurer {
         }
     }
 
-    /// Clear the measurement cache. Useful for memory management.
-    #[allow(dead_code)]
-    pub fn clear_cache(&mut self) {
-        self.measure_cache.clear();
-    }
-
     pub fn measure(&mut self, text: &str, font_size: f32, max_width: Option<f32>) -> Size {
         self.measure_styled(
             text,

--- a/src/surface_manager.rs
+++ b/src/surface_manager.rs
@@ -130,12 +130,6 @@ impl SurfaceManager {
         self.surfaces.remove(&id)
     }
 
-    /// Get a surface by ID.
-    #[allow(dead_code)]
-    pub fn get(&self, id: SurfaceId) -> Option<&ManagedSurface> {
-        self.surfaces.get(&id)
-    }
-
     /// Get a mutable surface by ID.
     pub fn get_mut(&mut self, id: SurfaceId) -> Option<&mut ManagedSurface> {
         self.surfaces.get_mut(&id)
@@ -144,18 +138,6 @@ impl SurfaceManager {
     /// Iterate over all surface IDs.
     pub fn ids(&self) -> impl Iterator<Item = SurfaceId> + '_ {
         self.surfaces.keys().copied()
-    }
-
-    /// Iterate over all surfaces.
-    #[allow(dead_code)]
-    pub fn iter(&self) -> impl Iterator<Item = (&SurfaceId, &ManagedSurface)> {
-        self.surfaces.iter()
-    }
-
-    /// Iterate over all surfaces mutably.
-    #[allow(dead_code)]
-    pub fn iter_mut(&mut self) -> impl Iterator<Item = (&SurfaceId, &mut ManagedSurface)> {
-        self.surfaces.iter_mut()
     }
 
     /// Check if empty.

--- a/src/widgets/container/scrollable.rs
+++ b/src/widgets/container/scrollable.rs
@@ -144,7 +144,7 @@ impl Container {
         if let Some(anim) = scale_anim {
             anim.animate_to(target_scale);
             if anim.is_animating() {
-                anim.advance();
+                let _ = anim.advance(); // Paint-only, ignore result
                 request_animation_frame();
             }
         }
@@ -270,7 +270,7 @@ impl Container {
         if let Some(anim) = scale_anim {
             anim.animate_to(target_scale);
             if anim.is_animating() {
-                anim.advance();
+                let _ = anim.advance(); // Paint-only, ignore result
                 animating = true;
             }
         }

--- a/src/widgets/into_child.rs
+++ b/src/widgets/into_child.rs
@@ -13,7 +13,7 @@ pub struct DynamicChild;
 ///
 /// This trait uses a marker type parameter to disambiguate between:
 /// - Static widgets (evaluated once at creation) - uses `StaticChild` marker
-/// - Dynamic closures returning Option<Widget> (reactive) - uses `DynamicChild` marker
+/// - Dynamic closures returning `Option<Widget>` (reactive) - uses `DynamicChild` marker
 ///
 /// The marker parameter defaults to `StaticChild` for backwards compatibility.
 pub trait IntoChild<Marker = StaticChild> {

--- a/src/widgets/text_input.rs
+++ b/src/widgets/text_input.rs
@@ -147,18 +147,6 @@ impl History {
             None
         }
     }
-
-    /// Check if undo is available
-    #[allow(dead_code)]
-    fn can_undo(&self) -> bool {
-        !self.undo_stack.is_empty()
-    }
-
-    /// Check if redo is available
-    #[allow(dead_code)]
-    fn can_redo(&self) -> bool {
-        !self.redo_stack.is_empty()
-    }
 }
 
 /// Selection state tracking anchor and cursor positions


### PR DESCRIPTION
## Summary

Remove unused code flagged by clippy dead_code lint and fix documentation warnings.

**Changes:**
- `surface_manager.rs`: remove unused `get()`, `iter()`, `iter_mut()` methods
- `renderer/mod.rs`: remove unused `format` field in Renderer
- `renderer/text_measurer.rs`: remove unused `clear_cache()` method
- `widgets/text_input.rs`: remove unused `can_undo()`/`can_redo()` in History

**Documentation fixes:**
- `reactive/maybe_dyn.rs`: escape `<T>` in doc comment
- `widgets/into_child.rs`: escape `<Widget>` in doc comment

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes with no warnings
- [x] `cargo test` - all 125 tests pass