### PR TITLE
feat: add visibility toggle to Container widget

### DIFF
--- a/book/src/concepts/container.md
+++ b/book/src/concepts/container.md
@@ -132,6 +132,24 @@ container()
 
 See [Animations](../animations/README.md) for timing and spring options.
 
+## Visibility
+
+Control whether a container is visible. When hidden, it takes up no space in layout, does not paint, and ignores all events.
+
+```rust
+// Static
+container().visible(false)
+
+// Reactive signal
+let show = create_signal(true);
+container().visible(show)
+
+// Reactive closure
+container().visible(move || tab.get() == "settings")
+```
+
+Unlike `.maybe_child()` which adds or removes a child from the tree, `.visible()` keeps the widget in the tree but hides it completely. This is useful when you want to toggle visibility without recreating the widget and its state.
+
 ## Scrolling
 
 Make containers scrollable when content overflows:
@@ -256,6 +274,9 @@ fn create_button(label: &str, on_click: impl Fn() + 'static) -> Container {
 - `.animate_transform(transition)` - Animate transform
 - `.animate_border_width(transition)` - Animate border width
 - `.animate_border_color(transition)` - Animate border color
+
+### Visibility
+- `.visible(condition)` - Show or hide the container (accepts static, signal, or closure)
 
 ### Scrolling
 - `.scrollable(axis)` - Enable scrolling (None, Vertical, Horizontal, Both)


### PR DESCRIPTION
## Summary
- Add a reactive `.visible()` property to Container that controls layout, painting, and event handling
- When `visible` is false, the container takes zero space, does not render, and ignores all events
- Accepts static values, signals, or closures via `IntoMaybeDyn<bool>`, enabling reactive visibility toggling
- Unlike `.maybe_child()` which removes widgets from the tree, `.visible()` keeps the widget in the tree but hides it — preserving widget state across toggles

## Implementation
- New `visible: MaybeDyn<bool>` field on `Container` (defaults to `true`)
- Guards in `layout_hints()`, `layout()`, `event()`, `has_focus_descendant()`, and `paint()`
- Uses `with_signal_tracking()` in `layout()` and `paint()` so visibility changes reactively trigger re-layout and repaint
- Book documentation updated with usage examples

## Test plan
- [ ] `cargo check` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes with zero warnings
- [ ] `cargo fmt --all` — no formatting changes needed
- [ ] `mdbook build book` renders correctly
- [ ] Manual test: toggle visibility with a signal, verify widget appears/disappears and takes no space when hidden