### PR TITLE
feat: add #[derive(SignalFields)] for per-field signal decomposition

### DIFF
--- a/book/src/concepts/reactive-model.md
+++ b/book/src/concepts/reactive-model.md
@@ -185,16 +185,6 @@ let count = create_signal(0);
 let doubled = create_memo(move || count.get() * 2);
 ```
 
-### Batch Updates
-
-When updating multiple signals, they naturally batch before the next render:
-
-```rust
-// Both updates happen before the next render
-first_name.set("John");
-last_name.set("Doe");
-```
-
 ## API Reference
 
 ### Signal Creation
@@ -221,7 +211,7 @@ impl<T: Clone> Signal<T> {
 ```rust
 impl<T: Clone + PartialEq> Memo<T> {
     pub fn get(&self) -> T;           // Read with tracking
-    pub fn get_untracked(&self) -> T; // Read without tracking
+    pub fn with<R>(&self, f: impl FnOnce(&T) -> R) -> R; // Borrow with tracking
 }
 ```
 

--- a/book/src/concepts/reactive-model.md
+++ b/book/src/concepts/reactive-model.md
@@ -146,7 +146,8 @@ let writers = state.writers();
 
 let _ = create_service::<(), _, _>(move |_rx, ctx| async move {
     while ctx.is_running() {
-        // Each field is set individually with PartialEq change detection
+        // Each field is set individually with PartialEq change detection.
+        // Effects that depend on multiple fields run only once (batched).
         writers.set(AppState {
             cpu: read_cpu(),
             memory: read_memory(),
@@ -155,6 +156,18 @@ let _ = create_service::<(), _, _>(move |_rx, ctx| async move {
         tokio::time::sleep(Duration::from_secs(1)).await;
     }
 });
+```
+
+Generic structs are supported — the generated types carry the same generic parameters:
+
+```rust
+#[derive(Clone, PartialEq, SignalFields)]
+pub struct Pair<A: Clone + PartialEq + Send + 'static, B: Clone + PartialEq + Send + 'static> {
+    pub first: A,
+    pub second: B,
+}
+
+let pair = PairSignals::new(Pair { first: 1i32, second: "hello".to_string() });
 ```
 
 ## Untracked Reads

--- a/docs/REACTIVE.md
+++ b/docs/REACTIVE.md
@@ -97,7 +97,19 @@ let _ = create_service::<(), _, _>(move |_rx, ctx| async move {
 });
 ```
 
-**Zero-clone decomposition:** `writers.set(state)` destructures the struct and moves each field into its signal. Each field's `set()` uses `PartialEq` to skip unchanged values — only the actually-changed widgets re-render.
+**Zero-clone decomposition:** `writers.set(state)` destructures the struct and moves each field into its signal. Each field's `set()` uses `PartialEq` to skip unchanged values — only the actually-changed widgets re-render. The call is batched so that shared effects (depending on multiple fields) run only once.
+
+**Generic structs** are supported — the generated types carry the same generic parameters:
+
+```rust
+#[derive(Clone, PartialEq, SignalFields)]
+pub struct Pair<A: Clone + PartialEq + Send + 'static, B: Clone + PartialEq + Send + 'static> {
+    pub first: A,
+    pub second: B,
+}
+
+let pair = PairSignals::new(Pair { first: 1i32, second: "hello".to_string() });
+```
 
 **When to use what:**
 - `Signal<T>` — single reactive value

--- a/docs/REACTIVE.md
+++ b/docs/REACTIVE.md
@@ -48,6 +48,62 @@ let label = create_memo(move || format!("Count: {}", count.get()));
 text(label)  // Only repaints when the formatted string changes
 ```
 
+### Per-Field Signals (`SignalFields`)
+
+When a `Signal<AppState>` changes, **all** subscribers re-render — even if only one field changed. The `#[derive(SignalFields)]` macro solves this by generating per-field signal decomposition with zero-clone updates.
+
+```rust
+use guido::prelude::*;
+
+#[derive(Clone, PartialEq, SignalFields)]
+pub struct AppState {
+    pub count: i32,
+    pub name: String,
+    pub items: Vec<Item>,
+}
+```
+
+This generates:
+- `AppStateSignals` — struct with `Signal<T>` per field (`Copy`)
+- `AppStateWriters` — struct with `WriteSignal<T>` per field (`Copy + Send`)
+
+**Usage:**
+
+```rust
+// Create per-field signals from initial values
+let state = AppStateSignals::new(AppState {
+    count: 0,
+    name: "foo".into(),
+    items: vec![],
+});
+
+// Widgets subscribe to individual signals — only re-render when their field changes
+text(move || format!("Count: {}", state.count.get()))  // ignores name/items changes
+text(move || state.name.get())                          // ignores count/items changes
+```
+
+**Background task integration:**
+
+```rust
+// Get writer handles (Send + Copy) for background services
+let writers = state.writers();
+
+let _ = create_service::<(), _, _>(move |_rx, ctx| async move {
+    while ctx.is_running() {
+        let new_state = fetch_state().await;
+        writers.set(new_state);  // Decomposes struct, sets each field individually
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+});
+```
+
+**Zero-clone decomposition:** `writers.set(state)` destructures the struct and moves each field into its signal. Each field's `set()` uses `PartialEq` to skip unchanged values — only the actually-changed widgets re-render.
+
+**When to use what:**
+- `Signal<T>` — single reactive value
+- `create_memo` — derived value from other signals
+- `#[derive(SignalFields)]` — struct with independently-changing fields (e.g., backend state with many independent pieces)
+
 ### Effects
 
 Side effects that re-run when tracked signals change:

--- a/docs/REACTIVE.md
+++ b/docs/REACTIVE.md
@@ -305,16 +305,6 @@ let count = create_signal(0);
 let doubled = create_memo(move || count.get() * 2);
 ```
 
-### Batch Updates
-
-When updating multiple related signals, the render will naturally batch:
-
-```rust
-// Both updates happen before the next render
-first_name.set("John");
-last_name.set("Doe");
-```
-
 ## Reactive Ownership (Resource Cleanup)
 
 Signals and effects persist in memory by default. The **reactive owner** system provides automatic cleanup when components are removed.
@@ -531,6 +521,6 @@ impl<T: Clone + Send> WriteSignal<T> {
 ```rust
 impl<T: Clone + PartialEq> Memo<T> {
     pub fn get(&self) -> T;           // Read with tracking
-    pub fn get_untracked(&self) -> T; // Read without tracking
+    pub fn with<R>(&self, f: impl FnOnce(&T) -> R) -> R; // Borrow with tracking
 }
 ```

--- a/docs/STATE_LAYER.md
+++ b/docs/STATE_LAYER.md
@@ -196,31 +196,6 @@ Ripples are rendered in the overlay layer (on top of text and other content). Th
 - Contract toward the release point when the mouse is released
 - Work correctly with transformed containers (rotated, scaled, translated)
 
-## Migration from Signal-Based Hover
-
-The state layer API replaces the older pattern of using signals for hover states:
-
-**Old pattern (deprecated):**
-```rust
-let hover_color = create_signal(Color::rgb(0.2, 0.2, 0.3));
-container()
-    .background(hover_color)
-    .on_hover(move |hovered| {
-        if hovered {
-            hover_color.set(Color::rgb(0.3, 0.3, 0.4));
-        } else {
-            hover_color.set(Color::rgb(0.2, 0.2, 0.3));
-        }
-    })
-```
-
-**New pattern (recommended):**
-```rust
-container()
-    .background(Color::rgb(0.2, 0.2, 0.3))
-    .hover_state(|s| s.lighter(0.1))
-    .pressed_state(|s| s.ripple())
-```
 
 Benefits of the new API:
 - Less boilerplate code

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ pub mod platform;
 pub mod renderer;
 
 // Re-export macros
-pub use guido_macros::component;
+pub use guido_macros::{SignalFields, component};
 
 use std::cell::RefCell;
 
@@ -85,7 +85,7 @@ pub mod prelude {
         ScrollbarVisibility, Selection, StateStyle, Text, TextInput, Widget, container, image,
         text, text_input,
     };
-    pub use crate::{App, component, default_font_family, set_default_font_family};
+    pub use crate::{App, SignalFields, component, default_font_family, set_default_font_family};
 }
 
 use smithay_client_toolkit::reexports::client::{Connection, QueueHandle};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,9 +68,8 @@ pub mod prelude {
     };
     pub use crate::platform::{Anchor, KeyboardInteractivity, Layer};
     pub use crate::reactive::{
-        CursorIcon, Effect, IntoMaybeDyn, MaybeDyn, Memo, ReadSignal, Service, ServiceContext,
-        Signal, WriteSignal, batch, create_effect, create_memo, create_service, create_signal,
-        on_cleanup, set_cursor,
+        CursorIcon, Memo, Service, Signal, WriteSignal, create_effect, create_memo, create_service,
+        create_signal, on_cleanup, set_cursor,
     };
     pub use crate::renderer::{PaintContext, Shadow, measure_text};
     pub use crate::surface::{

--- a/src/reactive/invalidation.rs
+++ b/src/reactive/invalidation.rs
@@ -139,20 +139,3 @@ pub fn notify_signal_change(signal_id: usize) {
 pub fn clear_signal_subscribers(signal_id: usize) {
     SIGNAL_SUBSCRIBERS.lock().unwrap().remove(&signal_id);
 }
-
-/// Notify all layout subscribers of a signal that it has changed.
-/// Called from Signal::set() and Signal::update().
-///
-/// This function now calls notify_signal_change which pushes jobs to the
-/// pending queue. The main loop calls `process_pending_jobs()` to process them.
-///
-/// This is kept for backward compatibility - new code should use notify_signal_change.
-pub fn notify_layout_subscribers(signal_id: usize) {
-    notify_signal_change(signal_id);
-}
-
-/// Clear layout subscribers for a specific signal (when signal is disposed)
-/// This is an alias for clear_signal_subscribers for backward compatibility.
-pub fn clear_layout_subscribers(signal_id: usize) {
-    clear_signal_subscribers(signal_id);
-}

--- a/src/reactive/maybe_dyn.rs
+++ b/src/reactive/maybe_dyn.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-use super::signal::{ReadSignal, Signal};
+use super::signal::Signal;
 
 /// A value that can be either static or dynamic (reactive).
 /// This allows widget properties to accept both plain values and signals.
@@ -109,12 +109,6 @@ where
 // ============================================================================
 
 impl<T: Clone + 'static> IntoMaybeDyn<T> for Signal<T> {
-    fn into_maybe_dyn(self) -> MaybeDyn<T> {
-        MaybeDyn::Dynamic(Rc::new(move || self.get()))
-    }
-}
-
-impl<T: Clone + 'static> IntoMaybeDyn<T> for ReadSignal<T> {
     fn into_maybe_dyn(self) -> MaybeDyn<T> {
         MaybeDyn::Dynamic(Rc::new(move || self.get()))
     }

--- a/src/reactive/memo.rs
+++ b/src/reactive/memo.rs
@@ -6,10 +6,9 @@ use super::signal::{Signal, create_signal};
 
 /// Eager computed value that recomputes immediately when dependencies change.
 ///
-/// Unlike lazy `Computed<T>`, a `Memo<T>` updates eagerly whenever any
-/// dependency signal changes. It only notifies downstream subscribers when
-/// the computed result actually differs (`PartialEq`), which prevents
-/// unnecessary repaints/relayouts.
+/// A `Memo<T>` updates eagerly whenever any dependency signal changes.
+/// It only notifies downstream subscribers when the computed result actually
+/// differs (`PartialEq`), which prevents unnecessary repaints/relayouts.
 ///
 /// `Memo<T>` is `Copy` (like `Signal<T>`) and can be used directly as a
 /// widget property via `IntoMaybeDyn`.

--- a/src/reactive/memo.rs
+++ b/src/reactive/memo.rs
@@ -71,19 +71,9 @@ impl<T: Clone + PartialEq + Send + 'static> Memo<T> {
         self.signal.get()
     }
 
-    /// Get the current memo value without tracking as a dependency.
-    pub fn get_untracked(&self) -> T {
-        self.signal.get_untracked()
-    }
-
     /// Borrow the current value (tracked for dependency tracking).
     pub fn with<R>(&self, f: impl FnOnce(&T) -> R) -> R {
         self.signal.with(f)
-    }
-
-    /// Get the underlying signal ID.
-    pub fn id(&self) -> usize {
-        self.signal.id()
     }
 }
 
@@ -111,13 +101,6 @@ mod tests {
         let memo2 = memo; // Copy
         assert_eq!(memo.get(), 1);
         assert_eq!(memo2.get(), 1);
-    }
-
-    #[test]
-    fn test_memo_get_untracked() {
-        let signal = create_signal(42);
-        let memo = create_memo(move || signal.get());
-        assert_eq!(memo.get_untracked(), 42);
     }
 
     #[test]

--- a/src/reactive/mod.rs
+++ b/src/reactive/mod.rs
@@ -11,17 +11,14 @@ pub mod service;
 pub mod signal;
 pub mod storage;
 
-pub use clipboard::{
-    clear_system_clipboard, clipboard_copy, clipboard_has_content, clipboard_paste,
-    request_clipboard_read, set_system_clipboard, take_clipboard_change,
-    take_clipboard_read_request,
+pub(crate) use clipboard::{
+    clipboard_copy, clipboard_paste, set_system_clipboard, take_clipboard_change,
 };
-pub use cursor::{CursorIcon, get_current_cursor, set_cursor, take_cursor_change};
+pub(crate) use cursor::take_cursor_change;
+pub use cursor::{CursorIcon, set_cursor};
 pub use effect::{Effect, create_effect};
-pub use focus::{clear_focus, focused_widget, has_focus, release_focus, request_focus};
-pub use invalidation::{
-    notify_signal_change, record_signal_read, register_subscriber, with_signal_tracking,
-};
+pub(crate) use focus::{focused_widget, has_focus, release_focus, request_focus};
+pub(crate) use invalidation::with_signal_tracking;
 pub use maybe_dyn::{IntoMaybeDyn, MaybeDyn};
 pub use memo::{Memo, create_memo};
 // Only on_cleanup is public API - with_owner, dispose_owner, and OwnerId are
@@ -35,6 +32,6 @@ pub(crate) use owner::{OwnerId, dispose_owner, with_owner};
 pub mod __internal {
     pub use super::owner::{OwnerId, dispose_owner, with_owner};
 }
-pub use runtime::{batch, flush_bg_writes};
+pub(crate) use runtime::flush_bg_writes;
 pub use service::{Service, ServiceContext, create_service};
-pub use signal::{ReadSignal, Signal, WriteSignal, create_signal};
+pub use signal::{Signal, WriteSignal, create_signal};

--- a/src/reactive/mod.rs
+++ b/src/reactive/mod.rs
@@ -31,6 +31,7 @@ pub(crate) use owner::{OwnerId, dispose_owner, with_owner};
 #[doc(hidden)]
 pub mod __internal {
     pub use super::owner::{OwnerId, dispose_owner, with_owner};
+    pub use super::runtime::batch;
 }
 pub(crate) use runtime::flush_bg_writes;
 pub use service::{Service, ServiceContext, create_service};

--- a/src/reactive/runtime.rs
+++ b/src/reactive/runtime.rs
@@ -15,12 +15,6 @@
 //! the effect's dependencies. When any dependency changes, the effect is scheduled
 //! to re-run.
 //!
-//! ## Batching
-//!
-//! The [`batch()`] function allows multiple signal updates to be grouped together,
-//! deferring effect execution until the batch completes. This prevents unnecessary
-//! intermediate re-renders.
-//!
 //! ## Usage
 //!
 //! Most code should use the higher-level APIs in the `reactive` module rather than
@@ -332,11 +326,4 @@ where
         }
         // If borrow fails (already borrowed), skip - this can happen during effect execution
     });
-}
-
-pub fn batch<F, R>(f: F) -> R
-where
-    F: FnOnce() -> R,
-{
-    with_runtime(|rt| rt.batch(f))
 }

--- a/src/widgets/into_child.rs
+++ b/src/widgets/into_child.rs
@@ -15,7 +15,7 @@ pub struct DynamicChild;
 /// - Static widgets (evaluated once at creation) - uses `StaticChild` marker
 /// - Dynamic closures returning `Option<Widget>` (reactive) - uses `DynamicChild` marker
 ///
-/// The marker parameter defaults to `StaticChild` for backwards compatibility.
+/// The marker parameter defaults to `StaticChild` so `.child(widget)` works without annotation.
 pub trait IntoChild<Marker = StaticChild> {
     fn add_to_container(self, children_source: &mut ChildrenSource);
 }
@@ -67,7 +67,7 @@ pub struct DynamicChildren;
 /// - Static children (iterator of widgets) - uses `StaticChildren` marker
 /// - Dynamic children (closure returning keyed items) - uses `DynamicChildren` marker
 ///
-/// The marker parameter defaults to `StaticChildren` for backwards compatibility.
+/// The marker parameter defaults to `StaticChildren` so `.children([...])` works without annotation.
 pub trait IntoChildren<Marker = StaticChildren> {
     fn add_to_container(self, children_source: &mut ChildrenSource);
 }

--- a/tests/signal_fields.rs
+++ b/tests/signal_fields.rs
@@ -1,0 +1,112 @@
+use guido::SignalFields;
+
+#[derive(Clone, PartialEq, SignalFields)]
+struct TestState {
+    count: i32,
+    name: String,
+}
+
+#[test]
+fn test_signal_fields_creation() {
+    let signals = TestStateSignals::new(TestState {
+        count: 0,
+        name: "test".into(),
+    });
+    assert_eq!(signals.count.get(), 0);
+    assert_eq!(signals.name.get(), "test");
+}
+
+#[test]
+fn test_writers_set_decomposes() {
+    let signals = TestStateSignals::new(TestState {
+        count: 0,
+        name: "a".into(),
+    });
+    let writers = signals.writers();
+    writers.set(TestState {
+        count: 5,
+        name: "a".into(),
+    });
+    assert_eq!(signals.count.get(), 5);
+    assert_eq!(signals.name.get(), "a");
+}
+
+#[test]
+fn test_writers_are_send() {
+    fn assert_send<T: Send>() {}
+    assert_send::<TestStateWriters>();
+}
+
+#[test]
+fn test_signals_are_copy() {
+    fn assert_copy<T: Copy>() {}
+    assert_copy::<TestStateSignals>();
+}
+
+#[test]
+fn test_individual_field_update() {
+    let signals = TestStateSignals::new(TestState {
+        count: 10,
+        name: "hello".into(),
+    });
+
+    // Update only count via its signal directly
+    signals.count.set(20);
+    assert_eq!(signals.count.get(), 20);
+    assert_eq!(signals.name.get(), "hello"); // unchanged
+}
+
+#[test]
+fn test_writers_copy() {
+    let signals = TestStateSignals::new(TestState {
+        count: 0,
+        name: "x".into(),
+    });
+    let w1 = signals.writers();
+    let w2 = w1; // Copy
+    w2.set(TestState {
+        count: 42,
+        name: "y".into(),
+    });
+    assert_eq!(signals.count.get(), 42);
+    assert_eq!(signals.name.get(), "y");
+    // w1 is still usable (Copy)
+    let _ = w1;
+}
+
+// Test with pub visibility
+#[derive(Clone, PartialEq, SignalFields)]
+pub struct PubState {
+    pub value: u32,
+}
+
+#[test]
+fn test_pub_visibility() {
+    let signals = PubStateSignals::new(PubState { value: 99 });
+    assert_eq!(signals.value.get(), 99);
+}
+
+// Test with Vec field
+#[derive(Clone, PartialEq, SignalFields)]
+struct VecState {
+    items: Vec<String>,
+    count: usize,
+}
+
+#[test]
+fn test_vec_field() {
+    let signals = VecStateSignals::new(VecState {
+        items: vec!["a".into(), "b".into()],
+        count: 2,
+    });
+    assert_eq!(signals.items.get(), vec!["a".to_string(), "b".to_string()]);
+    assert_eq!(signals.count.get(), 2);
+
+    let writers = signals.writers();
+    writers.set(VecState {
+        items: vec!["c".into()],
+        count: 1,
+    });
+    assert_eq!(signals.items.get(), vec!["c".to_string()]);
+    assert_eq!(signals.count.get(), 1);
+}


### PR DESCRIPTION
## Summary

- Adds `#[derive(SignalFields)]` proc macro that generates `{Name}Signals` and `{Name}Writers` companion structs from a struct, enabling independent per-field signal subscriptions instead of whole-struct reactivity
- Each field becomes its own `Signal<T>` / `WriteSignal<T>`, so widgets only re-render when the specific field they read changes
- `writers.set(state)` destructures the struct and moves each field into its signal with `PartialEq` dedup — zero clones in the decomposition layer

## Test plan

- [x] 8 integration tests covering creation, decomposition, `Send`/`Copy` bounds, pub visibility, and Vec fields
- [x] All 148 existing unit tests pass
- [x] `cargo fmt --all && cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] Verified in ashell-guido: `CompositorState` and `SystemInfoData` migrated to `SignalFields`, compiles and passes clippy