### PR TITLE
fix: animation rendering fixes and reverse transitions

### DIFF
--- a/src/animation/animatable.rs
+++ b/src/animation/animatable.rs
@@ -7,11 +7,25 @@ pub trait Animatable: Copy + PartialEq + Send + Sync + 'static {
     /// t = 0.0 returns `from`, t = 1.0 returns `to`
     /// t can exceed [0, 1] range for overshoot effects
     fn lerp(from: &Self, to: &Self, t: f32) -> Self;
+
+    /// Whether transitioning from `from` to `to` is a "reverse" direction.
+    /// Used to select the `.reverse()` transition when configured.
+    /// - `f32`: value decreasing
+    /// - `Transform`: scale decreasing
+    /// - `Color`: alpha decreasing, then luminance decreasing
+    /// - `Padding`: total padding decreasing
+    fn is_reverse(_from: &Self, _to: &Self) -> bool {
+        false
+    }
 }
 
 impl Animatable for f32 {
     fn lerp(from: &Self, to: &Self, t: f32) -> Self {
         from + (to - from) * t
+    }
+
+    fn is_reverse(from: &Self, to: &Self) -> bool {
+        to < from
     }
 }
 
@@ -24,6 +38,14 @@ impl Animatable for Color {
             a: from.a + (to.a - from.a) * t,
         }
     }
+
+    fn is_reverse(from: &Self, to: &Self) -> bool {
+        // Reverse when fading out (alpha decreasing),
+        // or when darkening (luminance decreasing) at same alpha
+        let to_lum = to.r * 0.299 + to.g * 0.587 + to.b * 0.114;
+        let from_lum = from.r * 0.299 + from.g * 0.587 + from.b * 0.114;
+        (to.a, to_lum) < (from.a, from_lum)
+    }
 }
 
 impl Animatable for Padding {
@@ -35,6 +57,12 @@ impl Animatable for Padding {
             bottom: from.bottom + (to.bottom - from.bottom) * t,
         }
     }
+
+    fn is_reverse(from: &Self, to: &Self) -> bool {
+        let to_total = to.left + to.right + to.top + to.bottom;
+        let from_total = from.left + from.right + from.top + from.bottom;
+        to_total < from_total
+    }
 }
 
 impl Animatable for Transform {
@@ -44,6 +72,10 @@ impl Animatable for Transform {
             *val = from.data[i] + (to.data[i] - from.data[i]) * t;
         }
         Transform { data }
+    }
+
+    fn is_reverse(from: &Self, to: &Self) -> bool {
+        to.extract_scale() < from.extract_scale()
     }
 }
 

--- a/src/animation/mod.rs
+++ b/src/animation/mod.rs
@@ -53,11 +53,41 @@ impl Transition {
         self.timing = timing;
         self
     }
+
+    /// Use a different transition when the animated value decreases (e.g., closing/shrinking).
+    ///
+    /// For dimensional values like width/height, "reverse" means the value is getting smaller.
+    /// This enables patterns like bouncy spring for open + smooth ease-out for close.
+    pub fn reverse(self, reverse: Transition) -> TransitionConfig {
+        TransitionConfig {
+            forward: self,
+            reverse: Some(reverse),
+        }
+    }
 }
 
 impl Default for Transition {
     /// Default transition uses spring physics with pleasant overshoot
     fn default() -> Self {
         Self::spring(SpringConfig::DEFAULT)
+    }
+}
+
+/// Holds a forward transition and an optional reverse transition.
+///
+/// When both are set, the forward transition is used when the value increases
+/// and the reverse transition when it decreases.
+#[derive(Clone, Debug)]
+pub struct TransitionConfig {
+    pub forward: Transition,
+    pub reverse: Option<Transition>,
+}
+
+impl From<Transition> for TransitionConfig {
+    fn from(t: Transition) -> Self {
+        TransitionConfig {
+            forward: t,
+            reverse: None,
+        }
     }
 }

--- a/src/layout/flex_layout.rs
+++ b/src/layout/flex_layout.rs
@@ -34,6 +34,10 @@ use crate::{
     tree::{Tree, WidgetId},
 };
 
+/// Children with main-axis size below this threshold are treated as invisible
+/// for spacing purposes (no gap is added on either side).
+const MIN_VISIBLE_SIZE: f32 = 0.5;
+
 /// Flex layout for rows and columns
 pub struct Flex {
     direction: Signal<Axis>,
@@ -294,7 +298,7 @@ impl Flex {
         let visible_count = self
             .child_sizes
             .iter()
-            .filter(|s| s.main_axis(axis) > 0.5)
+            .filter(|s| s.main_axis(axis) > MIN_VISIBLE_SIZE)
             .count();
         let visible_spacing = if visible_count > 1 {
             spacing * (visible_count - 1) as f32
@@ -335,7 +339,7 @@ impl Flex {
             let child_cross = child_size.cross_axis(axis);
 
             // Add spacing only between consecutive non-zero-sized children
-            if prev_nonzero && child_main > 0.5 {
+            if prev_nonzero && child_main > MIN_VISIBLE_SIZE {
                 main_pos += between_spacing;
             }
 
@@ -366,7 +370,7 @@ impl Flex {
             tree.set_origin(child_id, x, y);
             main_pos += child_main;
 
-            if child_main > 0.5 {
+            if child_main > MIN_VISIBLE_SIZE {
                 prev_nonzero = true;
             }
         }

--- a/src/layout/flex_layout.rs
+++ b/src/layout/flex_layout.rs
@@ -243,26 +243,10 @@ impl Flex {
         // Compute total main-axis usage
         let mut children_main: f32 = self.child_sizes.iter().map(|s| s.main_axis(axis)).sum();
 
-        let total_main = children_main + total_spacing;
-
         // Calculate final dimensions
         let (main_min, cross_constraint_min) = match axis {
             Axis::Horizontal => (constraints.min_width, constraints.min_height),
             Axis::Vertical => (constraints.min_height, constraints.min_width),
-        };
-
-        // Space-based alignments expand to fill available main axis so they can
-        // distribute the extra space between/around children.
-        // Start/Center/End only affect child *positioning* — they should not force
-        // the Flex to expand. Centering/end-alignment takes effect when the parent
-        // provides extra space via tight constraints (e.g. an exact or fill width).
-        let main_size = match main_align {
-            MainAlignment::SpaceBetween
-            | MainAlignment::SpaceAround
-            | MainAlignment::SpaceEvenly => main_max,
-            MainAlignment::Start | MainAlignment::Center | MainAlignment::End => {
-                total_main.max(main_min).min(main_max)
-            }
         };
 
         let cross_size = max_cross.max(cross_constraint_min).min(cross_max);
@@ -305,6 +289,28 @@ impl Flex {
             }
         }
 
+        // Collapse spacing around zero-sized children: a child with zero
+        // main-axis size should not contribute a gap on either side.
+        let visible_count = self
+            .child_sizes
+            .iter()
+            .filter(|s| s.main_axis(axis) > 0.5)
+            .count();
+        let visible_spacing = if visible_count > 1 {
+            spacing * (visible_count - 1) as f32
+        } else {
+            0.0
+        };
+        let visible_total_main = children_main + visible_spacing;
+        let main_size = match main_align {
+            MainAlignment::SpaceBetween
+            | MainAlignment::SpaceAround
+            | MainAlignment::SpaceEvenly => main_max,
+            MainAlignment::Start | MainAlignment::Center | MainAlignment::End => {
+                visible_total_main.max(main_min).min(main_max)
+            }
+        };
+
         let (width, height) = match axis {
             Axis::Horizontal => (main_size, cross_size),
             Axis::Vertical => (cross_size, main_size),
@@ -312,20 +318,26 @@ impl Flex {
         let size = Size::new(width, height);
 
         // Position children
-        let free_space = (main_size - children_main - total_spacing).max(0.0);
+        let free_space = (main_size - children_main - visible_spacing).max(0.0);
 
         let (initial_offset, between_spacing) =
-            self.calc_main_axis_spacing(main_align, spacing, free_space, children.len());
+            self.calc_main_axis_spacing(main_align, spacing, free_space, visible_count);
 
         let mut main_pos = match axis {
             Axis::Horizontal => origin.0,
             Axis::Vertical => origin.1,
         } + initial_offset;
 
+        let mut prev_nonzero = false;
         for (i, &child_id) in children.iter().enumerate() {
             let child_size = self.child_sizes[i];
             let child_main = child_size.main_axis(axis);
             let child_cross = child_size.cross_axis(axis);
+
+            // Add spacing only between consecutive non-zero-sized children
+            if prev_nonzero && child_main > 0.5 {
+                main_pos += between_spacing;
+            }
 
             let cross_pos = match cross_align {
                 CrossAlignment::Start => match axis {
@@ -352,7 +364,11 @@ impl Flex {
             };
 
             tree.set_origin(child_id, x, y);
-            main_pos += child_main + between_spacing;
+            main_pos += child_main;
+
+            if child_main > 0.5 {
+                prev_nonzero = true;
+            }
         }
 
         size

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,7 +124,7 @@ pub fn quit_app() {
 }
 
 pub mod prelude {
-    pub use crate::animation::{SpringConfig, TimingFunction, Transition};
+    pub use crate::animation::{SpringConfig, TimingFunction, Transition, TransitionConfig};
     pub use crate::layout::{
         Axis, Constraints, CrossAlignment, Flex, IntoF32, Length, MainAlignment, Overlay, Size,
         at_least, at_most, fill,

--- a/src/renderer/gpu.rs
+++ b/src/renderer/gpu.rs
@@ -128,7 +128,7 @@ pub struct ShapeInstance {
 
     // === Clip Region ===
     /// Clip rect in physical pixels [x, y, width, height]
-    /// If width or height <= 0, no clipping is applied
+    /// Negative width/height = no clipping. Zero width/height = clip everything.
     pub clip_rect: [f32; 4],
     /// Clip corner radius in physical pixels
     pub clip_corner_radius: f32,
@@ -168,7 +168,7 @@ impl Default for ShapeInstance {
             shadow_color: [0.0, 0.0, 0.0, 0.0],
             transform: [1.0, 0.0, 0.0, 0.0, 1.0, 0.0], // identity
             _pad2: [0.0, 0.0],
-            clip_rect: [0.0, 0.0, 0.0, 0.0], // No clipping (width/height = 0)
+            clip_rect: [0.0, 0.0, -1.0, -1.0], // No clipping (negative width/height)
             clip_corner_radius: 0.0,
             clip_curvature: 1.0,
             clip_is_local: 0.0,

--- a/src/renderer/image_quad.rs
+++ b/src/renderer/image_quad.rs
@@ -564,8 +564,8 @@ impl ImageQuadRenderer {
                 [clip.corner_radius * scale_factor, clip.curvature, 0.0, 0.0],
             )
         } else {
-            // No clipping (width/height = 0 disables clipping in shader)
-            ([0.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0])
+            // No clipping (negative width/height disables clipping in shader)
+            ([0.0, 0.0, -1.0, -1.0], [0.0, 1.0, 0.0, 0.0])
         };
 
         // Transform corners from local to screen coordinates

--- a/src/renderer/shader.wgsl
+++ b/src/renderer/shader.wgsl
@@ -357,8 +357,8 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     }
 
     // === Apply clipping ===
-    // Check if clipping is enabled (width and height > 0)
-    if (in.clip_rect.z > 0.0 && in.clip_rect.w > 0.0) {
+    // Check if clipping is enabled (negative width/height = no clip sentinel)
+    if (in.clip_rect.z >= 0.0 && in.clip_rect.w >= 0.0) {
         // Use frag_pos for local clips (overlay clips on transformed containers),
         // world_pos for world clips (regular clipping)
         let clip_pos = select(in.world_pos, in.frag_pos, in.clip_params.z > 0.5);

--- a/src/renderer/text.rs
+++ b/src/renderer/text.rs
@@ -66,19 +66,28 @@ impl TextRenderState {
         let mut culled_indices = HashSet::new();
 
         for (idx, entry) in texts.iter().enumerate() {
+            // Skip text invisible due to zero scale — avoids all rendering work
+            if !entry.transform.is_identity() && !entry.transform.is_translation_only() {
+                let (sx, sy) = (entry.transform.data[0], entry.transform.data[5]);
+                if sx.abs() < 1e-3 || sy.abs() < 1e-3 {
+                    culled_indices.insert(idx);
+                    continue;
+                }
+            }
+
             // Skip text that is completely outside its clip region (culling optimization)
             // Check this FIRST so culled texts don't get rendered via texture path either
             if let Some(clip) = &entry.clip_rect {
-                // Get text position (applying translation if any)
-                let (tx, ty) = if entry.transform.is_identity() {
-                    (0.0, 0.0)
-                } else {
-                    (entry.transform.tx(), entry.transform.ty())
-                };
-                let text_left = entry.rect.x + tx;
-                let text_top = entry.rect.y + ty;
-                let text_right = text_left + entry.rect.width;
-                let text_bottom = text_top + entry.rect.height;
+                // Get text bounding box in world space (same coordinate system as clip rect)
+                let (p1x, p1y) = entry.transform.transform_point(entry.rect.x, entry.rect.y);
+                let (p2x, p2y) = entry.transform.transform_point(
+                    entry.rect.x + entry.rect.width,
+                    entry.rect.y + entry.rect.height,
+                );
+                let text_left = p1x.min(p2x);
+                let text_top = p1y.min(p2y);
+                let text_right = p1x.max(p2x);
+                let text_bottom = p1y.max(p2y);
 
                 let clip_right = clip.x + clip.width;
                 let clip_bottom = clip.y + clip.height;
@@ -98,8 +107,9 @@ impl TextRenderState {
                 }
             }
 
-            // Check if text has a transform that affects rendering
-            if entry.transform.has_rotation_or_scale() {
+            // Route all non-translation transforms (rotation, scale) to TextQuadRenderer.
+            // This keeps the glyphon atlas stable — only identity/translation text goes through it.
+            if !entry.transform.is_identity() && !entry.transform.is_translation_only() {
                 transformed_indices.push(idx);
                 continue; // Skip transformed text in direct rendering
             }
@@ -150,16 +160,15 @@ impl TextRenderState {
             .iter()
             .zip(self.buffers.iter())
             .map(|(entry, buffer)| {
-                // Apply translation from transform (if any) to position
-                let (tx, ty) = if entry.transform.is_identity() {
-                    (0.0, 0.0)
-                } else {
-                    (entry.transform.tx(), entry.transform.ty())
-                };
+                // Position text in world space using the full transform.
+                // This is consistent with the clip rect (also in world space via
+                // transform_clip_to_world), so TextBounds clipping works correctly.
+                let (screen_x, screen_y) =
+                    entry.transform.transform_point(entry.rect.x, entry.rect.y);
 
                 // Scale positions for HiDPI rendering
-                let scaled_left = (entry.rect.x + tx) * scale_factor;
-                let scaled_top = (entry.rect.y + ty) * scale_factor;
+                let scaled_left = screen_x * scale_factor;
+                let scaled_top = screen_y * scale_factor;
 
                 // Use clip rect if provided, otherwise use full screen
                 // Clip bounds stay in screen space - don't apply transform translation

--- a/src/renderer/text_quad.rs
+++ b/src/renderer/text_quad.rs
@@ -234,9 +234,10 @@ impl TextQuadRenderer {
         entry: &TextEntry,
         scale_factor: f32,
     ) -> PreparedTextQuad {
-        // Extract scale from transform for crisp rendering
-        let transform_scale = entry.transform.extract_scale();
-        let effective_scale = scale_factor * transform_scale * QUALITY_MULTIPLIER;
+        // Rasterize at fixed resolution: scale_factor * QUALITY_MULTIPLIER.
+        // The transform's scale/rotation is applied via GPU quad vertices, not baked into the texture.
+        // This prevents atlas churn during scale animations (each frame would otherwise create new entries).
+        let effective_scale = scale_factor * QUALITY_MULTIPLIER;
 
         // Scale font size for crisp rendering
         let scaled_font_size = entry.font_size * effective_scale;
@@ -388,17 +389,18 @@ impl TextQuadRenderer {
         // to get screen coordinates. The world_transform already includes everything:
         // parent translations, rotations, scales, and center_at adjustments.
         //
-        // IMPORTANT: The texture was rendered at (transform_scale * QUALITY_MULTIPLIER) resolution.
-        // We need to compute display dimensions WITHOUT transform_scale, because the world_transform
-        // will apply the scaling. If we included transform_scale here, we'd get double-scaling.
+        // The texture was rendered at (scale_factor * QUALITY_MULTIPLIER) resolution.
+        // We divide by QUALITY_MULTIPLIER to get logical-pixel dimensions, then the
+        // world_transform applies scaling/rotation via transform_point() on quad corners.
 
-        // Calculate display size: divide by both QUALITY_MULTIPLIER and transform_scale
-        // This gives us the "pre-transform" size that the world_transform will then scale
-        let total_scale = QUALITY_MULTIPLIER * transform_scale;
+        // Calculate display size: divide by QUALITY_MULTIPLIER only.
+        // The texture is rendered at (scale_factor * QUALITY_MULTIPLIER) resolution.
+        // The transform's scale is applied by transform_point() on quad corners, not here.
+        let total_scale = QUALITY_MULTIPLIER;
         let display_width = tex_width as f32 / total_scale;
         let display_height = tex_height as f32 / total_scale;
 
-        // Padding in logical pixels (also needs to account for transform_scale)
+        // Padding in logical pixels
         let display_padding = padding / total_scale;
 
         // Get the local rect corners with padding adjustment
@@ -439,8 +441,8 @@ impl TextQuadRenderer {
                 [0.0, 1.0, 0.0, 0.0], // No corner radius for text clip (uses rect from TextEntry)
             )
         } else {
-            // No clipping (width/height = 0 disables clipping in shader)
-            ([0.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0])
+            // No clipping (negative width/height disables clipping in shader)
+            ([0.0, 0.0, -1.0, -1.0], [0.0, 1.0, 0.0, 0.0])
         };
 
         // Convert to NDC and create vertices with clip data

--- a/src/renderer/textured_quad_shader.wgsl
+++ b/src/renderer/textured_quad_shader.wgsl
@@ -67,8 +67,8 @@ fn rounded_rect_sdf(pos: vec2<f32>, rect: vec4<f32>, radius: f32) -> f32 {
 fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     var color = textureSample(t_texture, s_sampler, in.uv);
 
-    // Apply clipping if enabled (width and height > 0)
-    if (in.clip_rect.z > 0.0 && in.clip_rect.w > 0.0) {
+    // Apply clipping if enabled (negative width/height = no clip sentinel)
+    if (in.clip_rect.z >= 0.0 && in.clip_rect.w >= 0.0) {
         let clip_dist = rounded_rect_sdf(
             in.screen_pos,
             in.clip_rect,

--- a/src/widgets/container/animations.rs
+++ b/src/widgets/container/animations.rs
@@ -113,11 +113,16 @@ impl<T: Animatable> AnimationState<T> {
             return AdvanceResult::NoChange;
         }
 
-        // Extract active transition values upfront to avoid borrow conflicts
+        // Extract scalar transition values upfront to avoid borrow conflicts
+        // with self.spring_state. Copy SpringConfig (which is Copy) instead of
+        // cloning the entire TimingFunction (which may contain an Arc).
         let active = self.active_transition();
         let delay_ms = active.delay_ms;
         let duration_ms = active.duration_ms;
-        let timing = active.timing.clone();
+        let spring_config = match active.timing {
+            crate::animation::TimingFunction::Spring(config) => Some(config),
+            _ => None,
+        };
 
         let elapsed = self.start_time.elapsed().as_secs_f32() * 1000.0; // Convert to ms
         let adjusted_elapsed = (elapsed - delay_ms).max(0.0);
@@ -132,7 +137,7 @@ impl<T: Animatable> AnimationState<T> {
             // For spring animations: use real elapsed time in seconds (not normalized)
             // This allows the spring to continue oscillating until it naturally settles
             let elapsed_secs = adjusted_elapsed / 1000.0;
-            if let crate::animation::TimingFunction::Spring(ref config) = timing {
+            if let Some(ref config) = spring_config {
                 spring_state.step(elapsed_secs, config)
             } else {
                 // Fallback: shouldn't happen, but use normalized time
@@ -141,7 +146,8 @@ impl<T: Animatable> AnimationState<T> {
         } else {
             // For non-spring animations: use normalized time 0..1
             let t = (adjusted_elapsed / duration_ms).min(1.0);
-            timing.evaluate(t)
+            // Safe to borrow self again — spring_state mutable borrow ended above
+            self.active_transition().timing.evaluate(t)
         };
 
         // Interpolate

--- a/src/widgets/container/animations.rs
+++ b/src/widgets/container/animations.rs
@@ -1,6 +1,6 @@
 use std::time::Instant;
 
-use crate::animation::{Animatable, SpringState, Transition};
+use crate::animation::{Animatable, SpringState, Transition, TransitionConfig};
 
 /// Result of advancing an animation, indicating whether the value changed
 #[derive(Debug, Clone, PartialEq)]
@@ -30,8 +30,12 @@ pub struct AnimationState<T: Animatable> {
     progress: f32,
     /// Time when animation started
     start_time: Instant,
-    /// Transition configuration
+    /// Forward transition (used when value increases or no reverse is set)
     transition: Transition,
+    /// Optional reverse transition (used when value decreases)
+    reverse_transition: Option<Transition>,
+    /// Whether the current animation is using the reverse transition
+    using_reverse: bool,
     /// Spring state (for spring timing functions)
     spring_state: Option<SpringState>,
     /// Whether the animation has been initialized with its first real value
@@ -41,9 +45,10 @@ pub struct AnimationState<T: Animatable> {
 }
 
 impl<T: Animatable> AnimationState<T> {
-    pub fn new(initial_value: T, transition: Transition) -> Self {
+    pub fn new(initial_value: T, config: impl Into<TransitionConfig>) -> Self {
+        let config = config.into();
         let spring_state = if matches!(
-            transition.timing,
+            config.forward.timing,
             crate::animation::TimingFunction::Spring(_)
         ) {
             Some(SpringState::new())
@@ -56,10 +61,21 @@ impl<T: Animatable> AnimationState<T> {
             start: initial_value,
             progress: 1.0, // Start completed
             start_time: Instant::now(),
-            transition,
+            transition: config.forward,
+            reverse_transition: config.reverse,
+            using_reverse: false,
             spring_state,
             initialized: false, // Not yet initialized with real content-based value
             prev_value: None,
+        }
+    }
+
+    /// Get the currently active transition (forward or reverse).
+    fn active_transition(&self) -> &Transition {
+        if self.using_reverse {
+            self.reverse_transition.as_ref().unwrap_or(&self.transition)
+        } else {
+            &self.transition
         }
     }
 
@@ -70,14 +86,23 @@ impl<T: Animatable> AnimationState<T> {
             return;
         }
 
+        // Detect direction and select transition
+        self.using_reverse =
+            self.reverse_transition.is_some() && T::is_reverse(&self.current, &new_target);
+
+        // Check if active transition is spring before mutating other fields
+        let is_spring =
+            matches!(self.active_transition().timing, crate::animation::TimingFunction::Spring(_));
+
         self.start = self.current;
         self.target = new_target;
         self.progress = 0.0;
         self.start_time = Instant::now();
-        // Reset spring state for new animation
-        if self.spring_state.is_some() {
-            self.spring_state = Some(SpringState::new());
-        }
+        self.spring_state = if is_spring {
+            Some(SpringState::new())
+        } else {
+            None
+        };
     }
 
     /// Advance the animation and return whether the value changed
@@ -86,8 +111,14 @@ impl<T: Animatable> AnimationState<T> {
             return AdvanceResult::NoChange;
         }
 
+        // Extract active transition values upfront to avoid borrow conflicts
+        let active = self.active_transition();
+        let delay_ms = active.delay_ms;
+        let duration_ms = active.duration_ms;
+        let timing = active.timing.clone();
+
         let elapsed = self.start_time.elapsed().as_secs_f32() * 1000.0; // Convert to ms
-        let adjusted_elapsed = (elapsed - self.transition.delay_ms).max(0.0);
+        let adjusted_elapsed = (elapsed - delay_ms).max(0.0);
 
         if adjusted_elapsed <= 0.0 {
             // Still in delay period
@@ -99,16 +130,16 @@ impl<T: Animatable> AnimationState<T> {
             // For spring animations: use real elapsed time in seconds (not normalized)
             // This allows the spring to continue oscillating until it naturally settles
             let elapsed_secs = adjusted_elapsed / 1000.0;
-            if let crate::animation::TimingFunction::Spring(ref config) = self.transition.timing {
+            if let crate::animation::TimingFunction::Spring(ref config) = timing {
                 spring_state.step(elapsed_secs, config)
             } else {
                 // Fallback: shouldn't happen, but use normalized time
-                adjusted_elapsed / self.transition.duration_ms
+                adjusted_elapsed / duration_ms
             }
         } else {
             // For non-spring animations: use normalized time 0..1
-            let t = (adjusted_elapsed / self.transition.duration_ms).min(1.0);
-            self.transition.timing.evaluate(t)
+            let t = (adjusted_elapsed / duration_ms).min(1.0);
+            timing.evaluate(t)
         };
 
         // Interpolate
@@ -125,7 +156,7 @@ impl<T: Animatable> AnimationState<T> {
             }
         } else {
             // For non-spring animations, use time-based progress
-            let t = (adjusted_elapsed / self.transition.duration_ms).min(1.0);
+            let t = (adjusted_elapsed / duration_ms).min(1.0);
             self.progress = t;
         }
 

--- a/src/widgets/container/animations.rs
+++ b/src/widgets/container/animations.rs
@@ -91,8 +91,10 @@ impl<T: Animatable> AnimationState<T> {
             self.reverse_transition.is_some() && T::is_reverse(&self.current, &new_target);
 
         // Check if active transition is spring before mutating other fields
-        let is_spring =
-            matches!(self.active_transition().timing, crate::animation::TimingFunction::Spring(_));
+        let is_spring = matches!(
+            self.active_transition().timing,
+            crate::animation::TimingFunction::Spring(_)
+        );
 
         self.start = self.current;
         self.target = new_target;

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -1055,21 +1055,17 @@ impl Widget for Container {
                 )
             });
 
-        // Calculate current container dimensions
-        // Apply Length.max (from at_most()) early so children constraints and scroll
-        // viewport see the cap. Without this, a scrollable container with at_most(300)
-        // inside another scrollable (which passes max_height=INFINITY) would get
-        // viewport_height=INFINITY, making needs_vertical_scrollbar() always false.
-        let current_width = if let Some(ref anim) = self.width_anim {
-            if anim.is_initial() {
-                let w = width_length.exact.unwrap_or(constraints.max_width);
-                if let Some(max) = width_length.max {
-                    w.min(max)
-                } else {
-                    w
-                }
-            } else {
+        // Calculate dimensions for child layout constraints.
+        // When a layout animation is active and the width/height is exact, use
+        // the animated current value so children are positioned within the actual
+        // visible bounds (e.g., Center alignment tracks the animating size).
+        // For non-exact (shrink-to-fit) widths, use the signal value to avoid a
+        // circular dependency: animated width → constrains children → target = clamped.
+        let child_layout_width = if let Some(ref anim) = self.width_anim {
+            if !anim.is_initial() && width_length.exact.is_some() {
                 *anim.current()
+            } else {
+                width_length.exact.unwrap_or(constraints.max_width)
             }
         } else if let Some(exact) = width_length.exact {
             exact
@@ -1082,16 +1078,11 @@ impl Widget for Container {
             }
         };
 
-        let current_height = if let Some(ref anim) = self.height_anim {
-            if anim.is_initial() {
-                let h = height_length.exact.unwrap_or(constraints.max_height);
-                if let Some(max) = height_length.max {
-                    h.min(max)
-                } else {
-                    h
-                }
-            } else {
+        let child_layout_height = if let Some(ref anim) = self.height_anim {
+            if !anim.is_initial() && height_length.exact.is_some() {
                 *anim.current()
+            } else {
+                height_length.exact.unwrap_or(constraints.max_height)
             }
         } else if let Some(exact) = height_length.exact {
             exact
@@ -1104,24 +1095,9 @@ impl Widget for Container {
             }
         };
 
-        // Calculate undershoot for spring animations
-        let width_undershoot = if let Some(ref anim) = self.width_anim {
-            (*anim.target() - *anim.current()).max(0.0)
-        } else {
-            0.0
-        };
-
-        let height_undershoot = if let Some(ref anim) = self.height_anim {
-            (*anim.target() - *anim.current()).max(0.0)
-        } else {
-            0.0
-        };
-
-        // Child constraints with effective padding
-        let effective_h_padding = (padding.horizontal() - width_undershoot).max(0.0);
-        let effective_v_padding = (padding.vertical() - height_undershoot).max(0.0);
-        let mut child_max_width = (current_width - effective_h_padding).max(0.0);
-        let mut child_max_height = (current_height - effective_v_padding).max(0.0);
+        // Child constraints with padding
+        let mut child_max_width = (child_layout_width - padding.horizontal()).max(0.0);
+        let mut child_max_height = (child_layout_height - padding.vertical()).max(0.0);
 
         // Reserve gutter space for scrollbars
         if self.scrollbar_config.reserve_gutter
@@ -1143,7 +1119,7 @@ impl Widget for Container {
             // how much space they actually have to position children within.
             // Sources of minimum: explicit at_least(min) or parent constraints.
             let effective_min = width_length.min.unwrap_or(0.0).max(constraints.min_width);
-            (effective_min - effective_h_padding)
+            (effective_min - padding.horizontal())
                 .max(0.0)
                 .min(child_max_width)
         };
@@ -1151,7 +1127,7 @@ impl Widget for Container {
             child_max_height
         } else {
             let effective_min = height_length.min.unwrap_or(0.0).max(constraints.min_height);
-            (effective_min - effective_v_padding)
+            (effective_min - padding.vertical())
                 .max(0.0)
                 .min(child_max_height)
         };
@@ -1210,12 +1186,29 @@ impl Widget for Container {
             Size::zero()
         };
 
-        // Update scroll state
+        // Update scroll state — viewport uses the animated (visible) size, not the
+        // unconstrained child layout size, so scrollbars reflect the actual visible area.
         if scroll_axis != ScrollAxis::None {
             self.scroll_state.content_width = content_size.width + padding.horizontal();
             self.scroll_state.content_height = content_size.height + padding.vertical();
-            self.scroll_state.viewport_width = child_max_width;
-            self.scroll_state.viewport_height = child_max_height;
+            self.scroll_state.viewport_width = if let Some(ref anim) = self.width_anim {
+                if !anim.is_initial() {
+                    (*anim.current() - padding.horizontal()).max(0.0)
+                } else {
+                    child_max_width
+                }
+            } else {
+                child_max_width
+            };
+            self.scroll_state.viewport_height = if let Some(ref anim) = self.height_anim {
+                if !anim.is_initial() {
+                    (*anim.current() - padding.vertical()).max(0.0)
+                } else {
+                    child_max_height
+                }
+            } else {
+                child_max_height
+            };
             self.scroll_state.clamp_offsets();
         }
 
@@ -1230,17 +1223,17 @@ impl Widget for Container {
                 let min_w = width_length.min.unwrap_or(0.0);
                 content_width.max(min_w)
             };
-            if (effective_target - *anim.target()).abs() > 0.001 {
-                if anim.is_initial() {
-                    anim.set_immediate(effective_target);
-                } else {
-                    anim.animate_to(effective_target);
-                    // Width affects layout, so use RequiredJob::Layout
-                    request_job(id, JobRequest::Animation(RequiredJob::Layout));
-                    // Parent must reposition siblings as this child's width changes
-                    if let Some(parent_id) = tree.get_parent(id) {
-                        request_job(parent_id, JobRequest::Layout);
-                    }
+            if anim.is_initial() {
+                // Always mark as initialized on first layout so subsequent
+                // changes animate rather than snap.
+                anim.set_immediate(effective_target);
+            } else if (effective_target - *anim.target()).abs() > 0.001 {
+                anim.animate_to(effective_target);
+                // Width affects layout, so use RequiredJob::Layout
+                request_job(id, JobRequest::Animation(RequiredJob::Layout));
+                // Parent must reposition siblings as this child's width changes
+                if let Some(parent_id) = tree.get_parent(id) {
+                    request_job(parent_id, JobRequest::Layout);
                 }
             }
         }
@@ -1252,17 +1245,15 @@ impl Widget for Container {
                 let min_h = height_length.min.unwrap_or(0.0);
                 content_height.max(min_h)
             };
-            if (effective_target - *anim.target()).abs() > 0.001 {
-                if anim.is_initial() {
-                    anim.set_immediate(effective_target);
-                } else {
-                    anim.animate_to(effective_target);
-                    // Height affects layout, so use RequiredJob::Layout
-                    request_job(id, JobRequest::Animation(RequiredJob::Layout));
-                    // Parent must reposition siblings as this child's height changes
-                    if let Some(parent_id) = tree.get_parent(id) {
-                        request_job(parent_id, JobRequest::Layout);
-                    }
+            if anim.is_initial() {
+                anim.set_immediate(effective_target);
+            } else if (effective_target - *anim.target()).abs() > 0.001 {
+                anim.animate_to(effective_target);
+                // Height affects layout, so use RequiredJob::Layout
+                request_job(id, JobRequest::Animation(RequiredJob::Layout));
+                // Parent must reposition siblings as this child's height changes
+                if let Some(parent_id) = tree.get_parent(id) {
+                    request_job(parent_id, JobRequest::Layout);
                 }
             }
         }
@@ -1507,13 +1498,24 @@ impl Widget for Container {
             local_event.clone()
         };
 
+        // When overflow is hidden, children outside the container's bounds are
+        // clipped and invisible. Skip dispatching pointer events to them so that
+        // invisible children (e.g. inside a 0-height collapsed submenu) cannot
+        // steal clicks from siblings positioned below.
+        let skip_child_dispatch = self.overflow == Overflow::Hidden
+            && local_event
+                .coords()
+                .is_some_and(|(x, y)| !bounds.contains(x, y));
+
         // Let children handle first (layout already reconciled)
-        for &child_id in self.children_source.get() {
-            if let Some(response) = tree.with_widget_mut(child_id, |child, child_id, tree| {
-                child.event(tree, child_id, &child_event)
-            }) && response == EventResponse::Handled
-            {
-                return EventResponse::Handled;
+        if !skip_child_dispatch {
+            for &child_id in self.children_source.get() {
+                if let Some(response) = tree.with_widget_mut(child_id, |child, child_id, tree| {
+                    child.event(tree, child_id, &child_event)
+                }) && response == EventResponse::Handled
+                {
+                    return EventResponse::Handled;
+                }
             }
         }
 
@@ -1790,10 +1792,9 @@ impl Widget for Container {
         // Determine if we need to clip children
         let is_scrollable = self.scroll_axis != ScrollAxis::None;
 
-        // Set clip region for scrollable containers
+        // Set clip region for scrollable or overflow:hidden containers
         // This clips all children to the container bounds
-        if is_scrollable {
-            // Clip to container bounds (local coordinates)
+        if is_scrollable || self.overflow == Overflow::Hidden {
             ctx.set_clip(local_bounds, corner_radius, corner_curvature);
         }
 
@@ -1810,6 +1811,13 @@ impl Widget for Container {
         } else {
             ctx.cull_rect()
         };
+
+        // Skip painting children when the container has zero area — nothing
+        // can be visible and attempting to render (especially text) wastes
+        // atlas space and GPU work.
+        if bounds.width < 0.5 || bounds.height < 0.5 {
+            return;
+        }
 
         // Draw children - each gets its own node with position transform
         for &child_id in self.children_source.get() {

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -11,7 +11,7 @@ use std::borrow::Cow;
 use std::rc::Rc;
 
 use crate::advance_anim;
-use crate::animation::Transition;
+use crate::animation::TransitionConfig;
 use crate::jobs::{JobRequest, JobType, RequiredJob, request_job};
 use crate::layout::{Constraints, Flex, Layout, Length, Size};
 use crate::reactive::{
@@ -538,7 +538,7 @@ impl Container {
     }
 
     /// Enable animation for width changes
-    pub fn animate_width(mut self, transition: Transition) -> Self {
+    pub fn animate_width(mut self, transition: impl Into<TransitionConfig>) -> Self {
         let initial = self
             .width
             .as_ref()
@@ -552,7 +552,7 @@ impl Container {
     }
 
     /// Enable animation for height changes
-    pub fn animate_height(mut self, transition: Transition) -> Self {
+    pub fn animate_height(mut self, transition: impl Into<TransitionConfig>) -> Self {
         let initial = self
             .height
             .as_ref()
@@ -566,42 +566,42 @@ impl Container {
     }
 
     /// Enable animation for background color changes
-    pub fn animate_background(mut self, transition: Transition) -> Self {
+    pub fn animate_background(mut self, transition: impl Into<TransitionConfig>) -> Self {
         let initial = self.background.get_or(Color::TRANSPARENT);
         self.background_anim = Some(AnimationState::new(initial, transition));
         self
     }
 
     /// Enable animation for corner radius changes
-    pub fn animate_corner_radius(mut self, transition: Transition) -> Self {
+    pub fn animate_corner_radius(mut self, transition: impl Into<TransitionConfig>) -> Self {
         let initial = self.corner_radius.get_or(0.0);
         self.corner_radius_anim = Some(AnimationState::new(initial, transition));
         self
     }
 
     /// Enable animation for padding changes
-    pub fn animate_padding(mut self, transition: Transition) -> Self {
+    pub fn animate_padding(mut self, transition: impl Into<TransitionConfig>) -> Self {
         let initial = self.padding.get_or(Padding::default());
         self.padding_anim = Some(AnimationState::new(initial, transition));
         self
     }
 
     /// Enable animation for border width changes
-    pub fn animate_border_width(mut self, transition: Transition) -> Self {
+    pub fn animate_border_width(mut self, transition: impl Into<TransitionConfig>) -> Self {
         let initial = self.border_width.get_or(0.0);
         self.border_width_anim = Some(AnimationState::new(initial, transition));
         self
     }
 
     /// Enable animation for border color changes
-    pub fn animate_border_color(mut self, transition: Transition) -> Self {
+    pub fn animate_border_color(mut self, transition: impl Into<TransitionConfig>) -> Self {
         let initial = self.border_color.get_or(Color::TRANSPARENT);
         self.border_color_anim = Some(AnimationState::new(initial, transition));
         self
     }
 
     /// Enable animation for transform changes
-    pub fn animate_transform(mut self, transition: Transition) -> Self {
+    pub fn animate_transform(mut self, transition: impl Into<TransitionConfig>) -> Self {
         let initial = self.transform.get_or(Transform::IDENTITY);
         self.transform_anim = Some(AnimationState::new(initial, transition));
         self


### PR DESCRIPTION
## Summary

- **Directional reverse transitions**: `Transition::reverse()` lets you use different transitions for forward vs reverse animations (e.g., bouncy spring for open, smooth ease-out for close). Added `Animatable::is_reverse()` trait method and `TransitionConfig` struct.
- **Clip sentinel fix**: Use negative width/height (`-1, -1`) as the no-clip sentinel instead of zero, so zero-area clips correctly hide content (fixes containers animating from 0 size leaking children).
- **Overflow:hidden event fix**: Skip dispatching pointer events to children outside clipped bounds, preventing invisible children (e.g., inside collapsed submenus) from stealing clicks.
- **Flex spacing fix**: Collapse spacing around zero-sized children so animated containers at size 0 don't leave gaps.
- **Text rendering fixes**: Cull zero-scale text, use full transform for bounding box calculation, rasterize at fixed resolution to prevent atlas churn during scale animations.
- **Layout animation fixes**: Use animated size for child constraints only with exact widths (not shrink-to-fit), scroll viewport tracks animated size, always initialize animations on first layout.
- **Cleanup**: Extract `MIN_VISIBLE_SIZE` constant, avoid `TimingFunction` clone per animation frame.

## Test plan
- [ ] Run `cargo check`, `cargo clippy`, `cargo fmt` — all pass
- [ ] Verify animations with reverse transitions (open/close with different curves)
- [ ] Verify overflow:hidden containers clip events correctly
- [ ] Verify zero-sized animated containers don't leave spacing gaps
- [ ] Verify text renders correctly under scale/rotation transforms