### PR TITLE
feat: add #[prop(slot)] support to component macro

### DIFF
--- a/book/src/advanced/components.md
+++ b/book/src/advanced/components.md
@@ -135,6 +135,47 @@ card()
     .child(text("Second child"))
 ```
 
+## Slot Props
+
+Slots let a component accept named widget positions — useful for layout components
+like headers, sidebars, or multi-region containers:
+
+```rust
+#[component]
+pub struct CenterBox {
+    #[prop(slot)]
+    left: (),
+    #[prop(slot)]
+    center: (),
+    #[prop(slot)]
+    right: (),
+}
+
+impl CenterBox {
+    fn render(&self) -> impl Widget {
+        container()
+            .layout(Flex::row())
+            .children(vec![
+                self.take_left(),
+                self.take_center(),
+                self.take_right(),
+            ].into_iter().flatten())
+    }
+}
+```
+
+Use with the auto-generated builder methods:
+
+```rust
+center_box()
+    .left(text("Left"))
+    .center(text("Center"))
+    .right(text("Right"))
+```
+
+Each slot accepts any `impl Widget + 'static`. Inside `render`, call `self.take_<name>()`
+to consume the slot — it returns `Option<Box<dyn Widget>>`.
+
 ## Reactive Props
 
 Props accept signals and closures:

--- a/guido-macros/src/lib.rs
+++ b/guido-macros/src/lib.rs
@@ -9,6 +9,7 @@ use syn::{DeriveInput, Fields, ItemStruct, Meta, Type, parse_macro_input};
 /// - `#[prop(default = "expr")]` - Prop with default value
 /// - `#[prop(callback)]` - Generates callback accepting `impl Fn() + 'static`
 /// - `#[prop(children)]` - Marks field for children support
+/// - `#[prop(slot)]` - Named widget slot, generates `RefCell<Option<Box<dyn Widget>>>` with builder and `take_` accessor
 ///
 /// # Example
 /// ```ignore

--- a/src/widgets/widget.rs
+++ b/src/widgets/widget.rs
@@ -417,6 +417,30 @@ pub trait Widget {
     fn register_children(&mut self, _tree: &mut Tree, _id: WidgetId) {}
 }
 
+impl Widget for Box<dyn Widget> {
+    fn advance_animations(&mut self, tree: &mut Tree, id: WidgetId) -> bool {
+        (**self).advance_animations(tree, id)
+    }
+    fn reconcile_children(&mut self, tree: &mut Tree, id: WidgetId) -> bool {
+        (**self).reconcile_children(tree, id)
+    }
+    fn layout(&mut self, tree: &mut Tree, id: WidgetId, constraints: Constraints) -> Size {
+        (**self).layout(tree, id, constraints)
+    }
+    fn paint(&self, tree: &Tree, id: WidgetId, ctx: &mut PaintContext) {
+        (**self).paint(tree, id, ctx)
+    }
+    fn event(&mut self, tree: &mut Tree, id: WidgetId, event: &Event) -> EventResponse {
+        (**self).event(tree, id, event)
+    }
+    fn has_focus_descendant(&self, tree: &Tree, id: WidgetId) -> bool {
+        (**self).has_focus_descendant(tree, id)
+    }
+    fn register_children(&mut self, tree: &mut Tree, id: WidgetId) {
+        (**self).register_children(tree, id)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary
- Add `#[prop(slot)]` attribute for declaring named widget slots in `#[component]` structs
- Add `impl Widget for Box<dyn Widget>` so boxed widgets can be used as container children
- Slots generate `RefCell<Option<Box<dyn Widget>>>` fields with builder methods and `take_` accessors

This enables clean APIs like:
```rust
#[component]
pub struct CenterBox {
    #[prop(slot)]
    left: (),
    #[prop(slot)]
    center: (),
    #[prop(slot)]
    right: (),
}
```
replacing ~50 lines of manual `Widget` impl delegation boilerplate.

## Test plan
- [x] `cargo build` passes in guido
- [x] `cargo clippy` clean
- [x] Verified end-to-end in ashell-guido with CenterBox using `#[prop(slot)]`