### PR TITLE
fix: distribute remaining space to fill() children in Flex layout

### DIFF
--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -1013,6 +1013,9 @@ impl Widget for Container {
                 )
             });
 
+        // Record fill intent so parent Flex layout can distribute remaining space
+        tree.set_fills(id, width_length.fill, height_length.fill);
+
         // Calculate current container dimensions
         let current_width = if let Some(ref anim) = self.width_anim {
             if anim.is_initial() {


### PR DESCRIPTION
## Summary

- The Flex layout previously gave all children `max_width: main_max` in a single pass, so `container().width(fill())` expanded to the full row width instead of taking remaining space after fixed-size siblings
- Container now records fill intent (`fills_width`/`fills_height`) in the Tree during layout
- Flex reads these flags after the first measurement pass and re-measures fill children with `remaining_space / fill_count`

## Test plan

- [ ] `cargo build` passes
- [ ] Verify with ashell-guido: a `fill()` spacer in a Flex row properly takes remaining space (e.g., `[icon, label, fill_spacer, value]` stays within container bounds)