### PR TITLE
docs: add App Lifecycle chapter for quit/restart API

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -60,6 +60,7 @@
     - [Background Tasks](advanced/background-threads.md)
     - [Widget Ref](advanced/widget-ref.md)
     - [Wayland Layer Shell](advanced/wayland.md)
+    - [App Lifecycle](advanced/app-lifecycle.md)
 
 # Architecture
 

--- a/book/src/advanced/README.md
+++ b/book/src/advanced/README.md
@@ -7,7 +7,9 @@ This section covers advanced patterns for building complex Guido applications.
 - [Creating Components](components.md) - Reusable widgets with the `#[component]` macro
 - [Dynamic Children](dynamic-children.md) - Reactive lists and conditional rendering
 - [Background Tasks](background-threads.md) - Integrating async operations
+- [Widget Ref](widget-ref.md) - Querying widget bounds at runtime
 - [Wayland Layer Shell](wayland.md) - Positioning and layer configuration
+- [App Lifecycle](app-lifecycle.md) - Quit, restart, and exit handling
 
 ## When You Need These
 

--- a/book/src/advanced/app-lifecycle.md
+++ b/book/src/advanced/app-lifecycle.md
@@ -1,0 +1,117 @@
+# App Lifecycle
+
+Guido applications can programmatically quit or restart. `App::run()` returns an `ExitReason` so the caller knows why the loop exited.
+
+## Quitting
+
+Call `quit_app()` to request a clean shutdown:
+
+```rust
+use guido::prelude::*;
+
+container()
+    .padding([8.0, 16.0])
+    .background(Color::rgb(0.3, 0.3, 0.4))
+    .hover_state(|s| s.lighter(0.1))
+    .on_click(|| quit_app())
+    .child(text("Quit"))
+```
+
+The current `App::run()` loop exits and returns `ExitReason::Quit`.
+
+## Restarting
+
+Call `restart_app()` to request a restart. The loop exits and returns `ExitReason::Restart`, letting the caller re-create the app:
+
+```rust
+container()
+    .on_click(|| restart_app())
+    .child(text("Restart"))
+```
+
+### Restart Loop
+
+Use a loop in `main()` to support restart:
+
+```rust
+use guido::prelude::*;
+
+fn main() {
+    loop {
+        let reason = App::new().run(|app| {
+            app.add_surface(
+                SurfaceConfig::new()
+                    .height(32)
+                    .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+                    .layer(Layer::Top)
+                    .namespace("my-bar")
+                    .background_color(Color::rgb(0.1, 0.1, 0.15)),
+                || build_ui(),
+            );
+        });
+
+        match reason {
+            ExitReason::Quit => break,
+            ExitReason::Restart => continue,
+        }
+    }
+}
+```
+
+This is useful for reloading configuration, switching themes, or resetting application state.
+
+## Calling from Background Tasks
+
+Both `quit_app()` and `restart_app()` are `Send` — they work from any thread, including background services:
+
+```rust
+let _ = create_service::<(), _, _>(move |_rx, ctx| async move {
+    loop {
+        tokio::select! {
+            _ = watch_config_file() => {
+                // Config changed — trigger restart
+                restart_app();
+                break;
+            }
+            _ = tokio::time::sleep(Duration::from_millis(50)) => {
+                if !ctx.is_running() { break; }
+            }
+        }
+    }
+});
+```
+
+## API Reference
+
+### ExitReason
+
+```rust
+pub enum ExitReason {
+    /// Normal exit (compositor closed, all surfaces destroyed, etc.)
+    Quit,
+    /// Restart requested. The caller should re-create `App` and run again.
+    Restart,
+}
+```
+
+### Functions
+
+```rust
+/// Request a clean application quit.
+/// App::run() will return ExitReason::Quit.
+pub fn quit_app();
+
+/// Request a clean application restart.
+/// App::run() will return ExitReason::Restart.
+/// Call from any thread — uses an atomic + ping to wake the event loop.
+pub fn restart_app();
+```
+
+### App::run
+
+```rust
+impl App {
+    /// Run the application. Returns the reason the loop exited.
+    pub fn run(self, setup: impl FnOnce(&mut Self)) -> ExitReason;
+}
+```

--- a/book/src/advanced/wayland.md
+++ b/book/src/advanced/wayland.md
@@ -466,7 +466,7 @@ impl SurfaceConfig {
 ```rust
 impl App {
     pub fn new() -> Self;
-    pub fn run(self, setup: impl FnOnce(&mut Self));
+    pub fn run(self, setup: impl FnOnce(&mut Self)) -> ExitReason;
     pub fn add_surface<W, F>(&mut self, config: SurfaceConfig, widget_fn: F) -> SurfaceId
     where
         W: Widget + 'static,


### PR DESCRIPTION
## Summary
- Add new book chapter `advanced/app-lifecycle.md` documenting `quit_app()`, `restart_app()`, and `ExitReason`
- Covers restart loop pattern, calling from UI callbacks and background services
- Fix stale `App::run()` signature in the Wayland chapter (missing `-> ExitReason` return type)
- Add missing "Widget Ref" entry to the Advanced Topics README listing

## Test plan
- [ ] `mdbook build book` succeeds
- [ ] New chapter renders correctly with working links