### PR TITLE
fix: prefer PreMultiplied alpha mode for transparent surfaces

### DIFF
--- a/src/renderer/gpu_context.rs
+++ b/src/renderer/gpu_context.rs
@@ -96,9 +96,15 @@ impl GpuContext {
             present_mode: wgpu::PresentMode::Fifo,
             alpha_mode: caps
                 .alpha_modes
-                .first()
+                .iter()
+                .find(|m| **m == wgpu::CompositeAlphaMode::PreMultiplied)
                 .copied()
-                .unwrap_or(wgpu::CompositeAlphaMode::Auto),
+                .unwrap_or_else(|| {
+                    caps.alpha_modes
+                        .first()
+                        .copied()
+                        .unwrap_or(wgpu::CompositeAlphaMode::Auto)
+                }),
             view_formats: vec![],
             desired_maximum_frame_latency: 2,
         };


### PR DESCRIPTION
## Summary
- Prefer `CompositeAlphaMode::PreMultiplied` when available for surface configuration
- Falls back to previous behavior (first available mode) if PreMultiplied is not supported

The previous code picked `caps.alpha_modes.first()`, which on Wayland is typically `Opaque`. This caused surfaces configured with `background_color(Color::TRANSPARENT)` to render with a black background instead of being transparent.

## Test plan
- [x] `cargo build` / `cargo clippy` clean
- [ ] Run ashell-guido with `Color::TRANSPARENT` background — bar should be transparent