### PR TITLE
feat: API ergonomics improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ cargo test
 
 **`reactive/`** - Single-threaded reactive system inspired by SolidJS
 - `Signal<T>`: Main-thread reactive values with automatic dependency tracking. `!Send` — use `.writer()` for background thread updates
-- `MaybeDyn<T>`: Enum allowing widget properties to accept either static values or reactive signals/closures (uses `Rc<dyn Fn() -> T>`)
+- `MaybeDyn<T>`: Enum allowing widget properties to accept either static values or reactive signals/closures (uses `Rc<dyn Fn() -> T>`). `IntoMaybeDyn<T, M>` uses marker-type disambiguation for blanket impls — integers are accepted where `f32`/`Length`/`Padding` is expected
 - `Memo<T>`: Eager computed values that recompute when dependencies change, only notify on actual changes (`PartialEq`)
 - `Effect`: Side effects that re-run when tracked signals change
 - `Owner`: Ownership system for automatic resource cleanup (signals, effects, custom callbacks)
@@ -92,7 +92,9 @@ cargo test
 - `Container`: Handles padding, background colors, gradients, borders, corner radius, and event handlers (click, hover, scroll)
 - `Row` / `Column`: Flexbox-style layouts with alignment and spacing
 - `Text`: Text rendering with reactive content and styling
+- `AnyWidget`: Type alias for `Box<dyn Widget>` with `Widget::into_any()` for type erasure
 - All widget properties can be static values or reactive (via `IntoMaybeDyn` trait)
+- `#[component]` macro: Creates reusable widgets from functions with reactive props, callbacks, children, and slots
 
 **`renderer/`** - GPU rendering using wgpu
 - SDF-based shape rendering with custom shader pipeline

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Guido is a GPU-accelerated GUI library for building Wayland layer shell applicat
 - **Multi-Surface Apps** - Create multiple layer shell surfaces that share reactive state, with dynamic property modification
 - **Superellipse Corners** - Configurable corner curvature from squircle (iOS-style) to bevel to scoop
 - **SDF Borders** - Crisp anti-aliased borders using signed distance field rendering
+- **Component Macro** - `#[component]` macro for creating reusable widgets with reactive props, callbacks, children, and slots
+- **Type Erasure** - `AnyWidget` and `Widget::into_any()` for conditional widget branches
 - **Composable Widgets** - Build UIs from minimal primitives with pluggable Flex layout
 - **Layer Shell Support** - Native Wayland layer shell integration for status bars and panels
 - **HiDPI Support** - Automatic scaling for high-resolution displays

--- a/book/src/advanced/components.md
+++ b/book/src/advanced/components.md
@@ -129,7 +129,7 @@ pub fn card(
         .corner_radius(8.0)
         .layout(Flex::column().spacing(8.0))
         .child(text(title.clone()).font_size(18.0).color(Color::WHITE))
-        .children_source(self.take_children())
+        .children_source(children)
 }
 ```
 
@@ -157,9 +157,9 @@ pub fn center_box(
     container()
         .layout(Flex::row())
         .children(vec![
-            self.take_left(),
-            self.take_center(),
-            self.take_right(),
+            left,
+            center,
+            right,
         ].into_iter().flatten())
 }
 ```
@@ -173,8 +173,8 @@ center_box()
     .right(text("Right"))
 ```
 
-Each slot accepts any `impl Widget + 'static`. Inside the function body, call `self.take_<name>()`
-to consume the slot — it returns `Option<Box<dyn Widget>>`.
+Each slot accepts any `impl Widget + 'static`. Inside the function body, use the parameter name
+directly — it's an `Option<Box<dyn Widget>>` that was automatically consumed from the slot.
 
 ## Reactive Props
 
@@ -228,7 +228,7 @@ pub fn card(
         .corner_radius(8.0)
         .layout(Flex::column().spacing(8.0))
         .child(text(title.clone()).font_size(18.0).color(Color::WHITE))
-        .children_source(self.take_children())
+        .children_source(children)
 }
 
 fn main() {

--- a/book/src/advanced/components.md
+++ b/book/src/advanced/components.md
@@ -1,6 +1,6 @@
 # Creating Components
 
-The `#[component]` macro creates reusable widgets with props, callbacks, and children.
+The `#[component]` macro creates reusable widgets from functions. Function parameters become props, and the function body becomes the render method.
 
 ![Component Example](../images/component_example.png)
 
@@ -10,21 +10,14 @@ The `#[component]` macro creates reusable widgets with props, callbacks, and chi
 use guido::prelude::*;
 
 #[component]
-pub struct Button {
-    #[prop]
-    label: String,
-}
-
-impl Button {
-    fn render(&self) -> impl Widget {
-        container()
-            .padding(12.0)
-            .background(Color::rgb(0.3, 0.5, 0.8))
-            .corner_radius(6.0)
-            .hover_state(|s| s.lighter(0.1))
-            .pressed_state(|s| s.ripple())
-            .child(text(self.label.clone()).color(Color::WHITE))
-    }
+pub fn button(label: String) -> impl Widget {
+    container()
+        .padding(12.0)
+        .background(Color::rgb(0.3, 0.5, 0.8))
+        .corner_radius(6.0)
+        .hover_state(|s| s.lighter(0.1))
+        .pressed_state(|s| s.ripple())
+        .child(text(label.clone()).color(Color::WHITE))
 }
 ```
 
@@ -34,16 +27,22 @@ Use the component with the auto-generated builder:
 button().label("Click me")
 ```
 
+The macro generates a `Button` struct (PascalCase) and a `button()` constructor function from the function name.
+
 ## Props
 
-### Required Props
+All function parameters are props. Use `#[prop(...)]` attributes for special behavior.
+
+### Standard Props
+
+Parameters without attributes become standard props with `Default::default()`:
 
 ```rust
-#[prop]
-label: String,
+#[component]
+pub fn button(label: String) -> impl Widget {
+    container().child(text(label.clone()))
+}
 ```
-
-Must be provided when creating the component:
 
 ```rust
 button().label("Required")
@@ -52,14 +51,22 @@ button().label("Required")
 ### Props with Defaults
 
 ```rust
-#[prop(default = "Color::rgb(0.3, 0.3, 0.4)")]
-background: Color,
-
-#[prop(default = "8.0")]
-padding: f32,
+#[component]
+pub fn button(
+    label: String,
+    #[prop(default = "Color::rgb(0.3, 0.3, 0.4)")]
+    background: Color,
+    #[prop(default = "8.0")]
+    padding: f32,
+) -> impl Widget {
+    container()
+        .padding(padding.get())
+        .background(background.clone())
+        .child(text(label.clone()).color(Color::WHITE))
+}
 ```
 
-Optional - uses default if not specified:
+Optional — uses default if not specified:
 
 ```rust
 button().label("Uses defaults")
@@ -69,8 +76,15 @@ button().label("Custom").background(Color::RED).padding(16.0)
 ### Callback Props
 
 ```rust
-#[prop(callback)]
-on_click: (),
+#[component]
+pub fn button(
+    label: String,
+    #[prop(callback)] on_click: (),
+) -> impl Widget {
+    container()
+        .on_click_option(on_click.clone())
+        .child(text(label.clone()))
+}
 ```
 
 Provide closures for events:
@@ -81,24 +95,23 @@ button()
     .on_click(|| println!("Clicked!"))
 ```
 
-In render, use `on_click_option` for optional callbacks:
-
-```rust
-.on_click_option(self.on_click.clone())
-```
-
 ## Accessing Props
 
-In the `render` method:
+In the function body, each prop is available as a reference to its stored type. For standard props, this is `&MaybeDyn<T>`:
 
 ```rust
-impl Button {
-    fn render(&self) -> impl Widget {
-        container()
-            .padding(self.padding.get())      // Use .get() for value props
-            .background(self.background.clone())  // Clone for reactive props
-            .child(text(self.label.clone()))
-    }
+#[component]
+pub fn button(
+    label: String,
+    #[prop(default = "8.0")] padding: f32,
+    #[prop(default = "Color::rgb(0.3, 0.3, 0.4)")] background: Color,
+    #[prop(callback)] on_click: (),
+) -> impl Widget {
+    container()
+        .padding(padding.get())           // Use .get() for value props
+        .background(background.clone())   // Clone for reactive props
+        .on_click_option(on_click.clone()) // Clone optional callback
+        .child(text(label.clone()))
 }
 ```
 
@@ -106,23 +119,17 @@ impl Button {
 
 ```rust
 #[component]
-pub struct Card {
-    #[prop]
+pub fn card(
     title: String,
-    #[prop(children)]
-    children: (),
-}
-
-impl Card {
-    fn render(&self) -> impl Widget {
-        container()
-            .padding(16.0)
-            .background(Color::rgb(0.18, 0.18, 0.22))
-            .corner_radius(8.0)
-            .layout(Flex::column().spacing(8.0))
-            .child(text(self.title.clone()).font_size(18.0).color(Color::WHITE))
-            .children_source(self.take_children())
-    }
+    #[prop(children)] children: (),
+) -> impl Widget {
+    container()
+        .padding(16.0)
+        .background(Color::rgb(0.18, 0.18, 0.22))
+        .corner_radius(8.0)
+        .layout(Flex::column().spacing(8.0))
+        .child(text(title.clone()).font_size(18.0).color(Color::WHITE))
+        .children_source(self.take_children())
 }
 ```
 
@@ -142,25 +149,18 @@ like headers, sidebars, or multi-region containers:
 
 ```rust
 #[component]
-pub struct CenterBox {
-    #[prop(slot)]
-    left: (),
-    #[prop(slot)]
-    center: (),
-    #[prop(slot)]
-    right: (),
-}
-
-impl CenterBox {
-    fn render(&self) -> impl Widget {
-        container()
-            .layout(Flex::row())
-            .children(vec![
-                self.take_left(),
-                self.take_center(),
-                self.take_right(),
-            ].into_iter().flatten())
-    }
+pub fn center_box(
+    #[prop(slot)] left: (),
+    #[prop(slot)] center: (),
+    #[prop(slot)] right: (),
+) -> impl Widget {
+    container()
+        .layout(Flex::row())
+        .children(vec![
+            self.take_left(),
+            self.take_center(),
+            self.take_right(),
+        ].into_iter().flatten())
 }
 ```
 
@@ -173,7 +173,7 @@ center_box()
     .right(text("Right"))
 ```
 
-Each slot accepts any `impl Widget + 'static`. Inside `render`, call `self.take_<name>()`
+Each slot accepts any `impl Widget + 'static`. Inside the function body, call `self.take_<name>()`
 to consume the slot — it returns `Option<Box<dyn Widget>>`.
 
 ## Reactive Props
@@ -200,50 +200,35 @@ button()
 use guido::prelude::*;
 
 #[component]
-pub struct Button {
-    #[prop]
+pub fn button(
     label: String,
-    #[prop(default = "Color::rgb(0.3, 0.3, 0.4)")]
-    background: Color,
-    #[prop(default = "8.0")]
-    padding: f32,
-    #[prop(callback)]
-    on_click: (),
-}
-
-impl Button {
-    fn render(&self) -> impl Widget {
-        container()
-            .padding(self.padding.get())
-            .background(self.background.clone())
-            .corner_radius(6.0)
-            .hover_state(|s| s.lighter(0.1))
-            .pressed_state(|s| s.ripple())
-            .on_click_option(self.on_click.clone())
-            .child(text(self.label.clone()).color(Color::WHITE))
-    }
+    #[prop(default = "Color::rgb(0.3, 0.3, 0.4)")] background: Color,
+    #[prop(default = "8.0")] padding: f32,
+    #[prop(callback)] on_click: (),
+) -> impl Widget {
+    container()
+        .padding(padding.get())
+        .background(background.clone())
+        .corner_radius(6.0)
+        .hover_state(|s| s.lighter(0.1))
+        .pressed_state(|s| s.ripple())
+        .on_click_option(on_click.clone())
+        .child(text(label.clone()).color(Color::WHITE))
 }
 
 #[component]
-pub struct Card {
-    #[prop]
+pub fn card(
     title: String,
-    #[prop(default = "Color::rgb(0.18, 0.18, 0.22)")]
-    background: Color,
-    #[prop(children)]
-    children: (),
-}
-
-impl Card {
-    fn render(&self) -> impl Widget {
-        container()
-            .padding(16.0)
-            .background(self.background.get())
-            .corner_radius(8.0)
-            .layout(Flex::column().spacing(8.0))
-            .child(text(self.title.clone()).font_size(18.0).color(Color::WHITE))
-            .children_source(self.take_children())
-    }
+    #[prop(default = "Color::rgb(0.18, 0.18, 0.22)")] background: Color,
+    #[prop(children)] children: (),
+) -> impl Widget {
+    container()
+        .padding(16.0)
+        .background(background.get())
+        .corner_radius(8.0)
+        .layout(Flex::column().spacing(8.0))
+        .child(text(title.clone()).font_size(18.0).color(Color::WHITE))
+        .children_source(self.take_children())
 }
 
 fn main() {

--- a/book/src/advanced/components.md
+++ b/book/src/advanced/components.md
@@ -97,7 +97,7 @@ button()
 
 ## Accessing Props
 
-In the function body, each prop is available as a reference to its stored type. For standard props, this is `&MaybeDyn<T>`:
+In the function body, each prop is a reference to `&MaybeDyn<T>`. Use `.get()` to extract the current value, or `.clone()` to pass the whole `MaybeDyn<T>` to another widget method (preserving reactivity):
 
 ```rust
 #[component]
@@ -108,8 +108,8 @@ pub fn button(
     #[prop(callback)] on_click: (),
 ) -> impl Widget {
     container()
-        .padding(padding.get())           // Use .get() for value props
-        .background(background.clone())   // Clone for reactive props
+        .padding(padding.get())           // Extract value from MaybeDyn<f32>
+        .background(background.clone())   // Pass MaybeDyn<Color> (keeps reactivity)
         .on_click_option(on_click.clone()) // Clone optional callback
         .child(text(label.clone()))
 }

--- a/book/src/building-ui/styling.md
+++ b/book/src/building-ui/styling.md
@@ -67,6 +67,10 @@ container().elevation(16.0)  // Strong
 
 ```rust
 container().padding(16.0)              // All sides
+container().padding(16)                // Integers work too
+container().padding([8.0, 16.0])       // [vertical, horizontal]
+container().padding([8, 16])           // Integer arrays too
+container().padding([1.0, 2.0, 3.0, 4.0])  // [top, right, bottom, left]
 container().padding_horizontal(20.0)   // Left and right
 container().padding_vertical(10.0)     // Top and bottom
 ```

--- a/book/src/building-ui/styling.md
+++ b/book/src/building-ui/styling.md
@@ -81,6 +81,14 @@ container()
     .height(50.0)
 ```
 
+Integers work too:
+
+```rust
+container()
+    .width(100)
+    .height(50)
+```
+
 ### Constraints
 
 ```rust

--- a/book/src/building-ui/styling.md
+++ b/book/src/building-ui/styling.md
@@ -99,11 +99,13 @@ container()
     .max_height(100.0)
 ```
 
-### At Least
+### At Least / At Most
 
 ```rust
-container().width(at_least(100.0))  // At least 100px
-container().height(at_least(50.0))  // At least 50px
+container().width(at_least(100.0))           // At least 100px
+container().width(at_least(100))             // Integers work too
+container().width(at_most(400))              // At most 400px
+container().width(at_least(100).at_most(400)) // Range
 ```
 
 ## Complete Example

--- a/book/src/building-ui/text.md
+++ b/book/src/building-ui/text.md
@@ -230,11 +230,13 @@ fn article_card(title: &str, author: &str, preview: &str) -> Container {
 
 ## API Reference
 
+All properties accept static values, signals, or closures.
+
 ```rust
 text(content: impl IntoMaybeDyn<String>) -> Text
 
 impl Text {
-    pub fn font_size(self, size: impl IntoMaybeDyn<f32>) -> Self;
+    pub fn font_size(self, size: impl IntoMaybeDyn<f32>) -> Self;  // integers work: .font_size(16)
     pub fn color(self, color: impl IntoMaybeDyn<Color>) -> Self;
     pub fn font_family(self, family: impl IntoMaybeDyn<FontFamily>) -> Self;
     pub fn font_weight(self, weight: impl IntoMaybeDyn<FontWeight>) -> Self;

--- a/book/src/concepts/reactive-model.md
+++ b/book/src/concepts/reactive-model.md
@@ -112,7 +112,7 @@ pub enum MaybeDyn<T> {
 ```
 
 You don't need to use this directly - the `impl IntoMaybeDyn<T>` trait accepts:
-- Static values: `T`
+- Static values: `T` (including integers where `f32` is expected, e.g., `.width(100)`)
 - Signals: `Signal<T>`
 - Closures: `impl Fn() -> T`
 

--- a/book/src/transforms/basics.md
+++ b/book/src/transforms/basics.md
@@ -157,6 +157,8 @@ fn transform_demo() -> impl Widget {
 
 ### Container Methods
 
+All transform properties accept static values, signals, or closures. Integers also work (e.g., `.rotate(45)`, `.scale(2)`).
+
 ```rust
 impl Container {
     pub fn translate(self, x: f32, y: f32) -> Self;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -69,6 +69,10 @@ Text rendering with:
 - Font size, color, weight styling
 - Text wrapping or `nowrap()` mode
 
+**Type Erasure** (`widgets/widget.rs`)
+- `AnyWidget` type alias (`Box<dyn Widget>`) for type-erased widgets
+- `Widget::into_any()` method for boxing widgets in conditional branches
+
 **Layout System** (`widgets/layout.rs`)
 Pluggable layouts via the `Layout` trait:
 ```rust

--- a/docs/REACTIVE.md
+++ b/docs/REACTIVE.md
@@ -191,9 +191,10 @@ pub enum MaybeDyn<T> {
 ```
 
 Properties use `impl IntoMaybeDyn<T>` to accept any of:
-- Static value: `T`
+- Static value: `T` (including integers where `f32`/`Length`/`Padding` is expected)
 - Signal: `Signal<T>`
-- Closure: `impl Fn() -> T`
+- Closure: `impl Fn() -> T` (closures can also return integers for `f32` properties)
+- Memo: `Memo<T>`
 
 ## Background Task Updates
 

--- a/docs/REACTIVE.md
+++ b/docs/REACTIVE.md
@@ -429,30 +429,23 @@ Owner scopes are automatically nested. When a parent owner is disposed, children
 
 ### Component Macro Integration
 
-Components created with `#[component]` automatically wrap their `render()` in an owner scope. When the component is dropped, all its reactive resources are cleaned up:
+Components created with `#[component]` automatically wrap their render body in an owner scope. When the component is dropped, all its reactive resources are cleaned up:
 
 ```rust
 #[component]
-pub struct Counter {
-    #[prop]
-    initial: i32,
-}
+pub fn counter(initial: i32) -> impl Widget {
+    // This signal is owned by the component
+    let count = create_signal(initial.get());
 
-impl Counter {
-    fn render(&self) -> impl Widget {
-        // This signal is owned by the component
-        let count = create_signal(self.initial.get());
+    // This effect is also owned
+    create_effect(move || {
+        println!("Count: {}", count.get());
+    });
 
-        // This effect is also owned
-        create_effect(move || {
-            println!("Count: {}", count.get());
-        });
-
-        // When Counter is dropped, signal and effect are disposed
-        container()
-            .on_click(move || count.update(|c| *c += 1))
-            .child(text(move || count.get().to_string()))
-    }
+    // When Counter is dropped, signal and effect are disposed
+    container()
+        .on_click(move || count.update(|c| *c += 1))
+        .child(text(move || count.get().to_string()))
 }
 ```
 

--- a/docs/STYLING.md
+++ b/docs/STYLING.md
@@ -151,7 +151,9 @@ container()
 container().padding(16.0)                          // 16px on all sides
 container().padding(16)                            // integers work too
 container().padding([8.0, 16.0])                   // [vertical, horizontal]
+container().padding([8, 16])                       // integer arrays work too
 container().padding([1.0, 2.0, 3.0, 4.0])         // [top, right, bottom, left]
+container().padding([1, 2, 3, 4])                  // integer 4-value shorthand
 container().padding(Padding::all(8.0).top(20.0))   // builder pattern
 ```
 
@@ -163,6 +165,11 @@ container().padding(Padding::all(8.0).top(20.0))   // builder pattern
 container()
     .width(100.0)
     .height(50.0)
+
+// Integers work too
+container()
+    .width(100)
+    .height(50)
 ```
 
 ### Minimum/Maximum Size

--- a/examples/component_example.rs
+++ b/examples/component_example.rs
@@ -31,7 +31,7 @@ pub fn card(
         .corner_radius(8.0)
         .layout(Flex::column().spacing(8.0))
         .child(text(title.clone()).font_size(18.0).color(Color::WHITE))
-        .children_source(self.take_children())
+        .children_source(children)
 }
 
 fn main() {

--- a/examples/component_example.rs
+++ b/examples/component_example.rs
@@ -2,51 +2,36 @@ use guido::prelude::*;
 
 /// A reusable Button component
 #[component]
-pub struct Button {
-    #[prop]
+pub fn button(
     label: String,
-    #[prop(default = "Color::rgb(0.3, 0.3, 0.4)")]
-    background: Color,
-    #[prop(default = "8.0")]
-    padding: f32,
-    #[prop(callback)]
-    on_click: (),
-}
-
-impl Button {
-    fn render(&self) -> impl Widget + use<> {
-        container()
-            .padding(self.padding.get())
-            .background(self.background.clone())
-            .corner_radius(6.0)
-            .hover_state(|s| s.lighter(0.1))
-            .pressed_state(|s| s.ripple())
-            .on_click_option(self.on_click.clone())
-            .child(text(self.label.clone()).color(Color::WHITE))
-    }
+    #[prop(default = "Color::rgb(0.3, 0.3, 0.4)")] background: Color,
+    #[prop(default = "8.0")] padding: f32,
+    #[prop(callback)] on_click: (),
+) -> impl Widget {
+    container()
+        .padding(padding.get())
+        .background(background.clone())
+        .corner_radius(6.0)
+        .hover_state(|s| s.lighter(0.1))
+        .pressed_state(|s| s.ripple())
+        .on_click_option(on_click.clone())
+        .child(text(label.clone()).color(Color::WHITE))
 }
 
 /// A reusable Card component with children
 #[component]
-pub struct Card {
-    #[prop]
+pub fn card(
     title: String,
-    #[prop(default = "Color::rgb(0.18, 0.18, 0.22)")]
-    background: Color,
-    #[prop(children)]
-    children: (),
-}
-
-impl Card {
-    fn render(&self) -> impl Widget + use<> {
-        container()
-            .padding(16.0)
-            .background(self.background.get())
-            .corner_radius(8.0)
-            .layout(Flex::column().spacing(8.0))
-            .child(text(self.title.clone()).font_size(18.0).color(Color::WHITE))
-            .children_source(self.take_children())
-    }
+    #[prop(default = "Color::rgb(0.18, 0.18, 0.22)")] background: Color,
+    #[prop(children)] children: (),
+) -> impl Widget {
+    container()
+        .padding(16.0)
+        .background(background.get())
+        .corner_radius(8.0)
+        .layout(Flex::column().spacing(8.0))
+        .child(text(title.clone()).font_size(18.0).color(Color::WHITE))
+        .children_source(self.take_children())
 }
 
 fn main() {

--- a/guido-macros/src/lib.rs
+++ b/guido-macros/src/lib.rs
@@ -203,7 +203,7 @@ pub fn component(_attr: TokenStream, input: TokenStream) -> TokenStream {
             }
         } else {
             quote! {
-                #vis fn #name(mut self, value: impl ::guido::reactive::IntoMaybeDyn<#ty>) -> Self {
+                #vis fn #name<__M>(mut self, value: impl ::guido::reactive::IntoMaybeDyn<#ty, __M>) -> Self {
                     self.#name = value.into_maybe_dyn();
                     self
                 }

--- a/guido-macros/src/lib.rs
+++ b/guido-macros/src/lib.rs
@@ -1,6 +1,6 @@
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
-use syn::{DeriveInput, Fields, ItemFn, Meta, Type, TypeBareFn, parse_macro_input};
+use syn::{DeriveInput, Expr, Fields, ItemFn, Meta, Type, TypeBareFn, parse_macro_input};
 
 /// Attribute macro to create a reusable component from a function.
 ///
@@ -72,7 +72,7 @@ pub fn component(_attr: TokenStream, input: TokenStream) -> TokenStream {
             .iter()
             .find(|attr| attr.path().is_ident("prop"));
 
-        let mut default_value: Option<String> = None;
+        let mut default_value: Option<Expr> = None;
         let mut is_callback = false;
         let mut is_children = false;
         let mut is_slot = false;
@@ -80,26 +80,73 @@ pub fn component(_attr: TokenStream, input: TokenStream) -> TokenStream {
         if let Some(prop_attr) = prop_attr
             && let Meta::List(meta_list) = &prop_attr.meta
         {
-            let tokens_str = meta_list.tokens.to_string();
+            let nested = meta_list
+                .parse_args_with(
+                    syn::punctuated::Punctuated::<Meta, syn::Token![,]>::parse_terminated,
+                )
+                .unwrap_or_default();
 
-            if tokens_str.contains("callback") {
-                is_callback = true;
+            for meta in &nested {
+                if meta.path().is_ident("callback") {
+                    is_callback = true;
+                } else if meta.path().is_ident("children") {
+                    is_children = true;
+                    has_children = true;
+                } else if meta.path().is_ident("slot") {
+                    is_slot = true;
+                } else if meta.path().is_ident("default") {
+                    if let Meta::NameValue(nv) = meta {
+                        // If the value is a string literal, parse its contents as an expression.
+                        // This supports `#[prop(default = "Color::RED")]` syntax where the string
+                        // contains arbitrary Rust expressions.
+                        if let Expr::Lit(syn::ExprLit {
+                            lit: syn::Lit::Str(lit_str),
+                            ..
+                        }) = &nv.value
+                        {
+                            match lit_str.parse::<Expr>() {
+                                Ok(expr) => default_value = Some(expr),
+                                Err(e) => {
+                                    return syn::Error::new_spanned(
+                                        lit_str,
+                                        format!("failed to parse default value: {e}"),
+                                    )
+                                    .to_compile_error()
+                                    .into();
+                                }
+                            }
+                        } else {
+                            default_value = Some(nv.value.clone());
+                        }
+                    } else {
+                        return syn::Error::new_spanned(meta, "expected `default = <expr>`")
+                            .to_compile_error()
+                            .into();
+                    }
+                } else {
+                    return syn::Error::new_spanned(
+                        meta,
+                        format!(
+                            "unknown prop attribute: `{}`",
+                            meta.path()
+                                .get_ident()
+                                .map_or_else(|| "?".to_string(), |i| i.to_string())
+                        ),
+                    )
+                    .to_compile_error()
+                    .into();
+                }
             }
 
-            if tokens_str.contains("children") {
-                is_children = true;
-                has_children = true;
-            }
-
-            if tokens_str.contains("slot") {
-                is_slot = true;
-            }
-
-            if tokens_str.contains("default")
-                && let Some(start) = tokens_str.find('"')
-                && let Some(end) = tokens_str[start + 1..].find('"')
-            {
-                default_value = Some(tokens_str[start + 1..start + 1 + end].to_string());
+            // Validate: at most one of callback, children, slot
+            let special_count = is_callback as u8 + is_children as u8 + is_slot as u8;
+            if special_count > 1 {
+                return syn::Error::new_spanned(
+                    prop_attr,
+                    "conflicting prop attributes: only one of `callback`, `children`, `slot` is allowed",
+                )
+                .to_compile_error()
+                .into();
             }
         }
 
@@ -167,9 +214,8 @@ pub fn component(_attr: TokenStream, input: TokenStream) -> TokenStream {
                 #name: std::cell::RefCell::new(None)
             }
         } else if let Some(default) = &field.default_value {
-            let default_tokens: proc_macro2::TokenStream = default.parse().unwrap();
             quote! {
-                #name: ::guido::reactive::MaybeDyn::Static(#default_tokens)
+                #name: ::guido::reactive::MaybeDyn::Static(#default)
             }
         } else {
             quote! {
@@ -255,8 +301,14 @@ pub fn component(_attr: TokenStream, input: TokenStream) -> TokenStream {
     let prop_bindings = prop_fields.iter().map(|field| {
         let name = &field.name;
         if field.is_children {
-            // Children are accessed via take_children(), not a local binding
-            quote! {}
+            quote! {
+                let #name = self.take_children();
+            }
+        } else if field.is_slot {
+            let take_name = format_ident!("take_{}", name);
+            quote! {
+                let #name = self.#take_name();
+            }
         } else {
             quote! {
                 let #name = &self.#name;
@@ -370,7 +422,7 @@ pub fn component(_attr: TokenStream, input: TokenStream) -> TokenStream {
 struct PropField {
     name: syn::Ident,
     ty: Type,
-    default_value: Option<String>,
+    default_value: Option<Expr>,
     is_callback: bool,
     /// For callbacks: parameter types extracted from `fn(T1, T2, ...)` field type.
     /// Empty vec means `Fn()` (unit type or no params).

--- a/guido-macros/src/lib.rs
+++ b/guido-macros/src/lib.rs
@@ -316,6 +316,11 @@ pub fn component(_attr: TokenStream, input: TokenStream) -> TokenStream {
         }
 
         impl ::guido::widgets::Widget for #struct_name {
+            fn advance_animations(&mut self, tree: &mut ::guido::tree::Tree, id: ::guido::tree::WidgetId) -> bool {
+                self.ensure_built();
+                self.__inner.borrow_mut().as_mut().unwrap().advance_animations(tree, id)
+            }
+
             fn register_children(&mut self, tree: &mut ::guido::tree::Tree, id: ::guido::tree::WidgetId) {
                 self.ensure_built();
                 self.__inner.borrow_mut().as_mut().unwrap().register_children(tree, id)
@@ -324,6 +329,13 @@ pub fn component(_attr: TokenStream, input: TokenStream) -> TokenStream {
             fn reconcile_children(&mut self, tree: &mut ::guido::tree::Tree, id: ::guido::tree::WidgetId) -> bool {
                 self.ensure_built();
                 self.__inner.borrow_mut().as_mut().unwrap().reconcile_children(tree, id)
+            }
+
+            fn layout_hints(&self) -> ::guido::widgets::LayoutHints {
+                self.ensure_built();
+                self.__inner.borrow().as_ref()
+                    .map(|w| w.layout_hints())
+                    .unwrap_or_default()
             }
 
             fn layout(&mut self, tree: &mut ::guido::tree::Tree, id: ::guido::tree::WidgetId, constraints: ::guido::layout::Constraints) -> ::guido::layout::Size {

--- a/guido-macros/src/lib.rs
+++ b/guido-macros/src/lib.rs
@@ -148,6 +148,16 @@ pub fn component(_attr: TokenStream, input: TokenStream) -> TokenStream {
                 .to_compile_error()
                 .into();
             }
+
+            // Validate: callback, children, and slot props cannot have defaults
+            if (is_callback || is_children || is_slot) && default_value.is_some() {
+                return syn::Error::new_spanned(
+                    prop_attr,
+                    "callback, children, and slot props cannot have default values",
+                )
+                .to_compile_error()
+                .into();
+            }
         }
 
         // For callback fields, extract parameter types from `fn(T1, T2, ...)` syntax

--- a/guido-macros/src/lib.rs
+++ b/guido-macros/src/lib.rs
@@ -1,76 +1,85 @@
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
-use syn::{DeriveInput, Fields, ItemStruct, Meta, Type, TypeBareFn, parse_macro_input};
+use syn::{DeriveInput, Fields, ItemFn, Meta, Type, TypeBareFn, parse_macro_input};
 
-/// Attribute macro to create a reusable component with builder pattern that automatically implements Widget
+/// Attribute macro to create a reusable component from a function.
 ///
-/// # Attributes on fields
-/// - `#[prop]` - Standard prop, generates builder method accepting `impl IntoMaybeDyn<T>`
-/// - `#[prop(default = "expr")]` - Prop with default value
-/// - `#[prop(callback)]` - Generates callback accepting `impl Fn() + 'static`. Use `fn(T)` as the field type for typed params (e.g., `on_change: fn(i32)` → `Fn(i32)`)
-/// - `#[prop(children)]` - Marks field for children support
-/// - `#[prop(slot)]` - Named widget slot, generates `RefCell<Option<Box<dyn Widget>>>` with builder and `take_` accessor
+/// The function name becomes the constructor (snake_case), and a PascalCase struct
+/// is generated. Function parameters become props, and the function body becomes
+/// the render method.
+///
+/// # Attributes on parameters
+/// - No attribute — standard prop, `MaybeDyn<T>`, default = `Default::default()`
+/// - `#[prop(default = "expr")]` — standard prop with custom default
+/// - `#[prop(callback)]` — callback prop. Use `()` for `Fn()`, or `fn(T1, T2)` for typed params
+/// - `#[prop(children)]` — children support via `ChildrenSource`
+/// - `#[prop(slot)]` — named widget slot
 ///
 /// # Example
 /// ```ignore
 /// #[component]
-/// pub struct Button {
-///     #[prop]
+/// pub fn button(
 ///     label: String,
+///     #[prop(default = "Color::rgb(0.3, 0.3, 0.4)")]
+///     background: Color,
+///     #[prop(default = "8.0")]
+///     padding: f32,
 ///     #[prop(callback)]
 ///     on_click: (),
-/// }
-///
-/// impl Button {
-///     fn render(&self) -> impl Widget {
-///         container().child(text(self.label.clone()))
-///     }
+/// ) -> impl Widget {
+///     container()
+///         .padding(padding.get())
+///         .background(background.clone())
+///         .on_click_option(on_click.clone())
+///         .child(text(label.clone()).color(Color::WHITE))
 /// }
 /// ```
 #[proc_macro_attribute]
 pub fn component(_attr: TokenStream, input: TokenStream) -> TokenStream {
-    let input = parse_macro_input!(input as ItemStruct);
+    let input = parse_macro_input!(input as ItemFn);
 
-    let struct_name = &input.ident;
+    let fn_name = &input.sig.ident;
     let vis = &input.vis;
+    let body = &input.block;
+    let struct_name = format_ident!("{}", to_pascal_case(&fn_name.to_string()));
 
-    // Extract fields
-    let fields = match &input.fields {
-        Fields::Named(fields) => &fields.named,
-        _ => {
-            return syn::Error::new_spanned(
-                &input,
-                "Component can only be used on structs with named fields",
-            )
-            .to_compile_error()
-            .into();
-        }
-    };
-
-    // Parse field information
+    // Extract props from function parameters
     let mut prop_fields = Vec::new();
     let mut has_children = false;
 
-    for field in fields {
-        let field_name = field.ident.as_ref().unwrap();
-        let field_type = &field.ty;
+    for arg in &input.sig.inputs {
+        let syn::FnArg::Typed(pat_type) = arg else {
+            return syn::Error::new_spanned(arg, "Component functions cannot have self parameters")
+                .to_compile_error()
+                .into();
+        };
 
-        // Skip if no #[prop] attribute
-        let prop_attr = field.attrs.iter().find(|attr| attr.path().is_ident("prop"));
+        // Get the parameter name
+        let syn::Pat::Ident(pat_ident) = pat_type.pat.as_ref() else {
+            return syn::Error::new_spanned(
+                &pat_type.pat,
+                "Component parameters must be simple identifiers",
+            )
+            .to_compile_error()
+            .into();
+        };
+        let field_name = &pat_ident.ident;
+        let field_type = &*pat_type.ty;
 
-        if prop_attr.is_none() {
-            continue;
-        }
+        // Check for #[prop(...)] attributes on the parameter
+        let prop_attr = pat_type
+            .attrs
+            .iter()
+            .find(|attr| attr.path().is_ident("prop"));
 
-        let prop_attr = prop_attr.unwrap();
-
-        // Parse attribute arguments
         let mut default_value: Option<String> = None;
         let mut is_callback = false;
         let mut is_children = false;
         let mut is_slot = false;
 
-        if let Meta::List(meta_list) = &prop_attr.meta {
+        if let Some(prop_attr) = prop_attr
+            && let Meta::List(meta_list) = &prop_attr.meta
+        {
             let tokens_str = meta_list.tokens.to_string();
 
             if tokens_str.contains("callback") {
@@ -86,13 +95,11 @@ pub fn component(_attr: TokenStream, input: TokenStream) -> TokenStream {
                 is_slot = true;
             }
 
-            if tokens_str.contains("default") {
-                // Extract default value between quotes
-                if let Some(start) = tokens_str.find('"')
-                    && let Some(end) = tokens_str[start + 1..].find('"')
-                {
-                    default_value = Some(tokens_str[start + 1..start + 1 + end].to_string());
-                }
+            if tokens_str.contains("default")
+                && let Some(start) = tokens_str.find('"')
+                && let Some(end) = tokens_str[start + 1..].find('"')
+            {
+                default_value = Some(tokens_str[start + 1..start + 1 + end].to_string());
             }
         }
 
@@ -244,9 +251,18 @@ pub fn component(_attr: TokenStream, input: TokenStream) -> TokenStream {
         })
         .collect();
 
-    // Create snake_case constructor name
-    let constructor_name =
-        syn::Ident::new(&to_snake_case(&struct_name.to_string()), struct_name.span());
+    // Generate render method body: bind each prop as a local variable, then run the body
+    let prop_bindings = prop_fields.iter().map(|field| {
+        let name = &field.name;
+        if field.is_children {
+            // Children are accessed via take_children(), not a local binding
+            quote! {}
+        } else {
+            quote! {
+                let #name = &self.#name;
+            }
+        }
+    });
 
     let expanded = quote! {
         #vis struct #struct_name {
@@ -269,6 +285,11 @@ pub fn component(_attr: TokenStream, input: TokenStream) -> TokenStream {
             #children_methods
 
             #(#slot_methods)*
+
+            fn render(&self) -> impl ::guido::widgets::Widget + use<> {
+                #(#prop_bindings)*
+                #body
+            }
 
             fn ensure_built(&self) {
                 if self.__inner.borrow().is_some() {
@@ -326,7 +347,7 @@ pub fn component(_attr: TokenStream, input: TokenStream) -> TokenStream {
             }
         }
 
-        #vis fn #constructor_name() -> #struct_name {
+        #vis fn #fn_name() -> #struct_name {
             #struct_name::new()
         }
     };
@@ -346,20 +367,18 @@ struct PropField {
     is_slot: bool,
 }
 
-fn to_snake_case(s: &str) -> String {
+fn to_pascal_case(s: &str) -> String {
     let mut result = String::new();
-    let mut prev_is_lower = false;
+    let mut capitalize_next = true;
 
-    for (i, c) in s.chars().enumerate() {
-        if c.is_uppercase() {
-            if i > 0 && prev_is_lower {
-                result.push('_');
-            }
-            result.push(c.to_lowercase().next().unwrap());
-            prev_is_lower = false;
+    for c in s.chars() {
+        if c == '_' {
+            capitalize_next = true;
+        } else if capitalize_next {
+            result.push(c.to_uppercase().next().unwrap());
+            capitalize_next = false;
         } else {
             result.push(c);
-            prev_is_lower = c.is_lowercase();
         }
     }
 

--- a/src/animation/mod.rs
+++ b/src/animation/mod.rs
@@ -19,9 +19,9 @@ pub struct Transition {
 
 impl Transition {
     /// Create a new transition with the given duration and timing function
-    pub fn new(duration_ms: f32, timing: TimingFunction) -> Self {
+    pub fn new(duration_ms: impl crate::layout::IntoF32, timing: TimingFunction) -> Self {
         Self {
-            duration_ms,
+            duration_ms: duration_ms.into_f32(),
             timing,
             delay_ms: 0.0,
         }
@@ -37,14 +37,14 @@ impl Transition {
     }
 
     /// Set the delay before the animation starts
-    pub fn delay(mut self, delay_ms: f32) -> Self {
-        self.delay_ms = delay_ms;
+    pub fn delay(mut self, delay_ms: impl crate::layout::IntoF32) -> Self {
+        self.delay_ms = delay_ms.into_f32();
         self
     }
 
     /// Set the duration of the animation
-    pub fn duration(mut self, duration_ms: f32) -> Self {
-        self.duration_ms = duration_ms;
+    pub fn duration(mut self, duration_ms: impl crate::layout::IntoF32) -> Self {
+        self.duration_ms = duration_ms.into_f32();
         self
     }
 

--- a/src/layout/flex_layout.rs
+++ b/src/layout/flex_layout.rs
@@ -71,19 +71,19 @@ impl Flex {
     }
 
     /// Set the spacing between children
-    pub fn spacing(mut self, spacing: impl IntoMaybeDyn<f32>) -> Self {
+    pub fn spacing<M>(mut self, spacing: impl IntoMaybeDyn<f32, M>) -> Self {
         self.spacing = spacing.into_maybe_dyn();
         self
     }
 
     /// Set the main axis alignment
-    pub fn main_alignment(mut self, alignment: impl IntoMaybeDyn<MainAlignment>) -> Self {
+    pub fn main_alignment<M>(mut self, alignment: impl IntoMaybeDyn<MainAlignment, M>) -> Self {
         self.main_alignment = alignment.into_maybe_dyn();
         self
     }
 
     /// Set the cross axis alignment
-    pub fn cross_alignment(mut self, alignment: impl IntoMaybeDyn<CrossAlignment>) -> Self {
+    pub fn cross_alignment<M>(mut self, alignment: impl IntoMaybeDyn<CrossAlignment, M>) -> Self {
         self.cross_alignment = alignment.into_maybe_dyn();
         self
     }

--- a/src/layout/flex_layout.rs
+++ b/src/layout/flex_layout.rs
@@ -269,11 +269,18 @@ impl Flex {
 
         // For Stretch: if we didn't have a known cross size before, re-layout children
         // with the computed cross size. Fill children get tight main-axis constraints.
+        //
+        // Skip children that already match cross_size — re-constraining them to their
+        // own size is a no-op for sizing but creates tight constraints that turn them
+        // into relayout boundaries, preventing dynamic content changes from propagating
+        // up to recompute cross_size.
         if cross_align == CrossAlignment::Stretch && stretch_cross.is_none() && cross_size > 0.0 {
-            self.child_sizes.clear();
-            self.child_sizes.resize(children.len(), Size::zero());
             children_main = 0.0;
             for (i, &child_id) in children.iter().enumerate() {
+                if (self.child_sizes[i].cross_axis(axis) - cross_size).abs() < 0.5 {
+                    children_main += self.child_sizes[i].main_axis(axis);
+                    continue;
+                }
                 let main_constraint = if is_fill[i] { per_fill } else { main_max };
                 let stretch_constraints = match axis {
                     Axis::Horizontal => Constraints {

--- a/src/layout/flex_layout.rs
+++ b/src/layout/flex_layout.rs
@@ -260,9 +260,9 @@ impl Flex {
             MainAlignment::SpaceBetween
             | MainAlignment::SpaceAround
             | MainAlignment::SpaceEvenly => main_max,
-            MainAlignment::Start
-            | MainAlignment::Center
-            | MainAlignment::End => total_main.max(main_min).min(main_max),
+            MainAlignment::Start | MainAlignment::Center | MainAlignment::End => {
+                total_main.max(main_min).min(main_max)
+            }
         };
 
         let cross_size = max_cross.max(cross_constraint_min).min(cross_max);

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -6,10 +6,7 @@ pub use flex::{Constraints, Size};
 pub use flex_layout::Flex;
 pub use overlay::Overlay;
 
-use crate::{
-    reactive::{IntoMaybeDyn, MaybeDyn},
-    tree::{Tree, WidgetId},
-};
+use crate::tree::{Tree, WidgetId};
 
 /// Trait for types that can be converted to f32 for use in layout dimensions.
 ///
@@ -187,33 +184,30 @@ impl From<u32> for Length {
     }
 }
 
-impl IntoMaybeDyn<Length> for Length {
-    fn into_maybe_dyn(self) -> MaybeDyn<Length> {
-        MaybeDyn::Static(self)
+// IntoVal<Length> impls for closures returning numeric types
+use crate::reactive::IntoVal;
+
+impl IntoVal<Length> for i32 {
+    fn into_val(self) -> Length {
+        Length::from(self)
     }
 }
 
-impl IntoMaybeDyn<Length> for f32 {
-    fn into_maybe_dyn(self) -> MaybeDyn<Length> {
-        MaybeDyn::Static(Length::from(self))
+impl IntoVal<Length> for u32 {
+    fn into_val(self) -> Length {
+        Length::from(self)
     }
 }
 
-impl IntoMaybeDyn<Length> for i32 {
-    fn into_maybe_dyn(self) -> MaybeDyn<Length> {
-        MaybeDyn::Static(Length::from(self))
+impl IntoVal<Length> for u16 {
+    fn into_val(self) -> Length {
+        Length::from(self)
     }
 }
 
-impl IntoMaybeDyn<Length> for u16 {
-    fn into_maybe_dyn(self) -> MaybeDyn<Length> {
-        MaybeDyn::Static(Length::from(self))
-    }
-}
-
-impl IntoMaybeDyn<Length> for u32 {
-    fn into_maybe_dyn(self) -> MaybeDyn<Length> {
-        MaybeDyn::Static(Length::from(self))
+impl IntoVal<Length> for f32 {
+    fn into_val(self) -> Length {
+        Length::from(self)
     }
 }
 
@@ -256,22 +250,4 @@ pub enum CrossAlignment {
     Center,
     End,
     Stretch,
-}
-
-impl IntoMaybeDyn<Axis> for Axis {
-    fn into_maybe_dyn(self) -> MaybeDyn<Axis> {
-        MaybeDyn::Static(self)
-    }
-}
-
-impl IntoMaybeDyn<MainAlignment> for MainAlignment {
-    fn into_maybe_dyn(self) -> MaybeDyn<MainAlignment> {
-        MaybeDyn::Static(self)
-    }
-}
-
-impl IntoMaybeDyn<CrossAlignment> for CrossAlignment {
-    fn into_maybe_dyn(self) -> MaybeDyn<CrossAlignment> {
-        MaybeDyn::Static(self)
-    }
 }

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -122,6 +122,24 @@ impl From<f32> for Length {
     }
 }
 
+impl From<i32> for Length {
+    fn from(value: i32) -> Self {
+        Length::from(value as f32)
+    }
+}
+
+impl From<u16> for Length {
+    fn from(value: u16) -> Self {
+        Length::from(value as f32)
+    }
+}
+
+impl From<u32> for Length {
+    fn from(value: u32) -> Self {
+        Length::from(value as f32)
+    }
+}
+
 impl IntoMaybeDyn<Length> for Length {
     fn into_maybe_dyn(self) -> MaybeDyn<Length> {
         MaybeDyn::Static(self)
@@ -129,6 +147,24 @@ impl IntoMaybeDyn<Length> for Length {
 }
 
 impl IntoMaybeDyn<Length> for f32 {
+    fn into_maybe_dyn(self) -> MaybeDyn<Length> {
+        MaybeDyn::Static(Length::from(self))
+    }
+}
+
+impl IntoMaybeDyn<Length> for i32 {
+    fn into_maybe_dyn(self) -> MaybeDyn<Length> {
+        MaybeDyn::Static(Length::from(self))
+    }
+}
+
+impl IntoMaybeDyn<Length> for u16 {
+    fn into_maybe_dyn(self) -> MaybeDyn<Length> {
+        MaybeDyn::Static(Length::from(self))
+    }
+}
+
+impl IntoMaybeDyn<Length> for u32 {
     fn into_maybe_dyn(self) -> MaybeDyn<Length> {
         MaybeDyn::Static(Length::from(self))
     }

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -11,6 +11,38 @@ use crate::{
     tree::{Tree, WidgetId},
 };
 
+/// Trait for types that can be converted to f32 for use in layout dimensions.
+///
+/// This extends beyond `Into<f32>` to include `i32` and `u32` which don't have
+/// lossless `From<T>` impls for `f32` but are commonly used for pixel values.
+pub trait IntoF32 {
+    fn into_f32(self) -> f32;
+}
+
+impl IntoF32 for f32 {
+    fn into_f32(self) -> f32 {
+        self
+    }
+}
+
+impl IntoF32 for i32 {
+    fn into_f32(self) -> f32 {
+        self as f32
+    }
+}
+
+impl IntoF32 for u16 {
+    fn into_f32(self) -> f32 {
+        self as f32
+    }
+}
+
+impl IntoF32 for u32 {
+    fn into_f32(self) -> f32 {
+        self as f32
+    }
+}
+
 /// A unified sizing type that can specify exact, min, max, or range constraints.
 ///
 /// # Examples
@@ -43,15 +75,25 @@ pub struct Length {
 }
 
 impl Length {
+    /// Create a length with an exact value.
+    pub fn exact(value: impl IntoF32) -> Self {
+        Length {
+            min: None,
+            max: None,
+            exact: Some(value.into_f32()),
+            fill: false,
+        }
+    }
+
     /// Add a minimum constraint to this length.
-    pub fn at_least(mut self, min: f32) -> Self {
-        self.min = Some(min);
+    pub fn at_least(mut self, min: impl IntoF32) -> Self {
+        self.min = Some(min.into_f32());
         self
     }
 
     /// Add a maximum constraint to this length.
-    pub fn at_most(mut self, max: f32) -> Self {
-        self.max = Some(max);
+    pub fn at_most(mut self, max: impl IntoF32) -> Self {
+        self.max = Some(max.into_f32());
         self
     }
 }
@@ -63,11 +105,12 @@ impl Length {
 /// use guido::prelude::*;
 ///
 /// container().width(at_least(100.0));
+/// container().width(at_least(100));
 /// container().width(at_least(50.0).at_most(400.0));
 /// ```
-pub fn at_least(min: f32) -> Length {
+pub fn at_least(min: impl IntoF32) -> Length {
     Length {
-        min: Some(min),
+        min: Some(min.into_f32()),
         max: None,
         exact: None,
         fill: false,
@@ -81,12 +124,13 @@ pub fn at_least(min: f32) -> Length {
 /// use guido::prelude::*;
 ///
 /// container().width(at_most(400.0));
+/// container().width(at_most(400));
 /// container().width(at_most(400.0).at_least(50.0));
 /// ```
-pub fn at_most(max: f32) -> Length {
+pub fn at_most(max: impl IntoF32) -> Length {
     Length {
         min: None,
-        max: Some(max),
+        max: Some(max.into_f32()),
         exact: None,
         fill: false,
     }

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -20,6 +20,9 @@ use crate::{
 /// // Exact size (most common)
 /// container().width(200.0);
 ///
+/// // Integers also work
+/// container().width(200).height(100);
+///
 /// // Minimum only
 /// container().width(at_least(100.0));
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,13 +90,13 @@ pub fn load_font(data: Vec<u8>) {
     });
 }
 
-/// Take all registered custom font data (for loading into FontSystems).
+/// Get all registered custom font data (for loading into FontSystems).
 ///
-/// This drains the storage so the `Arc` pointers are released once all
-/// FontSystems have been initialized. Subsequent calls return an empty vec.
-pub(crate) fn take_registered_fonts() -> Vec<Arc<Vec<u8>>> {
+/// Returns cloned `Arc` pointers so every FontSystem (measurer, renderer)
+/// receives the same set of fonts.
+pub(crate) fn get_registered_fonts() -> Vec<Arc<Vec<u8>>> {
     FONTS_CONSUMED.with(|f| f.set(true));
-    CUSTOM_FONTS.with(|fonts| std::mem::take(&mut *fonts.borrow_mut()))
+    CUSTOM_FONTS.with(|fonts| fonts.borrow().clone())
 }
 
 /// The reason the application's main loop exited.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,11 +143,11 @@ pub mod prelude {
     pub use crate::transform_origin::{HorizontalAnchor, TransformOrigin, VerticalAnchor};
     pub use crate::widget_ref::{WidgetRef, create_widget_ref};
     pub use crate::widgets::{
-        Border, Color, Container, ContentFit, Event, EventResponse, FontFamily, FontWeight,
-        GradientDirection, Image, ImageSource, IntoChildren, Key, LinearGradient, Modifiers,
-        MouseButton, Overflow, Padding, Rect, ScrollAxis, ScrollSource, ScrollbarBuilder,
-        ScrollbarVisibility, Selection, StateStyle, Text, TextInput, Widget, container, image,
-        text, text_input,
+        AnyWidget, Border, Color, Container, ContentFit, Event, EventResponse, FontFamily,
+        FontWeight, GradientDirection, Image, ImageSource, IntoChildren, Key, LinearGradient,
+        Modifiers, MouseButton, Overflow, Padding, Rect, ScrollAxis, ScrollSource,
+        ScrollbarBuilder, ScrollbarVisibility, Selection, StateStyle, Text, TextInput, Widget,
+        container, image, text, text_input,
     };
     pub use crate::{
         App, ExitReason, SignalFields, component, default_font_family, load_font, quit_app,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,8 +126,8 @@ pub fn quit_app() {
 pub mod prelude {
     pub use crate::animation::{SpringConfig, TimingFunction, Transition};
     pub use crate::layout::{
-        Axis, Constraints, CrossAlignment, Flex, Length, MainAlignment, Overlay, Size, at_least,
-        at_most, fill,
+        Axis, Constraints, CrossAlignment, Flex, IntoF32, Length, MainAlignment, Overlay, Size,
+        at_least, at_most, fill,
     };
     pub use crate::platform::{Anchor, KeyboardInteractivity, Layer};
     pub use crate::reactive::{

--- a/src/reactive/maybe_dyn.rs
+++ b/src/reactive/maybe_dyn.rs
@@ -38,106 +38,114 @@ impl<T: Clone + 'static> Clone for MaybeDyn<T> {
     }
 }
 
+// ============================================================================
+// Marker types for IntoMaybeDyn disambiguation
+// ============================================================================
+
+#[doc(hidden)]
+pub struct ValueMarker;
+#[doc(hidden)]
+pub struct LossyMarker;
+#[doc(hidden)]
+pub struct ClosureMarker;
+#[doc(hidden)]
+pub struct SignalMarker;
+#[doc(hidden)]
+pub struct MemoMarker;
+#[doc(hidden)]
+pub struct MaybeDynMarker;
+
 /// Trait for types that can be converted into `MaybeDyn<T>`
-pub trait IntoMaybeDyn<T: Clone + 'static> {
+///
+/// The marker generic `M` disambiguates blanket impls so that static values,
+/// closures, signals, memos, and MaybeDyn each use a distinct marker.
+pub trait IntoMaybeDyn<T: Clone + 'static, M = ValueMarker> {
     fn into_maybe_dyn(self) -> MaybeDyn<T>;
 }
 
 // ============================================================================
-// Static value implementations for specific types
-// (We can't use a blanket impl because it would conflict with the closure impl)
+// IntoVal - conversion trait for closure return types
 // ============================================================================
 
-impl IntoMaybeDyn<String> for String {
-    fn into_maybe_dyn(self) -> MaybeDyn<String> {
-        MaybeDyn::Static(self)
+/// Trait that enables closures returning different types to work with `IntoMaybeDyn`.
+///
+/// For example, `|| 8` (returns `i32`) can be used where `MaybeDyn<f32>` is expected,
+/// because `IntoVal<f32>` is implemented for `i32`.
+pub trait IntoVal<T> {
+    fn into_val(self) -> T;
+}
+
+// Identity: any T converts to itself
+impl<T> IntoVal<T> for T {
+    fn into_val(self) -> T {
+        self
     }
 }
 
-impl IntoMaybeDyn<String> for &str {
-    fn into_maybe_dyn(self) -> MaybeDyn<String> {
-        MaybeDyn::Static(self.to_string())
+// Lossy integer → f32 conversions (no std From impl)
+impl IntoVal<f32> for i32 {
+    fn into_val(self) -> f32 {
+        self as f32
     }
 }
 
-impl IntoMaybeDyn<f32> for f32 {
-    fn into_maybe_dyn(self) -> MaybeDyn<f32> {
-        MaybeDyn::Static(self)
+impl IntoVal<f32> for u32 {
+    fn into_val(self) -> f32 {
+        self as f32
     }
 }
 
-impl IntoMaybeDyn<f64> for f64 {
-    fn into_maybe_dyn(self) -> MaybeDyn<f64> {
-        MaybeDyn::Static(self)
+impl IntoVal<f32> for u16 {
+    fn into_val(self) -> f32 {
+        self as f32
     }
 }
 
-impl IntoMaybeDyn<i32> for i32 {
-    fn into_maybe_dyn(self) -> MaybeDyn<i32> {
-        MaybeDyn::Static(self)
+// ============================================================================
+// Blanket IntoMaybeDyn impls with distinct markers
+// ============================================================================
+
+// 1. Static values: any I where Into<T> exists (identity + all From impls)
+impl<T: Clone + 'static, I: Into<T>> IntoMaybeDyn<T, ValueMarker> for I {
+    fn into_maybe_dyn(self) -> MaybeDyn<T> {
+        MaybeDyn::Static(self.into())
     }
 }
 
-impl IntoMaybeDyn<u32> for u32 {
-    fn into_maybe_dyn(self) -> MaybeDyn<u32> {
-        MaybeDyn::Static(self)
-    }
-}
-
-impl IntoMaybeDyn<bool> for bool {
-    fn into_maybe_dyn(self) -> MaybeDyn<bool> {
-        MaybeDyn::Static(self)
-    }
-}
-
-// Integer → f32 conversions: enables spacing(8), width(300), corner_radius(12), etc.
-impl IntoMaybeDyn<f32> for u16 {
-    fn into_maybe_dyn(self) -> MaybeDyn<f32> {
-        MaybeDyn::Static(f32::from(self))
-    }
-}
-
-impl IntoMaybeDyn<f32> for u32 {
+// 2. Lossy i32/u32 → f32 static conversions (no std From, can't use Into blanket)
+impl IntoMaybeDyn<f32, LossyMarker> for i32 {
     fn into_maybe_dyn(self) -> MaybeDyn<f32> {
         MaybeDyn::Static(self as f32)
     }
 }
 
-impl IntoMaybeDyn<f32> for i32 {
+impl IntoMaybeDyn<f32, LossyMarker> for u32 {
     fn into_maybe_dyn(self) -> MaybeDyn<f32> {
         MaybeDyn::Static(self as f32)
     }
 }
 
-// ============================================================================
-// Closure implementation - works for any Fn() -> T
-// ============================================================================
-
-impl<T, F> IntoMaybeDyn<T> for F
+// 3. Closures: Fn() -> R where R: IntoVal<T>
+impl<T, R, F> IntoMaybeDyn<T, ClosureMarker> for F
 where
     T: Clone + 'static,
-    F: Fn() -> T + 'static,
+    R: IntoVal<T> + 'static,
+    F: Fn() -> R + 'static,
 {
     fn into_maybe_dyn(self) -> MaybeDyn<T> {
-        MaybeDyn::Dynamic(Rc::new(self))
+        MaybeDyn::Dynamic(Rc::new(move || self().into_val()))
     }
 }
 
-// ============================================================================
-// Signal implementations
-// ============================================================================
-
-impl<T: Clone + 'static> IntoMaybeDyn<T> for Signal<T> {
+// 4. Signal<T>
+impl<T: Clone + 'static> IntoMaybeDyn<T, SignalMarker> for Signal<T> {
     fn into_maybe_dyn(self) -> MaybeDyn<T> {
         MaybeDyn::Dynamic(Rc::new(move || self.get()))
     }
 }
 
-// ============================================================================
-// Already a MaybeDyn
-// ============================================================================
-
-impl<T: Clone + 'static> IntoMaybeDyn<T> for MaybeDyn<T> {
+// 5. MaybeDyn<T> passthrough
+impl<T: Clone + 'static> IntoMaybeDyn<T, MaybeDynMarker> for MaybeDyn<T> {
     fn into_maybe_dyn(self) -> MaybeDyn<T> {
         self
     }

--- a/src/reactive/maybe_dyn.rs
+++ b/src/reactive/maybe_dyn.rs
@@ -244,6 +244,13 @@ mod tests {
     }
 
     #[test]
+    fn test_closure_lossy_conversion() {
+        // Closure returning i32 used where MaybeDyn<f32> is expected
+        let value: MaybeDyn<f32> = (|| 8i32).into_maybe_dyn();
+        assert_eq!(value.get(), 8.0);
+    }
+
+    #[test]
     fn test_maybe_dyn_into_maybe_dyn() {
         let value1 = MaybeDyn::fixed(7);
         let value2: MaybeDyn<i32> = value1.into_maybe_dyn();

--- a/src/reactive/memo.rs
+++ b/src/reactive/memo.rs
@@ -1,7 +1,7 @@
 use std::rc::Rc;
 
 use super::effect::create_effect;
-use super::maybe_dyn::{IntoMaybeDyn, MaybeDyn};
+use super::maybe_dyn::{IntoMaybeDyn, MaybeDyn, MemoMarker};
 use super::signal::{Signal, create_signal};
 
 /// Eager computed value that recomputes immediately when dependencies change.
@@ -80,7 +80,7 @@ impl<T: Clone + PartialEq + Send + 'static> Memo<T> {
     }
 }
 
-impl<T: Clone + PartialEq + Send + 'static> IntoMaybeDyn<T> for Memo<T> {
+impl<T: Clone + PartialEq + Send + 'static> IntoMaybeDyn<T, MemoMarker> for Memo<T> {
     fn into_maybe_dyn(self) -> MaybeDyn<T> {
         MaybeDyn::Dynamic(Rc::new(move || self.signal.get()))
     }

--- a/src/reactive/mod.rs
+++ b/src/reactive/mod.rs
@@ -23,7 +23,11 @@ pub use cursor::{CursorIcon, set_cursor};
 pub use effect::{Effect, create_effect};
 pub(crate) use focus::{focused_widget, has_focus, release_focus, request_focus};
 pub(crate) use invalidation::with_signal_tracking;
-pub use maybe_dyn::{IntoMaybeDyn, MaybeDyn};
+#[doc(hidden)]
+pub use maybe_dyn::{
+    ClosureMarker, LossyMarker, MaybeDynMarker, MemoMarker, SignalMarker, ValueMarker,
+};
+pub use maybe_dyn::{IntoMaybeDyn, IntoVal, MaybeDyn};
 pub use memo::{Memo, create_memo};
 // Only on_cleanup is public API - with_owner, dispose_owner, and OwnerId are
 // internal and automatically used by the dynamic children system

--- a/src/renderer/text.rs
+++ b/src/renderer/text.rs
@@ -24,7 +24,7 @@ pub struct TextRenderState {
 impl TextRenderState {
     pub fn new(device: &Device, queue: &Queue, format: wgpu::TextureFormat) -> Self {
         let mut font_system = FontSystem::new();
-        for data in crate::take_registered_fonts() {
+        for data in crate::get_registered_fonts() {
             font_system
                 .db_mut()
                 .load_font_source(glyphon::fontdb::Source::Binary(data));

--- a/src/renderer/text_measurer.rs
+++ b/src/renderer/text_measurer.rs
@@ -23,7 +23,7 @@ pub struct TextMeasurer {
 impl TextMeasurer {
     pub fn new() -> Self {
         let mut font_system = FontSystem::new();
-        for data in crate::take_registered_fonts() {
+        for data in crate::get_registered_fonts() {
             font_system
                 .db_mut()
                 .load_font_source(cosmic_text::fontdb::Source::Binary(data));

--- a/src/renderer/text_quad.rs
+++ b/src/renderer/text_quad.rs
@@ -71,7 +71,7 @@ impl TextQuadRenderer {
     pub fn new(device: &Device, queue: &Queue, format: TextureFormat) -> Self {
         // Initialize text rendering components
         let mut font_system = FontSystem::new();
-        for data in crate::take_registered_fonts() {
+        for data in crate::get_registered_fonts() {
             font_system
                 .db_mut()
                 .load_font_source(glyphon::fontdb::Source::Binary(data));

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -1136,20 +1136,18 @@ impl Widget for Container {
             // Propagate the effective minimum so layouts like Center/End know
             // how much space they actually have to position children within.
             // Sources of minimum: explicit at_least(min) or parent constraints.
-            let effective_min = width_length
-                .min
-                .unwrap_or(0.0)
-                .max(constraints.min_width);
-            (effective_min - effective_h_padding).max(0.0).min(child_max_width)
+            let effective_min = width_length.min.unwrap_or(0.0).max(constraints.min_width);
+            (effective_min - effective_h_padding)
+                .max(0.0)
+                .min(child_max_width)
         };
         let child_min_height = if height_length.exact.is_some() || height_length.fill {
             child_max_height
         } else {
-            let effective_min = height_length
-                .min
-                .unwrap_or(0.0)
-                .max(constraints.min_height);
-            (effective_min - effective_v_padding).max(0.0).min(child_max_height)
+            let effective_min = height_length.min.unwrap_or(0.0).max(constraints.min_height);
+            (effective_min - effective_v_padding)
+                .max(0.0)
+                .min(child_max_height)
         };
 
         // For scrollable containers, use unbounded constraints in scroll direction

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -102,8 +102,11 @@ pub struct Border {
 }
 
 impl Border {
-    pub fn new(width: f32, color: Color) -> Self {
-        Self { width, color }
+    pub fn new(width: impl crate::layout::IntoF32, color: Color) -> Self {
+        Self {
+            width: width.into_f32(),
+            color,
+        }
     }
 }
 

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -285,7 +285,7 @@ impl Container {
     /// - `padding([1.0, 2.0, 3.0, 4.0])` — `[top, right, bottom, left]` (CSS 4-value)
     /// - `padding(Padding::all(8.0).top(20.0))` — builder pattern
     /// - `padding(signal)` or `padding(move || ...)` — reactive
-    pub fn padding(mut self, value: impl IntoMaybeDyn<Padding>) -> Self {
+    pub fn padding<M>(mut self, value: impl IntoMaybeDyn<Padding, M>) -> Self {
         self.padding = value.into_maybe_dyn();
         self
     }
@@ -301,7 +301,7 @@ impl Container {
     /// container().background(Color::rgb(0.2, 0.2, 0.3))
     /// container().background(Color::rgba(0.0, 0.0, 0.0, 0.5))  // 50% transparent black
     /// ```
-    pub fn background(mut self, color: impl IntoMaybeDyn<Color>) -> Self {
+    pub fn background<M>(mut self, color: impl IntoMaybeDyn<Color, M>) -> Self {
         self.background = color.into_maybe_dyn();
         self
     }
@@ -318,13 +318,13 @@ impl Container {
     /// container().corner_radius(8.0)                    // Standard rounded corners
     /// container().corner_radius(12.0).squircle()        // iOS-style smooth corners
     /// ```
-    pub fn corner_radius(mut self, radius: impl IntoMaybeDyn<f32>) -> Self {
+    pub fn corner_radius<M>(mut self, radius: impl IntoMaybeDyn<f32, M>) -> Self {
         self.corner_radius = radius.into_maybe_dyn();
         self
     }
 
     /// Set the corner curvature using CSS K-value system
-    pub fn corner_curvature(mut self, curvature: impl IntoMaybeDyn<f32>) -> Self {
+    pub fn corner_curvature<M>(mut self, curvature: impl IntoMaybeDyn<f32, M>) -> Self {
         self.corner_curvature = curvature.into_maybe_dyn();
         self
     }
@@ -348,10 +348,10 @@ impl Container {
     }
 
     /// Set a border with the given width and color
-    pub fn border(
+    pub fn border<M1, M2>(
         mut self,
-        width: impl IntoMaybeDyn<f32>,
-        color: impl IntoMaybeDyn<Color>,
+        width: impl IntoMaybeDyn<f32, M1>,
+        color: impl IntoMaybeDyn<Color, M2>,
     ) -> Self {
         self.border_width = width.into_maybe_dyn();
         self.border_color = color.into_maybe_dyn();
@@ -377,13 +377,13 @@ impl Container {
     }
 
     /// Set the width of the container.
-    pub fn width(mut self, width: impl IntoMaybeDyn<Length>) -> Self {
+    pub fn width<M>(mut self, width: impl IntoMaybeDyn<Length, M>) -> Self {
         self.width = Some(width.into_maybe_dyn());
         self
     }
 
     /// Set the height of the container.
-    pub fn height(mut self, height: impl IntoMaybeDyn<Length>) -> Self {
+    pub fn height<M>(mut self, height: impl IntoMaybeDyn<Length, M>) -> Self {
         self.height = Some(height.into_maybe_dyn());
         self
     }
@@ -398,7 +398,7 @@ impl Container {
     ///
     /// When `visible` is false, the container takes up no space in layout,
     /// does not paint, and ignores all events.
-    pub fn visible(mut self, visible: impl IntoMaybeDyn<bool>) -> Self {
+    pub fn visible<M>(mut self, visible: impl IntoMaybeDyn<bool, M>) -> Self {
         self.visible = visible.into_maybe_dyn();
         self
     }
@@ -467,19 +467,19 @@ impl Container {
         self
     }
 
-    pub fn elevation(mut self, level: impl IntoMaybeDyn<f32>) -> Self {
+    pub fn elevation<M>(mut self, level: impl IntoMaybeDyn<f32, M>) -> Self {
         self.elevation = level.into_maybe_dyn();
         self
     }
 
     /// Set the transform for this container
-    pub fn transform(mut self, t: impl IntoMaybeDyn<Transform>) -> Self {
+    pub fn transform<M>(mut self, t: impl IntoMaybeDyn<Transform, M>) -> Self {
         self.transform = t.into_maybe_dyn();
         self
     }
 
     /// Rotate this container by the given angle in degrees
-    pub fn rotate(mut self, degrees: impl IntoMaybeDyn<f32>) -> Self {
+    pub fn rotate<M>(mut self, degrees: impl IntoMaybeDyn<f32, M>) -> Self {
         let degrees = degrees.into_maybe_dyn();
         let prev_transform =
             std::mem::replace(&mut self.transform, MaybeDyn::Static(Transform::IDENTITY));
@@ -492,7 +492,7 @@ impl Container {
     }
 
     /// Scale this container uniformly
-    pub fn scale(mut self, s: impl IntoMaybeDyn<f32>) -> Self {
+    pub fn scale<M>(mut self, s: impl IntoMaybeDyn<f32, M>) -> Self {
         let s = s.into_maybe_dyn();
         let prev_transform =
             std::mem::replace(&mut self.transform, MaybeDyn::Static(Transform::IDENTITY));
@@ -503,7 +503,11 @@ impl Container {
     }
 
     /// Scale this container non-uniformly
-    pub fn scale_xy(mut self, sx: impl IntoMaybeDyn<f32>, sy: impl IntoMaybeDyn<f32>) -> Self {
+    pub fn scale_xy<M1, M2>(
+        mut self,
+        sx: impl IntoMaybeDyn<f32, M1>,
+        sy: impl IntoMaybeDyn<f32, M2>,
+    ) -> Self {
         let sx = sx.into_maybe_dyn();
         let sy = sy.into_maybe_dyn();
         let prev_transform =
@@ -517,7 +521,11 @@ impl Container {
     }
 
     /// Translate (move) this container by the given offset
-    pub fn translate(mut self, x: impl IntoMaybeDyn<f32>, y: impl IntoMaybeDyn<f32>) -> Self {
+    pub fn translate<M1, M2>(
+        mut self,
+        x: impl IntoMaybeDyn<f32, M1>,
+        y: impl IntoMaybeDyn<f32, M2>,
+    ) -> Self {
         let x = x.into_maybe_dyn();
         let y = y.into_maybe_dyn();
         let prev_transform =
@@ -531,7 +539,7 @@ impl Container {
     }
 
     /// Set the transform origin (pivot point) for this container.
-    pub fn transform_origin(mut self, origin: impl IntoMaybeDyn<TransformOrigin>) -> Self {
+    pub fn transform_origin<M>(mut self, origin: impl IntoMaybeDyn<TransformOrigin, M>) -> Self {
         self.transform_origin = origin.into_maybe_dyn();
         self
     }

--- a/src/widgets/image.rs
+++ b/src/widgets/image.rs
@@ -67,30 +67,6 @@ impl From<PathBuf> for ImageSource {
     }
 }
 
-impl IntoMaybeDyn<ImageSource> for ImageSource {
-    fn into_maybe_dyn(self) -> MaybeDyn<ImageSource> {
-        MaybeDyn::Static(self)
-    }
-}
-
-impl IntoMaybeDyn<ImageSource> for &str {
-    fn into_maybe_dyn(self) -> MaybeDyn<ImageSource> {
-        MaybeDyn::Static(ImageSource::from(self))
-    }
-}
-
-impl IntoMaybeDyn<ImageSource> for String {
-    fn into_maybe_dyn(self) -> MaybeDyn<ImageSource> {
-        MaybeDyn::Static(ImageSource::from(self))
-    }
-}
-
-impl IntoMaybeDyn<ImageSource> for PathBuf {
-    fn into_maybe_dyn(self) -> MaybeDyn<ImageSource> {
-        MaybeDyn::Static(ImageSource::from(self))
-    }
-}
-
 /// How the image content should fit within its bounds.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub enum ContentFit {
@@ -121,7 +97,7 @@ pub struct Image {
 
 impl Image {
     /// Create a new image widget from a source.
-    pub fn new(source: impl IntoMaybeDyn<ImageSource>) -> Self {
+    pub fn new<M>(source: impl IntoMaybeDyn<ImageSource, M>) -> Self {
         Self {
             source: source.into_maybe_dyn(),
             width: None,
@@ -133,13 +109,13 @@ impl Image {
     }
 
     /// Set a fixed width for the image.
-    pub fn width(mut self, width: impl IntoMaybeDyn<f32>) -> Self {
+    pub fn width<M>(mut self, width: impl IntoMaybeDyn<f32, M>) -> Self {
         self.width = Some(width.into_maybe_dyn());
         self
     }
 
     /// Set a fixed height for the image.
-    pub fn height(mut self, height: impl IntoMaybeDyn<f32>) -> Self {
+    pub fn height<M>(mut self, height: impl IntoMaybeDyn<f32, M>) -> Self {
         self.height = Some(height.into_maybe_dyn());
         self
     }
@@ -312,6 +288,6 @@ impl Widget for Image {
 /// // From ImageSource
 /// image(ImageSource::SvgBytes(svg_data.into()))
 /// ```
-pub fn image(source: impl IntoMaybeDyn<ImageSource>) -> Image {
+pub fn image<M>(source: impl IntoMaybeDyn<ImageSource, M>) -> Image {
     Image::new(source)
 }

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -19,8 +19,8 @@ pub use state_layer::{BackgroundOverride, RippleConfig, StateStyle};
 pub use text::{Text, text};
 pub use text_input::{Selection, TextInput, text_input};
 pub use widget::{
-    Color, Event, EventResponse, Key, LayoutHints, Modifiers, MouseButton, Padding, Rect,
-    ScrollSource, Widget,
+    AnyWidget, Color, Event, EventResponse, Key, LayoutHints, Modifiers, MouseButton, Padding,
+    Rect, ScrollSource, Widget,
 };
 
 // IntoMaybeDyn implementations for widget types

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -23,80 +23,29 @@ pub use widget::{
     Rect, ScrollSource, Widget,
 };
 
-// IntoMaybeDyn implementations for widget types
-use crate::reactive::{IntoMaybeDyn, MaybeDyn};
-use crate::transform::Transform;
-use crate::transform_origin::TransformOrigin;
+// IntoVal<Padding> impls for closures returning numeric types
+use crate::reactive::IntoVal;
 
-impl IntoMaybeDyn<Color> for Color {
-    fn into_maybe_dyn(self) -> MaybeDyn<Color> {
-        MaybeDyn::Static(self)
+impl IntoVal<Padding> for i32 {
+    fn into_val(self) -> Padding {
+        Padding::from(self)
     }
 }
 
-impl IntoMaybeDyn<Padding> for Padding {
-    fn into_maybe_dyn(self) -> MaybeDyn<Padding> {
-        MaybeDyn::Static(self)
+impl IntoVal<Padding> for u32 {
+    fn into_val(self) -> Padding {
+        Padding::from(self)
     }
 }
 
-// Convenience conversions: padding(8.0), padding(8), padding([8.0, 16.0]), etc.
-impl IntoMaybeDyn<Padding> for f32 {
-    fn into_maybe_dyn(self) -> MaybeDyn<Padding> {
-        MaybeDyn::Static(Padding::from(self))
+impl IntoVal<Padding> for u16 {
+    fn into_val(self) -> Padding {
+        Padding::from(self)
     }
 }
 
-impl IntoMaybeDyn<Padding> for i32 {
-    fn into_maybe_dyn(self) -> MaybeDyn<Padding> {
-        MaybeDyn::Static(Padding::from(self))
-    }
-}
-
-impl IntoMaybeDyn<Padding> for u16 {
-    fn into_maybe_dyn(self) -> MaybeDyn<Padding> {
-        MaybeDyn::Static(Padding::from(self))
-    }
-}
-
-impl IntoMaybeDyn<Padding> for u32 {
-    fn into_maybe_dyn(self) -> MaybeDyn<Padding> {
-        MaybeDyn::Static(Padding::from(self))
-    }
-}
-
-impl IntoMaybeDyn<Padding> for [f32; 2] {
-    fn into_maybe_dyn(self) -> MaybeDyn<Padding> {
-        MaybeDyn::Static(Padding::from(self))
-    }
-}
-
-impl IntoMaybeDyn<Padding> for [f32; 4] {
-    fn into_maybe_dyn(self) -> MaybeDyn<Padding> {
-        MaybeDyn::Static(Padding::from(self))
-    }
-}
-
-impl IntoMaybeDyn<Transform> for Transform {
-    fn into_maybe_dyn(self) -> MaybeDyn<Transform> {
-        MaybeDyn::Static(self)
-    }
-}
-
-impl IntoMaybeDyn<TransformOrigin> for TransformOrigin {
-    fn into_maybe_dyn(self) -> MaybeDyn<TransformOrigin> {
-        MaybeDyn::Static(self)
-    }
-}
-
-impl IntoMaybeDyn<FontFamily> for FontFamily {
-    fn into_maybe_dyn(self) -> MaybeDyn<FontFamily> {
-        MaybeDyn::Static(self)
-    }
-}
-
-impl IntoMaybeDyn<FontWeight> for FontWeight {
-    fn into_maybe_dyn(self) -> MaybeDyn<FontWeight> {
-        MaybeDyn::Static(self)
+impl IntoVal<Padding> for f32 {
+    fn into_val(self) -> Padding {
+        Padding::from(self)
     }
 }

--- a/src/widgets/text.rs
+++ b/src/widgets/text.rs
@@ -24,7 +24,7 @@ pub struct Text {
 }
 
 impl Text {
-    pub fn new(content: impl IntoMaybeDyn<String>) -> Self {
+    pub fn new<M>(content: impl IntoMaybeDyn<String, M>) -> Self {
         let content = content.into_maybe_dyn();
         // Don't read content during widget creation - this would register layout dependencies
         // with the wrong widget (the parent container that's currently being laid out).
@@ -44,12 +44,12 @@ impl Text {
         }
     }
 
-    pub fn color(mut self, color: impl IntoMaybeDyn<Color>) -> Self {
+    pub fn color<M>(mut self, color: impl IntoMaybeDyn<Color, M>) -> Self {
         self.color = color.into_maybe_dyn();
         self
     }
 
-    pub fn font_size(mut self, size: impl IntoMaybeDyn<f32>) -> Self {
+    pub fn font_size<M>(mut self, size: impl IntoMaybeDyn<f32, M>) -> Self {
         self.font_size = size.into_maybe_dyn();
         self
     }
@@ -62,7 +62,7 @@ impl Text {
     /// text("Hello").font_family(FontFamily::Monospace)
     /// text("Hello").font_family(FontFamily::Name("Inter".into()))
     /// ```
-    pub fn font_family(mut self, family: impl IntoMaybeDyn<FontFamily>) -> Self {
+    pub fn font_family<M>(mut self, family: impl IntoMaybeDyn<FontFamily, M>) -> Self {
         self.font_family = family.into_maybe_dyn();
         self
     }
@@ -75,7 +75,7 @@ impl Text {
     /// text("Hello").font_weight(FontWeight::BOLD)
     /// text("Hello").font_weight(FontWeight(600))
     /// ```
-    pub fn font_weight(mut self, weight: impl IntoMaybeDyn<FontWeight>) -> Self {
+    pub fn font_weight<M>(mut self, weight: impl IntoMaybeDyn<FontWeight, M>) -> Self {
         self.font_weight = weight.into_maybe_dyn();
         self
     }
@@ -205,6 +205,6 @@ impl Widget for Text {
 /// text(move || format!("Count: {}", count.get()))  // reactive closure
 /// text(my_signal)  // reactive signal
 /// ```
-pub fn text(content: impl IntoMaybeDyn<String>) -> Text {
+pub fn text<M>(content: impl IntoMaybeDyn<String, M>) -> Text {
     Text::new(content)
 }

--- a/src/widgets/text_input.rs
+++ b/src/widgets/text_input.rs
@@ -295,25 +295,25 @@ impl TextInput {
     }
 
     /// Set the text color
-    pub fn text_color(mut self, color: impl IntoMaybeDyn<Color>) -> Self {
+    pub fn text_color<M>(mut self, color: impl IntoMaybeDyn<Color, M>) -> Self {
         self.text_color = color.into_maybe_dyn();
         self
     }
 
     /// Set the cursor color
-    pub fn cursor_color(mut self, color: impl IntoMaybeDyn<Color>) -> Self {
+    pub fn cursor_color<M>(mut self, color: impl IntoMaybeDyn<Color, M>) -> Self {
         self.cursor_color = color.into_maybe_dyn();
         self
     }
 
     /// Set the selection highlight color
-    pub fn selection_color(mut self, color: impl IntoMaybeDyn<Color>) -> Self {
+    pub fn selection_color<M>(mut self, color: impl IntoMaybeDyn<Color, M>) -> Self {
         self.selection_color = color.into_maybe_dyn();
         self
     }
 
     /// Set the font size
-    pub fn font_size(mut self, size: impl IntoMaybeDyn<f32>) -> Self {
+    pub fn font_size<M>(mut self, size: impl IntoMaybeDyn<f32, M>) -> Self {
         self.font_size = size.into_maybe_dyn();
         self
     }
@@ -325,7 +325,7 @@ impl TextInput {
     /// ```ignore
     /// text_input(signal).font_family(FontFamily::Monospace)
     /// ```
-    pub fn font_family(mut self, family: impl IntoMaybeDyn<FontFamily>) -> Self {
+    pub fn font_family<M>(mut self, family: impl IntoMaybeDyn<FontFamily, M>) -> Self {
         self.font_family = family.into_maybe_dyn();
         self
     }
@@ -337,7 +337,7 @@ impl TextInput {
     /// ```ignore
     /// text_input(signal).font_weight(FontWeight::BOLD)
     /// ```
-    pub fn font_weight(mut self, weight: impl IntoMaybeDyn<FontWeight>) -> Self {
+    pub fn font_weight<M>(mut self, weight: impl IntoMaybeDyn<FontWeight, M>) -> Self {
         self.font_weight = weight.into_maybe_dyn();
         self
     }

--- a/src/widgets/widget.rs
+++ b/src/widgets/widget.rs
@@ -383,6 +383,30 @@ impl From<[f32; 4]> for Padding {
     }
 }
 
+/// `[vertical, horizontal]` — CSS-style 2-value shorthand (integer).
+impl From<[i32; 2]> for Padding {
+    fn from(v: [i32; 2]) -> Self {
+        Padding {
+            top: v[0] as f32,
+            right: v[1] as f32,
+            bottom: v[0] as f32,
+            left: v[1] as f32,
+        }
+    }
+}
+
+/// `[top, right, bottom, left]` — CSS-style 4-value shorthand (integer).
+impl From<[i32; 4]> for Padding {
+    fn from(v: [i32; 4]) -> Self {
+        Padding {
+            top: v[0] as f32,
+            right: v[1] as f32,
+            bottom: v[2] as f32,
+            left: v[3] as f32,
+        }
+    }
+}
+
 impl Default for Padding {
     fn default() -> Self {
         Self {

--- a/src/widgets/widget.rs
+++ b/src/widgets/widget.rs
@@ -634,7 +634,27 @@ pub trait Widget {
     ///
     /// Default implementation does nothing (leaf widgets have no children).
     fn register_children(&mut self, _tree: &mut Tree, _id: WidgetId) {}
+
+    /// Type-erase this widget into a boxed trait object.
+    ///
+    /// Useful when returning different widget types from conditional branches:
+    /// ```ignore
+    /// if condition {
+    ///     widget_a.into_any()
+    /// } else {
+    ///     widget_b.into_any()
+    /// }
+    /// ```
+    fn into_any(self) -> AnyWidget
+    where
+        Self: Sized + 'static,
+    {
+        Box::new(self)
+    }
 }
+
+/// A type-erased widget. Shorthand for `Box<dyn Widget>`.
+pub type AnyWidget = Box<dyn Widget>;
 
 impl Widget for Box<dyn Widget> {
     fn advance_animations(&mut self, tree: &mut Tree, id: WidgetId) -> bool {


### PR DESCRIPTION
## Summary

- **Function-based `#[component]` macro** — replaces struct-based syntax with a more ergonomic function-based API. Props are function parameters, the body is the render method.
- **Marker-based `IntoMaybeDyn` blanket impls** — removes dozens of per-type impls using marker-type disambiguation (`ValueMarker`, `ClosureMarker`, `SignalMarker`, etc.)
- **Integer support** — `IntoF32` trait and `From<i32/u32/u16>` impls let users write `.width(100)`, `.padding([8, 16])`, `.rotate(45)` instead of requiring floats everywhere
- **`AnyWidget` / `Widget::into_any()`** — type erasure for conditional widget branches
- **Flex layout fix** — cross-axis stretch now uses 0.5px tolerance to avoid unnecessary re-layout
- **Custom font fix** — `get_registered_fonts()` clones Arc pointers so all FontSystems (measurer, renderer, quad renderer) receive custom fonts (previously only the first one did)
- **Macro validation** — `callback`, `children`, and `slot` props now emit a compile error if combined with `default`
- **Documentation updates** — README, CLAUDE.md, book chapters, and dev docs updated for all changes

## Test plan

- [x] `cargo test` — 197 tests pass (including new closure lossy conversion test)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo check --example component_example` — compiles
- [x] `mdbook build book` — builds without errors