### PR TITLE
feat: render culling for scrollable containers

### DIFF
--- a/src/renderer/paint_context.rs
+++ b/src/renderer/paint_context.rs
@@ -55,12 +55,29 @@ use crate::widgets::{Color, Rect};
 pub struct PaintContext<'a> {
     /// The node being built
     node: &'a mut RenderNode,
+    /// Optional viewport rect for culling off-screen children.
+    /// Set by scrollable containers and propagated to descendants.
+    /// Coordinates are in this node's local space.
+    cull_rect: Option<Rect>,
 }
 
 impl<'a> PaintContext<'a> {
     /// Create a context for painting to a node.
     pub fn new(node: &'a mut RenderNode) -> Self {
-        Self { node }
+        Self {
+            node,
+            cull_rect: None,
+        }
+    }
+
+    /// Get the cull rect (viewport in this node's local space), if set by a scrollable ancestor.
+    pub fn cull_rect(&self) -> Option<Rect> {
+        self.cull_rect
+    }
+
+    /// Set the cull rect (viewport in this node's local space) for culling off-screen children.
+    pub fn set_cull_rect(&mut self, rect: Rect) {
+        self.cull_rect = Some(rect);
     }
 
     // -------------------------------------------------------------------------

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -1687,6 +1687,20 @@ impl Widget for Container {
                 Transform::translate(child_offset_x, child_offset_y)
             };
 
+            // Cull clean off-screen children in scrollable containers
+            if is_scrollable && !tree.needs_paint(child_id) {
+                let scrolled_rect = Rect::new(
+                    child_offset_x - self.scroll_state.offset_x,
+                    child_offset_y - self.scroll_state.offset_y,
+                    child_bounds.width,
+                    child_bounds.height,
+                );
+                if !local_bounds.intersects(&scrolled_rect) {
+                    crate::render_stats::record_paint_child_culled();
+                    continue;
+                }
+            }
+
             // Try cached paint for clean children
             if !tree.needs_paint(child_id)
                 && let Some(cached) = tree.cached_paint(child_id)

--- a/src/widgets/widget.rs
+++ b/src/widgets/widget.rs
@@ -83,6 +83,13 @@ impl Rect {
         }
     }
 
+    pub fn intersects(&self, other: &Rect) -> bool {
+        self.x < other.x + other.width
+            && self.x + self.width > other.x
+            && self.y < other.y + other.height
+            && self.y + self.height > other.y
+    }
+
     pub fn contains(&self, x: f32, y: f32) -> bool {
         x >= self.x && x < self.x + self.width && y >= self.y && y < self.y + self.height
     }


### PR DESCRIPTION
## Summary
- Skip painting clean off-screen children in scrollable containers, reducing per-frame paint/flatten cost from O(n) to O(visible)
- Dirty off-screen children are still painted to clear their `needs_paint` flag, preserving frame-skip correctness
- Add `Rect::intersects()` AABB intersection method and `paint_children_culled` render stat counter

## Test plan
- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test` — 153 tests pass
- [x] `cargo test --features render-stats` — 11 render stats tests pass (including updated reset test)
- [ ] Run `cargo run --example scroll_example` — verify scrolling works, no visual glitches
- [ ] Run with `--features render-stats` and verify culled counter shows off-screen items being skipped