### PR TITLE
fix: code review cleanups from #100

### DIFF
--- a/src/animation/animatable.rs
+++ b/src/animation/animatable.rs
@@ -42,9 +42,7 @@ impl Animatable for Color {
     fn is_reverse(from: &Self, to: &Self) -> bool {
         // Reverse when fading out (alpha decreasing),
         // or when darkening (luminance decreasing) at same alpha
-        let to_lum = to.r * 0.299 + to.g * 0.587 + to.b * 0.114;
-        let from_lum = from.r * 0.299 + from.g * 0.587 + from.b * 0.114;
-        (to.a, to_lum) < (from.a, from_lum)
+        (to.a, to.luminance()) < (from.a, from.luminance())
     }
 }
 

--- a/src/renderer/gpu.rs
+++ b/src/renderer/gpu.rs
@@ -6,6 +6,9 @@
 
 use wgpu::{VertexAttribute, VertexBufferLayout, VertexFormat, VertexStepMode};
 
+/// Clip rect sentinel: negative width/height disables clipping in the shader.
+pub const NO_CLIP_RECT: [f32; 4] = [0.0, 0.0, -1.0, -1.0];
+
 /// Uniform buffer data passed to the shader.
 ///
 /// Contains screen-wide information needed for coordinate conversion.
@@ -168,7 +171,7 @@ impl Default for ShapeInstance {
             shadow_color: [0.0, 0.0, 0.0, 0.0],
             transform: [1.0, 0.0, 0.0, 0.0, 1.0, 0.0], // identity
             _pad2: [0.0, 0.0],
-            clip_rect: [0.0, 0.0, -1.0, -1.0], // No clipping (negative width/height)
+            clip_rect: NO_CLIP_RECT,
             clip_corner_radius: 0.0,
             clip_curvature: 1.0,
             clip_is_local: 0.0,

--- a/src/renderer/image_quad.rs
+++ b/src/renderer/image_quad.rs
@@ -14,9 +14,9 @@ use wgpu::{
 };
 
 use super::commands::DrawCommand;
-use super::gpu::NO_CLIP_RECT;
 use super::constants::{IMAGE_HASH_SAMPLE_SIZE, SVG_QUALITY_MULTIPLIER};
 use super::flatten::FlattenedCommand;
+use super::gpu::NO_CLIP_RECT;
 use super::textured_vertex::{TexturedVertex, to_ndc};
 use crate::widgets::Rect;
 use crate::widgets::image::{ContentFit, ImageSource};

--- a/src/renderer/image_quad.rs
+++ b/src/renderer/image_quad.rs
@@ -14,6 +14,7 @@ use wgpu::{
 };
 
 use super::commands::DrawCommand;
+use super::gpu::NO_CLIP_RECT;
 use super::constants::{IMAGE_HASH_SAMPLE_SIZE, SVG_QUALITY_MULTIPLIER};
 use super::flatten::FlattenedCommand;
 use super::textured_vertex::{TexturedVertex, to_ndc};
@@ -564,8 +565,8 @@ impl ImageQuadRenderer {
                 [clip.corner_radius * scale_factor, clip.curvature, 0.0, 0.0],
             )
         } else {
-            // No clipping (negative width/height disables clipping in shader)
-            ([0.0, 0.0, -1.0, -1.0], [0.0, 1.0, 0.0, 0.0])
+            // No clipping
+            (NO_CLIP_RECT, [0.0, 1.0, 0.0, 0.0])
         };
 
         // Transform corners from local to screen coordinates

--- a/src/renderer/text_quad.rs
+++ b/src/renderer/text_quad.rs
@@ -21,6 +21,7 @@ use wgpu::{
 };
 
 use super::constants::{TEXT_BUFFER_MARGIN_MULTIPLIER, TEXT_TEXTURE_PADDING};
+use super::gpu::NO_CLIP_RECT;
 use super::textured_vertex::{TexturedVertex, to_ndc};
 use super::types::TextEntry;
 use crate::widgets::font::FontWeight;
@@ -441,8 +442,8 @@ impl TextQuadRenderer {
                 [0.0, 1.0, 0.0, 0.0], // No corner radius for text clip (uses rect from TextEntry)
             )
         } else {
-            // No clipping (negative width/height disables clipping in shader)
-            ([0.0, 0.0, -1.0, -1.0], [0.0, 1.0, 0.0, 0.0])
+            // No clipping
+            (NO_CLIP_RECT, [0.0, 1.0, 0.0, 0.0])
         };
 
         // Convert to NDC and create vertices with clip data

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -1191,24 +1191,8 @@ impl Widget for Container {
         if scroll_axis != ScrollAxis::None {
             self.scroll_state.content_width = content_size.width + padding.horizontal();
             self.scroll_state.content_height = content_size.height + padding.vertical();
-            self.scroll_state.viewport_width = if let Some(ref anim) = self.width_anim {
-                if !anim.is_initial() {
-                    (*anim.current() - padding.horizontal()).max(0.0)
-                } else {
-                    child_max_width
-                }
-            } else {
-                child_max_width
-            };
-            self.scroll_state.viewport_height = if let Some(ref anim) = self.height_anim {
-                if !anim.is_initial() {
-                    (*anim.current() - padding.vertical()).max(0.0)
-                } else {
-                    child_max_height
-                }
-            } else {
-                child_max_height
-            };
+            self.scroll_state.viewport_width = child_max_width;
+            self.scroll_state.viewport_height = child_max_height;
             self.scroll_state.clamp_offsets();
         }
 
@@ -1502,7 +1486,8 @@ impl Widget for Container {
         // clipped and invisible. Skip dispatching pointer events to them so that
         // invisible children (e.g. inside a 0-height collapsed submenu) cannot
         // steal clicks from siblings positioned below.
-        let skip_child_dispatch = self.overflow == Overflow::Hidden
+        let skip_child_dispatch = (self.overflow == Overflow::Hidden
+            || self.scroll_axis != ScrollAxis::None)
             && local_event
                 .coords()
                 .is_some_and(|(x, y)| !bounds.contains(x, y));


### PR DESCRIPTION
## Summary
- **Extract `NO_CLIP_RECT` constant** — the `[0.0, 0.0, -1.0, -1.0]` clip sentinel was duplicated across `gpu.rs`, `image_quad.rs`, and `text_quad.rs`
- **Use existing `Color::luminance()`** in `is_reverse` — was inlining Rec. 601 coefficients while `luminance()` already exists with Rec. 709
- **Fix `skip_child_dispatch` for scroll containers** — previously only checked `overflow == Hidden`, but scrollable containers also clip children visually, so scrolled-out-of-view children could receive click events
- **Simplify scroll viewport calculation** — `child_max_width`/`child_max_height` already incorporate the animated value, so the redundant if-let branches were removed

## Test plan
- [ ] `cargo check` passes
- [ ] `cargo clippy` clean
- [ ] Verify scroll containers don't dispatch events to clipped children
- [ ] Verify animated width/height scroll containers still clamp scroll offsets correctly