### PR TITLE
feat: function-based component macro + integer Length support

### DIFF
--- a/book/src/advanced/components.md
+++ b/book/src/advanced/components.md
@@ -1,6 +1,6 @@
 # Creating Components
 
-The `#[component]` macro creates reusable widgets with props, callbacks, and children.
+The `#[component]` macro creates reusable widgets from functions. Function parameters become props, and the function body becomes the render method.
 
 ![Component Example](../images/component_example.png)
 
@@ -10,21 +10,14 @@ The `#[component]` macro creates reusable widgets with props, callbacks, and chi
 use guido::prelude::*;
 
 #[component]
-pub struct Button {
-    #[prop]
-    label: String,
-}
-
-impl Button {
-    fn render(&self) -> impl Widget {
-        container()
-            .padding(12.0)
-            .background(Color::rgb(0.3, 0.5, 0.8))
-            .corner_radius(6.0)
-            .hover_state(|s| s.lighter(0.1))
-            .pressed_state(|s| s.ripple())
-            .child(text(self.label.clone()).color(Color::WHITE))
-    }
+pub fn button(label: String) -> impl Widget {
+    container()
+        .padding(12.0)
+        .background(Color::rgb(0.3, 0.5, 0.8))
+        .corner_radius(6.0)
+        .hover_state(|s| s.lighter(0.1))
+        .pressed_state(|s| s.ripple())
+        .child(text(label.clone()).color(Color::WHITE))
 }
 ```
 
@@ -34,16 +27,22 @@ Use the component with the auto-generated builder:
 button().label("Click me")
 ```
 
+The macro generates a `Button` struct (PascalCase) and a `button()` constructor function from the function name.
+
 ## Props
 
-### Required Props
+All function parameters are props. Use `#[prop(...)]` attributes for special behavior.
+
+### Standard Props
+
+Parameters without attributes become standard props with `Default::default()`:
 
 ```rust
-#[prop]
-label: String,
+#[component]
+pub fn button(label: String) -> impl Widget {
+    container().child(text(label.clone()))
+}
 ```
-
-Must be provided when creating the component:
 
 ```rust
 button().label("Required")
@@ -52,14 +51,22 @@ button().label("Required")
 ### Props with Defaults
 
 ```rust
-#[prop(default = "Color::rgb(0.3, 0.3, 0.4)")]
-background: Color,
-
-#[prop(default = "8.0")]
-padding: f32,
+#[component]
+pub fn button(
+    label: String,
+    #[prop(default = "Color::rgb(0.3, 0.3, 0.4)")]
+    background: Color,
+    #[prop(default = "8.0")]
+    padding: f32,
+) -> impl Widget {
+    container()
+        .padding(padding.get())
+        .background(background.clone())
+        .child(text(label.clone()).color(Color::WHITE))
+}
 ```
 
-Optional - uses default if not specified:
+Optional — uses default if not specified:
 
 ```rust
 button().label("Uses defaults")
@@ -69,8 +76,15 @@ button().label("Custom").background(Color::RED).padding(16.0)
 ### Callback Props
 
 ```rust
-#[prop(callback)]
-on_click: (),
+#[component]
+pub fn button(
+    label: String,
+    #[prop(callback)] on_click: (),
+) -> impl Widget {
+    container()
+        .on_click_option(on_click.clone())
+        .child(text(label.clone()))
+}
 ```
 
 Provide closures for events:
@@ -81,24 +95,23 @@ button()
     .on_click(|| println!("Clicked!"))
 ```
 
-In render, use `on_click_option` for optional callbacks:
-
-```rust
-.on_click_option(self.on_click.clone())
-```
-
 ## Accessing Props
 
-In the `render` method:
+In the function body, each prop is available as a reference to its stored type. For standard props, this is `&MaybeDyn<T>`:
 
 ```rust
-impl Button {
-    fn render(&self) -> impl Widget {
-        container()
-            .padding(self.padding.get())      // Use .get() for value props
-            .background(self.background.clone())  // Clone for reactive props
-            .child(text(self.label.clone()))
-    }
+#[component]
+pub fn button(
+    label: String,
+    #[prop(default = "8.0")] padding: f32,
+    #[prop(default = "Color::rgb(0.3, 0.3, 0.4)")] background: Color,
+    #[prop(callback)] on_click: (),
+) -> impl Widget {
+    container()
+        .padding(padding.get())           // Use .get() for value props
+        .background(background.clone())   // Clone for reactive props
+        .on_click_option(on_click.clone()) // Clone optional callback
+        .child(text(label.clone()))
 }
 ```
 
@@ -106,23 +119,17 @@ impl Button {
 
 ```rust
 #[component]
-pub struct Card {
-    #[prop]
+pub fn card(
     title: String,
-    #[prop(children)]
-    children: (),
-}
-
-impl Card {
-    fn render(&self) -> impl Widget {
-        container()
-            .padding(16.0)
-            .background(Color::rgb(0.18, 0.18, 0.22))
-            .corner_radius(8.0)
-            .layout(Flex::column().spacing(8.0))
-            .child(text(self.title.clone()).font_size(18.0).color(Color::WHITE))
-            .children_source(self.take_children())
-    }
+    #[prop(children)] children: (),
+) -> impl Widget {
+    container()
+        .padding(16.0)
+        .background(Color::rgb(0.18, 0.18, 0.22))
+        .corner_radius(8.0)
+        .layout(Flex::column().spacing(8.0))
+        .child(text(title.clone()).font_size(18.0).color(Color::WHITE))
+        .children_source(self.take_children())
 }
 ```
 
@@ -142,25 +149,18 @@ like headers, sidebars, or multi-region containers:
 
 ```rust
 #[component]
-pub struct CenterBox {
-    #[prop(slot)]
-    left: (),
-    #[prop(slot)]
-    center: (),
-    #[prop(slot)]
-    right: (),
-}
-
-impl CenterBox {
-    fn render(&self) -> impl Widget {
-        container()
-            .layout(Flex::row())
-            .children(vec![
-                self.take_left(),
-                self.take_center(),
-                self.take_right(),
-            ].into_iter().flatten())
-    }
+pub fn center_box(
+    #[prop(slot)] left: (),
+    #[prop(slot)] center: (),
+    #[prop(slot)] right: (),
+) -> impl Widget {
+    container()
+        .layout(Flex::row())
+        .children(vec![
+            self.take_left(),
+            self.take_center(),
+            self.take_right(),
+        ].into_iter().flatten())
 }
 ```
 
@@ -173,7 +173,7 @@ center_box()
     .right(text("Right"))
 ```
 
-Each slot accepts any `impl Widget + 'static`. Inside `render`, call `self.take_<name>()`
+Each slot accepts any `impl Widget + 'static`. Inside the function body, call `self.take_<name>()`
 to consume the slot — it returns `Option<Box<dyn Widget>>`.
 
 ## Reactive Props
@@ -200,50 +200,35 @@ button()
 use guido::prelude::*;
 
 #[component]
-pub struct Button {
-    #[prop]
+pub fn button(
     label: String,
-    #[prop(default = "Color::rgb(0.3, 0.3, 0.4)")]
-    background: Color,
-    #[prop(default = "8.0")]
-    padding: f32,
-    #[prop(callback)]
-    on_click: (),
-}
-
-impl Button {
-    fn render(&self) -> impl Widget {
-        container()
-            .padding(self.padding.get())
-            .background(self.background.clone())
-            .corner_radius(6.0)
-            .hover_state(|s| s.lighter(0.1))
-            .pressed_state(|s| s.ripple())
-            .on_click_option(self.on_click.clone())
-            .child(text(self.label.clone()).color(Color::WHITE))
-    }
+    #[prop(default = "Color::rgb(0.3, 0.3, 0.4)")] background: Color,
+    #[prop(default = "8.0")] padding: f32,
+    #[prop(callback)] on_click: (),
+) -> impl Widget {
+    container()
+        .padding(padding.get())
+        .background(background.clone())
+        .corner_radius(6.0)
+        .hover_state(|s| s.lighter(0.1))
+        .pressed_state(|s| s.ripple())
+        .on_click_option(on_click.clone())
+        .child(text(label.clone()).color(Color::WHITE))
 }
 
 #[component]
-pub struct Card {
-    #[prop]
+pub fn card(
     title: String,
-    #[prop(default = "Color::rgb(0.18, 0.18, 0.22)")]
-    background: Color,
-    #[prop(children)]
-    children: (),
-}
-
-impl Card {
-    fn render(&self) -> impl Widget {
-        container()
-            .padding(16.0)
-            .background(self.background.get())
-            .corner_radius(8.0)
-            .layout(Flex::column().spacing(8.0))
-            .child(text(self.title.clone()).font_size(18.0).color(Color::WHITE))
-            .children_source(self.take_children())
-    }
+    #[prop(default = "Color::rgb(0.18, 0.18, 0.22)")] background: Color,
+    #[prop(children)] children: (),
+) -> impl Widget {
+    container()
+        .padding(16.0)
+        .background(background.get())
+        .corner_radius(8.0)
+        .layout(Flex::column().spacing(8.0))
+        .child(text(title.clone()).font_size(18.0).color(Color::WHITE))
+        .children_source(self.take_children())
 }
 
 fn main() {

--- a/book/src/building-ui/styling.md
+++ b/book/src/building-ui/styling.md
@@ -81,6 +81,14 @@ container()
     .height(50.0)
 ```
 
+Integers work too:
+
+```rust
+container()
+    .width(100)
+    .height(50)
+```
+
 ### Constraints
 
 ```rust

--- a/book/src/building-ui/styling.md
+++ b/book/src/building-ui/styling.md
@@ -99,11 +99,13 @@ container()
     .max_height(100.0)
 ```
 
-### At Least
+### At Least / At Most
 
 ```rust
-container().width(at_least(100.0))  // At least 100px
-container().height(at_least(50.0))  // At least 50px
+container().width(at_least(100.0))           // At least 100px
+container().width(at_least(100))             // Integers work too
+container().width(at_most(400))              // At most 400px
+container().width(at_least(100).at_most(400)) // Range
 ```
 
 ## Complete Example

--- a/docs/REACTIVE.md
+++ b/docs/REACTIVE.md
@@ -429,30 +429,23 @@ Owner scopes are automatically nested. When a parent owner is disposed, children
 
 ### Component Macro Integration
 
-Components created with `#[component]` automatically wrap their `render()` in an owner scope. When the component is dropped, all its reactive resources are cleaned up:
+Components created with `#[component]` automatically wrap their render body in an owner scope. When the component is dropped, all its reactive resources are cleaned up:
 
 ```rust
 #[component]
-pub struct Counter {
-    #[prop]
-    initial: i32,
-}
+pub fn counter(initial: i32) -> impl Widget {
+    // This signal is owned by the component
+    let count = create_signal(initial.get());
 
-impl Counter {
-    fn render(&self) -> impl Widget {
-        // This signal is owned by the component
-        let count = create_signal(self.initial.get());
+    // This effect is also owned
+    create_effect(move || {
+        println!("Count: {}", count.get());
+    });
 
-        // This effect is also owned
-        create_effect(move || {
-            println!("Count: {}", count.get());
-        });
-
-        // When Counter is dropped, signal and effect are disposed
-        container()
-            .on_click(move || count.update(|c| *c += 1))
-            .child(text(move || count.get().to_string()))
-    }
+    // When Counter is dropped, signal and effect are disposed
+    container()
+        .on_click(move || count.update(|c| *c += 1))
+        .child(text(move || count.get().to_string()))
 }
 ```
 

--- a/examples/component_example.rs
+++ b/examples/component_example.rs
@@ -2,51 +2,36 @@ use guido::prelude::*;
 
 /// A reusable Button component
 #[component]
-pub struct Button {
-    #[prop]
+pub fn button(
     label: String,
-    #[prop(default = "Color::rgb(0.3, 0.3, 0.4)")]
-    background: Color,
-    #[prop(default = "8.0")]
-    padding: f32,
-    #[prop(callback)]
-    on_click: (),
-}
-
-impl Button {
-    fn render(&self) -> impl Widget + use<> {
-        container()
-            .padding(self.padding.get())
-            .background(self.background.clone())
-            .corner_radius(6.0)
-            .hover_state(|s| s.lighter(0.1))
-            .pressed_state(|s| s.ripple())
-            .on_click_option(self.on_click.clone())
-            .child(text(self.label.clone()).color(Color::WHITE))
-    }
+    #[prop(default = "Color::rgb(0.3, 0.3, 0.4)")] background: Color,
+    #[prop(default = "8.0")] padding: f32,
+    #[prop(callback)] on_click: (),
+) -> impl Widget {
+    container()
+        .padding(padding.get())
+        .background(background.clone())
+        .corner_radius(6.0)
+        .hover_state(|s| s.lighter(0.1))
+        .pressed_state(|s| s.ripple())
+        .on_click_option(on_click.clone())
+        .child(text(label.clone()).color(Color::WHITE))
 }
 
 /// A reusable Card component with children
 #[component]
-pub struct Card {
-    #[prop]
+pub fn card(
     title: String,
-    #[prop(default = "Color::rgb(0.18, 0.18, 0.22)")]
-    background: Color,
-    #[prop(children)]
-    children: (),
-}
-
-impl Card {
-    fn render(&self) -> impl Widget + use<> {
-        container()
-            .padding(16.0)
-            .background(self.background.get())
-            .corner_radius(8.0)
-            .layout(Flex::column().spacing(8.0))
-            .child(text(self.title.clone()).font_size(18.0).color(Color::WHITE))
-            .children_source(self.take_children())
-    }
+    #[prop(default = "Color::rgb(0.18, 0.18, 0.22)")] background: Color,
+    #[prop(children)] children: (),
+) -> impl Widget {
+    container()
+        .padding(16.0)
+        .background(background.get())
+        .corner_radius(8.0)
+        .layout(Flex::column().spacing(8.0))
+        .child(text(title.clone()).font_size(18.0).color(Color::WHITE))
+        .children_source(self.take_children())
 }
 
 fn main() {

--- a/guido-macros/src/lib.rs
+++ b/guido-macros/src/lib.rs
@@ -1,76 +1,85 @@
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
-use syn::{DeriveInput, Fields, ItemStruct, Meta, Type, TypeBareFn, parse_macro_input};
+use syn::{DeriveInput, Fields, ItemFn, Meta, Type, TypeBareFn, parse_macro_input};
 
-/// Attribute macro to create a reusable component with builder pattern that automatically implements Widget
+/// Attribute macro to create a reusable component from a function.
 ///
-/// # Attributes on fields
-/// - `#[prop]` - Standard prop, generates builder method accepting `impl IntoMaybeDyn<T>`
-/// - `#[prop(default = "expr")]` - Prop with default value
-/// - `#[prop(callback)]` - Generates callback accepting `impl Fn() + 'static`. Use `fn(T)` as the field type for typed params (e.g., `on_change: fn(i32)` → `Fn(i32)`)
-/// - `#[prop(children)]` - Marks field for children support
-/// - `#[prop(slot)]` - Named widget slot, generates `RefCell<Option<Box<dyn Widget>>>` with builder and `take_` accessor
+/// The function name becomes the constructor (snake_case), and a PascalCase struct
+/// is generated. Function parameters become props, and the function body becomes
+/// the render method.
+///
+/// # Attributes on parameters
+/// - No attribute — standard prop, `MaybeDyn<T>`, default = `Default::default()`
+/// - `#[prop(default = "expr")]` — standard prop with custom default
+/// - `#[prop(callback)]` — callback prop. Use `()` for `Fn()`, or `fn(T1, T2)` for typed params
+/// - `#[prop(children)]` — children support via `ChildrenSource`
+/// - `#[prop(slot)]` — named widget slot
 ///
 /// # Example
 /// ```ignore
 /// #[component]
-/// pub struct Button {
-///     #[prop]
+/// pub fn button(
 ///     label: String,
+///     #[prop(default = "Color::rgb(0.3, 0.3, 0.4)")]
+///     background: Color,
+///     #[prop(default = "8.0")]
+///     padding: f32,
 ///     #[prop(callback)]
 ///     on_click: (),
-/// }
-///
-/// impl Button {
-///     fn render(&self) -> impl Widget {
-///         container().child(text(self.label.clone()))
-///     }
+/// ) -> impl Widget {
+///     container()
+///         .padding(padding.get())
+///         .background(background.clone())
+///         .on_click_option(on_click.clone())
+///         .child(text(label.clone()).color(Color::WHITE))
 /// }
 /// ```
 #[proc_macro_attribute]
 pub fn component(_attr: TokenStream, input: TokenStream) -> TokenStream {
-    let input = parse_macro_input!(input as ItemStruct);
+    let input = parse_macro_input!(input as ItemFn);
 
-    let struct_name = &input.ident;
+    let fn_name = &input.sig.ident;
     let vis = &input.vis;
+    let body = &input.block;
+    let struct_name = format_ident!("{}", to_pascal_case(&fn_name.to_string()));
 
-    // Extract fields
-    let fields = match &input.fields {
-        Fields::Named(fields) => &fields.named,
-        _ => {
-            return syn::Error::new_spanned(
-                &input,
-                "Component can only be used on structs with named fields",
-            )
-            .to_compile_error()
-            .into();
-        }
-    };
-
-    // Parse field information
+    // Extract props from function parameters
     let mut prop_fields = Vec::new();
     let mut has_children = false;
 
-    for field in fields {
-        let field_name = field.ident.as_ref().unwrap();
-        let field_type = &field.ty;
+    for arg in &input.sig.inputs {
+        let syn::FnArg::Typed(pat_type) = arg else {
+            return syn::Error::new_spanned(arg, "Component functions cannot have self parameters")
+                .to_compile_error()
+                .into();
+        };
 
-        // Skip if no #[prop] attribute
-        let prop_attr = field.attrs.iter().find(|attr| attr.path().is_ident("prop"));
+        // Get the parameter name
+        let syn::Pat::Ident(pat_ident) = pat_type.pat.as_ref() else {
+            return syn::Error::new_spanned(
+                &pat_type.pat,
+                "Component parameters must be simple identifiers",
+            )
+            .to_compile_error()
+            .into();
+        };
+        let field_name = &pat_ident.ident;
+        let field_type = &*pat_type.ty;
 
-        if prop_attr.is_none() {
-            continue;
-        }
+        // Check for #[prop(...)] attributes on the parameter
+        let prop_attr = pat_type
+            .attrs
+            .iter()
+            .find(|attr| attr.path().is_ident("prop"));
 
-        let prop_attr = prop_attr.unwrap();
-
-        // Parse attribute arguments
         let mut default_value: Option<String> = None;
         let mut is_callback = false;
         let mut is_children = false;
         let mut is_slot = false;
 
-        if let Meta::List(meta_list) = &prop_attr.meta {
+        if let Some(prop_attr) = prop_attr
+            && let Meta::List(meta_list) = &prop_attr.meta
+        {
             let tokens_str = meta_list.tokens.to_string();
 
             if tokens_str.contains("callback") {
@@ -86,13 +95,11 @@ pub fn component(_attr: TokenStream, input: TokenStream) -> TokenStream {
                 is_slot = true;
             }
 
-            if tokens_str.contains("default") {
-                // Extract default value between quotes
-                if let Some(start) = tokens_str.find('"')
-                    && let Some(end) = tokens_str[start + 1..].find('"')
-                {
-                    default_value = Some(tokens_str[start + 1..start + 1 + end].to_string());
-                }
+            if tokens_str.contains("default")
+                && let Some(start) = tokens_str.find('"')
+                && let Some(end) = tokens_str[start + 1..].find('"')
+            {
+                default_value = Some(tokens_str[start + 1..start + 1 + end].to_string());
             }
         }
 
@@ -244,9 +251,18 @@ pub fn component(_attr: TokenStream, input: TokenStream) -> TokenStream {
         })
         .collect();
 
-    // Create snake_case constructor name
-    let constructor_name =
-        syn::Ident::new(&to_snake_case(&struct_name.to_string()), struct_name.span());
+    // Generate render method body: bind each prop as a local variable, then run the body
+    let prop_bindings = prop_fields.iter().map(|field| {
+        let name = &field.name;
+        if field.is_children {
+            // Children are accessed via take_children(), not a local binding
+            quote! {}
+        } else {
+            quote! {
+                let #name = &self.#name;
+            }
+        }
+    });
 
     let expanded = quote! {
         #vis struct #struct_name {
@@ -269,6 +285,11 @@ pub fn component(_attr: TokenStream, input: TokenStream) -> TokenStream {
             #children_methods
 
             #(#slot_methods)*
+
+            fn render(&self) -> impl ::guido::widgets::Widget + use<> {
+                #(#prop_bindings)*
+                #body
+            }
 
             fn ensure_built(&self) {
                 if self.__inner.borrow().is_some() {
@@ -326,7 +347,7 @@ pub fn component(_attr: TokenStream, input: TokenStream) -> TokenStream {
             }
         }
 
-        #vis fn #constructor_name() -> #struct_name {
+        #vis fn #fn_name() -> #struct_name {
             #struct_name::new()
         }
     };
@@ -346,20 +367,18 @@ struct PropField {
     is_slot: bool,
 }
 
-fn to_snake_case(s: &str) -> String {
+fn to_pascal_case(s: &str) -> String {
     let mut result = String::new();
-    let mut prev_is_lower = false;
+    let mut capitalize_next = true;
 
-    for (i, c) in s.chars().enumerate() {
-        if c.is_uppercase() {
-            if i > 0 && prev_is_lower {
-                result.push('_');
-            }
-            result.push(c.to_lowercase().next().unwrap());
-            prev_is_lower = false;
+    for c in s.chars() {
+        if c == '_' {
+            capitalize_next = true;
+        } else if capitalize_next {
+            result.push(c.to_uppercase().next().unwrap());
+            capitalize_next = false;
         } else {
             result.push(c);
-            prev_is_lower = c.is_lowercase();
         }
     }
 

--- a/src/animation/mod.rs
+++ b/src/animation/mod.rs
@@ -19,9 +19,9 @@ pub struct Transition {
 
 impl Transition {
     /// Create a new transition with the given duration and timing function
-    pub fn new(duration_ms: f32, timing: TimingFunction) -> Self {
+    pub fn new(duration_ms: impl crate::layout::IntoF32, timing: TimingFunction) -> Self {
         Self {
-            duration_ms,
+            duration_ms: duration_ms.into_f32(),
             timing,
             delay_ms: 0.0,
         }
@@ -37,14 +37,14 @@ impl Transition {
     }
 
     /// Set the delay before the animation starts
-    pub fn delay(mut self, delay_ms: f32) -> Self {
-        self.delay_ms = delay_ms;
+    pub fn delay(mut self, delay_ms: impl crate::layout::IntoF32) -> Self {
+        self.delay_ms = delay_ms.into_f32();
         self
     }
 
     /// Set the duration of the animation
-    pub fn duration(mut self, duration_ms: f32) -> Self {
-        self.duration_ms = duration_ms;
+    pub fn duration(mut self, duration_ms: impl crate::layout::IntoF32) -> Self {
+        self.duration_ms = duration_ms.into_f32();
         self
     }
 

--- a/src/layout/flex_layout.rs
+++ b/src/layout/flex_layout.rs
@@ -260,9 +260,9 @@ impl Flex {
             MainAlignment::SpaceBetween
             | MainAlignment::SpaceAround
             | MainAlignment::SpaceEvenly => main_max,
-            MainAlignment::Start
-            | MainAlignment::Center
-            | MainAlignment::End => total_main.max(main_min).min(main_max),
+            MainAlignment::Start | MainAlignment::Center | MainAlignment::End => {
+                total_main.max(main_min).min(main_max)
+            }
         };
 
         let cross_size = max_cross.max(cross_constraint_min).min(cross_max);

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -122,6 +122,24 @@ impl From<f32> for Length {
     }
 }
 
+impl From<i32> for Length {
+    fn from(value: i32) -> Self {
+        Length::from(value as f32)
+    }
+}
+
+impl From<u16> for Length {
+    fn from(value: u16) -> Self {
+        Length::from(value as f32)
+    }
+}
+
+impl From<u32> for Length {
+    fn from(value: u32) -> Self {
+        Length::from(value as f32)
+    }
+}
+
 impl IntoMaybeDyn<Length> for Length {
     fn into_maybe_dyn(self) -> MaybeDyn<Length> {
         MaybeDyn::Static(self)
@@ -129,6 +147,24 @@ impl IntoMaybeDyn<Length> for Length {
 }
 
 impl IntoMaybeDyn<Length> for f32 {
+    fn into_maybe_dyn(self) -> MaybeDyn<Length> {
+        MaybeDyn::Static(Length::from(self))
+    }
+}
+
+impl IntoMaybeDyn<Length> for i32 {
+    fn into_maybe_dyn(self) -> MaybeDyn<Length> {
+        MaybeDyn::Static(Length::from(self))
+    }
+}
+
+impl IntoMaybeDyn<Length> for u16 {
+    fn into_maybe_dyn(self) -> MaybeDyn<Length> {
+        MaybeDyn::Static(Length::from(self))
+    }
+}
+
+impl IntoMaybeDyn<Length> for u32 {
     fn into_maybe_dyn(self) -> MaybeDyn<Length> {
         MaybeDyn::Static(Length::from(self))
     }

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -11,6 +11,38 @@ use crate::{
     tree::{Tree, WidgetId},
 };
 
+/// Trait for types that can be converted to f32 for use in layout dimensions.
+///
+/// This extends beyond `Into<f32>` to include `i32` and `u32` which don't have
+/// lossless `From<T>` impls for `f32` but are commonly used for pixel values.
+pub trait IntoF32 {
+    fn into_f32(self) -> f32;
+}
+
+impl IntoF32 for f32 {
+    fn into_f32(self) -> f32 {
+        self
+    }
+}
+
+impl IntoF32 for i32 {
+    fn into_f32(self) -> f32 {
+        self as f32
+    }
+}
+
+impl IntoF32 for u16 {
+    fn into_f32(self) -> f32 {
+        self as f32
+    }
+}
+
+impl IntoF32 for u32 {
+    fn into_f32(self) -> f32 {
+        self as f32
+    }
+}
+
 /// A unified sizing type that can specify exact, min, max, or range constraints.
 ///
 /// # Examples
@@ -43,15 +75,25 @@ pub struct Length {
 }
 
 impl Length {
+    /// Create a length with an exact value.
+    pub fn exact(value: impl IntoF32) -> Self {
+        Length {
+            min: None,
+            max: None,
+            exact: Some(value.into_f32()),
+            fill: false,
+        }
+    }
+
     /// Add a minimum constraint to this length.
-    pub fn at_least(mut self, min: f32) -> Self {
-        self.min = Some(min);
+    pub fn at_least(mut self, min: impl IntoF32) -> Self {
+        self.min = Some(min.into_f32());
         self
     }
 
     /// Add a maximum constraint to this length.
-    pub fn at_most(mut self, max: f32) -> Self {
-        self.max = Some(max);
+    pub fn at_most(mut self, max: impl IntoF32) -> Self {
+        self.max = Some(max.into_f32());
         self
     }
 }
@@ -63,11 +105,12 @@ impl Length {
 /// use guido::prelude::*;
 ///
 /// container().width(at_least(100.0));
+/// container().width(at_least(100));
 /// container().width(at_least(50.0).at_most(400.0));
 /// ```
-pub fn at_least(min: f32) -> Length {
+pub fn at_least(min: impl IntoF32) -> Length {
     Length {
-        min: Some(min),
+        min: Some(min.into_f32()),
         max: None,
         exact: None,
         fill: false,
@@ -81,12 +124,13 @@ pub fn at_least(min: f32) -> Length {
 /// use guido::prelude::*;
 ///
 /// container().width(at_most(400.0));
+/// container().width(at_most(400));
 /// container().width(at_most(400.0).at_least(50.0));
 /// ```
-pub fn at_most(max: f32) -> Length {
+pub fn at_most(max: impl IntoF32) -> Length {
     Length {
         min: None,
-        max: Some(max),
+        max: Some(max.into_f32()),
         exact: None,
         fill: false,
     }

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -20,6 +20,9 @@ use crate::{
 /// // Exact size (most common)
 /// container().width(200.0);
 ///
+/// // Integers also work
+/// container().width(200).height(100);
+///
 /// // Minimum only
 /// container().width(at_least(100.0));
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,8 +126,8 @@ pub fn quit_app() {
 pub mod prelude {
     pub use crate::animation::{SpringConfig, TimingFunction, Transition};
     pub use crate::layout::{
-        Axis, Constraints, CrossAlignment, Flex, Length, MainAlignment, Overlay, Size, at_least,
-        at_most, fill,
+        Axis, Constraints, CrossAlignment, Flex, IntoF32, Length, MainAlignment, Overlay, Size,
+        at_least, at_most, fill,
     };
     pub use crate::platform::{Anchor, KeyboardInteractivity, Layer};
     pub use crate::reactive::{

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -1136,20 +1136,18 @@ impl Widget for Container {
             // Propagate the effective minimum so layouts like Center/End know
             // how much space they actually have to position children within.
             // Sources of minimum: explicit at_least(min) or parent constraints.
-            let effective_min = width_length
-                .min
-                .unwrap_or(0.0)
-                .max(constraints.min_width);
-            (effective_min - effective_h_padding).max(0.0).min(child_max_width)
+            let effective_min = width_length.min.unwrap_or(0.0).max(constraints.min_width);
+            (effective_min - effective_h_padding)
+                .max(0.0)
+                .min(child_max_width)
         };
         let child_min_height = if height_length.exact.is_some() || height_length.fill {
             child_max_height
         } else {
-            let effective_min = height_length
-                .min
-                .unwrap_or(0.0)
-                .max(constraints.min_height);
-            (effective_min - effective_v_padding).max(0.0).min(child_max_height)
+            let effective_min = height_length.min.unwrap_or(0.0).max(constraints.min_height);
+            (effective_min - effective_v_padding)
+                .max(0.0)
+                .min(child_max_height)
         };
 
         // For scrollable containers, use unbounded constraints in scroll direction

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -102,8 +102,11 @@ pub struct Border {
 }
 
 impl Border {
-    pub fn new(width: f32, color: Color) -> Self {
-        Self { width, color }
+    pub fn new(width: impl crate::layout::IntoF32, color: Color) -> Self {
+        Self {
+            width: width.into_f32(),
+            color,
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- **Function-based `#[component]` macro**: Replace struct-based component definitions with function-based syntax. Function parameters become props, the function body becomes the render method, and a PascalCase struct is auto-generated from the function name. All parameters are implicitly props; only special modifiers (`callback`, `children`, `slot`, `default`) need `#[prop(...)]`.
- **Integer support for `Length`**: Add `From<i32/u16/u32>` and `IntoMaybeDyn<Length>` for integer types, enabling `container().width(300).height(200)` without requiring f32 literals.

## Test plan

- [x] `cargo test` — all 211 tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — no warnings
- [x] `cargo fmt --all` — formatted
- [x] `cargo check --example component_example` — function-based components compile
- [x] `mdbook build book` — docs build successfully
- [ ] CI checks pass