### PR TITLE
feat: add load_font() API for embedding custom fonts

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ use smithay_client_toolkit::reexports::calloop_wayland_source::WaylandSource;
 // Thread-local storage for the default font family
 thread_local! {
     static DEFAULT_FONT_FAMILY: RefCell<FontFamily> = const { RefCell::new(FontFamily::SansSerif) };
+    static CUSTOM_FONTS: RefCell<Vec<Vec<u8>>> = const { RefCell::new(Vec::new()) };
 }
 
 /// Set the application-wide default font family.
@@ -59,6 +60,30 @@ pub fn set_default_font_family(family: FontFamily) {
 /// Get the current application-wide default font family.
 pub fn default_font_family() -> FontFamily {
     DEFAULT_FONT_FAMILY.with(|f| f.borrow().clone())
+}
+
+/// Load custom font data into the application.
+///
+/// The font bytes will be loaded into all internal FontSystem instances,
+/// making the font available for use via `FontFamily::Name(...)`.
+///
+/// This should be called before creating any widgets or surfaces.
+///
+/// # Example
+///
+/// ```ignore
+/// const NERD_FONT: &[u8] = include_bytes!("../assets/MyFont.ttf");
+/// guido::load_font(NERD_FONT.to_vec());
+/// ```
+pub fn load_font(data: Vec<u8>) {
+    CUSTOM_FONTS.with(|fonts| {
+        fonts.borrow_mut().push(data);
+    });
+}
+
+/// Get clones of all registered custom font data (for loading into FontSystems).
+pub(crate) fn registered_fonts() -> Vec<Vec<u8>> {
+    CUSTOM_FONTS.with(|fonts| fonts.borrow().clone())
 }
 
 pub mod prelude {
@@ -85,7 +110,9 @@ pub mod prelude {
         ScrollbarVisibility, Selection, StateStyle, Text, TextInput, Widget, container, image,
         text, text_input,
     };
-    pub use crate::{App, SignalFields, component, default_font_family, set_default_font_family};
+    pub use crate::{
+        App, SignalFields, component, default_font_family, load_font, set_default_font_family,
+    };
 }
 
 use smithay_client_toolkit::reexports::client::{Connection, QueueHandle};

--- a/src/renderer/text.rs
+++ b/src/renderer/text.rs
@@ -23,7 +23,10 @@ pub struct TextRenderState {
 
 impl TextRenderState {
     pub fn new(device: &Device, queue: &Queue, format: wgpu::TextureFormat) -> Self {
-        let font_system = FontSystem::new();
+        let mut font_system = FontSystem::new();
+        for data in crate::registered_fonts() {
+            font_system.db_mut().load_font_data(data);
+        }
         let swash_cache = SwashCache::new();
         let cache = Cache::new(device);
         let mut atlas = TextAtlas::new(device, queue, &cache, format);

--- a/src/renderer/text.rs
+++ b/src/renderer/text.rs
@@ -24,8 +24,10 @@ pub struct TextRenderState {
 impl TextRenderState {
     pub fn new(device: &Device, queue: &Queue, format: wgpu::TextureFormat) -> Self {
         let mut font_system = FontSystem::new();
-        for data in crate::registered_fonts() {
-            font_system.db_mut().load_font_data(data);
+        for data in crate::take_registered_fonts() {
+            font_system
+                .db_mut()
+                .load_font_source(glyphon::fontdb::Source::Binary(data));
         }
         let swash_cache = SwashCache::new();
         let cache = Cache::new(device);

--- a/src/renderer/text_measurer.rs
+++ b/src/renderer/text_measurer.rs
@@ -23,8 +23,10 @@ pub struct TextMeasurer {
 impl TextMeasurer {
     pub fn new() -> Self {
         let mut font_system = FontSystem::new();
-        for data in crate::registered_fonts() {
-            font_system.db_mut().load_font_data(data);
+        for data in crate::take_registered_fonts() {
+            font_system
+                .db_mut()
+                .load_font_source(cosmic_text::fontdb::Source::Binary(data));
         }
         Self {
             font_system,

--- a/src/renderer/text_measurer.rs
+++ b/src/renderer/text_measurer.rs
@@ -22,8 +22,12 @@ pub struct TextMeasurer {
 
 impl TextMeasurer {
     pub fn new() -> Self {
+        let mut font_system = FontSystem::new();
+        for data in crate::registered_fonts() {
+            font_system.db_mut().load_font_data(data);
+        }
         Self {
-            font_system: FontSystem::new(),
+            font_system,
             measure_cache: HashMap::new(),
         }
     }

--- a/src/renderer/text_quad.rs
+++ b/src/renderer/text_quad.rs
@@ -71,8 +71,10 @@ impl TextQuadRenderer {
     pub fn new(device: &Device, queue: &Queue, format: TextureFormat) -> Self {
         // Initialize text rendering components
         let mut font_system = FontSystem::new();
-        for data in crate::registered_fonts() {
-            font_system.db_mut().load_font_data(data);
+        for data in crate::take_registered_fonts() {
+            font_system
+                .db_mut()
+                .load_font_source(glyphon::fontdb::Source::Binary(data));
         }
         let swash_cache = SwashCache::new();
         let cache = Cache::new(device);

--- a/src/renderer/text_quad.rs
+++ b/src/renderer/text_quad.rs
@@ -70,7 +70,10 @@ pub struct TextQuadRenderer {
 impl TextQuadRenderer {
     pub fn new(device: &Device, queue: &Queue, format: TextureFormat) -> Self {
         // Initialize text rendering components
-        let font_system = FontSystem::new();
+        let mut font_system = FontSystem::new();
+        for data in crate::registered_fonts() {
+            font_system.db_mut().load_font_data(data);
+        }
         let swash_cache = SwashCache::new();
         let cache = Cache::new(device);
         let mut atlas = TextAtlas::new(device, queue, &cache, format);


### PR DESCRIPTION
## Summary
- Add `load_font(Vec<u8>)` public API for embedding custom fonts (e.g., Nerd Fonts via `include_bytes!`)
- Font data stored as `Arc<Vec<u8>>` and shared zero-copy across all 3 `FontSystem` instances via `load_font_source(Source::Binary(arc))` — avoids 3 multi-MB deep copies per font
- `take_registered_fonts()` drains storage after initialization so Arc pointers are released (font data stays alive in FontSystems)
- `log::warn!` if `load_font()` is called after FontSystems have been created
- Exported in prelude

## Test plan
- [x] `cargo build` compiles clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test` — all 146 tests pass
- [ ] Run `cargo run --example status_bar` to verify fonts render correctly