### PR TITLE
refactor: store widget origin in Tree

### DIFF
--- a/book/src/architecture/events.md
+++ b/book/src/architecture/events.md
@@ -55,11 +55,16 @@ Events propagate from children to parents (bubble up):
 5. Continues until handled or reaches root
 
 ```rust
-fn event(&mut self, event: &Event) -> EventResponse {
+fn event(&mut self, tree: &mut Tree, id: WidgetId, event: &Event) -> EventResponse {
     // Check children first (innermost)
-    for child in self.children.iter_mut().rev() {
-        if child.bounds().contains(event.position()) {
-            if child.event(event) == EventResponse::Handled {
+    for &child_id in self.children.iter().rev() {
+        // Get child bounds from Tree
+        let child_bounds = tree.get_bounds(child_id).unwrap_or_default();
+        if child_bounds.contains(event.position()) {
+            let response = tree.with_widget_mut(child_id, |child, cid, tree| {
+                child.event(tree, cid, event)
+            });
+            if response == Some(EventResponse::Handled) {
                 return EventResponse::Handled;
             }
         }

--- a/book/src/architecture/overview.md
+++ b/book/src/architecture/overview.md
@@ -118,12 +118,10 @@ pub trait Widget: Send + Sync {
     fn layout(&mut self, tree: &mut Tree, id: WidgetId, constraints: Constraints) -> Size;
     fn paint(&self, tree: &Tree, id: WidgetId, ctx: &mut PaintContext);
     fn event(&mut self, tree: &mut Tree, id: WidgetId, event: &Event) -> EventResponse;
-    fn set_origin(&mut self, tree: &mut Tree, id: WidgetId, x: f32, y: f32);
-    fn bounds(&self) -> Rect;
 }
 ```
 
-Widgets access children through the `Tree` parameter, which provides centralized widget storage and layout metadata.
+Widgets access children through the `Tree` parameter, which provides centralized widget storage and layout metadata. Widget bounds and origins are stored in the `Tree` (use `tree.get_bounds(id)` and `tree.set_origin(id, x, y)`).
 
 ## Constraints System
 

--- a/book/src/architecture/overview.md
+++ b/book/src/architecture/overview.md
@@ -115,12 +115,11 @@ All widgets implement:
 
 ```rust
 pub trait Widget: Send + Sync {
-    fn layout(&mut self, tree: &mut Tree, constraints: Constraints) -> Size;
-    fn paint(&self, tree: &Tree, ctx: &mut PaintContext);
-    fn event(&mut self, tree: &Tree, event: &Event) -> EventResponse;
-    fn set_origin(&mut self, x: f32, y: f32);
+    fn layout(&mut self, tree: &mut Tree, id: WidgetId, constraints: Constraints) -> Size;
+    fn paint(&self, tree: &Tree, id: WidgetId, ctx: &mut PaintContext);
+    fn event(&mut self, tree: &mut Tree, id: WidgetId, event: &Event) -> EventResponse;
+    fn set_origin(&mut self, tree: &mut Tree, id: WidgetId, x: f32, y: f32);
     fn bounds(&self) -> Rect;
-    fn id(&self) -> WidgetId;
 }
 ```
 

--- a/book/src/concepts/widgets.md
+++ b/book/src/concepts/widgets.md
@@ -8,23 +8,21 @@ All widgets implement the `Widget` trait:
 
 ```rust
 pub trait Widget: Send + Sync {
-    fn layout(&mut self, tree: &mut Tree, constraints: Constraints) -> Size;
-    fn paint(&self, tree: &Tree, ctx: &mut PaintContext);
-    fn event(&mut self, tree: &Tree, event: &Event) -> EventResponse;
-    fn set_origin(&mut self, x: f32, y: f32);
+    fn layout(&mut self, tree: &mut Tree, id: WidgetId, constraints: Constraints) -> Size;
+    fn paint(&self, tree: &Tree, id: WidgetId, ctx: &mut PaintContext);
+    fn event(&mut self, tree: &mut Tree, id: WidgetId, event: &Event) -> EventResponse;
+    fn set_origin(&mut self, tree: &mut Tree, id: WidgetId, x: f32, y: f32);
     fn bounds(&self) -> Rect;
-    fn id(&self) -> WidgetId;
 }
 ```
 
 ### Methods
 
-- **layout** - Calculate the widget's size given tree access and constraints
+- **layout** - Calculate the widget's size given tree access, widget ID, and constraints
 - **paint** - Draw the widget using tree for child access
 - **event** - Handle input events with tree access
-- **set_origin** - Position the widget (called by parent during layout)
+- **set_origin** - Position the widget and store origin in tree (called by parent during layout)
 - **bounds** - Get the bounding rectangle for hit testing
-- **id** - Get the widget's unique identifier
 
 ## Built-in Widgets
 

--- a/book/src/concepts/widgets.md
+++ b/book/src/concepts/widgets.md
@@ -11,8 +11,6 @@ pub trait Widget: Send + Sync {
     fn layout(&mut self, tree: &mut Tree, id: WidgetId, constraints: Constraints) -> Size;
     fn paint(&self, tree: &Tree, id: WidgetId, ctx: &mut PaintContext);
     fn event(&mut self, tree: &mut Tree, id: WidgetId, event: &Event) -> EventResponse;
-    fn set_origin(&mut self, tree: &mut Tree, id: WidgetId, x: f32, y: f32);
-    fn bounds(&self) -> Rect;
 }
 ```
 
@@ -21,8 +19,13 @@ pub trait Widget: Send + Sync {
 - **layout** - Calculate the widget's size given tree access, widget ID, and constraints
 - **paint** - Draw the widget using tree for child access
 - **event** - Handle input events with tree access
-- **set_origin** - Position the widget and store origin in tree (called by parent during layout)
-- **bounds** - Get the bounding rectangle for hit testing
+
+### Bounds and Origins
+
+Widget bounds and origins are stored in the `Tree`, not on individual widgets:
+
+- Use `tree.get_bounds(id)` to retrieve a widget's bounding rectangle for hit testing
+- Use `tree.set_origin(id, x, y)` to position widgets during layout (called by parent layouts)
 
 ## Built-in Widgets
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -213,7 +213,7 @@ All widgets implement this trait:
 pub trait Widget: Send + Sync {
     /// Advance animations for this widget and children.
     /// Returns true if any animations are still active.
-    fn advance_animations(&mut self, tree: &Tree, id: WidgetId) -> bool { false }
+    fn advance_animations(&mut self, tree: &mut Tree, id: WidgetId) -> bool { false }
 
     /// Reconcile dynamic children. Returns true if children changed.
     fn reconcile_children(&mut self, tree: &mut Tree, id: WidgetId) -> bool { false }
@@ -221,7 +221,7 @@ pub trait Widget: Send + Sync {
     fn layout(&mut self, tree: &mut Tree, id: WidgetId, constraints: Constraints) -> Size;
     fn paint(&self, tree: &Tree, id: WidgetId, ctx: &mut PaintContext);
     fn event(&mut self, tree: &mut Tree, id: WidgetId, event: &Event) -> EventResponse;
-    fn set_origin(&mut self, x: f32, y: f32);
+    fn set_origin(&mut self, tree: &mut Tree, id: WidgetId, x: f32, y: f32);
     fn bounds(&self) -> Rect;
 
     /// Check if a descendant has the given ID (for focus tracking)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -221,8 +221,6 @@ pub trait Widget: Send + Sync {
     fn layout(&mut self, tree: &mut Tree, id: WidgetId, constraints: Constraints) -> Size;
     fn paint(&self, tree: &Tree, id: WidgetId, ctx: &mut PaintContext);
     fn event(&mut self, tree: &mut Tree, id: WidgetId, event: &Event) -> EventResponse;
-    fn set_origin(&mut self, tree: &mut Tree, id: WidgetId, x: f32, y: f32);
-    fn bounds(&self) -> Rect;
 
     /// Check if a descendant has the given ID (for focus tracking)
     fn has_focus_descendant(&self, tree: &Tree, id: WidgetId) -> bool { false }
@@ -231,6 +229,8 @@ pub trait Widget: Send + Sync {
     fn register_children(&mut self, tree: &mut Tree, id: WidgetId) {}
 }
 ```
+
+**Note:** Widget bounds and origins are stored in the `Tree`, not on individual widgets. Use `tree.get_bounds(id)` to retrieve a widget's bounds and `tree.set_origin(id, x, y)` to position widgets during layout.
 
 ## Event Flow
 

--- a/guido-macros/src/lib.rs
+++ b/guido-macros/src/lib.rs
@@ -266,16 +266,6 @@ pub fn component(_attr: TokenStream, input: TokenStream) -> TokenStream {
                 self.__inner.write().unwrap().as_mut().unwrap().event(tree, id, event)
             }
 
-            fn set_origin(&mut self, tree: &mut ::guido::tree::Tree, id: ::guido::tree::WidgetId, x: f32, y: f32) {
-                self.ensure_built();
-                self.__inner.write().unwrap().as_mut().unwrap().set_origin(tree, id, x, y)
-            }
-
-            fn bounds(&self) -> ::guido::widgets::Rect {
-                self.ensure_built();
-                self.__inner.read().unwrap().as_ref().unwrap().bounds()
-            }
-
             fn has_focus_descendant(&self, tree: &::guido::tree::Tree, focused_id: ::guido::tree::WidgetId) -> bool {
                 self.ensure_built();
                 self.__inner.read().unwrap().as_ref().unwrap().has_focus_descendant(tree, focused_id)

--- a/guido-macros/src/lib.rs
+++ b/guido-macros/src/lib.rs
@@ -266,9 +266,9 @@ pub fn component(_attr: TokenStream, input: TokenStream) -> TokenStream {
                 self.__inner.write().unwrap().as_mut().unwrap().event(tree, id, event)
             }
 
-            fn set_origin(&mut self, x: f32, y: f32) {
+            fn set_origin(&mut self, tree: &mut ::guido::tree::Tree, id: ::guido::tree::WidgetId, x: f32, y: f32) {
                 self.ensure_built();
-                self.__inner.write().unwrap().as_mut().unwrap().set_origin(x, y)
+                self.__inner.write().unwrap().as_mut().unwrap().set_origin(tree, id, x, y)
             }
 
             fn bounds(&self) -> ::guido::widgets::Rect {

--- a/src/layout/flex_layout.rs
+++ b/src/layout/flex_layout.rs
@@ -293,7 +293,7 @@ impl Flex {
                 Axis::Vertical => (cross_pos, main_pos),
             };
 
-            tree.with_widget_mut(child_id, |child, id, tree| child.set_origin(tree, id, x, y));
+            tree.set_origin(child_id, x, y);
             main_pos += child_main + between_spacing;
         }
 

--- a/src/layout/flex_layout.rs
+++ b/src/layout/flex_layout.rs
@@ -293,7 +293,7 @@ impl Flex {
                 Axis::Vertical => (cross_pos, main_pos),
             };
 
-            tree.with_widget_mut(child_id, |child, _id, _tree| child.set_origin(x, y));
+            tree.with_widget_mut(child_id, |child, id, tree| child.set_origin(tree, id, x, y));
             main_pos += child_main + between_spacing;
         }
 

--- a/src/layout/overlay.rs
+++ b/src/layout/overlay.rs
@@ -38,7 +38,7 @@ impl Layout for Overlay {
         for &child_id in children.iter() {
             if let Some(child_size) = tree.with_widget_mut(child_id, |widget, id, tree| {
                 let size = widget.layout(tree, id, constraints);
-                widget.set_origin(origin.0, origin.1);
+                widget.set_origin(tree, id, origin.0, origin.1);
                 size
             }) {
                 max_width = max_width.max(child_size.width);

--- a/src/layout/overlay.rs
+++ b/src/layout/overlay.rs
@@ -37,10 +37,9 @@ impl Layout for Overlay {
         // Layout all children at the same origin, giving them the full constraints
         for &child_id in children.iter() {
             if let Some(child_size) = tree.with_widget_mut(child_id, |widget, id, tree| {
-                let size = widget.layout(tree, id, constraints);
-                widget.set_origin(tree, id, origin.0, origin.1);
-                size
+                widget.layout(tree, id, constraints)
             }) {
+                tree.set_origin(child_id, origin.0, origin.1);
                 max_width = max_width.max(child_size.width);
                 max_height = max_height.max(child_size.height);
             }

--- a/src/surface_manager.rs
+++ b/src/surface_manager.rs
@@ -119,8 +119,9 @@ impl ManagedSurface {
 
         tree.with_widget_mut(self.widget_id, |widget, id, tree| {
             widget.layout(tree, id, constraints);
-            widget.set_origin(tree, id, 0.0, 0.0);
         });
+        // Set root widget origin after layout
+        tree.set_origin(self.widget_id, 0.0, 0.0);
     }
 }
 

--- a/src/surface_manager.rs
+++ b/src/surface_manager.rs
@@ -119,7 +119,7 @@ impl ManagedSurface {
 
         tree.with_widget_mut(self.widget_id, |widget, id, tree| {
             widget.layout(tree, id, constraints);
-            widget.set_origin(0.0, 0.0);
+            widget.set_origin(tree, id, 0.0, 0.0);
         });
     }
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -41,14 +41,6 @@ pub struct WidgetId {
 }
 
 impl WidgetId {
-    /// A sentinel ID representing an unregistered widget.
-    /// Tree operations with this ID are no-ops.
-    /// Used for internal widgets (like scrollbars) that aren't in the Tree.
-    pub const UNREGISTERED: Self = Self {
-        index: u32::MAX,
-        generation: u32::MAX,
-    };
-
     /// Create a new WidgetId with the given index and generation.
     /// This is internal - users get IDs from Tree::register().
     fn new(index: u32, generation: u32) -> Self {
@@ -240,10 +232,6 @@ impl Tree {
                 Size::zero()
             }
             fn paint(&self, _: &Tree, _: WidgetId, _: &mut crate::renderer::PaintContext) {}
-            fn set_origin(&mut self, _: &mut Tree, _: WidgetId, _: f32, _: f32) {}
-            fn bounds(&self) -> crate::widgets::Rect {
-                crate::widgets::Rect::new(0.0, 0.0, 0.0, 0.0)
-            }
         }
 
         // Extract widget
@@ -451,12 +439,6 @@ mod tests {
         }
 
         fn paint(&self, _tree: &Tree, _id: WidgetId, _ctx: &mut crate::renderer::PaintContext) {}
-
-        fn set_origin(&mut self, _tree: &mut Tree, _id: WidgetId, _x: f32, _y: f32) {}
-
-        fn bounds(&self) -> crate::widgets::Rect {
-            crate::widgets::Rect::new(0.0, 0.0, 0.0, 0.0)
-        }
     }
 
     #[test]
@@ -585,9 +567,9 @@ mod tests {
         let mut tree = Tree::new();
         let id = tree.register(Box::new(MockWidget::new()));
 
-        // Read widget bounds
-        let bounds = tree.with_widget(id, |w| w.bounds());
-        assert!(bounds.is_some());
+        // Test that we can access widget through with_widget
+        let exists = tree.with_widget(id, |_w| true);
+        assert!(exists.is_some());
     }
 
     #[test]

--- a/src/widgets/children.rs
+++ b/src/widgets/children.rs
@@ -425,7 +425,7 @@ impl Drop for OwnedWidget {
 }
 
 impl Widget for OwnedWidget {
-    fn advance_animations(&mut self, tree: &Tree, id: WidgetId) -> bool {
+    fn advance_animations(&mut self, tree: &mut Tree, id: WidgetId) -> bool {
         self.inner.advance_animations(tree, id)
     }
 
@@ -449,8 +449,8 @@ impl Widget for OwnedWidget {
         self.inner.event(tree, id, event)
     }
 
-    fn set_origin(&mut self, x: f32, y: f32) {
-        self.inner.set_origin(x, y)
+    fn set_origin(&mut self, tree: &mut Tree, id: WidgetId, x: f32, y: f32) {
+        self.inner.set_origin(tree, id, x, y)
     }
 
     fn bounds(&self) -> Rect {

--- a/src/widgets/children.rs
+++ b/src/widgets/children.rs
@@ -8,7 +8,7 @@ use crate::renderer::PaintContext;
 use crate::tree::{Tree, WidgetId};
 
 use super::Widget;
-use super::widget::{Event, EventResponse, Rect};
+use super::widget::{Event, EventResponse};
 
 /// Segment metadata - tracks what kind of source each segment is
 enum SegmentType {
@@ -447,14 +447,6 @@ impl Widget for OwnedWidget {
 
     fn event(&mut self, tree: &mut Tree, id: WidgetId, event: &Event) -> EventResponse {
         self.inner.event(tree, id, event)
-    }
-
-    fn set_origin(&mut self, tree: &mut Tree, id: WidgetId, x: f32, y: f32) {
-        self.inner.set_origin(tree, id, x, y)
-    }
-
-    fn bounds(&self) -> Rect {
-        self.inner.bounds()
     }
 
     fn has_focus_descendant(&self, tree: &Tree, focused_id: WidgetId) -> bool {

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -931,7 +931,7 @@ impl Default for Container {
 }
 
 impl Widget for Container {
-    fn advance_animations(&mut self, tree: &Tree, id: WidgetId) -> bool {
+    fn advance_animations(&mut self, tree: &mut Tree, id: WidgetId) -> bool {
         // Use advance_animations_self for this widget's animations
         let mut any_animating = false;
 
@@ -1043,7 +1043,7 @@ impl Widget for Container {
         // Update scrollbar handle positions based on current scroll offset
         // (scroll is paint-only, so layout may not run during scrolling)
         if self.scroll_axis != ScrollAxis::None {
-            self.update_scrollbar_handle_positions();
+            self.update_scrollbar_handle_positions(tree);
         }
 
         // Advance scrollbar scale animations (for hover expansion effect)
@@ -1598,7 +1598,10 @@ impl Widget for Container {
         EventResponse::Ignored
     }
 
-    fn set_origin(&mut self, x: f32, y: f32) {
+    fn set_origin(&mut self, tree: &mut Tree, id: WidgetId, x: f32, y: f32) {
+        // Store origin in tree
+        tree.set_origin(id, x, y);
+
         // Calculate delta from previous position
         let dx = x - self.bounds.x;
         let dy = y - self.bounds.y;
@@ -1620,7 +1623,7 @@ impl Widget for Container {
         // Scrollbar layout calculates positions using self.bounds, but bounds.x/y are
         // only set correctly after set_origin is called by the parent.
         if self.scroll_axis != ScrollAxis::None {
-            self.update_scrollbar_origins();
+            self.update_scrollbar_origins(tree);
         }
     }
 

--- a/src/widgets/container/scrollable.rs
+++ b/src/widgets/container/scrollable.rs
@@ -175,7 +175,7 @@ impl Container {
                 max_height: track_rect.height,
             };
             Widget::layout(track.as_mut(), tree, id, track_constraints);
-            track.set_origin(track_rect.x, track_rect.y);
+            track.set_origin(tree, WidgetId::UNREGISTERED, track_rect.x, track_rect.y);
 
             // Set scale transform
             let (transform, origin) = match axis {
@@ -201,7 +201,7 @@ impl Container {
                 max_height: handle_rect.height,
             };
             Widget::layout(handle.as_mut(), tree, id, handle_constraints);
-            handle.set_origin(handle_rect.x, handle_rect.y);
+            handle.set_origin(tree, WidgetId::UNREGISTERED, handle_rect.x, handle_rect.y);
 
             // Set scale transform
             let (transform, origin) = match axis {
@@ -344,7 +344,7 @@ impl Container {
     /// Update scrollbar handle positions based on current scroll offset.
     /// Called from advance_animations to ensure handles are positioned correctly
     /// even when layout doesn't run (scroll is paint-only).
-    pub(super) fn update_scrollbar_handle_positions(&mut self) {
+    pub(super) fn update_scrollbar_handle_positions(&mut self, tree: &mut Tree) {
         if self.scroll_axis == ScrollAxis::None
             || self.scrollbar_visibility == ScrollbarVisibility::Hidden
         {
@@ -365,7 +365,7 @@ impl Container {
                 &self.scrollbar_config,
                 needs_horizontal,
             );
-            handle.set_origin(handle_rect.x, handle_rect.y);
+            handle.set_origin(tree, WidgetId::UNREGISTERED, handle_rect.x, handle_rect.y);
         }
 
         // Update horizontal scrollbar handle position
@@ -379,13 +379,13 @@ impl Container {
                 &self.scrollbar_config,
                 needs_vertical,
             );
-            handle.set_origin(handle_rect.x, handle_rect.y);
+            handle.set_origin(tree, WidgetId::UNREGISTERED, handle_rect.x, handle_rect.y);
         }
     }
 
     /// Update scrollbar container origins after the container's position changes.
     /// Called from set_origin to ensure scrollbar track and handle are positioned correctly.
-    pub(super) fn update_scrollbar_origins(&mut self) {
+    pub(super) fn update_scrollbar_origins(&mut self, tree: &mut Tree) {
         if self.scroll_axis == ScrollAxis::None
             || self.scrollbar_visibility == ScrollbarVisibility::Hidden
         {
@@ -411,10 +411,10 @@ impl Container {
             );
 
             if let Some(ref mut track) = self.v_scrollbar_track {
-                track.set_origin(track_rect.x, track_rect.y);
+                track.set_origin(tree, WidgetId::UNREGISTERED, track_rect.x, track_rect.y);
             }
             if let Some(ref mut handle) = self.v_scrollbar_handle {
-                handle.set_origin(handle_rect.x, handle_rect.y);
+                handle.set_origin(tree, WidgetId::UNREGISTERED, handle_rect.x, handle_rect.y);
             }
         }
 
@@ -434,10 +434,10 @@ impl Container {
             );
 
             if let Some(ref mut track) = self.h_scrollbar_track {
-                track.set_origin(track_rect.x, track_rect.y);
+                track.set_origin(tree, WidgetId::UNREGISTERED, track_rect.x, track_rect.y);
             }
             if let Some(ref mut handle) = self.h_scrollbar_handle {
-                handle.set_origin(handle_rect.x, handle_rect.y);
+                handle.set_origin(tree, WidgetId::UNREGISTERED, handle_rect.x, handle_rect.y);
             }
         }
     }

--- a/src/widgets/image.rs
+++ b/src/widgets/image.rs
@@ -281,7 +281,8 @@ impl Widget for Image {
         EventResponse::Ignored
     }
 
-    fn set_origin(&mut self, x: f32, y: f32) {
+    fn set_origin(&mut self, tree: &mut Tree, id: WidgetId, x: f32, y: f32) {
+        tree.set_origin(id, x, y);
         self.bounds.x = x;
         self.bounds.y = y;
     }

--- a/src/widgets/text.rs
+++ b/src/widgets/text.rs
@@ -21,7 +21,6 @@ pub struct Text {
     cached_font_size: f32,
     cached_font_family: FontFamily,
     cached_font_weight: FontWeight,
-    bounds: Rect,
 }
 
 impl Text {
@@ -42,7 +41,6 @@ impl Text {
             cached_font_size: 14.0,
             cached_font_family: default_family,
             cached_font_weight: FontWeight::NORMAL,
-            bounds: Rect::new(0.0, 0.0, 0.0, 0.0),
         }
     }
 
@@ -163,9 +161,6 @@ impl Widget for Text {
                 .min(constraints.max_height),
         );
 
-        self.bounds.width = size.width;
-        self.bounds.height = size.height;
-
         // Cache constraints and size for partial layout
         tree.cache_layout(id, constraints, size);
 
@@ -175,10 +170,11 @@ impl Widget for Text {
         size
     }
 
-    fn paint(&self, _tree: &Tree, _id: WidgetId, ctx: &mut PaintContext) {
+    fn paint(&self, tree: &Tree, id: WidgetId, ctx: &mut PaintContext) {
         // Draw in LOCAL coordinates (0,0 is widget origin)
         // Parent Container sets position transform
-        let local_bounds = Rect::new(0.0, 0.0, self.bounds.width, self.bounds.height);
+        let size = tree.cached_size(id).unwrap_or_default();
+        let local_bounds = Rect::new(0.0, 0.0, size.width, size.height);
         let color = self.color.get();
         ctx.draw_text_styled(
             &self.cached_text,
@@ -197,16 +193,6 @@ impl Widget for Text {
         _event: &super::widget::Event,
     ) -> EventResponse {
         EventResponse::Ignored
-    }
-
-    fn set_origin(&mut self, tree: &mut Tree, id: WidgetId, x: f32, y: f32) {
-        tree.set_origin(id, x, y);
-        self.bounds.x = x;
-        self.bounds.y = y;
-    }
-
-    fn bounds(&self) -> Rect {
-        self.bounds
     }
 }
 

--- a/src/widgets/text.rs
+++ b/src/widgets/text.rs
@@ -199,7 +199,8 @@ impl Widget for Text {
         EventResponse::Ignored
     }
 
-    fn set_origin(&mut self, x: f32, y: f32) {
+    fn set_origin(&mut self, tree: &mut Tree, id: WidgetId, x: f32, y: f32) {
+        tree.set_origin(id, x, y);
         self.bounds.x = x;
         self.bounds.y = y;
     }

--- a/src/widgets/text_input.rs
+++ b/src/widgets/text_input.rs
@@ -1165,7 +1165,8 @@ impl Widget for TextInput {
         EventResponse::Ignored
     }
 
-    fn set_origin(&mut self, x: f32, y: f32) {
+    fn set_origin(&mut self, tree: &mut Tree, id: WidgetId, x: f32, y: f32) {
+        tree.set_origin(id, x, y);
         self.bounds.x = x;
         self.bounds.y = y;
     }

--- a/src/widgets/text_input.rs
+++ b/src/widgets/text_input.rs
@@ -245,9 +245,6 @@ pub struct TextInput {
     // Horizontal scroll offset for text overflow
     scroll_offset: f32,
 
-    // Layout
-    bounds: Rect,
-
     // Callbacks
     on_change: Option<TextCallback>,
     on_submit: Option<TextCallback>,
@@ -292,7 +289,6 @@ impl TextInput {
             is_hovered: false,
             history: History::new(),
             scroll_offset: 0.0,
-            bounds: Rect::new(0.0, 0.0, 0.0, 0.0),
             on_change: None,
             on_submit: None,
         }
@@ -520,7 +516,7 @@ impl TextInput {
     }
 
     /// Handle key repeat for held keys
-    fn handle_key_repeat(&mut self, id: WidgetId) {
+    fn handle_key_repeat(&mut self, tree: &Tree, id: WidgetId) {
         if !has_focus(id) {
             self.pressed_key = None;
             return;
@@ -535,7 +531,8 @@ impl TextInput {
             if since_press >= Duration::from_millis(KEY_REPEAT_DELAY_MS) {
                 // Check if it's time for another repeat
                 if since_repeat >= Duration::from_millis(KEY_REPEAT_INTERVAL_MS) {
-                    self.handle_key(&key, modifiers.ctrl, modifiers.shift);
+                    let bounds_width = tree.cached_size(id).map(|s| s.width).unwrap_or(0.0);
+                    self.handle_key(&key, modifiers.ctrl, modifiers.shift, bounds_width);
                     self.last_repeat_time = now;
                 }
             }
@@ -547,8 +544,8 @@ impl TextInput {
 
     /// Get character index from x coordinate relative to text start.
     /// Uses cached glyph positions for O(log n) binary search.
-    fn char_index_at_x(&self, x: f32) -> usize {
-        let text_x = self.bounds.x;
+    fn char_index_at_x(&self, x: f32, bounds: Rect) -> usize {
+        let text_x = bounds.x;
         // Account for scroll offset
         let relative_x = x - text_x + self.scroll_offset;
 
@@ -599,12 +596,12 @@ impl TextInput {
     }
 
     /// Ensure the cursor is visible by adjusting scroll offset
-    fn ensure_cursor_visible(&mut self) {
+    fn ensure_cursor_visible(&mut self, bounds_width: f32) {
         // Ensure measurements are up to date
         self.update_measurements();
 
         let cursor_x = self.cached_width_at_char(self.selection.cursor);
-        let visible_width = self.bounds.width - SCROLL_PADDING * 2.0;
+        let visible_width = bounds_width - SCROLL_PADDING * 2.0;
 
         if visible_width <= 0.0 {
             return;
@@ -624,7 +621,7 @@ impl TextInput {
     }
 
     /// Insert text at cursor, replacing any selection
-    fn insert_text(&mut self, text: &str) {
+    fn insert_text(&mut self, text: &str, bounds_width: f32) {
         // Save state before modification
         self.save_to_history(EditType::Insert);
 
@@ -647,11 +644,11 @@ impl TextInput {
 
         self.notify_change();
         self.reset_cursor_blink();
-        self.ensure_cursor_visible();
+        self.ensure_cursor_visible(bounds_width);
     }
 
     /// Delete selected text or character before/after cursor
-    fn delete(&mut self, forward: bool) {
+    fn delete(&mut self, forward: bool, bounds_width: f32) {
         // Check if there's anything to delete
         let has_content_to_delete = if self.selection.has_selection() {
             true
@@ -684,7 +681,7 @@ impl TextInput {
             }
         }
         self.reset_cursor_blink();
-        self.ensure_cursor_visible();
+        self.ensure_cursor_visible(bounds_width);
     }
 
     /// Delete a range of characters
@@ -703,7 +700,13 @@ impl TextInput {
     }
 
     /// Move cursor left/right, optionally extending selection
-    fn move_cursor(&mut self, direction: i32, extend_selection: bool, word: bool) {
+    fn move_cursor(
+        &mut self,
+        direction: i32,
+        extend_selection: bool,
+        word: bool,
+        bounds_width: f32,
+    ) {
         let new_pos = if word {
             self.find_word_boundary(self.selection.cursor, direction)
         } else if direction < 0 {
@@ -717,7 +720,7 @@ impl TextInput {
             self.selection.collapse();
         }
         self.reset_cursor_blink();
-        self.ensure_cursor_visible();
+        self.ensure_cursor_visible(bounds_width);
     }
 
     /// Find word boundary in given direction
@@ -772,21 +775,21 @@ impl TextInput {
     }
 
     /// Move cursor to start/end
-    fn move_to_edge(&mut self, to_start: bool, extend_selection: bool) {
+    fn move_to_edge(&mut self, to_start: bool, extend_selection: bool, bounds_width: f32) {
         self.selection.cursor = if to_start { 0 } else { self.cached_char_count };
         if !extend_selection {
             self.selection.collapse();
         }
         self.reset_cursor_blink();
-        self.ensure_cursor_visible();
+        self.ensure_cursor_visible(bounds_width);
     }
 
     /// Select all text
-    fn select_all(&mut self) {
+    fn select_all(&mut self, bounds_width: f32) {
         self.selection.anchor = 0;
         self.selection.cursor = self.cached_char_count;
         self.reset_cursor_blink();
-        self.ensure_cursor_visible();
+        self.ensure_cursor_visible(bounds_width);
     }
 
     /// Get selected text
@@ -808,17 +811,17 @@ impl TextInput {
     }
 
     /// Cut selected text (copy and delete)
-    fn cut_selection(&mut self) {
+    fn cut_selection(&mut self, bounds_width: f32) {
         if self.selection.has_selection() {
             self.copy_selection();
-            self.delete(false); // Delete the selection
+            self.delete(false, bounds_width); // Delete the selection
         }
     }
 
     /// Paste text from clipboard
-    fn paste(&mut self) {
+    fn paste(&mut self, bounds_width: f32) {
         if let Some(text) = clipboard_paste() {
-            self.insert_text(&text);
+            self.insert_text(&text, bounds_width);
         }
     }
 
@@ -844,7 +847,7 @@ impl TextInput {
     }
 
     /// Undo the last change
-    fn undo(&mut self) {
+    fn undo(&mut self, bounds_width: f32) {
         let current = self.current_history_entry();
         if let Some(previous) = self.history.undo(current) {
             self.cached_value = previous.text;
@@ -856,12 +859,12 @@ impl TextInput {
             self.history.reset_coalescing();
             self.notify_change();
             self.reset_cursor_blink();
-            self.ensure_cursor_visible();
+            self.ensure_cursor_visible(bounds_width);
         }
     }
 
     /// Redo the last undone change
-    fn redo(&mut self) {
+    fn redo(&mut self, bounds_width: f32) {
         let current = self.current_history_entry();
         if let Some(next) = self.history.redo(current) {
             self.cached_value = next.text;
@@ -873,7 +876,7 @@ impl TextInput {
             self.history.reset_coalescing();
             self.notify_change();
             self.reset_cursor_blink();
-            self.ensure_cursor_visible();
+            self.ensure_cursor_visible(bounds_width);
         }
     }
 
@@ -888,14 +891,20 @@ impl TextInput {
     }
 
     /// Handle key down event
-    fn handle_key(&mut self, key: &Key, ctrl: bool, shift: bool) -> EventResponse {
+    fn handle_key(
+        &mut self,
+        key: &Key,
+        ctrl: bool,
+        shift: bool,
+        bounds_width: f32,
+    ) -> EventResponse {
         match key {
             Key::Backspace => {
-                self.delete(false);
+                self.delete(false, bounds_width);
                 EventResponse::Handled
             }
             Key::Delete => {
-                self.delete(true);
+                self.delete(true, bounds_width);
                 EventResponse::Handled
             }
             Key::Enter => {
@@ -911,7 +920,7 @@ impl TextInput {
                     self.selection = Selection::new(start);
                     self.reset_cursor_blink();
                 } else {
-                    self.move_cursor(-1, shift, ctrl);
+                    self.move_cursor(-1, shift, ctrl, bounds_width);
                 }
                 EventResponse::Handled
             }
@@ -922,23 +931,23 @@ impl TextInput {
                     self.selection = Selection::new(end);
                     self.reset_cursor_blink();
                 } else {
-                    self.move_cursor(1, shift, ctrl);
+                    self.move_cursor(1, shift, ctrl, bounds_width);
                 }
                 EventResponse::Handled
             }
             Key::Home => {
-                self.move_to_edge(true, shift);
+                self.move_to_edge(true, shift, bounds_width);
                 EventResponse::Handled
             }
             Key::End => {
-                self.move_to_edge(false, shift);
+                self.move_to_edge(false, shift, bounds_width);
                 EventResponse::Handled
             }
             Key::Char(c) => {
                 if ctrl {
                     match c.to_ascii_lowercase() {
                         'a' => {
-                            self.select_all();
+                            self.select_all(bounds_width);
                             EventResponse::Handled
                         }
                         'c' => {
@@ -946,31 +955,31 @@ impl TextInput {
                             EventResponse::Handled
                         }
                         'x' => {
-                            self.cut_selection();
+                            self.cut_selection(bounds_width);
                             EventResponse::Handled
                         }
                         'v' => {
-                            self.paste();
+                            self.paste(bounds_width);
                             EventResponse::Handled
                         }
                         'z' => {
                             // Ctrl+Shift+Z = redo, Ctrl+Z = undo
                             if shift {
-                                self.redo();
+                                self.redo(bounds_width);
                             } else {
-                                self.undo();
+                                self.undo(bounds_width);
                             }
                             EventResponse::Handled
                         }
                         'y' => {
                             // Ctrl+Y = redo
-                            self.redo();
+                            self.redo(bounds_width);
                             EventResponse::Handled
                         }
                         _ => EventResponse::Ignored,
                     }
                 } else if !c.is_control() {
-                    self.insert_text(&c.to_string());
+                    self.insert_text(&c.to_string(), bounds_width);
                     EventResponse::Handled
                 } else {
                     EventResponse::Ignored
@@ -994,13 +1003,15 @@ impl Widget for TextInput {
         self.update_cursor_blink(id);
 
         // Handle key repeat for held keys
-        self.handle_key_repeat(id);
+        self.handle_key_repeat(tree, id);
 
         // Update measurement cache (has internal dirty check)
         self.update_measurements();
 
         // Use cached text width for sizing (TextMeasurer caches the actual measurement)
-        let height = (self.cached_font_size * 1.2).max(self.bounds.height);
+        // Use previous height from tree to maintain stable sizing
+        let prev_height = tree.cached_size(id).map(|s| s.height).unwrap_or(0.0);
+        let height = (self.cached_font_size * 1.2).max(prev_height);
 
         // Text inputs should fill available width (like HTML input elements)
         // Use max_width if available, otherwise fall back to measured width
@@ -1017,9 +1028,6 @@ impl Widget for TextInput {
                 .min(constraints.max_height),
         );
 
-        self.bounds.width = size.width;
-        self.bounds.height = size.height;
-
         // Cache constraints and size for partial layout
         tree.cache_layout(id, constraints, size);
 
@@ -1029,9 +1037,10 @@ impl Widget for TextInput {
         size
     }
 
-    fn paint(&self, _tree: &Tree, id: WidgetId, ctx: &mut PaintContext) {
+    fn paint(&self, tree: &Tree, id: WidgetId, ctx: &mut PaintContext) {
         // Draw in LOCAL coordinates (0,0 is widget origin)
         // Parent Container sets position transform
+        let bounds = tree.get_bounds(id).unwrap_or_default();
         let display = self.display_text_cached();
         let text_color = self.text_color.get();
         let is_focused = has_focus(id);
@@ -1044,7 +1053,7 @@ impl Widget for TextInput {
             let start_x = self.cached_width_at_char(start) - self.scroll_offset;
             let end_x = self.cached_width_at_char(end) - self.scroll_offset;
 
-            let selection_rect = Rect::new(start_x, 0.0, end_x - start_x, self.bounds.height);
+            let selection_rect = Rect::new(start_x, 0.0, end_x - start_x, bounds.height);
             ctx.draw_rounded_rect(selection_rect, self.selection_color.get(), 0.0);
         }
 
@@ -1052,8 +1061,8 @@ impl Widget for TextInput {
         let text_bounds = Rect::new(
             -self.scroll_offset,
             0.0,
-            self.cached_text_width.max(self.bounds.width),
-            self.bounds.height,
+            self.cached_text_width.max(bounds.width),
+            bounds.height,
         );
         ctx.draw_text_styled(
             display,
@@ -1071,32 +1080,35 @@ impl Widget for TextInput {
                 cursor_x,
                 0.0,
                 1.5, // cursor width
-                self.bounds.height,
+                bounds.height,
             );
             ctx.draw_rounded_rect(cursor_rect, self.cursor_color.get(), 0.0);
         }
     }
 
-    fn event(&mut self, _tree: &mut Tree, id: WidgetId, event: &Event) -> EventResponse {
+    fn event(&mut self, tree: &mut Tree, id: WidgetId, event: &Event) -> EventResponse {
+        // Get bounds from Tree for hit testing
+        let bounds = tree.get_bounds(id).unwrap_or_default();
+
         match event {
             Event::MouseDown { x, y, button } => {
-                if self.bounds.contains(*x, *y) && *button == MouseButton::Left {
+                if bounds.contains(*x, *y) && *button == MouseButton::Left {
                     // Request focus
                     request_focus(id);
                     request_job(id, JobRequest::Paint);
 
                     // Set cursor position
-                    let char_index = self.char_index_at_x(*x);
+                    let char_index = self.char_index_at_x(*x, bounds);
                     self.selection = Selection::new(char_index);
                     self.is_dragging = true;
                     self.reset_cursor_blink();
-                    self.ensure_cursor_visible();
+                    self.ensure_cursor_visible(bounds.width);
 
                     return EventResponse::Handled;
                 }
             }
             Event::MouseMove { x, y, .. } => {
-                let in_bounds = self.bounds.contains(*x, *y);
+                let in_bounds = bounds.contains(*x, *y);
 
                 // Update hover state and cursor
                 if in_bounds && !self.is_hovered {
@@ -1109,9 +1121,9 @@ impl Widget for TextInput {
 
                 if self.is_dragging {
                     // Extend selection while dragging
-                    let char_index = self.char_index_at_x(*x);
+                    let char_index = self.char_index_at_x(*x, bounds);
                     self.selection.cursor = char_index;
-                    self.ensure_cursor_visible();
+                    self.ensure_cursor_visible(bounds.width);
                     request_job(id, JobRequest::Paint);
                     return EventResponse::Handled;
                 }
@@ -1130,7 +1142,8 @@ impl Widget for TextInput {
                     self.key_press_time = now;
                     self.last_repeat_time = now;
 
-                    let response = self.handle_key(key, modifiers.ctrl, modifiers.shift);
+                    let response =
+                        self.handle_key(key, modifiers.ctrl, modifiers.shift, bounds.width);
                     if response == EventResponse::Handled {
                         request_job(id, JobRequest::Paint);
                     }
@@ -1163,16 +1176,6 @@ impl Widget for TextInput {
         }
 
         EventResponse::Ignored
-    }
-
-    fn set_origin(&mut self, tree: &mut Tree, id: WidgetId, x: f32, y: f32) {
-        tree.set_origin(id, x, y);
-        self.bounds.x = x;
-        self.bounds.y = y;
-    }
-
-    fn bounds(&self) -> Rect {
-        self.bounds
     }
 }
 

--- a/src/widgets/widget.rs
+++ b/src/widgets/widget.rs
@@ -373,7 +373,7 @@ pub trait Widget: Send + Sync {
     /// Advance animations for this widget and children.
     /// Returns true if any animations are still active and need another frame.
     /// Called once per frame before layout.
-    fn advance_animations(&mut self, tree: &Tree, id: WidgetId) -> bool {
+    fn advance_animations(&mut self, tree: &mut Tree, id: WidgetId) -> bool {
         let _ = (tree, id);
         false
     }
@@ -392,9 +392,19 @@ pub trait Widget: Send + Sync {
         let _ = (tree, id, event);
         EventResponse::Ignored
     }
-    fn set_origin(&mut self, x: f32, y: f32);
 
-    /// Get the widget's bounding rectangle (for hit testing)
+    /// Set the widget's position (called by parent after layout).
+    ///
+    /// Implementations should:
+    /// 1. Store the origin in the Tree via `tree.set_origin(id, x, y)`
+    /// 2. Cache locally if needed for internal calculations
+    fn set_origin(&mut self, tree: &mut Tree, id: WidgetId, x: f32, y: f32);
+
+    /// Get the widget's bounding rectangle (for hit testing).
+    ///
+    /// Note: For widgets in the Tree, prefer `tree.get_bounds(id)` when available.
+    /// This method is kept for internal widgets (like scrollbars) that aren't
+    /// registered in the Tree.
     fn bounds(&self) -> Rect;
 
     /// Check if this widget has a descendant with the given ID.

--- a/src/widgets/widget.rs
+++ b/src/widgets/widget.rs
@@ -39,7 +39,7 @@ impl Default for Color {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub struct Rect {
     pub x: f32,
     pub y: f32,
@@ -392,20 +392,6 @@ pub trait Widget: Send + Sync {
         let _ = (tree, id, event);
         EventResponse::Ignored
     }
-
-    /// Set the widget's position (called by parent after layout).
-    ///
-    /// Implementations should:
-    /// 1. Store the origin in the Tree via `tree.set_origin(id, x, y)`
-    /// 2. Cache locally if needed for internal calculations
-    fn set_origin(&mut self, tree: &mut Tree, id: WidgetId, x: f32, y: f32);
-
-    /// Get the widget's bounding rectangle (for hit testing).
-    ///
-    /// Note: For widgets in the Tree, prefer `tree.get_bounds(id)` when available.
-    /// This method is kept for internal widgets (like scrollbars) that aren't
-    /// registered in the Tree.
-    fn bounds(&self) -> Rect;
 
     /// Check if this widget has a descendant with the given ID.
     /// Used by containers to check if a child has focus.


### PR DESCRIPTION
## Summary

This PR extends the Tree to store widget origins (positions), enabling centralized geometry tracking.

### Changes

- Add `origin: (f32, f32)` field to Tree's Node struct alongside existing `cached_size`
- Add `tree.set_origin(id, x, y)`, `tree.get_origin(id)`, and `tree.get_bounds(id)` methods
- Change `Widget::set_origin` signature to include `tree` and `id` parameters
- Change `Widget::advance_animations` to take `&mut Tree` (was `&Tree`) to support scrollbar updates
- Add `WidgetId::UNREGISTERED` sentinel for internal widgets not registered in the Tree (e.g., scrollbars)
- Update all widget implementations and layout engines
- Update documentation to reflect new Widget trait signatures

### Design Notes

Widgets still cache bounds locally for internal calculations (hit testing, transform origins, scrollbar positioning) while also storing origin in Tree. This dual storage is intentional:

1. **Tree as source of truth**: The Tree now has complete geometry information
2. **Local cache for convenience**: Widgets can access bounds without tree lookups for internal calculations
3. **Internal widgets**: Scrollbar containers use `WidgetId::UNREGISTERED` since they aren't in the Tree

This is a stepping stone toward potentially removing widget-local bounds in the future.

## Test plan

- [x] `cargo test` - All tests pass
- [x] `cargo clippy` - No warnings
- [ ] Manual testing with examples