### PR TITLE
feat: root owner architecture for clean App restart

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,17 +228,29 @@ let view = container()
 ### App Configuration
 
 ```rust
-let (app, surface_id) = App::new().add_surface(
-    SurfaceConfig::new()
-        .height(32)
-        .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
-        .layer(Layer::Top)
-        .keyboard_interactivity(KeyboardInteractivity::OnDemand)
-        .namespace("my-app")
-        .background_color(Color::rgb(0.1, 0.1, 0.15)),
-    move || view,
-);
-app.run();
+App::new().run(|app| {
+    let count = create_signal(0);
+    let view = container()
+        .layout(Flex::row().spacing(8.0))
+        .children([
+            text(move || format!("Count: {}", count.get())),
+            container()
+                .background(Color::rgb(0.3, 0.3, 0.4))
+                .on_click(move || count.update(|c| *c += 1))
+                .child(text("Click me"))
+        ]);
+
+    app.add_surface(
+        SurfaceConfig::new()
+            .height(32)
+            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+            .layer(Layer::Top)
+            .keyboard_interactivity(KeyboardInteractivity::OnDemand)
+            .namespace("my-app")
+            .background_color(Color::rgb(0.1, 0.1, 0.15)),
+        move || view,
+    );
+});
 ```
 
 ### Dynamic Surface Properties

--- a/book/src/README.md
+++ b/book/src/README.md
@@ -29,10 +29,10 @@ Guido is a GPU-accelerated GUI library built with Rust and wgpu, designed specif
 use guido::prelude::*;
 
 fn main() {
-    let count = create_signal(0);
+    App::new().run(|app| {
+        let count = create_signal(0);
 
-    App::new()
-        .add_surface(
+        app.add_surface(
             SurfaceConfig::new()
                 .width(300)
                 .height(100)
@@ -56,8 +56,8 @@ fn main() {
                             .child(text(move || format!("Clicked {} times", count.get())))
                     )
             },
-        )
-        .run();
+        );
+    });
 }
 ```
 

--- a/book/src/advanced/components.md
+++ b/book/src/advanced/components.md
@@ -247,24 +247,32 @@ impl Card {
 }
 
 fn main() {
-    let count = create_signal(0);
+    App::new().run(|app| {
+        let count = create_signal(0);
 
-    let view = container()
-        .padding(16.0)
-        .layout(Flex::column().spacing(12.0))
-        .child(
-            card()
-                .title("Counter")
-                .child(text(move || format!("Count: {}", count.get())).color(Color::WHITE))
-                .child(
-                    container()
-                        .layout(Flex::row().spacing(8.0))
-                        .child(button().label("Increment").on_click(move || count.update(|c| *c += 1)))
-                        .child(button().label("Reset").on_click(move || count.set(0)))
-                )
+        let view = container()
+            .padding(16.0)
+            .layout(Flex::column().spacing(12.0))
+            .child(
+                card()
+                    .title("Counter")
+                    .child(text(move || format!("Count: {}", count.get())).color(Color::WHITE))
+                    .child(
+                        container()
+                            .layout(Flex::row().spacing(8.0))
+                            .child(button().label("Increment").on_click(move || count.update(|c| *c += 1)))
+                            .child(button().label("Reset").on_click(move || count.set(0)))
+                    )
+            );
+
+        app.add_surface(
+            SurfaceConfig::new()
+                .width(400)
+                .height(200)
+                .background_color(Color::rgb(0.1, 0.1, 0.15)),
+            move || view,
         );
-
-    App::new().width(400).height(200).run(view);
+    });
 }
 ```
 

--- a/book/src/building-ui/images.md
+++ b/book/src/building-ui/images.md
@@ -176,41 +176,46 @@ Here's a complete example showing various image features:
 use guido::prelude::*;
 
 fn main() {
-    let svg_icon = r##"
-        <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-            <circle cx="12" cy="12" r="10" fill="#3b82f6"/>
-        </svg>
-    "##;
+    App::new().run(|app| {
+        let svg_icon = r##"
+            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <circle cx="12" cy="12" r="10" fill="#3b82f6"/>
+            </svg>
+        "##;
 
-    let view = container()
-        .padding(16.0)
-        .layout(Flex::row().spacing(16.0))
-        .child(
-            // PNG image
-            image("./logo.png")
-                .width(48.0)
-                .height(48.0)
-        )
-        .child(
-            // SVG from memory
-            image(ImageSource::SvgBytes(svg_icon.as_bytes().into()))
-                .width(32.0)
-                .height(32.0)
-        )
-        .child(
-            // Rotated image
-            container()
-                .rotate(15.0)
-                .child(
-                    image("./icon.svg")
-                        .width(24.0)
-                        .height(24.0)
-                )
+        let view = container()
+            .padding(16.0)
+            .layout(Flex::row().spacing(16.0))
+            .child(
+                // PNG image
+                image("./logo.png")
+                    .width(48.0)
+                    .height(48.0)
+            )
+            .child(
+                // SVG from memory
+                image(ImageSource::SvgBytes(svg_icon.as_bytes().into()))
+                    .width(32.0)
+                    .height(32.0)
+            )
+            .child(
+                // Rotated image
+                container()
+                    .rotate(15.0)
+                    .child(
+                        image("./icon.svg")
+                            .width(24.0)
+                            .height(24.0)
+                    )
+            );
+
+        app.add_surface(
+            SurfaceConfig::new()
+                .height(80)
+                .background_color(Color::rgb(0.1, 0.1, 0.15)),
+            move || view,
         );
-
-    App::new()
-        .height(80)
-        .run(view);
+    });
 }
 ```
 

--- a/book/src/building-ui/text.md
+++ b/book/src/building-ui/text.md
@@ -188,7 +188,9 @@ Set a default font family for the entire application:
 ```rust
 App::new()
     .default_font_family(FontFamily::Name("Inter".into()))
-    .add_surface(config, || view)
+    .run(|app| {
+        app.add_surface(config, || view);
+    });
 ```
 
 All text widgets will use this font family unless they explicitly override it.

--- a/book/src/getting-started/hello-world.md
+++ b/book/src/getting-started/hello-world.md
@@ -22,38 +22,39 @@ Replace `src/main.rs` with:
 use guido::prelude::*;
 
 fn main() {
-    let (app, _) = App::new().add_surface(
-        SurfaceConfig::new()
-            .height(32)
-            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
-            .background_color(Color::rgb(0.1, 0.1, 0.15)),
-        || {
-            container()
-                .height(fill())
-                .layout(
-                    Flex::row()
-                        .spacing(8.0)
-                        .main_axis_alignment(MainAxisAlignment::SpaceBetween)
-                        .cross_axis_alignment(CrossAxisAlignment::Center),
-                )
-                .child(
-                    container()
-                        .padding(8.0)
-                        .background(Color::rgb(0.2, 0.2, 0.3))
-                        .corner_radius(4.0)
-                        .child(text("Guido")),
-                )
-                .child(container().padding(8.0).child(text("Hello World!")))
-                .child(
-                    container()
-                        .padding(8.0)
-                        .background(Color::rgb(0.3, 0.2, 0.2))
-                        .corner_radius(4.0)
-                        .child(text("Status Bar")),
-                )
-        },
-    );
-    app.run();
+    App::new().run(|app| {
+        app.add_surface(
+            SurfaceConfig::new()
+                .height(32)
+                .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+                .background_color(Color::rgb(0.1, 0.1, 0.15)),
+            || {
+                container()
+                    .height(fill())
+                    .layout(
+                        Flex::row()
+                            .spacing(8.0)
+                            .main_axis_alignment(MainAxisAlignment::SpaceBetween)
+                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                    )
+                    .child(
+                        container()
+                            .padding(8.0)
+                            .background(Color::rgb(0.2, 0.2, 0.3))
+                            .corner_radius(4.0)
+                            .child(text("Guido")),
+                    )
+                    .child(container().padding(8.0).child(text("Hello World!")))
+                    .child(
+                        container()
+                            .padding(8.0)
+                            .background(Color::rgb(0.3, 0.2, 0.2))
+                            .corner_radius(4.0)
+                            .child(text("Status Bar")),
+                    )
+            },
+        );
+    });
 }
 ```
 
@@ -74,14 +75,15 @@ The prelude imports everything you need: widgets, colors, layout types, and reac
 ### Surface Configuration
 
 ```rust
-let (app, _surface_id) = App::new().add_surface(
-    SurfaceConfig::new()
-        .height(32)
-        .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
-        .background_color(Color::rgb(0.1, 0.1, 0.15)),
-    || { /* widget tree */ },
-);
-app.run();
+App::new().run(|app| {
+    let _surface_id = app.add_surface(
+        SurfaceConfig::new()
+            .height(32)
+            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+            .background_color(Color::rgb(0.1, 0.1, 0.15)),
+        || { /* widget tree */ },
+    );
+});
 ```
 
 The `SurfaceConfig` defines how the window appears:
@@ -89,7 +91,7 @@ The `SurfaceConfig` defines how the window appears:
 - **Anchor** - Attached to top, left, and right edges (full width)
 - **Background color** - Dark background for the bar
 
-Note: `add_surface()` returns a tuple `(App, SurfaceId)`. The `SurfaceId` can be used later to get a `SurfaceHandle` for modifying surface properties dynamically.
+Note: `run()` takes a setup closure where you add surfaces. `add_surface()` returns a `SurfaceId` that can be used to get a `SurfaceHandle` for modifying surface properties dynamically.
 
 ### Building the View
 
@@ -148,43 +150,44 @@ Let's make it interactive with a click counter. Update your code:
 use guido::prelude::*;
 
 fn main() {
-    let count = create_signal(0);
+    App::new().run(|app| {
+        let count = create_signal(0);
 
-    let (app, _) = App::new().add_surface(
-        SurfaceConfig::new()
-            .height(32)
-            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
-            .background_color(Color::rgb(0.1, 0.1, 0.15)),
-        move || {
-            container()
-                .height(fill())
-                .layout(
-                    Flex::row()
-                        .spacing(8.0)
-                        .main_axis_alignment(MainAxisAlignment::SpaceBetween)
-                        .cross_axis_alignment(CrossAxisAlignment::Center),
-                )
-                .child(
-                    container()
-                        .padding(8.0)
-                        .background(Color::rgb(0.2, 0.2, 0.3))
-                        .corner_radius(4.0)
-                        .hover_state(|s| s.lighter(0.1))
-                        .pressed_state(|s| s.ripple())
-                        .on_click(move || count.update(|c| *c += 1))
-                        .child(text(move || format!("Clicks: {}", count.get()))),
-                )
-                .child(container().padding(8.0).child(text("Hello World!")))
-                .child(
-                    container()
-                        .padding(8.0)
-                        .background(Color::rgb(0.3, 0.2, 0.2))
-                        .corner_radius(4.0)
-                        .child(text("Status Bar")),
-                )
-        },
-    );
-    app.run();
+        app.add_surface(
+            SurfaceConfig::new()
+                .height(32)
+                .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+                .background_color(Color::rgb(0.1, 0.1, 0.15)),
+            move || {
+                container()
+                    .height(fill())
+                    .layout(
+                        Flex::row()
+                            .spacing(8.0)
+                            .main_axis_alignment(MainAxisAlignment::SpaceBetween)
+                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                    )
+                    .child(
+                        container()
+                            .padding(8.0)
+                            .background(Color::rgb(0.2, 0.2, 0.3))
+                            .corner_radius(4.0)
+                            .hover_state(|s| s.lighter(0.1))
+                            .pressed_state(|s| s.ripple())
+                            .on_click(move || count.update(|c| *c += 1))
+                            .child(text(move || format!("Clicks: {}", count.get()))),
+                    )
+                    .child(container().padding(8.0).child(text("Hello World!")))
+                    .child(
+                        container()
+                            .padding(8.0)
+                            .background(Color::rgb(0.3, 0.2, 0.2))
+                            .corner_radius(4.0)
+                            .child(text("Status Bar")),
+                    )
+            },
+        );
+    });
 }
 ```
 

--- a/book/src/getting-started/installation.md
+++ b/book/src/getting-started/installation.md
@@ -70,15 +70,20 @@ Create a minimal test application to verify everything works:
 use guido::prelude::*;
 
 fn main() {
-    let view = container()
-        .padding(20.0)
-        .background(Color::rgb(0.2, 0.3, 0.4))
-        .child(text("Hello, Guido!").color(Color::WHITE));
-
-    App::new()
-        .width(200)
-        .height(100)
-        .run(view);
+    App::new().run(|app| {
+        app.add_surface(
+            SurfaceConfig::new()
+                .width(200)
+                .height(100)
+                .background_color(Color::rgb(0.1, 0.1, 0.15)),
+            || {
+                container()
+                    .padding(20.0)
+                    .background(Color::rgb(0.2, 0.3, 0.4))
+                    .child(text("Hello, Guido!").color(Color::WHITE))
+            },
+        );
+    });
 }
 ```
 

--- a/examples/animation_example.rs
+++ b/examples/animation_example.rs
@@ -1,35 +1,36 @@
 use guido::prelude::*;
 
 fn main() {
-    // State signals for animations
-    let expanded = create_signal(false);
+    App::new().run(|app| {
+        // State signals for animations
+        let expanded = create_signal(false);
 
-    let (app, _) = App::new().add_surface(
-        SurfaceConfig::new()
-            .width(800)
-            .height(400)
-            .anchor(Anchor::TOP | Anchor::LEFT)
-            .background_color(Color::rgb(0.08, 0.08, 0.12)),
-        move || {
-            container()
-                .background(Color::rgb(0.08, 0.08, 0.12))
-                .padding(20.0)
-                .layout(Flex::column().spacing(20.0))
-                .children([
-                    // Row 1
-                    container().layout(Flex::row().spacing(20.0)).children([
-                        create_width_animation_card(expanded),
-                        create_color_animation_card(),
-                    ]),
-                    // Row 2
-                    container().layout(Flex::row().spacing(20.0)).children([
-                        create_combined_animation_card(),
-                        create_border_animation_card(),
-                    ]),
-                ])
-        },
-    );
-    app.run();
+        app.add_surface(
+            SurfaceConfig::new()
+                .width(800)
+                .height(400)
+                .anchor(Anchor::TOP | Anchor::LEFT)
+                .background_color(Color::rgb(0.08, 0.08, 0.12)),
+            move || {
+                container()
+                    .background(Color::rgb(0.08, 0.08, 0.12))
+                    .padding(20.0)
+                    .layout(Flex::column().spacing(20.0))
+                    .children([
+                        // Row 1
+                        container().layout(Flex::row().spacing(20.0)).children([
+                            create_width_animation_card(expanded),
+                            create_color_animation_card(),
+                        ]),
+                        // Row 2
+                        container().layout(Flex::row().spacing(20.0)).children([
+                            create_combined_animation_card(),
+                            create_border_animation_card(),
+                        ]),
+                    ])
+            },
+        );
+    });
 }
 
 /// Card demonstrating width animation with spring physics

--- a/examples/children_example.rs
+++ b/examples/children_example.rs
@@ -19,6 +19,7 @@ struct Item {
 }
 
 fn main() {
+    App::new().run(|app| {
     // === Signals for reactive state ===
     // No need to clone signals anymore - they implement Copy!
     let show_optional = create_signal(true);
@@ -429,7 +430,7 @@ fn main() {
         )
         );
 
-    let (app, _) = App::new().add_surface(
+    app.add_surface(
         SurfaceConfig::new()
             .width(1800)
             .height(450)
@@ -437,5 +438,5 @@ fn main() {
             .background_color(Color::rgb(0.1, 0.1, 0.15)),
         move || view,
     );
-    app.run();
+    });
 }

--- a/examples/clip_test.rs
+++ b/examples/clip_test.rs
@@ -11,28 +11,29 @@
 use guido::prelude::*;
 
 fn main() {
-    let (app, _) = App::new().add_surface(
-        SurfaceConfig::new()
-            .height(480)
-            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
-            .background_color(Color::rgb(0.12, 0.12, 0.16)),
-        move || {
-            container()
-                .layout(Flex::column().spacing(20.0))
-                .padding(20.0)
-                .children([
-                    // Row 1: Simple clip (no transforms)
-                    simple_clip_row(),
-                    // Row 2: Clip on rotated shape
-                    rotated_clip_row(),
-                    // Row 3: Clip on scaled shape
-                    scaled_clip_row(),
-                    // Row 4: Nested transforms with clip
-                    nested_clip_row(),
-                ])
-        },
-    );
-    app.run();
+    App::new().run(|app| {
+        app.add_surface(
+            SurfaceConfig::new()
+                .height(480)
+                .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+                .background_color(Color::rgb(0.12, 0.12, 0.16)),
+            move || {
+                container()
+                    .layout(Flex::column().spacing(20.0))
+                    .padding(20.0)
+                    .children([
+                        // Row 1: Simple clip (no transforms)
+                        simple_clip_row(),
+                        // Row 2: Clip on rotated shape
+                        rotated_clip_row(),
+                        // Row 3: Clip on scaled shape
+                        scaled_clip_row(),
+                        // Row 4: Nested transforms with clip
+                        nested_clip_row(),
+                    ])
+            },
+        );
+    });
 }
 
 /// Row 1: Simple clip - parent clips child that extends beyond bounds

--- a/examples/component_example.rs
+++ b/examples/component_example.rs
@@ -52,134 +52,135 @@ impl Card {
 fn main() {
     let _ = env_logger::try_init();
 
-    // Create some reactive state
-    // No need to clone signals anymore - they implement Copy!
-    let count = create_signal(0);
+    App::new().run(|app| {
+        // Create some reactive state
+        // No need to clone signals anymore - they implement Copy!
+        let count = create_signal(0);
 
-    let (app, _) = App::new().add_surface(
-        SurfaceConfig::new()
-            .width(600)
-            .height(500)
-            .anchor(Anchor::TOP | Anchor::LEFT)
-            .layer(Layer::Overlay)
-            .namespace("component-example")
-            .background_color(Color::rgb(0.1, 0.1, 0.15)),
-        move || {
-            container()
-                .padding(16.0)
-                .background(Color::rgb(0.1, 0.1, 0.15))
-                .layout(Flex::column().spacing(12.0))
-                .child(
-                    text("Component Example")
-                        .font_size(24.0)
-                        .color(Color::WHITE),
-                )
-                .child(
-                    card()
-                        .title("Counter")
-                        .background(Color::rgb(0.15, 0.2, 0.25))
-                        .child(
-                            text(move || format!("Count: {}", count.get()))
-                                .font_size(16.0)
-                                .color(Color::WHITE),
-                        )
-                        .child(
+        app.add_surface(
+            SurfaceConfig::new()
+                .width(600)
+                .height(500)
+                .anchor(Anchor::TOP | Anchor::LEFT)
+                .layer(Layer::Overlay)
+                .namespace("component-example")
+                .background_color(Color::rgb(0.1, 0.1, 0.15)),
+            move || {
+                container()
+                    .padding(16.0)
+                    .background(Color::rgb(0.1, 0.1, 0.15))
+                    .layout(Flex::column().spacing(12.0))
+                    .child(
+                        text("Component Example")
+                            .font_size(24.0)
+                            .color(Color::WHITE),
+                    )
+                    .child(
+                        card()
+                            .title("Counter")
+                            .background(Color::rgb(0.15, 0.2, 0.25))
+                            .child(
+                                text(move || format!("Count: {}", count.get()))
+                                    .font_size(16.0)
+                                    .color(Color::WHITE),
+                            )
+                            .child(
+                                container()
+                                    .layout(Flex::row().spacing(8.0))
+                                    .child(
+                                        button()
+                                            .label("Increment")
+                                            .background(Color::rgb(0.2, 0.6, 0.3))
+                                            .on_click(move || count.update(|c| *c += 1)),
+                                    )
+                                    .child(
+                                        button()
+                                            .label("Decrement")
+                                            .background(Color::rgb(0.6, 0.2, 0.2))
+                                            .on_click(move || count.update(|c| *c -= 1)),
+                                    )
+                                    .child(
+                                        button()
+                                            .label("Reset")
+                                            .background(Color::rgb(0.4, 0.4, 0.5))
+                                            .on_click(move || count.set(0)),
+                                    ),
+                            ),
+                    )
+                    .child(
+                        card()
+                            .title("Static Content")
+                            .child(
+                                text("This is a card with static content.")
+                                    .color(Color::rgb(0.8, 0.8, 0.8)),
+                            )
+                            .child(
+                                text("Cards can have multiple children.")
+                                    .color(Color::rgb(0.8, 0.8, 0.8)),
+                            ),
+                    )
+                    .child(
+                        card().title("Styled Buttons").child(
                             container()
                                 .layout(Flex::row().spacing(8.0))
                                 .child(
                                     button()
-                                        .label("Increment")
-                                        .background(Color::rgb(0.2, 0.6, 0.3))
-                                        .on_click(move || count.update(|c| *c += 1)),
+                                        .label("Primary")
+                                        .background(Color::rgb(0.2, 0.4, 0.8))
+                                        .padding(12.0)
+                                        .on_click(|| println!("Primary clicked")),
                                 )
                                 .child(
                                     button()
-                                        .label("Decrement")
-                                        .background(Color::rgb(0.6, 0.2, 0.2))
-                                        .on_click(move || count.update(|c| *c -= 1)),
+                                        .label("Secondary")
+                                        .background(Color::rgb(0.5, 0.5, 0.6))
+                                        .padding(12.0)
+                                        .on_click(|| println!("Secondary clicked")),
                                 )
                                 .child(
                                     button()
-                                        .label("Reset")
-                                        .background(Color::rgb(0.4, 0.4, 0.5))
-                                        .on_click(move || count.set(0)),
+                                        .label("Danger")
+                                        .background(Color::rgb(0.8, 0.2, 0.2))
+                                        .padding(12.0)
+                                        .on_click(|| println!("Danger clicked")),
                                 ),
                         ),
-                )
-                .child(
-                    card()
-                        .title("Static Content")
-                        .child(
-                            text("This is a card with static content.")
-                                .color(Color::rgb(0.8, 0.8, 0.8)),
-                        )
-                        .child(
-                            text("Cards can have multiple children.")
-                                .color(Color::rgb(0.8, 0.8, 0.8)),
-                        ),
-                )
-                .child(
-                    card().title("Styled Buttons").child(
-                        container()
-                            .layout(Flex::row().spacing(8.0))
+                    )
+                    .child(
+                        card()
+                            .title("Reactive Props Example")
+                            .background(move || {
+                                // Card background changes based on count
+                                if count.get() > 5 {
+                                    Color::rgb(0.2, 0.3, 0.2)
+                                } else if count.get() < -5 {
+                                    Color::rgb(0.3, 0.2, 0.2)
+                                } else {
+                                    Color::rgb(0.18, 0.18, 0.22)
+                                }
+                            })
                             .child(
-                                button()
-                                    .label("Primary")
-                                    .background(Color::rgb(0.2, 0.4, 0.8))
-                                    .padding(12.0)
-                                    .on_click(|| println!("Primary clicked")),
+                                text("The card background changes color based on the count value.")
+                                    .color(Color::rgb(0.8, 0.8, 0.8)),
                             )
                             .child(
-                                button()
-                                    .label("Secondary")
-                                    .background(Color::rgb(0.5, 0.5, 0.6))
-                                    .padding(12.0)
-                                    .on_click(|| println!("Secondary clicked")),
-                            )
-                            .child(
-                                button()
-                                    .label("Danger")
-                                    .background(Color::rgb(0.8, 0.2, 0.2))
-                                    .padding(12.0)
-                                    .on_click(|| println!("Danger clicked")),
+                                container().layout(Flex::row().spacing(8.0)).child(
+                                    button()
+                                        .label(move || format!("Count is {}", count.get()))
+                                        .background(move || {
+                                            // Button color changes based on count
+                                            let c = count.get();
+                                            if c % 2 == 0 {
+                                                Color::rgb(0.3, 0.5, 0.7)
+                                            } else {
+                                                Color::rgb(0.7, 0.5, 0.3)
+                                            }
+                                        })
+                                        .on_click(move || count.update(|c| *c += 1)),
+                                ),
                             ),
-                    ),
-                )
-                .child(
-                    card()
-                        .title("Reactive Props Example")
-                        .background(move || {
-                            // Card background changes based on count
-                            if count.get() > 5 {
-                                Color::rgb(0.2, 0.3, 0.2)
-                            } else if count.get() < -5 {
-                                Color::rgb(0.3, 0.2, 0.2)
-                            } else {
-                                Color::rgb(0.18, 0.18, 0.22)
-                            }
-                        })
-                        .child(
-                            text("The card background changes color based on the count value.")
-                                .color(Color::rgb(0.8, 0.8, 0.8)),
-                        )
-                        .child(
-                            container().layout(Flex::row().spacing(8.0)).child(
-                                button()
-                                    .label(move || format!("Count is {}", count.get()))
-                                    .background(move || {
-                                        // Button color changes based on count
-                                        let c = count.get();
-                                        if c % 2 == 0 {
-                                            Color::rgb(0.3, 0.5, 0.7)
-                                        } else {
-                                            Color::rgb(0.7, 0.5, 0.3)
-                                        }
-                                    })
-                                    .on_click(move || count.update(|c| *c += 1)),
-                            ),
-                        ),
-                )
-        },
-    );
-    app.run();
+                    )
+            },
+        );
+    });
 }

--- a/examples/effect_cleanup_test.rs
+++ b/examples/effect_cleanup_test.rs
@@ -114,110 +114,113 @@ fn main() {
     log::info!("Child creation is extracted into a function - signals are still owned!");
     log::info!("When a child is removed, its OwnedWidget drops and calls dispose_owner().\n");
 
-    // Signal holding the list of child IDs
-    let children_ids = create_signal(Vec::<u64>::new());
+    App::new().run(|app| {
+        // Signal holding the list of child IDs
+        let children_ids = create_signal(Vec::<u64>::new());
 
-    let view = container()
-        .layout(Flex::column().spacing(12.0))
-        .padding(16.0)
-        .child(
-            // Title and instructions
-            container()
-                .layout(Flex::column().spacing(4.0))
-                .child(text("Effect Cleanup Test (Automatic Ownership)").color(Color::WHITE))
-                .child(
-                    text("Watch the console: each child logs every 2 seconds.")
-                        .color(Color::rgb(0.7, 0.7, 0.7)),
-                )
-                .child(
-                    text("When removed, on_cleanup runs and effect logs STOP.")
-                        .color(Color::rgb(0.7, 0.7, 0.7)),
-                ),
-        )
-        .child(
-            // Control buttons
-            container()
-                .layout(Flex::row().spacing(8.0))
-                .child(
-                    container()
-                        .padding(10.0)
-                        .background(Color::rgb(0.2, 0.5, 0.3))
-                        .corner_radius(6.0)
-                        .hover_state(|s| s.lighter(0.1))
-                        .pressed_state(|s| s.ripple())
-                        .on_click(move || {
-                            let id = NEXT_ID.fetch_add(1, Ordering::SeqCst);
-                            log::info!("[Child {}] Adding to list", id);
-                            children_ids.update(|list| list.push(id));
-                        })
-                        .child(text("Add Child").color(Color::WHITE)),
-                )
-                .child(
-                    container()
-                        .padding(10.0)
-                        .background(Color::rgb(0.5, 0.2, 0.2))
-                        .corner_radius(6.0)
-                        .hover_state(|s| s.lighter(0.1))
-                        .pressed_state(|s| s.ripple())
-                        .on_click(move || {
-                            children_ids.update(|list| {
-                                if let Some(id) = list.pop() {
-                                    log::info!(
+        let view = container()
+            .layout(Flex::column().spacing(12.0))
+            .padding(16.0)
+            .child(
+                // Title and instructions
+                container()
+                    .layout(Flex::column().spacing(4.0))
+                    .child(
+                        text("Effect Cleanup Test (Automatic Ownership)").color(Color::WHITE),
+                    )
+                    .child(
+                        text("Watch the console: each child logs every 2 seconds.")
+                            .color(Color::rgb(0.7, 0.7, 0.7)),
+                    )
+                    .child(
+                        text("When removed, on_cleanup runs and effect logs STOP.")
+                            .color(Color::rgb(0.7, 0.7, 0.7)),
+                    ),
+            )
+            .child(
+                // Control buttons
+                container()
+                    .layout(Flex::row().spacing(8.0))
+                    .child(
+                        container()
+                            .padding(10.0)
+                            .background(Color::rgb(0.2, 0.5, 0.3))
+                            .corner_radius(6.0)
+                            .hover_state(|s| s.lighter(0.1))
+                            .pressed_state(|s| s.ripple())
+                            .on_click(move || {
+                                let id = NEXT_ID.fetch_add(1, Ordering::SeqCst);
+                                log::info!("[Child {}] Adding to list", id);
+                                children_ids.update(|list| list.push(id));
+                            })
+                            .child(text("Add Child").color(Color::WHITE)),
+                    )
+                    .child(
+                        container()
+                            .padding(10.0)
+                            .background(Color::rgb(0.5, 0.2, 0.2))
+                            .corner_radius(6.0)
+                            .hover_state(|s| s.lighter(0.1))
+                            .pressed_state(|s| s.ripple())
+                            .on_click(move || {
+                                children_ids.update(|list| {
+                                    if let Some(id) = list.pop() {
+                                        log::info!(
                                         "[Child {}] Removing from list (automatic cleanup will happen)",
                                         id
                                     );
-                                }
-                            });
-                        })
-                        .child(text("Remove Last").color(Color::WHITE)),
-                )
-                .child(
-                    container()
-                        .padding(10.0)
-                        .background(Color::rgb(0.5, 0.3, 0.2))
-                        .corner_radius(6.0)
-                        .hover_state(|s| s.lighter(0.1))
-                        .pressed_state(|s| s.ripple())
-                        .on_click(move || {
-                            children_ids.update(|list| {
-                                log::info!(
-                                    "Removing all {} children (automatic cleanup for each)",
-                                    list.len()
-                                );
-                                list.clear();
-                            });
-                        })
-                        .child(text("Remove All").color(Color::WHITE)),
-                ),
-        )
-        .child(
-            // Status display
-            text(move || {
-                let count = children_ids.get().len();
-                format!("Active children: {}", count)
-            })
-            .color(Color::WHITE),
-        )
-        .child(
-            // Children container with dynamic children
-            // The closure wrapper ensures create_child_widget runs inside owner scope
-            container()
-                .layout(Flex::column().spacing(8.0))
-                .children(move || {
-                    children_ids
-                        .get()
-                        .into_iter()
-                        .map(|id| (id, move || create_child_widget(id)))
-                }),
-        );
+                                    }
+                                });
+                            })
+                            .child(text("Remove Last").color(Color::WHITE)),
+                    )
+                    .child(
+                        container()
+                            .padding(10.0)
+                            .background(Color::rgb(0.5, 0.3, 0.2))
+                            .corner_radius(6.0)
+                            .hover_state(|s| s.lighter(0.1))
+                            .pressed_state(|s| s.ripple())
+                            .on_click(move || {
+                                children_ids.update(|list| {
+                                    log::info!(
+                                        "Removing all {} children (automatic cleanup for each)",
+                                        list.len()
+                                    );
+                                    list.clear();
+                                });
+                            })
+                            .child(text("Remove All").color(Color::WHITE)),
+                    ),
+            )
+            .child(
+                // Status display
+                text(move || {
+                    let count = children_ids.get().len();
+                    format!("Active children: {}", count)
+                })
+                .color(Color::WHITE),
+            )
+            .child(
+                // Children container with dynamic children
+                // The closure wrapper ensures create_child_widget runs inside owner scope
+                container()
+                    .layout(Flex::column().spacing(8.0))
+                    .children(move || {
+                        children_ids
+                            .get()
+                            .into_iter()
+                            .map(|id| (id, move || create_child_widget(id)))
+                    }),
+            );
 
-    let (app, _) = App::new().add_surface(
-        SurfaceConfig::new()
-            .width(500)
-            .height(400)
-            .anchor(Anchor::TOP | Anchor::LEFT)
-            .background_color(Color::rgb(0.1, 0.1, 0.15)),
-        move || view,
-    );
-    app.run();
+        app.add_surface(
+            SurfaceConfig::new()
+                .width(500)
+                .height(400)
+                .anchor(Anchor::TOP | Anchor::LEFT)
+                .background_color(Color::rgb(0.1, 0.1, 0.15)),
+            move || view,
+        );
+    });
 }

--- a/examples/elevation_example.rs
+++ b/examples/elevation_example.rs
@@ -10,159 +10,164 @@
 use guido::prelude::*;
 
 fn main() {
-    let (app, _) = App::new().add_surface(
-        SurfaceConfig::new()
-            .width(600)
-            .height(280)
-            .anchor(Anchor::TOP | Anchor::LEFT)
-            .background_color(Color::rgb(0.85, 0.85, 0.9)),
-        || {
-            container()
-                .layout(Flex::column().spacing(16.0))
-                .child(
-                    // Row 1: Basic elevation levels
-                    container()
-                        .layout(Flex::row().spacing(16.0))
-                        .child(
-                            container()
-                                .padding(16.0)
-                                .background(Color::WHITE)
-                                .corner_radius(8.0)
-                                .elevation(0.0)
-                                .child(
-                                    text("Level 0\n(No shadow)").color(Color::rgb(0.2, 0.2, 0.2)),
-                                ),
-                        )
-                        .child(
-                            container()
-                                .padding(16.0)
-                                .background(Color::WHITE)
-                                .corner_radius(8.0)
-                                .elevation(1.0)
-                                .child(text("Level 1").color(Color::rgb(0.2, 0.2, 0.2))),
-                        )
-                        .child(
-                            container()
-                                .padding(16.0)
-                                .background(Color::WHITE)
-                                .corner_radius(8.0)
-                                .elevation(2.0)
-                                .child(text("Level 2").color(Color::rgb(0.2, 0.2, 0.2))),
-                        )
-                        .child(
-                            container()
-                                .padding(16.0)
-                                .background(Color::WHITE)
-                                .corner_radius(8.0)
-                                .elevation(3.0)
-                                .child(text("Level 3").color(Color::rgb(0.2, 0.2, 0.2))),
-                        ),
-                )
-                .child(
-                    // Row 2: Higher elevation levels
-                    container()
-                        .layout(Flex::row().spacing(16.0))
-                        .child(
-                            container()
-                                .padding(16.0)
-                                .background(Color::WHITE)
-                                .corner_radius(8.0)
-                                .elevation(4.0)
-                                .child(text("Level 4").color(Color::rgb(0.2, 0.2, 0.2))),
-                        )
-                        .child(
-                            container()
-                                .padding(16.0)
-                                .background(Color::WHITE)
-                                .corner_radius(8.0)
-                                .elevation(5.0)
-                                .child(text("Level 5").color(Color::rgb(0.2, 0.2, 0.2))),
-                        )
-                        .child(
-                            container()
-                                .padding(16.0)
-                                .background(Color::WHITE)
-                                .corner_radius(8.0)
-                                .elevation(7.0)
-                                .child(text("Level 7").color(Color::rgb(0.2, 0.2, 0.2))),
-                        )
-                        .child(
-                            container()
-                                .padding(16.0)
-                                .background(Color::WHITE)
-                                .corner_radius(8.0)
-                                .elevation(10.0)
-                                .child(text("Level 10").color(Color::rgb(0.2, 0.2, 0.2))),
-                        ),
-                )
-                .child(
-                    // Row 3: Colored cards with elevation
-                    container()
-                        .layout(Flex::row().spacing(16.0))
-                        .child(
-                            container()
-                                .padding(16.0)
-                                .background(Color::rgb(0.9, 0.7, 0.7))
-                                .corner_radius(12.0)
-                                .elevation(2.0)
-                                .child(text("Card 1").color(Color::rgb(0.3, 0.1, 0.1))),
-                        )
-                        .child(
-                            container()
-                                .padding(16.0)
-                                .background(Color::rgb(0.7, 0.9, 0.7))
-                                .corner_radius(12.0)
-                                .elevation(3.0)
-                                .child(text("Card 2").color(Color::rgb(0.1, 0.3, 0.1))),
-                        )
-                        .child(
-                            container()
-                                .padding(16.0)
-                                .background(Color::rgb(0.7, 0.7, 0.9))
-                                .corner_radius(12.0)
-                                .elevation(4.0)
-                                .child(text("Card 3").color(Color::rgb(0.1, 0.1, 0.3))),
-                        ),
-                )
-                .child(
-                    // Row 4: Squircle with elevation
-                    container()
-                        .layout(Flex::row().spacing(16.0))
-                        .child(
-                            container()
-                                .padding(16.0)
-                                .background(Color::rgb(0.95, 0.95, 0.95))
-                                .corner_radius(16.0)
-                                .squircle()
-                                .elevation(2.0)
-                                .child(
-                                    text("Squircle\nElevation 2").color(Color::rgb(0.2, 0.2, 0.2)),
-                                ),
-                        )
-                        .child(
-                            container()
-                                .padding(16.0)
-                                .background(Color::rgb(0.95, 0.95, 0.95))
-                                .corner_radius(16.0)
-                                .squircle()
-                                .elevation(4.0)
-                                .child(
-                                    text("Squircle\nElevation 4").color(Color::rgb(0.2, 0.2, 0.2)),
-                                ),
-                        )
-                        .child(
-                            container()
-                                .padding(16.0)
-                                .background(Color::rgb(0.95, 0.95, 0.95))
-                                .corner_radius(16.0)
-                                .squircle()
-                                .elevation(6.0)
-                                .child(
-                                    text("Squircle\nElevation 6").color(Color::rgb(0.2, 0.2, 0.2)),
-                                ),
-                        ),
-                )
-        },
-    );
-    app.run();
+    App::new().run(|app| {
+        app.add_surface(
+            SurfaceConfig::new()
+                .width(600)
+                .height(280)
+                .anchor(Anchor::TOP | Anchor::LEFT)
+                .background_color(Color::rgb(0.85, 0.85, 0.9)),
+            || {
+                container()
+                    .layout(Flex::column().spacing(16.0))
+                    .child(
+                        // Row 1: Basic elevation levels
+                        container()
+                            .layout(Flex::row().spacing(16.0))
+                            .child(
+                                container()
+                                    .padding(16.0)
+                                    .background(Color::WHITE)
+                                    .corner_radius(8.0)
+                                    .elevation(0.0)
+                                    .child(
+                                        text("Level 0\n(No shadow)")
+                                            .color(Color::rgb(0.2, 0.2, 0.2)),
+                                    ),
+                            )
+                            .child(
+                                container()
+                                    .padding(16.0)
+                                    .background(Color::WHITE)
+                                    .corner_radius(8.0)
+                                    .elevation(1.0)
+                                    .child(text("Level 1").color(Color::rgb(0.2, 0.2, 0.2))),
+                            )
+                            .child(
+                                container()
+                                    .padding(16.0)
+                                    .background(Color::WHITE)
+                                    .corner_radius(8.0)
+                                    .elevation(2.0)
+                                    .child(text("Level 2").color(Color::rgb(0.2, 0.2, 0.2))),
+                            )
+                            .child(
+                                container()
+                                    .padding(16.0)
+                                    .background(Color::WHITE)
+                                    .corner_radius(8.0)
+                                    .elevation(3.0)
+                                    .child(text("Level 3").color(Color::rgb(0.2, 0.2, 0.2))),
+                            ),
+                    )
+                    .child(
+                        // Row 2: Higher elevation levels
+                        container()
+                            .layout(Flex::row().spacing(16.0))
+                            .child(
+                                container()
+                                    .padding(16.0)
+                                    .background(Color::WHITE)
+                                    .corner_radius(8.0)
+                                    .elevation(4.0)
+                                    .child(text("Level 4").color(Color::rgb(0.2, 0.2, 0.2))),
+                            )
+                            .child(
+                                container()
+                                    .padding(16.0)
+                                    .background(Color::WHITE)
+                                    .corner_radius(8.0)
+                                    .elevation(5.0)
+                                    .child(text("Level 5").color(Color::rgb(0.2, 0.2, 0.2))),
+                            )
+                            .child(
+                                container()
+                                    .padding(16.0)
+                                    .background(Color::WHITE)
+                                    .corner_radius(8.0)
+                                    .elevation(7.0)
+                                    .child(text("Level 7").color(Color::rgb(0.2, 0.2, 0.2))),
+                            )
+                            .child(
+                                container()
+                                    .padding(16.0)
+                                    .background(Color::WHITE)
+                                    .corner_radius(8.0)
+                                    .elevation(10.0)
+                                    .child(text("Level 10").color(Color::rgb(0.2, 0.2, 0.2))),
+                            ),
+                    )
+                    .child(
+                        // Row 3: Colored cards with elevation
+                        container()
+                            .layout(Flex::row().spacing(16.0))
+                            .child(
+                                container()
+                                    .padding(16.0)
+                                    .background(Color::rgb(0.9, 0.7, 0.7))
+                                    .corner_radius(12.0)
+                                    .elevation(2.0)
+                                    .child(text("Card 1").color(Color::rgb(0.3, 0.1, 0.1))),
+                            )
+                            .child(
+                                container()
+                                    .padding(16.0)
+                                    .background(Color::rgb(0.7, 0.9, 0.7))
+                                    .corner_radius(12.0)
+                                    .elevation(3.0)
+                                    .child(text("Card 2").color(Color::rgb(0.1, 0.3, 0.1))),
+                            )
+                            .child(
+                                container()
+                                    .padding(16.0)
+                                    .background(Color::rgb(0.7, 0.7, 0.9))
+                                    .corner_radius(12.0)
+                                    .elevation(4.0)
+                                    .child(text("Card 3").color(Color::rgb(0.1, 0.1, 0.3))),
+                            ),
+                    )
+                    .child(
+                        // Row 4: Squircle with elevation
+                        container()
+                            .layout(Flex::row().spacing(16.0))
+                            .child(
+                                container()
+                                    .padding(16.0)
+                                    .background(Color::rgb(0.95, 0.95, 0.95))
+                                    .corner_radius(16.0)
+                                    .squircle()
+                                    .elevation(2.0)
+                                    .child(
+                                        text("Squircle\nElevation 2")
+                                            .color(Color::rgb(0.2, 0.2, 0.2)),
+                                    ),
+                            )
+                            .child(
+                                container()
+                                    .padding(16.0)
+                                    .background(Color::rgb(0.95, 0.95, 0.95))
+                                    .corner_radius(16.0)
+                                    .squircle()
+                                    .elevation(4.0)
+                                    .child(
+                                        text("Squircle\nElevation 4")
+                                            .color(Color::rgb(0.2, 0.2, 0.2)),
+                                    ),
+                            )
+                            .child(
+                                container()
+                                    .padding(16.0)
+                                    .background(Color::rgb(0.95, 0.95, 0.95))
+                                    .corner_radius(16.0)
+                                    .squircle()
+                                    .elevation(6.0)
+                                    .child(
+                                        text("Squircle\nElevation 6")
+                                            .color(Color::rgb(0.2, 0.2, 0.2)),
+                                    ),
+                            ),
+                    )
+            },
+        );
+    });
 }

--- a/examples/flex_layout_test.rs
+++ b/examples/flex_layout_test.rs
@@ -9,59 +9,60 @@
 use guido::prelude::*;
 
 fn main() {
-    let (app, _) = App::new().add_surface(
-        SurfaceConfig::new()
-            .width(1000)
-            .height(400)
-            .anchor(Anchor::TOP | Anchor::LEFT)
-            .background_color(Color::rgb(0.08, 0.08, 0.1)),
-        || {
-            container()
-                .layout(Flex::column().spacing(8.0))
-                .padding(8.0)
-                // Row tests side by side
-                .child(
-                    container()
-                        .layout(Flex::row().spacing(16.0))
-                        .child(
-                            container()
-                                .layout(Flex::column().spacing(3.0))
-                                .child(section_title("Row - MainAxisAlignment"))
-                                .child(row_main_axis_tests()),
-                        )
-                        .child(
-                            container()
-                                .layout(Flex::column().spacing(3.0))
-                                .child(section_title("Row - CrossAxisAlignment"))
-                                .child(row_cross_axis_tests()),
-                        )
-                        .child(
-                            container()
-                                .layout(Flex::column().spacing(3.0))
-                                .child(section_title("Center Test"))
-                                .child(center_test()),
-                        ),
-                )
-                // Column tests side by side
-                .child(
-                    container()
-                        .layout(Flex::row().spacing(16.0))
-                        .child(
-                            container()
-                                .layout(Flex::column().spacing(3.0))
-                                .child(section_title("Column - MainAxisAlignment"))
-                                .child(column_main_axis_tests()),
-                        )
-                        .child(
-                            container()
-                                .layout(Flex::column().spacing(3.0))
-                                .child(section_title("Column - CrossAxisAlignment"))
-                                .child(column_cross_axis_tests()),
-                        ),
-                )
-        },
-    );
-    app.run();
+    App::new().run(|app| {
+        app.add_surface(
+            SurfaceConfig::new()
+                .width(1000)
+                .height(400)
+                .anchor(Anchor::TOP | Anchor::LEFT)
+                .background_color(Color::rgb(0.08, 0.08, 0.1)),
+            || {
+                container()
+                    .layout(Flex::column().spacing(8.0))
+                    .padding(8.0)
+                    // Row tests side by side
+                    .child(
+                        container()
+                            .layout(Flex::row().spacing(16.0))
+                            .child(
+                                container()
+                                    .layout(Flex::column().spacing(3.0))
+                                    .child(section_title("Row - MainAxisAlignment"))
+                                    .child(row_main_axis_tests()),
+                            )
+                            .child(
+                                container()
+                                    .layout(Flex::column().spacing(3.0))
+                                    .child(section_title("Row - CrossAxisAlignment"))
+                                    .child(row_cross_axis_tests()),
+                            )
+                            .child(
+                                container()
+                                    .layout(Flex::column().spacing(3.0))
+                                    .child(section_title("Center Test"))
+                                    .child(center_test()),
+                            ),
+                    )
+                    // Column tests side by side
+                    .child(
+                        container()
+                            .layout(Flex::row().spacing(16.0))
+                            .child(
+                                container()
+                                    .layout(Flex::column().spacing(3.0))
+                                    .child(section_title("Column - MainAxisAlignment"))
+                                    .child(column_main_axis_tests()),
+                            )
+                            .child(
+                                container()
+                                    .layout(Flex::column().spacing(3.0))
+                                    .child(section_title("Column - CrossAxisAlignment"))
+                                    .child(column_cross_axis_tests()),
+                            ),
+                    )
+            },
+        );
+    });
 }
 
 fn section_title(title: &'static str) -> impl Widget {

--- a/examples/image_example.rs
+++ b/examples/image_example.rs
@@ -111,15 +111,16 @@ fn main() {
                 ),
         );
 
-    let (app, _) = App::new().add_surface(
-        SurfaceConfig::new()
-            .width(820)
-            .height(400)
-            .anchor(Anchor::TOP | Anchor::LEFT)
-            .layer(Layer::Top)
-            .namespace("image-example")
-            .background_color(Color::rgb(0.1, 0.1, 0.15)),
-        || view,
-    );
-    app.run();
+    App::new().run(|app| {
+        app.add_surface(
+            SurfaceConfig::new()
+                .width(820)
+                .height(400)
+                .anchor(Anchor::TOP | Anchor::LEFT)
+                .layer(Layer::Top)
+                .namespace("image-example")
+                .background_color(Color::rgb(0.1, 0.1, 0.15)),
+            || view,
+        );
+    });
 }

--- a/examples/image_fit_none_test.rs
+++ b/examples/image_fit_none_test.rs
@@ -150,15 +150,16 @@ fn main() {
                 )),
         );
 
-    let (app, _) = App::new().add_surface(
-        SurfaceConfig::new()
-            .width(900)
-            .height(700)
-            .anchor(Anchor::TOP | Anchor::LEFT)
-            .layer(Layer::Top)
-            .namespace("image-fit-none-test")
-            .background_color(Color::rgb(0.1, 0.1, 0.15)),
-        || view,
-    );
-    app.run();
+    App::new().run(|app| {
+        app.add_surface(
+            SurfaceConfig::new()
+                .width(900)
+                .height(700)
+                .anchor(Anchor::TOP | Anchor::LEFT)
+                .layer(Layer::Top)
+                .namespace("image-fit-none-test")
+                .background_color(Color::rgb(0.1, 0.1, 0.15)),
+            || view,
+        );
+    });
 }

--- a/examples/multi_surface.rs
+++ b/examples/multi_surface.rs
@@ -9,83 +9,84 @@
 use guido::prelude::*;
 
 fn main() {
-    // Shared signal that can be updated from any surface
-    let count = create_signal(0);
+    App::new().run(|app| {
+        // Shared signal that can be updated from any surface
+        let count = create_signal(0);
 
-    let (app, _bar_id) = App::new().add_surface(
-        // Top status bar
-        SurfaceConfig::new()
-            .height(32)
-            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
-            .layer(Layer::Top)
-            .namespace("status-bar")
-            .background_color(Color::rgb(0.1, 0.1, 0.15)),
-        move || {
-            container()
-                .height(fill())
-                .layout(
-                    Flex::row()
-                        .spacing(8.0)
-                        .main_axis_alignment(MainAxisAlignment::SpaceBetween)
-                        .cross_axis_alignment(CrossAxisAlignment::Center),
-                )
-                .padding_xy(16.0, 0.0)
-                .child(
-                    text("Multi-Surface Demo")
-                        .color(Color::WHITE)
-                        .font_size(14.0),
-                )
-                .child(
-                    text(move || format!("Count: {}", count.get()))
-                        .color(Color::WHITE)
-                        .font_size(14.0),
-                )
-        },
-    );
-    // Bottom dock
-    let (app, _dock_id) = app.add_surface(
-        SurfaceConfig::new()
-            .height(48)
-            .anchor(Anchor::BOTTOM | Anchor::LEFT | Anchor::RIGHT)
-            .layer(Layer::Top)
-            .namespace("dock")
-            .background_color(Color::rgb(0.15, 0.15, 0.2)),
-        move || {
-            container()
-                .height(fill())
-                .layout(
-                    Flex::row()
-                        .spacing(16.0)
-                        .main_axis_alignment(MainAxisAlignment::Center)
-                        .cross_axis_alignment(CrossAxisAlignment::Center),
-                )
-                .children([
-                    container()
-                        .background(Color::rgb(0.3, 0.3, 0.4))
-                        .padding_xy(16.0, 8.0)
-                        .corner_radius(8.0)
-                        .hover_state(|s| s.lighter(0.1))
-                        .pressed_state(|s| s.ripple())
-                        .on_click(move || count.update(|c| *c += 1))
-                        .child(text("+").color(Color::WHITE).font_size(16.0)),
-                    container()
-                        .background(Color::rgb(0.3, 0.3, 0.4))
-                        .padding_xy(16.0, 8.0)
-                        .corner_radius(8.0)
-                        .hover_state(|s| s.lighter(0.1))
-                        .pressed_state(|s| s.ripple())
-                        .on_click(move || count.update(|c| *c -= 1))
-                        .child(text("-").color(Color::WHITE).font_size(16.0)),
-                    container()
-                        .background(Color::rgb(0.4, 0.2, 0.2))
-                        .padding_xy(16.0, 8.0)
-                        .corner_radius(8.0)
-                        .hover_state(|s| s.lighter(0.1))
-                        .pressed_state(|s| s.ripple())
-                        .on_click(move || count.set(0))
-                        .child(text("Reset").color(Color::WHITE).font_size(16.0)),
-                ])
-        },
-    );
-    app.run();
+        app.add_surface(
+            // Top status bar
+            SurfaceConfig::new()
+                .height(32)
+                .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+                .layer(Layer::Top)
+                .namespace("status-bar")
+                .background_color(Color::rgb(0.1, 0.1, 0.15)),
+            move || {
+                container()
+                    .height(fill())
+                    .layout(
+                        Flex::row()
+                            .spacing(8.0)
+                            .main_axis_alignment(MainAxisAlignment::SpaceBetween)
+                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                    )
+                    .padding_xy(16.0, 0.0)
+                    .child(
+                        text("Multi-Surface Demo")
+                            .color(Color::WHITE)
+                            .font_size(14.0),
+                    )
+                    .child(
+                        text(move || format!("Count: {}", count.get()))
+                            .color(Color::WHITE)
+                            .font_size(14.0),
+                    )
+            },
+        );
+        // Bottom dock
+        app.add_surface(
+            SurfaceConfig::new()
+                .height(48)
+                .anchor(Anchor::BOTTOM | Anchor::LEFT | Anchor::RIGHT)
+                .layer(Layer::Top)
+                .namespace("dock")
+                .background_color(Color::rgb(0.15, 0.15, 0.2)),
+            move || {
+                container()
+                    .height(fill())
+                    .layout(
+                        Flex::row()
+                            .spacing(16.0)
+                            .main_axis_alignment(MainAxisAlignment::Center)
+                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                    )
+                    .children([
+                        container()
+                            .background(Color::rgb(0.3, 0.3, 0.4))
+                            .padding_xy(16.0, 8.0)
+                            .corner_radius(8.0)
+                            .hover_state(|s| s.lighter(0.1))
+                            .pressed_state(|s| s.ripple())
+                            .on_click(move || count.update(|c| *c += 1))
+                            .child(text("+").color(Color::WHITE).font_size(16.0)),
+                        container()
+                            .background(Color::rgb(0.3, 0.3, 0.4))
+                            .padding_xy(16.0, 8.0)
+                            .corner_radius(8.0)
+                            .hover_state(|s| s.lighter(0.1))
+                            .pressed_state(|s| s.ripple())
+                            .on_click(move || count.update(|c| *c -= 1))
+                            .child(text("-").color(Color::WHITE).font_size(16.0)),
+                        container()
+                            .background(Color::rgb(0.4, 0.2, 0.2))
+                            .padding_xy(16.0, 8.0)
+                            .corner_radius(8.0)
+                            .hover_state(|s| s.lighter(0.1))
+                            .pressed_state(|s| s.ripple())
+                            .on_click(move || count.set(0))
+                            .child(text("Reset").color(Color::WHITE).font_size(16.0)),
+                    ])
+            },
+        );
+    });
 }

--- a/examples/nested_transform_example.rs
+++ b/examples/nested_transform_example.rs
@@ -6,100 +6,101 @@
 use guido::prelude::*;
 
 fn main() {
-    let (app, _) = App::new().add_surface(
-        SurfaceConfig::new()
-            .height(200)
-            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
-            .background_color(Color::rgb(0.1, 0.1, 0.15)),
-        || {
-            container()
-                .layout(
-                    Flex::row()
-                        .spacing(40.0)
-                        .main_axis_alignment(MainAxisAlignment::Center)
-                        .cross_axis_alignment(CrossAxisAlignment::Center),
-                )
-                .padding(20.0)
-                .children([
-                    // Case 0: Parent, child
-                    // Expected: Inner box centered
-                    container()
-                        .width(100.0)
-                        .height(100.0)
-                        .background(Color::rgba(0.8, 0.3, 0.3, 0.5))
-                        .corner_radius(8.0)
-                        .child(
-                            container()
-                                .width(60.0)
-                                .height(60.0)
-                                .background(Color::rgb(0.3, 0.8, 0.3))
-                                .corner_radius(4.0),
-                        ),
-                    // Case 1: Parent rotated 30, child scaled 0.7
-                    // Expected: Inner box rotated 30deg AND smaller
-                    container()
-                        .width(100.0)
-                        .height(100.0)
-                        .background(Color::rgba(0.8, 0.3, 0.3, 0.5))
-                        .corner_radius(8.0)
-                        .rotate(30.0)
-                        .child(
-                            container()
-                                .width(60.0)
-                                .height(60.0)
-                                .background(Color::rgb(0.3, 0.8, 0.3))
-                                .corner_radius(4.0)
-                                .scale(0.7),
-                        ),
-                    // Case 2: Both parent and child rotated 20deg each
-                    // Expected: Inner box rotated 40deg total
-                    container()
-                        .width(100.0)
-                        .height(100.0)
-                        .background(Color::rgba(0.3, 0.3, 0.8, 0.5))
-                        .corner_radius(8.0)
-                        .rotate(20.0)
-                        .child(
-                            container()
-                                .width(60.0)
-                                .height(60.0)
-                                .background(Color::rgb(0.8, 0.8, 0.3))
-                                .corner_radius(4.0)
-                                .rotate(20.0),
-                        ),
-                    // Case 3: Parent scaled 1.3, child rotated 45deg
-                    // Expected: Inner box rotated AND the whole group larger
-                    container()
-                        .width(100.0)
-                        .height(100.0)
-                        .background(Color::rgba(0.8, 0.5, 0.2, 0.5))
-                        .corner_radius(8.0)
-                        .scale(1.3)
-                        .child(
-                            container()
-                                .width(60.0)
-                                .height(60.0)
-                                .background(Color::rgb(0.5, 0.2, 0.8))
-                                .corner_radius(4.0)
-                                .rotate(45.0),
-                        ),
-                    // Case 4: Child with NO transform (inherits parent's rotation)
-                    // Expected: Inner box rotated same as parent (30deg)
-                    container()
-                        .width(100.0)
-                        .height(100.0)
-                        .background(Color::rgba(0.2, 0.7, 0.7, 0.5))
-                        .corner_radius(8.0)
-                        .rotate(30.0)
-                        .child(
-                            container()
-                                .width(60.0)
-                                .height(60.0)
-                                .background(Color::rgb(0.7, 0.2, 0.7))
-                                .corner_radius(4.0),
-                        ),
-                ])
-        },
-    );
-    app.run();
+    App::new().run(|app| {
+        app.add_surface(
+            SurfaceConfig::new()
+                .height(200)
+                .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+                .background_color(Color::rgb(0.1, 0.1, 0.15)),
+            || {
+                container()
+                    .layout(
+                        Flex::row()
+                            .spacing(40.0)
+                            .main_axis_alignment(MainAxisAlignment::Center)
+                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                    )
+                    .padding(20.0)
+                    .children([
+                        // Case 0: Parent, child
+                        // Expected: Inner box centered
+                        container()
+                            .width(100.0)
+                            .height(100.0)
+                            .background(Color::rgba(0.8, 0.3, 0.3, 0.5))
+                            .corner_radius(8.0)
+                            .child(
+                                container()
+                                    .width(60.0)
+                                    .height(60.0)
+                                    .background(Color::rgb(0.3, 0.8, 0.3))
+                                    .corner_radius(4.0),
+                            ),
+                        // Case 1: Parent rotated 30, child scaled 0.7
+                        // Expected: Inner box rotated 30deg AND smaller
+                        container()
+                            .width(100.0)
+                            .height(100.0)
+                            .background(Color::rgba(0.8, 0.3, 0.3, 0.5))
+                            .corner_radius(8.0)
+                            .rotate(30.0)
+                            .child(
+                                container()
+                                    .width(60.0)
+                                    .height(60.0)
+                                    .background(Color::rgb(0.3, 0.8, 0.3))
+                                    .corner_radius(4.0)
+                                    .scale(0.7),
+                            ),
+                        // Case 2: Both parent and child rotated 20deg each
+                        // Expected: Inner box rotated 40deg total
+                        container()
+                            .width(100.0)
+                            .height(100.0)
+                            .background(Color::rgba(0.3, 0.3, 0.8, 0.5))
+                            .corner_radius(8.0)
+                            .rotate(20.0)
+                            .child(
+                                container()
+                                    .width(60.0)
+                                    .height(60.0)
+                                    .background(Color::rgb(0.8, 0.8, 0.3))
+                                    .corner_radius(4.0)
+                                    .rotate(20.0),
+                            ),
+                        // Case 3: Parent scaled 1.3, child rotated 45deg
+                        // Expected: Inner box rotated AND the whole group larger
+                        container()
+                            .width(100.0)
+                            .height(100.0)
+                            .background(Color::rgba(0.8, 0.5, 0.2, 0.5))
+                            .corner_radius(8.0)
+                            .scale(1.3)
+                            .child(
+                                container()
+                                    .width(60.0)
+                                    .height(60.0)
+                                    .background(Color::rgb(0.5, 0.2, 0.8))
+                                    .corner_radius(4.0)
+                                    .rotate(45.0),
+                            ),
+                        // Case 4: Child with NO transform (inherits parent's rotation)
+                        // Expected: Inner box rotated same as parent (30deg)
+                        container()
+                            .width(100.0)
+                            .height(100.0)
+                            .background(Color::rgba(0.2, 0.7, 0.7, 0.5))
+                            .corner_radius(8.0)
+                            .rotate(30.0)
+                            .child(
+                                container()
+                                    .width(60.0)
+                                    .height(60.0)
+                                    .background(Color::rgb(0.7, 0.2, 0.7))
+                                    .corner_radius(4.0),
+                            ),
+                    ])
+            },
+        );
+    });
 }

--- a/examples/reactive_example.rs
+++ b/examples/reactive_example.rs
@@ -13,85 +13,89 @@ use std::time::Duration;
 use guido::prelude::*;
 
 fn main() {
-    // Create signals for reactive state
-    let count = create_signal(0i32);
-    let scroll_offset = create_signal(0.0f32);
+    App::new().run(|app| {
+        // Create signals for reactive state
+        let count = create_signal(0i32);
+        let scroll_offset = create_signal(0.0f32);
 
-    // Spawn a background thread that increments count every 2 seconds
-    // Use .writer() to get a Send-able handle for the background thread
-    let count_w = count.writer();
-    thread::spawn(move || {
-        loop {
-            thread::sleep(Duration::from_secs(2));
-            count_w.update(|c| *c += 1);
-        }
+        // Spawn a background thread that increments count every 2 seconds
+        // Use .writer() to get a Send-able handle for the background thread
+        let count_w = count.writer();
+        thread::spawn(move || {
+            loop {
+                thread::sleep(Duration::from_secs(2));
+                count_w.update(|c| *c += 1);
+            }
+        });
+
+        // Run the app
+        app.add_surface(
+            SurfaceConfig::new()
+                .height(32)
+                .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+                .background_color(Color::rgb(0.1, 0.1, 0.15)),
+            move || {
+                container()
+                    .layout(
+                        Flex::row()
+                            .spacing(8.0)
+                            .main_axis_alignment(MainAxisAlignment::SpaceBetween),
+                    )
+                    .child(
+                        // Clickable container with state layer - click to increment count
+                        container()
+                            .padding(8.0)
+                            .background(Color::rgb(0.2, 0.2, 0.3))
+                            .corner_radius(4.0)
+                            .hover_state(|s| s.lighter(0.1))
+                            .pressed_state(|s| s.ripple())
+                            .on_click(move || {
+                                count.update(|c| *c += 10);
+                            })
+                            .child(
+                                text(move || format!("Count: {} (click me!)", count.get()))
+                                    .color(Color::WHITE),
+                            ),
+                    )
+                    .child(
+                        // Scrollable container with hover state
+                        container()
+                            .padding(8.0)
+                            .background(Color::rgb(0.2, 0.3, 0.2))
+                            .corner_radius(4.0)
+                            .hover_state(|s| s.lighter(0.05))
+                            .on_scroll(move |_dx, dy, _source| {
+                                scroll_offset.update(|offset| {
+                                    *offset += dy;
+                                });
+                            })
+                            .child(
+                                text(move || format!("Scroll: {:.0}px", scroll_offset.get()))
+                                    .color(Color::WHITE),
+                            ),
+                    )
+                    .child(
+                        // Container with border and hover state
+                        container()
+                            .padding(8.0)
+                            .background(Color::rgb(0.15, 0.15, 0.2))
+                            .border(2.0, Color::rgb(0.4, 0.6, 0.8))
+                            .hover_state(|s| s.lighter(0.1))
+                            .child(text("With border").color(Color::WHITE)),
+                    )
+                    .child(
+                        // Container with gradient and hover state
+                        container()
+                            .padding(8.0)
+                            .gradient_horizontal(
+                                Color::rgb(0.3, 0.1, 0.4),
+                                Color::rgb(0.1, 0.3, 0.5),
+                            )
+                            .corner_radius(4.0)
+                            .hover_state(|s| s.lighter(0.1))
+                            .child(text("Gradient!").color(Color::WHITE)),
+                    )
+            },
+        );
     });
-
-    // Run the app
-    let (app, _) = App::new().add_surface(
-        SurfaceConfig::new()
-            .height(32)
-            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
-            .background_color(Color::rgb(0.1, 0.1, 0.15)),
-        move || {
-            container()
-                .layout(
-                    Flex::row()
-                        .spacing(8.0)
-                        .main_axis_alignment(MainAxisAlignment::SpaceBetween),
-                )
-                .child(
-                    // Clickable container with state layer - click to increment count
-                    container()
-                        .padding(8.0)
-                        .background(Color::rgb(0.2, 0.2, 0.3))
-                        .corner_radius(4.0)
-                        .hover_state(|s| s.lighter(0.1))
-                        .pressed_state(|s| s.ripple())
-                        .on_click(move || {
-                            count.update(|c| *c += 10);
-                        })
-                        .child(
-                            text(move || format!("Count: {} (click me!)", count.get()))
-                                .color(Color::WHITE),
-                        ),
-                )
-                .child(
-                    // Scrollable container with hover state
-                    container()
-                        .padding(8.0)
-                        .background(Color::rgb(0.2, 0.3, 0.2))
-                        .corner_radius(4.0)
-                        .hover_state(|s| s.lighter(0.05))
-                        .on_scroll(move |_dx, dy, _source| {
-                            scroll_offset.update(|offset| {
-                                *offset += dy;
-                            });
-                        })
-                        .child(
-                            text(move || format!("Scroll: {:.0}px", scroll_offset.get()))
-                                .color(Color::WHITE),
-                        ),
-                )
-                .child(
-                    // Container with border and hover state
-                    container()
-                        .padding(8.0)
-                        .background(Color::rgb(0.15, 0.15, 0.2))
-                        .border(2.0, Color::rgb(0.4, 0.6, 0.8))
-                        .hover_state(|s| s.lighter(0.1))
-                        .child(text("With border").color(Color::WHITE)),
-                )
-                .child(
-                    // Container with gradient and hover state
-                    container()
-                        .padding(8.0)
-                        .gradient_horizontal(Color::rgb(0.3, 0.1, 0.4), Color::rgb(0.1, 0.3, 0.5))
-                        .corner_radius(4.0)
-                        .hover_state(|s| s.lighter(0.1))
-                        .child(text("Gradient!").color(Color::WHITE)),
-                )
-        },
-    );
-    app.run();
 }

--- a/examples/render_stats_test.rs
+++ b/examples/render_stats_test.rs
@@ -13,55 +13,56 @@ use guido::prelude::*;
 
 #[tokio::main]
 async fn main() {
-    // Signal to drive rotation animation
-    let rotation = create_signal(0.0f32);
+    App::new().run(|app| {
+        // Signal to drive rotation animation
+        let rotation = create_signal(0.0f32);
 
-    // Continuously update rotation to force frame rendering
-    let rotation_w = rotation.writer();
-    let _ = create_service::<(), _, _>(move |_rx, ctx| async move {
-        while ctx.is_running() {
-            rotation_w.update(|r| *r += 1.0);
-            tokio::time::sleep(std::time::Duration::from_millis(16)).await; // ~60fps
-        }
-    });
+        // Continuously update rotation to force frame rendering
+        let rotation_w = rotation.writer();
+        let _ = create_service::<(), _, _>(move |_rx, ctx| async move {
+            while ctx.is_running() {
+                rotation_w.update(|r| *r += 1.0);
+                tokio::time::sleep(std::time::Duration::from_millis(16)).await; // ~60fps
+            }
+        });
 
-    let view = container()
-        .width(400.0)
-        .height(200.0)
-        .padding(16.0)
-        .background(Color::rgb(0.1, 0.1, 0.15))
-        .layout(Flex::column().spacing(8.0))
-        // Animated container (will re-layout due to transform animation)
-        .child(
-            container()
-                .padding(8.0)
-                .background(Color::rgb(0.2, 0.2, 0.3))
-                .rotate(rotation)
-                .child(text("Rotating").color(Color::WHITE)),
-        )
-        // Static containers (should have layout skipped after first frame)
-        .child(
-            container()
-                .padding(8.0)
-                .background(Color::rgb(0.2, 0.3, 0.2))
-                .child(text("Static text 1").color(Color::WHITE)),
-        )
-        .child(
-            container()
-                .padding(8.0)
-                .background(Color::rgb(0.3, 0.2, 0.2))
-                .child(text("Static text 2").color(Color::WHITE)),
+        let view = container()
+            .width(400.0)
+            .height(200.0)
+            .padding(16.0)
+            .background(Color::rgb(0.1, 0.1, 0.15))
+            .layout(Flex::column().spacing(8.0))
+            // Animated container (will re-layout due to transform animation)
+            .child(
+                container()
+                    .padding(8.0)
+                    .background(Color::rgb(0.2, 0.2, 0.3))
+                    .rotate(rotation)
+                    .child(text("Rotating").color(Color::WHITE)),
+            )
+            // Static containers (should have layout skipped after first frame)
+            .child(
+                container()
+                    .padding(8.0)
+                    .background(Color::rgb(0.2, 0.3, 0.2))
+                    .child(text("Static text 1").color(Color::WHITE)),
+            )
+            .child(
+                container()
+                    .padding(8.0)
+                    .background(Color::rgb(0.3, 0.2, 0.2))
+                    .child(text("Static text 2").color(Color::WHITE)),
+            );
+
+        app.add_surface(
+            SurfaceConfig::new()
+                .width(400)
+                .height(200)
+                .anchor(Anchor::TOP | Anchor::LEFT)
+                .layer(Layer::Top)
+                .namespace("render-stats-test")
+                .background_color(Color::rgb(0.08, 0.08, 0.12)),
+            move || view,
         );
-
-    let (app, _) = App::new().add_surface(
-        SurfaceConfig::new()
-            .width(400)
-            .height(200)
-            .anchor(Anchor::TOP | Anchor::LEFT)
-            .layer(Layer::Top)
-            .namespace("render-stats-test")
-            .background_color(Color::rgb(0.08, 0.08, 0.12)),
-        move || view,
-    );
-    app.run();
+    });
 }

--- a/examples/renderer_v2_test.rs
+++ b/examples/renderer_v2_test.rs
@@ -6,110 +6,110 @@
 use guido::prelude::*;
 
 fn main() {
-    let (app, _) = App::new().add_surface(
-        SurfaceConfig::new()
-            .height(140)
-            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
-            .background_color(Color::rgb(0.1, 0.1, 0.15)),
-        move || {
-            container()
-                .layout(
-                    Flex::row()
-                        .spacing(10.0)
-                        .main_axis_alignment(MainAxisAlignment::Center),
-                )
-                .padding(16.0)
-                .children([
-                    // Simple colored box
-                    container()
-                        .width(60.0)
-                        .height(60.0)
-                        .background(Color::rgb(0.8, 0.2, 0.2))
-                        .corner_radius(8.0),
-                    // Box with border
-                    container()
-                        .width(60.0)
-                        .height(60.0)
-                        .background(Color::rgb(0.2, 0.8, 0.2))
-                        .corner_radius(8.0)
-                        .border(2.0, Color::WHITE),
-                    // Rotated box
-                    container()
-                        .width(60.0)
-                        .height(60.0)
-                        .background(Color::rgb(0.2, 0.2, 0.8))
-                        .corner_radius(8.0)
-                        .rotate(15.0),
-                    // Scaled box
-                    container()
-                        .width(60.0)
-                        .height(60.0)
-                        .background(Color::rgb(0.8, 0.8, 0.2))
-                        .corner_radius(8.0)
-                        .scale(0.8),
-                    // Box with squircle corners
-                    container()
-                        .width(60.0)
-                        .height(60.0)
-                        .background(Color::rgb(0.8, 0.2, 0.8))
-                        .corner_radius(12.0)
-                        .squircle(),
-                    // Squircle with border
-                    container()
-                        .width(60.0)
-                        .height(60.0)
-                        .background(Color::rgb(0.6, 0.3, 0.7))
-                        .corner_radius(12.0)
-                        .squircle()
-                        .border(2.0, Color::WHITE),
-                    // Scoop corners (concave)
-                    container()
-                        .width(60.0)
-                        .height(60.0)
-                        .background(Color::rgb(0.9, 0.5, 0.2))
-                        .corner_radius(16.0)
-                        .scoop(),
-                    // Scoop with border
-                    container()
-                        .width(60.0)
-                        .height(60.0)
-                        .background(Color::rgb(0.7, 0.4, 0.1))
-                        .corner_radius(16.0)
-                        .scoop()
-                        .border(2.0, Color::WHITE),
-                    // Box with shadow (elevation)
-                    container()
-                        .width(60.0)
-                        .height(60.0)
-                        .background(Color::rgb(0.2, 0.8, 0.8))
-                        .corner_radius(8.0)
-                        .elevation(4.0),
-                    // Clickable box with ripple
-                    container()
-                        .width(60.0)
-                        .height(60.0)
-                        .background(Color::rgb(0.5, 0.5, 0.5))
-                        .corner_radius(8.0)
-                        .hover_state(|s| s.lighter(0.1))
-                        .pressed_state(|s| s.ripple())
-                        .on_click(|| {
-                            println!("Clicked!");
-                        }),
-                    // Nested containers
-                    container()
-                        .width(70.0)
-                        .height(60.0)
-                        .background(Color::rgb(0.3, 0.3, 0.4))
-                        .corner_radius(8.0)
-                        .padding(8.0)
-                        .child(
-                            container()
-                                .background(Color::rgb(0.6, 0.4, 0.2))
-                                .corner_radius(4.0),
-                        ),
-                ])
-        },
-    );
-
-    app.run();
+    App::new().run(|app| {
+        app.add_surface(
+            SurfaceConfig::new()
+                .height(140)
+                .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+                .background_color(Color::rgb(0.1, 0.1, 0.15)),
+            move || {
+                container()
+                    .layout(
+                        Flex::row()
+                            .spacing(10.0)
+                            .main_axis_alignment(MainAxisAlignment::Center),
+                    )
+                    .padding(16.0)
+                    .children([
+                        // Simple colored box
+                        container()
+                            .width(60.0)
+                            .height(60.0)
+                            .background(Color::rgb(0.8, 0.2, 0.2))
+                            .corner_radius(8.0),
+                        // Box with border
+                        container()
+                            .width(60.0)
+                            .height(60.0)
+                            .background(Color::rgb(0.2, 0.8, 0.2))
+                            .corner_radius(8.0)
+                            .border(2.0, Color::WHITE),
+                        // Rotated box
+                        container()
+                            .width(60.0)
+                            .height(60.0)
+                            .background(Color::rgb(0.2, 0.2, 0.8))
+                            .corner_radius(8.0)
+                            .rotate(15.0),
+                        // Scaled box
+                        container()
+                            .width(60.0)
+                            .height(60.0)
+                            .background(Color::rgb(0.8, 0.8, 0.2))
+                            .corner_radius(8.0)
+                            .scale(0.8),
+                        // Box with squircle corners
+                        container()
+                            .width(60.0)
+                            .height(60.0)
+                            .background(Color::rgb(0.8, 0.2, 0.8))
+                            .corner_radius(12.0)
+                            .squircle(),
+                        // Squircle with border
+                        container()
+                            .width(60.0)
+                            .height(60.0)
+                            .background(Color::rgb(0.6, 0.3, 0.7))
+                            .corner_radius(12.0)
+                            .squircle()
+                            .border(2.0, Color::WHITE),
+                        // Scoop corners (concave)
+                        container()
+                            .width(60.0)
+                            .height(60.0)
+                            .background(Color::rgb(0.9, 0.5, 0.2))
+                            .corner_radius(16.0)
+                            .scoop(),
+                        // Scoop with border
+                        container()
+                            .width(60.0)
+                            .height(60.0)
+                            .background(Color::rgb(0.7, 0.4, 0.1))
+                            .corner_radius(16.0)
+                            .scoop()
+                            .border(2.0, Color::WHITE),
+                        // Box with shadow (elevation)
+                        container()
+                            .width(60.0)
+                            .height(60.0)
+                            .background(Color::rgb(0.2, 0.8, 0.8))
+                            .corner_radius(8.0)
+                            .elevation(4.0),
+                        // Clickable box with ripple
+                        container()
+                            .width(60.0)
+                            .height(60.0)
+                            .background(Color::rgb(0.5, 0.5, 0.5))
+                            .corner_radius(8.0)
+                            .hover_state(|s| s.lighter(0.1))
+                            .pressed_state(|s| s.ripple())
+                            .on_click(|| {
+                                println!("Clicked!");
+                            }),
+                        // Nested containers
+                        container()
+                            .width(70.0)
+                            .height(60.0)
+                            .background(Color::rgb(0.3, 0.3, 0.4))
+                            .corner_radius(8.0)
+                            .padding(8.0)
+                            .child(
+                                container()
+                                    .background(Color::rgb(0.6, 0.4, 0.2))
+                                    .corner_radius(4.0),
+                            ),
+                    ])
+            },
+        );
+    });
 }

--- a/examples/rounded_hitbox_test.rs
+++ b/examples/rounded_hitbox_test.rs
@@ -7,15 +7,16 @@
 use guido::prelude::*;
 
 fn main() {
-    let click_count = create_signal(0);
+    App::new().run(|app| {
+        let click_count = create_signal(0);
 
-    let (app, _) = App::new().add_surface(
-        SurfaceConfig::new()
-            .height(300)
-            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
-            .background_color(Color::rgb(0.1, 0.1, 0.15)),
-        move || {
-            container()
+        app.add_surface(
+            SurfaceConfig::new()
+                .height(300)
+                .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+                .background_color(Color::rgb(0.1, 0.1, 0.15)),
+            move || {
+                container()
                 .layout(
                     Flex::column()
                         .spacing(30.0)
@@ -54,9 +55,9 @@ fn main() {
                             .color(Color::WHITE),
                     ),
                 ])
-        },
-    );
-    app.run();
+            },
+        );
+    });
 }
 
 fn make_box(

--- a/examples/rounded_transform_test.rs
+++ b/examples/rounded_transform_test.rs
@@ -7,64 +7,67 @@
 use guido::prelude::*;
 
 fn main() {
-    let click_count = create_signal(0);
+    App::new().run(|app| {
+        let click_count = create_signal(0);
 
-    let (app, _) = App::new().add_surface(
-        SurfaceConfig::new()
-            .height(280)
-            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
-            .background_color(Color::rgb(0.1, 0.1, 0.15)),
-        move || {
-            container()
-                .layout(
-                    Flex::column()
-                        .spacing(30.0)
-                        .main_axis_alignment(MainAxisAlignment::Center)
-                        .cross_axis_alignment(CrossAxisAlignment::Center),
-                )
-                .padding(40.0)
-                .children([
-                    // Row with transforms
-                    container()
-                        .layout(
-                            Flex::row()
-                                .spacing(50.0)
-                                .main_axis_alignment(MainAxisAlignment::Center),
-                        )
-                        .children([
-                            // No transform (control)
-                            make_box("None", Color::rgb(0.5, 0.5, 0.5), click_count),
-                            // Translate
-                            make_box("Translate", Color::rgb(0.3, 0.8, 0.3), click_count)
-                                .translate(15.0, 10.0),
-                            // Rotate
-                            make_box("Rotate", Color::rgb(0.3, 0.3, 0.8), click_count).rotate(20.0),
-                            // All 3 transforms (nested)
-                            container().translate(10.0, 15.0).child(
-                                container().scale(1.15).child(
-                                    make_box("All 3", Color::rgb(0.8, 0.8, 0.3), click_count)
-                                        .rotate(25.0),
+        app.add_surface(
+            SurfaceConfig::new()
+                .height(280)
+                .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+                .background_color(Color::rgb(0.1, 0.1, 0.15)),
+            move || {
+                container()
+                    .layout(
+                        Flex::column()
+                            .spacing(30.0)
+                            .main_axis_alignment(MainAxisAlignment::Center)
+                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                    )
+                    .padding(40.0)
+                    .children([
+                        // Row with transforms
+                        container()
+                            .layout(
+                                Flex::row()
+                                    .spacing(50.0)
+                                    .main_axis_alignment(MainAxisAlignment::Center),
+                            )
+                            .children([
+                                // No transform (control)
+                                make_box("None", Color::rgb(0.5, 0.5, 0.5), click_count),
+                                // Translate
+                                make_box("Translate", Color::rgb(0.3, 0.8, 0.3), click_count)
+                                    .translate(15.0, 10.0),
+                                // Rotate
+                                make_box("Rotate", Color::rgb(0.3, 0.3, 0.8), click_count)
+                                    .rotate(20.0),
+                                // All 3 transforms (nested)
+                                container().translate(10.0, 15.0).child(
+                                    container().scale(1.15).child(
+                                        make_box("All 3", Color::rgb(0.8, 0.8, 0.3), click_count)
+                                            .rotate(25.0),
+                                    ),
                                 ),
-                            ),
-                            // Scale
-                            make_box("Scale", Color::rgb(0.8, 0.3, 0.8), click_count).scale(1.2),
-                        ]),
-                    // Instructions
-                    container().child(
-                        text("Rectangular boxes with transforms. Hover and click to test.")
-                            .font_size(14.0)
-                            .color(Color::rgb(0.7, 0.7, 0.7)),
-                    ),
-                    // Click counter display
-                    container().child(
-                        text(move || format!("Clicks: {}", click_count.get()))
-                            .font_size(20.0)
-                            .color(Color::WHITE),
-                    ),
-                ])
-        },
-    );
-    app.run();
+                                // Scale
+                                make_box("Scale", Color::rgb(0.8, 0.3, 0.8), click_count)
+                                    .scale(1.2),
+                            ]),
+                        // Instructions
+                        container().child(
+                            text("Rectangular boxes with transforms. Hover and click to test.")
+                                .font_size(14.0)
+                                .color(Color::rgb(0.7, 0.7, 0.7)),
+                        ),
+                        // Click counter display
+                        container().child(
+                            text(move || format!("Clicks: {}", click_count.get()))
+                                .font_size(20.0)
+                                .color(Color::WHITE),
+                        ),
+                    ])
+            },
+        );
+    });
 }
 
 fn make_box(label: &'static str, base_color: Color, click_count: Signal<i32>) -> Container {

--- a/examples/scroll_example.rs
+++ b/examples/scroll_example.rs
@@ -173,13 +173,14 @@ fn main() {
         );
 
     // Run the app with a larger window for the demo
-    let (app, _) = App::new().add_surface(
-        SurfaceConfig::new()
-            .width(900)
-            .height(300)
-            .anchor(Anchor::TOP | Anchor::LEFT)
-            .background_color(Color::rgb(0.1, 0.1, 0.15)),
-        move || view,
-    );
-    app.run();
+    App::new().run(|app| {
+        app.add_surface(
+            SurfaceConfig::new()
+                .width(900)
+                .height(300)
+                .anchor(Anchor::TOP | Anchor::LEFT)
+                .background_color(Color::rgb(0.1, 0.1, 0.15)),
+            move || view,
+        );
+    });
 }

--- a/examples/scroll_mixed_content.rs
+++ b/examples/scroll_mixed_content.rs
@@ -9,350 +9,357 @@
 use guido::prelude::*;
 
 fn main() {
-    // Signals for text inputs
-    let name = create_signal(String::new());
-    let email = create_signal(String::new());
-    let bio = create_signal(String::new());
+    App::new().run(|app| {
+        // Signals for text inputs
+        let name = create_signal(String::new());
+        let email = create_signal(String::new());
+        let bio = create_signal(String::new());
 
-    // Helper to create a form field
-    fn form_field(label: &'static str, input_signal: Signal<String>) -> Container {
-        container()
-            .layout(Flex::column().spacing(4.0))
-            .child(text(label).color(Color::rgb(0.7, 0.7, 0.8)).font_size(12.0))
-            .child(
-                container()
-                    .padding(8.0)
-                    .background(Color::rgb(0.18, 0.18, 0.24))
-                    .border(1.0, Color::rgb(0.3, 0.3, 0.4))
-                    .corner_radius(6.0)
-                    .focused_state(|s| s.border(2.0, Color::rgb(0.4, 0.8, 1.0)))
-                    .child(
-                        text_input(input_signal)
-                            .text_color(Color::WHITE)
-                            .cursor_color(Color::rgb(0.4, 0.8, 1.0))
-                            .selection_color(Color::rgba(0.4, 0.6, 1.0, 0.4))
-                            .font_size(14.0),
-                    ),
-            )
-    }
+        // Helper to create a form field
+        fn form_field(label: &'static str, input_signal: Signal<String>) -> Container {
+            container()
+                .layout(Flex::column().spacing(4.0))
+                .child(text(label).color(Color::rgb(0.7, 0.7, 0.8)).font_size(12.0))
+                .child(
+                    container()
+                        .padding(8.0)
+                        .background(Color::rgb(0.18, 0.18, 0.24))
+                        .border(1.0, Color::rgb(0.3, 0.3, 0.4))
+                        .corner_radius(6.0)
+                        .focused_state(|s| s.border(2.0, Color::rgb(0.4, 0.8, 1.0)))
+                        .child(
+                            text_input(input_signal)
+                                .text_color(Color::WHITE)
+                                .cursor_color(Color::rgb(0.4, 0.8, 1.0))
+                                .selection_color(Color::rgba(0.4, 0.6, 1.0, 0.4))
+                                .font_size(14.0),
+                        ),
+                )
+        }
 
-    // Helper to create an image card
-    fn image_card(path: &'static str, label: &'static str) -> Container {
-        container()
-            .layout(Flex::column().spacing(8.0))
-            .child(
-                container()
-                    .background(Color::rgb(0.2, 0.2, 0.25))
-                    .corner_radius(8.0)
-                    .hover_state(|s| s.lighter(0.05))
-                    .child(
-                        image(path)
-                            .width(120.0)
-                            .height(90.0)
-                            .content_fit(ContentFit::Cover),
-                    ),
-            )
-            .child(text(label).font_size(11.0).color(Color::rgb(0.6, 0.6, 0.7)))
-    }
-
-    // Main scrollable content
-    let view = container()
-        .padding(16.0)
-        .layout(Flex::row().spacing(16.0))
-        // Left panel: Vertical scroll with form and content
-        .child(
+        // Helper to create an image card
+        fn image_card(path: &'static str, label: &'static str) -> Container {
             container()
                 .layout(Flex::column().spacing(8.0))
                 .child(
-                    text("User Profile")
-                        .color(Color::WHITE)
-                        .font_size(16.0)
-                        .font_weight(FontWeight::BOLD),
-                )
-                .child(
                     container()
-                        .width(320.0)
-                        .height(400.0)
-                        .background(Color::rgb(0.12, 0.12, 0.18))
-                        .corner_radius(12.0)
-                        .scrollable(ScrollAxis::Vertical)
-                        .scrollbar(|sb| {
-                            sb.width(6.0)
-                                .handle_color(Color::rgb(0.4, 0.5, 0.6))
-                                .handle_hover_color(Color::rgb(0.5, 0.6, 0.7))
-                                .track_color(Color::rgba(0.3, 0.3, 0.4, 0.3))
-                        })
+                        .background(Color::rgb(0.2, 0.2, 0.25))
+                        .corner_radius(8.0)
+                        .hover_state(|s| s.lighter(0.05))
                         .child(
-                            container()
-                                .layout(Flex::column().spacing(16.0))
-                                .padding(16.0)
-                                // Profile header with image
-                                .child(
-                                    container()
-                                        .layout(
-                                            Flex::row()
-                                                .spacing(16.0)
-                                                .cross_axis_alignment(CrossAxisAlignment::Center),
-                                        )
-                                        .child(
-                                            container()
-                                                .corner_radius(40.0)
-                                                .background(Color::rgb(0.25, 0.25, 0.3))
-                                                .child(
-                                                    image("examples/assets/photo.webp")
-                                                        .width(80.0)
-                                                        .height(80.0)
-                                                        .content_fit(ContentFit::Cover),
+                            image(path)
+                                .width(120.0)
+                                .height(90.0)
+                                .content_fit(ContentFit::Cover),
+                        ),
+                )
+                .child(text(label).font_size(11.0).color(Color::rgb(0.6, 0.6, 0.7)))
+        }
+
+        // Main scrollable content
+        let view = container()
+            .padding(16.0)
+            .layout(Flex::row().spacing(16.0))
+            // Left panel: Vertical scroll with form and content
+            .child(
+                container()
+                    .layout(Flex::column().spacing(8.0))
+                    .child(
+                        text("User Profile")
+                            .color(Color::WHITE)
+                            .font_size(16.0)
+                            .font_weight(FontWeight::BOLD),
+                    )
+                    .child(
+                        container()
+                            .width(320.0)
+                            .height(400.0)
+                            .background(Color::rgb(0.12, 0.12, 0.18))
+                            .corner_radius(12.0)
+                            .scrollable(ScrollAxis::Vertical)
+                            .scrollbar(|sb| {
+                                sb.width(6.0)
+                                    .handle_color(Color::rgb(0.4, 0.5, 0.6))
+                                    .handle_hover_color(Color::rgb(0.5, 0.6, 0.7))
+                                    .track_color(Color::rgba(0.3, 0.3, 0.4, 0.3))
+                            })
+                            .child(
+                                container()
+                                    .layout(Flex::column().spacing(16.0))
+                                    .padding(16.0)
+                                    // Profile header with image
+                                    .child(
+                                        container()
+                                            .layout(
+                                                Flex::row().spacing(16.0).cross_axis_alignment(
+                                                    CrossAxisAlignment::Center,
                                                 ),
-                                        )
-                                        .child(
-                                            container()
-                                                .layout(Flex::column().spacing(4.0))
-                                                .child(
-                                                    text("Edit Profile")
-                                                        .color(Color::WHITE)
-                                                        .font_size(18.0),
-                                                )
-                                                .child(
-                                                    text("Update your information")
-                                                        .color(Color::rgb(0.5, 0.5, 0.6))
-                                                        .font_size(12.0),
-                                                ),
-                                        ),
-                                )
-                                // Form fields
-                                .child(form_field("Name", name))
-                                .child(form_field("Email", email))
-                                .child(form_field("Bio", bio))
-                                // Additional info section
-                                .child(
-                                    container()
-                                        .layout(Flex::column().spacing(8.0))
-                                        .child(
-                                            text("Account Settings")
-                                                .color(Color::WHITE)
-                                                .font_size(14.0),
-                                        )
-                                        .children(
-                                            [
-                                                "Notifications",
-                                                "Privacy",
-                                                "Security",
-                                                "Appearance",
-                                                "Language",
-                                            ]
-                                            .into_iter()
-                                            .map(|item| {
+                                            )
+                                            .child(
                                                 container()
-                                                    .padding(12.0)
-                                                    .background(Color::rgb(0.18, 0.18, 0.24))
-                                                    .corner_radius(6.0)
-                                                    .hover_state(|s| s.lighter(0.05))
-                                                    .pressed_state(|s| s.ripple())
+                                                    .corner_radius(40.0)
+                                                    .background(Color::rgb(0.25, 0.25, 0.3))
                                                     .child(
-                                                        text(item).color(Color::rgb(0.8, 0.8, 0.9)),
+                                                        image("examples/assets/photo.webp")
+                                                            .width(80.0)
+                                                            .height(80.0)
+                                                            .content_fit(ContentFit::Cover),
+                                                    ),
+                                            )
+                                            .child(
+                                                container()
+                                                    .layout(Flex::column().spacing(4.0))
+                                                    .child(
+                                                        text("Edit Profile")
+                                                            .color(Color::WHITE)
+                                                            .font_size(18.0),
                                                     )
-                                            })
-                                            .collect::<Vec<_>>(),
-                                        ),
-                                )
-                                // More content to ensure scroll
-                                .child(
-                                    container()
-                                        .layout(Flex::column().spacing(8.0))
-                                        .child(
-                                            text("Recent Activity")
-                                                .color(Color::WHITE)
-                                                .font_size(14.0),
-                                        )
-                                        .children(
-                                            (1..=8)
-                                                .map(|i| {
+                                                    .child(
+                                                        text("Update your information")
+                                                            .color(Color::rgb(0.5, 0.5, 0.6))
+                                                            .font_size(12.0),
+                                                    ),
+                                            ),
+                                    )
+                                    // Form fields
+                                    .child(form_field("Name", name))
+                                    .child(form_field("Email", email))
+                                    .child(form_field("Bio", bio))
+                                    // Additional info section
+                                    .child(
+                                        container()
+                                            .layout(Flex::column().spacing(8.0))
+                                            .child(
+                                                text("Account Settings")
+                                                    .color(Color::WHITE)
+                                                    .font_size(14.0),
+                                            )
+                                            .children(
+                                                [
+                                                    "Notifications",
+                                                    "Privacy",
+                                                    "Security",
+                                                    "Appearance",
+                                                    "Language",
+                                                ]
+                                                .into_iter()
+                                                .map(|item| {
                                                     container()
-                                                        .layout(Flex::row().spacing(8.0))
-                                                        .padding(8.0)
-                                                        .background(Color::rgb(0.15, 0.15, 0.2))
-                                                        .corner_radius(4.0)
+                                                        .padding(12.0)
+                                                        .background(Color::rgb(0.18, 0.18, 0.24))
+                                                        .corner_radius(6.0)
+                                                        .hover_state(|s| s.lighter(0.05))
+                                                        .pressed_state(|s| s.ripple())
                                                         .child(
-                                                            container()
-                                                                .width(32.0)
-                                                                .height(32.0)
-                                                                .background(Color::rgb(
-                                                                    0.2 + (i as f32) * 0.02,
-                                                                    0.3,
-                                                                    0.4,
-                                                                ))
-                                                                .corner_radius(16.0),
+                                                            text(item)
+                                                                .color(Color::rgb(0.8, 0.8, 0.9)),
                                                         )
-                                                        .child(
-                                                            container()
-                                                                .layout(Flex::column().spacing(2.0))
-                                                                .child(
-                                                                    text(format!("Activity {}", i))
+                                                })
+                                                .collect::<Vec<_>>(),
+                                            ),
+                                    )
+                                    // More content to ensure scroll
+                                    .child(
+                                        container()
+                                            .layout(Flex::column().spacing(8.0))
+                                            .child(
+                                                text("Recent Activity")
+                                                    .color(Color::WHITE)
+                                                    .font_size(14.0),
+                                            )
+                                            .children(
+                                                (1..=8)
+                                                    .map(|i| {
+                                                        container()
+                                                            .layout(Flex::row().spacing(8.0))
+                                                            .padding(8.0)
+                                                            .background(Color::rgb(0.15, 0.15, 0.2))
+                                                            .corner_radius(4.0)
+                                                            .child(
+                                                                container()
+                                                                    .width(32.0)
+                                                                    .height(32.0)
+                                                                    .background(Color::rgb(
+                                                                        0.2 + (i as f32) * 0.02,
+                                                                        0.3,
+                                                                        0.4,
+                                                                    ))
+                                                                    .corner_radius(16.0),
+                                                            )
+                                                            .child(
+                                                                container()
+                                                                    .layout(
+                                                                        Flex::column().spacing(2.0),
+                                                                    )
+                                                                    .child(
+                                                                        text(format!(
+                                                                            "Activity {}",
+                                                                            i
+                                                                        ))
                                                                         .color(Color::rgb(
                                                                             0.8, 0.8, 0.9,
                                                                         ))
                                                                         .font_size(13.0),
-                                                                )
-                                                                .child(
-                                                                    text(format!(
-                                                                        "{} hours ago",
-                                                                        i * 2
-                                                                    ))
-                                                                    .color(Color::rgb(
-                                                                        0.5, 0.5, 0.6,
-                                                                    ))
-                                                                    .font_size(11.0),
-                                                                ),
-                                                        )
-                                                })
-                                                .collect::<Vec<_>>(),
-                                        ),
-                                ),
-                        ),
-                ),
-        )
-        // Right panel: Horizontal scroll gallery
-        .child(
-            container()
-                .layout(Flex::column().spacing(8.0))
-                .child(
-                    text("Image Gallery")
-                        .color(Color::WHITE)
-                        .font_size(16.0)
-                        .font_weight(FontWeight::BOLD),
-                )
-                .child(
-                    container()
-                        .width(400.0)
-                        .height(160.0)
-                        .background(Color::rgb(0.12, 0.12, 0.18))
-                        .corner_radius(12.0)
-                        .scrollable(ScrollAxis::Horizontal)
-                        .scrollbar(|sb| {
-                            sb.width(6.0)
-                                .handle_color(Color::rgb(0.5, 0.6, 0.4))
-                                .handle_hover_color(Color::rgb(0.6, 0.7, 0.5))
-                                .track_color(Color::rgba(0.3, 0.4, 0.3, 0.3))
-                        })
-                        .child(
-                            container()
-                                .layout(Flex::row().spacing(12.0))
-                                .padding(12.0)
-                                .child(image_card("examples/assets/photo.webp", "Photo 1"))
-                                .child(image_card("examples/assets/photo.webp", "Photo 2"))
-                                .child(image_card("examples/assets/photo.webp", "Photo 3"))
-                                .child(image_card("examples/assets/photo.webp", "Photo 4"))
-                                .child(image_card("examples/assets/photo.webp", "Photo 5"))
-                                .child(image_card("examples/assets/photo.webp", "Photo 6")),
-                        ),
-                )
-                // SVG icons row
-                .child(
-                    text("Icons")
-                        .color(Color::WHITE)
-                        .font_size(16.0)
-                        .font_weight(FontWeight::BOLD),
-                )
-                .child(
-                    container()
-                        .width(400.0)
-                        .height(100.0)
-                        .background(Color::rgb(0.12, 0.12, 0.18))
-                        .corner_radius(12.0)
-                        .scrollable(ScrollAxis::Horizontal)
-                        .scrollbar(|sb| {
-                            sb.width(4.0)
-                                .handle_color(Color::rgb(0.6, 0.5, 0.7))
-                                .handle_hover_color(Color::rgb(0.7, 0.6, 0.8))
-                        })
-                        .child(
-                            container()
-                                .layout(Flex::row().spacing(16.0))
-                                .padding(12.0)
-                                .children(
-                                    (0..12)
-                                        .map(|i| {
-                                            container()
-                                                .layout(
-                                                    Flex::column()
-                                                        .spacing(4.0)
-                                                        .cross_axis_alignment(
-                                                            CrossAxisAlignment::Center,
-                                                        ),
-                                                )
-                                                .child(
-                                                    container()
-                                                        .width(48.0)
-                                                        .height(48.0)
-                                                        .background(Color::rgb(0.2, 0.2, 0.28))
-                                                        .corner_radius(8.0)
-                                                        .hover_state(|s| s.lighter(0.1))
-                                                        .pressed_state(|s| s.ripple())
-                                                        .layout(
-                                                            Flex::column()
-                                                                .main_axis_alignment(
-                                                                    MainAxisAlignment::Center,
-                                                                )
-                                                                .cross_axis_alignment(
-                                                                    CrossAxisAlignment::Center,
-                                                                ),
-                                                        )
-                                                        .child(
-                                                            image("examples/assets/logo.svg")
-                                                                .width(32.0)
-                                                                .height(24.0),
-                                                        ),
-                                                )
-                                                .child(
-                                                    text(format!("Icon {}", i + 1))
-                                                        .font_size(10.0)
-                                                        .color(Color::rgb(0.5, 0.5, 0.6)),
-                                                )
-                                        })
-                                        .collect::<Vec<_>>(),
-                                ),
-                        ),
-                )
-                // Current input values display
-                .child(
-                    container()
-                        .padding(12.0)
-                        .background(Color::rgb(0.12, 0.12, 0.18))
-                        .corner_radius(8.0)
-                        .layout(Flex::column().spacing(4.0))
-                        .child(
-                            text("Form Values:")
-                                .color(Color::rgb(0.5, 0.5, 0.6))
-                                .font_size(11.0),
-                        )
-                        .child(
-                            text(move || format!("Name: {}", name.get()))
-                                .color(Color::rgb(0.7, 0.7, 0.8))
-                                .font_size(12.0),
-                        )
-                        .child(
-                            text(move || format!("Email: {}", email.get()))
-                                .color(Color::rgb(0.7, 0.7, 0.8))
-                                .font_size(12.0),
-                        )
-                        .child(
-                            text(move || format!("Bio: {}", bio.get()))
-                                .color(Color::rgb(0.7, 0.7, 0.8))
-                                .font_size(12.0),
-                        ),
-                ),
-        );
+                                                                    )
+                                                                    .child(
+                                                                        text(format!(
+                                                                            "{} hours ago",
+                                                                            i * 2
+                                                                        ))
+                                                                        .color(Color::rgb(
+                                                                            0.5, 0.5, 0.6,
+                                                                        ))
+                                                                        .font_size(11.0),
+                                                                    ),
+                                                            )
+                                                    })
+                                                    .collect::<Vec<_>>(),
+                                            ),
+                                    ),
+                            ),
+                    ),
+            )
+            // Right panel: Horizontal scroll gallery
+            .child(
+                container()
+                    .layout(Flex::column().spacing(8.0))
+                    .child(
+                        text("Image Gallery")
+                            .color(Color::WHITE)
+                            .font_size(16.0)
+                            .font_weight(FontWeight::BOLD),
+                    )
+                    .child(
+                        container()
+                            .width(400.0)
+                            .height(160.0)
+                            .background(Color::rgb(0.12, 0.12, 0.18))
+                            .corner_radius(12.0)
+                            .scrollable(ScrollAxis::Horizontal)
+                            .scrollbar(|sb| {
+                                sb.width(6.0)
+                                    .handle_color(Color::rgb(0.5, 0.6, 0.4))
+                                    .handle_hover_color(Color::rgb(0.6, 0.7, 0.5))
+                                    .track_color(Color::rgba(0.3, 0.4, 0.3, 0.3))
+                            })
+                            .child(
+                                container()
+                                    .layout(Flex::row().spacing(12.0))
+                                    .padding(12.0)
+                                    .child(image_card("examples/assets/photo.webp", "Photo 1"))
+                                    .child(image_card("examples/assets/photo.webp", "Photo 2"))
+                                    .child(image_card("examples/assets/photo.webp", "Photo 3"))
+                                    .child(image_card("examples/assets/photo.webp", "Photo 4"))
+                                    .child(image_card("examples/assets/photo.webp", "Photo 5"))
+                                    .child(image_card("examples/assets/photo.webp", "Photo 6")),
+                            ),
+                    )
+                    // SVG icons row
+                    .child(
+                        text("Icons")
+                            .color(Color::WHITE)
+                            .font_size(16.0)
+                            .font_weight(FontWeight::BOLD),
+                    )
+                    .child(
+                        container()
+                            .width(400.0)
+                            .height(100.0)
+                            .background(Color::rgb(0.12, 0.12, 0.18))
+                            .corner_radius(12.0)
+                            .scrollable(ScrollAxis::Horizontal)
+                            .scrollbar(|sb| {
+                                sb.width(4.0)
+                                    .handle_color(Color::rgb(0.6, 0.5, 0.7))
+                                    .handle_hover_color(Color::rgb(0.7, 0.6, 0.8))
+                            })
+                            .child(
+                                container()
+                                    .layout(Flex::row().spacing(16.0))
+                                    .padding(12.0)
+                                    .children(
+                                        (0..12)
+                                            .map(|i| {
+                                                container()
+                                                    .layout(
+                                                        Flex::column()
+                                                            .spacing(4.0)
+                                                            .cross_axis_alignment(
+                                                                CrossAxisAlignment::Center,
+                                                            ),
+                                                    )
+                                                    .child(
+                                                        container()
+                                                            .width(48.0)
+                                                            .height(48.0)
+                                                            .background(Color::rgb(0.2, 0.2, 0.28))
+                                                            .corner_radius(8.0)
+                                                            .hover_state(|s| s.lighter(0.1))
+                                                            .pressed_state(|s| s.ripple())
+                                                            .layout(
+                                                                Flex::column()
+                                                                    .main_axis_alignment(
+                                                                        MainAxisAlignment::Center,
+                                                                    )
+                                                                    .cross_axis_alignment(
+                                                                        CrossAxisAlignment::Center,
+                                                                    ),
+                                                            )
+                                                            .child(
+                                                                image("examples/assets/logo.svg")
+                                                                    .width(32.0)
+                                                                    .height(24.0),
+                                                            ),
+                                                    )
+                                                    .child(
+                                                        text(format!("Icon {}", i + 1))
+                                                            .font_size(10.0)
+                                                            .color(Color::rgb(0.5, 0.5, 0.6)),
+                                                    )
+                                            })
+                                            .collect::<Vec<_>>(),
+                                    ),
+                            ),
+                    )
+                    // Current input values display
+                    .child(
+                        container()
+                            .padding(12.0)
+                            .background(Color::rgb(0.12, 0.12, 0.18))
+                            .corner_radius(8.0)
+                            .layout(Flex::column().spacing(4.0))
+                            .child(
+                                text("Form Values:")
+                                    .color(Color::rgb(0.5, 0.5, 0.6))
+                                    .font_size(11.0),
+                            )
+                            .child(
+                                text(move || format!("Name: {}", name.get()))
+                                    .color(Color::rgb(0.7, 0.7, 0.8))
+                                    .font_size(12.0),
+                            )
+                            .child(
+                                text(move || format!("Email: {}", email.get()))
+                                    .color(Color::rgb(0.7, 0.7, 0.8))
+                                    .font_size(12.0),
+                            )
+                            .child(
+                                text(move || format!("Bio: {}", bio.get()))
+                                    .color(Color::rgb(0.7, 0.7, 0.8))
+                                    .font_size(12.0),
+                            ),
+                    ),
+            );
 
-    let (app, _) = App::new().add_surface(
-        SurfaceConfig::new()
-            .width(780)
-            .height(500)
-            .anchor(Anchor::TOP | Anchor::LEFT)
-            .layer(Layer::Top)
-            .namespace("scroll-mixed-content")
-            .background_color(Color::rgb(0.08, 0.08, 0.12)),
-        move || view,
-    );
-    app.run();
+        app.add_surface(
+            SurfaceConfig::new()
+                .width(780)
+                .height(500)
+                .anchor(Anchor::TOP | Anchor::LEFT)
+                .layer(Layer::Top)
+                .namespace("scroll-mixed-content")
+                .background_color(Color::rgb(0.08, 0.08, 0.12)),
+            move || view,
+        );
+    });
 }

--- a/examples/service_example.rs
+++ b/examples/service_example.rs
@@ -18,103 +18,104 @@ enum WorkspaceCmd {
 
 #[tokio::main]
 async fn main() {
-    // Clock signal - updated by a read-only service
-    let time = create_signal(get_current_time());
-    let time_w = time.writer(); // WriteSignal is Send — can be captured by service
+    App::new().run(|app| {
+        // Clock signal - updated by a read-only service
+        let time = create_signal(get_current_time());
+        let time_w = time.writer(); // WriteSignal is Send — can be captured by service
 
-    // Clock service - read-only (ignore the receiver)
-    let _ = create_service::<(), _, _>(move |_rx, ctx| async move {
-        log::info!("Clock service started");
+        // Clock service - read-only (ignore the receiver)
+        let _ = create_service::<(), _, _>(move |_rx, ctx| async move {
+            log::info!("Clock service started");
 
-        while ctx.is_running() {
-            time_w.set(get_current_time());
-            tokio::time::sleep(Duration::from_secs(1)).await;
-        }
-
-        log::info!("Clock service stopped");
-    });
-
-    // Workspace signals
-    let active = create_signal(1i32);
-    let active_w = active.writer(); // WriteSignal is Send
-    let workspaces: Vec<i32> = vec![1, 2, 3, 4, 5];
-
-    // Workspace service - bidirectional
-    let service = create_service(move |mut rx, ctx| async move {
-        log::info!("Workspace service started");
-
-        while ctx.is_running() {
-            // Handle commands from UI
-            while let Ok(cmd) = rx.try_recv() {
-                match cmd {
-                    WorkspaceCmd::Switch(id) => {
-                        log::info!("Switching to workspace {}", id);
-                        active_w.set(id);
-                    }
-                }
+            while ctx.is_running() {
+                time_w.set(get_current_time());
+                tokio::time::sleep(Duration::from_secs(1)).await;
             }
 
-            tokio::time::sleep(Duration::from_millis(16)).await;
-        }
+            log::info!("Clock service stopped");
+        });
 
-        log::info!("Workspace service stopped");
-    });
+        // Workspace signals
+        let active = create_signal(1i32);
+        let active_w = active.writer(); // WriteSignal is Send
+        let workspaces: Vec<i32> = vec![1, 2, 3, 4, 5];
 
-    let (app, _) = App::new().add_surface(
-        SurfaceConfig::new()
-            .height(40)
-            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
-            .background_color(Color::rgb(0.1, 0.1, 0.15)),
-        move || {
-            let svc = service.clone();
+        // Workspace service - bidirectional
+        let service = create_service(move |mut rx, ctx| async move {
+            log::info!("Workspace service started");
 
-            container()
-                .layout(
-                    Flex::row()
-                        .spacing(16.0)
-                        .main_axis_alignment(MainAxisAlignment::SpaceBetween),
-                )
-                .padding(4.0)
-                // Workspace buttons
-                .child(container().layout(Flex::row().spacing(4.0)).children(
-                    workspaces.clone().into_iter().map(move |id| {
-                        let svc = svc.clone();
+            while ctx.is_running() {
+                // Handle commands from UI
+                while let Ok(cmd) = rx.try_recv() {
+                    match cmd {
+                        WorkspaceCmd::Switch(id) => {
+                            log::info!("Switching to workspace {}", id);
+                            active_w.set(id);
+                        }
+                    }
+                }
+
+                tokio::time::sleep(Duration::from_millis(16)).await;
+            }
+
+            log::info!("Workspace service stopped");
+        });
+
+        app.add_surface(
+            SurfaceConfig::new()
+                .height(40)
+                .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+                .background_color(Color::rgb(0.1, 0.1, 0.15)),
+            move || {
+                let svc = service.clone();
+
+                container()
+                    .layout(
+                        Flex::row()
+                            .spacing(16.0)
+                            .main_axis_alignment(MainAxisAlignment::SpaceBetween),
+                    )
+                    .padding(4.0)
+                    // Workspace buttons
+                    .child(container().layout(Flex::row().spacing(4.0)).children(
+                        workspaces.clone().into_iter().map(move |id| {
+                            let svc = svc.clone();
+                            container()
+                                .width(32.0)
+                                .height(32.0)
+                                .background(move || {
+                                    if active.get() == id {
+                                        Color::rgb(0.3, 0.5, 0.8)
+                                    } else {
+                                        Color::rgb(0.2, 0.2, 0.3)
+                                    }
+                                })
+                                .corner_radius(4.0)
+                                .hover_state(|s| s.lighter(0.1))
+                                .pressed_state(|s| s.ripple())
+                                .on_click(move || svc.send(WorkspaceCmd::Switch(id)))
+                                .child(
+                                    container()
+                                        .layout(
+                                            Flex::row()
+                                                .main_axis_alignment(MainAxisAlignment::Center)
+                                                .cross_axis_alignment(CrossAxisAlignment::Center),
+                                        )
+                                        .child(text(format!("{}", id)).color(Color::WHITE)),
+                                )
+                        }),
+                    ))
+                    // Clock display
+                    .child(
                         container()
-                            .width(32.0)
-                            .height(32.0)
-                            .background(move || {
-                                if active.get() == id {
-                                    Color::rgb(0.3, 0.5, 0.8)
-                                } else {
-                                    Color::rgb(0.2, 0.2, 0.3)
-                                }
-                            })
+                            .padding(8.0)
+                            .background(Color::rgb(0.2, 0.2, 0.3))
                             .corner_radius(4.0)
-                            .hover_state(|s| s.lighter(0.1))
-                            .pressed_state(|s| s.ripple())
-                            .on_click(move || svc.send(WorkspaceCmd::Switch(id)))
-                            .child(
-                                container()
-                                    .layout(
-                                        Flex::row()
-                                            .main_axis_alignment(MainAxisAlignment::Center)
-                                            .cross_axis_alignment(CrossAxisAlignment::Center),
-                                    )
-                                    .child(text(format!("{}", id)).color(Color::WHITE)),
-                            )
-                    }),
-                ))
-                // Clock display
-                .child(
-                    container()
-                        .padding(8.0)
-                        .background(Color::rgb(0.2, 0.2, 0.3))
-                        .corner_radius(4.0)
-                        .child(text(move || time.get()).color(Color::WHITE)),
-                )
-        },
-    );
-    app.run();
+                            .child(text(move || time.get()).color(Color::WHITE)),
+                    )
+            },
+        );
+    });
 }
 
 fn get_current_time() -> String {

--- a/examples/showcase.rs
+++ b/examples/showcase.rs
@@ -9,182 +9,183 @@
 use guido::prelude::*;
 
 fn main() {
-    let (app, _) = App::new().add_surface(
-        SurfaceConfig::new()
-            .width(500)
-            .height(250)
-            .anchor(Anchor::TOP | Anchor::LEFT)
-            .background_color(Color::rgb(0.1, 0.1, 0.15)),
-        || {
-            container()
-                .layout(Flex::column().spacing(12.0))
-                .child(
-                    // Row 1: Different curvature values with solid colors
-                    container()
-                        .layout(Flex::row().spacing(8.0))
-                        .child(
-                            container()
-                                .padding(12.0)
-                                .background(Color::rgb(0.3, 0.2, 0.4))
-                                .corner_radius(12.0)
-                                .squircle() // K=2 → n=4
-                                .child(text("Squircle\n(K=2)").color(Color::WHITE)),
-                        )
-                        .child(
-                            container()
-                                .padding(12.0)
-                                .background(Color::rgb(0.2, 0.3, 0.4))
-                                .corner_radius(12.0)
-                                // Default circular K=1 → n=2
-                                .child(text("Circle\n(K=1)").color(Color::WHITE)),
-                        )
-                        .child(
-                            container()
-                                .padding(12.0)
-                                .background(Color::rgb(0.4, 0.3, 0.2))
-                                .corner_radius(12.0)
-                                .bevel() // K=0 → n=1
-                                .child(text("Bevel\n(K=0)").color(Color::WHITE)),
-                        )
-                        .child(
-                            container()
-                                .padding(12.0)
-                                .background(Color::rgb(0.2, 0.4, 0.3))
-                                .corner_radius(12.0)
-                                .scoop() // K=-1 → n=0.5
-                                .hover_state(|s| s.lighter(0.1))
-                                .pressed_state(|s| s.ripple())
-                                .child(text("Scoop\n(K=-1)").color(Color::WHITE)),
-                        ),
-                )
-                .child(
-                    // Row 2: With borders
-                    container()
-                        .layout(Flex::row().spacing(8.0))
-                        .child(
-                            container()
-                                .padding(12.0)
-                                .background(Color::rgb(0.15, 0.15, 0.2))
-                                .corner_radius(12.0)
-                                .border(2.0, Color::rgb(0.5, 0.3, 0.7))
-                                .squircle()
-                                .child(text("Squircle\nBorder").color(Color::WHITE)),
-                        )
-                        .child(
-                            container()
-                                .padding(12.0)
-                                .background(Color::rgb(0.15, 0.15, 0.2))
-                                .corner_radius(12.0)
-                                .border(2.0, Color::rgb(0.3, 0.5, 0.7))
-                                .child(text("Circle\nBorder").color(Color::WHITE)),
-                        )
-                        .child(
-                            container()
-                                .padding(12.0)
-                                .background(Color::rgb(0.15, 0.15, 0.2))
-                                .corner_radius(12.0)
-                                .border(2.0, Color::rgb(0.7, 0.5, 0.3))
-                                .bevel()
-                                .child(text("Bevel\nBorder").color(Color::WHITE)),
-                        )
-                        .child(
-                            container()
-                                .padding(12.0)
-                                .background(Color::rgb(0.15, 0.15, 0.2))
-                                .corner_radius(12.0)
-                                .border(2.0, Color::rgb(0.3, 0.7, 0.5))
-                                .scoop()
-                                .hover_state(|s| s.lighter(0.1))
-                                .pressed_state(|s| s.ripple())
-                                .child(text("Scoop\nBorder").color(Color::WHITE)),
-                        ),
-                )
-                .child(
-                    // Row 3: With gradients
-                    container()
-                        .layout(Flex::row().spacing(8.0))
-                        .child(
-                            container()
-                                .padding(12.0)
-                                .gradient_horizontal(
-                                    Color::rgb(0.4, 0.2, 0.5),
-                                    Color::rgb(0.2, 0.4, 0.6),
-                                )
-                                .corner_radius(12.0)
-                                .squircle()
-                                .child(text("Squircle\nGradient").color(Color::WHITE)),
-                        )
-                        .child(
-                            container()
-                                .padding(12.0)
-                                .gradient_horizontal(
-                                    Color::rgb(0.2, 0.4, 0.5),
-                                    Color::rgb(0.4, 0.2, 0.6),
-                                )
-                                .corner_radius(12.0)
-                                .child(text("Circle\nGradient").color(Color::WHITE)),
-                        )
-                        .child(
-                            container()
-                                .padding(12.0)
-                                .gradient_horizontal(
-                                    Color::rgb(0.5, 0.4, 0.2),
-                                    Color::rgb(0.6, 0.2, 0.4),
-                                )
-                                .corner_radius(12.0)
-                                .bevel()
-                                .child(text("Bevel\nGradient").color(Color::WHITE)),
-                        )
-                        .child(
-                            container()
-                                .padding(12.0)
-                                .gradient_horizontal(
-                                    Color::rgb(0.2, 0.5, 0.4),
-                                    Color::rgb(0.4, 0.6, 0.2),
-                                )
-                                .corner_radius(12.0)
-                                .scoop()
-                                .child(text("Scoop\nGradient").color(Color::WHITE)),
-                        ),
-                )
-                .child(
-                    // Row 4: Custom curvature values
-                    container()
-                        .layout(Flex::row().spacing(8.0))
-                        .child(
-                            container()
-                                .padding(12.0)
-                                .background(Color::rgb(0.3, 0.3, 0.4))
-                                .corner_radius(12.0)
-                                .corner_curvature(0.5) // K=0.5 → n=1.41
-                                .child(text("K=0.5").color(Color::WHITE)),
-                        )
-                        .child(
-                            container()
-                                .padding(12.0)
-                                .background(Color::rgb(0.3, 0.4, 0.3))
-                                .corner_radius(12.0)
-                                .corner_curvature(1.5) // K=1.5 → n=2.83
-                                .child(text("K=1.5").color(Color::WHITE)),
-                        )
-                        .child(
-                            container()
-                                .padding(12.0)
-                                .background(Color::rgb(0.4, 0.3, 0.3))
-                                .corner_radius(12.0)
-                                .corner_curvature(2.5) // K=2.5 → n=5.66
-                                .child(text("K=2.5").color(Color::WHITE)),
-                        )
-                        .child(
-                            container()
-                                .padding(12.0)
-                                .background(Color::rgb(0.35, 0.3, 0.4))
-                                .corner_radius(12.0)
-                                .corner_curvature(-0.5) // K=-0.5 → n=0.707
-                                .child(text("K=-0.5").color(Color::WHITE)),
-                        ),
-                )
-        },
-    );
-    app.run();
+    App::new().run(|app| {
+        app.add_surface(
+            SurfaceConfig::new()
+                .width(500)
+                .height(250)
+                .anchor(Anchor::TOP | Anchor::LEFT)
+                .background_color(Color::rgb(0.1, 0.1, 0.15)),
+            || {
+                container()
+                    .layout(Flex::column().spacing(12.0))
+                    .child(
+                        // Row 1: Different curvature values with solid colors
+                        container()
+                            .layout(Flex::row().spacing(8.0))
+                            .child(
+                                container()
+                                    .padding(12.0)
+                                    .background(Color::rgb(0.3, 0.2, 0.4))
+                                    .corner_radius(12.0)
+                                    .squircle() // K=2 → n=4
+                                    .child(text("Squircle\n(K=2)").color(Color::WHITE)),
+                            )
+                            .child(
+                                container()
+                                    .padding(12.0)
+                                    .background(Color::rgb(0.2, 0.3, 0.4))
+                                    .corner_radius(12.0)
+                                    // Default circular K=1 → n=2
+                                    .child(text("Circle\n(K=1)").color(Color::WHITE)),
+                            )
+                            .child(
+                                container()
+                                    .padding(12.0)
+                                    .background(Color::rgb(0.4, 0.3, 0.2))
+                                    .corner_radius(12.0)
+                                    .bevel() // K=0 → n=1
+                                    .child(text("Bevel\n(K=0)").color(Color::WHITE)),
+                            )
+                            .child(
+                                container()
+                                    .padding(12.0)
+                                    .background(Color::rgb(0.2, 0.4, 0.3))
+                                    .corner_radius(12.0)
+                                    .scoop() // K=-1 → n=0.5
+                                    .hover_state(|s| s.lighter(0.1))
+                                    .pressed_state(|s| s.ripple())
+                                    .child(text("Scoop\n(K=-1)").color(Color::WHITE)),
+                            ),
+                    )
+                    .child(
+                        // Row 2: With borders
+                        container()
+                            .layout(Flex::row().spacing(8.0))
+                            .child(
+                                container()
+                                    .padding(12.0)
+                                    .background(Color::rgb(0.15, 0.15, 0.2))
+                                    .corner_radius(12.0)
+                                    .border(2.0, Color::rgb(0.5, 0.3, 0.7))
+                                    .squircle()
+                                    .child(text("Squircle\nBorder").color(Color::WHITE)),
+                            )
+                            .child(
+                                container()
+                                    .padding(12.0)
+                                    .background(Color::rgb(0.15, 0.15, 0.2))
+                                    .corner_radius(12.0)
+                                    .border(2.0, Color::rgb(0.3, 0.5, 0.7))
+                                    .child(text("Circle\nBorder").color(Color::WHITE)),
+                            )
+                            .child(
+                                container()
+                                    .padding(12.0)
+                                    .background(Color::rgb(0.15, 0.15, 0.2))
+                                    .corner_radius(12.0)
+                                    .border(2.0, Color::rgb(0.7, 0.5, 0.3))
+                                    .bevel()
+                                    .child(text("Bevel\nBorder").color(Color::WHITE)),
+                            )
+                            .child(
+                                container()
+                                    .padding(12.0)
+                                    .background(Color::rgb(0.15, 0.15, 0.2))
+                                    .corner_radius(12.0)
+                                    .border(2.0, Color::rgb(0.3, 0.7, 0.5))
+                                    .scoop()
+                                    .hover_state(|s| s.lighter(0.1))
+                                    .pressed_state(|s| s.ripple())
+                                    .child(text("Scoop\nBorder").color(Color::WHITE)),
+                            ),
+                    )
+                    .child(
+                        // Row 3: With gradients
+                        container()
+                            .layout(Flex::row().spacing(8.0))
+                            .child(
+                                container()
+                                    .padding(12.0)
+                                    .gradient_horizontal(
+                                        Color::rgb(0.4, 0.2, 0.5),
+                                        Color::rgb(0.2, 0.4, 0.6),
+                                    )
+                                    .corner_radius(12.0)
+                                    .squircle()
+                                    .child(text("Squircle\nGradient").color(Color::WHITE)),
+                            )
+                            .child(
+                                container()
+                                    .padding(12.0)
+                                    .gradient_horizontal(
+                                        Color::rgb(0.2, 0.4, 0.5),
+                                        Color::rgb(0.4, 0.2, 0.6),
+                                    )
+                                    .corner_radius(12.0)
+                                    .child(text("Circle\nGradient").color(Color::WHITE)),
+                            )
+                            .child(
+                                container()
+                                    .padding(12.0)
+                                    .gradient_horizontal(
+                                        Color::rgb(0.5, 0.4, 0.2),
+                                        Color::rgb(0.6, 0.2, 0.4),
+                                    )
+                                    .corner_radius(12.0)
+                                    .bevel()
+                                    .child(text("Bevel\nGradient").color(Color::WHITE)),
+                            )
+                            .child(
+                                container()
+                                    .padding(12.0)
+                                    .gradient_horizontal(
+                                        Color::rgb(0.2, 0.5, 0.4),
+                                        Color::rgb(0.4, 0.6, 0.2),
+                                    )
+                                    .corner_radius(12.0)
+                                    .scoop()
+                                    .child(text("Scoop\nGradient").color(Color::WHITE)),
+                            ),
+                    )
+                    .child(
+                        // Row 4: Custom curvature values
+                        container()
+                            .layout(Flex::row().spacing(8.0))
+                            .child(
+                                container()
+                                    .padding(12.0)
+                                    .background(Color::rgb(0.3, 0.3, 0.4))
+                                    .corner_radius(12.0)
+                                    .corner_curvature(0.5) // K=0.5 → n=1.41
+                                    .child(text("K=0.5").color(Color::WHITE)),
+                            )
+                            .child(
+                                container()
+                                    .padding(12.0)
+                                    .background(Color::rgb(0.3, 0.4, 0.3))
+                                    .corner_radius(12.0)
+                                    .corner_curvature(1.5) // K=1.5 → n=2.83
+                                    .child(text("K=1.5").color(Color::WHITE)),
+                            )
+                            .child(
+                                container()
+                                    .padding(12.0)
+                                    .background(Color::rgb(0.4, 0.3, 0.3))
+                                    .corner_radius(12.0)
+                                    .corner_curvature(2.5) // K=2.5 → n=5.66
+                                    .child(text("K=2.5").color(Color::WHITE)),
+                            )
+                            .child(
+                                container()
+                                    .padding(12.0)
+                                    .background(Color::rgb(0.35, 0.3, 0.4))
+                                    .corner_radius(12.0)
+                                    .corner_curvature(-0.5) // K=-0.5 → n=0.707
+                                    .child(text("K=-0.5").color(Color::WHITE)),
+                            ),
+                    )
+            },
+        );
+    });
 }

--- a/examples/simple_text_transform.rs
+++ b/examples/simple_text_transform.rs
@@ -52,13 +52,14 @@ fn main() {
                 .child(text("Scale 1.2").font_size(14.0).color(Color::WHITE)),
         ]);
 
-    let (app, _) = App::new().add_surface(
-        SurfaceConfig::new()
-            .width(600)
-            .height(200)
-            .anchor(Anchor::TOP | Anchor::LEFT)
-            .background_color(Color::rgb(0.15, 0.15, 0.2)),
-        move || view,
-    );
-    app.run();
+    App::new().run(|app| {
+        app.add_surface(
+            SurfaceConfig::new()
+                .width(600)
+                .height(200)
+                .anchor(Anchor::TOP | Anchor::LEFT)
+                .background_color(Color::rgb(0.15, 0.15, 0.2)),
+            move || view,
+        );
+    });
 }

--- a/examples/state_layer_example.rs
+++ b/examples/state_layer_example.rs
@@ -7,14 +7,15 @@
 use guido::prelude::*;
 
 fn main() {
-    let (app, _) = App::new().add_surface(
-        SurfaceConfig::new()
-            .width(700)
-            .height(400)
-            .anchor(Anchor::TOP | Anchor::LEFT)
-            .background_color(Color::rgb(0.08, 0.08, 0.12)),
-        || {
-            container()
+    App::new().run(|app| {
+        app.add_surface(
+            SurfaceConfig::new()
+                .width(700)
+                .height(400)
+                .anchor(Anchor::TOP | Anchor::LEFT)
+                .background_color(Color::rgb(0.08, 0.08, 0.12)),
+            || {
+                container()
                 .background(Color::rgb(0.08, 0.08, 0.12))
                 .padding(24.0)
                 .layout(Flex::column().spacing(16.0))
@@ -49,9 +50,9 @@ fn main() {
                         ]),
                     ]),
                 )
-        },
-    );
-    app.run();
+            },
+        );
+    });
 }
 
 /// Button with lighter() hover effect

--- a/examples/status_bar.rs
+++ b/examples/status_bar.rs
@@ -1,34 +1,35 @@
 use guido::prelude::*;
 
 fn main() {
-    let (app, _) = App::new().add_surface(
-        SurfaceConfig::new()
-            .height(32)
-            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
-            .background_color(Color::rgb(0.1, 0.1, 0.15)),
-        || {
-            container()
-                .layout(
-                    Flex::row()
-                        .spacing(8.0)
-                        .main_axis_alignment(MainAxisAlignment::SpaceBetween),
-                )
-                .child(
-                    container()
-                        .padding(8.0)
-                        .background(Color::rgb(0.2, 0.2, 0.3))
-                        .corner_radius(4.0)
-                        .child(text("Guido")),
-                )
-                .child(container().padding(8.0).child(text("Hello World!")))
-                .child(
-                    container()
-                        .padding(8.0)
-                        .background(Color::rgb(0.3, 0.2, 0.2))
-                        .corner_radius(4.0)
-                        .child(text("Status Bar")),
-                )
-        },
-    );
-    app.run();
+    App::new().run(|app| {
+        app.add_surface(
+            SurfaceConfig::new()
+                .height(32)
+                .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+                .background_color(Color::rgb(0.1, 0.1, 0.15)),
+            || {
+                container()
+                    .layout(
+                        Flex::row()
+                            .spacing(8.0)
+                            .main_axis_alignment(MainAxisAlignment::SpaceBetween),
+                    )
+                    .child(
+                        container()
+                            .padding(8.0)
+                            .background(Color::rgb(0.2, 0.2, 0.3))
+                            .corner_radius(4.0)
+                            .child(text("Guido")),
+                    )
+                    .child(container().padding(8.0).child(text("Hello World!")))
+                    .child(
+                        container()
+                            .padding(8.0)
+                            .background(Color::rgb(0.3, 0.2, 0.2))
+                            .corner_radius(4.0)
+                            .child(text("Status Bar")),
+                    )
+            },
+        );
+    });
 }

--- a/examples/surface_properties_example.rs
+++ b/examples/surface_properties_example.rs
@@ -10,156 +10,156 @@
 use guido::prelude::*;
 
 fn main() {
-    // Store the surface ID so we can get a handle to it later
-    let surface_id_signal = create_signal(None::<SurfaceId>);
+    App::new().run(|app| {
+        // Store the surface ID so we can get a handle to it later
+        let surface_id_signal = create_signal(None::<SurfaceId>);
 
-    // Track current layer and keyboard mode for display
-    let current_layer = create_signal("Top");
-    let current_keyboard = create_signal("OnDemand");
+        // Track current layer and keyboard mode for display
+        let current_layer = create_signal("Top");
+        let current_keyboard = create_signal("OnDemand");
 
-    let (app, surface_id) = App::new().add_surface(
-        SurfaceConfig::new()
-            .width(500)
-            .height(300)
-            .anchor(Anchor::TOP | Anchor::LEFT)
-            .layer(Layer::Top)
-            .keyboard_interactivity(KeyboardInteractivity::OnDemand)
-            .namespace("surface-properties-example")
-            .background_color(Color::rgb(0.1, 0.1, 0.15)),
-        move || {
-            container()
-                .padding(24.0)
-                .layout(Flex::column().spacing(16.0))
-                .child(
-                    text("Surface Properties Demo")
-                        .font_size(20.0)
-                        .color(Color::WHITE),
-                )
-                // Current state display
-                .child(
-                    container()
-                        .padding(12.0)
-                        .background(Color::rgb(0.15, 0.15, 0.2))
-                        .corner_radius(8.0)
-                        .layout(Flex::column().spacing(8.0))
-                        .child(
-                            text(move || format!("Current Layer: {}", current_layer.get()))
+        let surface_id = app.add_surface(
+            SurfaceConfig::new()
+                .width(500)
+                .height(300)
+                .anchor(Anchor::TOP | Anchor::LEFT)
+                .layer(Layer::Top)
+                .keyboard_interactivity(KeyboardInteractivity::OnDemand)
+                .namespace("surface-properties-example")
+                .background_color(Color::rgb(0.1, 0.1, 0.15)),
+            move || {
+                container()
+                    .padding(24.0)
+                    .layout(Flex::column().spacing(16.0))
+                    .child(
+                        text("Surface Properties Demo")
+                            .font_size(20.0)
+                            .color(Color::WHITE),
+                    )
+                    // Current state display
+                    .child(
+                        container()
+                            .padding(12.0)
+                            .background(Color::rgb(0.15, 0.15, 0.2))
+                            .corner_radius(8.0)
+                            .layout(Flex::column().spacing(8.0))
+                            .child(
+                                text(move || format!("Current Layer: {}", current_layer.get()))
+                                    .color(Color::rgb(0.7, 0.9, 0.7))
+                                    .font_size(14.0),
+                            )
+                            .child(
+                                text(move || {
+                                    format!("Keyboard Interactivity: {}", current_keyboard.get())
+                                })
                                 .color(Color::rgb(0.7, 0.9, 0.7))
                                 .font_size(14.0),
-                        )
-                        .child(
-                            text(move || {
-                                format!("Keyboard Interactivity: {}", current_keyboard.get())
-                            })
-                            .color(Color::rgb(0.7, 0.9, 0.7))
-                            .font_size(14.0),
-                        ),
-                )
-                // Layer controls
-                .child(
-                    container()
-                        .layout(Flex::column().spacing(8.0))
-                        .child(
-                            text("Change Layer:")
-                                .color(Color::rgb(0.6, 0.6, 0.7))
-                                .font_size(12.0),
-                        )
-                        .child(
-                            container()
-                                .layout(Flex::row().spacing(8.0))
-                                .child(layer_button(
-                                    "Background",
-                                    Layer::Background,
-                                    surface_id_signal,
-                                    current_layer,
-                                ))
-                                .child(layer_button(
-                                    "Bottom",
-                                    Layer::Bottom,
-                                    surface_id_signal,
-                                    current_layer,
-                                ))
-                                .child(layer_button(
-                                    "Top",
-                                    Layer::Top,
-                                    surface_id_signal,
-                                    current_layer,
-                                ))
-                                .child(layer_button(
-                                    "Overlay",
-                                    Layer::Overlay,
-                                    surface_id_signal,
-                                    current_layer,
-                                )),
-                        ),
-                )
-                // Keyboard interactivity controls
-                .child(
-                    container()
-                        .layout(Flex::column().spacing(8.0))
-                        .child(
-                            text("Change Keyboard Interactivity:")
-                                .color(Color::rgb(0.6, 0.6, 0.7))
-                                .font_size(12.0),
-                        )
-                        .child(
-                            container()
-                                .layout(Flex::row().spacing(8.0))
-                                .child(keyboard_button(
-                                    "None",
-                                    KeyboardInteractivity::None,
-                                    surface_id_signal,
-                                    current_keyboard,
-                                ))
-                                .child(keyboard_button(
-                                    "OnDemand",
-                                    KeyboardInteractivity::OnDemand,
-                                    surface_id_signal,
-                                    current_keyboard,
-                                ))
-                                .child(keyboard_button(
-                                    "Exclusive",
-                                    KeyboardInteractivity::Exclusive,
-                                    surface_id_signal,
-                                    current_keyboard,
-                                )),
-                        ),
-                )
-                // Instructions
-                .child(
-                    container()
-                        .padding(12.0)
-                        .background(Color::rgb(0.12, 0.12, 0.16))
-                        .corner_radius(6.0)
-                        .layout(Flex::column().spacing(4.0))
-                        .child(
-                            text("Tips:")
-                                .color(Color::rgb(0.5, 0.5, 0.6))
-                                .font_size(11.0),
-                        )
-                        .child(
-                            text("- Overlay layer appears above other windows")
-                                .color(Color::rgb(0.5, 0.5, 0.6))
-                                .font_size(11.0),
-                        )
-                        .child(
-                            text("- Background layer appears below the desktop")
-                                .color(Color::rgb(0.5, 0.5, 0.6))
-                                .font_size(11.0),
-                        )
-                        .child(
-                            text("- Exclusive keyboard grabs focus from other apps")
-                                .color(Color::rgb(0.5, 0.5, 0.6))
-                                .font_size(11.0),
-                        ),
-                )
-        },
-    );
+                            ),
+                    )
+                    // Layer controls
+                    .child(
+                        container()
+                            .layout(Flex::column().spacing(8.0))
+                            .child(
+                                text("Change Layer:")
+                                    .color(Color::rgb(0.6, 0.6, 0.7))
+                                    .font_size(12.0),
+                            )
+                            .child(
+                                container()
+                                    .layout(Flex::row().spacing(8.0))
+                                    .child(layer_button(
+                                        "Background",
+                                        Layer::Background,
+                                        surface_id_signal,
+                                        current_layer,
+                                    ))
+                                    .child(layer_button(
+                                        "Bottom",
+                                        Layer::Bottom,
+                                        surface_id_signal,
+                                        current_layer,
+                                    ))
+                                    .child(layer_button(
+                                        "Top",
+                                        Layer::Top,
+                                        surface_id_signal,
+                                        current_layer,
+                                    ))
+                                    .child(layer_button(
+                                        "Overlay",
+                                        Layer::Overlay,
+                                        surface_id_signal,
+                                        current_layer,
+                                    )),
+                            ),
+                    )
+                    // Keyboard interactivity controls
+                    .child(
+                        container()
+                            .layout(Flex::column().spacing(8.0))
+                            .child(
+                                text("Change Keyboard Interactivity:")
+                                    .color(Color::rgb(0.6, 0.6, 0.7))
+                                    .font_size(12.0),
+                            )
+                            .child(
+                                container()
+                                    .layout(Flex::row().spacing(8.0))
+                                    .child(keyboard_button(
+                                        "None",
+                                        KeyboardInteractivity::None,
+                                        surface_id_signal,
+                                        current_keyboard,
+                                    ))
+                                    .child(keyboard_button(
+                                        "OnDemand",
+                                        KeyboardInteractivity::OnDemand,
+                                        surface_id_signal,
+                                        current_keyboard,
+                                    ))
+                                    .child(keyboard_button(
+                                        "Exclusive",
+                                        KeyboardInteractivity::Exclusive,
+                                        surface_id_signal,
+                                        current_keyboard,
+                                    )),
+                            ),
+                    )
+                    // Instructions
+                    .child(
+                        container()
+                            .padding(12.0)
+                            .background(Color::rgb(0.12, 0.12, 0.16))
+                            .corner_radius(6.0)
+                            .layout(Flex::column().spacing(4.0))
+                            .child(
+                                text("Tips:")
+                                    .color(Color::rgb(0.5, 0.5, 0.6))
+                                    .font_size(11.0),
+                            )
+                            .child(
+                                text("- Overlay layer appears above other windows")
+                                    .color(Color::rgb(0.5, 0.5, 0.6))
+                                    .font_size(11.0),
+                            )
+                            .child(
+                                text("- Background layer appears below the desktop")
+                                    .color(Color::rgb(0.5, 0.5, 0.6))
+                                    .font_size(11.0),
+                            )
+                            .child(
+                                text("- Exclusive keyboard grabs focus from other apps")
+                                    .color(Color::rgb(0.5, 0.5, 0.6))
+                                    .font_size(11.0),
+                            ),
+                    )
+            },
+        );
 
-    // Store the surface ID so the buttons can access it
-    surface_id_signal.set(Some(surface_id));
-
-    app.run();
+        // Store the surface ID so the buttons can access it
+        surface_id_signal.set(Some(surface_id));
+    });
 }
 
 fn layer_button(

--- a/examples/test_dynamic.rs
+++ b/examples/test_dynamic.rs
@@ -10,49 +10,52 @@ static ADD_TRIGGERED: AtomicBool = AtomicBool::new(false);
 
 #[tokio::main]
 async fn main() {
-    let items = create_signal(vec![1u64, 2, 3]);
+    App::new().run(|app| {
+        let items = create_signal(vec![1u64, 2, 3]);
 
-    // Create a service that adds an item after 2 seconds
-    let items_w = items.writer();
-    let _ = create_service::<(), _, _>(move |_rx, ctx| async move {
-        tokio::time::sleep(Duration::from_secs(2)).await;
-        if ctx.is_running() && !ADD_TRIGGERED.swap(true, Ordering::SeqCst) {
-            items_w.update(|list| {
-                list.push(4);
-            });
-        }
-    });
+        // Create a service that adds an item after 2 seconds
+        let items_w = items.writer();
+        let _ = create_service::<(), _, _>(move |_rx, ctx| async move {
+            tokio::time::sleep(Duration::from_secs(2)).await;
+            if ctx.is_running() && !ADD_TRIGGERED.swap(true, Ordering::SeqCst) {
+                items_w.update(|list| {
+                    list.push(4);
+                });
+            }
+        });
 
-    let view = container()
-        .layout(Flex::column().spacing(8.0))
-        .padding(20.0)
-        .background(Color::rgb(0.1, 0.1, 0.15))
-        .child(text("Dynamic Children Test").color(Color::WHITE))
-        .child(text("An item will be added after 2 seconds...").color(Color::rgb(0.7, 0.7, 0.7)))
-        .child(
-            container()
-                .layout(Flex::row().spacing(4.0))
-                .children(move || {
-                    let list = items.get();
-                    list.into_iter().map(|id| {
-                        (id, move || {
-                            container()
-                                .padding(8.0)
-                                .background(Color::rgb(0.3 + id as f32 * 0.1, 0.3, 0.4))
-                                .corner_radius(4.0)
-                                .child(text(format!("Item {}", id)).color(Color::WHITE))
+        let view = container()
+            .layout(Flex::column().spacing(8.0))
+            .padding(20.0)
+            .background(Color::rgb(0.1, 0.1, 0.15))
+            .child(text("Dynamic Children Test").color(Color::WHITE))
+            .child(
+                text("An item will be added after 2 seconds...").color(Color::rgb(0.7, 0.7, 0.7)),
+            )
+            .child(
+                container()
+                    .layout(Flex::row().spacing(4.0))
+                    .children(move || {
+                        let list = items.get();
+                        list.into_iter().map(|id| {
+                            (id, move || {
+                                container()
+                                    .padding(8.0)
+                                    .background(Color::rgb(0.3 + id as f32 * 0.1, 0.3, 0.4))
+                                    .corner_radius(4.0)
+                                    .child(text(format!("Item {}", id)).color(Color::WHITE))
+                            })
                         })
-                    })
-                }),
-        );
+                    }),
+            );
 
-    let (app, _) = App::new().add_surface(
-        SurfaceConfig::new()
-            .width(600)
-            .height(200)
-            .anchor(Anchor::TOP | Anchor::LEFT)
-            .background_color(Color::rgb(0.1, 0.1, 0.15)),
-        move || view,
-    );
-    app.run();
+        app.add_surface(
+            SurfaceConfig::new()
+                .width(600)
+                .height(200)
+                .anchor(Anchor::TOP | Anchor::LEFT)
+                .background_color(Color::rgb(0.1, 0.1, 0.15)),
+            move || view,
+        );
+    });
 }

--- a/examples/text_input_example.rs
+++ b/examples/text_input_example.rs
@@ -12,181 +12,182 @@
 use guido::prelude::*;
 
 fn main() {
-    let username = create_signal(String::new());
-    let password = create_signal(String::new());
-    let submitted = create_signal(String::new());
+    App::new().run(|app| {
+        let username = create_signal(String::new());
+        let password = create_signal(String::new());
+        let submitted = create_signal(String::new());
 
-    let view = container()
-        .background(Color::rgb(0.12, 0.12, 0.18))
-        .padding(24.0)
-        .layout(Flex::column().spacing(16.0))
-        .child(
-            // Title
-            text("Text Input Demo").color(Color::WHITE).font_size(20.0),
-        )
-        .child(
-            // Username section
-            container()
-                .layout(Flex::column().spacing(4.0))
-                .child(
-                    text("Username")
-                        .color(Color::rgb(0.7, 0.7, 0.8))
-                        .font_size(12.0),
-                )
-                .child(
-                    container()
-                        .width(at_least(300.0))
-                        .padding(8.0)
-                        .background(Color::rgb(0.18, 0.18, 0.24))
-                        .border(1.0, Color::rgb(0.3, 0.3, 0.4))
-                        .corner_radius(6.0)
-                        // Highlight border when text input is focused
-                        .focused_state(|s| s.border(2.0, Color::rgb(0.4, 0.8, 1.0)))
-                        .child(
-                            text_input(username)
-                                .text_color(Color::WHITE)
-                                .cursor_color(Color::rgb(0.4, 0.8, 1.0))
-                                .selection_color(Color::rgba(0.4, 0.6, 1.0, 0.4))
-                                .font_size(14.0),
-                        ),
-                ),
-        )
-        .child(
-            // Password section
-            container()
-                .layout(Flex::column().spacing(4.0))
-                .child(
-                    text("Password")
-                        .color(Color::rgb(0.7, 0.7, 0.8))
-                        .font_size(12.0),
-                )
-                .child(
-                    container()
-                        .width(at_least(300.0))
-                        .padding(8.0)
-                        .background(Color::rgb(0.18, 0.18, 0.24))
-                        .border(1.0, Color::rgb(0.3, 0.3, 0.4))
-                        .corner_radius(6.0)
-                        // Highlight border when text input is focused
-                        .focused_state(|s| s.border(2.0, Color::rgb(0.4, 0.8, 1.0)))
-                        .child(
-                            text_input(password)
-                                .text_color(Color::WHITE)
-                                .cursor_color(Color::rgb(0.4, 0.8, 1.0))
-                                .selection_color(Color::rgba(0.4, 0.6, 1.0, 0.4))
-                                .font_size(14.0)
-                                .password(true)
-                                .on_submit(move |_| {
-                                    let msg = format!("Login attempt: {}", username.get());
-                                    submitted.set(msg);
-                                }),
-                        ),
-                ),
-        )
-        .child(
-            // Current values display
-            container()
-                .padding(12.0)
-                .background(Color::rgb(0.15, 0.15, 0.2))
-                .corner_radius(6.0)
-                .layout(Flex::column().spacing(8.0))
-                .child(
-                    text("Current Values:")
-                        .color(Color::rgb(0.6, 0.6, 0.7))
-                        .font_size(12.0),
-                )
-                .child(
-                    text(move || format!("Username: {}", username.get()))
-                        .color(Color::rgb(0.8, 0.8, 0.9))
-                        .font_size(13.0),
-                )
-                .child(
-                    text(move || format!("Password: {} chars", password.get().len()))
-                        .color(Color::rgb(0.8, 0.8, 0.9))
-                        .font_size(13.0),
-                ),
-        )
-        .child(
-            // Submit status
-            text(move || {
-                let msg = submitted.get();
-                if msg.is_empty() {
-                    "Press Enter in password field to submit".to_string()
-                } else {
-                    msg
-                }
-            })
-            .color(Color::rgb(0.5, 0.8, 0.5))
-            .font_size(13.0),
-        )
-        .child(
-            // Instructions
-            container()
-                .padding(12.0)
-                .background(Color::rgb(0.1, 0.1, 0.14))
-                .corner_radius(6.0)
-                .layout(Flex::column().spacing(4.0))
-                .child(
-                    text("Keyboard shortcuts:")
-                        .color(Color::rgb(0.5, 0.5, 0.6))
-                        .font_size(11.0),
-                )
-                .child(
-                    text("• Click to focus and position cursor")
-                        .color(Color::rgb(0.5, 0.5, 0.6))
-                        .font_size(11.0),
-                )
-                .child(
-                    text("• Arrow keys to move cursor")
-                        .color(Color::rgb(0.5, 0.5, 0.6))
-                        .font_size(11.0),
-                )
-                .child(
-                    text("• Shift+Arrow to select text")
-                        .color(Color::rgb(0.5, 0.5, 0.6))
-                        .font_size(11.0),
-                )
-                .child(
-                    text("• Ctrl+A to select all")
-                        .color(Color::rgb(0.5, 0.5, 0.6))
-                        .font_size(11.0),
-                )
-                .child(
-                    text("• Ctrl+Arrow for word jump")
-                        .color(Color::rgb(0.5, 0.5, 0.6))
-                        .font_size(11.0),
-                )
-                .child(
-                    text("• Home/End to go to start/end")
-                        .color(Color::rgb(0.5, 0.5, 0.6))
-                        .font_size(11.0),
-                )
-                .child(
-                    text("• Enter to submit (in password field)")
-                        .color(Color::rgb(0.5, 0.5, 0.6))
-                        .font_size(11.0),
-                )
-                .child(
-                    text("• Ctrl+C/X/V to copy/cut/paste")
-                        .color(Color::rgb(0.5, 0.5, 0.6))
-                        .font_size(11.0),
-                )
-                .child(
-                    text("• Ctrl+Z to undo, Ctrl+Y to redo")
-                        .color(Color::rgb(0.5, 0.5, 0.6))
-                        .font_size(11.0),
-                ),
+        let view = container()
+            .background(Color::rgb(0.12, 0.12, 0.18))
+            .padding(24.0)
+            .layout(Flex::column().spacing(16.0))
+            .child(
+                // Title
+                text("Text Input Demo").color(Color::WHITE).font_size(20.0),
+            )
+            .child(
+                // Username section
+                container()
+                    .layout(Flex::column().spacing(4.0))
+                    .child(
+                        text("Username")
+                            .color(Color::rgb(0.7, 0.7, 0.8))
+                            .font_size(12.0),
+                    )
+                    .child(
+                        container()
+                            .width(at_least(300.0))
+                            .padding(8.0)
+                            .background(Color::rgb(0.18, 0.18, 0.24))
+                            .border(1.0, Color::rgb(0.3, 0.3, 0.4))
+                            .corner_radius(6.0)
+                            // Highlight border when text input is focused
+                            .focused_state(|s| s.border(2.0, Color::rgb(0.4, 0.8, 1.0)))
+                            .child(
+                                text_input(username)
+                                    .text_color(Color::WHITE)
+                                    .cursor_color(Color::rgb(0.4, 0.8, 1.0))
+                                    .selection_color(Color::rgba(0.4, 0.6, 1.0, 0.4))
+                                    .font_size(14.0),
+                            ),
+                    ),
+            )
+            .child(
+                // Password section
+                container()
+                    .layout(Flex::column().spacing(4.0))
+                    .child(
+                        text("Password")
+                            .color(Color::rgb(0.7, 0.7, 0.8))
+                            .font_size(12.0),
+                    )
+                    .child(
+                        container()
+                            .width(at_least(300.0))
+                            .padding(8.0)
+                            .background(Color::rgb(0.18, 0.18, 0.24))
+                            .border(1.0, Color::rgb(0.3, 0.3, 0.4))
+                            .corner_radius(6.0)
+                            // Highlight border when text input is focused
+                            .focused_state(|s| s.border(2.0, Color::rgb(0.4, 0.8, 1.0)))
+                            .child(
+                                text_input(password)
+                                    .text_color(Color::WHITE)
+                                    .cursor_color(Color::rgb(0.4, 0.8, 1.0))
+                                    .selection_color(Color::rgba(0.4, 0.6, 1.0, 0.4))
+                                    .font_size(14.0)
+                                    .password(true)
+                                    .on_submit(move |_| {
+                                        let msg = format!("Login attempt: {}", username.get());
+                                        submitted.set(msg);
+                                    }),
+                            ),
+                    ),
+            )
+            .child(
+                // Current values display
+                container()
+                    .padding(12.0)
+                    .background(Color::rgb(0.15, 0.15, 0.2))
+                    .corner_radius(6.0)
+                    .layout(Flex::column().spacing(8.0))
+                    .child(
+                        text("Current Values:")
+                            .color(Color::rgb(0.6, 0.6, 0.7))
+                            .font_size(12.0),
+                    )
+                    .child(
+                        text(move || format!("Username: {}", username.get()))
+                            .color(Color::rgb(0.8, 0.8, 0.9))
+                            .font_size(13.0),
+                    )
+                    .child(
+                        text(move || format!("Password: {} chars", password.get().len()))
+                            .color(Color::rgb(0.8, 0.8, 0.9))
+                            .font_size(13.0),
+                    ),
+            )
+            .child(
+                // Submit status
+                text(move || {
+                    let msg = submitted.get();
+                    if msg.is_empty() {
+                        "Press Enter in password field to submit".to_string()
+                    } else {
+                        msg
+                    }
+                })
+                .color(Color::rgb(0.5, 0.8, 0.5))
+                .font_size(13.0),
+            )
+            .child(
+                // Instructions
+                container()
+                    .padding(12.0)
+                    .background(Color::rgb(0.1, 0.1, 0.14))
+                    .corner_radius(6.0)
+                    .layout(Flex::column().spacing(4.0))
+                    .child(
+                        text("Keyboard shortcuts:")
+                            .color(Color::rgb(0.5, 0.5, 0.6))
+                            .font_size(11.0),
+                    )
+                    .child(
+                        text("• Click to focus and position cursor")
+                            .color(Color::rgb(0.5, 0.5, 0.6))
+                            .font_size(11.0),
+                    )
+                    .child(
+                        text("• Arrow keys to move cursor")
+                            .color(Color::rgb(0.5, 0.5, 0.6))
+                            .font_size(11.0),
+                    )
+                    .child(
+                        text("• Shift+Arrow to select text")
+                            .color(Color::rgb(0.5, 0.5, 0.6))
+                            .font_size(11.0),
+                    )
+                    .child(
+                        text("• Ctrl+A to select all")
+                            .color(Color::rgb(0.5, 0.5, 0.6))
+                            .font_size(11.0),
+                    )
+                    .child(
+                        text("• Ctrl+Arrow for word jump")
+                            .color(Color::rgb(0.5, 0.5, 0.6))
+                            .font_size(11.0),
+                    )
+                    .child(
+                        text("• Home/End to go to start/end")
+                            .color(Color::rgb(0.5, 0.5, 0.6))
+                            .font_size(11.0),
+                    )
+                    .child(
+                        text("• Enter to submit (in password field)")
+                            .color(Color::rgb(0.5, 0.5, 0.6))
+                            .font_size(11.0),
+                    )
+                    .child(
+                        text("• Ctrl+C/X/V to copy/cut/paste")
+                            .color(Color::rgb(0.5, 0.5, 0.6))
+                            .font_size(11.0),
+                    )
+                    .child(
+                        text("• Ctrl+Z to undo, Ctrl+Y to redo")
+                            .color(Color::rgb(0.5, 0.5, 0.6))
+                            .font_size(11.0),
+                    ),
+            );
+
+        app.add_surface(
+            SurfaceConfig::new()
+                .width(400)
+                .height(500)
+                .anchor(Anchor::TOP | Anchor::LEFT)
+                .layer(Layer::Top)
+                .namespace("text-input-example")
+                .background_color(Color::rgb(0.12, 0.12, 0.18)),
+            move || view,
         );
-
-    let (app, _) = App::new().add_surface(
-        SurfaceConfig::new()
-            .width(400)
-            .height(500)
-            .anchor(Anchor::TOP | Anchor::LEFT)
-            .layer(Layer::Top)
-            .namespace("text-input-example")
-            .background_color(Color::rgb(0.12, 0.12, 0.18)),
-        move || view,
-    );
-    app.run();
+    });
 }

--- a/examples/text_input_transform_test.rs
+++ b/examples/text_input_transform_test.rs
@@ -8,165 +8,166 @@
 use guido::prelude::*;
 
 fn main() {
-    let input1 = create_signal(String::from("Normal input"));
-    let input2 = create_signal(String::from("Rotated 15°"));
-    let input3 = create_signal(String::from("Scaled 1.2x"));
-    let input4 = create_signal(String::from("Translated"));
-    let input5 = create_signal(String::from("All transforms"));
+    App::new().run(|app| {
+        let input1 = create_signal(String::from("Normal input"));
+        let input2 = create_signal(String::from("Rotated 15°"));
+        let input3 = create_signal(String::from("Scaled 1.2x"));
+        let input4 = create_signal(String::from("Translated"));
+        let input5 = create_signal(String::from("All transforms"));
 
-    let view = container()
-        .background(Color::rgb(0.1, 0.1, 0.15))
-        .padding(32.0)
-        .layout(Flex::column().spacing(32.0))
-        .child(
-            text("TextInput Transform Test")
-                .color(Color::WHITE)
-                .font_size(18.0),
-        )
-        // 1. Normal (no transform) - baseline
-        .child(
-            container()
-                .layout(Flex::column().spacing(4.0))
-                .child(
-                    text("No transform (baseline)")
-                        .color(Color::rgb(0.6, 0.6, 0.7))
-                        .font_size(12.0),
-                )
-                .child(
-                    container()
-                        .width(at_least(300.0))
-                        .padding(8.0)
-                        .background(Color::rgb(0.18, 0.18, 0.24))
-                        .border(1.0, Color::rgb(0.3, 0.8, 0.3))
-                        .corner_radius(6.0)
-                        .child(
-                            text_input(input1)
-                                .text_color(Color::WHITE)
-                                .cursor_color(Color::rgb(0.4, 0.8, 1.0))
-                                .font_size(14.0),
-                        ),
-                ),
-        )
-        // 2. Rotated container
-        .child(
-            container()
-                .layout(Flex::column().spacing(4.0))
-                .child(
-                    text("Rotated 15°")
-                        .color(Color::rgb(0.6, 0.6, 0.7))
-                        .font_size(12.0),
-                )
-                .child(
-                    container()
-                        .width(at_least(300.0))
-                        .padding(8.0)
-                        .background(Color::rgb(0.18, 0.18, 0.24))
-                        .border(1.0, Color::rgb(0.8, 0.5, 0.3))
-                        .corner_radius(6.0)
-                        .rotate(15.0)
-                        .child(
-                            text_input(input2)
-                                .text_color(Color::WHITE)
-                                .cursor_color(Color::rgb(0.4, 0.8, 1.0))
-                                .font_size(14.0),
-                        ),
-                ),
-        )
-        // 3. Scaled container
-        .child(
-            container()
-                .layout(Flex::column().spacing(4.0))
-                .child(
-                    text("Scaled 1.2x")
-                        .color(Color::rgb(0.6, 0.6, 0.7))
-                        .font_size(12.0),
-                )
-                .child(
-                    container()
-                        .width(at_least(250.0))
-                        .padding(8.0)
-                        .background(Color::rgb(0.18, 0.18, 0.24))
-                        .border(1.0, Color::rgb(0.3, 0.5, 0.8))
-                        .corner_radius(6.0)
-                        .scale(1.2)
-                        .child(
-                            text_input(input3)
-                                .text_color(Color::WHITE)
-                                .cursor_color(Color::rgb(0.4, 0.8, 1.0))
-                                .font_size(14.0),
-                        ),
-                ),
-        )
-        // 4. Translated container
-        .child(
-            container()
-                .layout(Flex::column().spacing(4.0))
-                .child(
-                    text("Translated (50, 10)")
-                        .color(Color::rgb(0.6, 0.6, 0.7))
-                        .font_size(12.0),
-                )
-                .child(
-                    container()
-                        .width(at_least(300.0))
-                        .padding(8.0)
-                        .background(Color::rgb(0.18, 0.18, 0.24))
-                        .border(1.0, Color::rgb(0.8, 0.8, 0.3))
-                        .corner_radius(6.0)
-                        .translate(50.0, 10.0)
-                        .child(
-                            text_input(input4)
-                                .text_color(Color::WHITE)
-                                .cursor_color(Color::rgb(0.4, 0.8, 1.0))
-                                .font_size(14.0),
-                        ),
-                ),
-        )
-        // 5. All transforms combined: translate + rotate + scale
-        .child(
-            container()
-                .layout(Flex::column().spacing(4.0))
-                .child(
-                    text("Translate(20,5) + Rotate(-10°) + Scale(0.9)")
-                        .color(Color::rgb(0.6, 0.6, 0.7))
-                        .font_size(12.0),
-                )
-                .child(
-                    container()
-                        .width(at_least(300.0))
-                        .padding(8.0)
-                        .background(Color::rgb(0.18, 0.18, 0.24))
-                        .border(1.0, Color::rgb(0.8, 0.3, 0.8))
-                        .corner_radius(6.0)
-                        .transform(
-                            Transform::translate(20.0, 5.0)
-                                .then(&Transform::rotate_degrees(-10.0))
-                                .then(&Transform::scale(0.9)),
-                        )
-                        .child(
-                            text_input(input5)
-                                .text_color(Color::WHITE)
-                                .cursor_color(Color::rgb(0.4, 0.8, 1.0))
-                                .font_size(14.0),
-                        ),
-                ),
-        )
-        // Instructions
-        .child(
-            text("Click in each input to test cursor positioning")
-                .color(Color::rgb(0.5, 0.5, 0.6))
-                .font_size(11.0),
+        let view = container()
+            .background(Color::rgb(0.1, 0.1, 0.15))
+            .padding(32.0)
+            .layout(Flex::column().spacing(32.0))
+            .child(
+                text("TextInput Transform Test")
+                    .color(Color::WHITE)
+                    .font_size(18.0),
+            )
+            // 1. Normal (no transform) - baseline
+            .child(
+                container()
+                    .layout(Flex::column().spacing(4.0))
+                    .child(
+                        text("No transform (baseline)")
+                            .color(Color::rgb(0.6, 0.6, 0.7))
+                            .font_size(12.0),
+                    )
+                    .child(
+                        container()
+                            .width(at_least(300.0))
+                            .padding(8.0)
+                            .background(Color::rgb(0.18, 0.18, 0.24))
+                            .border(1.0, Color::rgb(0.3, 0.8, 0.3))
+                            .corner_radius(6.0)
+                            .child(
+                                text_input(input1)
+                                    .text_color(Color::WHITE)
+                                    .cursor_color(Color::rgb(0.4, 0.8, 1.0))
+                                    .font_size(14.0),
+                            ),
+                    ),
+            )
+            // 2. Rotated container
+            .child(
+                container()
+                    .layout(Flex::column().spacing(4.0))
+                    .child(
+                        text("Rotated 15°")
+                            .color(Color::rgb(0.6, 0.6, 0.7))
+                            .font_size(12.0),
+                    )
+                    .child(
+                        container()
+                            .width(at_least(300.0))
+                            .padding(8.0)
+                            .background(Color::rgb(0.18, 0.18, 0.24))
+                            .border(1.0, Color::rgb(0.8, 0.5, 0.3))
+                            .corner_radius(6.0)
+                            .rotate(15.0)
+                            .child(
+                                text_input(input2)
+                                    .text_color(Color::WHITE)
+                                    .cursor_color(Color::rgb(0.4, 0.8, 1.0))
+                                    .font_size(14.0),
+                            ),
+                    ),
+            )
+            // 3. Scaled container
+            .child(
+                container()
+                    .layout(Flex::column().spacing(4.0))
+                    .child(
+                        text("Scaled 1.2x")
+                            .color(Color::rgb(0.6, 0.6, 0.7))
+                            .font_size(12.0),
+                    )
+                    .child(
+                        container()
+                            .width(at_least(250.0))
+                            .padding(8.0)
+                            .background(Color::rgb(0.18, 0.18, 0.24))
+                            .border(1.0, Color::rgb(0.3, 0.5, 0.8))
+                            .corner_radius(6.0)
+                            .scale(1.2)
+                            .child(
+                                text_input(input3)
+                                    .text_color(Color::WHITE)
+                                    .cursor_color(Color::rgb(0.4, 0.8, 1.0))
+                                    .font_size(14.0),
+                            ),
+                    ),
+            )
+            // 4. Translated container
+            .child(
+                container()
+                    .layout(Flex::column().spacing(4.0))
+                    .child(
+                        text("Translated (50, 10)")
+                            .color(Color::rgb(0.6, 0.6, 0.7))
+                            .font_size(12.0),
+                    )
+                    .child(
+                        container()
+                            .width(at_least(300.0))
+                            .padding(8.0)
+                            .background(Color::rgb(0.18, 0.18, 0.24))
+                            .border(1.0, Color::rgb(0.8, 0.8, 0.3))
+                            .corner_radius(6.0)
+                            .translate(50.0, 10.0)
+                            .child(
+                                text_input(input4)
+                                    .text_color(Color::WHITE)
+                                    .cursor_color(Color::rgb(0.4, 0.8, 1.0))
+                                    .font_size(14.0),
+                            ),
+                    ),
+            )
+            // 5. All transforms combined: translate + rotate + scale
+            .child(
+                container()
+                    .layout(Flex::column().spacing(4.0))
+                    .child(
+                        text("Translate(20,5) + Rotate(-10°) + Scale(0.9)")
+                            .color(Color::rgb(0.6, 0.6, 0.7))
+                            .font_size(12.0),
+                    )
+                    .child(
+                        container()
+                            .width(at_least(300.0))
+                            .padding(8.0)
+                            .background(Color::rgb(0.18, 0.18, 0.24))
+                            .border(1.0, Color::rgb(0.8, 0.3, 0.8))
+                            .corner_radius(6.0)
+                            .transform(
+                                Transform::translate(20.0, 5.0)
+                                    .then(&Transform::rotate_degrees(-10.0))
+                                    .then(&Transform::scale(0.9)),
+                            )
+                            .child(
+                                text_input(input5)
+                                    .text_color(Color::WHITE)
+                                    .cursor_color(Color::rgb(0.4, 0.8, 1.0))
+                                    .font_size(14.0),
+                            ),
+                    ),
+            )
+            // Instructions
+            .child(
+                text("Click in each input to test cursor positioning")
+                    .color(Color::rgb(0.5, 0.5, 0.6))
+                    .font_size(11.0),
+            );
+
+        app.add_surface(
+            SurfaceConfig::new()
+                .width(550)
+                .height(680)
+                .anchor(Anchor::TOP | Anchor::LEFT)
+                .layer(Layer::Top)
+                .namespace("text-input-transform-test")
+                .background_color(Color::rgb(0.1, 0.1, 0.15)),
+            move || view,
         );
-
-    let (app, _) = App::new().add_surface(
-        SurfaceConfig::new()
-            .width(550)
-            .height(680)
-            .anchor(Anchor::TOP | Anchor::LEFT)
-            .layer(Layer::Top)
-            .namespace("text-input-transform-test")
-            .background_color(Color::rgb(0.1, 0.1, 0.15)),
-        move || view,
-    );
-    app.run();
+    });
 }

--- a/examples/text_styling_example.rs
+++ b/examples/text_styling_example.rs
@@ -8,33 +8,34 @@ use guido::prelude::*;
 fn main() {
     // Set an app-level default font (widgets will use this unless overridden)
     // Note: The actual font availability depends on the system
-    let (app, _) = App::new()
+    App::new()
         .default_font_family(FontFamily::SansSerif)
-        .add_surface(
-            SurfaceConfig::new()
-                .width(600)
-                .height(600)
-                .anchor(Anchor::TOP | Anchor::LEFT)
-                .background_color(Color::rgb(0.08, 0.08, 0.12)),
-            || {
-                container()
-                    .background(Color::rgb(0.08, 0.08, 0.12))
-                    .padding(24.0)
-                    .layout(Flex::column().spacing(20.0))
-                    .child(
-                        // Title
-                        text("Text Styling Demo")
-                            .font_size(28.0)
-                            .bold()
-                            .color(Color::rgb(0.9, 0.9, 0.95)),
-                    )
-                    .child(create_font_family_section())
-                    .child(create_font_weight_section())
-                    .child(create_combined_section())
-                    .child(create_text_input_section())
-            },
-        );
-    app.run();
+        .run(|app| {
+            app.add_surface(
+                SurfaceConfig::new()
+                    .width(600)
+                    .height(600)
+                    .anchor(Anchor::TOP | Anchor::LEFT)
+                    .background_color(Color::rgb(0.08, 0.08, 0.12)),
+                || {
+                    container()
+                        .background(Color::rgb(0.08, 0.08, 0.12))
+                        .padding(24.0)
+                        .layout(Flex::column().spacing(20.0))
+                        .child(
+                            // Title
+                            text("Text Styling Demo")
+                                .font_size(28.0)
+                                .bold()
+                                .color(Color::rgb(0.9, 0.9, 0.95)),
+                        )
+                        .child(create_font_family_section())
+                        .child(create_font_weight_section())
+                        .child(create_combined_section())
+                        .child(create_text_input_section())
+                },
+            );
+        });
 }
 
 /// Section demonstrating different font families

--- a/examples/text_transform_example.rs
+++ b/examples/text_transform_example.rs
@@ -15,289 +15,290 @@ use std::time::Duration;
 
 #[tokio::main]
 async fn main() {
-    // Animated rotation angle
-    let angle = create_signal(0.0_f32);
+    App::new().run(|app| {
+        // Animated rotation angle
+        let angle = create_signal(0.0_f32);
 
-    // Animation service - updates the angle signal continuously
-    let start_time = std::time::Instant::now();
-    let angle_w = angle.writer();
-    let _ = create_service::<(), _, _>(move |_rx, ctx| async move {
-        while ctx.is_running() {
-            let elapsed = start_time.elapsed().as_secs_f32();
-            let new_angle = (elapsed * PI / 2.0).to_degrees() % 360.0;
-            angle_w.set(new_angle);
-            tokio::time::sleep(Duration::from_millis(16)).await;
-        }
+        // Animation service - updates the angle signal continuously
+        let start_time = std::time::Instant::now();
+        let angle_w = angle.writer();
+        let _ = create_service::<(), _, _>(move |_rx, ctx| async move {
+            while ctx.is_running() {
+                let elapsed = start_time.elapsed().as_secs_f32();
+                let new_angle = (elapsed * PI / 2.0).to_degrees() % 360.0;
+                angle_w.set(new_angle);
+                tokio::time::sleep(Duration::from_millis(16)).await;
+            }
+        });
+
+        let view = container()
+            .layout(
+                Flex::column()
+                    .spacing(20.0)
+                    .main_axis_alignment(MainAxisAlignment::Center)
+                    .cross_axis_alignment(CrossAxisAlignment::Center),
+            )
+            .padding(30.0)
+            .children([
+                // Title
+                container().child(
+                    text("Text Transform Demo")
+                        .font_size(24.0)
+                        .color(Color::WHITE),
+                ),
+                // Row 1: Basic transforms (rotation, scale, translation)
+                container()
+                    .layout(
+                        Flex::row()
+                            .spacing(30.0)
+                            .main_axis_alignment(MainAxisAlignment::Center)
+                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                    )
+                    .children([
+                        // Rotation
+                        container()
+                            .width(110.0)
+                            .height(70.0)
+                            .background(Color::rgba(0.3, 0.5, 0.8, 0.8))
+                            .corner_radius(8.0)
+                            .layout(
+                                Flex::column()
+                                    .main_axis_alignment(MainAxisAlignment::Center)
+                                    .cross_axis_alignment(CrossAxisAlignment::Center),
+                            )
+                            .rotate(15.0)
+                            .child(text("Rotate 15°").font_size(13.0).color(Color::WHITE)),
+                        // Scale
+                        container()
+                            .width(110.0)
+                            .height(70.0)
+                            .background(Color::rgba(0.8, 0.5, 0.3, 0.8))
+                            .corner_radius(8.0)
+                            .layout(
+                                Flex::column()
+                                    .main_axis_alignment(MainAxisAlignment::Center)
+                                    .cross_axis_alignment(CrossAxisAlignment::Center),
+                            )
+                            .scale(1.2)
+                            .child(text("Scale 1.2x").font_size(13.0).color(Color::WHITE)),
+                        // Translation
+                        container()
+                            .width(110.0)
+                            .height(70.0)
+                            .background(Color::rgba(0.5, 0.8, 0.3, 0.8))
+                            .corner_radius(8.0)
+                            .layout(
+                                Flex::column()
+                                    .main_axis_alignment(MainAxisAlignment::Center)
+                                    .cross_axis_alignment(CrossAxisAlignment::Center),
+                            )
+                            .translate(10.0, -10.0)
+                            .child(text("Translate").font_size(13.0).color(Color::WHITE)),
+                        // Rotation + Scale
+                        container()
+                            .width(110.0)
+                            .height(70.0)
+                            .background(Color::rgba(0.8, 0.3, 0.8, 0.8))
+                            .corner_radius(8.0)
+                            .layout(
+                                Flex::column()
+                                    .main_axis_alignment(MainAxisAlignment::Center)
+                                    .cross_axis_alignment(CrossAxisAlignment::Center),
+                            )
+                            .rotate(-20.0)
+                            .scale(0.9)
+                            .child(text("Rot + Scale").font_size(13.0).color(Color::WHITE)),
+                    ]),
+                // Row 2: Combined transforms and custom origin
+                container()
+                    .layout(
+                        Flex::row()
+                            .spacing(30.0)
+                            .main_axis_alignment(MainAxisAlignment::Center)
+                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                    )
+                    .children([
+                        // All three: rotation + scale + translation
+                        container()
+                            .width(130.0)
+                            .height(80.0)
+                            .background(Color::rgba(0.3, 0.7, 0.7, 0.8))
+                            .corner_radius(8.0)
+                            .layout(
+                                Flex::column()
+                                    .main_axis_alignment(MainAxisAlignment::Center)
+                                    .cross_axis_alignment(CrossAxisAlignment::Center),
+                            )
+                            .rotate(10.0)
+                            .scale(1.1)
+                            .translate(5.0, 5.0)
+                            .child(text("All Combined").font_size(13.0).color(Color::WHITE)),
+                        // Custom origin: top-left
+                        container()
+                            .width(130.0)
+                            .height(80.0)
+                            .background(Color::rgba(0.7, 0.5, 0.2, 0.8))
+                            .corner_radius(8.0)
+                            .layout(
+                                Flex::column()
+                                    .main_axis_alignment(MainAxisAlignment::Center)
+                                    .cross_axis_alignment(CrossAxisAlignment::Center),
+                            )
+                            .transform_origin(TransformOrigin::TOP_LEFT)
+                            .rotate(15.0)
+                            .child(text("Origin: Top-Left").font_size(12.0).color(Color::WHITE)),
+                        // Custom origin: bottom-right
+                        container()
+                            .width(130.0)
+                            .height(80.0)
+                            .background(Color::rgba(0.2, 0.5, 0.7, 0.8))
+                            .corner_radius(8.0)
+                            .layout(
+                                Flex::column()
+                                    .main_axis_alignment(MainAxisAlignment::Center)
+                                    .cross_axis_alignment(CrossAxisAlignment::Center),
+                            )
+                            .transform_origin(TransformOrigin::BOTTOM_RIGHT)
+                            .rotate(15.0)
+                            .child(
+                                text("Origin: Bot-Right")
+                                    .font_size(12.0)
+                                    .color(Color::WHITE),
+                            ),
+                        // Custom origin with scale
+                        container()
+                            .width(130.0)
+                            .height(80.0)
+                            .background(Color::rgba(0.7, 0.3, 0.5, 0.8))
+                            .corner_radius(8.0)
+                            .layout(
+                                Flex::column()
+                                    .main_axis_alignment(MainAxisAlignment::Center)
+                                    .cross_axis_alignment(CrossAxisAlignment::Center),
+                            )
+                            .transform_origin(TransformOrigin::TOP_RIGHT)
+                            .scale(1.15)
+                            .rotate(-10.0)
+                            .child(text("Origin + Scale").font_size(12.0).color(Color::WHITE)),
+                    ]),
+                // Row 3: Nested transforms
+                container()
+                    .layout(
+                        Flex::row()
+                            .spacing(30.0)
+                            .main_axis_alignment(MainAxisAlignment::Center)
+                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                    )
+                    .children([
+                        // Nested: parent rotated, child has text
+                        container()
+                            .width(130.0)
+                            .height(90.0)
+                            .background(Color::rgba(0.6, 0.3, 0.6, 0.5))
+                            .corner_radius(12.0)
+                            .layout(
+                                Flex::column()
+                                    .main_axis_alignment(MainAxisAlignment::Center)
+                                    .cross_axis_alignment(CrossAxisAlignment::Center),
+                            )
+                            .rotate(20.0)
+                            .child(
+                                container()
+                                    .width(90.0)
+                                    .height(50.0)
+                                    .background(Color::rgba(0.8, 0.6, 0.8, 0.9))
+                                    .corner_radius(6.0)
+                                    .layout(
+                                        Flex::column()
+                                            .main_axis_alignment(MainAxisAlignment::Center)
+                                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                                    )
+                                    .child(text("Nested").font_size(14.0).color(Color::WHITE)),
+                            ),
+                        // Double nested with additional rotation
+                        container()
+                            .width(130.0)
+                            .height(90.0)
+                            .background(Color::rgba(0.3, 0.6, 0.6, 0.5))
+                            .corner_radius(12.0)
+                            .layout(
+                                Flex::column()
+                                    .main_axis_alignment(MainAxisAlignment::Center)
+                                    .cross_axis_alignment(CrossAxisAlignment::Center),
+                            )
+                            .rotate(15.0)
+                            .child(
+                                container()
+                                    .width(90.0)
+                                    .height(50.0)
+                                    .background(Color::rgba(0.5, 0.8, 0.8, 0.9))
+                                    .corner_radius(6.0)
+                                    .layout(
+                                        Flex::column()
+                                            .main_axis_alignment(MainAxisAlignment::Center)
+                                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                                    )
+                                    .rotate(15.0)
+                                    .child(
+                                        text("30° Total")
+                                            .font_size(13.0)
+                                            .color(Color::rgb(0.1, 0.1, 0.1)),
+                                    ),
+                            ),
+                        // Nested with scale + translation
+                        container()
+                            .width(130.0)
+                            .height(90.0)
+                            .background(Color::rgba(0.6, 0.6, 0.3, 0.5))
+                            .corner_radius(12.0)
+                            .layout(
+                                Flex::column()
+                                    .main_axis_alignment(MainAxisAlignment::Center)
+                                    .cross_axis_alignment(CrossAxisAlignment::Center),
+                            )
+                            .scale(1.1)
+                            .translate(5.0, 0.0)
+                            .child(
+                                container()
+                                    .width(90.0)
+                                    .height(50.0)
+                                    .background(Color::rgba(0.8, 0.8, 0.5, 0.9))
+                                    .corner_radius(6.0)
+                                    .layout(
+                                        Flex::column()
+                                            .main_axis_alignment(MainAxisAlignment::Center)
+                                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                                    )
+                                    .rotate(-10.0)
+                                    .child(
+                                        text("Scale+Trans")
+                                            .font_size(12.0)
+                                            .color(Color::rgb(0.1, 0.1, 0.1)),
+                                    ),
+                            ),
+                        // Animated rotating text
+                        container()
+                            .width(110.0)
+                            .height(70.0)
+                            .background(Color::rgba(0.8, 0.3, 0.5, 0.8))
+                            .corner_radius(8.0)
+                            .layout(
+                                Flex::column()
+                                    .main_axis_alignment(MainAxisAlignment::Center)
+                                    .cross_axis_alignment(CrossAxisAlignment::Center),
+                            )
+                            .rotate(move || angle.get())
+                            .child(text("Spinning!").font_size(14.0).color(Color::WHITE)),
+                    ]),
+            ]);
+
+        app.add_surface(
+            SurfaceConfig::new()
+                .width(900)
+                .height(450)
+                .anchor(Anchor::TOP | Anchor::LEFT)
+                .background_color(Color::rgb(0.1, 0.1, 0.15)),
+            move || view,
+        );
     });
-
-    let view = container()
-        .layout(
-            Flex::column()
-                .spacing(20.0)
-                .main_axis_alignment(MainAxisAlignment::Center)
-                .cross_axis_alignment(CrossAxisAlignment::Center),
-        )
-        .padding(30.0)
-        .children([
-            // Title
-            container().child(
-                text("Text Transform Demo")
-                    .font_size(24.0)
-                    .color(Color::WHITE),
-            ),
-            // Row 1: Basic transforms (rotation, scale, translation)
-            container()
-                .layout(
-                    Flex::row()
-                        .spacing(30.0)
-                        .main_axis_alignment(MainAxisAlignment::Center)
-                        .cross_axis_alignment(CrossAxisAlignment::Center),
-                )
-                .children([
-                    // Rotation
-                    container()
-                        .width(110.0)
-                        .height(70.0)
-                        .background(Color::rgba(0.3, 0.5, 0.8, 0.8))
-                        .corner_radius(8.0)
-                        .layout(
-                            Flex::column()
-                                .main_axis_alignment(MainAxisAlignment::Center)
-                                .cross_axis_alignment(CrossAxisAlignment::Center),
-                        )
-                        .rotate(15.0)
-                        .child(text("Rotate 15°").font_size(13.0).color(Color::WHITE)),
-                    // Scale
-                    container()
-                        .width(110.0)
-                        .height(70.0)
-                        .background(Color::rgba(0.8, 0.5, 0.3, 0.8))
-                        .corner_radius(8.0)
-                        .layout(
-                            Flex::column()
-                                .main_axis_alignment(MainAxisAlignment::Center)
-                                .cross_axis_alignment(CrossAxisAlignment::Center),
-                        )
-                        .scale(1.2)
-                        .child(text("Scale 1.2x").font_size(13.0).color(Color::WHITE)),
-                    // Translation
-                    container()
-                        .width(110.0)
-                        .height(70.0)
-                        .background(Color::rgba(0.5, 0.8, 0.3, 0.8))
-                        .corner_radius(8.0)
-                        .layout(
-                            Flex::column()
-                                .main_axis_alignment(MainAxisAlignment::Center)
-                                .cross_axis_alignment(CrossAxisAlignment::Center),
-                        )
-                        .translate(10.0, -10.0)
-                        .child(text("Translate").font_size(13.0).color(Color::WHITE)),
-                    // Rotation + Scale
-                    container()
-                        .width(110.0)
-                        .height(70.0)
-                        .background(Color::rgba(0.8, 0.3, 0.8, 0.8))
-                        .corner_radius(8.0)
-                        .layout(
-                            Flex::column()
-                                .main_axis_alignment(MainAxisAlignment::Center)
-                                .cross_axis_alignment(CrossAxisAlignment::Center),
-                        )
-                        .rotate(-20.0)
-                        .scale(0.9)
-                        .child(text("Rot + Scale").font_size(13.0).color(Color::WHITE)),
-                ]),
-            // Row 2: Combined transforms and custom origin
-            container()
-                .layout(
-                    Flex::row()
-                        .spacing(30.0)
-                        .main_axis_alignment(MainAxisAlignment::Center)
-                        .cross_axis_alignment(CrossAxisAlignment::Center),
-                )
-                .children([
-                    // All three: rotation + scale + translation
-                    container()
-                        .width(130.0)
-                        .height(80.0)
-                        .background(Color::rgba(0.3, 0.7, 0.7, 0.8))
-                        .corner_radius(8.0)
-                        .layout(
-                            Flex::column()
-                                .main_axis_alignment(MainAxisAlignment::Center)
-                                .cross_axis_alignment(CrossAxisAlignment::Center),
-                        )
-                        .rotate(10.0)
-                        .scale(1.1)
-                        .translate(5.0, 5.0)
-                        .child(text("All Combined").font_size(13.0).color(Color::WHITE)),
-                    // Custom origin: top-left
-                    container()
-                        .width(130.0)
-                        .height(80.0)
-                        .background(Color::rgba(0.7, 0.5, 0.2, 0.8))
-                        .corner_radius(8.0)
-                        .layout(
-                            Flex::column()
-                                .main_axis_alignment(MainAxisAlignment::Center)
-                                .cross_axis_alignment(CrossAxisAlignment::Center),
-                        )
-                        .transform_origin(TransformOrigin::TOP_LEFT)
-                        .rotate(15.0)
-                        .child(text("Origin: Top-Left").font_size(12.0).color(Color::WHITE)),
-                    // Custom origin: bottom-right
-                    container()
-                        .width(130.0)
-                        .height(80.0)
-                        .background(Color::rgba(0.2, 0.5, 0.7, 0.8))
-                        .corner_radius(8.0)
-                        .layout(
-                            Flex::column()
-                                .main_axis_alignment(MainAxisAlignment::Center)
-                                .cross_axis_alignment(CrossAxisAlignment::Center),
-                        )
-                        .transform_origin(TransformOrigin::BOTTOM_RIGHT)
-                        .rotate(15.0)
-                        .child(
-                            text("Origin: Bot-Right")
-                                .font_size(12.0)
-                                .color(Color::WHITE),
-                        ),
-                    // Custom origin with scale
-                    container()
-                        .width(130.0)
-                        .height(80.0)
-                        .background(Color::rgba(0.7, 0.3, 0.5, 0.8))
-                        .corner_radius(8.0)
-                        .layout(
-                            Flex::column()
-                                .main_axis_alignment(MainAxisAlignment::Center)
-                                .cross_axis_alignment(CrossAxisAlignment::Center),
-                        )
-                        .transform_origin(TransformOrigin::TOP_RIGHT)
-                        .scale(1.15)
-                        .rotate(-10.0)
-                        .child(text("Origin + Scale").font_size(12.0).color(Color::WHITE)),
-                ]),
-            // Row 3: Nested transforms
-            container()
-                .layout(
-                    Flex::row()
-                        .spacing(30.0)
-                        .main_axis_alignment(MainAxisAlignment::Center)
-                        .cross_axis_alignment(CrossAxisAlignment::Center),
-                )
-                .children([
-                    // Nested: parent rotated, child has text
-                    container()
-                        .width(130.0)
-                        .height(90.0)
-                        .background(Color::rgba(0.6, 0.3, 0.6, 0.5))
-                        .corner_radius(12.0)
-                        .layout(
-                            Flex::column()
-                                .main_axis_alignment(MainAxisAlignment::Center)
-                                .cross_axis_alignment(CrossAxisAlignment::Center),
-                        )
-                        .rotate(20.0)
-                        .child(
-                            container()
-                                .width(90.0)
-                                .height(50.0)
-                                .background(Color::rgba(0.8, 0.6, 0.8, 0.9))
-                                .corner_radius(6.0)
-                                .layout(
-                                    Flex::column()
-                                        .main_axis_alignment(MainAxisAlignment::Center)
-                                        .cross_axis_alignment(CrossAxisAlignment::Center),
-                                )
-                                .child(text("Nested").font_size(14.0).color(Color::WHITE)),
-                        ),
-                    // Double nested with additional rotation
-                    container()
-                        .width(130.0)
-                        .height(90.0)
-                        .background(Color::rgba(0.3, 0.6, 0.6, 0.5))
-                        .corner_radius(12.0)
-                        .layout(
-                            Flex::column()
-                                .main_axis_alignment(MainAxisAlignment::Center)
-                                .cross_axis_alignment(CrossAxisAlignment::Center),
-                        )
-                        .rotate(15.0)
-                        .child(
-                            container()
-                                .width(90.0)
-                                .height(50.0)
-                                .background(Color::rgba(0.5, 0.8, 0.8, 0.9))
-                                .corner_radius(6.0)
-                                .layout(
-                                    Flex::column()
-                                        .main_axis_alignment(MainAxisAlignment::Center)
-                                        .cross_axis_alignment(CrossAxisAlignment::Center),
-                                )
-                                .rotate(15.0)
-                                .child(
-                                    text("30° Total")
-                                        .font_size(13.0)
-                                        .color(Color::rgb(0.1, 0.1, 0.1)),
-                                ),
-                        ),
-                    // Nested with scale + translation
-                    container()
-                        .width(130.0)
-                        .height(90.0)
-                        .background(Color::rgba(0.6, 0.6, 0.3, 0.5))
-                        .corner_radius(12.0)
-                        .layout(
-                            Flex::column()
-                                .main_axis_alignment(MainAxisAlignment::Center)
-                                .cross_axis_alignment(CrossAxisAlignment::Center),
-                        )
-                        .scale(1.1)
-                        .translate(5.0, 0.0)
-                        .child(
-                            container()
-                                .width(90.0)
-                                .height(50.0)
-                                .background(Color::rgba(0.8, 0.8, 0.5, 0.9))
-                                .corner_radius(6.0)
-                                .layout(
-                                    Flex::column()
-                                        .main_axis_alignment(MainAxisAlignment::Center)
-                                        .cross_axis_alignment(CrossAxisAlignment::Center),
-                                )
-                                .rotate(-10.0)
-                                .child(
-                                    text("Scale+Trans")
-                                        .font_size(12.0)
-                                        .color(Color::rgb(0.1, 0.1, 0.1)),
-                                ),
-                        ),
-                    // Animated rotating text
-                    container()
-                        .width(110.0)
-                        .height(70.0)
-                        .background(Color::rgba(0.8, 0.3, 0.5, 0.8))
-                        .corner_radius(8.0)
-                        .layout(
-                            Flex::column()
-                                .main_axis_alignment(MainAxisAlignment::Center)
-                                .cross_axis_alignment(CrossAxisAlignment::Center),
-                        )
-                        .rotate(move || angle.get())
-                        .child(text("Spinning!").font_size(14.0).color(Color::WHITE)),
-                ]),
-        ]);
-
-    let (app, _) = App::new().add_surface(
-        SurfaceConfig::new()
-            .width(900)
-            .height(450)
-            .anchor(Anchor::TOP | Anchor::LEFT)
-            .background_color(Color::rgb(0.1, 0.1, 0.15)),
-        move || view,
-    );
-    app.run();
 }

--- a/examples/transform_events_test.rs
+++ b/examples/transform_events_test.rs
@@ -11,90 +11,102 @@
 use guido::prelude::*;
 
 fn main() {
-    let click_count = create_signal(0);
+    App::new().run(|app| {
+        let click_count = create_signal(0);
 
-    let (app, _) = App::new().add_surface(
-        SurfaceConfig::new()
-            .height(350)
-            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
-            .background_color(Color::rgb(0.1, 0.1, 0.15)),
-        move || {
-            container()
-                .layout(
-                    Flex::column()
-                        .spacing(20.0)
-                        .cross_axis_alignment(CrossAxisAlignment::Center),
-                )
-                .padding(20.0)
-                .children([
-                    // Row 1: Basic transforms
-                    container()
-                        .layout(
-                            Flex::row()
-                                .spacing(30.0)
-                                .main_axis_alignment(MainAxisAlignment::Center),
-                        )
-                        .children([
-                            // No transform (control)
-                            make_box("None", Color::rgb(0.5, 0.5, 0.5), click_count),
-                            // Translation
-                            make_box("Translate", Color::rgb(0.3, 0.8, 0.3), click_count)
-                                .translate(20.0, 10.0),
-                            // Rotation
-                            make_box("Rotate", Color::rgb(0.3, 0.3, 0.8), click_count).rotate(15.0),
-                            // Scale up
-                            make_box("Scale+", Color::rgb(0.8, 0.3, 0.8), click_count).scale(1.2),
-                            // Scale down
-                            make_box("Scale-", Color::rgb(0.8, 0.6, 0.3), click_count).scale(0.7),
-                        ]),
-                    // Row 2: Nested transforms
-                    container()
-                        .layout(
-                            Flex::row()
-                                .spacing(50.0)
-                                .main_axis_alignment(MainAxisAlignment::Center),
-                        )
-                        .children([
-                            // Nested: parent rotated, child clickable
-                            container()
-                                .width(100.0)
-                                .height(100.0)
-                                .background(Color::rgba(0.8, 0.3, 0.3, 0.3))
-                                .corner_radius(8.0)
-                                .rotate(20.0)
-                                .layout(
-                                    Flex::column()
-                                        .main_axis_alignment(MainAxisAlignment::Center)
-                                        .cross_axis_alignment(CrossAxisAlignment::Center),
-                                )
-                                .child(make_box("Nested", Color::rgb(0.8, 0.8, 0.3), click_count)),
-                            // Nested: parent scaled, child rotated and clickable
-                            container()
-                                .width(100.0)
-                                .height(100.0)
-                                .background(Color::rgba(0.3, 0.8, 0.3, 0.3))
-                                .corner_radius(8.0)
-                                .scale(1.3)
-                                .layout(
-                                    Flex::column()
-                                        .main_axis_alignment(MainAxisAlignment::Center)
-                                        .cross_axis_alignment(CrossAxisAlignment::Center),
-                                )
-                                .child(
-                                    make_box("Nest+Rot", Color::rgb(0.3, 0.8, 0.8), click_count)
+        app.add_surface(
+            SurfaceConfig::new()
+                .height(350)
+                .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+                .background_color(Color::rgb(0.1, 0.1, 0.15)),
+            move || {
+                container()
+                    .layout(
+                        Flex::column()
+                            .spacing(20.0)
+                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                    )
+                    .padding(20.0)
+                    .children([
+                        // Row 1: Basic transforms
+                        container()
+                            .layout(
+                                Flex::row()
+                                    .spacing(30.0)
+                                    .main_axis_alignment(MainAxisAlignment::Center),
+                            )
+                            .children([
+                                // No transform (control)
+                                make_box("None", Color::rgb(0.5, 0.5, 0.5), click_count),
+                                // Translation
+                                make_box("Translate", Color::rgb(0.3, 0.8, 0.3), click_count)
+                                    .translate(20.0, 10.0),
+                                // Rotation
+                                make_box("Rotate", Color::rgb(0.3, 0.3, 0.8), click_count)
+                                    .rotate(15.0),
+                                // Scale up
+                                make_box("Scale+", Color::rgb(0.8, 0.3, 0.8), click_count)
+                                    .scale(1.2),
+                                // Scale down
+                                make_box("Scale-", Color::rgb(0.8, 0.6, 0.3), click_count)
+                                    .scale(0.7),
+                            ]),
+                        // Row 2: Nested transforms
+                        container()
+                            .layout(
+                                Flex::row()
+                                    .spacing(50.0)
+                                    .main_axis_alignment(MainAxisAlignment::Center),
+                            )
+                            .children([
+                                // Nested: parent rotated, child clickable
+                                container()
+                                    .width(100.0)
+                                    .height(100.0)
+                                    .background(Color::rgba(0.8, 0.3, 0.3, 0.3))
+                                    .corner_radius(8.0)
+                                    .rotate(20.0)
+                                    .layout(
+                                        Flex::column()
+                                            .main_axis_alignment(MainAxisAlignment::Center)
+                                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                                    )
+                                    .child(make_box(
+                                        "Nested",
+                                        Color::rgb(0.8, 0.8, 0.3),
+                                        click_count,
+                                    )),
+                                // Nested: parent scaled, child rotated and clickable
+                                container()
+                                    .width(100.0)
+                                    .height(100.0)
+                                    .background(Color::rgba(0.3, 0.8, 0.3, 0.3))
+                                    .corner_radius(8.0)
+                                    .scale(1.3)
+                                    .layout(
+                                        Flex::column()
+                                            .main_axis_alignment(MainAxisAlignment::Center)
+                                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                                    )
+                                    .child(
+                                        make_box(
+                                            "Nest+Rot",
+                                            Color::rgb(0.3, 0.8, 0.8),
+                                            click_count,
+                                        )
                                         .rotate(30.0),
-                                ),
-                        ]),
-                    // Click counter display
-                    container().child(
-                        text(move || format!("Clicks: {}", click_count.get()))
-                            .font_size(20.0)
-                            .color(Color::WHITE),
-                    ),
-                ])
-        },
-    );
-    app.run();
+                                    ),
+                            ]),
+                        // Click counter display
+                        container().child(
+                            text(move || format!("Clicks: {}", click_count.get()))
+                                .font_size(20.0)
+                                .color(Color::WHITE),
+                        ),
+                    ])
+            },
+        );
+    });
 }
 
 fn make_box(label: &'static str, base_color: Color, click_count: Signal<i32>) -> Container {

--- a/examples/transform_example.rs
+++ b/examples/transform_example.rs
@@ -10,174 +10,57 @@
 use guido::prelude::*;
 
 fn main() {
-    // Signals for interactive transforms
-    let rotation = create_signal(0.0f32);
-    let scale_factor = create_signal(1.0f32);
-    let is_scaled = create_signal(false);
+    App::new().run(|app| {
+        // Signals for interactive transforms
+        let rotation = create_signal(0.0f32);
+        let scale_factor = create_signal(1.0f32);
+        let is_scaled = create_signal(false);
 
-    // Run the app with taller height to see transforms
-    let (app, _) = App::new().add_surface(
-        SurfaceConfig::new()
-            .height(120)
-            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
-            .background_color(Color::rgb(0.1, 0.1, 0.15)),
-        move || {
-            container()
-                .layout(
-                    Flex::row()
-                        .spacing(20.0)
-                        .main_axis_alignment(MainAxisAlignment::Center)
-                        .cross_axis_alignment(CrossAxisAlignment::Center),
-                )
-                .padding(16.0)
-                .children([
-                    // 1. Static rotation (45 degrees)
-                    container()
-                        .width(60.0)
-                        .height(60.0)
-                        .background(Color::rgb(0.8, 0.3, 0.3))
-                        .corner_radius(8.0)
-                        .rotate(45.0)
-                        .child(
-                            container()
-                                .layout(
-                                    Flex::column()
-                                        .main_axis_alignment(MainAxisAlignment::Center)
-                                        .cross_axis_alignment(CrossAxisAlignment::Center),
-                                )
-                                .child(text("45").color(Color::WHITE).font_size(12.0)),
-                        ),
-                    // 2. Click to rotate (increments by 45 degrees)
-                    container()
-                        .width(60.0)
-                        .height(60.0)
-                        .background(Color::rgb(0.3, 0.6, 0.8))
-                        .corner_radius(8.0)
-                        .rotate(rotation)
-                        .animate_transform(Transition::new(300.0, TimingFunction::EaseOut))
-                        .hover_state(|s| s.lighter(0.1))
-                        .pressed_state(|s| s.ripple())
-                        .on_click(move || {
-                            rotation.update(|r| *r += 45.0);
-                        })
-                        .child(
-                            container()
-                                .layout(
-                                    Flex::column()
-                                        .main_axis_alignment(MainAxisAlignment::Center)
-                                        .cross_axis_alignment(CrossAxisAlignment::Center),
-                                )
-                                .child(text("Click").color(Color::WHITE).font_size(10.0).nowrap()),
-                        ),
-                    // 3. Click to toggle scale with spring animation
-                    container()
-                        .width(60.0)
-                        .height(60.0)
-                        .background(Color::rgb(0.3, 0.8, 0.4))
-                        .corner_radius(8.0)
-                        .scale(scale_factor)
-                        .animate_transform(Transition::spring(SpringConfig::BOUNCY))
-                        .hover_state(|s| s.lighter(0.1))
-                        .pressed_state(|s| s.ripple())
-                        .on_click(move || {
-                            is_scaled.update(|s| *s = !*s);
-                            let target = if is_scaled.get() { 1.3 } else { 1.0 };
-                            scale_factor.set(target);
-                        })
-                        .child(
-                            container()
-                                .layout(
-                                    Flex::column()
-                                        .main_axis_alignment(MainAxisAlignment::Center)
-                                        .cross_axis_alignment(CrossAxisAlignment::Center),
-                                )
-                                .child(text("Scale").color(Color::WHITE).font_size(10.0).nowrap()),
-                        ),
-                    // 4. Static scale (smaller)
-                    container()
-                        .width(60.0)
-                        .height(60.0)
-                        .background(Color::rgb(0.6, 0.4, 0.8))
-                        .corner_radius(8.0)
-                        .scale(0.7)
-                        .child(
-                            container()
-                                .layout(
-                                    Flex::column()
-                                        .main_axis_alignment(MainAxisAlignment::Center)
-                                        .cross_axis_alignment(CrossAxisAlignment::Center),
-                                )
-                                .child(text("0.7x").color(Color::WHITE).font_size(12.0)),
-                        ),
-                    // 5. Combined rotation + scale
-                    container()
-                        .width(60.0)
-                        .height(60.0)
-                        .background(Color::rgb(0.8, 0.6, 0.2))
-                        .corner_radius(8.0)
-                        .transform(Transform::rotate_degrees(30.0).then(&Transform::scale(0.8)))
-                        .child(
-                            container()
-                                .layout(
-                                    Flex::column()
-                                        .main_axis_alignment(MainAxisAlignment::Center)
-                                        .cross_axis_alignment(CrossAxisAlignment::Center),
-                                )
-                                .child(text("Both").color(Color::WHITE).font_size(10.0).nowrap()),
-                        ),
-                    // 6. Rotation around top-left corner (transform origin)
-                    container()
-                        .width(60.0)
-                        .height(60.0)
-                        .background(Color::rgb(0.8, 0.5, 0.7))
-                        .corner_radius(8.0)
-                        .rotate(45.0)
-                        .transform_origin(TransformOrigin::TOP_LEFT)
-                        .child(
-                            container()
-                                .layout(
-                                    Flex::column()
-                                        .main_axis_alignment(MainAxisAlignment::Center)
-                                        .cross_axis_alignment(CrossAxisAlignment::Center),
-                                )
-                                .child(text("TL").color(Color::WHITE).font_size(12.0)),
-                        ),
-                    // 7. Scale from bottom-right corner (transform origin)
-                    container()
-                        .width(60.0)
-                        .height(60.0)
-                        .background(Color::rgb(0.5, 0.7, 0.8))
-                        .corner_radius(8.0)
-                        .scale(0.8)
-                        .transform_origin(TransformOrigin::BOTTOM_RIGHT)
-                        .child(
-                            container()
-                                .layout(
-                                    Flex::column()
-                                        .main_axis_alignment(MainAxisAlignment::Center)
-                                        .cross_axis_alignment(CrossAxisAlignment::Center),
-                                )
-                                .child(text("BR").color(Color::WHITE).font_size(12.0)),
-                        ),
-                    // 8. Interactive: click to cycle through origins
-                    {
-                        let origin_index = create_signal(0usize);
+        // Run the app with taller height to see transforms
+        app.add_surface(
+            SurfaceConfig::new()
+                .height(120)
+                .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+                .background_color(Color::rgb(0.1, 0.1, 0.15)),
+            move || {
+                container()
+                    .layout(
+                        Flex::row()
+                            .spacing(20.0)
+                            .main_axis_alignment(MainAxisAlignment::Center)
+                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                    )
+                    .padding(16.0)
+                    .children([
+                        // 1. Static rotation (45 degrees)
                         container()
                             .width(60.0)
                             .height(60.0)
-                            .background(Color::rgb(0.7, 0.8, 0.5))
+                            .background(Color::rgb(0.8, 0.3, 0.3))
                             .corner_radius(8.0)
-                            .rotate(30.0)
-                            .transform_origin(move || match origin_index.get() % 5 {
-                                0 => TransformOrigin::CENTER,
-                                1 => TransformOrigin::TOP_LEFT,
-                                2 => TransformOrigin::TOP_RIGHT,
-                                3 => TransformOrigin::BOTTOM_LEFT,
-                                _ => TransformOrigin::BOTTOM_RIGHT,
-                            })
+                            .rotate(45.0)
+                            .child(
+                                container()
+                                    .layout(
+                                        Flex::column()
+                                            .main_axis_alignment(MainAxisAlignment::Center)
+                                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                                    )
+                                    .child(text("45").color(Color::WHITE).font_size(12.0)),
+                            ),
+                        // 2. Click to rotate (increments by 45 degrees)
+                        container()
+                            .width(60.0)
+                            .height(60.0)
+                            .background(Color::rgb(0.3, 0.6, 0.8))
+                            .corner_radius(8.0)
+                            .rotate(rotation)
+                            .animate_transform(Transition::new(300.0, TimingFunction::EaseOut))
                             .hover_state(|s| s.lighter(0.1))
                             .pressed_state(|s| s.ripple())
-                            .on_click(move || origin_index.update(|i| *i += 1))
+                            .on_click(move || {
+                                rotation.update(|r| *r += 45.0);
+                            })
                             .child(
                                 container()
                                     .layout(
@@ -186,12 +69,139 @@ fn main() {
                                             .cross_axis_alignment(CrossAxisAlignment::Center),
                                     )
                                     .child(
-                                        text("Cycle").color(Color::WHITE).font_size(10.0).nowrap(),
+                                        text("Click").color(Color::WHITE).font_size(10.0).nowrap(),
                                     ),
-                            )
-                    },
-                ])
-        },
-    );
-    app.run();
+                            ),
+                        // 3. Click to toggle scale with spring animation
+                        container()
+                            .width(60.0)
+                            .height(60.0)
+                            .background(Color::rgb(0.3, 0.8, 0.4))
+                            .corner_radius(8.0)
+                            .scale(scale_factor)
+                            .animate_transform(Transition::spring(SpringConfig::BOUNCY))
+                            .hover_state(|s| s.lighter(0.1))
+                            .pressed_state(|s| s.ripple())
+                            .on_click(move || {
+                                is_scaled.update(|s| *s = !*s);
+                                let target = if is_scaled.get() { 1.3 } else { 1.0 };
+                                scale_factor.set(target);
+                            })
+                            .child(
+                                container()
+                                    .layout(
+                                        Flex::column()
+                                            .main_axis_alignment(MainAxisAlignment::Center)
+                                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                                    )
+                                    .child(
+                                        text("Scale").color(Color::WHITE).font_size(10.0).nowrap(),
+                                    ),
+                            ),
+                        // 4. Static scale (smaller)
+                        container()
+                            .width(60.0)
+                            .height(60.0)
+                            .background(Color::rgb(0.6, 0.4, 0.8))
+                            .corner_radius(8.0)
+                            .scale(0.7)
+                            .child(
+                                container()
+                                    .layout(
+                                        Flex::column()
+                                            .main_axis_alignment(MainAxisAlignment::Center)
+                                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                                    )
+                                    .child(text("0.7x").color(Color::WHITE).font_size(12.0)),
+                            ),
+                        // 5. Combined rotation + scale
+                        container()
+                            .width(60.0)
+                            .height(60.0)
+                            .background(Color::rgb(0.8, 0.6, 0.2))
+                            .corner_radius(8.0)
+                            .transform(Transform::rotate_degrees(30.0).then(&Transform::scale(0.8)))
+                            .child(
+                                container()
+                                    .layout(
+                                        Flex::column()
+                                            .main_axis_alignment(MainAxisAlignment::Center)
+                                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                                    )
+                                    .child(
+                                        text("Both").color(Color::WHITE).font_size(10.0).nowrap(),
+                                    ),
+                            ),
+                        // 6. Rotation around top-left corner (transform origin)
+                        container()
+                            .width(60.0)
+                            .height(60.0)
+                            .background(Color::rgb(0.8, 0.5, 0.7))
+                            .corner_radius(8.0)
+                            .rotate(45.0)
+                            .transform_origin(TransformOrigin::TOP_LEFT)
+                            .child(
+                                container()
+                                    .layout(
+                                        Flex::column()
+                                            .main_axis_alignment(MainAxisAlignment::Center)
+                                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                                    )
+                                    .child(text("TL").color(Color::WHITE).font_size(12.0)),
+                            ),
+                        // 7. Scale from bottom-right corner (transform origin)
+                        container()
+                            .width(60.0)
+                            .height(60.0)
+                            .background(Color::rgb(0.5, 0.7, 0.8))
+                            .corner_radius(8.0)
+                            .scale(0.8)
+                            .transform_origin(TransformOrigin::BOTTOM_RIGHT)
+                            .child(
+                                container()
+                                    .layout(
+                                        Flex::column()
+                                            .main_axis_alignment(MainAxisAlignment::Center)
+                                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                                    )
+                                    .child(text("BR").color(Color::WHITE).font_size(12.0)),
+                            ),
+                        // 8. Interactive: click to cycle through origins
+                        {
+                            let origin_index = create_signal(0usize);
+                            container()
+                                .width(60.0)
+                                .height(60.0)
+                                .background(Color::rgb(0.7, 0.8, 0.5))
+                                .corner_radius(8.0)
+                                .rotate(30.0)
+                                .transform_origin(move || match origin_index.get() % 5 {
+                                    0 => TransformOrigin::CENTER,
+                                    1 => TransformOrigin::TOP_LEFT,
+                                    2 => TransformOrigin::TOP_RIGHT,
+                                    3 => TransformOrigin::BOTTOM_LEFT,
+                                    _ => TransformOrigin::BOTTOM_RIGHT,
+                                })
+                                .hover_state(|s| s.lighter(0.1))
+                                .pressed_state(|s| s.ripple())
+                                .on_click(move || origin_index.update(|i| *i += 1))
+                                .child(
+                                    container()
+                                        .layout(
+                                            Flex::column()
+                                                .main_axis_alignment(MainAxisAlignment::Center)
+                                                .cross_axis_alignment(CrossAxisAlignment::Center),
+                                        )
+                                        .child(
+                                            text("Cycle")
+                                                .color(Color::WHITE)
+                                                .font_size(10.0)
+                                                .nowrap(),
+                                        ),
+                                )
+                        },
+                    ])
+            },
+        );
+    });
 }

--- a/examples/transform_origin_test.rs
+++ b/examples/transform_origin_test.rs
@@ -7,202 +7,203 @@ use std::time::Duration;
 
 #[tokio::main]
 async fn main() {
-    let angle = create_signal(0.0_f32);
+    App::new().run(|app| {
+        let angle = create_signal(0.0_f32);
 
-    // Animation service - updates the angle signal continuously
-    let start_time = std::time::Instant::now();
-    let angle_w = angle.writer();
-    let _ = create_service::<(), _, _>(move |_rx, ctx| async move {
-        while ctx.is_running() {
-            let elapsed = start_time.elapsed().as_secs_f32();
-            let new_angle = (elapsed * 45.0) % 360.0; // 45 degrees per second
-            angle_w.set(new_angle);
-            tokio::time::sleep(Duration::from_millis(16)).await;
-        }
+        // Animation service - updates the angle signal continuously
+        let start_time = std::time::Instant::now();
+        let angle_w = angle.writer();
+        let _ = create_service::<(), _, _>(move |_rx, ctx| async move {
+            while ctx.is_running() {
+                let elapsed = start_time.elapsed().as_secs_f32();
+                let new_angle = (elapsed * 45.0) % 360.0; // 45 degrees per second
+                angle_w.set(new_angle);
+                tokio::time::sleep(Duration::from_millis(16)).await;
+            }
+        });
+
+        app.add_surface(
+            SurfaceConfig::new()
+                .width(900)
+                .height(550)
+                .anchor(Anchor::TOP | Anchor::LEFT)
+                .background_color(Color::rgb(0.1, 0.1, 0.15)),
+            move || {
+                container()
+                    .layout(
+                        Flex::column()
+                            .spacing(40.0)
+                            .main_axis_alignment(MainAxisAlignment::Center)
+                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                    )
+                    .padding(40.0)
+                    .children([
+                        // Row 1: Different origins with same rotation
+                        container()
+                            .layout(
+                                Flex::row()
+                                    .spacing(80.0)
+                                    .main_axis_alignment(MainAxisAlignment::Center)
+                                    .cross_axis_alignment(CrossAxisAlignment::Center),
+                            )
+                            .children([
+                                // Default origin (center)
+                                container()
+                                    .width(100.0)
+                                    .height(80.0)
+                                    .background(Color::rgba(0.3, 0.5, 0.8, 0.8))
+                                    .corner_radius(8.0)
+                                    .rotate(20.0),
+                                // Top-left origin
+                                container()
+                                    .width(100.0)
+                                    .height(80.0)
+                                    .background(Color::rgba(0.8, 0.5, 0.3, 0.8))
+                                    .corner_radius(8.0)
+                                    .transform_origin(TransformOrigin::TOP_LEFT)
+                                    .rotate(20.0),
+                                // Top-right origin
+                                container()
+                                    .width(100.0)
+                                    .height(80.0)
+                                    .background(Color::rgba(0.5, 0.8, 0.3, 0.8))
+                                    .corner_radius(8.0)
+                                    .transform_origin(TransformOrigin::TOP_RIGHT)
+                                    .rotate(20.0),
+                                // Bottom-left origin
+                                container()
+                                    .width(100.0)
+                                    .height(80.0)
+                                    .background(Color::rgba(0.8, 0.3, 0.8, 0.8))
+                                    .corner_radius(8.0)
+                                    .transform_origin(TransformOrigin::BOTTOM_LEFT)
+                                    .rotate(20.0),
+                                // Bottom-right origin
+                                container()
+                                    .width(100.0)
+                                    .height(80.0)
+                                    .background(Color::rgba(0.3, 0.8, 0.8, 0.8))
+                                    .corner_radius(8.0)
+                                    .transform_origin(TransformOrigin::BOTTOM_RIGHT)
+                                    .rotate(20.0),
+                            ]),
+                        // Row 2: Scale with different origins
+                        container()
+                            .layout(
+                                Flex::row()
+                                    .spacing(80.0)
+                                    .main_axis_alignment(MainAxisAlignment::Center)
+                                    .cross_axis_alignment(CrossAxisAlignment::Center),
+                            )
+                            .children([
+                                // Default origin (center) - scale
+                                container()
+                                    .width(80.0)
+                                    .height(60.0)
+                                    .background(Color::rgba(0.6, 0.3, 0.3, 0.8))
+                                    .corner_radius(6.0)
+                                    .scale(1.3),
+                                // Top-left origin - scale
+                                container()
+                                    .width(80.0)
+                                    .height(60.0)
+                                    .background(Color::rgba(0.3, 0.6, 0.3, 0.8))
+                                    .corner_radius(6.0)
+                                    .transform_origin(TransformOrigin::TOP_LEFT)
+                                    .scale(1.3),
+                                // Bottom-right origin - scale
+                                container()
+                                    .width(80.0)
+                                    .height(60.0)
+                                    .background(Color::rgba(0.3, 0.3, 0.6, 0.8))
+                                    .corner_radius(6.0)
+                                    .transform_origin(TransformOrigin::BOTTOM_RIGHT)
+                                    .scale(1.3),
+                            ]),
+                        // Row 3: Animated rotation with different origins
+                        container()
+                            .layout(
+                                Flex::row()
+                                    .spacing(80.0)
+                                    .main_axis_alignment(MainAxisAlignment::Center)
+                                    .cross_axis_alignment(CrossAxisAlignment::Center),
+                            )
+                            .children([
+                                // Center origin - animated
+                                container()
+                                    .width(80.0)
+                                    .height(60.0)
+                                    .background(Color::rgba(0.7, 0.5, 0.2, 0.8))
+                                    .corner_radius(6.0)
+                                    .rotate(move || angle.get()),
+                                // Top-left origin - animated
+                                container()
+                                    .width(80.0)
+                                    .height(60.0)
+                                    .background(Color::rgba(0.2, 0.5, 0.7, 0.8))
+                                    .corner_radius(6.0)
+                                    .transform_origin(TransformOrigin::TOP_LEFT)
+                                    .rotate(move || angle.get()),
+                                // Custom origin (25%, 75%) - animated
+                                container()
+                                    .width(80.0)
+                                    .height(60.0)
+                                    .background(Color::rgba(0.5, 0.7, 0.2, 0.8))
+                                    .corner_radius(6.0)
+                                    .transform_origin(TransformOrigin::percent(25.0, 75.0))
+                                    .rotate(move || angle.get()),
+                            ]),
+                        // Row 4: Nested containers with different origins
+                        container()
+                            .layout(
+                                Flex::row()
+                                    .spacing(80.0)
+                                    .main_axis_alignment(MainAxisAlignment::Center)
+                                    .cross_axis_alignment(CrossAxisAlignment::Center),
+                            )
+                            .children([
+                                // Parent rotated at center, child inside
+                                container()
+                                    .width(120.0)
+                                    .height(100.0)
+                                    .background(Color::rgba(0.4, 0.4, 0.6, 0.5))
+                                    .corner_radius(10.0)
+                                    .layout(
+                                        Flex::column()
+                                            .main_axis_alignment(MainAxisAlignment::Center)
+                                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                                    )
+                                    .rotate(15.0)
+                                    .child(
+                                        container()
+                                            .width(60.0)
+                                            .height(40.0)
+                                            .background(Color::rgba(0.6, 0.6, 0.8, 0.9))
+                                            .corner_radius(4.0),
+                                    ),
+                                // Parent rotated at top-left, child inside
+                                container()
+                                    .width(120.0)
+                                    .height(100.0)
+                                    .background(Color::rgba(0.6, 0.4, 0.4, 0.5))
+                                    .corner_radius(10.0)
+                                    .layout(
+                                        Flex::column()
+                                            .main_axis_alignment(MainAxisAlignment::Center)
+                                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                                    )
+                                    .transform_origin(TransformOrigin::TOP_LEFT)
+                                    .rotate(15.0)
+                                    .child(
+                                        container()
+                                            .width(60.0)
+                                            .height(40.0)
+                                            .background(Color::rgba(0.8, 0.6, 0.6, 0.9))
+                                            .corner_radius(4.0),
+                                    ),
+                            ]),
+                    ])
+            },
+        );
     });
-
-    let (app, _) = App::new().add_surface(
-        SurfaceConfig::new()
-            .width(900)
-            .height(550)
-            .anchor(Anchor::TOP | Anchor::LEFT)
-            .background_color(Color::rgb(0.1, 0.1, 0.15)),
-        move || {
-            container()
-                .layout(
-                    Flex::column()
-                        .spacing(40.0)
-                        .main_axis_alignment(MainAxisAlignment::Center)
-                        .cross_axis_alignment(CrossAxisAlignment::Center),
-                )
-                .padding(40.0)
-                .children([
-                    // Row 1: Different origins with same rotation
-                    container()
-                        .layout(
-                            Flex::row()
-                                .spacing(80.0)
-                                .main_axis_alignment(MainAxisAlignment::Center)
-                                .cross_axis_alignment(CrossAxisAlignment::Center),
-                        )
-                        .children([
-                            // Default origin (center)
-                            container()
-                                .width(100.0)
-                                .height(80.0)
-                                .background(Color::rgba(0.3, 0.5, 0.8, 0.8))
-                                .corner_radius(8.0)
-                                .rotate(20.0),
-                            // Top-left origin
-                            container()
-                                .width(100.0)
-                                .height(80.0)
-                                .background(Color::rgba(0.8, 0.5, 0.3, 0.8))
-                                .corner_radius(8.0)
-                                .transform_origin(TransformOrigin::TOP_LEFT)
-                                .rotate(20.0),
-                            // Top-right origin
-                            container()
-                                .width(100.0)
-                                .height(80.0)
-                                .background(Color::rgba(0.5, 0.8, 0.3, 0.8))
-                                .corner_radius(8.0)
-                                .transform_origin(TransformOrigin::TOP_RIGHT)
-                                .rotate(20.0),
-                            // Bottom-left origin
-                            container()
-                                .width(100.0)
-                                .height(80.0)
-                                .background(Color::rgba(0.8, 0.3, 0.8, 0.8))
-                                .corner_radius(8.0)
-                                .transform_origin(TransformOrigin::BOTTOM_LEFT)
-                                .rotate(20.0),
-                            // Bottom-right origin
-                            container()
-                                .width(100.0)
-                                .height(80.0)
-                                .background(Color::rgba(0.3, 0.8, 0.8, 0.8))
-                                .corner_radius(8.0)
-                                .transform_origin(TransformOrigin::BOTTOM_RIGHT)
-                                .rotate(20.0),
-                        ]),
-                    // Row 2: Scale with different origins
-                    container()
-                        .layout(
-                            Flex::row()
-                                .spacing(80.0)
-                                .main_axis_alignment(MainAxisAlignment::Center)
-                                .cross_axis_alignment(CrossAxisAlignment::Center),
-                        )
-                        .children([
-                            // Default origin (center) - scale
-                            container()
-                                .width(80.0)
-                                .height(60.0)
-                                .background(Color::rgba(0.6, 0.3, 0.3, 0.8))
-                                .corner_radius(6.0)
-                                .scale(1.3),
-                            // Top-left origin - scale
-                            container()
-                                .width(80.0)
-                                .height(60.0)
-                                .background(Color::rgba(0.3, 0.6, 0.3, 0.8))
-                                .corner_radius(6.0)
-                                .transform_origin(TransformOrigin::TOP_LEFT)
-                                .scale(1.3),
-                            // Bottom-right origin - scale
-                            container()
-                                .width(80.0)
-                                .height(60.0)
-                                .background(Color::rgba(0.3, 0.3, 0.6, 0.8))
-                                .corner_radius(6.0)
-                                .transform_origin(TransformOrigin::BOTTOM_RIGHT)
-                                .scale(1.3),
-                        ]),
-                    // Row 3: Animated rotation with different origins
-                    container()
-                        .layout(
-                            Flex::row()
-                                .spacing(80.0)
-                                .main_axis_alignment(MainAxisAlignment::Center)
-                                .cross_axis_alignment(CrossAxisAlignment::Center),
-                        )
-                        .children([
-                            // Center origin - animated
-                            container()
-                                .width(80.0)
-                                .height(60.0)
-                                .background(Color::rgba(0.7, 0.5, 0.2, 0.8))
-                                .corner_radius(6.0)
-                                .rotate(move || angle.get()),
-                            // Top-left origin - animated
-                            container()
-                                .width(80.0)
-                                .height(60.0)
-                                .background(Color::rgba(0.2, 0.5, 0.7, 0.8))
-                                .corner_radius(6.0)
-                                .transform_origin(TransformOrigin::TOP_LEFT)
-                                .rotate(move || angle.get()),
-                            // Custom origin (25%, 75%) - animated
-                            container()
-                                .width(80.0)
-                                .height(60.0)
-                                .background(Color::rgba(0.5, 0.7, 0.2, 0.8))
-                                .corner_radius(6.0)
-                                .transform_origin(TransformOrigin::percent(25.0, 75.0))
-                                .rotate(move || angle.get()),
-                        ]),
-                    // Row 4: Nested containers with different origins
-                    container()
-                        .layout(
-                            Flex::row()
-                                .spacing(80.0)
-                                .main_axis_alignment(MainAxisAlignment::Center)
-                                .cross_axis_alignment(CrossAxisAlignment::Center),
-                        )
-                        .children([
-                            // Parent rotated at center, child inside
-                            container()
-                                .width(120.0)
-                                .height(100.0)
-                                .background(Color::rgba(0.4, 0.4, 0.6, 0.5))
-                                .corner_radius(10.0)
-                                .layout(
-                                    Flex::column()
-                                        .main_axis_alignment(MainAxisAlignment::Center)
-                                        .cross_axis_alignment(CrossAxisAlignment::Center),
-                                )
-                                .rotate(15.0)
-                                .child(
-                                    container()
-                                        .width(60.0)
-                                        .height(40.0)
-                                        .background(Color::rgba(0.6, 0.6, 0.8, 0.9))
-                                        .corner_radius(4.0),
-                                ),
-                            // Parent rotated at top-left, child inside
-                            container()
-                                .width(120.0)
-                                .height(100.0)
-                                .background(Color::rgba(0.6, 0.4, 0.4, 0.5))
-                                .corner_radius(10.0)
-                                .layout(
-                                    Flex::column()
-                                        .main_axis_alignment(MainAxisAlignment::Center)
-                                        .cross_axis_alignment(CrossAxisAlignment::Center),
-                                )
-                                .transform_origin(TransformOrigin::TOP_LEFT)
-                                .rotate(15.0)
-                                .child(
-                                    container()
-                                        .width(60.0)
-                                        .height(40.0)
-                                        .background(Color::rgba(0.8, 0.6, 0.6, 0.9))
-                                        .corner_radius(4.0),
-                                ),
-                        ]),
-                ])
-        },
-    );
-    app.run();
 }

--- a/examples/transform_scale_test.rs
+++ b/examples/transform_scale_test.rs
@@ -3,46 +3,47 @@
 use guido::prelude::*;
 
 fn main() {
-    let (app, _) = App::new().add_surface(
-        SurfaceConfig::new()
-            .height(150)
-            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
-            .background_color(Color::rgb(0.15, 0.15, 0.2)),
-        || {
-            container()
-                .layout(
-                    Flex::row()
-                        .spacing(40.0)
-                        .main_axis_alignment(MainAxisAlignment::Center)
-                        .cross_axis_alignment(CrossAxisAlignment::Center),
-                )
-                .padding(16.0)
-                .children([
-                    // Normal box
-                    container()
-                        .width(60.0)
-                        .height(60.0)
-                        .padding(10.)
-                        .background(Color::rgb(0.8, 0.3, 0.3))
-                        .corner_radius(8.0),
-                    // Scaled up box (should be bigger)
-                    container()
-                        .width(60.0)
-                        .height(60.0)
-                        .padding(10.0)
-                        .background(Color::rgb(0.3, 0.8, 0.3))
-                        .corner_radius(8.0)
-                        .scale(1.5),
-                    // Scaled down box (should be smaller)
-                    container()
-                        .width(60.0)
-                        .height(60.0)
-                        .padding(10.0)
-                        .background(Color::rgb(0.3, 0.3, 0.8))
-                        .corner_radius(8.0)
-                        .scale(0.5),
-                ])
-        },
-    );
-    app.run();
+    App::new().run(|app| {
+        app.add_surface(
+            SurfaceConfig::new()
+                .height(150)
+                .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+                .background_color(Color::rgb(0.15, 0.15, 0.2)),
+            || {
+                container()
+                    .layout(
+                        Flex::row()
+                            .spacing(40.0)
+                            .main_axis_alignment(MainAxisAlignment::Center)
+                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                    )
+                    .padding(16.0)
+                    .children([
+                        // Normal box
+                        container()
+                            .width(60.0)
+                            .height(60.0)
+                            .padding(10.)
+                            .background(Color::rgb(0.8, 0.3, 0.3))
+                            .corner_radius(8.0),
+                        // Scaled up box (should be bigger)
+                        container()
+                            .width(60.0)
+                            .height(60.0)
+                            .padding(10.0)
+                            .background(Color::rgb(0.3, 0.8, 0.3))
+                            .corner_radius(8.0)
+                            .scale(1.5),
+                        // Scaled down box (should be smaller)
+                        container()
+                            .width(60.0)
+                            .height(60.0)
+                            .padding(10.0)
+                            .background(Color::rgb(0.3, 0.3, 0.8))
+                            .corner_radius(8.0)
+                            .scale(0.5),
+                    ])
+            },
+        );
+    });
 }

--- a/examples/transform_test.rs
+++ b/examples/transform_test.rs
@@ -3,30 +3,31 @@
 use guido::prelude::*;
 
 fn main() {
-    let (app, _) = App::new().add_surface(
-        SurfaceConfig::new()
-            .height(300)
-            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
-            .background_color(Color::rgb(0.1, 0.1, 0.15)),
-        || {
-            container()
-                .layout(
-                    Flex::column()
-                        .main_axis_alignment(MainAxisAlignment::Center)
-                        .cross_axis_alignment(CrossAxisAlignment::Center),
-                )
-                .padding(16.0)
-                .child(
-                    container()
-                        .width(200.0)
-                        .height(100.0)
-                        .padding(10.0)
-                        .background(Color::rgb(0.8, 0.3, 0.3))
-                        .corner_radius(8.0)
-                        .elevation(4.0) // Add shadow to test shadow rendering with rotation
-                        .rotate(45.0), // Should be clearly rotated
-                )
-        },
-    );
-    app.run();
+    App::new().run(|app| {
+        app.add_surface(
+            SurfaceConfig::new()
+                .height(300)
+                .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+                .background_color(Color::rgb(0.1, 0.1, 0.15)),
+            || {
+                container()
+                    .layout(
+                        Flex::column()
+                            .main_axis_alignment(MainAxisAlignment::Center)
+                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                    )
+                    .padding(16.0)
+                    .child(
+                        container()
+                            .width(200.0)
+                            .height(100.0)
+                            .padding(10.0)
+                            .background(Color::rgb(0.8, 0.3, 0.3))
+                            .corner_radius(8.0)
+                            .elevation(4.0) // Add shadow to test shadow rendering with rotation
+                            .rotate(45.0), // Should be clearly rotated
+                    )
+            },
+        );
+    });
 }

--- a/examples/transform_test_3level.rs
+++ b/examples/transform_test_3level.rs
@@ -5,32 +5,33 @@
 use guido::prelude::*;
 
 fn main() {
-    let (app, _) = App::new().add_surface(
-        SurfaceConfig::new()
-            .height(180)
-            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
-            .background_color(Color::rgb(0.12, 0.12, 0.16)),
-        move || {
-            container()
-                .layout(
-                    Flex::row()
-                        .spacing(60.0)
-                        .main_axis_alignment(MainAxisAlignment::Center),
-                )
-                .padding(30.0)
-                .children([
-                    // Reference: no rotation at any level
-                    three_level(0.0, 0.0, 0.0),
-                    // Only grandparent rotates 20°
-                    three_level(20.0, 0.0, 0.0),
-                    // Each level rotates 10° (total 30°)
-                    three_level(10.0, 10.0, 10.0),
-                    // Grandparent 30°, others 0°
-                    three_level(30.0, 0.0, 0.0),
-                ])
-        },
-    );
-    app.run();
+    App::new().run(|app| {
+        app.add_surface(
+            SurfaceConfig::new()
+                .height(180)
+                .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+                .background_color(Color::rgb(0.12, 0.12, 0.16)),
+            move || {
+                container()
+                    .layout(
+                        Flex::row()
+                            .spacing(60.0)
+                            .main_axis_alignment(MainAxisAlignment::Center),
+                    )
+                    .padding(30.0)
+                    .children([
+                        // Reference: no rotation at any level
+                        three_level(0.0, 0.0, 0.0),
+                        // Only grandparent rotates 20°
+                        three_level(20.0, 0.0, 0.0),
+                        // Each level rotates 10° (total 30°)
+                        three_level(10.0, 10.0, 10.0),
+                        // Grandparent 30°, others 0°
+                        three_level(30.0, 0.0, 0.0),
+                    ])
+            },
+        );
+    });
 }
 
 fn three_level(gp_rot: f32, p_rot: f32, c_rot: f32) -> Container {

--- a/examples/transform_test_nested.rs
+++ b/examples/transform_test_nested.rs
@@ -5,32 +5,33 @@
 use guido::prelude::*;
 
 fn main() {
-    let (app, _) = App::new().add_surface(
-        SurfaceConfig::new()
-            .height(160)
-            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
-            .background_color(Color::rgb(0.12, 0.12, 0.16)),
-        move || {
-            container()
-                .layout(
-                    Flex::row()
-                        .spacing(40.0)
-                        .main_axis_alignment(MainAxisAlignment::Center),
-                )
-                .padding(20.0)
-                .children([
-                    // Reference: no rotation
-                    nested(0.0, Color::rgb(0.9, 0.5, 0.3)),
-                    // Parent rotated 15°
-                    nested(15.0, Color::rgb(0.3, 0.9, 0.5)),
-                    // Parent rotated 30°
-                    nested(30.0, Color::rgb(0.5, 0.3, 0.9)),
-                    // Parent rotated 45°
-                    nested(45.0, Color::rgb(0.9, 0.9, 0.3)),
-                ])
-        },
-    );
-    app.run();
+    App::new().run(|app| {
+        app.add_surface(
+            SurfaceConfig::new()
+                .height(160)
+                .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+                .background_color(Color::rgb(0.12, 0.12, 0.16)),
+            move || {
+                container()
+                    .layout(
+                        Flex::row()
+                            .spacing(40.0)
+                            .main_axis_alignment(MainAxisAlignment::Center),
+                    )
+                    .padding(20.0)
+                    .children([
+                        // Reference: no rotation
+                        nested(0.0, Color::rgb(0.9, 0.5, 0.3)),
+                        // Parent rotated 15°
+                        nested(15.0, Color::rgb(0.3, 0.9, 0.5)),
+                        // Parent rotated 30°
+                        nested(30.0, Color::rgb(0.5, 0.3, 0.9)),
+                        // Parent rotated 45°
+                        nested(45.0, Color::rgb(0.9, 0.9, 0.3)),
+                    ])
+            },
+        );
+    });
 }
 
 fn nested(parent_rotation: f32, child_color: Color) -> Container {

--- a/examples/transform_test_origin.rs
+++ b/examples/transform_test_origin.rs
@@ -5,34 +5,35 @@
 use guido::prelude::*;
 
 fn main() {
-    let (app, _) = App::new().add_surface(
-        SurfaceConfig::new()
-            .height(160)
-            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
-            .background_color(Color::rgb(0.12, 0.12, 0.16)),
-        move || {
-            container()
-                .layout(
-                    Flex::row()
-                        .spacing(50.0)
-                        .main_axis_alignment(MainAxisAlignment::Center),
-                )
-                .padding(30.0)
-                .children([
-                    // CENTER (default)
-                    box_with_origin(Color::rgb(0.8, 0.3, 0.3), TransformOrigin::CENTER),
-                    // TOP_LEFT
-                    box_with_origin(Color::rgb(0.3, 0.8, 0.3), TransformOrigin::TOP_LEFT),
-                    // TOP_RIGHT
-                    box_with_origin(Color::rgb(0.3, 0.3, 0.8), TransformOrigin::TOP_RIGHT),
-                    // BOTTOM_LEFT
-                    box_with_origin(Color::rgb(0.8, 0.8, 0.3), TransformOrigin::BOTTOM_LEFT),
-                    // BOTTOM_RIGHT
-                    box_with_origin(Color::rgb(0.8, 0.3, 0.8), TransformOrigin::BOTTOM_RIGHT),
-                ])
-        },
-    );
-    app.run();
+    App::new().run(|app| {
+        app.add_surface(
+            SurfaceConfig::new()
+                .height(160)
+                .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+                .background_color(Color::rgb(0.12, 0.12, 0.16)),
+            move || {
+                container()
+                    .layout(
+                        Flex::row()
+                            .spacing(50.0)
+                            .main_axis_alignment(MainAxisAlignment::Center),
+                    )
+                    .padding(30.0)
+                    .children([
+                        // CENTER (default)
+                        box_with_origin(Color::rgb(0.8, 0.3, 0.3), TransformOrigin::CENTER),
+                        // TOP_LEFT
+                        box_with_origin(Color::rgb(0.3, 0.8, 0.3), TransformOrigin::TOP_LEFT),
+                        // TOP_RIGHT
+                        box_with_origin(Color::rgb(0.3, 0.3, 0.8), TransformOrigin::TOP_RIGHT),
+                        // BOTTOM_LEFT
+                        box_with_origin(Color::rgb(0.8, 0.8, 0.3), TransformOrigin::BOTTOM_LEFT),
+                        // BOTTOM_RIGHT
+                        box_with_origin(Color::rgb(0.8, 0.3, 0.8), TransformOrigin::BOTTOM_RIGHT),
+                    ])
+            },
+        );
+    });
 }
 
 fn box_with_origin(color: Color, origin: TransformOrigin) -> Container {

--- a/examples/transform_test_rotation.rs
+++ b/examples/transform_test_rotation.rs
@@ -5,34 +5,35 @@
 use guido::prelude::*;
 
 fn main() {
-    let (app, _) = App::new().add_surface(
-        SurfaceConfig::new()
-            .height(120)
-            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
-            .background_color(Color::rgb(0.12, 0.12, 0.16)),
-        move || {
-            container()
-                .layout(
-                    Flex::row()
-                        .spacing(30.0)
-                        .main_axis_alignment(MainAxisAlignment::Center),
-                )
-                .padding(20.0)
-                .children([
-                    // 0° (reference)
-                    box_60(Color::rgb(0.8, 0.3, 0.3)),
-                    // 15°
-                    box_60(Color::rgb(0.3, 0.8, 0.3)).rotate(15.0),
-                    // 30°
-                    box_60(Color::rgb(0.3, 0.3, 0.8)).rotate(30.0),
-                    // 45°
-                    box_60(Color::rgb(0.8, 0.8, 0.3)).rotate(45.0),
-                    // -30°
-                    box_60(Color::rgb(0.8, 0.3, 0.8)).rotate(-30.0),
-                ])
-        },
-    );
-    app.run();
+    App::new().run(|app| {
+        app.add_surface(
+            SurfaceConfig::new()
+                .height(120)
+                .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+                .background_color(Color::rgb(0.12, 0.12, 0.16)),
+            move || {
+                container()
+                    .layout(
+                        Flex::row()
+                            .spacing(30.0)
+                            .main_axis_alignment(MainAxisAlignment::Center),
+                    )
+                    .padding(20.0)
+                    .children([
+                        // 0° (reference)
+                        box_60(Color::rgb(0.8, 0.3, 0.3)),
+                        // 15°
+                        box_60(Color::rgb(0.3, 0.8, 0.3)).rotate(15.0),
+                        // 30°
+                        box_60(Color::rgb(0.3, 0.3, 0.8)).rotate(30.0),
+                        // 45°
+                        box_60(Color::rgb(0.8, 0.8, 0.3)).rotate(45.0),
+                        // -30°
+                        box_60(Color::rgb(0.8, 0.3, 0.8)).rotate(-30.0),
+                    ])
+            },
+        );
+    });
 }
 
 fn box_60(color: Color) -> Container {

--- a/examples/transform_test_scale.rs
+++ b/examples/transform_test_scale.rs
@@ -5,34 +5,35 @@
 use guido::prelude::*;
 
 fn main() {
-    let (app, _) = App::new().add_surface(
-        SurfaceConfig::new()
-            .height(140)
-            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
-            .background_color(Color::rgb(0.12, 0.12, 0.16)),
-        move || {
-            container()
-                .layout(
-                    Flex::row()
-                        .spacing(40.0)
-                        .main_axis_alignment(MainAxisAlignment::Center),
-                )
-                .padding(20.0)
-                .children([
-                    // 1.0 (reference)
-                    box_60(Color::rgb(0.8, 0.3, 0.3)),
-                    // 0.5
-                    box_60(Color::rgb(0.3, 0.8, 0.3)).scale(0.5),
-                    // 0.8
-                    box_60(Color::rgb(0.3, 0.3, 0.8)).scale(0.8),
-                    // 1.2
-                    box_60(Color::rgb(0.8, 0.8, 0.3)).scale(1.2),
-                    // Non-uniform: 1.3 x 0.6
-                    box_60(Color::rgb(0.8, 0.3, 0.8)).scale_xy(1.3, 0.6),
-                ])
-        },
-    );
-    app.run();
+    App::new().run(|app| {
+        app.add_surface(
+            SurfaceConfig::new()
+                .height(140)
+                .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+                .background_color(Color::rgb(0.12, 0.12, 0.16)),
+            move || {
+                container()
+                    .layout(
+                        Flex::row()
+                            .spacing(40.0)
+                            .main_axis_alignment(MainAxisAlignment::Center),
+                    )
+                    .padding(20.0)
+                    .children([
+                        // 1.0 (reference)
+                        box_60(Color::rgb(0.8, 0.3, 0.3)),
+                        // 0.5
+                        box_60(Color::rgb(0.3, 0.8, 0.3)).scale(0.5),
+                        // 0.8
+                        box_60(Color::rgb(0.3, 0.3, 0.8)).scale(0.8),
+                        // 1.2
+                        box_60(Color::rgb(0.8, 0.8, 0.3)).scale(1.2),
+                        // Non-uniform: 1.3 x 0.6
+                        box_60(Color::rgb(0.8, 0.3, 0.8)).scale_xy(1.3, 0.6),
+                    ])
+            },
+        );
+    });
 }
 
 fn box_60(color: Color) -> Container {

--- a/examples/transform_translate_test.rs
+++ b/examples/transform_translate_test.rs
@@ -3,38 +3,39 @@
 use guido::prelude::*;
 
 fn main() {
-    let (app, _) = App::new().add_surface(
-        SurfaceConfig::new()
-            .height(200)
-            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
-            .background_color(Color::rgb(0.1, 0.1, 0.15)),
-        || {
-            container()
-                .layout(
-                    Flex::row()
-                        .spacing(20.0)
-                        .main_axis_alignment(MainAxisAlignment::Center)
-                        .cross_axis_alignment(CrossAxisAlignment::Center),
-                )
-                .padding(16.0)
-                .children([
-                    // No transform
-                    container()
-                        .width(80.0)
-                        .height(80.0)
-                        .padding(10.0)
-                        .background(Color::rgb(0.8, 0.3, 0.3))
-                        .corner_radius(8.0),
-                    // With translation - should move right and down
-                    container()
-                        .width(80.0)
-                        .height(80.0)
-                        .padding(10.0)
-                        .background(Color::rgb(0.3, 0.8, 0.3))
-                        .corner_radius(8.0)
-                        .translate(100.0, 10.0), // Move 10px right, 10px down
-                ])
-        },
-    );
-    app.run();
+    App::new().run(|app| {
+        app.add_surface(
+            SurfaceConfig::new()
+                .height(200)
+                .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+                .background_color(Color::rgb(0.1, 0.1, 0.15)),
+            || {
+                container()
+                    .layout(
+                        Flex::row()
+                            .spacing(20.0)
+                            .main_axis_alignment(MainAxisAlignment::Center)
+                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                    )
+                    .padding(16.0)
+                    .children([
+                        // No transform
+                        container()
+                            .width(80.0)
+                            .height(80.0)
+                            .padding(10.0)
+                            .background(Color::rgb(0.8, 0.3, 0.3))
+                            .corner_radius(8.0),
+                        // With translation - should move right and down
+                        container()
+                            .width(80.0)
+                            .height(80.0)
+                            .padding(10.0)
+                            .background(Color::rgb(0.3, 0.8, 0.3))
+                            .corner_radius(8.0)
+                            .translate(100.0, 10.0), // Move 10px right, 10px down
+                    ])
+            },
+        );
+    });
 }

--- a/examples/widget_ref_example.rs
+++ b/examples/widget_ref_example.rs
@@ -6,52 +6,53 @@
 use guido::prelude::*;
 
 fn main() {
-    let module_ref = create_widget_ref();
+    App::new().run(|app| {
+        let module_ref = create_widget_ref();
 
-    let (app, _) = App::new().add_surface(
-        SurfaceConfig::new()
-            .height(64)
-            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
-            .background_color(Color::rgb(0.1, 0.1, 0.15)),
-        move || {
-            container()
-                .layout(
-                    Flex::row()
-                        .spacing(16.0)
-                        .main_axis_alignment(MainAxisAlignment::Center)
-                        .cross_axis_alignment(CrossAxisAlignment::Center),
-                )
-                .child(
-                    // Spacer
-                    container().width(100.0),
-                )
-                .child(
-                    // The measured module
-                    container()
-                        .widget_ref(module_ref)
-                        .padding_xy(16.0, 8.0)
-                        .background(Color::rgb(0.25, 0.25, 0.35))
-                        .corner_radius(6.0)
-                        .child(text("Measured Module").color(Color::WHITE)),
-                )
-                .child(
-                    // Display the bounds reactively
-                    container()
-                        .padding_xy(16.0, 8.0)
-                        .background(Color::rgb(0.15, 0.2, 0.15))
-                        .corner_radius(6.0)
-                        .child(
-                            text(move || {
-                                let r = module_ref.rect().get();
-                                format!(
-                                    "Bounds: x={:.0} y={:.0} w={:.0} h={:.0}",
-                                    r.x, r.y, r.width, r.height
-                                )
-                            })
-                            .color(Color::WHITE),
-                        ),
-                )
-        },
-    );
-    app.run();
+        app.add_surface(
+            SurfaceConfig::new()
+                .height(64)
+                .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+                .background_color(Color::rgb(0.1, 0.1, 0.15)),
+            move || {
+                container()
+                    .layout(
+                        Flex::row()
+                            .spacing(16.0)
+                            .main_axis_alignment(MainAxisAlignment::Center)
+                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                    )
+                    .child(
+                        // Spacer
+                        container().width(100.0),
+                    )
+                    .child(
+                        // The measured module
+                        container()
+                            .widget_ref(module_ref)
+                            .padding_xy(16.0, 8.0)
+                            .background(Color::rgb(0.25, 0.25, 0.35))
+                            .corner_radius(6.0)
+                            .child(text("Measured Module").color(Color::WHITE)),
+                    )
+                    .child(
+                        // Display the bounds reactively
+                        container()
+                            .padding_xy(16.0, 8.0)
+                            .background(Color::rgb(0.15, 0.2, 0.15))
+                            .corner_radius(6.0)
+                            .child(
+                                text(move || {
+                                    let r = module_ref.rect().get();
+                                    format!(
+                                        "Bounds: x={:.0} y={:.0} w={:.0} h={:.0}",
+                                        r.x, r.y, r.width, r.height
+                                    )
+                                })
+                                .color(Color::WHITE),
+                            ),
+                    )
+            },
+        );
+    });
 }

--- a/src/reactive/clipboard.rs
+++ b/src/reactive/clipboard.rs
@@ -87,6 +87,16 @@ pub fn request_clipboard_read() {
     });
 }
 
+/// Reset all clipboard state.
+///
+/// Called during `App::drop()` to wipe clipboard buffers.
+pub(crate) fn reset_clipboard() {
+    CLIPBOARD.with(|c| *c.borrow_mut() = None);
+    CLIPBOARD_CHANGED.with(|c| *c.borrow_mut() = false);
+    CLIPBOARD_READ_REQUESTED.with(|c| *c.borrow_mut() = false);
+    SYSTEM_CLIPBOARD.with(|c| *c.borrow_mut() = None);
+}
+
 /// Check and clear clipboard read request
 pub fn take_clipboard_read_request() -> bool {
     CLIPBOARD_READ_REQUESTED.with(|r| {

--- a/src/reactive/cursor.rs
+++ b/src/reactive/cursor.rs
@@ -82,6 +82,14 @@ pub fn take_cursor_change() -> Option<CursorIcon> {
     }
 }
 
+/// Reset cursor state to defaults.
+///
+/// Called during `App::drop()` to clear cursor state.
+pub(crate) fn reset_cursor() {
+    CURRENT_CURSOR.with(|c| *c.borrow_mut() = CursorIcon::Default);
+    CURSOR_CHANGED.with(|c| *c.borrow_mut() = false);
+}
+
 /// Get the current cursor without clearing the change flag.
 pub fn get_current_cursor() -> CursorIcon {
     CURRENT_CURSOR.with(|c| *c.borrow())

--- a/src/reactive/focus.rs
+++ b/src/reactive/focus.rs
@@ -52,6 +52,13 @@ pub fn focused_widget() -> Option<WidgetId> {
     FOCUSED_WIDGET.with(|cell| *cell.borrow())
 }
 
+/// Reset focus state (without paint jobs — used during App teardown).
+///
+/// Called during `App::drop()` to clear focus state.
+pub(crate) fn reset_focus() {
+    FOCUSED_WIDGET.with(|f| *f.borrow_mut() = None);
+}
+
 /// Clear all focus (no widget will have focus).
 /// Repaints the previously focused widget if any.
 pub fn clear_focus() {

--- a/src/reactive/invalidation.rs
+++ b/src/reactive/invalidation.rs
@@ -157,6 +157,14 @@ pub fn clear_widget_subscribers(widget_id: WidgetId) {
     });
 }
 
+/// Reset all invalidation state (tracking context + subscriber registry).
+///
+/// Called during `App::drop()` to wipe stale widget-signal subscriptions.
+pub(crate) fn reset_invalidation() {
+    TRACKING_CONTEXT.with(|ctx| ctx.borrow_mut().clear());
+    SIGNAL_SUBSCRIBERS.with(|subs| subs.borrow_mut().clear());
+}
+
 /// Get the number of signals with active subscribers (for testing).
 #[cfg(test)]
 fn subscriber_count() -> usize {

--- a/src/reactive/mod.rs
+++ b/src/reactive/mod.rs
@@ -24,7 +24,7 @@ pub use memo::{Memo, create_memo};
 // Only on_cleanup is public API - with_owner, dispose_owner, and OwnerId are
 // internal and automatically used by the dynamic children system
 pub use owner::on_cleanup;
-pub(crate) use owner::{OwnerId, dispose_owner, with_owner};
+pub(crate) use owner::{OwnerId, create_root_owner, dispose_owner, with_owner};
 
 /// Internal module for macro support. NOT PART OF PUBLIC API.
 /// Do not use directly - these are re-exported for proc macros only.
@@ -36,3 +36,17 @@ pub mod __internal {
 pub(crate) use runtime::flush_bg_writes;
 pub use service::{Service, ServiceContext, create_service};
 pub use signal::{Signal, WriteSignal, create_signal};
+
+/// Reset all reactive system state.
+///
+/// Called during `App::drop()` to wipe all thread-local reactive state,
+/// enabling clean restart of the application.
+pub(crate) fn reset_reactive() {
+    owner::reset_owners();
+    runtime::reset_runtime();
+    storage::reset_storage();
+    invalidation::reset_invalidation();
+    clipboard::reset_clipboard();
+    cursor::reset_cursor();
+    focus::reset_focus();
+}

--- a/src/reactive/runtime.rs
+++ b/src/reactive/runtime.rs
@@ -251,6 +251,18 @@ where
     });
 }
 
+/// Reset all runtime state (effects, tracking, batch depth, write queue).
+///
+/// Called during `App::drop()` to ensure the next `App` run starts fresh.
+pub(crate) fn reset_runtime() {
+    RUNTIME.with(|rt| *rt.borrow_mut() = Runtime::new());
+    EFFECT_TRACKING.with(|et| et.borrow_mut().clear());
+    BATCH_DEPTH.with(|bd| bd.set(0));
+    if let Ok(mut q) = WRITE_QUEUE.lock() {
+        q.clear();
+    }
+}
+
 /// Batch multiple signal writes so that shared effects run only once.
 ///
 /// Inside the closure, `notify_write()` collects pending effects but defers

--- a/src/reactive/storage.rs
+++ b/src/reactive/storage.rs
@@ -136,6 +136,13 @@ pub fn with_signal_value<T: 'static, R>(id: SignalId, f: impl FnOnce(&T) -> R) -
     with_signal_cell(id, "borrow", |cell: &RefCell<T>| f(&cell.borrow()))
 }
 
+/// Reset all signal storage.
+///
+/// Called during `App::drop()` to wipe all stored signal values.
+pub(crate) fn reset_storage() {
+    STORAGE.with(|s| *s.borrow_mut() = SignalStorage::new());
+}
+
 /// Check if a signal exists in the current thread's storage.
 /// Used by `WriteSignal` to determine if we can write directly (same thread)
 /// or must queue the write for the main thread.

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -7,16 +7,16 @@
 //! # Static Surface Definition (at startup)
 //!
 //! ```ignore
-//! App::new()
-//!     .add_surface(
+//! App::new().run(|app| {
+//!     app.add_surface(
 //!         SurfaceConfig::new()
 //!             .height(32)
 //!             .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
 //!             .layer(Layer::Top)
 //!             .namespace("status-bar"),
 //!         move || status_bar_widget()
-//!     )
-//!     .run();
+//!     );
+//! });
 //! ```
 //!
 //! # Dynamic Surface Creation (at runtime)
@@ -304,6 +304,13 @@ fn push_surface_command(cmd: SurfaceCommand) {
     crate::jobs::request_frame();
 }
 
+/// Reset the surface command queue.
+///
+/// Called during `App::drop()` to clear stale surface commands.
+pub(crate) fn reset_surface_commands() {
+    SURFACE_COMMANDS.with(|cmds| cmds.borrow_mut().clear());
+}
+
 /// Drain all pending surface commands. Called by the main event loop.
 pub(crate) fn drain_surface_commands() -> Vec<SurfaceCommand> {
     SURFACE_COMMANDS.with(|cmds| cmds.borrow_mut().drain(..).collect())
@@ -369,8 +376,8 @@ where
 ///
 /// ```ignore
 /// // Store the ID when adding the surface
-/// let (app, status_bar_id) = App::new()
-///     .add_surface(config, move || {
+/// App::new().run(|app| {
+///     let status_bar_id = app.add_surface(config, move || {
 ///         container()
 ///             .on_click(move || {
 ///                 // Get handle and modify properties
@@ -379,7 +386,7 @@ where
 ///             })
 ///             .child(text("Click to promote to overlay"))
 ///     });
-/// app.run();
+/// });
 /// ```
 pub fn surface_handle(id: SurfaceId) -> SurfaceHandle {
     SurfaceHandle { id }

--- a/src/widget_ref.rs
+++ b/src/widget_ref.rs
@@ -53,6 +53,13 @@ pub(crate) fn register_widget_ref(id: WidgetId, signal: Signal<Rect>) {
     });
 }
 
+/// Reset the widget ref registry.
+///
+/// Called during `App::drop()` to clear stale widget ref entries.
+pub(crate) fn reset_widget_refs() {
+    WIDGET_REF_REGISTRY.with(|r| r.borrow_mut().clear());
+}
+
 /// Update all registered widget ref signals with current bounds from `tree`.
 ///
 /// Entries whose widget no longer exists in the tree are removed (GC).


### PR DESCRIPTION
## Summary

- Add root owner to `App` so dropping it cascades disposal through the entire reactive graph and resets all thread-local state, enabling clean app restart in a loop
- Change `App` API: `run()` takes a setup closure where all signals/effects are created inside a root owner scope; `add_surface()` takes `&mut self` and returns `SurfaceId`
- Add `Drop` impl for `App` that disposes the root owner, resets all 16+ thread-locals and 4 global statics
- Migrate all 42 examples and book documentation to the new API

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean (0 warnings)
- [x] `cargo test` — all tests pass (including new `test_root_owner_and_reset`)
- [x] `cargo check --examples` — all 42 examples compile
- [x] `mdbook build book` — builds successfully
- [ ] Run `cargo run --example status_bar` to verify normal operation
- [ ] Run `cargo run --example multi_surface` to verify shared state across surfaces