### PR TITLE
feat: add context API for app-wide state sharing

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -61,6 +61,7 @@
     - [Widget Ref](advanced/widget-ref.md)
     - [Wayland Layer Shell](advanced/wayland.md)
     - [App Lifecycle](advanced/app-lifecycle.md)
+    - [Context](advanced/context.md)
 
 # Architecture
 

--- a/book/src/advanced/README.md
+++ b/book/src/advanced/README.md
@@ -10,6 +10,7 @@ This section covers advanced patterns for building complex Guido applications.
 - [Widget Ref](widget-ref.md) - Querying widget bounds at runtime
 - [Wayland Layer Shell](wayland.md) - Positioning and layer configuration
 - [App Lifecycle](app-lifecycle.md) - Quit, restart, and exit handling
+- [Context](context.md) - App-wide state without prop drilling
 
 ## When You Need These
 

--- a/book/src/advanced/context.md
+++ b/book/src/advanced/context.md
@@ -1,0 +1,167 @@
+# Context
+
+Context provides a way to share app-wide state (config, theme, services) across widgets without passing values through every level of the widget tree.
+
+## When to Use Context
+
+Use context for **cross-cutting concerns** that many widgets need:
+
+- Application configuration
+- Theme or styling data
+- Service handles (loggers, API clients)
+- User preferences
+
+For state that only a few nearby widgets share, passing signals directly is simpler and preferred.
+
+## Providing Context
+
+Call `provide_context` in your `App::run()` setup to make a value available everywhere:
+
+```rust
+use guido::prelude::*;
+
+App::new().run(|app| {
+    provide_context(Config::load());
+
+    app.add_surface(config, || build_ui());
+});
+```
+
+## Retrieving Context
+
+### use_context (fallible)
+
+Returns `Option<T>` — useful when the context is optional:
+
+```rust
+if let Some(cfg) = use_context::<Config>() {
+    println!("threshold: {}", cfg.warn_threshold);
+}
+```
+
+### expect_context (infallible)
+
+Panics with a helpful message if the context was not provided:
+
+```rust
+let cfg = expect_context::<Config>();
+```
+
+### with_context (zero-clone)
+
+Borrows the value without cloning — ideal for large structs when you only need one field:
+
+```rust
+let threshold = with_context::<Config, _>(|cfg| cfg.cpu.warn_threshold);
+```
+
+### has_context (existence check)
+
+Check if a context has been provided without retrieving it:
+
+```rust
+if has_context::<Logger>() {
+    expect_context::<Logger>().info("ready");
+}
+```
+
+## Reactive Context
+
+For mutable shared state, store a `Signal<T>` as context. This is the most powerful pattern — any widget reading the signal during paint/layout auto-tracks it for reactive updates.
+
+### provide_signal_context
+
+Creates a signal and provides it as context in one step:
+
+```rust
+App::new().run(|app| {
+    // Creates Signal<Theme> and stores it as context
+    let theme = provide_signal_context(Theme::default());
+
+    app.add_surface(config, || build_ui());
+});
+```
+
+### Reading a signal context
+
+```rust
+fn themed_box() -> Container {
+    let theme = expect_context::<Signal<Theme>>();
+
+    container()
+        .background(move || theme.get().bg_color)
+        .child(text(move || theme.get().title.clone()))
+}
+```
+
+When the signal is updated anywhere, all widgets reading it automatically repaint.
+
+## Combining with SignalFields
+
+For config structs with many fields, use `#[derive(SignalFields)]` with context so each widget only repaints when the specific field it reads changes:
+
+```rust
+#[derive(Clone, PartialEq, SignalFields)]
+pub struct AppConfig {
+    pub cpu_warn: f64,
+    pub mem_warn: f64,
+    pub title: String,
+}
+
+App::new().run(|app| {
+    let config = AppConfigSignals::new(AppConfig {
+        cpu_warn: 80.0,
+        mem_warn: 90.0,
+        title: "My App".into(),
+    });
+    provide_context(config);
+
+    app.add_surface(surface_config, || build_ui());
+});
+
+// In a widget — only repaints when cpu_warn changes
+fn cpu_indicator() -> Container {
+    let config = expect_context::<AppConfigSignals>();
+    let threshold = config.cpu_warn;  // Signal<f64>
+
+    container()
+        .background(move || {
+            if current_cpu() > threshold.get() {
+                Color::RED
+            } else {
+                Color::GREEN
+            }
+        })
+}
+```
+
+## Context vs Passing Signals
+
+| Approach | Best for |
+|----------|----------|
+| **Pass signals directly** | Parent-child, 1-2 levels deep, few consumers |
+| **Context** | App-wide state, many consumers across modules |
+
+Since `Signal<T>` is `Copy`, passing them directly is zero-cost. Context adds a Vec scan + downcast, which is negligible but unnecessary when only a few widgets need the value.
+
+## API Reference
+
+```rust
+// Store a value (one per type, replaces if exists)
+pub fn provide_context<T: 'static>(value: T);
+
+// Retrieve (clones)
+pub fn use_context<T: Clone + 'static>() -> Option<T>;
+pub fn expect_context<T: Clone + 'static>() -> T;
+
+// Borrow without cloning
+pub fn with_context<T: 'static, R>(f: impl FnOnce(&T) -> R) -> Option<R>;
+
+// Existence check
+pub fn has_context<T: 'static>() -> bool;
+
+// Create signal + provide as context
+pub fn provide_signal_context<T: Clone + PartialEq + Send + 'static>(
+    value: T
+) -> Signal<T>;
+```

--- a/book/src/concepts/reactive-model.md
+++ b/book/src/concepts/reactive-model.md
@@ -224,6 +224,20 @@ let value = count.get();
 text(format!("Count: {}", value))  // Won't update!
 ```
 
+### Use Context for App-Wide State
+
+For values that many widgets across different modules need (config, theme, services), use the [Context API](../advanced/context.md) instead of passing signals through every function:
+
+```rust
+// Setup
+provide_context(Config::load());
+
+// Any widget, any module
+let cfg = expect_context::<Config>();
+```
+
+For mutable shared state, use `provide_signal_context` to combine context with reactivity.
+
 ### Use Memo for Derived State
 
 Instead of manually syncing values:

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -1,0 +1,114 @@
+# Context API: `provide_context` / `use_context`
+
+## Motivation
+
+After porting ashell's config system, we hit three pain points:
+
+1. **Theme colors changed from `const` to `fn()`** — required updating 17 files (`theme::TEXT` → `theme::TEXT()`)
+2. **Config structs cloned everywhere** — closures need `'static`, so `cfg.system_info.clone()` proliferates through main.rs
+3. **Hand-rolled thread-local Cell** — we built our own `thread_local! { static COLORS: Cell<ThemeColors> }` in the theme module
+
+All of these stem from guido lacking a way to store app-wide state that any widget can access without explicit parameter passing. Adding a **context system** (like React/Leptos) solves all three.
+
+## Design
+
+A thread-local `Vec<(TypeId, Box<dyn Any>)>` that stores one value per type with linear scan. At ~3-8 entries (config, theme, services), this fits in 1-2 cache lines and avoids HashMap overhead. `TypeId` comparison is a single `u64` eq. Scoped to the app lifetime — `App::drop()` resets it via `reset_contexts()`.
+
+## API
+
+```rust
+// Core
+pub fn provide_context<T: 'static>(value: T);
+pub fn use_context<T: Clone + 'static>() -> Option<T>;
+pub fn expect_context<T: Clone + 'static>() -> T;
+
+// Zero-clone borrow
+pub fn with_context<T: 'static, R>(f: impl FnOnce(&T) -> R) -> Option<R>;
+
+// Existence check
+pub fn has_context<T: 'static>() -> bool;
+
+// Signal helper (create + provide in one step)
+pub fn provide_signal_context<T: Clone + PartialEq + Send + 'static>(value: T) -> Signal<T>;
+
+// Internal cleanup
+pub(crate) fn reset_contexts();
+```
+
+## Implementation
+
+### `src/reactive/context.rs`
+
+Thread-local Vec storage with:
+- `provide_context`: replaces existing entry if same TypeId exists, otherwise pushes
+- `use_context`: linear scan + downcast + clone
+- `expect_context`: delegates to `use_context` with `type_name::<T>()` in panic message
+- `with_context`: linear scan + downcast + borrow (no clone)
+- `has_context`: linear scan, returns bool
+- `provide_signal_context`: `create_signal(value)` + `provide_context(signal)` + return signal
+- `reset_contexts`: `Vec::clear()`
+
+### `src/reactive/mod.rs`
+
+- `pub mod context;`
+- Re-exports: `provide_context`, `use_context`, `expect_context`, `with_context`, `has_context`, `provide_signal_context`
+- `reset_reactive()` calls `context::reset_contexts()`
+
+### `src/lib.rs` (prelude)
+
+All public context functions exported.
+
+## Usage
+
+### Static config
+
+```rust
+App::new().run(|app| {
+    provide_context(Config::load());
+    // ...
+});
+
+// In any widget module:
+let cfg = expect_context::<Config>();
+```
+
+### Reactive context (recommended for mutable state)
+
+```rust
+// Setup: create signal + provide as context in one step
+let theme = provide_signal_context(Theme::default());
+
+// Any widget: retrieve signal, auto-tracks during paint/layout
+let theme = expect_context::<Signal<Theme>>();
+container().background(move || theme.get().bg_color)
+```
+
+### Zero-clone access
+
+```rust
+// Borrow without cloning — good for large config structs
+let threshold = with_context::<Config, _>(|cfg| cfg.cpu.warn_threshold);
+```
+
+## Design Decisions
+
+### Why global instead of owner-scoped?
+
+Layer shell widgets (status bars, panels) are 3-5 levels deep, not 20. Tree scoping adds complexity for no benefit. Owner-scoped context can be added later without breaking the global API.
+
+### Why Vec instead of HashMap?
+
+Context stores ~3-8 values. At this scale, `Vec` with linear scan beats `HashMap`: fits in 1-2 cache lines, no hash computation, no bucket overhead. Matches the `storage.rs` pattern.
+
+### Why keep theme as separate Cell?
+
+Theme is read 100s of times per frame. `Cell` memcpy beats Vec scan + RefCell borrow + downcast. Correct separation of concerns.
+
+## Verification
+
+1. `cargo build` in guido
+2. `cargo test` in guido (unit tests for all 6 public functions + reset)
+3. `cargo clippy --all-targets --all-features -- -D warnings` — clean
+4. `cargo fmt --all` — formatted
+5. `cargo build` in ashell-guido
+6. Run ashell-guido — config values should take effect

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,7 +132,8 @@ pub mod prelude {
     pub use crate::platform::{Anchor, KeyboardInteractivity, Layer};
     pub use crate::reactive::{
         CursorIcon, Memo, Service, Signal, WriteSignal, create_effect, create_memo, create_service,
-        create_signal, on_cleanup, set_cursor,
+        create_signal, expect_context, has_context, on_cleanup, provide_context,
+        provide_signal_context, set_cursor, use_context, with_context,
     };
     pub use crate::renderer::{PaintContext, Shadow, measure_text};
     pub use crate::surface::{

--- a/src/reactive/context.rs
+++ b/src/reactive/context.rs
@@ -1,0 +1,300 @@
+//! App-global context system for sharing state across widgets.
+//!
+//! Context provides a way to store and retrieve app-wide values (config, theme,
+//! services) without passing them through every level of the widget tree. Values
+//! are keyed by their concrete type — one value per type.
+//!
+//! ## Storage
+//!
+//! Uses `Vec<(TypeId, Box<dyn Any>)>` with linear scan. Context stores ~3-8
+//! values in practice (config, theme, services), so this fits in 1-2 cache
+//! lines and avoids HashMap overhead. `TypeId` comparison is a single `u64` eq.
+//!
+//! ## Reactive Context
+//!
+//! Storing `Signal<T>` as context is the recommended pattern for mutable state.
+//! Any widget reading the signal during paint/layout auto-tracks it:
+//!
+//! ```ignore
+//! // In App::run() setup:
+//! let theme = provide_signal_context(MyTheme::default());
+//!
+//! // In any widget:
+//! let theme = expect_context::<Signal<MyTheme>>();
+//! container().background(move || theme.get().bg_color)
+//! ```
+
+use std::any::{Any, TypeId};
+use std::cell::RefCell;
+
+use super::signal::{Signal, create_signal};
+
+thread_local! {
+    static CONTEXTS: RefCell<Vec<(TypeId, Box<dyn Any>)>> = const { RefCell::new(Vec::new()) };
+}
+
+/// Store a value in the global context, keyed by its type.
+///
+/// If a value of the same type already exists, it is replaced.
+///
+/// # Example
+///
+/// ```ignore
+/// App::new().run(|app| {
+///     provide_context(MyConfig::load());
+///     provide_context(create_signal(Theme::default())); // Signal as context
+///     // ...
+/// });
+/// ```
+pub fn provide_context<T: 'static>(value: T) {
+    let type_id = TypeId::of::<T>();
+    CONTEXTS.with(|ctx| {
+        let mut ctx = ctx.borrow_mut();
+        // Replace if exists
+        for entry in ctx.iter_mut() {
+            if entry.0 == type_id {
+                entry.1 = Box::new(value);
+                return;
+            }
+        }
+        ctx.push((type_id, Box::new(value)));
+    });
+}
+
+/// Retrieve a context value by type, returning `None` if not provided.
+///
+/// Clones the value — for large structs, use [`with_context`] to borrow
+/// or store a `Signal<T>` instead.
+///
+/// # Example
+///
+/// ```ignore
+/// if let Some(cfg) = use_context::<MyConfig>() {
+///     println!("threshold: {}", cfg.warn_threshold);
+/// }
+/// ```
+pub fn use_context<T: Clone + 'static>() -> Option<T> {
+    let type_id = TypeId::of::<T>();
+    CONTEXTS.with(|ctx| {
+        let ctx = ctx.borrow();
+        for entry in ctx.iter() {
+            if entry.0 == type_id {
+                return Some(
+                    entry
+                        .1
+                        .downcast_ref::<T>()
+                        .expect("context type mismatch (should be impossible)")
+                        .clone(),
+                );
+            }
+        }
+        None
+    })
+}
+
+/// Retrieve a context value by type, panicking if not provided.
+///
+/// Use this when the context is required and its absence is a programming error.
+///
+/// # Panics
+///
+/// Panics with a helpful message including the type name if the context
+/// was not provided.
+///
+/// # Example
+///
+/// ```ignore
+/// let cfg = expect_context::<MyConfig>();
+/// ```
+pub fn expect_context<T: Clone + 'static>() -> T {
+    use_context::<T>().unwrap_or_else(|| {
+        panic!(
+            "Context not found for type `{}`.\n\
+             Did you forget to call provide_context() in your App::run() setup?",
+            std::any::type_name::<T>()
+        )
+    })
+}
+
+/// Borrow a context value without cloning.
+///
+/// Returns `None` if the context was not provided. Use this for large structs
+/// where you only need to read a single field.
+///
+/// # Example
+///
+/// ```ignore
+/// let threshold = with_context::<Config, _>(|cfg| cfg.cpu.warn_threshold);
+/// ```
+pub fn with_context<T: 'static, R>(f: impl FnOnce(&T) -> R) -> Option<R> {
+    let type_id = TypeId::of::<T>();
+    CONTEXTS.with(|ctx| {
+        let ctx = ctx.borrow();
+        for entry in ctx.iter() {
+            if entry.0 == type_id {
+                let value = entry
+                    .1
+                    .downcast_ref::<T>()
+                    .expect("context type mismatch (should be impossible)");
+                return Some(f(value));
+            }
+        }
+        None
+    })
+}
+
+/// Check if a context value of type `T` has been provided.
+///
+/// Useful for optional features: "if a logger context exists, use it."
+///
+/// # Example
+///
+/// ```ignore
+/// if has_context::<Logger>() {
+///     let logger = expect_context::<Logger>();
+///     logger.info("widget created");
+/// }
+/// ```
+pub fn has_context<T: 'static>() -> bool {
+    let type_id = TypeId::of::<T>();
+    CONTEXTS.with(|ctx| {
+        let ctx = ctx.borrow();
+        ctx.iter().any(|entry| entry.0 == type_id)
+    })
+}
+
+/// Provide a `Signal<T>` context wrapping the given value.
+///
+/// This is the recommended pattern for mutable shared state. Creates a signal,
+/// stores it as context, and returns it. Any widget reading the signal during
+/// paint/layout auto-tracks it for reactive updates.
+///
+/// # Example
+///
+/// ```ignore
+/// // In setup:
+/// let theme = provide_signal_context(Theme::default());
+///
+/// // In any widget:
+/// let theme = expect_context::<Signal<Theme>>();
+/// container().background(move || theme.get().bg_color)
+/// ```
+pub fn provide_signal_context<T: Clone + PartialEq + Send + 'static>(value: T) -> Signal<T> {
+    let signal = create_signal(value);
+    provide_context(signal);
+    signal
+}
+
+/// Reset all context state.
+///
+/// Called during `App::drop()` to wipe thread-local context storage,
+/// enabling clean restart of the application.
+pub(crate) fn reset_contexts() {
+    CONTEXTS.with(|ctx| ctx.borrow_mut().clear());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Reset contexts before each test to avoid cross-test contamination.
+    // Tests in Rust run in the same thread sequentially per file.
+    fn setup() {
+        reset_contexts();
+    }
+
+    #[test]
+    fn test_provide_and_use_context() {
+        setup();
+        provide_context(42u32);
+        assert_eq!(use_context::<u32>(), Some(42));
+    }
+
+    #[test]
+    fn test_use_context_returns_none_when_missing() {
+        setup();
+        assert_eq!(use_context::<String>(), None);
+    }
+
+    #[test]
+    fn test_expect_context_returns_value() {
+        setup();
+        provide_context("hello".to_string());
+        assert_eq!(expect_context::<String>(), "hello");
+    }
+
+    #[test]
+    #[should_panic(expected = "Context not found for type")]
+    fn test_expect_context_panics_when_missing() {
+        setup();
+        expect_context::<f64>();
+    }
+
+    #[test]
+    fn test_with_context_borrows_without_clone() {
+        setup();
+        provide_context(vec![1, 2, 3]);
+        let sum = with_context::<Vec<i32>, _>(|v| v.iter().sum::<i32>());
+        assert_eq!(sum, Some(6));
+    }
+
+    #[test]
+    fn test_with_context_returns_none_when_missing() {
+        setup();
+        let result = with_context::<Vec<i32>, _>(|v| v.len());
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_has_context() {
+        setup();
+        assert!(!has_context::<u64>());
+        provide_context(99u64);
+        assert!(has_context::<u64>());
+    }
+
+    #[test]
+    fn test_provide_replaces_existing() {
+        setup();
+        provide_context(10u32);
+        provide_context(20u32);
+        assert_eq!(use_context::<u32>(), Some(20));
+    }
+
+    #[test]
+    fn test_multiple_types() {
+        setup();
+        provide_context(42u32);
+        provide_context("hello".to_string());
+        provide_context(2.72f64);
+
+        assert_eq!(use_context::<u32>(), Some(42));
+        assert_eq!(use_context::<String>(), Some("hello".to_string()));
+        assert_eq!(use_context::<f64>(), Some(2.72));
+    }
+
+    #[test]
+    fn test_reset_clears_all() {
+        setup();
+        provide_context(42u32);
+        provide_context("hello".to_string());
+        reset_contexts();
+        assert_eq!(use_context::<u32>(), None);
+        assert_eq!(use_context::<String>(), None);
+    }
+
+    #[test]
+    fn test_provide_signal_context() {
+        setup();
+        let signal = provide_signal_context(100i32);
+        assert_eq!(signal.get(), 100);
+
+        // Retrieve via use_context
+        let retrieved = use_context::<Signal<i32>>().unwrap();
+        assert_eq!(retrieved.get(), 100);
+
+        // Signal set propagates
+        signal.set(200);
+        assert_eq!(retrieved.get(), 200);
+    }
+}

--- a/src/reactive/mod.rs
+++ b/src/reactive/mod.rs
@@ -1,4 +1,5 @@
 pub mod clipboard;
+pub mod context;
 pub mod cursor;
 pub mod effect;
 pub mod focus;
@@ -13,6 +14,9 @@ pub mod storage;
 
 pub(crate) use clipboard::{
     clipboard_copy, clipboard_paste, set_system_clipboard, take_clipboard_change,
+};
+pub use context::{
+    expect_context, has_context, provide_context, provide_signal_context, use_context, with_context,
 };
 pub(crate) use cursor::take_cursor_change;
 pub use cursor::{CursorIcon, set_cursor};
@@ -49,4 +53,5 @@ pub(crate) fn reset_reactive() {
     clipboard::reset_clipboard();
     cursor::reset_cursor();
     focus::reset_focus();
+    context::reset_contexts();
 }


### PR DESCRIPTION
## Summary

- Adds a global context system (`provide_context` / `use_context` / `expect_context`) for sharing app-wide state (config, theme, services) without prop drilling
- Uses `Vec<(TypeId, Box<dyn Any>)>` with linear scan — optimal for the ~3-8 context values typical in layer shell apps
- Additional APIs: `with_context` (zero-clone borrow), `has_context` (existence check), `provide_signal_context` (creates a reactive signal context in one step)
- Integrated into `reset_reactive()` for clean `App::drop()` lifecycle
- 11 unit tests, design doc update, new book chapter

## Test plan

- [x] `cargo build` compiles
- [x] `cargo test` — 172 tests pass (11 new context tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all --check` — formatted
- [x] `mdbook build book` — book builds without errors