### PR TITLE
fix: animation 1-frame delay + add Effect::detach()

### DIFF
--- a/src/jobs.rs
+++ b/src/jobs.rs
@@ -180,8 +180,8 @@ pub fn drain_pending_jobs() -> Vec<Job> {
 }
 
 /// Drain all pending jobs EXCEPT Animation jobs.
-/// Animation jobs are left in PENDING_JOBS for centralized processing
-/// in the main loop, preventing cross-surface job loss.
+/// Used to collect follow-up jobs (Paint/Layout) pushed by animation
+/// advances and reconciliation, without re-draining Animation jobs.
 pub fn drain_non_animation_jobs() -> Vec<Job> {
     PENDING_JOBS.with(|jobs| jobs.borrow_mut().drain_non_animation())
 }


### PR DESCRIPTION
## Summary

- **Fix animation 1-frame delay**: Process animation jobs inside `render_surface()` before paint, so animated values (hover/pressed state transitions) are current when painting. Previously, `advance_animations()` ran after all surfaces rendered, causing a visible 1-frame flicker.
- **Add `Effect::detach()`**: Allows effects created outside widget/owner scopes (e.g. in `main()`) to persist for the application's lifetime via `mem::forget`.
- **Update `drain_non_animation_jobs` doc comment**: Reflects its new role (collecting follow-up jobs after animation processing).

## Test plan
- [x] `cargo fmt --all` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test` — all 153 tests pass (including new `test_effect_detach_prevents_disposal`)
- [ ] `cargo run --example status_bar` — verify hover/pressed animations have no 1-frame flicker