### PR TITLE
fix: reactive system improvements (subscriber leak, Mutex removal, dead code, O(1) dedup)

### DIFF
--- a/src/reactive/owner.rs
+++ b/src/reactive/owner.rs
@@ -37,6 +37,7 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
 
+use super::invalidation::clear_signal_subscribers;
 use super::runtime::{EffectId, SignalId, with_runtime};
 use super::storage::dispose_signal;
 
@@ -196,8 +197,9 @@ pub fn dispose_owner(id: OwnerId) {
         with_runtime(|rt| rt.dispose_effect(effect_id));
     }
 
-    // Dispose signals
+    // Dispose signals (clear subscribers first to prevent stale notifications)
     for signal_id in owner.signals {
+        clear_signal_subscribers(signal_id);
         dispose_signal(signal_id);
     }
 }

--- a/src/reactive/signal.rs
+++ b/src/reactive/signal.rs
@@ -9,10 +9,9 @@ use super::storage::{
 };
 
 /// Common read operations for signal types.
-/// Tracks reads for effect dependencies and layout invalidation.
+/// Tracks reads for effect dependencies and widget invalidation.
 fn tracked_get<T: Clone + 'static>(id: SignalId) -> T {
     record_effect_read(id);
-    try_with_runtime(|rt| rt.track_read(id));
     record_signal_read(id);
     get_signal_value(id)
 }
@@ -20,7 +19,6 @@ fn tracked_get<T: Clone + 'static>(id: SignalId) -> T {
 /// Common read-with-borrow operation for signal types.
 fn tracked_with<T: 'static, R>(id: SignalId, f: impl FnOnce(&T) -> R) -> R {
     record_effect_read(id);
-    try_with_runtime(|rt| rt.track_read(id));
     record_signal_read(id);
     with_signal_value(id, f)
 }


### PR DESCRIPTION
## Summary

- **Fix widget subscriber memory leak**: When widgets are unregistered or signals disposed, their entries in `SIGNAL_SUBSCRIBERS` are now cleaned up. `clear_widget_subscribers(widget_id)` removes a widget from all signal subscriber sets; `clear_signal_subscribers(signal_id)` is called before `dispose_signal()` in `dispose_owner()`. Without this, apps with dynamic children had unbounded memory growth and wasted job creation for stale widget IDs.

- **Remove Mutex from signal read hot path**: `SIGNAL_SUBSCRIBERS` was `LazyLock<Mutex<HashMap>>`, but all access is on the main thread (background writes go through `queue_bg_write()` → `flush_bg_writes()`). Replaced with `thread_local! { RefCell<HashMap> }` to eliminate unnecessary lock contention on every `signal.get()`.

- **Remove dead `track_read` calls**: `try_with_runtime(|rt| rt.track_read(id))` in `tracked_get`/`tracked_with` was dead code — during effect execution the Runtime RefCell is already borrowed (so `try_borrow_mut()` fails silently), and outside effects `current_effect` is `None` (so `track_read()` is a no-op). Removed the dead method and calls. Signal reads now do 2 operations instead of 3.

- **O(1) job dedup**: Replaced `Vec::contains()` (O(n) per push, O(N²) for N subscribers) with a `JobQueue` struct using `HashSet` for O(1) dedup + `Vec` for ordered iteration.

## Test plan

- [x] All 152 existing + new tests pass (`cargo test`)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] New tests for `clear_signal_subscribers`, `clear_widget_subscribers`, and signal tracking registration
- [ ] `cargo run --example reactive_example` — verify reactive behavior
- [ ] `cargo run --example status_bar` — verify rendering