### PR TITLE
fix: remove WriteSignal::get() to prevent thread-safety panic

### DIFF
--- a/src/reactive/signal.rs
+++ b/src/reactive/signal.rs
@@ -204,11 +204,6 @@ impl<T: Clone + PartialEq + Send + 'static> WriteSignal<T> {
             });
         }
     }
-
-    /// Get the current value (useful for read-modify-write patterns on main thread)
-    pub fn get(&self) -> T {
-        get_signal_value(self.id)
-    }
 }
 
 pub fn create_signal<T: Clone + PartialEq + Send + 'static>(value: T) -> Signal<T> {


### PR DESCRIPTION
## Summary
- Remove `WriteSignal::get()` which accessed thread-local signal storage without checking thread affinity
- `WriteSignal<T>` is `Send` and used from background threads (tokio tasks), but `get()` would panic when called off the main thread since the thread-local `STORAGE` is empty there
- The method was unused across the codebase

## Test plan
- [x] `cargo clippy` passes
- [x] `cargo test` (existing signal tests cover remaining WriteSignal API)