### PR TITLE
feat: ergonomic padding API and shorter alignment type names

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ fn main() {
                 .layout(
                     Flex::row()
                         .spacing(16.0)
-                        .cross_axis_alignment(CrossAxisAlignment::Center),
+                        .cross_alignment(CrossAlignment::Center),
                 )
                 .padding([0.0, 16.0])
                 .child(text(move || format!("Count: {}", count.get())).color(Color::WHITE))

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ fn main() {
                         .spacing(16.0)
                         .cross_axis_alignment(CrossAxisAlignment::Center),
                 )
-                .padding_xy(16.0, 0.0)
+                .padding([0.0, 16.0])
                 .child(text(move || format!("Count: {}", count.get())).color(Color::WHITE))
                 .child(
                     container()

--- a/book/src/README.md
+++ b/book/src/README.md
@@ -42,8 +42,8 @@ fn main() {
                     .height(fill())
                     .layout(
                         Flex::row()
-                            .main_axis_alignment(MainAxisAlignment::Center)
-                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                            .main_alignment(MainAlignment::Center)
+                            .cross_alignment(CrossAlignment::Center),
                     )
                     .child(
                         container()

--- a/book/src/advanced/wayland.md
+++ b/book/src/advanced/wayland.md
@@ -197,7 +197,7 @@ fn main() {
                             .main_axis_alignment(MainAxisAlignment::SpaceBetween)
                             .cross_axis_alignment(CrossAxisAlignment::Center)
                     )
-                    .padding_xy(16.0, 0.0)
+                    .padding([0.0, 16.0])
                     .child(text("Status Bar"))
                     .child(text(move || format!("Count: {}", count.get())))
             },
@@ -222,7 +222,7 @@ fn main() {
                     )
                     .child(
                         container()
-                            .padding_xy(16.0, 8.0)
+                            .padding([8.0, 16.0])
                             .background(Color::rgb(0.3, 0.3, 0.4))
                             .corner_radius(8.0)
                             .hover_state(|s| s.lighter(0.1))

--- a/book/src/advanced/wayland.md
+++ b/book/src/advanced/wayland.md
@@ -194,8 +194,8 @@ fn main() {
                     .height(fill())
                     .layout(
                         Flex::row()
-                            .main_axis_alignment(MainAxisAlignment::SpaceBetween)
-                            .cross_axis_alignment(CrossAxisAlignment::Center)
+                            .main_alignment(MainAlignment::SpaceBetween)
+                            .cross_alignment(CrossAlignment::Center)
                     )
                     .padding([0.0, 16.0])
                     .child(text("Status Bar"))
@@ -217,8 +217,8 @@ fn main() {
                     .layout(
                         Flex::row()
                             .spacing(16.0)
-                            .main_axis_alignment(MainAxisAlignment::Center)
-                            .cross_axis_alignment(CrossAxisAlignment::Center)
+                            .main_alignment(MainAlignment::Center)
+                            .cross_alignment(CrossAlignment::Center)
                     )
                     .child(
                         container()
@@ -370,8 +370,8 @@ fn main() {
                     .height(fill())
                     .layout(
                         Flex::row()
-                            .main_axis_alignment(MainAxisAlignment::SpaceBetween)
-                            .cross_axis_alignment(CrossAxisAlignment::Center)
+                            .main_alignment(MainAlignment::SpaceBetween)
+                            .cross_alignment(CrossAlignment::Center)
                     )
                     .children([
                         left_section(),
@@ -403,8 +403,8 @@ fn main() {
                     .layout(
                         Flex::row()
                             .spacing(8.0)
-                            .main_axis_alignment(MainAxisAlignment::Center)
-                            .cross_axis_alignment(CrossAxisAlignment::Center)
+                            .main_alignment(MainAlignment::Center)
+                            .cross_alignment(CrossAlignment::Center)
                     )
                     .children([
                         dock_icon("terminal"),

--- a/book/src/concepts/container.md
+++ b/book/src/concepts/container.md
@@ -74,8 +74,8 @@ container()
     .layout(
         Flex::row()
             .spacing(8.0)
-            .main_axis_alignment(MainAxisAlignment::Center)
-            .cross_axis_alignment(CrossAxisAlignment::Center)
+            .main_alignment(MainAlignment::Center)
+            .cross_alignment(CrossAlignment::Center)
     )
     .children([...])
 ```

--- a/book/src/concepts/layout.md
+++ b/book/src/concepts/layout.md
@@ -45,7 +45,7 @@ container()
 Control distribution along the layout direction:
 
 ```rust
-Flex::row().main_axis_alignment(MainAxisAlignment::Center)
+Flex::row().main_alignment(MainAlignment::Center)
 ```
 
 ### Options
@@ -75,7 +75,7 @@ SpaceEvenly:    [A]   [B]   [C]
 Control alignment perpendicular to the layout direction:
 
 ```rust
-Flex::row().cross_axis_alignment(CrossAxisAlignment::Center)
+Flex::row().cross_alignment(CrossAlignment::Center)
 ```
 
 ### Options
@@ -120,8 +120,8 @@ container()
     .layout(
         Flex::row()
             .spacing(16.0)
-            .main_axis_alignment(MainAxisAlignment::SpaceBetween)
-            .cross_axis_alignment(CrossAxisAlignment::Center)
+            .main_alignment(MainAlignment::SpaceBetween)
+            .cross_alignment(CrossAlignment::Center)
     )
     .padding(20.0)
     .children([
@@ -146,7 +146,7 @@ container()
     .children([
         // Header row
         container()
-            .layout(Flex::row().main_axis_alignment(MainAxisAlignment::SpaceBetween))
+            .layout(Flex::row().main_alignment(MainAlignment::SpaceBetween))
             .children([
                 text("Logo"),
                 text("Menu"),
@@ -160,7 +160,7 @@ container()
             ]),
         // Footer row
         container()
-            .layout(Flex::row().main_axis_alignment(MainAxisAlignment::Center))
+            .layout(Flex::row().main_alignment(MainAlignment::Center))
             .child(text("Footer")),
     ])
 ```
@@ -211,8 +211,8 @@ container()
     .height(fill())
     .layout(
         Flex::row()
-            .main_axis_alignment(MainAxisAlignment::Center)
-            .cross_axis_alignment(CrossAxisAlignment::Center)
+            .main_alignment(MainAlignment::Center)
+            .cross_alignment(CrossAlignment::Center)
     )
     .child(text("Centered in available space"))
 ```
@@ -238,26 +238,26 @@ container()
 Flex::row() -> Flex                    // Horizontal layout
 Flex::column() -> Flex                 // Vertical layout
 .spacing(f32) -> Flex                  // Space between children
-.main_axis_alignment(MainAxisAlignment) -> Flex
-.cross_axis_alignment(CrossAxisAlignment) -> Flex
+.main_alignment(MainAlignment) -> Flex
+.cross_alignment(CrossAlignment) -> Flex
 ```
 
-### MainAxisAlignment
+### MainAlignment
 
 ```rust
-MainAxisAlignment::Start
-MainAxisAlignment::Center
-MainAxisAlignment::End
-MainAxisAlignment::SpaceBetween
-MainAxisAlignment::SpaceAround
-MainAxisAlignment::SpaceEvenly
+MainAlignment::Start
+MainAlignment::Center
+MainAlignment::End
+MainAlignment::SpaceBetween
+MainAlignment::SpaceAround
+MainAlignment::SpaceEvenly
 ```
 
-### CrossAxisAlignment
+### CrossAlignment
 
 ```rust
-CrossAxisAlignment::Start
-CrossAxisAlignment::Center
-CrossAxisAlignment::End
-CrossAxisAlignment::Stretch
+CrossAlignment::Start
+CrossAlignment::Center
+CrossAlignment::End
+CrossAlignment::Stretch
 ```

--- a/book/src/getting-started/examples.md
+++ b/book/src/getting-started/examples.md
@@ -141,8 +141,8 @@ cargo run --example flex_layout_test
 ![Flex Layout](../images/flex_layout.png)
 
 **Features demonstrated:**
-- `MainAxisAlignment`: Start, Center, End, SpaceBetween, SpaceAround, SpaceEvenly
-- `CrossAxisAlignment`: Start, Center, End, Stretch
+- `MainAlignment`: Start, Center, End, SpaceBetween, SpaceAround, SpaceEvenly
+- `CrossAlignment`: Start, Center, End, Stretch
 - Row and column layouts
 
 ---

--- a/book/src/getting-started/hello-world.md
+++ b/book/src/getting-started/hello-world.md
@@ -34,8 +34,8 @@ fn main() {
                     .layout(
                         Flex::row()
                             .spacing(8.0)
-                            .main_axis_alignment(MainAxisAlignment::SpaceBetween)
-                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                            .main_alignment(MainAlignment::SpaceBetween)
+                            .cross_alignment(CrossAlignment::Center),
                     )
                     .child(
                         container()
@@ -103,15 +103,15 @@ container()
     .layout(
         Flex::row()
             .spacing(8.0)
-            .main_axis_alignment(MainAxisAlignment::SpaceBetween)
-            .cross_axis_alignment(CrossAxisAlignment::Center),
+            .main_alignment(MainAlignment::SpaceBetween)
+            .cross_alignment(CrossAlignment::Center),
     )
 ```
 
 This creates a container that:
 - Fills the available height with `fill()`
 - Uses a horizontal flex layout
-- Centers children vertically with `cross_axis_alignment`
+- Centers children vertically with `cross_alignment`
 - Spreads children across the space with `SpaceBetween`
 
 ### Adding Children
@@ -164,8 +164,8 @@ fn main() {
                     .layout(
                         Flex::row()
                             .spacing(8.0)
-                            .main_axis_alignment(MainAxisAlignment::SpaceBetween)
-                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                            .main_alignment(MainAlignment::SpaceBetween)
+                            .cross_alignment(CrossAlignment::Center),
                     )
                     .child(
                         container()

--- a/book/src/transforms/animated.md
+++ b/book/src/transforms/animated.md
@@ -130,7 +130,7 @@ fn animated_transforms_demo() -> impl Widget {
                 .hover_state(|s| s.lighter(0.1))
                 .pressed_state(|s| s.ripple())
                 .on_click(move || rotation.update(|r| *r += 45.0))
-                .layout(Flex::column().main_axis_alignment(MainAxisAlignment::Center).cross_axis_alignment(CrossAxisAlignment::Center))
+                .layout(Flex::column().main_alignment(MainAlignment::Center).cross_alignment(CrossAlignment::Center))
                 .child(text("Rotate").color(Color::WHITE).font_size(12.0)),
 
             // Spring-based scale
@@ -147,7 +147,7 @@ fn animated_transforms_demo() -> impl Widget {
                     is_scaled.update(|s| *s = !*s);
                     scale.set(if is_scaled.get() { 1.3 } else { 1.0 });
                 })
-                .layout(Flex::column().main_axis_alignment(MainAxisAlignment::Center).cross_axis_alignment(CrossAxisAlignment::Center))
+                .layout(Flex::column().main_alignment(MainAlignment::Center).cross_alignment(CrossAlignment::Center))
                 .child(text("Scale").color(Color::WHITE).font_size(12.0)),
         ])
 }

--- a/book/src/transforms/nested.md
+++ b/book/src/transforms/nested.md
@@ -110,7 +110,7 @@ fn nested_transforms_demo() -> impl Widget {
                 .background(Color::rgb(0.2, 0.2, 0.3))
                 .corner_radius(16.0)
                 .rotate(10.0)
-                .layout(Flex::column().spacing(16.0).main_axis_alignment(MainAxisAlignment::Center).cross_axis_alignment(CrossAxisAlignment::Center))
+                .layout(Flex::column().spacing(16.0).main_alignment(MainAlignment::Center).cross_alignment(CrossAlignment::Center))
                 .children([
                     text("Parent (rotated 10°)").color(Color::WHITE).font_size(12.0),
 
@@ -123,7 +123,7 @@ fn nested_transforms_demo() -> impl Widget {
                         .scale(0.9)
                         .hover_state(|s| s.lighter(0.1))
                         .pressed_state(|s| s.ripple())
-                        .layout(Flex::column().main_axis_alignment(MainAxisAlignment::Center).cross_axis_alignment(CrossAxisAlignment::Center))
+                        .layout(Flex::column().main_alignment(MainAlignment::Center).cross_alignment(CrossAlignment::Center))
                         .child(
                             text("Child (scaled 0.9)")
                                 .color(Color::WHITE)

--- a/docs/STYLING.md
+++ b/docs/STYLING.md
@@ -147,18 +147,12 @@ container()
 
 ## Padding
 
-### Uniform Padding
-
 ```rust
-container().padding(16.0)  // 16px on all sides
-```
-
-### Directional Padding
-
-```rust
-container()
-    .padding_horizontal(20.0)  // Left and right
-    .padding_vertical(10.0)    // Top and bottom
+container().padding(16.0)                          // 16px on all sides
+container().padding(16)                            // integers work too
+container().padding([8.0, 16.0])                   // [vertical, horizontal]
+container().padding([1.0, 2.0, 3.0, 4.0])         // [top, right, bottom, left]
+container().padding(Padding::all(8.0).top(20.0))   // builder pattern
 ```
 
 ## Sizing

--- a/docs/STYLING.md
+++ b/docs/STYLING.md
@@ -195,26 +195,26 @@ container()
     .layout(
         Flex::row()
             .spacing(8.0)
-            .main_axis_alignment(MainAxisAlignment::Center)
-            .cross_axis_alignment(CrossAxisAlignment::Center)
+            .main_alignment(MainAlignment::Center)
+            .cross_alignment(CrossAlignment::Center)
     )
 ```
 
 ### Alignment Options
 
 **Main Axis (direction of flow):**
-- `MainAxisAlignment::Start`
-- `MainAxisAlignment::End`
-- `MainAxisAlignment::Center`
-- `MainAxisAlignment::SpaceBetween`
-- `MainAxisAlignment::SpaceAround`
-- `MainAxisAlignment::SpaceEvenly`
+- `MainAlignment::Start`
+- `MainAlignment::End`
+- `MainAlignment::Center`
+- `MainAlignment::SpaceBetween`
+- `MainAlignment::SpaceAround`
+- `MainAlignment::SpaceEvenly`
 
 **Cross Axis (perpendicular to flow):**
-- `CrossAxisAlignment::Start`
-- `CrossAxisAlignment::End`
-- `CrossAxisAlignment::Center`
-- `CrossAxisAlignment::Stretch`
+- `CrossAlignment::Start`
+- `CrossAlignment::End`
+- `CrossAlignment::Center`
+- `CrossAlignment::Stretch`
 
 ## Complete Example
 

--- a/examples/flex_layout_test.rs
+++ b/examples/flex_layout_test.rs
@@ -1,8 +1,8 @@
 //! Flex Layout Test Example
 //!
 //! This example demonstrates and tests all flex layout alignment options:
-//! - MainAxisAlignment: Start, Center, End, SpaceBetween, SpaceAround, SpaceEvenly
-//! - CrossAxisAlignment: Start, Center, End, Stretch
+//! - MainAlignment: Start, Center, End, SpaceBetween, SpaceAround, SpaceEvenly
+//! - CrossAlignment: Start, Center, End, Stretch
 //!
 //! Run with: cargo run --example flex_layout_test
 
@@ -27,13 +27,13 @@ fn main() {
                             .child(
                                 container()
                                     .layout(Flex::column().spacing(3.0))
-                                    .child(section_title("Row - MainAxisAlignment"))
+                                    .child(section_title("Row - MainAlignment"))
                                     .child(row_main_axis_tests()),
                             )
                             .child(
                                 container()
                                     .layout(Flex::column().spacing(3.0))
-                                    .child(section_title("Row - CrossAxisAlignment"))
+                                    .child(section_title("Row - CrossAlignment"))
                                     .child(row_cross_axis_tests()),
                             )
                             .child(
@@ -50,13 +50,13 @@ fn main() {
                             .child(
                                 container()
                                     .layout(Flex::column().spacing(3.0))
-                                    .child(section_title("Column - MainAxisAlignment"))
+                                    .child(section_title("Column - MainAlignment"))
                                     .child(column_main_axis_tests()),
                             )
                             .child(
                                 container()
                                     .layout(Flex::column().spacing(3.0))
-                                    .child(section_title("Column - CrossAxisAlignment"))
+                                    .child(section_title("Column - CrossAlignment"))
                                     .child(column_cross_axis_tests()),
                             ),
                     )
@@ -90,7 +90,7 @@ fn test_box_varied(width: f32, height: f32, color: Color) -> Container {
 }
 
 /// Test box with minimum height (for row cross-axis tests)
-/// Height can stretch beyond min_height when CrossAxisAlignment::Stretch is used
+/// Height can stretch beyond min_height when CrossAlignment::Stretch is used
 fn test_box_min_height(width: f32, min_height: f32, color: Color) -> Container {
     container()
         .width(width)
@@ -100,7 +100,7 @@ fn test_box_min_height(width: f32, min_height: f32, color: Color) -> Container {
 }
 
 /// Test box with minimum width (for column cross-axis tests)
-/// Width can stretch beyond min_width when CrossAxisAlignment::Stretch is used
+/// Width can stretch beyond min_width when CrossAlignment::Stretch is used
 fn test_box_min_width(min_width: f32, height: f32, color: Color) -> Container {
     container()
         .width(at_least(min_width))
@@ -110,24 +110,21 @@ fn test_box_min_width(min_width: f32, height: f32, color: Color) -> Container {
 }
 
 // =============================================================================
-// Row MainAxisAlignment Tests
+// Row MainAlignment Tests
 // =============================================================================
 
 fn row_main_axis_tests() -> impl Widget {
     container()
         .layout(Flex::column().spacing(2.0))
-        .child(row_main_axis_row("Start", MainAxisAlignment::Start))
-        .child(row_main_axis_row("Center", MainAxisAlignment::Center))
-        .child(row_main_axis_row("End", MainAxisAlignment::End))
-        .child(row_main_axis_row(
-            "Between",
-            MainAxisAlignment::SpaceBetween,
-        ))
-        .child(row_main_axis_row("Around", MainAxisAlignment::SpaceAround))
-        .child(row_main_axis_row("Evenly", MainAxisAlignment::SpaceEvenly))
+        .child(row_main_axis_row("Start", MainAlignment::Start))
+        .child(row_main_axis_row("Center", MainAlignment::Center))
+        .child(row_main_axis_row("End", MainAlignment::End))
+        .child(row_main_axis_row("Between", MainAlignment::SpaceBetween))
+        .child(row_main_axis_row("Around", MainAlignment::SpaceAround))
+        .child(row_main_axis_row("Evenly", MainAlignment::SpaceEvenly))
 }
 
-fn row_main_axis_row(name: &'static str, alignment: MainAxisAlignment) -> impl Widget {
+fn row_main_axis_row(name: &'static str, alignment: MainAlignment) -> impl Widget {
     container()
         .layout(Flex::row().spacing(4.0))
         .child(container().width(42.0).child(label(name)))
@@ -137,7 +134,7 @@ fn row_main_axis_row(name: &'static str, alignment: MainAxisAlignment) -> impl W
                 .height(22.0)
                 .background(Color::rgb(0.15, 0.15, 0.2))
                 .corner_radius(3.0)
-                .layout(Flex::row().spacing(3.0).main_axis_alignment(alignment))
+                .layout(Flex::row().spacing(3.0).main_alignment(alignment))
                 .child(test_box(Color::rgb(0.8, 0.3, 0.3)))
                 .child(test_box(Color::rgb(0.3, 0.8, 0.3)))
                 .child(test_box(Color::rgb(0.3, 0.3, 0.8))),
@@ -145,19 +142,19 @@ fn row_main_axis_row(name: &'static str, alignment: MainAxisAlignment) -> impl W
 }
 
 // =============================================================================
-// Row CrossAxisAlignment Tests
+// Row CrossAlignment Tests
 // =============================================================================
 
 fn row_cross_axis_tests() -> impl Widget {
     container()
         .layout(Flex::column().spacing(2.0))
-        .child(row_cross_axis_row("Start", CrossAxisAlignment::Start))
-        .child(row_cross_axis_row("Center", CrossAxisAlignment::Center))
-        .child(row_cross_axis_row("End", CrossAxisAlignment::End))
-        .child(row_cross_axis_row("Stretch", CrossAxisAlignment::Stretch))
+        .child(row_cross_axis_row("Start", CrossAlignment::Start))
+        .child(row_cross_axis_row("Center", CrossAlignment::Center))
+        .child(row_cross_axis_row("End", CrossAlignment::End))
+        .child(row_cross_axis_row("Stretch", CrossAlignment::Stretch))
 }
 
-fn row_cross_axis_row(name: &'static str, alignment: CrossAxisAlignment) -> impl Widget {
+fn row_cross_axis_row(name: &'static str, alignment: CrossAlignment) -> impl Widget {
     container()
         .layout(Flex::row().spacing(4.0))
         .child(container().width(42.0).child(label(name)))
@@ -167,7 +164,7 @@ fn row_cross_axis_row(name: &'static str, alignment: CrossAxisAlignment) -> impl
                 .height(36.0)
                 .background(Color::rgb(0.15, 0.15, 0.2))
                 .corner_radius(3.0)
-                .layout(Flex::row().spacing(3.0).cross_axis_alignment(alignment))
+                .layout(Flex::row().spacing(3.0).cross_alignment(alignment))
                 // Use at_least() for height (cross-axis in row) so Stretch can expand them
                 .child(test_box_min_height(24.0, 12.0, Color::rgb(0.8, 0.3, 0.3)))
                 .child(test_box_min_height(24.0, 26.0, Color::rgb(0.3, 0.8, 0.3)))
@@ -176,30 +173,21 @@ fn row_cross_axis_row(name: &'static str, alignment: CrossAxisAlignment) -> impl
 }
 
 // =============================================================================
-// Column MainAxisAlignment Tests
+// Column MainAlignment Tests
 // =============================================================================
 
 fn column_main_axis_tests() -> impl Widget {
     container()
         .layout(Flex::row().spacing(4.0))
-        .child(column_main_axis_col("Start", MainAxisAlignment::Start))
-        .child(column_main_axis_col("Center", MainAxisAlignment::Center))
-        .child(column_main_axis_col("End", MainAxisAlignment::End))
-        .child(column_main_axis_col(
-            "Between",
-            MainAxisAlignment::SpaceBetween,
-        ))
-        .child(column_main_axis_col(
-            "Around",
-            MainAxisAlignment::SpaceAround,
-        ))
-        .child(column_main_axis_col(
-            "Evenly",
-            MainAxisAlignment::SpaceEvenly,
-        ))
+        .child(column_main_axis_col("Start", MainAlignment::Start))
+        .child(column_main_axis_col("Center", MainAlignment::Center))
+        .child(column_main_axis_col("End", MainAlignment::End))
+        .child(column_main_axis_col("Between", MainAlignment::SpaceBetween))
+        .child(column_main_axis_col("Around", MainAlignment::SpaceAround))
+        .child(column_main_axis_col("Evenly", MainAlignment::SpaceEvenly))
 }
 
-fn column_main_axis_col(name: &'static str, alignment: MainAxisAlignment) -> impl Widget {
+fn column_main_axis_col(name: &'static str, alignment: MainAlignment) -> impl Widget {
     container()
         .layout(Flex::column().spacing(2.0))
         .child(label(name))
@@ -209,7 +197,7 @@ fn column_main_axis_col(name: &'static str, alignment: MainAxisAlignment) -> imp
                 .height(80.0)
                 .background(Color::rgb(0.15, 0.15, 0.2))
                 .corner_radius(3.0)
-                .layout(Flex::column().spacing(2.0).main_axis_alignment(alignment))
+                .layout(Flex::column().spacing(2.0).main_alignment(alignment))
                 .child(test_box_varied(32.0, 12.0, Color::rgb(0.8, 0.5, 0.3)))
                 .child(test_box_varied(32.0, 12.0, Color::rgb(0.5, 0.8, 0.3)))
                 .child(test_box_varied(32.0, 12.0, Color::rgb(0.3, 0.5, 0.8))),
@@ -217,22 +205,19 @@ fn column_main_axis_col(name: &'static str, alignment: MainAxisAlignment) -> imp
 }
 
 // =============================================================================
-// Column CrossAxisAlignment Tests
+// Column CrossAlignment Tests
 // =============================================================================
 
 fn column_cross_axis_tests() -> impl Widget {
     container()
         .layout(Flex::row().spacing(4.0))
-        .child(column_cross_axis_col("Start", CrossAxisAlignment::Start))
-        .child(column_cross_axis_col("Center", CrossAxisAlignment::Center))
-        .child(column_cross_axis_col("End", CrossAxisAlignment::End))
-        .child(column_cross_axis_col(
-            "Stretch",
-            CrossAxisAlignment::Stretch,
-        ))
+        .child(column_cross_axis_col("Start", CrossAlignment::Start))
+        .child(column_cross_axis_col("Center", CrossAlignment::Center))
+        .child(column_cross_axis_col("End", CrossAlignment::End))
+        .child(column_cross_axis_col("Stretch", CrossAlignment::Stretch))
 }
 
-fn column_cross_axis_col(name: &'static str, alignment: CrossAxisAlignment) -> impl Widget {
+fn column_cross_axis_col(name: &'static str, alignment: CrossAlignment) -> impl Widget {
     container()
         .layout(Flex::column().spacing(2.0))
         .child(label(name))
@@ -242,7 +227,7 @@ fn column_cross_axis_col(name: &'static str, alignment: CrossAxisAlignment) -> i
                 .height(80.0)
                 .background(Color::rgb(0.15, 0.15, 0.2))
                 .corner_radius(3.0)
-                .layout(Flex::column().spacing(2.0).cross_axis_alignment(alignment))
+                .layout(Flex::column().spacing(2.0).cross_alignment(alignment))
                 // Use at_least() for width (cross-axis in column) so Stretch can expand them
                 .child(test_box_min_width(16.0, 12.0, Color::rgb(0.8, 0.5, 0.3)))
                 .child(test_box_min_width(38.0, 12.0, Color::rgb(0.5, 0.8, 0.3)))
@@ -269,8 +254,8 @@ fn center_test() -> impl Widget {
                         .corner_radius(4.0)
                         .layout(
                             Flex::row()
-                                .main_axis_alignment(MainAxisAlignment::Center)
-                                .cross_axis_alignment(CrossAxisAlignment::Center),
+                                .main_alignment(MainAlignment::Center)
+                                .cross_alignment(CrossAlignment::Center),
                         )
                         .child(test_box(Color::rgb(0.8, 0.4, 0.4))),
                 )
@@ -282,8 +267,8 @@ fn center_test() -> impl Widget {
                         .corner_radius(4.0)
                         .layout(
                             Flex::column()
-                                .main_axis_alignment(MainAxisAlignment::Center)
-                                .cross_axis_alignment(CrossAxisAlignment::Center),
+                                .main_alignment(MainAlignment::Center)
+                                .cross_alignment(CrossAlignment::Center),
                         )
                         .child(test_box(Color::rgb(0.4, 0.8, 0.4))),
                 ),
@@ -294,7 +279,7 @@ fn center_test() -> impl Widget {
                 .layout(
                     Flex::row()
                         .spacing(6.0)
-                        .cross_axis_alignment(CrossAxisAlignment::Start),
+                        .cross_alignment(CrossAlignment::Start),
                 )
                 .child(container().width(36.0).child(label("Single")))
                 .child(
@@ -305,8 +290,8 @@ fn center_test() -> impl Widget {
                         .corner_radius(4.0)
                         .layout(
                             Flex::row()
-                                .main_axis_alignment(MainAxisAlignment::Center)
-                                .cross_axis_alignment(CrossAxisAlignment::Center),
+                                .main_alignment(MainAlignment::Center)
+                                .cross_alignment(CrossAlignment::Center),
                         )
                         .child(test_box(Color::rgb(0.8, 0.4, 0.4))),
                 ),
@@ -317,7 +302,7 @@ fn center_test() -> impl Widget {
                 .layout(
                     Flex::row()
                         .spacing(6.0)
-                        .cross_axis_alignment(CrossAxisAlignment::Start),
+                        .cross_alignment(CrossAlignment::Start),
                 )
                 .child(container().width(36.0).child(label("Multi")))
                 .child(
@@ -329,8 +314,8 @@ fn center_test() -> impl Widget {
                         .layout(
                             Flex::row()
                                 .spacing(6.0)
-                                .main_axis_alignment(MainAxisAlignment::Center)
-                                .cross_axis_alignment(CrossAxisAlignment::Center),
+                                .main_alignment(MainAlignment::Center)
+                                .cross_alignment(CrossAlignment::Center),
                         )
                         .child(test_box(Color::rgb(0.8, 0.4, 0.4)))
                         .child(test_box(Color::rgb(0.4, 0.8, 0.4))),

--- a/examples/image_fit_none_test.rs
+++ b/examples/image_fit_none_test.rs
@@ -95,7 +95,7 @@ fn main() {
                         .layout(
                             Flex::row()
                                 .spacing(24.0)
-                                .cross_axis_alignment(CrossAxisAlignment::End),
+                                .cross_alignment(CrossAlignment::End),
                         )
                         .child(labeled(
                             "60x60",

--- a/examples/multi_surface.rs
+++ b/examples/multi_surface.rs
@@ -30,7 +30,7 @@ fn main() {
                             .main_axis_alignment(MainAxisAlignment::SpaceBetween)
                             .cross_axis_alignment(CrossAxisAlignment::Center),
                     )
-                    .padding_xy(16.0, 0.0)
+                    .padding([0.0, 16.0])
                     .child(
                         text("Multi-Surface Demo")
                             .color(Color::WHITE)
@@ -63,7 +63,7 @@ fn main() {
                     .children([
                         container()
                             .background(Color::rgb(0.3, 0.3, 0.4))
-                            .padding_xy(16.0, 8.0)
+                            .padding([8.0, 16.0])
                             .corner_radius(8.0)
                             .hover_state(|s| s.lighter(0.1))
                             .pressed_state(|s| s.ripple())
@@ -71,7 +71,7 @@ fn main() {
                             .child(text("+").color(Color::WHITE).font_size(16.0)),
                         container()
                             .background(Color::rgb(0.3, 0.3, 0.4))
-                            .padding_xy(16.0, 8.0)
+                            .padding([8.0, 16.0])
                             .corner_radius(8.0)
                             .hover_state(|s| s.lighter(0.1))
                             .pressed_state(|s| s.ripple())
@@ -79,7 +79,7 @@ fn main() {
                             .child(text("-").color(Color::WHITE).font_size(16.0)),
                         container()
                             .background(Color::rgb(0.4, 0.2, 0.2))
-                            .padding_xy(16.0, 8.0)
+                            .padding([8.0, 16.0])
                             .corner_radius(8.0)
                             .hover_state(|s| s.lighter(0.1))
                             .pressed_state(|s| s.ripple())

--- a/examples/multi_surface.rs
+++ b/examples/multi_surface.rs
@@ -27,8 +27,8 @@ fn main() {
                     .layout(
                         Flex::row()
                             .spacing(8.0)
-                            .main_axis_alignment(MainAxisAlignment::SpaceBetween)
-                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                            .main_alignment(MainAlignment::SpaceBetween)
+                            .cross_alignment(CrossAlignment::Center),
                     )
                     .padding([0.0, 16.0])
                     .child(
@@ -57,8 +57,8 @@ fn main() {
                     .layout(
                         Flex::row()
                             .spacing(16.0)
-                            .main_axis_alignment(MainAxisAlignment::Center)
-                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                            .main_alignment(MainAlignment::Center)
+                            .cross_alignment(CrossAlignment::Center),
                     )
                     .children([
                         container()

--- a/examples/nested_transform_example.rs
+++ b/examples/nested_transform_example.rs
@@ -17,8 +17,8 @@ fn main() {
                     .layout(
                         Flex::row()
                             .spacing(40.0)
-                            .main_axis_alignment(MainAxisAlignment::Center)
-                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                            .main_alignment(MainAlignment::Center)
+                            .cross_alignment(CrossAlignment::Center),
                     )
                     .padding(20.0)
                     .children([

--- a/examples/perf_stress_test.rs
+++ b/examples/perf_stress_test.rs
@@ -102,7 +102,7 @@ fn create_add_button(
     item_store: Rc<RefCell<Vec<ItemData>>>,
 ) -> Container {
     container()
-        .padding_xy(16.0, 8.0)
+        .padding([8.0, 16.0])
         .background(Color::rgb(0.2, 0.4, 0.6))
         .corner_radius(6.0)
         .hover_state(|s| s.lighter(0.1))
@@ -142,7 +142,7 @@ fn create_toggle_button(enabled: Signal<bool>) -> Container {
     container()
         .width(100.0)
         .height(30.0) // Fixed dimensions make this a relayout boundary
-        .padding_xy(12.0, 6.0)
+        .padding([6.0, 12.0])
         .background(move || {
             if enabled.get() {
                 Color::rgb(0.2, 0.5, 0.3)

--- a/examples/perf_stress_test.rs
+++ b/examples/perf_stress_test.rs
@@ -130,7 +130,7 @@ fn create_item_row(enabled: Signal<bool>, input_value: Signal<String>, index: us
         .layout(
             Flex::row()
                 .spacing(20.0)
-                .cross_axis_alignment(CrossAxisAlignment::Center),
+                .cross_alignment(CrossAlignment::Center),
         )
         .child(create_toggle_button(enabled))
         .child(create_info_section(name, description, input_value))

--- a/examples/reactive_example.rs
+++ b/examples/reactive_example.rs
@@ -39,7 +39,7 @@ fn main() {
                     .layout(
                         Flex::row()
                             .spacing(8.0)
-                            .main_axis_alignment(MainAxisAlignment::SpaceBetween),
+                            .main_alignment(MainAlignment::SpaceBetween),
                     )
                     .child(
                         // Clickable container with state layer - click to increment count

--- a/examples/renderer_v2_test.rs
+++ b/examples/renderer_v2_test.rs
@@ -17,7 +17,7 @@ fn main() {
                     .layout(
                         Flex::row()
                             .spacing(10.0)
-                            .main_axis_alignment(MainAxisAlignment::Center),
+                            .main_alignment(MainAlignment::Center),
                     )
                     .padding(16.0)
                     .children([

--- a/examples/rounded_hitbox_test.rs
+++ b/examples/rounded_hitbox_test.rs
@@ -20,8 +20,8 @@ fn main() {
                 .layout(
                     Flex::column()
                         .spacing(30.0)
-                        .main_axis_alignment(MainAxisAlignment::Center)
-                        .cross_axis_alignment(CrossAxisAlignment::Center),
+                        .main_alignment(MainAlignment::Center)
+                        .cross_alignment(CrossAlignment::Center),
                 )
                 .padding(40.0)
                 .children([
@@ -30,7 +30,7 @@ fn main() {
                         .layout(
                             Flex::row()
                                 .spacing(40.0)
-                                .main_axis_alignment(MainAxisAlignment::Center),
+                                .main_alignment(MainAlignment::Center),
                         )
                         .children([
                             // No corner radius (control)
@@ -76,8 +76,8 @@ fn make_box(
         .on_click(move || click_count.update(|c| *c += 1))
         .layout(
             Flex::column()
-                .main_axis_alignment(MainAxisAlignment::Center)
-                .cross_axis_alignment(CrossAxisAlignment::Center),
+                .main_alignment(MainAlignment::Center)
+                .cross_alignment(CrossAlignment::Center),
         )
         .child(text(label).font_size(14.0).color(Color::WHITE))
 }

--- a/examples/rounded_transform_test.rs
+++ b/examples/rounded_transform_test.rs
@@ -20,8 +20,8 @@ fn main() {
                     .layout(
                         Flex::column()
                             .spacing(30.0)
-                            .main_axis_alignment(MainAxisAlignment::Center)
-                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                            .main_alignment(MainAlignment::Center)
+                            .cross_alignment(CrossAlignment::Center),
                     )
                     .padding(40.0)
                     .children([
@@ -30,7 +30,7 @@ fn main() {
                             .layout(
                                 Flex::row()
                                     .spacing(50.0)
-                                    .main_axis_alignment(MainAxisAlignment::Center),
+                                    .main_alignment(MainAlignment::Center),
                             )
                             .children([
                                 // No transform (control)
@@ -80,8 +80,8 @@ fn make_box(label: &'static str, base_color: Color, click_count: Signal<i32>) ->
         .on_click(move || click_count.update(|c| *c += 1))
         .layout(
             Flex::column()
-                .main_axis_alignment(MainAxisAlignment::Center)
-                .cross_axis_alignment(CrossAxisAlignment::Center),
+                .main_alignment(MainAlignment::Center)
+                .cross_alignment(CrossAlignment::Center),
         )
         .child(text(label).font_size(12.0).color(Color::WHITE))
 }

--- a/examples/scroll_example.rs
+++ b/examples/scroll_example.rs
@@ -78,12 +78,8 @@ fn main() {
                                                 .hover_state(|s| s.lighter(0.1))
                                                 .layout(
                                                     Flex::column()
-                                                        .main_axis_alignment(
-                                                            MainAxisAlignment::Center,
-                                                        )
-                                                        .cross_axis_alignment(
-                                                            CrossAxisAlignment::Center,
-                                                        ),
+                                                        .main_alignment(MainAlignment::Center)
+                                                        .cross_alignment(CrossAlignment::Center),
                                                 )
                                                 .child(
                                                     text(format!("{}", i + 1)).color(Color::WHITE),

--- a/examples/scroll_mixed_content.rs
+++ b/examples/scroll_mixed_content.rs
@@ -91,9 +91,9 @@ fn main() {
                                     .child(
                                         container()
                                             .layout(
-                                                Flex::row().spacing(16.0).cross_axis_alignment(
-                                                    CrossAxisAlignment::Center,
-                                                ),
+                                                Flex::row()
+                                                    .spacing(16.0)
+                                                    .cross_alignment(CrossAlignment::Center),
                                             )
                                             .child(
                                                 container()
@@ -284,8 +284,8 @@ fn main() {
                                                     .layout(
                                                         Flex::column()
                                                             .spacing(4.0)
-                                                            .cross_axis_alignment(
-                                                                CrossAxisAlignment::Center,
+                                                            .cross_alignment(
+                                                                CrossAlignment::Center,
                                                             ),
                                                     )
                                                     .child(
@@ -298,11 +298,11 @@ fn main() {
                                                             .pressed_state(|s| s.ripple())
                                                             .layout(
                                                                 Flex::column()
-                                                                    .main_axis_alignment(
-                                                                        MainAxisAlignment::Center,
+                                                                    .main_alignment(
+                                                                        MainAlignment::Center,
                                                                     )
-                                                                    .cross_axis_alignment(
-                                                                        CrossAxisAlignment::Center,
+                                                                    .cross_alignment(
+                                                                        CrossAlignment::Center,
                                                                     ),
                                                             )
                                                             .child(

--- a/examples/service_example.rs
+++ b/examples/service_example.rs
@@ -73,7 +73,7 @@ async fn main() {
                     .layout(
                         Flex::row()
                             .spacing(16.0)
-                            .main_axis_alignment(MainAxisAlignment::SpaceBetween),
+                            .main_alignment(MainAlignment::SpaceBetween),
                     )
                     .padding(4.0)
                     // Workspace buttons
@@ -98,8 +98,8 @@ async fn main() {
                                     container()
                                         .layout(
                                             Flex::row()
-                                                .main_axis_alignment(MainAxisAlignment::Center)
-                                                .cross_axis_alignment(CrossAxisAlignment::Center),
+                                                .main_alignment(MainAlignment::Center)
+                                                .cross_alignment(CrossAlignment::Center),
                                         )
                                         .child(text(format!("{}", id)).color(Color::WHITE)),
                                 )

--- a/examples/simple_text_transform.rs
+++ b/examples/simple_text_transform.rs
@@ -7,8 +7,8 @@ fn main() {
         .layout(
             Flex::row()
                 .spacing(50.0)
-                .main_axis_alignment(MainAxisAlignment::Center)
-                .cross_axis_alignment(CrossAxisAlignment::Center),
+                .main_alignment(MainAlignment::Center)
+                .cross_alignment(CrossAlignment::Center),
         )
         .padding(50.0)
         .children([
@@ -20,8 +20,8 @@ fn main() {
                 .corner_radius(8.0)
                 .layout(
                     Flex::column()
-                        .main_axis_alignment(MainAxisAlignment::Center)
-                        .cross_axis_alignment(CrossAxisAlignment::Center),
+                        .main_alignment(MainAlignment::Center)
+                        .cross_alignment(CrossAlignment::Center),
                 )
                 .child(text("No Transform").font_size(14.0).color(Color::WHITE)),
             // With rotation - should use texture
@@ -32,8 +32,8 @@ fn main() {
                 .corner_radius(8.0)
                 .layout(
                     Flex::column()
-                        .main_axis_alignment(MainAxisAlignment::Center)
-                        .cross_axis_alignment(CrossAxisAlignment::Center),
+                        .main_alignment(MainAlignment::Center)
+                        .cross_alignment(CrossAlignment::Center),
                 )
                 .rotate(15.0)
                 .child(text("Rotated 15").font_size(14.0).color(Color::WHITE)),
@@ -45,8 +45,8 @@ fn main() {
                 .corner_radius(8.0)
                 .layout(
                     Flex::column()
-                        .main_axis_alignment(MainAxisAlignment::Center)
-                        .cross_axis_alignment(CrossAxisAlignment::Center),
+                        .main_alignment(MainAlignment::Center)
+                        .cross_alignment(CrossAlignment::Center),
                 )
                 .scale(1.2)
                 .child(text("Scale 1.2").font_size(14.0).color(Color::WHITE)),

--- a/examples/status_bar.rs
+++ b/examples/status_bar.rs
@@ -12,7 +12,7 @@ fn main() {
                     .layout(
                         Flex::row()
                             .spacing(8.0)
-                            .main_axis_alignment(MainAxisAlignment::SpaceBetween),
+                            .main_alignment(MainAlignment::SpaceBetween),
                     )
                     .child(
                         container()

--- a/examples/surface_properties_example.rs
+++ b/examples/surface_properties_example.rs
@@ -169,7 +169,7 @@ fn layer_button(
     current_layer: Signal<&'static str>,
 ) -> Container {
     container()
-        .padding_xy(12.0, 8.0)
+        .padding([8.0, 12.0])
         .background(Color::rgb(0.25, 0.25, 0.35))
         .corner_radius(6.0)
         .hover_state(|s| s.lighter(0.1))
@@ -191,7 +191,7 @@ fn keyboard_button(
     current_keyboard: Signal<&'static str>,
 ) -> Container {
     container()
-        .padding_xy(12.0, 8.0)
+        .padding([8.0, 12.0])
         .background(Color::rgb(0.25, 0.3, 0.35))
         .corner_radius(6.0)
         .hover_state(|s| s.lighter(0.1))

--- a/examples/text_transform_example.rs
+++ b/examples/text_transform_example.rs
@@ -35,8 +35,8 @@ async fn main() {
             .layout(
                 Flex::column()
                     .spacing(20.0)
-                    .main_axis_alignment(MainAxisAlignment::Center)
-                    .cross_axis_alignment(CrossAxisAlignment::Center),
+                    .main_alignment(MainAlignment::Center)
+                    .cross_alignment(CrossAlignment::Center),
             )
             .padding(30.0)
             .children([
@@ -51,8 +51,8 @@ async fn main() {
                     .layout(
                         Flex::row()
                             .spacing(30.0)
-                            .main_axis_alignment(MainAxisAlignment::Center)
-                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                            .main_alignment(MainAlignment::Center)
+                            .cross_alignment(CrossAlignment::Center),
                     )
                     .children([
                         // Rotation
@@ -63,8 +63,8 @@ async fn main() {
                             .corner_radius(8.0)
                             .layout(
                                 Flex::column()
-                                    .main_axis_alignment(MainAxisAlignment::Center)
-                                    .cross_axis_alignment(CrossAxisAlignment::Center),
+                                    .main_alignment(MainAlignment::Center)
+                                    .cross_alignment(CrossAlignment::Center),
                             )
                             .rotate(15.0)
                             .child(text("Rotate 15°").font_size(13.0).color(Color::WHITE)),
@@ -76,8 +76,8 @@ async fn main() {
                             .corner_radius(8.0)
                             .layout(
                                 Flex::column()
-                                    .main_axis_alignment(MainAxisAlignment::Center)
-                                    .cross_axis_alignment(CrossAxisAlignment::Center),
+                                    .main_alignment(MainAlignment::Center)
+                                    .cross_alignment(CrossAlignment::Center),
                             )
                             .scale(1.2)
                             .child(text("Scale 1.2x").font_size(13.0).color(Color::WHITE)),
@@ -89,8 +89,8 @@ async fn main() {
                             .corner_radius(8.0)
                             .layout(
                                 Flex::column()
-                                    .main_axis_alignment(MainAxisAlignment::Center)
-                                    .cross_axis_alignment(CrossAxisAlignment::Center),
+                                    .main_alignment(MainAlignment::Center)
+                                    .cross_alignment(CrossAlignment::Center),
                             )
                             .translate(10.0, -10.0)
                             .child(text("Translate").font_size(13.0).color(Color::WHITE)),
@@ -102,8 +102,8 @@ async fn main() {
                             .corner_radius(8.0)
                             .layout(
                                 Flex::column()
-                                    .main_axis_alignment(MainAxisAlignment::Center)
-                                    .cross_axis_alignment(CrossAxisAlignment::Center),
+                                    .main_alignment(MainAlignment::Center)
+                                    .cross_alignment(CrossAlignment::Center),
                             )
                             .rotate(-20.0)
                             .scale(0.9)
@@ -114,8 +114,8 @@ async fn main() {
                     .layout(
                         Flex::row()
                             .spacing(30.0)
-                            .main_axis_alignment(MainAxisAlignment::Center)
-                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                            .main_alignment(MainAlignment::Center)
+                            .cross_alignment(CrossAlignment::Center),
                     )
                     .children([
                         // All three: rotation + scale + translation
@@ -126,8 +126,8 @@ async fn main() {
                             .corner_radius(8.0)
                             .layout(
                                 Flex::column()
-                                    .main_axis_alignment(MainAxisAlignment::Center)
-                                    .cross_axis_alignment(CrossAxisAlignment::Center),
+                                    .main_alignment(MainAlignment::Center)
+                                    .cross_alignment(CrossAlignment::Center),
                             )
                             .rotate(10.0)
                             .scale(1.1)
@@ -141,8 +141,8 @@ async fn main() {
                             .corner_radius(8.0)
                             .layout(
                                 Flex::column()
-                                    .main_axis_alignment(MainAxisAlignment::Center)
-                                    .cross_axis_alignment(CrossAxisAlignment::Center),
+                                    .main_alignment(MainAlignment::Center)
+                                    .cross_alignment(CrossAlignment::Center),
                             )
                             .transform_origin(TransformOrigin::TOP_LEFT)
                             .rotate(15.0)
@@ -155,8 +155,8 @@ async fn main() {
                             .corner_radius(8.0)
                             .layout(
                                 Flex::column()
-                                    .main_axis_alignment(MainAxisAlignment::Center)
-                                    .cross_axis_alignment(CrossAxisAlignment::Center),
+                                    .main_alignment(MainAlignment::Center)
+                                    .cross_alignment(CrossAlignment::Center),
                             )
                             .transform_origin(TransformOrigin::BOTTOM_RIGHT)
                             .rotate(15.0)
@@ -173,8 +173,8 @@ async fn main() {
                             .corner_radius(8.0)
                             .layout(
                                 Flex::column()
-                                    .main_axis_alignment(MainAxisAlignment::Center)
-                                    .cross_axis_alignment(CrossAxisAlignment::Center),
+                                    .main_alignment(MainAlignment::Center)
+                                    .cross_alignment(CrossAlignment::Center),
                             )
                             .transform_origin(TransformOrigin::TOP_RIGHT)
                             .scale(1.15)
@@ -186,8 +186,8 @@ async fn main() {
                     .layout(
                         Flex::row()
                             .spacing(30.0)
-                            .main_axis_alignment(MainAxisAlignment::Center)
-                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                            .main_alignment(MainAlignment::Center)
+                            .cross_alignment(CrossAlignment::Center),
                     )
                     .children([
                         // Nested: parent rotated, child has text
@@ -198,8 +198,8 @@ async fn main() {
                             .corner_radius(12.0)
                             .layout(
                                 Flex::column()
-                                    .main_axis_alignment(MainAxisAlignment::Center)
-                                    .cross_axis_alignment(CrossAxisAlignment::Center),
+                                    .main_alignment(MainAlignment::Center)
+                                    .cross_alignment(CrossAlignment::Center),
                             )
                             .rotate(20.0)
                             .child(
@@ -210,8 +210,8 @@ async fn main() {
                                     .corner_radius(6.0)
                                     .layout(
                                         Flex::column()
-                                            .main_axis_alignment(MainAxisAlignment::Center)
-                                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                                            .main_alignment(MainAlignment::Center)
+                                            .cross_alignment(CrossAlignment::Center),
                                     )
                                     .child(text("Nested").font_size(14.0).color(Color::WHITE)),
                             ),
@@ -223,8 +223,8 @@ async fn main() {
                             .corner_radius(12.0)
                             .layout(
                                 Flex::column()
-                                    .main_axis_alignment(MainAxisAlignment::Center)
-                                    .cross_axis_alignment(CrossAxisAlignment::Center),
+                                    .main_alignment(MainAlignment::Center)
+                                    .cross_alignment(CrossAlignment::Center),
                             )
                             .rotate(15.0)
                             .child(
@@ -235,8 +235,8 @@ async fn main() {
                                     .corner_radius(6.0)
                                     .layout(
                                         Flex::column()
-                                            .main_axis_alignment(MainAxisAlignment::Center)
-                                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                                            .main_alignment(MainAlignment::Center)
+                                            .cross_alignment(CrossAlignment::Center),
                                     )
                                     .rotate(15.0)
                                     .child(
@@ -253,8 +253,8 @@ async fn main() {
                             .corner_radius(12.0)
                             .layout(
                                 Flex::column()
-                                    .main_axis_alignment(MainAxisAlignment::Center)
-                                    .cross_axis_alignment(CrossAxisAlignment::Center),
+                                    .main_alignment(MainAlignment::Center)
+                                    .cross_alignment(CrossAlignment::Center),
                             )
                             .scale(1.1)
                             .translate(5.0, 0.0)
@@ -266,8 +266,8 @@ async fn main() {
                                     .corner_radius(6.0)
                                     .layout(
                                         Flex::column()
-                                            .main_axis_alignment(MainAxisAlignment::Center)
-                                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                                            .main_alignment(MainAlignment::Center)
+                                            .cross_alignment(CrossAlignment::Center),
                                     )
                                     .rotate(-10.0)
                                     .child(
@@ -284,8 +284,8 @@ async fn main() {
                             .corner_radius(8.0)
                             .layout(
                                 Flex::column()
-                                    .main_axis_alignment(MainAxisAlignment::Center)
-                                    .cross_axis_alignment(CrossAxisAlignment::Center),
+                                    .main_alignment(MainAlignment::Center)
+                                    .cross_alignment(CrossAlignment::Center),
                             )
                             .rotate(move || angle.get())
                             .child(text("Spinning!").font_size(14.0).color(Color::WHITE)),

--- a/examples/transform_events_test.rs
+++ b/examples/transform_events_test.rs
@@ -24,7 +24,7 @@ fn main() {
                     .layout(
                         Flex::column()
                             .spacing(20.0)
-                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                            .cross_alignment(CrossAlignment::Center),
                     )
                     .padding(20.0)
                     .children([
@@ -33,7 +33,7 @@ fn main() {
                             .layout(
                                 Flex::row()
                                     .spacing(30.0)
-                                    .main_axis_alignment(MainAxisAlignment::Center),
+                                    .main_alignment(MainAlignment::Center),
                             )
                             .children([
                                 // No transform (control)
@@ -56,7 +56,7 @@ fn main() {
                             .layout(
                                 Flex::row()
                                     .spacing(50.0)
-                                    .main_axis_alignment(MainAxisAlignment::Center),
+                                    .main_alignment(MainAlignment::Center),
                             )
                             .children([
                                 // Nested: parent rotated, child clickable
@@ -68,8 +68,8 @@ fn main() {
                                     .rotate(20.0)
                                     .layout(
                                         Flex::column()
-                                            .main_axis_alignment(MainAxisAlignment::Center)
-                                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                                            .main_alignment(MainAlignment::Center)
+                                            .cross_alignment(CrossAlignment::Center),
                                     )
                                     .child(make_box(
                                         "Nested",
@@ -85,8 +85,8 @@ fn main() {
                                     .scale(1.3)
                                     .layout(
                                         Flex::column()
-                                            .main_axis_alignment(MainAxisAlignment::Center)
-                                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                                            .main_alignment(MainAlignment::Center)
+                                            .cross_alignment(CrossAlignment::Center),
                                     )
                                     .child(
                                         make_box(
@@ -120,8 +120,8 @@ fn make_box(label: &'static str, base_color: Color, click_count: Signal<i32>) ->
         .on_click(move || click_count.update(|c| *c += 1))
         .layout(
             Flex::column()
-                .main_axis_alignment(MainAxisAlignment::Center)
-                .cross_axis_alignment(CrossAxisAlignment::Center),
+                .main_alignment(MainAlignment::Center)
+                .cross_alignment(CrossAlignment::Center),
         )
         .child(text(label).font_size(10.0).color(Color::WHITE).nowrap())
 }

--- a/examples/transform_example.rs
+++ b/examples/transform_example.rs
@@ -27,8 +27,8 @@ fn main() {
                     .layout(
                         Flex::row()
                             .spacing(20.0)
-                            .main_axis_alignment(MainAxisAlignment::Center)
-                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                            .main_alignment(MainAlignment::Center)
+                            .cross_alignment(CrossAlignment::Center),
                     )
                     .padding(16.0)
                     .children([
@@ -43,8 +43,8 @@ fn main() {
                                 container()
                                     .layout(
                                         Flex::column()
-                                            .main_axis_alignment(MainAxisAlignment::Center)
-                                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                                            .main_alignment(MainAlignment::Center)
+                                            .cross_alignment(CrossAlignment::Center),
                                     )
                                     .child(text("45").color(Color::WHITE).font_size(12.0)),
                             ),
@@ -65,8 +65,8 @@ fn main() {
                                 container()
                                     .layout(
                                         Flex::column()
-                                            .main_axis_alignment(MainAxisAlignment::Center)
-                                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                                            .main_alignment(MainAlignment::Center)
+                                            .cross_alignment(CrossAlignment::Center),
                                     )
                                     .child(
                                         text("Click").color(Color::WHITE).font_size(10.0).nowrap(),
@@ -91,8 +91,8 @@ fn main() {
                                 container()
                                     .layout(
                                         Flex::column()
-                                            .main_axis_alignment(MainAxisAlignment::Center)
-                                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                                            .main_alignment(MainAlignment::Center)
+                                            .cross_alignment(CrossAlignment::Center),
                                     )
                                     .child(
                                         text("Scale").color(Color::WHITE).font_size(10.0).nowrap(),
@@ -109,8 +109,8 @@ fn main() {
                                 container()
                                     .layout(
                                         Flex::column()
-                                            .main_axis_alignment(MainAxisAlignment::Center)
-                                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                                            .main_alignment(MainAlignment::Center)
+                                            .cross_alignment(CrossAlignment::Center),
                                     )
                                     .child(text("0.7x").color(Color::WHITE).font_size(12.0)),
                             ),
@@ -125,8 +125,8 @@ fn main() {
                                 container()
                                     .layout(
                                         Flex::column()
-                                            .main_axis_alignment(MainAxisAlignment::Center)
-                                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                                            .main_alignment(MainAlignment::Center)
+                                            .cross_alignment(CrossAlignment::Center),
                                     )
                                     .child(
                                         text("Both").color(Color::WHITE).font_size(10.0).nowrap(),
@@ -144,8 +144,8 @@ fn main() {
                                 container()
                                     .layout(
                                         Flex::column()
-                                            .main_axis_alignment(MainAxisAlignment::Center)
-                                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                                            .main_alignment(MainAlignment::Center)
+                                            .cross_alignment(CrossAlignment::Center),
                                     )
                                     .child(text("TL").color(Color::WHITE).font_size(12.0)),
                             ),
@@ -161,8 +161,8 @@ fn main() {
                                 container()
                                     .layout(
                                         Flex::column()
-                                            .main_axis_alignment(MainAxisAlignment::Center)
-                                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                                            .main_alignment(MainAlignment::Center)
+                                            .cross_alignment(CrossAlignment::Center),
                                     )
                                     .child(text("BR").color(Color::WHITE).font_size(12.0)),
                             ),
@@ -189,8 +189,8 @@ fn main() {
                                     container()
                                         .layout(
                                             Flex::column()
-                                                .main_axis_alignment(MainAxisAlignment::Center)
-                                                .cross_axis_alignment(CrossAxisAlignment::Center),
+                                                .main_alignment(MainAlignment::Center)
+                                                .cross_alignment(CrossAlignment::Center),
                                         )
                                         .child(
                                             text("Cycle")

--- a/examples/transform_origin_test.rs
+++ b/examples/transform_origin_test.rs
@@ -33,8 +33,8 @@ async fn main() {
                     .layout(
                         Flex::column()
                             .spacing(40.0)
-                            .main_axis_alignment(MainAxisAlignment::Center)
-                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                            .main_alignment(MainAlignment::Center)
+                            .cross_alignment(CrossAlignment::Center),
                     )
                     .padding(40.0)
                     .children([
@@ -43,8 +43,8 @@ async fn main() {
                             .layout(
                                 Flex::row()
                                     .spacing(80.0)
-                                    .main_axis_alignment(MainAxisAlignment::Center)
-                                    .cross_axis_alignment(CrossAxisAlignment::Center),
+                                    .main_alignment(MainAlignment::Center)
+                                    .cross_alignment(CrossAlignment::Center),
                             )
                             .children([
                                 // Default origin (center)
@@ -92,8 +92,8 @@ async fn main() {
                             .layout(
                                 Flex::row()
                                     .spacing(80.0)
-                                    .main_axis_alignment(MainAxisAlignment::Center)
-                                    .cross_axis_alignment(CrossAxisAlignment::Center),
+                                    .main_alignment(MainAlignment::Center)
+                                    .cross_alignment(CrossAlignment::Center),
                             )
                             .children([
                                 // Default origin (center) - scale
@@ -125,8 +125,8 @@ async fn main() {
                             .layout(
                                 Flex::row()
                                     .spacing(80.0)
-                                    .main_axis_alignment(MainAxisAlignment::Center)
-                                    .cross_axis_alignment(CrossAxisAlignment::Center),
+                                    .main_alignment(MainAlignment::Center)
+                                    .cross_alignment(CrossAlignment::Center),
                             )
                             .children([
                                 // Center origin - animated
@@ -158,8 +158,8 @@ async fn main() {
                             .layout(
                                 Flex::row()
                                     .spacing(80.0)
-                                    .main_axis_alignment(MainAxisAlignment::Center)
-                                    .cross_axis_alignment(CrossAxisAlignment::Center),
+                                    .main_alignment(MainAlignment::Center)
+                                    .cross_alignment(CrossAlignment::Center),
                             )
                             .children([
                                 // Parent rotated at center, child inside
@@ -170,8 +170,8 @@ async fn main() {
                                     .corner_radius(10.0)
                                     .layout(
                                         Flex::column()
-                                            .main_axis_alignment(MainAxisAlignment::Center)
-                                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                                            .main_alignment(MainAlignment::Center)
+                                            .cross_alignment(CrossAlignment::Center),
                                     )
                                     .rotate(15.0)
                                     .child(
@@ -189,8 +189,8 @@ async fn main() {
                                     .corner_radius(10.0)
                                     .layout(
                                         Flex::column()
-                                            .main_axis_alignment(MainAxisAlignment::Center)
-                                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                                            .main_alignment(MainAlignment::Center)
+                                            .cross_alignment(CrossAlignment::Center),
                                     )
                                     .transform_origin(TransformOrigin::TOP_LEFT)
                                     .rotate(15.0)

--- a/examples/transform_scale_test.rs
+++ b/examples/transform_scale_test.rs
@@ -14,8 +14,8 @@ fn main() {
                     .layout(
                         Flex::row()
                             .spacing(40.0)
-                            .main_axis_alignment(MainAxisAlignment::Center)
-                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                            .main_alignment(MainAlignment::Center)
+                            .cross_alignment(CrossAlignment::Center),
                     )
                     .padding(16.0)
                     .children([

--- a/examples/transform_test.rs
+++ b/examples/transform_test.rs
@@ -13,8 +13,8 @@ fn main() {
                 container()
                     .layout(
                         Flex::column()
-                            .main_axis_alignment(MainAxisAlignment::Center)
-                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                            .main_alignment(MainAlignment::Center)
+                            .cross_alignment(CrossAlignment::Center),
                     )
                     .padding(16.0)
                     .child(

--- a/examples/transform_test_3level.rs
+++ b/examples/transform_test_3level.rs
@@ -16,7 +16,7 @@ fn main() {
                     .layout(
                         Flex::row()
                             .spacing(60.0)
-                            .main_axis_alignment(MainAxisAlignment::Center),
+                            .main_alignment(MainAlignment::Center),
                     )
                     .padding(30.0)
                     .children([

--- a/examples/transform_test_nested.rs
+++ b/examples/transform_test_nested.rs
@@ -16,7 +16,7 @@ fn main() {
                     .layout(
                         Flex::row()
                             .spacing(40.0)
-                            .main_axis_alignment(MainAxisAlignment::Center),
+                            .main_alignment(MainAlignment::Center),
                     )
                     .padding(20.0)
                     .children([

--- a/examples/transform_test_origin.rs
+++ b/examples/transform_test_origin.rs
@@ -16,7 +16,7 @@ fn main() {
                     .layout(
                         Flex::row()
                             .spacing(50.0)
-                            .main_axis_alignment(MainAxisAlignment::Center),
+                            .main_alignment(MainAlignment::Center),
                     )
                     .padding(30.0)
                     .children([

--- a/examples/transform_test_rotation.rs
+++ b/examples/transform_test_rotation.rs
@@ -16,7 +16,7 @@ fn main() {
                     .layout(
                         Flex::row()
                             .spacing(30.0)
-                            .main_axis_alignment(MainAxisAlignment::Center),
+                            .main_alignment(MainAlignment::Center),
                     )
                     .padding(20.0)
                     .children([

--- a/examples/transform_test_scale.rs
+++ b/examples/transform_test_scale.rs
@@ -16,7 +16,7 @@ fn main() {
                     .layout(
                         Flex::row()
                             .spacing(40.0)
-                            .main_axis_alignment(MainAxisAlignment::Center),
+                            .main_alignment(MainAlignment::Center),
                     )
                     .padding(20.0)
                     .children([

--- a/examples/transform_translate_test.rs
+++ b/examples/transform_translate_test.rs
@@ -14,8 +14,8 @@ fn main() {
                     .layout(
                         Flex::row()
                             .spacing(20.0)
-                            .main_axis_alignment(MainAxisAlignment::Center)
-                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                            .main_alignment(MainAlignment::Center)
+                            .cross_alignment(CrossAlignment::Center),
                     )
                     .padding(16.0)
                     .children([

--- a/examples/widget_ref_example.rs
+++ b/examples/widget_ref_example.rs
@@ -30,7 +30,7 @@ fn main() {
                         // The measured module
                         container()
                             .widget_ref(module_ref)
-                            .padding_xy(16.0, 8.0)
+                            .padding([8.0, 16.0])
                             .background(Color::rgb(0.25, 0.25, 0.35))
                             .corner_radius(6.0)
                             .child(text("Measured Module").color(Color::WHITE)),
@@ -38,7 +38,7 @@ fn main() {
                     .child(
                         // Display the bounds reactively
                         container()
-                            .padding_xy(16.0, 8.0)
+                            .padding([8.0, 16.0])
                             .background(Color::rgb(0.15, 0.2, 0.15))
                             .corner_radius(6.0)
                             .child(

--- a/examples/widget_ref_example.rs
+++ b/examples/widget_ref_example.rs
@@ -19,8 +19,8 @@ fn main() {
                     .layout(
                         Flex::row()
                             .spacing(16.0)
-                            .main_axis_alignment(MainAxisAlignment::Center)
-                            .cross_axis_alignment(CrossAxisAlignment::Center),
+                            .main_alignment(MainAlignment::Center)
+                            .cross_alignment(CrossAlignment::Center),
                     )
                     .child(
                         // Spacer

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -157,7 +157,7 @@ pub enum Axis {
 
 /// Main axis alignment for flex layouts
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum MainAxisAlignment {
+pub enum MainAlignment {
     Start,
     Center,
     End,
@@ -168,7 +168,7 @@ pub enum MainAxisAlignment {
 
 /// Cross axis alignment for flex layouts
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CrossAxisAlignment {
+pub enum CrossAlignment {
     Start,
     Center,
     End,
@@ -181,14 +181,14 @@ impl IntoMaybeDyn<Axis> for Axis {
     }
 }
 
-impl IntoMaybeDyn<MainAxisAlignment> for MainAxisAlignment {
-    fn into_maybe_dyn(self) -> MaybeDyn<MainAxisAlignment> {
+impl IntoMaybeDyn<MainAlignment> for MainAlignment {
+    fn into_maybe_dyn(self) -> MaybeDyn<MainAlignment> {
         MaybeDyn::Static(self)
     }
 }
 
-impl IntoMaybeDyn<CrossAxisAlignment> for CrossAxisAlignment {
-    fn into_maybe_dyn(self) -> MaybeDyn<CrossAxisAlignment> {
+impl IntoMaybeDyn<CrossAlignment> for CrossAlignment {
+    fn into_maybe_dyn(self) -> MaybeDyn<CrossAlignment> {
         MaybeDyn::Static(self)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,8 +102,8 @@ pub(crate) fn take_registered_fonts() -> Vec<Arc<Vec<u8>>> {
 pub mod prelude {
     pub use crate::animation::{SpringConfig, TimingFunction, Transition};
     pub use crate::layout::{
-        Axis, Constraints, CrossAxisAlignment, Flex, Length, MainAxisAlignment, Overlay, Size,
-        at_least, at_most, fill,
+        Axis, Constraints, CrossAlignment, Flex, Length, MainAlignment, Overlay, Size, at_least,
+        at_most, fill,
     };
     pub use crate::platform::{Anchor, KeyboardInteractivity, Layer};
     pub use crate::reactive::{

--- a/src/reactive/maybe_dyn.rs
+++ b/src/reactive/maybe_dyn.rs
@@ -90,6 +90,25 @@ impl IntoMaybeDyn<bool> for bool {
     }
 }
 
+// Integer → f32 conversions: enables spacing(8), width(300), corner_radius(12), etc.
+impl IntoMaybeDyn<f32> for u16 {
+    fn into_maybe_dyn(self) -> MaybeDyn<f32> {
+        MaybeDyn::Static(f32::from(self))
+    }
+}
+
+impl IntoMaybeDyn<f32> for u32 {
+    fn into_maybe_dyn(self) -> MaybeDyn<f32> {
+        MaybeDyn::Static(self as f32)
+    }
+}
+
+impl IntoMaybeDyn<f32> for i32 {
+    fn into_maybe_dyn(self) -> MaybeDyn<f32> {
+        MaybeDyn::Static(self as f32)
+    }
+}
+
 // ============================================================================
 // Closure implementation - works for any Fn() -> T
 // ============================================================================

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -274,49 +274,16 @@ impl Container {
         self
     }
 
-    /// Set uniform padding on all sides in logical pixels.
+    /// Set padding in logical pixels.
     ///
-    /// Accepts static values or reactive signals/closures.
-    ///
-    /// # Example
-    ///
-    /// ```ignore
-    /// // Static padding
-    /// container().padding(8.0)
-    ///
-    /// // Reactive padding
-    /// let padding = create_signal(8.0);
-    /// container().padding(padding)
-    /// ```
-    pub fn padding(mut self, value: impl IntoMaybeDyn<f32>) -> Self {
-        let value = value.into_maybe_dyn();
-        self.padding = MaybeDyn::Dynamic(Rc::new(move || Padding::all(value.get())));
-        self
-    }
-
-    /// Set separate horizontal and vertical padding in logical pixels.
-    ///
-    /// Horizontal padding applies to left and right, vertical to top and bottom.
-    /// Accepts static values or reactive signals/closures.
-    ///
-    /// # Example
-    ///
-    /// ```ignore
-    /// container().padding_xy(16.0, 8.0)  // 16px horizontal, 8px vertical
-    /// ```
-    pub fn padding_xy(
-        mut self,
-        horizontal: impl IntoMaybeDyn<f32>,
-        vertical: impl IntoMaybeDyn<f32>,
-    ) -> Self {
-        let h = horizontal.into_maybe_dyn();
-        let v = vertical.into_maybe_dyn();
-        self.padding = MaybeDyn::Dynamic(Rc::new(move || Padding {
-            left: h.get(),
-            right: h.get(),
-            top: v.get(),
-            bottom: v.get(),
-        }));
+    /// Accepts multiple formats via `From` conversions:
+    /// - `padding(8.0)` or `padding(8)` — uniform on all sides
+    /// - `padding([8.0, 16.0])` — `[vertical, horizontal]` (CSS 2-value shorthand)
+    /// - `padding([1.0, 2.0, 3.0, 4.0])` — `[top, right, bottom, left]` (CSS 4-value)
+    /// - `padding(Padding::all(8.0).top(20.0))` — builder pattern
+    /// - `padding(signal)` or `padding(move || ...)` — reactive
+    pub fn padding(mut self, value: impl IntoMaybeDyn<Padding>) -> Self {
+        self.padding = value.into_maybe_dyn();
         self
     }
 

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -40,6 +40,43 @@ impl IntoMaybeDyn<Padding> for Padding {
     }
 }
 
+// Convenience conversions: padding(8.0), padding(8), padding([8.0, 16.0]), etc.
+impl IntoMaybeDyn<Padding> for f32 {
+    fn into_maybe_dyn(self) -> MaybeDyn<Padding> {
+        MaybeDyn::Static(Padding::from(self))
+    }
+}
+
+impl IntoMaybeDyn<Padding> for i32 {
+    fn into_maybe_dyn(self) -> MaybeDyn<Padding> {
+        MaybeDyn::Static(Padding::from(self))
+    }
+}
+
+impl IntoMaybeDyn<Padding> for u16 {
+    fn into_maybe_dyn(self) -> MaybeDyn<Padding> {
+        MaybeDyn::Static(Padding::from(self))
+    }
+}
+
+impl IntoMaybeDyn<Padding> for u32 {
+    fn into_maybe_dyn(self) -> MaybeDyn<Padding> {
+        MaybeDyn::Static(Padding::from(self))
+    }
+}
+
+impl IntoMaybeDyn<Padding> for [f32; 2] {
+    fn into_maybe_dyn(self) -> MaybeDyn<Padding> {
+        MaybeDyn::Static(Padding::from(self))
+    }
+}
+
+impl IntoMaybeDyn<Padding> for [f32; 4] {
+    fn into_maybe_dyn(self) -> MaybeDyn<Padding> {
+        MaybeDyn::Static(Padding::from(self))
+    }
+}
+
 impl IntoMaybeDyn<Transform> for Transform {
     fn into_maybe_dyn(self) -> MaybeDyn<Transform> {
         MaybeDyn::Static(self)

--- a/src/widgets/widget.rs
+++ b/src/widgets/widget.rs
@@ -196,6 +196,80 @@ impl Padding {
     pub fn vertical(&self) -> f32 {
         self.top + self.bottom
     }
+
+    /// Override the top padding value.
+    pub fn top(mut self, v: f32) -> Self {
+        self.top = v;
+        self
+    }
+
+    /// Override the bottom padding value.
+    pub fn bottom(mut self, v: f32) -> Self {
+        self.bottom = v;
+        self
+    }
+
+    /// Override the left padding value.
+    pub fn left(mut self, v: f32) -> Self {
+        self.left = v;
+        self
+    }
+
+    /// Override the right padding value.
+    pub fn right(mut self, v: f32) -> Self {
+        self.right = v;
+        self
+    }
+}
+
+// From conversions for Padding — enables padding(8.0), padding(8), padding([8.0, 16.0]), etc.
+
+impl From<f32> for Padding {
+    fn from(v: f32) -> Self {
+        Padding::all(v)
+    }
+}
+
+impl From<u16> for Padding {
+    fn from(v: u16) -> Self {
+        Padding::all(f32::from(v))
+    }
+}
+
+impl From<u32> for Padding {
+    fn from(v: u32) -> Self {
+        Padding::all(v as f32)
+    }
+}
+
+impl From<i32> for Padding {
+    fn from(v: i32) -> Self {
+        Padding::all(v as f32)
+    }
+}
+
+/// `[vertical, horizontal]` — CSS-style 2-value shorthand.
+impl From<[f32; 2]> for Padding {
+    fn from(v: [f32; 2]) -> Self {
+        Padding {
+            top: v[0],
+            right: v[1],
+            bottom: v[0],
+            left: v[1],
+        }
+    }
+}
+
+/// `[top, right, bottom, left]` — CSS-style 4-value shorthand.
+impl From<[f32; 4]> for Padding {
+    fn from(v: [f32; 4]) -> Self {
+        Padding {
+            top: v[0],
+            right: v[1],
+            bottom: v[2],
+            left: v[3],
+        }
+    }
 }
 
 impl Default for Padding {
@@ -608,5 +682,56 @@ mod tests {
         assert_eq!(padding.right, 0.0);
         assert_eq!(padding.bottom, 0.0);
         assert_eq!(padding.left, 0.0);
+    }
+
+    #[test]
+    fn test_padding_builder_methods() {
+        let padding = Padding::all(8.0).top(20.0).left(0.0);
+        assert_eq!(padding.top, 20.0);
+        assert_eq!(padding.right, 8.0);
+        assert_eq!(padding.bottom, 8.0);
+        assert_eq!(padding.left, 0.0);
+    }
+
+    #[test]
+    fn test_padding_from_f32() {
+        let padding = Padding::from(10.0);
+        assert_eq!(padding, Padding::all(10.0));
+    }
+
+    #[test]
+    fn test_padding_from_i32() {
+        let padding = Padding::from(10i32);
+        assert_eq!(padding, Padding::all(10.0));
+    }
+
+    #[test]
+    fn test_padding_from_u16() {
+        let padding = Padding::from(10u16);
+        assert_eq!(padding, Padding::all(10.0));
+    }
+
+    #[test]
+    fn test_padding_from_u32() {
+        let padding = Padding::from(10u32);
+        assert_eq!(padding, Padding::all(10.0));
+    }
+
+    #[test]
+    fn test_padding_from_array_2() {
+        let padding = Padding::from([8.0, 16.0]);
+        assert_eq!(padding.top, 8.0);
+        assert_eq!(padding.right, 16.0);
+        assert_eq!(padding.bottom, 8.0);
+        assert_eq!(padding.left, 16.0);
+    }
+
+    #[test]
+    fn test_padding_from_array_4() {
+        let padding = Padding::from([1.0, 2.0, 3.0, 4.0]);
+        assert_eq!(padding.top, 1.0);
+        assert_eq!(padding.right, 2.0);
+        assert_eq!(padding.bottom, 3.0);
+        assert_eq!(padding.left, 4.0);
     }
 }


### PR DESCRIPTION
## Summary

- **Unified padding API**: Replace `padding(f32)` + `padding_xy(h, v)` with a single `padding()` that accepts numeric literals (`f32`, `i32`, `u16`, `u32`), CSS-style arrays (`[v, h]` and `[t, r, b, l]`), builder pattern (`Padding::all(8).top(20)`), and reactive values (signals/closures)
- **Shorter alignment type names**: Rename `MainAxisAlignment` → `MainAlignment`, `CrossAxisAlignment` → `CrossAlignment`, and shorten method names (`main_alignment()`, `cross_alignment()`)
- **Full migration**: All 37+ examples, docs, and book chapters updated to use the new API

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test` — all 161 tests pass (includes 13 dedicated padding tests)
- [x] `mdbook build book` succeeds
- [x] No remaining references to `padding_xy`, `MainAxisAlignment`, or `CrossAxisAlignment`