### PR TITLE
feat: add Signal::select() for zero-clone field-level reactivity

### DIFF
--- a/examples/select_example.rs
+++ b/examples/select_example.rs
@@ -1,0 +1,144 @@
+//! Example demonstrating Signal::select() for field-level reactivity.
+//!
+//! This example shows:
+//! - Using select() to derive signals from specific fields of a struct
+//! - Chained selects for nested fields
+//! - Only the selected field triggers updates (not changes to other fields)
+//! - Background thread updates via create_service with select()
+
+use std::time::Duration;
+
+use guido::prelude::*;
+
+/// Top-level application state
+#[derive(Clone, Debug, PartialEq)]
+struct AppState {
+    user: String,
+    count: i32,
+    stats: Stats,
+}
+
+/// Nested struct to demonstrate chained selects
+#[derive(Clone, Debug, PartialEq)]
+struct Stats {
+    cpu: f32,
+    mem: f32,
+}
+
+fn main() {
+    // A single signal holding the entire app state
+    let state = create_signal(AppState {
+        user: "Alice".into(),
+        count: 0,
+        stats: Stats { cpu: 0.0, mem: 0.0 },
+    });
+
+    // Derive field-level signals — each only updates when its field changes
+    let user = state.select(|s| &s.user);
+    let count = state.select(|s| &s.count);
+    let stats = state.select(|s| &s.stats);
+
+    // Chained select: state -> stats -> cpu
+    let cpu = stats.select(|s| &s.cpu);
+    let mem = stats.select(|s| &s.mem);
+
+    // Background service that simulates CPU/mem changes every second
+    let _ = create_service::<(), _>(move |_rx, ctx| {
+        let mut tick = 0u32;
+        while ctx.is_running() {
+            std::thread::sleep(Duration::from_secs(1));
+            tick += 1;
+
+            state.update(|s| {
+                // CPU/mem change every tick
+                s.stats.cpu = 10.0 + (tick as f32 * 0.7).sin() * 40.0;
+                s.stats.mem = 50.0 + (tick as f32 * 0.3).cos() * 20.0;
+            });
+        }
+    });
+
+    let users = ["Alice", "Bob", "Charlie", "Diana"];
+
+    let (app, _) = App::new().add_surface(
+        SurfaceConfig::new()
+            .height(80)
+            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+            .background_color(Color::rgb(0.1, 0.1, 0.15)),
+        move || {
+            container()
+                .layout(
+                    Flex::row()
+                        .spacing(12.0)
+                        .main_axis_alignment(MainAxisAlignment::Center)
+                        .cross_axis_alignment(CrossAxisAlignment::Center),
+                )
+                .padding(8.0)
+                // User display — only updates when user field changes
+                .child(
+                    container()
+                        .padding(12.0)
+                        .background(Color::rgb(0.2, 0.2, 0.35))
+                        .corner_radius(8.0)
+                        .child(text(move || format!("User: {}", user.get())).color(Color::WHITE)),
+                )
+                // Count display — only updates when count changes
+                .child(
+                    container()
+                        .padding(12.0)
+                        .background(Color::rgb(0.2, 0.3, 0.2))
+                        .corner_radius(8.0)
+                        .child(text(move || format!("Count: {}", count.get())).color(Color::WHITE)),
+                )
+                // CPU display — updates via chained select (state -> stats -> cpu)
+                .child(
+                    container()
+                        .padding(12.0)
+                        .background(Color::rgb(0.3, 0.2, 0.2))
+                        .corner_radius(8.0)
+                        .child(text(move || format!("CPU: {:.1}%", cpu.get())).color(Color::WHITE)),
+                )
+                // Mem display — updates via chained select (state -> stats -> mem)
+                .child(
+                    container()
+                        .padding(12.0)
+                        .background(Color::rgb(0.25, 0.2, 0.3))
+                        .corner_radius(8.0)
+                        .child(text(move || format!("Mem: {:.1}%", mem.get())).color(Color::WHITE)),
+                )
+                // Button: cycle user name (only user field changes)
+                .child(
+                    container()
+                        .padding(12.0)
+                        .background(Color::rgb(0.2, 0.3, 0.4))
+                        .corner_radius(8.0)
+                        .hover_state(|s| s.lighter(0.1))
+                        .pressed_state(|s| s.ripple())
+                        .on_click(move || {
+                            state.update(|s| {
+                                let idx = users
+                                    .iter()
+                                    .position(|u| *u == s.user)
+                                    .map(|i| (i + 1) % users.len())
+                                    .unwrap_or(0);
+                                s.user = users[idx].into();
+                            });
+                        })
+                        .child(text("Cycle User").color(Color::WHITE)),
+                )
+                // Button: increment count (only count field changes)
+                .child(
+                    container()
+                        .padding(12.0)
+                        .background(Color::rgb(0.3, 0.35, 0.2))
+                        .corner_radius(8.0)
+                        .hover_state(|s| s.lighter(0.1))
+                        .pressed_state(|s| s.ripple())
+                        .on_click(move || {
+                            state.update(|s| s.count += 1);
+                        })
+                        .child(text("+1 Count").color(Color::WHITE)),
+                )
+        },
+    );
+    app.run();
+}

--- a/src/reactive/invalidation.rs
+++ b/src/reactive/invalidation.rs
@@ -20,7 +20,8 @@
 
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
-use std::sync::{LazyLock, Mutex};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, LazyLock, Mutex};
 
 use crate::jobs::{JobRequest, JobType, request_job};
 use crate::tree::WidgetId;
@@ -81,6 +82,48 @@ struct Subscriber {
 static SIGNAL_SUBSCRIBERS: LazyLock<Mutex<HashMap<usize, HashSet<Subscriber>>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
+// ============================================================================
+// Signal Callbacks (for select() — field-level reactivity)
+// ============================================================================
+
+/// Unique ID for a registered signal callback
+pub(crate) type CallbackId = usize;
+
+/// A callback invoked when a signal changes.
+/// Wrapped in `Arc` so it can be cloned out of the lock before firing.
+type SignalCallback = Arc<dyn Fn() + Send + Sync>;
+
+/// Map from signal ID → list of (callback_id, callback)
+type CallbackMap = HashMap<usize, Vec<(CallbackId, SignalCallback)>>;
+static SIGNAL_CALLBACKS: LazyLock<Mutex<CallbackMap>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Monotonically increasing counter for callback IDs
+static NEXT_CALLBACK_ID: AtomicUsize = AtomicUsize::new(0);
+
+/// Register a callback that fires when a signal changes.
+/// Returns a `CallbackId` that can be used to unregister later.
+pub(crate) fn register_signal_callback(
+    signal_id: usize,
+    callback: impl Fn() + Send + Sync + 'static,
+) -> CallbackId {
+    let id = NEXT_CALLBACK_ID.fetch_add(1, Ordering::Relaxed);
+    SIGNAL_CALLBACKS
+        .lock()
+        .unwrap()
+        .entry(signal_id)
+        .or_default()
+        .push((id, Arc::new(callback)));
+    id
+}
+
+/// Remove a previously registered signal callback.
+pub(crate) fn unregister_signal_callback(signal_id: usize, callback_id: CallbackId) {
+    if let Some(callbacks) = SIGNAL_CALLBACKS.lock().unwrap().get_mut(&signal_id) {
+        callbacks.retain(|(id, _)| *id != callback_id);
+    }
+}
+
 /// Register a widget as a subscriber for a signal with a specific job type
 pub fn register_subscriber(widget_id: WidgetId, signal_id: usize, job_type: JobType) {
     SIGNAL_SUBSCRIBERS
@@ -114,11 +157,26 @@ pub fn notify_signal_change(signal_id: usize) {
         };
         request_job(sub.widget_id, request);
     }
+
+    // Fire signal callbacks (for select() derived signals).
+    // Clone Arc handles under the lock, then fire after releasing — prevents
+    // deadlock when a callback triggers cascading signal updates (which re-lock).
+    let callbacks: Vec<SignalCallback> = SIGNAL_CALLBACKS
+        .lock()
+        .unwrap()
+        .get(&signal_id)
+        .map(|cbs| cbs.iter().map(|(_, cb)| Arc::clone(cb)).collect())
+        .unwrap_or_default();
+
+    for cb in &callbacks {
+        cb();
+    }
 }
 
-/// Clear signal subscribers for a specific signal (when signal is disposed)
+/// Clear signal subscribers and callbacks for a specific signal (when signal is disposed)
 pub fn clear_signal_subscribers(signal_id: usize) {
     SIGNAL_SUBSCRIBERS.lock().unwrap().remove(&signal_id);
+    SIGNAL_CALLBACKS.lock().unwrap().remove(&signal_id);
 }
 
 /// Register a layout dependency: when the signal changes, the widget needs re-layout.

--- a/src/reactive/signal.rs
+++ b/src/reactive/signal.rs
@@ -1,7 +1,9 @@
 use std::marker::PhantomData;
 
-use super::invalidation::{notify_signal_change, record_signal_read};
-use super::owner::register_signal;
+use super::invalidation::{
+    notify_signal_change, record_signal_read, register_signal_callback, unregister_signal_callback,
+};
+use super::owner::{on_cleanup, register_signal};
 use super::runtime::{SignalId, try_with_runtime};
 use super::storage::{
     create_signal_value, get_signal_value, set_signal_value, update_signal_value, with_signal_value,
@@ -130,6 +132,51 @@ impl<T: Clone + PartialEq + Send + Sync + 'static> Signal<T> {
             },
         )
     }
+
+    /// Create a derived signal that tracks a specific field of this signal's value.
+    ///
+    /// The selector function borrows the parent value and returns a reference to
+    /// a field. The derived signal only updates (clones) when the selected field
+    /// actually changes, avoiding unnecessary clones of the entire parent object.
+    ///
+    /// This uses the invalidation system (global `Mutex`), NOT effects, so it
+    /// works correctly with background thread updates from `create_service`.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let data = create_signal(MyStruct { name: "Alice".into(), count: 0 });
+    /// let name: Signal<String> = data.select(|d| &d.name);
+    ///
+    /// // `name` only updates when the `name` field actually changes
+    /// data.update(|d| d.count += 1); // name signal NOT updated
+    /// data.update(|d| d.name = "Bob".into()); // name signal IS updated
+    /// ```
+    pub fn select<U, F>(&self, f: F) -> Signal<U>
+    where
+        U: Clone + PartialEq + Send + Sync + 'static,
+        F: Fn(&T) -> &U + Send + Sync + 'static,
+    {
+        let source = *self;
+        let derived = create_signal(self.with(|v| f(v).clone()));
+
+        let callback_id = register_signal_callback(source.id(), move || {
+            source.with(|parent| {
+                let field_ref: &U = f(parent);
+                let changed = derived.with_untracked(|current| current != field_ref);
+                if changed {
+                    derived.set(field_ref.clone());
+                }
+            });
+        });
+
+        let source_id = source.id();
+        on_cleanup(move || {
+            unregister_signal_callback(source_id, callback_id);
+        });
+
+        derived
+    }
 }
 
 /// Read-only handle to a signal.
@@ -169,6 +216,36 @@ impl<T: Clone + Send + Sync + 'static> ReadSignal<T> {
 
     pub fn with_untracked<R>(&self, f: impl FnOnce(&T) -> R) -> R {
         with_signal_value(self.id, f)
+    }
+}
+
+impl<T: Clone + PartialEq + Send + Sync + 'static> ReadSignal<T> {
+    /// Create a derived signal that tracks a specific field of this signal's value.
+    ///
+    /// See [`Signal::select()`] for full documentation.
+    pub fn select<U, F>(&self, f: F) -> Signal<U>
+    where
+        U: Clone + PartialEq + Send + Sync + 'static,
+        F: Fn(&T) -> &U + Send + Sync + 'static,
+    {
+        let source_id = self.id;
+        let derived = create_signal(self.with(|v| f(v).clone()));
+
+        let callback_id = register_signal_callback(source_id, move || {
+            with_signal_value(source_id, |parent: &T| {
+                let field_ref: &U = f(parent);
+                let changed = derived.with_untracked(|current| current != field_ref);
+                if changed {
+                    derived.set(field_ref.clone());
+                }
+            });
+        });
+
+        on_cleanup(move || {
+            unregister_signal_callback(source_id, callback_id);
+        });
+
+        derived
     }
 }
 
@@ -324,5 +401,104 @@ mod tests {
         let _copy2 = signal;
         // If Signal wasn't Copy, this wouldn't compile
         assert_eq!(signal.get(), 42);
+    }
+
+    // ================================================================
+    // select() tests
+    // ================================================================
+
+    #[derive(Clone, Debug, PartialEq)]
+    struct Inner {
+        value: i32,
+    }
+
+    #[derive(Clone, Debug, PartialEq)]
+    struct Outer {
+        name: String,
+        count: i32,
+        inner: Inner,
+    }
+
+    #[test]
+    fn test_select_returns_field_value() {
+        let source = create_signal(Outer {
+            name: "Alice".into(),
+            count: 0,
+            inner: Inner { value: 42 },
+        });
+        let name = source.select(|o| &o.name);
+        assert_eq!(name.get(), "Alice");
+    }
+
+    #[test]
+    fn test_select_updates_when_field_changes() {
+        let source = create_signal(Outer {
+            name: "Alice".into(),
+            count: 0,
+            inner: Inner { value: 42 },
+        });
+        let name = source.select(|o| &o.name);
+
+        source.update(|o| o.name = "Bob".into());
+        assert_eq!(name.get(), "Bob");
+    }
+
+    #[test]
+    fn test_select_no_update_when_field_unchanged() {
+        let source = create_signal(Outer {
+            name: "Alice".into(),
+            count: 0,
+            inner: Inner { value: 42 },
+        });
+        let name = source.select(|o| &o.name);
+        let count = source.select(|o| &o.count);
+
+        // Change only count — name should remain unchanged
+        source.update(|o| o.count += 1);
+        assert_eq!(name.get(), "Alice");
+        assert_eq!(count.get(), 1);
+
+        // Verify name signal ID hasn't changed (same derived signal)
+        let name_id = name.id();
+        source.update(|o| o.count += 1);
+        assert_eq!(name.id(), name_id);
+        assert_eq!(name.get(), "Alice");
+        assert_eq!(count.get(), 2);
+    }
+
+    #[test]
+    fn test_select_chaining() {
+        let source = create_signal(Outer {
+            name: "Alice".into(),
+            count: 0,
+            inner: Inner { value: 42 },
+        });
+        let inner = source.select(|o| &o.inner);
+        let value = inner.select(|i| &i.value);
+
+        assert_eq!(value.get(), 42);
+
+        source.update(|o| o.inner.value = 99);
+        assert_eq!(value.get(), 99);
+
+        // Changing unrelated field should not affect chained selects
+        source.update(|o| o.name = "Bob".into());
+        assert_eq!(value.get(), 99);
+    }
+
+    #[test]
+    fn test_select_on_read_signal() {
+        let source = create_signal(Outer {
+            name: "Alice".into(),
+            count: 0,
+            inner: Inner { value: 42 },
+        });
+        let (read, write) = source.split();
+
+        let name = read.select(|o| &o.name);
+        assert_eq!(name.get(), "Alice");
+
+        write.update(|o| o.name = "Bob".into());
+        assert_eq!(name.get(), "Bob");
     }
 }


### PR DESCRIPTION
## Summary

- Adds `Signal::select()` and `ReadSignal::select()` for deriving signals that track specific fields of a parent signal's value
- Field comparison happens in-place (no clone needed) — only clones when the selected field actually changed
- Uses the invalidation system (global `Mutex`), not effects (thread-local runtime), so it works correctly with background thread updates from `create_service`
- Supports chaining: `signal.select(|o| &o.inner).select(|i| &i.value)`

### User API

```rust
let data = create_signal(BigObject::default());
let items: Signal<Vec<Item>> = data.select(|obj| &obj.items);

// UI only updates when items actually changes — no unnecessary clones
container().child(text(move || format!("{} items", items.get().len())))
```

### Implementation

1. **`src/reactive/invalidation.rs`** — Signal callback registry (`register_signal_callback` / `unregister_signal_callback`), fired from `notify_signal_change()` after widget subscribers. Uses `Arc` wrapping so callbacks can be cloned out of the lock before firing (prevents deadlock from cascading updates).

2. **`src/reactive/signal.rs`** — `select()` on both `Signal<T>` and `ReadSignal<T>`. Registers a callback on the source signal that compares the field in-place and only calls `derived.set()` when changed. Cleanup via `on_cleanup`.

3. **`docs/REACTIVE.md`** and **`book/src/concepts/reactive-model.md`** — Documentation with examples.

## Test plan

- [x] `cargo build` compiles
- [x] `cargo fmt --all && cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test` — all 146 tests pass, including 5 new select tests:
  - `test_select_returns_field_value` — basic field extraction
  - `test_select_updates_when_field_changes` — derived updates on field change
  - `test_select_no_update_when_field_unchanged` — derived skips when other fields change
  - `test_select_chaining` — `signal.select().select()` works
  - `test_select_on_read_signal` — works on `ReadSignal<T>`