### PR TITLE
fix: resolve multi-surface render delay

### DIFF
--- a/src/surface.rs
+++ b/src/surface.rs
@@ -301,6 +301,7 @@ fn push_surface_command(cmd: SurfaceCommand) {
     SURFACE_COMMANDS.with(|cmds| {
         cmds.borrow_mut().push(cmd);
     });
+    crate::jobs::request_frame();
 }
 
 /// Drain all pending surface commands. Called by the main event loop.


### PR DESCRIPTION
## Summary
- Surface commands (`SetLayer`, `SetSize`, etc.) now call `request_frame()` to wake the event loop immediately, fixing delays when showing menus on overlay surfaces
- `take_frame_request()` moved from per-surface to once-before-all-surfaces, preventing the first surface from consuming the flag and starving subsequent surfaces
- Added `tree.needs_paint()` to the render guard so surfaces with pending paint from signal changes render without needing a frame request

## Test plan
- [ ] Verify menu opens immediately on click (no delay)
- [ ] Verify hover effects work on system_info buttons
- [ ] Verify dynamic surface property changes (layer, size, anchor) take effect promptly
- [ ] Verify animations still play smoothly