### PR TITLE
feat: migrate service system from std threads to tokio async tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -700,6 +700,7 @@ dependencies = [
  "raw-window-handle",
  "resvg",
  "smithay-client-toolkit",
+ "tokio",
  "wayland-backend",
  "wgpu",
 ]
@@ -1736,6 +1737,27 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+dependencies = [
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "tracing"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,9 +47,11 @@ log = "0.4"
 env_logger = "0.11"
 bitflags = "2.4"
 libc = "0.2"
+tokio = { version = "1", features = ["sync", "rt", "time"] }
 
 [dev-dependencies]
 env_logger = "0.11"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 
 [[example]]
 name = "status_bar"

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -57,7 +57,7 @@
 - [Advanced Topics](advanced/README.md)
     - [Creating Components](advanced/components.md)
     - [Dynamic Children](advanced/dynamic-children.md)
-    - [Background Threads](advanced/background-threads.md)
+    - [Background Tasks](advanced/background-threads.md)
     - [Wayland Layer Shell](advanced/wayland.md)
 
 # Architecture

--- a/book/src/advanced/README.md
+++ b/book/src/advanced/README.md
@@ -6,7 +6,7 @@ This section covers advanced patterns for building complex Guido applications.
 
 - [Creating Components](components.md) - Reusable widgets with the `#[component]` macro
 - [Dynamic Children](dynamic-children.md) - Reactive lists and conditional rendering
-- [Background Threads](background-threads.md) - Integrating async operations
+- [Background Tasks](background-threads.md) - Integrating async operations
 - [Wayland Layer Shell](wayland.md) - Positioning and layer configuration
 
 ## When You Need These

--- a/book/src/concepts/reactive-model.md
+++ b/book/src/concepts/reactive-model.md
@@ -24,7 +24,7 @@ count.update(|c| *c += 1);
 ### Key Properties
 
 - **Copy** - Signals implement `Copy`, so you can use them in multiple closures without cloning
-- **Background updates** - Use `.writer()` to get a `WriteSignal<T>` for background thread updates
+- **Background updates** - Use `.writer()` to get a `WriteSignal<T>` for background task updates
 - **Automatic tracking** - Dependencies are tracked when reading inside reactive contexts
 
 ## Memos
@@ -235,11 +235,12 @@ pub fn on_cleanup(f: impl FnOnce() + 'static);
 ### Background Services
 
 ```rust
-// Create a background service with automatic cleanup
-pub fn create_service<Cmd, F>(f: F) -> Service<Cmd>
+// Create an async background service with automatic cleanup
+pub fn create_service<Cmd, F, Fut>(f: F) -> Service<Cmd>
 where
     Cmd: Send + 'static,
-    F: FnOnce(Receiver<Cmd>, ServiceContext) + Send + 'static;
+    F: FnOnce(UnboundedReceiver<Cmd>, ServiceContext) -> Fut + Send + 'static,
+    Fut: Future<Output = ()> + Send + 'static;
 ```
 
-See [Background Threads](../advanced/background-threads.md) for detailed usage.
+See [Background Tasks](../advanced/background-threads.md) for detailed usage.

--- a/examples/render_stats_test.rs
+++ b/examples/render_stats_test.rs
@@ -11,16 +11,17 @@
 
 use guido::prelude::*;
 
-fn main() {
+#[tokio::main]
+async fn main() {
     // Signal to drive rotation animation
     let rotation = create_signal(0.0f32);
 
     // Continuously update rotation to force frame rendering
     let rotation_w = rotation.writer();
-    let _ = create_service::<(), _>(move |_rx, ctx| {
+    let _ = create_service::<(), _, _>(move |_rx, ctx| async move {
         while ctx.is_running() {
             rotation_w.update(|r| *r += 1.0);
-            std::thread::sleep(std::time::Duration::from_millis(16)); // ~60fps
+            tokio::time::sleep(std::time::Duration::from_millis(16)).await; // ~60fps
         }
     });
 

--- a/examples/test_dynamic.rs
+++ b/examples/test_dynamic.rs
@@ -8,13 +8,14 @@ use std::time::Duration;
 
 static ADD_TRIGGERED: AtomicBool = AtomicBool::new(false);
 
-fn main() {
+#[tokio::main]
+async fn main() {
     let items = create_signal(vec![1u64, 2, 3]);
 
     // Create a service that adds an item after 2 seconds
     let items_w = items.writer();
-    let _ = create_service::<(), _>(move |_rx, ctx| {
-        std::thread::sleep(Duration::from_secs(2));
+    let _ = create_service::<(), _, _>(move |_rx, ctx| async move {
+        tokio::time::sleep(Duration::from_secs(2)).await;
         if ctx.is_running() && !ADD_TRIGGERED.swap(true, Ordering::SeqCst) {
             items_w.update(|list| {
                 list.push(4);

--- a/examples/text_transform_example.rs
+++ b/examples/text_transform_example.rs
@@ -13,19 +13,20 @@ use guido::prelude::*;
 use std::f32::consts::PI;
 use std::time::Duration;
 
-fn main() {
+#[tokio::main]
+async fn main() {
     // Animated rotation angle
     let angle = create_signal(0.0_f32);
 
     // Animation service - updates the angle signal continuously
     let start_time = std::time::Instant::now();
     let angle_w = angle.writer();
-    let _ = create_service::<(), _>(move |_rx, ctx| {
+    let _ = create_service::<(), _, _>(move |_rx, ctx| async move {
         while ctx.is_running() {
             let elapsed = start_time.elapsed().as_secs_f32();
             let new_angle = (elapsed * PI / 2.0).to_degrees() % 360.0;
             angle_w.set(new_angle);
-            std::thread::sleep(Duration::from_millis(16));
+            tokio::time::sleep(Duration::from_millis(16)).await;
         }
     });
 

--- a/examples/transform_origin_test.rs
+++ b/examples/transform_origin_test.rs
@@ -5,18 +5,19 @@
 use guido::prelude::*;
 use std::time::Duration;
 
-fn main() {
+#[tokio::main]
+async fn main() {
     let angle = create_signal(0.0_f32);
 
     // Animation service - updates the angle signal continuously
     let start_time = std::time::Instant::now();
     let angle_w = angle.writer();
-    let _ = create_service::<(), _>(move |_rx, ctx| {
+    let _ = create_service::<(), _, _>(move |_rx, ctx| async move {
         while ctx.is_running() {
             let elapsed = start_time.elapsed().as_secs_f32();
             let new_angle = (elapsed * 45.0) % 360.0; // 45 degrees per second
             angle_w.set(new_angle);
-            std::thread::sleep(Duration::from_millis(16));
+            tokio::time::sleep(Duration::from_millis(16)).await;
         }
     });
 

--- a/src/reactive/signal.rs
+++ b/src/reactive/signal.rs
@@ -205,10 +205,10 @@ impl<T: Clone + 'static> ReadSignal<T> {
 /// let time = create_signal(get_current_time());
 /// let time_w = time.writer();
 ///
-/// let _ = create_service::<(), _>(move |_rx, ctx| {
+/// let _ = create_service::<(), _, _>(move |_rx, ctx| async move {
 ///     while ctx.is_running() {
 ///         time_w.set(get_current_time()); // queued for main thread
-///         std::thread::sleep(Duration::from_secs(1));
+///         tokio::time::sleep(Duration::from_secs(1)).await;
 ///     }
 /// });
 /// ```


### PR DESCRIPTION
## Summary
- Replace `std::thread::spawn` with `tokio::spawn` and `std::sync::mpsc` with `tokio::sync::mpsc` for the `create_service` API
- Service closures now return a `Future`, enabling idiomatic async patterns (`tokio::select!`, `tokio::time::sleep().await`)
- Update all documentation (CLAUDE.md, docs/REACTIVE.md, book chapters) to reflect the new async API

## Test plan
- [x] All 148 tests pass (`cargo test`)
- [x] Clippy clean with `-D warnings`
- [x] Formatting clean (`cargo fmt --check`)
- [x] Book builds successfully (`mdbook build book`)
- [ ] CI checks pass