### PR TITLE
fix: use ColorMode::Web for text atlas color handling

### DIFF
--- a/src/renderer/text.rs
+++ b/src/renderer/text.rs
@@ -1,8 +1,8 @@
 use std::collections::HashSet;
 
 use glyphon::{
-    Attrs, Buffer, Cache, Color as GlyphonColor, FontSystem, Metrics, Resolution, Shaping,
-    SwashCache, TextArea, TextAtlas, TextBounds, TextRenderer, Viewport,
+    Attrs, Buffer, Cache, Color as GlyphonColor, ColorMode, FontSystem, Metrics, Resolution,
+    Shaping, SwashCache, TextArea, TextAtlas, TextBounds, TextRenderer, Viewport,
 };
 use wgpu::{Device, MultisampleState, Queue};
 
@@ -31,7 +31,7 @@ impl TextRenderState {
         }
         let swash_cache = SwashCache::new();
         let cache = Cache::new(device);
-        let mut atlas = TextAtlas::new(device, queue, &cache, format);
+        let mut atlas = TextAtlas::with_color_mode(device, queue, &cache, format, ColorMode::Web);
         let text_renderer =
             TextRenderer::new(&mut atlas, device, MultisampleState::default(), None);
         let viewport = Viewport::new(device, &cache);

--- a/src/renderer/text_quad.rs
+++ b/src/renderer/text_quad.rs
@@ -10,8 +10,8 @@
 use std::sync::Arc;
 
 use glyphon::{
-    Attrs, Buffer, Cache, Color as GlyphonColor, FontSystem, Metrics, Resolution, Shaping,
-    SwashCache, TextArea, TextAtlas, TextBounds, TextRenderer, Viewport,
+    Attrs, Buffer, Cache, Color as GlyphonColor, ColorMode, FontSystem, Metrics, Resolution,
+    Shaping, SwashCache, TextArea, TextAtlas, TextBounds, TextRenderer, Viewport,
 };
 use wgpu::util::DeviceExt;
 use wgpu::{
@@ -78,7 +78,7 @@ impl TextQuadRenderer {
         }
         let swash_cache = SwashCache::new();
         let cache = Cache::new(device);
-        let mut atlas = TextAtlas::new(device, queue, &cache, format);
+        let mut atlas = TextAtlas::with_color_mode(device, queue, &cache, format, ColorMode::Web);
         let text_renderer =
             TextRenderer::new(&mut atlas, device, MultisampleState::default(), None);
         let viewport = Viewport::new(device, &cache);


### PR DESCRIPTION
## Summary

- Switch `TextAtlas::new()` to `TextAtlas::with_color_mode(..., ColorMode::Web)` in both text renderers (`text.rs` and `text_quad.rs`) for correct web-standard color interpretation.

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [ ] Visual verification: text colors render correctly