### PR TITLE
fix: prevent compose key from inserting intermediate characters

### DIFF
--- a/src/widgets/text_input.rs
+++ b/src/widgets/text_input.rs
@@ -537,8 +537,8 @@ impl TextInput {
                 }
             }
 
-            // Keep requesting frames while a key is held
-            request_job(id, JobRequest::Paint);
+            // Keep requesting layout while a key is held so handle_key_repeat() runs each frame
+            request_job(id, JobRequest::Layout);
         }
     }
 


### PR DESCRIPTION
## Summary
- Fix compose key sequences (e.g., `ralt + ` + e` → `è`) inserting intermediate raw characters (like backtick) before the composed character in text_input
- Add `is_press` parameter to `keysym_to_key()` to skip the ASCII keysym fallback on press events where `utf8=None` signals a compose sequence in progress
- The fallback is preserved for release events where `utf8` is always `None` per the Wayland protocol, ensuring KeyUp tracking continues to work

## Test plan
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] `cargo test` passes
- [ ] Run `cargo run --example reactive_example` and verify compose key sequences (e.g., ralt + ` + e) produce only the composed character (`è`) without stray intermediate characters
- [ ] Verify normal typing still works without regressions
- [ ] Verify key release tracking still works (key repeat stops when key is released)