### PR TITLE
perf: optimize memory layout and fix O(n²) hotspots for large widget trees

### DIFF
--- a/examples/perf_stress_test.rs
+++ b/examples/perf_stress_test.rs
@@ -13,10 +13,9 @@ use guido::prelude::*;
 use std::cell::RefCell;
 use std::rc::Rc;
 
-const INITIAL_ITEM_COUNT: usize = 1000;
+const INITIAL_ITEM_COUNT: usize = 10000;
 
 struct ItemData {
-    id: u64,
     enabled: Signal<bool>,
     input_value: Signal<String>,
 }
@@ -26,8 +25,7 @@ fn main() {
         // Store item data in a Rc<RefCell<Vec>> since Signal requires Send and ItemData contains !Send signals
         let item_store: Rc<RefCell<Vec<ItemData>>> = Rc::new(RefCell::new(
             (0..INITIAL_ITEM_COUNT)
-                .map(|i| ItemData {
-                    id: i as u64,
+                .map(|_| ItemData {
                     enabled: create_signal(false),
                     input_value: create_signal(String::new()),
                 })
@@ -47,7 +45,7 @@ fn main() {
                     let ids = item_ids.get();
                     ids.iter()
                         .filter_map(|&id| {
-                            store.iter().find(|item| item.id == id).map(|item| {
+                            store.get(id as usize).map(|item| {
                                 let enabled = item.enabled;
                                 let input_value = item.input_value;
                                 (id, move || {
@@ -110,7 +108,6 @@ fn create_add_button(
         .on_click(move || {
             let id = item_store.borrow().len() as u64;
             item_store.borrow_mut().push(ItemData {
-                id,
                 enabled: create_signal(false),
                 input_value: create_signal(String::new()),
             });

--- a/src/layout/flex_layout.rs
+++ b/src/layout/flex_layout.rs
@@ -46,6 +46,7 @@ pub struct Flex {
     cross_alignment: Option<Signal<CrossAlignment>>,
 
     child_sizes: Vec<Size>,
+    fill_indices: Vec<usize>,
 }
 
 impl Flex {
@@ -61,6 +62,7 @@ impl Flex {
             main_alignment: None,
             cross_alignment: None,
             child_sizes: Vec::with_capacity(8),
+            fill_indices: Vec::new(),
         }
     }
 
@@ -149,19 +151,6 @@ impl Flex {
             ),
         };
 
-        // Pre-scan fill flags via layout_hints() before any layout
-        let is_fill: Vec<bool> = children
-            .iter()
-            .map(|&id| {
-                tree.with_widget(id, |w| match axis {
-                    Axis::Horizontal => w.layout_hints().fill_width,
-                    Axis::Vertical => w.layout_hints().fill_height,
-                })
-                .unwrap_or(false)
-            })
-            .collect();
-        let fill_count = is_fill.iter().filter(|&&f| f).count();
-
         // For Stretch alignment, use min constraint if set
         let stretch_cross = if cross_align == CrossAlignment::Stretch && cross_min > 0.0 {
             Some(cross_min)
@@ -188,16 +177,24 @@ impl Flex {
         self.child_sizes.clear();
         self.child_sizes.resize(children.len(), Size::zero());
 
-        // Pass 1: layout non-fill children to measure their main-axis contribution
+        // Pass 1: layout non-fill children and collect fill child indices
         let mut non_fill_main = 0.0f32;
         let mut max_cross = 0.0f32;
+        self.fill_indices.clear();
 
         for (i, &child_id) in children.iter().enumerate() {
-            if !is_fill[i]
-                && let Some(size) = tree.with_widget_mut(child_id, |widget, id, tree| {
-                    widget.layout(tree, id, child_constraints)
+            let is_fill = tree
+                .with_widget(child_id, |w| match axis {
+                    Axis::Horizontal => w.layout_hints().fill_width,
+                    Axis::Vertical => w.layout_hints().fill_height,
                 })
-            {
+                .unwrap_or(false);
+
+            if is_fill {
+                self.fill_indices.push(i);
+            } else if let Some(size) = tree.with_widget_mut(child_id, |widget, id, tree| {
+                widget.layout(tree, id, child_constraints)
+            }) {
                 non_fill_main += size.main_axis(axis);
                 max_cross = max_cross.max(size.cross_axis(axis));
                 self.child_sizes[i] = size;
@@ -210,15 +207,15 @@ impl Flex {
         } else {
             0.0
         };
-        let per_fill = if fill_count > 0 {
+        let per_fill = if !self.fill_indices.is_empty() {
             let remaining = (main_max - non_fill_main - total_spacing).max(0.0);
-            remaining / fill_count as f32
+            remaining / self.fill_indices.len() as f32
         } else {
             0.0
         };
 
         // Pass 2: layout fill children with tight main-axis constraints
-        if fill_count > 0 {
+        if !self.fill_indices.is_empty() {
             let fill_constraints = match axis {
                 Axis::Horizontal => Constraints {
                     min_width: per_fill,
@@ -232,12 +229,11 @@ impl Flex {
                 },
             };
 
-            for (i, &child_id) in children.iter().enumerate() {
-                if is_fill[i]
-                    && let Some(size) = tree.with_widget_mut(child_id, |widget, id, tree| {
-                        widget.layout(tree, id, fill_constraints)
-                    })
-                {
+            for &i in &self.fill_indices {
+                let child_id = children[i];
+                if let Some(size) = tree.with_widget_mut(child_id, |widget, id, tree| {
+                    widget.layout(tree, id, fill_constraints)
+                }) {
                     max_cross = max_cross.max(size.cross_axis(axis));
                     self.child_sizes[i] = size;
                 }
@@ -269,17 +265,18 @@ impl Flex {
                     children_main += self.child_sizes[i].main_axis(axis);
                     continue;
                 }
-                let main_constraint = if is_fill[i] { per_fill } else { main_max };
+                let child_is_fill = self.fill_indices.contains(&i);
+                let main_constraint = if child_is_fill { per_fill } else { main_max };
                 let stretch_constraints = match axis {
                     Axis::Horizontal => Constraints {
-                        min_width: if is_fill[i] { per_fill } else { 0.0 },
+                        min_width: if child_is_fill { per_fill } else { 0.0 },
                         min_height: cross_size,
                         max_width: main_constraint,
                         max_height: cross_size,
                     },
                     Axis::Vertical => Constraints {
                         min_width: cross_size,
-                        min_height: if is_fill[i] { per_fill } else { 0.0 },
+                        min_height: if child_is_fill { per_fill } else { 0.0 },
                         max_width: cross_size,
                         max_height: main_constraint,
                     },

--- a/src/layout/flex_layout.rs
+++ b/src/layout/flex_layout.rs
@@ -265,7 +265,7 @@ impl Flex {
                     children_main += self.child_sizes[i].main_axis(axis);
                     continue;
                 }
-                let child_is_fill = self.fill_indices.contains(&i);
+                let child_is_fill = self.fill_indices.binary_search(&i).is_ok();
                 let main_constraint = if child_is_fill { per_fill } else { main_max };
                 let stretch_constraints = match axis {
                     Axis::Horizontal => Constraints {

--- a/src/reactive/invalidation.rs
+++ b/src/reactive/invalidation.rs
@@ -11,7 +11,8 @@
 //! ## Subscriber Registry
 //!
 //! A global registry maps signal IDs to their subscribers (widget + job type pairs).
-//! When a signal changes, all subscribers receive jobs via the jobs system.
+//! Signal IDs are dense sequential integers so we use `Vec` for direct O(1) indexing.
+//! A reverse index maps widget IDs to their subscribed signals for O(1) cleanup.
 //!
 //! ## Integration with Jobs System
 //!
@@ -19,7 +20,9 @@
 //! subscribers. The jobs system deduplicates these and wakes the event loop.
 
 use std::cell::RefCell;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
+
+use smallvec::SmallVec;
 
 use crate::jobs::{JobRequest, JobType, request_job};
 use crate::tree::WidgetId;
@@ -94,38 +97,80 @@ struct Subscriber {
     job_type: JobType,
 }
 
+/// Most signals have 1-2 widget subscribers (e.g. one paint, one layout).
+type SubscriberList = SmallVec<[Subscriber; 2]>;
+
+/// Most widgets subscribe to 2-6 signals (background, padding, etc.).
+type SignalList = SmallVec<[usize; 4]>;
+
+struct SubscriberRegistry {
+    /// Forward index: signal_id → subscribers. Direct Vec indexing (signal IDs are dense).
+    signal_to_widgets: Vec<SubscriberList>,
+    /// Reverse index: widget_id → subscribed signal IDs. For O(1) widget cleanup.
+    widget_to_signals: HashMap<WidgetId, SignalList>,
+}
+
+impl SubscriberRegistry {
+    fn new() -> Self {
+        Self {
+            signal_to_widgets: Vec::new(),
+            widget_to_signals: HashMap::new(),
+        }
+    }
+
+    /// Ensure the forward index has capacity for the given signal ID.
+    fn ensure_signal_capacity(&mut self, signal_id: usize) {
+        if signal_id >= self.signal_to_widgets.len() {
+            self.signal_to_widgets
+                .resize_with(signal_id + 1, SmallVec::new);
+        }
+    }
+}
+
 thread_local! {
-    /// Map from signal ID to subscribers.
-    /// All access is on the main thread — background writes go through
-    /// `queue_bg_write()` → `flush_bg_writes()` which executes on the main thread.
-    static SIGNAL_SUBSCRIBERS: RefCell<HashMap<usize, HashSet<Subscriber>>> =
-        RefCell::new(HashMap::new());
+    /// Subscriber registry. All access is on the main thread — background writes go
+    /// through `queue_bg_write()` → `flush_bg_writes()` which executes on the main thread.
+    static REGISTRY: RefCell<SubscriberRegistry> = RefCell::new(SubscriberRegistry::new());
 }
 
 /// Register a widget as a subscriber for a signal with a specific job type
 pub fn register_subscriber(widget_id: WidgetId, signal_id: usize, job_type: JobType) {
-    SIGNAL_SUBSCRIBERS.with(|subs| {
-        subs.borrow_mut()
-            .entry(signal_id)
-            .or_default()
-            .insert(Subscriber {
-                widget_id,
-                job_type,
-            });
+    REGISTRY.with(|reg| {
+        let mut reg = reg.borrow_mut();
+        reg.ensure_signal_capacity(signal_id);
+
+        let sub = Subscriber {
+            widget_id,
+            job_type,
+        };
+
+        let subs = &mut reg.signal_to_widgets[signal_id];
+        if !subs.contains(&sub) {
+            subs.push(sub);
+        }
+
+        // Update reverse index
+        let signals = reg.widget_to_signals.entry(widget_id).or_default();
+        if !signals.contains(&signal_id) {
+            signals.push(signal_id);
+        }
     });
 }
 
 /// Notify all subscribers of a signal change by creating jobs
 pub fn notify_signal_change(signal_id: usize) {
-    let subscribers: Vec<Subscriber> = SIGNAL_SUBSCRIBERS.with(|subs| {
-        subs.borrow()
-            .get(&signal_id)
-            .map(|s| s.iter().copied().collect())
-            .unwrap_or_default()
+    // Collect subscribers while holding the borrow, then release before calling request_job
+    // (which may trigger further signal reads/writes)
+    let subscribers: SmallVec<[Subscriber; 4]> = REGISTRY.with(|reg| {
+        let reg = reg.borrow();
+        if signal_id < reg.signal_to_widgets.len() {
+            reg.signal_to_widgets[signal_id].iter().copied().collect()
+        } else {
+            SmallVec::new()
+        }
     });
 
     for sub in &subscribers {
-        // Convert JobType to JobRequest for the new API
         let request = match sub.job_type {
             JobType::Layout => JobRequest::Layout,
             JobType::Paint => JobRequest::Paint,
@@ -139,8 +184,20 @@ pub fn notify_signal_change(signal_id: usize) {
 
 /// Clear signal subscribers for a specific signal (when signal is disposed)
 pub fn clear_signal_subscribers(signal_id: usize) {
-    SIGNAL_SUBSCRIBERS.with(|subs| {
-        subs.borrow_mut().remove(&signal_id);
+    REGISTRY.with(|reg| {
+        let mut reg = reg.borrow_mut();
+        if signal_id < reg.signal_to_widgets.len() {
+            // Remove this signal from the reverse index of each subscriber
+            let subs = std::mem::take(&mut reg.signal_to_widgets[signal_id]);
+            for sub in &subs {
+                if let Some(signals) = reg.widget_to_signals.get_mut(&sub.widget_id) {
+                    signals.retain(|&mut s| s != signal_id);
+                    if signals.is_empty() {
+                        reg.widget_to_signals.remove(&sub.widget_id);
+                    }
+                }
+            }
+        }
     });
 }
 
@@ -148,12 +205,16 @@ pub fn clear_signal_subscribers(signal_id: usize) {
 /// Called when a widget is unregistered to prevent stale subscribers
 /// from causing wasted job creation.
 pub fn clear_widget_subscribers(widget_id: WidgetId) {
-    SIGNAL_SUBSCRIBERS.with(|subs| {
-        let mut subs = subs.borrow_mut();
-        subs.retain(|_, subscribers| {
-            subscribers.retain(|s| s.widget_id != widget_id);
-            !subscribers.is_empty()
-        });
+    REGISTRY.with(|reg| {
+        let mut reg = reg.borrow_mut();
+        // Use reverse index: only touch the signals this widget actually subscribes to
+        if let Some(signal_ids) = reg.widget_to_signals.remove(&widget_id) {
+            for signal_id in signal_ids {
+                if signal_id < reg.signal_to_widgets.len() {
+                    reg.signal_to_widgets[signal_id].retain(|s| s.widget_id != widget_id);
+                }
+            }
+        }
     });
 }
 
@@ -162,13 +223,19 @@ pub fn clear_widget_subscribers(widget_id: WidgetId) {
 /// Called during `App::drop()` to wipe stale widget-signal subscriptions.
 pub(crate) fn reset_invalidation() {
     TRACKING_CONTEXT.with(|ctx| ctx.borrow_mut().clear());
-    SIGNAL_SUBSCRIBERS.with(|subs| subs.borrow_mut().clear());
+    REGISTRY.with(|reg| *reg.borrow_mut() = SubscriberRegistry::new());
 }
 
 /// Get the number of signals with active subscribers (for testing).
 #[cfg(test)]
 fn subscriber_count() -> usize {
-    SIGNAL_SUBSCRIBERS.with(|subs| subs.borrow().len())
+    REGISTRY.with(|reg| {
+        reg.borrow()
+            .signal_to_widgets
+            .iter()
+            .filter(|s| !s.is_empty())
+            .count()
+    })
 }
 
 #[cfg(test)]
@@ -188,9 +255,10 @@ mod tests {
 
         clear_signal_subscribers(42);
 
-        // Signal 42 should be removed
-        SIGNAL_SUBSCRIBERS.with(|subs| {
-            assert!(!subs.borrow().contains_key(&42));
+        // Signal 42 should have no subscribers
+        REGISTRY.with(|reg| {
+            let reg = reg.borrow();
+            assert!(reg.signal_to_widgets.get(42).is_none_or(|s| s.is_empty()));
         });
     }
 
@@ -207,14 +275,14 @@ mod tests {
 
         clear_widget_subscribers(wid);
 
-        SIGNAL_SUBSCRIBERS.with(|subs| {
-            let subs = subs.borrow();
-            // Signal 10 should still exist (widget 201 still subscribes)
-            let s10 = subs.get(&10).unwrap();
+        REGISTRY.with(|reg| {
+            let reg = reg.borrow();
+            // Signal 10 should still have widget 201
+            let s10 = &reg.signal_to_widgets[10];
             assert!(s10.iter().all(|s| s.widget_id != wid));
             assert!(s10.iter().any(|s| s.widget_id == other));
-            // Signal 11 should be removed entirely (only widget 200 subscribed)
-            assert!(!subs.contains_key(&11));
+            // Signal 11 should be empty (only widget 200 subscribed)
+            assert!(reg.signal_to_widgets[11].is_empty());
         });
     }
 
@@ -227,9 +295,9 @@ mod tests {
             record_signal_read(signal_id);
         });
 
-        SIGNAL_SUBSCRIBERS.with(|subs| {
-            let subs = subs.borrow();
-            let s = subs.get(&signal_id).unwrap();
+        REGISTRY.with(|reg| {
+            let reg = reg.borrow();
+            let s = &reg.signal_to_widgets[signal_id];
             assert!(s.contains(&Subscriber {
                 widget_id: wid,
                 job_type: JobType::Paint,
@@ -238,5 +306,26 @@ mod tests {
 
         // Clean up
         clear_signal_subscribers(signal_id);
+    }
+
+    #[test]
+    fn test_reverse_index_consistency() {
+        let wid = widget_id(400);
+        register_subscriber(wid, 50, JobType::Paint);
+        register_subscriber(wid, 51, JobType::Layout);
+
+        REGISTRY.with(|reg| {
+            let reg = reg.borrow();
+            let signals = reg.widget_to_signals.get(&wid).unwrap();
+            assert!(signals.contains(&50));
+            assert!(signals.contains(&51));
+        });
+
+        clear_widget_subscribers(wid);
+
+        REGISTRY.with(|reg| {
+            let reg = reg.borrow();
+            assert!(!reg.widget_to_signals.contains_key(&wid));
+        });
     }
 }

--- a/src/renderer/tree.rs
+++ b/src/renderer/tree.rs
@@ -2,6 +2,8 @@
 
 use std::rc::Rc;
 
+use smallvec::SmallVec;
+
 use crate::transform::Transform;
 use crate::transform_origin::TransformOrigin;
 use crate::widgets::Rect;
@@ -68,14 +70,16 @@ pub struct RenderNode {
     /// Draw commands for this node (shapes, text, etc.).
     /// These are in LOCAL coordinates - world transform applied during flatten.
     /// Wrapped in Rc so flatten can share them via Rc::clone() instead of deep-cloning.
-    pub commands: Vec<Rc<DrawCommand>>,
+    /// SmallVec: most nodes have 1-2 commands (background + border).
+    pub commands: SmallVec<[Rc<DrawCommand>; 2]>,
 
     /// Child nodes (nested widgets)
     pub children: Vec<RenderNode>,
 
     /// Overlay commands - drawn AFTER all children (for ripples, effects).
     /// These are also in local coordinates.
-    pub overlay_commands: Vec<Rc<DrawCommand>>,
+    /// SmallVec: most nodes have 0-1 overlay commands (ripple only).
+    pub overlay_commands: SmallVec<[Rc<DrawCommand>; 1]>,
 
     /// Optional clip region that applies to this node and children.
     /// The clip rect is in local coordinates (0,0 = node origin).
@@ -104,9 +108,9 @@ impl RenderNode {
             parent_position: Transform::IDENTITY,
             transform_origin: TransformOrigin::CENTER,
             bounds: Rect::new(0.0, 0.0, 0.0, 0.0),
-            commands: Vec::new(),
+            commands: SmallVec::new(),
             children: Vec::new(),
-            overlay_commands: Vec::new(),
+            overlay_commands: SmallVec::new(),
             clip: None,
             overlay_clip: None,
             repainted: true,

--- a/src/widgets/container/animations.rs
+++ b/src/widgets/container/animations.rs
@@ -278,10 +278,13 @@ macro_rules! advance_anim {
 /// Helper to get an animated value or a fallback
 #[inline]
 pub fn get_animated_value<T: Animatable + Copy>(
-    anim: &Option<AnimationState<T>>,
+    anim: Option<&AnimationState<T>>,
     fallback: impl FnOnce() -> T,
 ) -> T {
-    anim.as_ref().map(|a| *a.current()).unwrap_or_else(fallback)
+    match anim {
+        Some(a) => *a.current(),
+        None => fallback(),
+    }
 }
 
 #[cfg(test)]
@@ -353,17 +356,14 @@ mod tests {
         let transition = Transition::new(300.0, TimingFunction::Linear);
         let mut state = AnimationState::new(42.0f32, transition);
         state.set_immediate(42.0);
-        let opt = Some(state);
 
-        let value = get_animated_value(&opt, || 0.0);
+        let value = get_animated_value(Some(&state), || 0.0);
         assert_eq!(value, 42.0);
     }
 
     #[test]
     fn test_get_animated_value_with_none() {
-        let opt: Option<AnimationState<f32>> = None;
-
-        let value = get_animated_value(&opt, || 99.0);
+        let value = get_animated_value::<f32>(None, || 99.0);
         assert_eq!(value, 99.0);
     }
 }

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -123,6 +123,20 @@ pub enum Overflow {
     Hidden,
 }
 
+/// Boxed animation states. Only allocated when `.transition()` or
+/// `.animate_*()` is called, saving ~400 bytes per non-animated Container.
+#[derive(Default)]
+pub(super) struct ContainerAnims {
+    pub(super) width: Option<AnimationState<f32>>,
+    pub(super) height: Option<AnimationState<f32>>,
+    pub(super) background: Option<AnimationState<Color>>,
+    pub(super) corner_radius: Option<AnimationState<f32>>,
+    pub(super) padding: Option<AnimationState<Padding>>,
+    pub(super) border_width: Option<AnimationState<f32>>,
+    pub(super) border_color: Option<AnimationState<Color>>,
+    pub(super) transform: Option<AnimationState<Transform>>,
+}
+
 /// Scroll state and configuration, boxed to avoid bloating Container.
 /// Only allocated when `.scrollable()` is called.
 pub(super) struct ScrollData {
@@ -189,15 +203,8 @@ pub struct Container {
     pub(super) is_hovered: bool,
     pub(super) is_pressed: bool,
 
-    // Animation state
-    pub(super) width_anim: Option<AnimationState<f32>>,
-    pub(super) height_anim: Option<AnimationState<f32>>,
-    pub(super) background_anim: Option<AnimationState<Color>>,
-    pub(super) corner_radius_anim: Option<AnimationState<f32>>,
-    pub(super) padding_anim: Option<AnimationState<Padding>>,
-    pub(super) border_width_anim: Option<AnimationState<f32>>,
-    pub(super) border_color_anim: Option<AnimationState<Color>>,
-    pub(super) transform_anim: Option<AnimationState<Transform>>,
+    // Animation state (boxed to save ~400 bytes per non-animated container)
+    pub(super) anims: Option<Box<ContainerAnims>>,
 
     // State layer styles (hover/pressed/focused overrides)
     pub(super) hover_state: Option<StateStyle>,
@@ -241,14 +248,7 @@ impl Container {
             widget_ref: None,
             is_hovered: false,
             is_pressed: false,
-            width_anim: None,
-            height_anim: None,
-            background_anim: None,
-            corner_radius_anim: None,
-            padding_anim: None,
-            border_width_anim: None,
-            border_color_anim: None,
-            transform_anim: None,
+            anims: None,
             hover_state: None,
             pressed_state: None,
             focused_state: None,
@@ -273,6 +273,11 @@ impl Container {
     /// Get or create scroll data
     fn scroll_or_init(&mut self) -> &mut ScrollData {
         self.scroll_data.get_or_insert_with(Box::default)
+    }
+
+    /// Get or create animation states box
+    fn anims_mut(&mut self) -> &mut ContainerAnims {
+        self.anims.get_or_insert_with(Box::default)
     }
 
     /// Set the layout strategy for this container
@@ -577,7 +582,7 @@ impl Container {
                 len.exact.or(len.min).unwrap_or(0.0)
             })
             .unwrap_or(0.0);
-        self.width_anim = Some(AnimationState::new(initial, transition));
+        self.anims_mut().width = Some(AnimationState::new(initial, transition));
         self
     }
 
@@ -591,49 +596,49 @@ impl Container {
                 len.exact.or(len.min).unwrap_or(0.0)
             })
             .unwrap_or(0.0);
-        self.height_anim = Some(AnimationState::new(initial, transition));
+        self.anims_mut().height = Some(AnimationState::new(initial, transition));
         self
     }
 
     /// Enable animation for background color changes
     pub fn animate_background(mut self, transition: impl Into<TransitionConfig>) -> Self {
         let initial = self.background.get_or(Color::TRANSPARENT);
-        self.background_anim = Some(AnimationState::new(initial, transition));
+        self.anims_mut().background = Some(AnimationState::new(initial, transition));
         self
     }
 
     /// Enable animation for corner radius changes
     pub fn animate_corner_radius(mut self, transition: impl Into<TransitionConfig>) -> Self {
         let initial = self.corner_radius.get_or(0.0);
-        self.corner_radius_anim = Some(AnimationState::new(initial, transition));
+        self.anims_mut().corner_radius = Some(AnimationState::new(initial, transition));
         self
     }
 
     /// Enable animation for padding changes
     pub fn animate_padding(mut self, transition: impl Into<TransitionConfig>) -> Self {
         let initial = self.padding.get_or(Padding::default());
-        self.padding_anim = Some(AnimationState::new(initial, transition));
+        self.anims_mut().padding = Some(AnimationState::new(initial, transition));
         self
     }
 
     /// Enable animation for border width changes
     pub fn animate_border_width(mut self, transition: impl Into<TransitionConfig>) -> Self {
         let initial = self.border_width.get_or(0.0);
-        self.border_width_anim = Some(AnimationState::new(initial, transition));
+        self.anims_mut().border_width = Some(AnimationState::new(initial, transition));
         self
     }
 
     /// Enable animation for border color changes
     pub fn animate_border_color(mut self, transition: impl Into<TransitionConfig>) -> Self {
         let initial = self.border_color.get_or(Color::TRANSPARENT);
-        self.border_color_anim = Some(AnimationState::new(initial, transition));
+        self.anims_mut().border_color = Some(AnimationState::new(initial, transition));
         self
     }
 
     /// Enable animation for transform changes
     pub fn animate_transform(mut self, transition: impl Into<TransitionConfig>) -> Self {
         let initial = self.transform.get_or(Transform::IDENTITY);
-        self.transform_anim = Some(AnimationState::new(initial, transition));
+        self.anims_mut().transform = Some(AnimationState::new(initial, transition));
         self
     }
 
@@ -704,9 +709,11 @@ impl Container {
     fn is_relayout_boundary_for(&self, constraints: Constraints) -> bool {
         // A widget with an active layout-affecting animation is NOT a boundary,
         // because its size changes each frame and the parent must reposition siblings.
-        let has_active_layout_anim = self.width_anim.as_ref().is_some_and(|a| a.is_animating())
-            || self.height_anim.as_ref().is_some_and(|a| a.is_animating())
-            || self.padding_anim.as_ref().is_some_and(|a| a.is_animating());
+        let has_active_layout_anim = self.anims.as_ref().is_some_and(|a| {
+            a.width.as_ref().is_some_and(|x| x.is_animating())
+                || a.height.as_ref().is_some_and(|x| x.is_animating())
+                || a.padding.as_ref().is_some_and(|x| x.is_animating())
+        });
         if has_active_layout_anim {
             return false;
         }
@@ -812,52 +819,59 @@ impl Container {
 
     /// Get current padding (animated or static)
     fn animated_padding(&self) -> Padding {
-        get_animated_value(&self.padding_anim, || {
+        get_animated_value(self.anims.as_ref().and_then(|a| a.padding.as_ref()), || {
             self.padding.get_or(Padding::default())
         })
     }
 
     /// Get current background color (animated or effective target)
     fn animated_background(&self, tree: &Tree) -> Color {
-        get_animated_value(&self.background_anim, || {
-            self.effective_background_target(tree)
-        })
+        get_animated_value(
+            self.anims.as_ref().and_then(|a| a.background.as_ref()),
+            || self.effective_background_target(tree),
+        )
     }
 
     /// Get current corner radius (animated or effective target)
     fn animated_corner_radius(&self, tree: &Tree) -> f32 {
-        get_animated_value(&self.corner_radius_anim, || {
-            self.effective_corner_radius_target(tree)
-        })
+        get_animated_value(
+            self.anims.as_ref().and_then(|a| a.corner_radius.as_ref()),
+            || self.effective_corner_radius_target(tree),
+        )
     }
 
     /// Get current border width (animated or effective target)
     fn animated_border_width(&self, tree: &Tree) -> f32 {
-        get_animated_value(&self.border_width_anim, || {
-            self.effective_border_width_target(tree)
-        })
+        get_animated_value(
+            self.anims.as_ref().and_then(|a| a.border_width.as_ref()),
+            || self.effective_border_width_target(tree),
+        )
     }
 
     /// Get current border color (animated or effective target)
     fn animated_border_color(&self, tree: &Tree) -> Color {
-        get_animated_value(&self.border_color_anim, || {
-            self.effective_border_color_target(tree)
-        })
+        get_animated_value(
+            self.anims.as_ref().and_then(|a| a.border_color.as_ref()),
+            || self.effective_border_color_target(tree),
+        )
     }
 
     /// Get current transform (animated or effective target)
     fn animated_transform(&self, tree: &Tree) -> Transform {
-        get_animated_value(&self.transform_anim, || {
-            self.effective_transform_target(tree)
-        })
+        get_animated_value(
+            self.anims.as_ref().and_then(|a| a.transform.as_ref()),
+            || self.effective_transform_target(tree),
+        )
     }
 
     /// Check if any state layer properties have animations enabled
     fn has_animated_state_properties(&self) -> bool {
-        self.background_anim.is_some()
-            || self.corner_radius_anim.is_some()
-            || self.border_color_anim.is_some()
-            || self.transform_anim.is_some()
+        self.anims.as_ref().is_some_and(|a| {
+            a.background.is_some()
+                || a.corner_radius.is_some()
+                || a.border_color.is_some()
+                || a.transform.is_some()
+        })
     }
 
     /// Request repaint for state changes (hover/press), with Animation job if needed
@@ -909,60 +923,48 @@ impl Widget for Container {
         // Use advance_animations_self for this widget's animations
         let mut any_animating = false;
 
-        // Layout-affecting animations: width, height, padding
-        advance_anim!(self, width_anim, id, any_animating, layout);
-        advance_anim!(self, height_anim, id, any_animating, layout);
-        advance_anim!(
-            self,
-            padding_anim,
-            self.padding.get_or(Padding::default()),
-            id,
-            any_animating,
-            layout
-        );
-
-        // Paint-only animations: border_width, background, corner_radius, border_color, transform
+        // Compute targets before borrowing anims mutably
+        let padding_target = self.padding.get_or(Padding::default());
         let border_width_target = self.effective_border_width_target(tree);
-        advance_anim!(
-            self,
-            border_width_anim,
-            border_width_target,
-            id,
-            any_animating,
-            paint
-        );
         let bg_target = self.effective_background_target(tree);
-        advance_anim!(self, background_anim, bg_target, id, any_animating, paint);
-
         let corner_radius_target = self.effective_corner_radius_target(tree);
-        advance_anim!(
-            self,
-            corner_radius_anim,
-            corner_radius_target,
-            id,
-            any_animating,
-            paint
-        );
-
         let border_color_target = self.effective_border_color_target(tree);
-        advance_anim!(
-            self,
-            border_color_anim,
-            border_color_target,
-            id,
-            any_animating,
-            paint
-        );
-
         let transform_target = self.effective_transform_target(tree);
-        advance_anim!(
-            self,
-            transform_anim,
-            transform_target,
-            id,
-            any_animating,
-            paint
-        );
+
+        if let Some(ref mut anims) = self.anims {
+            // Layout-affecting animations: width, height, padding
+            advance_anim!(anims, width, id, any_animating, layout);
+            advance_anim!(anims, height, id, any_animating, layout);
+            advance_anim!(anims, padding, padding_target, id, any_animating, layout);
+
+            // Paint-only animations: border_width, background, corner_radius, border_color, transform
+            advance_anim!(
+                anims,
+                border_width,
+                border_width_target,
+                id,
+                any_animating,
+                paint
+            );
+            advance_anim!(anims, background, bg_target, id, any_animating, paint);
+            advance_anim!(
+                anims,
+                corner_radius,
+                corner_radius_target,
+                id,
+                any_animating,
+                paint
+            );
+            advance_anim!(
+                anims,
+                border_color,
+                border_color_target,
+                id,
+                any_animating,
+                paint
+            );
+            advance_anim!(anims, transform, transform_target, id, any_animating, paint);
+        }
 
         // Advance ripple animation
         if self.ripple.is_active()
@@ -1093,39 +1095,41 @@ impl Widget for Container {
         // visible bounds (e.g., Center alignment tracks the animating size).
         // For non-exact (shrink-to-fit) widths, use the signal value to avoid a
         // circular dependency: animated width → constrains children → target = clamped.
-        let child_layout_width = if let Some(ref anim) = self.width_anim {
-            if !anim.is_initial() && width_length.exact.is_some() {
-                *anim.current()
+        let child_layout_width =
+            if let Some(anim) = self.anims.as_ref().and_then(|a| a.width.as_ref()) {
+                if !anim.is_initial() && width_length.exact.is_some() {
+                    *anim.current()
+                } else {
+                    width_length.exact.unwrap_or(constraints.max_width)
+                }
+            } else if let Some(exact) = width_length.exact {
+                exact
             } else {
-                width_length.exact.unwrap_or(constraints.max_width)
-            }
-        } else if let Some(exact) = width_length.exact {
-            exact
-        } else {
-            let w = constraints.max_width;
-            if let Some(max) = width_length.max {
-                w.min(max)
-            } else {
-                w
-            }
-        };
+                let w = constraints.max_width;
+                if let Some(max) = width_length.max {
+                    w.min(max)
+                } else {
+                    w
+                }
+            };
 
-        let child_layout_height = if let Some(ref anim) = self.height_anim {
-            if !anim.is_initial() && height_length.exact.is_some() {
-                *anim.current()
+        let child_layout_height =
+            if let Some(anim) = self.anims.as_ref().and_then(|a| a.height.as_ref()) {
+                if !anim.is_initial() && height_length.exact.is_some() {
+                    *anim.current()
+                } else {
+                    height_length.exact.unwrap_or(constraints.max_height)
+                }
+            } else if let Some(exact) = height_length.exact {
+                exact
             } else {
-                height_length.exact.unwrap_or(constraints.max_height)
-            }
-        } else if let Some(exact) = height_length.exact {
-            exact
-        } else {
-            let h = constraints.max_height;
-            if let Some(max) = height_length.max {
-                h.min(max)
-            } else {
-                h
-            }
-        };
+                let h = constraints.max_height;
+                if let Some(max) = height_length.max {
+                    h.min(max)
+                } else {
+                    h
+                }
+            };
 
         // Child constraints with padding
         let mut child_max_width = (child_layout_width - padding.horizontal()).max(0.0);
@@ -1228,44 +1232,46 @@ impl Widget for Container {
         let content_height = content_size.height + padding.vertical();
 
         // Update animation targets
-        if let Some(ref mut anim) = self.width_anim {
-            let effective_target = if let Some(exact) = width_length.exact {
-                exact
-            } else {
-                let min_w = width_length.min.unwrap_or(0.0);
-                content_width.max(min_w)
-            };
-            if anim.is_initial() {
-                // Always mark as initialized on first layout so subsequent
-                // changes animate rather than snap.
-                anim.set_immediate(effective_target);
-            } else if (effective_target - *anim.target()).abs() > 0.001 {
-                anim.animate_to(effective_target);
-                // Width affects layout, so use RequiredJob::Layout
-                request_job(id, JobRequest::Animation(RequiredJob::Layout));
-                // Parent must reposition siblings as this child's width changes
-                if let Some(parent_id) = tree.get_parent(id) {
-                    request_job(parent_id, JobRequest::Layout);
+        if let Some(ref mut anims) = self.anims {
+            if let Some(ref mut anim) = anims.width {
+                let effective_target = if let Some(exact) = width_length.exact {
+                    exact
+                } else {
+                    let min_w = width_length.min.unwrap_or(0.0);
+                    content_width.max(min_w)
+                };
+                if anim.is_initial() {
+                    // Always mark as initialized on first layout so subsequent
+                    // changes animate rather than snap.
+                    anim.set_immediate(effective_target);
+                } else if (effective_target - *anim.target()).abs() > 0.001 {
+                    anim.animate_to(effective_target);
+                    // Width affects layout, so use RequiredJob::Layout
+                    request_job(id, JobRequest::Animation(RequiredJob::Layout));
+                    // Parent must reposition siblings as this child's width changes
+                    if let Some(parent_id) = tree.get_parent(id) {
+                        request_job(parent_id, JobRequest::Layout);
+                    }
                 }
             }
-        }
 
-        if let Some(ref mut anim) = self.height_anim {
-            let effective_target = if let Some(exact) = height_length.exact {
-                exact
-            } else {
-                let min_h = height_length.min.unwrap_or(0.0);
-                content_height.max(min_h)
-            };
-            if anim.is_initial() {
-                anim.set_immediate(effective_target);
-            } else if (effective_target - *anim.target()).abs() > 0.001 {
-                anim.animate_to(effective_target);
-                // Height affects layout, so use RequiredJob::Layout
-                request_job(id, JobRequest::Animation(RequiredJob::Layout));
-                // Parent must reposition siblings as this child's height changes
-                if let Some(parent_id) = tree.get_parent(id) {
-                    request_job(parent_id, JobRequest::Layout);
+            if let Some(ref mut anim) = anims.height {
+                let effective_target = if let Some(exact) = height_length.exact {
+                    exact
+                } else {
+                    let min_h = height_length.min.unwrap_or(0.0);
+                    content_height.max(min_h)
+                };
+                if anim.is_initial() {
+                    anim.set_immediate(effective_target);
+                } else if (effective_target - *anim.target()).abs() > 0.001 {
+                    anim.animate_to(effective_target);
+                    // Height affects layout, so use RequiredJob::Layout
+                    request_job(id, JobRequest::Animation(RequiredJob::Layout));
+                    // Parent must reposition siblings as this child's height changes
+                    if let Some(parent_id) = tree.get_parent(id) {
+                        request_job(parent_id, JobRequest::Layout);
+                    }
                 }
             }
         }
@@ -1274,18 +1280,25 @@ impl Widget for Container {
         // from the correct signal value rather than a stale construction-time value)
         // Compute targets first to avoid borrow conflicts with &mut anim + &self
         let bg_init = self
-            .background_anim
+            .anims
             .as_ref()
+            .and_then(|a| a.background.as_ref())
             .is_some_and(|a| a.is_initial());
         let cr_init = self
-            .corner_radius_anim
+            .anims
             .as_ref()
+            .and_then(|a| a.corner_radius.as_ref())
             .is_some_and(|a| a.is_initial());
         let bc_init = self
-            .border_color_anim
+            .anims
             .as_ref()
+            .and_then(|a| a.border_color.as_ref())
             .is_some_and(|a| a.is_initial());
-        let tf_init = self.transform_anim.as_ref().is_some_and(|a| a.is_initial());
+        let tf_init = self
+            .anims
+            .as_ref()
+            .and_then(|a| a.transform.as_ref())
+            .is_some_and(|a| a.is_initial());
         if bg_init || cr_init || bc_init || tf_init {
             let bg_target = if bg_init {
                 Some(self.effective_background_target(tree))
@@ -1307,23 +1320,33 @@ impl Widget for Container {
             } else {
                 None
             };
-            if let (Some(anim), Some(target)) = (&mut self.background_anim, bg_target) {
-                anim.set_immediate(target);
-            }
-            if let (Some(anim), Some(target)) = (&mut self.corner_radius_anim, cr_target) {
-                anim.set_immediate(target);
-            }
-            if let (Some(anim), Some(target)) = (&mut self.border_color_anim, bc_target) {
-                anim.set_immediate(target);
-            }
-            if let (Some(anim), Some(target)) = (&mut self.transform_anim, tf_target) {
-                anim.set_immediate(target);
+            if let Some(ref mut anims) = self.anims {
+                if let (Some(anim), Some(target)) = (&mut anims.background, bg_target) {
+                    anim.set_immediate(target);
+                }
+                if let (Some(anim), Some(target)) = (&mut anims.corner_radius, cr_target) {
+                    anim.set_immediate(target);
+                }
+                if let (Some(anim), Some(target)) = (&mut anims.border_color, bc_target) {
+                    anim.set_immediate(target);
+                }
+                if let (Some(anim), Some(target)) = (&mut anims.transform, tf_target) {
+                    anim.set_immediate(target);
+                }
             }
         }
 
         // Determine shrink behavior
-        let width_animating = self.width_anim.as_ref().is_some_and(|a| a.is_animating());
-        let height_animating = self.height_anim.as_ref().is_some_and(|a| a.is_animating());
+        let width_animating = self
+            .anims
+            .as_ref()
+            .and_then(|a| a.width.as_ref())
+            .is_some_and(|a| a.is_animating());
+        let height_animating = self
+            .anims
+            .as_ref()
+            .and_then(|a| a.height.as_ref())
+            .is_some_and(|a| a.is_animating());
         let has_exact_width = width_length.exact.is_some();
         let has_exact_height = height_length.exact.is_some();
         let allow_shrink_width = self.overflow == Overflow::Hidden
@@ -1336,7 +1359,7 @@ impl Widget for Container {
             || self.scroll_axis.allows_vertical();
 
         // Calculate final dimensions
-        let mut width = if let Some(ref anim) = self.width_anim {
+        let mut width = if let Some(anim) = self.anims.as_ref().and_then(|a| a.width.as_ref()) {
             if allow_shrink_width {
                 *anim.current()
             } else {
@@ -1358,7 +1381,7 @@ impl Widget for Container {
             width = width.min(max);
         }
 
-        let mut height = if let Some(ref anim) = self.height_anim {
+        let mut height = if let Some(anim) = self.anims.as_ref().and_then(|a| a.height.as_ref()) {
             if allow_shrink_height {
                 *anim.current()
             } else {
@@ -1380,10 +1403,12 @@ impl Widget for Container {
             height = height.min(max);
         }
 
-        if !allow_shrink_width && self.width_anim.is_none() && !has_exact_width {
+        let has_width_anim = self.anims.as_ref().is_some_and(|a| a.width.is_some());
+        let has_height_anim = self.anims.as_ref().is_some_and(|a| a.height.is_some());
+        if !allow_shrink_width && !has_width_anim && !has_exact_width {
             width = width.max(content_width);
         }
-        if !allow_shrink_height && self.height_anim.is_none() && !has_exact_height {
+        if !allow_shrink_height && !has_height_anim && !has_exact_height {
             height = height.max(content_height);
         }
 

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -484,8 +484,8 @@ impl Container {
 
     /// Accept an optional click callback (useful for components)
     pub fn on_click_option(mut self, callback: Option<ClickCallback>) -> Self {
-        if let Some(cb) = callback {
-            self.interact_mut().on_click = Some(cb);
+        if callback.is_some() || self.interaction.is_some() {
+            self.interact_mut().on_click = callback;
         }
         self
     }
@@ -942,15 +942,19 @@ impl Widget for Container {
         // Use advance_animations_self for this widget's animations
         let mut any_animating = false;
 
-        // Compute targets before borrowing anims mutably
-        let padding_target = self.padding.get_or(Padding::default());
-        let border_width_target = self.effective_border_width_target(tree);
-        let bg_target = self.effective_background_target(tree);
-        let corner_radius_target = self.effective_corner_radius_target(tree);
-        let border_color_target = self.effective_border_color_target(tree);
-        let transform_target = self.effective_transform_target(tree);
-
-        if let Some(ref mut anims) = self.anims {
+        #[allow(clippy::unnecessary_unwrap)]
+        // Intentional: compute targets with &self before &mut borrow
+        if self.anims.is_some() {
+            // Compute targets before borrowing anims mutably (&self methods conflict
+            // with &mut self.anims). Skipped entirely for the majority of non-animated
+            // containers since self.anims is None.
+            let padding_target = self.padding.get_or(Padding::default());
+            let border_width_target = self.effective_border_width_target(tree);
+            let bg_target = self.effective_background_target(tree);
+            let corner_radius_target = self.effective_corner_radius_target(tree);
+            let border_color_target = self.effective_border_color_target(tree);
+            let transform_target = self.effective_transform_target(tree);
+            let anims = self.anims.as_mut().unwrap();
             // Layout-affecting animations: width, height, padding
             advance_anim!(anims, width, id, any_animating, layout);
             advance_anim!(anims, height, id, any_animating, layout);
@@ -1500,14 +1504,8 @@ impl Widget for Container {
         // Pre-dispatch: update hover state and fire pointer move callback
         // before children get the event. This ensures parent hover tracking
         // works even when a child container handles the MouseMove/MouseEnter.
+        let has_animated = self.has_animated_state_properties();
         if let Some(ref mut ix) = self.interaction {
-            // Cache this before borrowing ix mutably to avoid borrow conflicts
-            let has_animated = self.anims.as_ref().is_some_and(|a| {
-                a.background.is_some()
-                    || a.corner_radius.is_some()
-                    || a.border_color.is_some()
-                    || a.transform.is_some()
-            });
             let request_repaint = |id: WidgetId| {
                 if has_animated {
                     request_job(id, JobRequest::Animation(RequiredJob::Paint));

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -1170,11 +1170,6 @@ impl Widget for Container {
         // Reconcile and get children IDs
         let children = self.children_source.reconcile_and_get(tree);
 
-        // Update parent tracking for all children in the tree
-        for &child_id in children.iter() {
-            tree.set_parent(child_id, id);
-        }
-
         let content_size = if !children.is_empty() {
             self.layout.layout(
                 tree,
@@ -1186,8 +1181,7 @@ impl Widget for Container {
             Size::zero()
         };
 
-        // Update scroll state — viewport uses the animated (visible) size, not the
-        // unconstrained child layout size, so scrollbars reflect the actual visible area.
+        // Update scroll state with the viewport dimensions available for children.
         if scroll_axis != ScrollAxis::None {
             self.scroll_state.content_width = content_size.width + padding.horizontal();
             self.scroll_state.content_height = content_size.height + padding.vertical();

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -137,6 +137,42 @@ pub(super) struct ContainerAnims {
     pub(super) transform: Option<AnimationState<Transform>>,
 }
 
+/// Interaction state (callbacks, hover/press tracking, state styles, ripple).
+/// Only allocated when `.on_click()`, `.hover_state()`, `.pressed_state()`, etc. are called.
+pub(super) struct InteractionState {
+    pub(super) on_click: Option<ClickCallback>,
+    pub(super) on_hover: Option<HoverCallback>,
+    pub(super) on_scroll: Option<ScrollCallback>,
+    pub(super) on_pointer_move: Option<PointerMoveCallback>,
+    pub(super) on_mouse_down: Option<MouseDownCallback>,
+    pub(super) on_mouse_up: Option<MouseUpCallback>,
+    pub(super) is_hovered: bool,
+    pub(super) is_pressed: bool,
+    pub(super) hover_state: Option<StateStyle>,
+    pub(super) pressed_state: Option<StateStyle>,
+    pub(super) focused_state: Option<StateStyle>,
+    pub(super) ripple: RippleState,
+}
+
+impl Default for InteractionState {
+    fn default() -> Self {
+        Self {
+            on_click: None,
+            on_hover: None,
+            on_scroll: None,
+            on_pointer_move: None,
+            on_mouse_down: None,
+            on_mouse_up: None,
+            is_hovered: false,
+            is_pressed: false,
+            hover_state: None,
+            pressed_state: None,
+            focused_state: None,
+            ripple: RippleState::new(),
+        }
+    }
+}
+
 /// Scroll state and configuration, boxed to avoid bloating Container.
 /// Only allocated when `.scrollable()` is called.
 pub(super) struct ScrollData {
@@ -188,35 +224,19 @@ pub struct Container {
     pub(super) transform: Option<Signal<Transform>>,
     pub(super) transform_origin: Option<Signal<TransformOrigin>>,
 
-    // Event callbacks
-    pub(super) on_click: Option<ClickCallback>,
-    pub(super) on_hover: Option<HoverCallback>,
-    pub(super) on_scroll: Option<ScrollCallback>,
-    pub(super) on_pointer_move: Option<PointerMoveCallback>,
-    pub(super) on_mouse_down: Option<MouseDownCallback>,
-    pub(super) on_mouse_up: Option<MouseUpCallback>,
+    // Interaction state (callbacks, hover/press, state styles, ripple)
+    // Only allocated when interaction features are used
+    pub(super) interaction: Option<Box<InteractionState>>,
 
     // Widget ref for reactive bounds tracking
     pub(super) widget_ref: Option<WidgetRef>,
 
-    // Internal state for event handling
-    pub(super) is_hovered: bool,
-    pub(super) is_pressed: bool,
-
     // Animation state (boxed to save ~400 bytes per non-animated container)
     pub(super) anims: Option<Box<ContainerAnims>>,
-
-    // State layer styles (hover/pressed/focused overrides)
-    pub(super) hover_state: Option<StateStyle>,
-    pub(super) pressed_state: Option<StateStyle>,
-    pub(super) focused_state: Option<StateStyle>,
 
     // Scroll configuration
     pub(super) scroll_axis: ScrollAxis,
     pub(super) scroll_data: Option<Box<ScrollData>>,
-
-    // Ripple animation state
-    pub(super) ripple: RippleState,
 }
 
 impl Container {
@@ -239,22 +259,11 @@ impl Container {
             visible: None,
             transform: None,
             transform_origin: None,
-            on_click: None,
-            on_hover: None,
-            on_scroll: None,
-            on_pointer_move: None,
-            on_mouse_down: None,
-            on_mouse_up: None,
+            interaction: None,
             widget_ref: None,
-            is_hovered: false,
-            is_pressed: false,
             anims: None,
-            hover_state: None,
-            pressed_state: None,
-            focused_state: None,
             scroll_axis: ScrollAxis::None,
             scroll_data: None,
-            ripple: RippleState::new(),
         }
     }
 
@@ -278,6 +287,11 @@ impl Container {
     /// Get or create animation states box
     fn anims_mut(&mut self) -> &mut ContainerAnims {
         self.anims.get_or_insert_with(Box::default)
+    }
+
+    /// Get or create interaction state
+    fn interact_mut(&mut self) -> &mut InteractionState {
+        self.interaction.get_or_insert_with(Box::default)
     }
 
     /// Set the layout strategy for this container
@@ -464,38 +478,40 @@ impl Container {
     }
 
     pub fn on_click<F: Fn() + 'static>(mut self, callback: F) -> Self {
-        self.on_click = Some(Rc::new(callback));
+        self.interact_mut().on_click = Some(Rc::new(callback));
         self
     }
 
     /// Accept an optional click callback (useful for components)
     pub fn on_click_option(mut self, callback: Option<ClickCallback>) -> Self {
-        self.on_click = callback;
+        if let Some(cb) = callback {
+            self.interact_mut().on_click = Some(cb);
+        }
         self
     }
 
     pub fn on_hover<F: Fn(bool) + 'static>(mut self, callback: F) -> Self {
-        self.on_hover = Some(Rc::new(callback));
+        self.interact_mut().on_hover = Some(Rc::new(callback));
         self
     }
 
     pub fn on_scroll<F: Fn(f32, f32, ScrollSource) + 'static>(mut self, callback: F) -> Self {
-        self.on_scroll = Some(Rc::new(callback));
+        self.interact_mut().on_scroll = Some(Rc::new(callback));
         self
     }
 
     pub fn on_pointer_move<F: Fn(f32, f32) + 'static>(mut self, callback: F) -> Self {
-        self.on_pointer_move = Some(Rc::new(callback));
+        self.interact_mut().on_pointer_move = Some(Rc::new(callback));
         self
     }
 
     pub fn on_mouse_down<F: Fn(f32, f32) + 'static>(mut self, callback: F) -> Self {
-        self.on_mouse_down = Some(Rc::new(callback));
+        self.interact_mut().on_mouse_down = Some(Rc::new(callback));
         self
     }
 
     pub fn on_mouse_up<F: Fn(f32, f32) + 'static>(mut self, callback: F) -> Self {
-        self.on_mouse_up = Some(Rc::new(callback));
+        self.interact_mut().on_mouse_up = Some(Rc::new(callback));
         self
     }
 
@@ -647,7 +663,7 @@ impl Container {
     where
         F: FnOnce(StateStyle) -> StateStyle,
     {
-        self.hover_state = Some(f(StateStyle::new()));
+        self.interact_mut().hover_state = Some(f(StateStyle::new()));
         self
     }
 
@@ -656,7 +672,7 @@ impl Container {
     where
         F: FnOnce(StateStyle) -> StateStyle,
     {
-        self.pressed_state = Some(f(StateStyle::new()));
+        self.interact_mut().pressed_state = Some(f(StateStyle::new()));
         self
     }
 
@@ -675,7 +691,7 @@ impl Container {
     where
         F: FnOnce(StateStyle) -> StateStyle,
     {
-        self.focused_state = Some(f(StateStyle::new()));
+        self.interact_mut().focused_state = Some(f(StateStyle::new()));
         self
     }
 
@@ -740,22 +756,25 @@ impl Container {
         base: T,
         extractor: impl Fn(&StateStyle) -> Option<T>,
     ) -> T {
-        if self.is_pressed
-            && let Some(ref state) = self.pressed_state
+        let Some(ref ix) = self.interaction else {
+            return base;
+        };
+        if ix.is_pressed
+            && let Some(ref state) = ix.pressed_state
             && let Some(value) = extractor(state)
         {
             return value;
         }
         // Check focused state
-        if self.focused_state.is_some()
+        if ix.focused_state.is_some()
             && self.has_child_focus(tree)
-            && let Some(ref state) = self.focused_state
+            && let Some(ref state) = ix.focused_state
             && let Some(value) = extractor(state)
         {
             return value;
         }
-        if self.is_hovered
-            && let Some(ref state) = self.hover_state
+        if ix.is_hovered
+            && let Some(ref state) = ix.hover_state
             && let Some(value) = extractor(state)
         {
             return value;
@@ -967,11 +986,12 @@ impl Widget for Container {
         }
 
         // Advance ripple animation
-        if self.ripple.is_active()
-            && let Some(ref state) = self.pressed_state
+        if let Some(ref mut ix) = self.interaction
+            && ix.ripple.is_active()
+            && let Some(ref state) = ix.pressed_state
             && let Some(ref config) = state.ripple
         {
-            let ripple_animating = self.ripple.advance(config);
+            let ripple_animating = ix.ripple.advance(config);
             if ripple_animating {
                 // Ripple is paint-only, request animation continuation with paint
                 request_job(id, JobRequest::Animation(RequiredJob::Paint));
@@ -1480,38 +1500,54 @@ impl Widget for Container {
         // Pre-dispatch: update hover state and fire pointer move callback
         // before children get the event. This ensures parent hover tracking
         // works even when a child container handles the MouseMove/MouseEnter.
-        match local_event.as_ref() {
-            Event::MouseEnter { x, y } => {
-                if bounds.contains_rounded(*x, *y, corner_radius) && !self.is_hovered {
-                    self.is_hovered = true;
-                    if self.hover_state.is_some() {
-                        self.request_state_change_repaint(id);
-                    }
-                    if let Some(ref callback) = self.on_hover {
-                        callback(true);
+        if let Some(ref mut ix) = self.interaction {
+            // Cache this before borrowing ix mutably to avoid borrow conflicts
+            let has_animated = self.anims.as_ref().is_some_and(|a| {
+                a.background.is_some()
+                    || a.corner_radius.is_some()
+                    || a.border_color.is_some()
+                    || a.transform.is_some()
+            });
+            let request_repaint = |id: WidgetId| {
+                if has_animated {
+                    request_job(id, JobRequest::Animation(RequiredJob::Paint));
+                } else {
+                    request_job(id, JobRequest::Paint);
+                }
+            };
+            match local_event.as_ref() {
+                Event::MouseEnter { x, y } => {
+                    if bounds.contains_rounded(*x, *y, corner_radius) && !ix.is_hovered {
+                        ix.is_hovered = true;
+                        if ix.hover_state.is_some() {
+                            request_repaint(id);
+                        }
+                        if let Some(ref callback) = ix.on_hover {
+                            callback(true);
+                        }
                     }
                 }
-            }
-            Event::MouseMove { x, y } => {
-                if let Some(ref callback) = self.on_pointer_move
-                    && (bounds.contains_rounded(*x, *y, corner_radius) || self.is_pressed)
-                {
-                    callback(*x - bounds.x, *y - bounds.y);
-                }
+                Event::MouseMove { x, y } => {
+                    if let Some(ref callback) = ix.on_pointer_move
+                        && (bounds.contains_rounded(*x, *y, corner_radius) || ix.is_pressed)
+                    {
+                        callback(*x - bounds.x, *y - bounds.y);
+                    }
 
-                let was_hovered = self.is_hovered;
-                self.is_hovered = bounds.contains_rounded(*x, *y, corner_radius);
+                    let was_hovered = ix.is_hovered;
+                    ix.is_hovered = bounds.contains_rounded(*x, *y, corner_radius);
 
-                if was_hovered != self.is_hovered {
-                    if self.hover_state.is_some() {
-                        self.request_state_change_repaint(id);
-                    }
-                    if let Some(ref callback) = self.on_hover {
-                        callback(self.is_hovered);
+                    if was_hovered != ix.is_hovered {
+                        if ix.hover_state.is_some() {
+                            request_repaint(id);
+                        }
+                        if let Some(ref callback) = ix.on_hover {
+                            callback(ix.is_hovered);
+                        }
                     }
                 }
+                _ => {}
             }
-            _ => {}
         }
 
         // Transform event coordinates to local space (relative to container origin)
@@ -1565,12 +1601,15 @@ impl Widget for Container {
             // sibling containers from tracking their own hover state.
             Event::MouseEnter { .. } | Event::MouseMove { .. } => {}
             Event::MouseDown { x, y, button } => {
-                if bounds.contains_rounded(*x, *y, corner_radius) && *button == MouseButton::Left {
-                    let was_pressed = self.is_pressed;
-                    self.is_pressed = true;
+                if bounds.contains_rounded(*x, *y, corner_radius)
+                    && *button == MouseButton::Left
+                    && let Some(ref mut ix) = self.interaction
+                {
+                    let was_pressed = ix.is_pressed;
+                    ix.is_pressed = true;
 
                     // Start ripple animation if configured
-                    let has_ripple = self
+                    let has_ripple = ix
                         .pressed_state
                         .as_ref()
                         .is_some_and(|s| s.ripple.is_some());
@@ -1587,30 +1626,37 @@ impl Widget for Container {
                         } else {
                             (screen_x - bounds.x, screen_y - bounds.y)
                         };
-                        self.ripple.start(local_x, local_y);
+                        ix.ripple.start(local_x, local_y);
                         // Ripple animation needs Animation + Paint
                         request_job(id, JobRequest::Animation(RequiredJob::Paint));
                     }
 
-                    if !was_pressed && self.pressed_state.is_some() {
+                    if !was_pressed && ix.pressed_state.is_some() {
                         self.request_state_change_repaint(id);
                     }
-                    if let Some(ref callback) = self.on_mouse_down {
+                    if let Some(ref ix) = self.interaction
+                        && let Some(ref callback) = ix.on_mouse_down
+                    {
                         callback(*x - bounds.x, *y - bounds.y);
                         return EventResponse::Handled;
                     }
-                    if self.on_click.is_some() || self.on_mouse_up.is_some() {
+                    if let Some(ref ix) = self.interaction
+                        && (ix.on_click.is_some() || ix.on_mouse_up.is_some())
+                    {
                         return EventResponse::Handled;
                     }
                 }
             }
             Event::MouseUp { x, y, button } => {
-                if self.is_pressed && *button == MouseButton::Left {
-                    let was_pressed = self.is_pressed;
-                    self.is_pressed = false;
+                if let Some(ref mut ix) = self.interaction
+                    && ix.is_pressed
+                    && *button == MouseButton::Left
+                {
+                    let was_pressed = ix.is_pressed;
+                    ix.is_pressed = false;
 
                     // Start ripple fade animation
-                    if self.ripple.is_active() {
+                    if ix.ripple.is_active() {
                         // Convert screen coords to local coords accounting for transform
                         let (screen_x, screen_y) = event.coords().unwrap_or((*x, *y));
                         let (local_x, local_y) = if !transform.is_identity() {
@@ -1623,21 +1669,24 @@ impl Widget for Container {
                         } else {
                             (screen_x - bounds.x, screen_y - bounds.y)
                         };
-                        self.ripple.start_fade(local_x, local_y);
+                        ix.ripple.start_fade(local_x, local_y);
                         // Ripple fade animation needs Animation + Paint
                         request_job(id, JobRequest::Animation(RequiredJob::Paint));
                     }
 
-                    if was_pressed && self.pressed_state.is_some() {
+                    if was_pressed && ix.pressed_state.is_some() {
                         self.request_state_change_repaint(id);
                     }
                     let mut handled = false;
-                    if let Some(ref callback) = self.on_mouse_up {
+                    if let Some(ref ix) = self.interaction
+                        && let Some(ref callback) = ix.on_mouse_up
+                    {
                         callback(*x - bounds.x, *y - bounds.y);
                         handled = true;
                     }
-                    if bounds.contains_rounded(*x, *y, corner_radius)
-                        && let Some(ref callback) = self.on_click
+                    if let Some(ref ix) = self.interaction
+                        && bounds.contains_rounded(*x, *y, corner_radius)
+                        && let Some(ref callback) = ix.on_click
                     {
                         callback();
                         return EventResponse::Handled;
@@ -1648,28 +1697,29 @@ impl Widget for Container {
                 }
             }
             Event::MouseLeave => {
-                let was_hovered = self.is_hovered;
-                let was_pressed = self.is_pressed;
-                if self.is_hovered {
-                    self.is_hovered = false;
-                    if let Some(ref callback) = self.on_hover {
-                        callback(false);
+                if let Some(ref mut ix) = self.interaction {
+                    let was_hovered = ix.is_hovered;
+                    let was_pressed = ix.is_pressed;
+                    if ix.is_hovered {
+                        ix.is_hovered = false;
+                        if let Some(ref callback) = ix.on_hover {
+                            callback(false);
+                        }
                     }
-                }
-                self.is_pressed = false;
+                    ix.is_pressed = false;
 
-                // Start ripple fade to center
-                if self.ripple.is_active() {
-                    self.ripple
-                        .start_fade_to_center(bounds.width, bounds.height);
-                    // Ripple fade animation needs Animation + Paint
-                    request_job(id, JobRequest::Animation(RequiredJob::Paint));
-                }
+                    // Start ripple fade to center
+                    if ix.ripple.is_active() {
+                        ix.ripple.start_fade_to_center(bounds.width, bounds.height);
+                        // Ripple fade animation needs Animation + Paint
+                        request_job(id, JobRequest::Animation(RequiredJob::Paint));
+                    }
 
-                if (was_hovered && self.hover_state.is_some())
-                    || (was_pressed && self.pressed_state.is_some())
-                {
-                    self.request_state_change_repaint(id);
+                    if (was_hovered && ix.hover_state.is_some())
+                        || (was_pressed && ix.pressed_state.is_some())
+                    {
+                        self.request_state_change_repaint(id);
+                    }
                 }
             }
             Event::Scroll {
@@ -1696,7 +1746,9 @@ impl Widget for Container {
                         }
                     }
 
-                    if let Some(ref callback) = self.on_scroll {
+                    if let Some(ref ix) = self.interaction
+                        && let Some(ref callback) = ix.on_scroll
+                    {
                         callback(*delta_x, *delta_y, *source);
                         return EventResponse::Handled;
                     }
@@ -1948,10 +2000,11 @@ impl Widget for Container {
         }
 
         // Draw ripple effect as overlay (ripple.center is already in local coordinates)
-        if let Some((local_cx, local_cy)) = self.ripple.center
-            && let Some(ref pressed_state) = self.pressed_state
+        if let Some(ref ix) = self.interaction
+            && let Some((local_cx, local_cy)) = ix.ripple.center
+            && let Some(ref pressed_state) = ix.pressed_state
             && let Some(ref ripple_config) = pressed_state.ripple
-            && self.ripple.opacity > 0.0
+            && ix.ripple.opacity > 0.0
         {
             // Set overlay clip to container bounds with rounded corners
             // This clips the ripple without affecting children
@@ -1960,13 +2013,13 @@ impl Widget for Container {
             let max_dist_x = local_cx.max(bounds.width - local_cx);
             let max_dist_y = local_cy.max(bounds.height - local_cy);
             let max_radius = (max_dist_x * max_dist_x + max_dist_y * max_dist_y).sqrt();
-            let current_radius = max_radius * self.ripple.progress;
+            let current_radius = max_radius * ix.ripple.progress;
 
             let ripple_color = Color::rgba(
                 ripple_config.color.r,
                 ripple_config.color.g,
                 ripple_config.color.b,
-                ripple_config.color.a * self.ripple.opacity,
+                ripple_config.color.a * ix.ripple.opacity,
             );
 
             ctx.draw_overlay_circle(local_cx, local_cy, current_radius, ripple_color);

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -123,6 +123,36 @@ pub enum Overflow {
     Hidden,
 }
 
+/// Scroll state and configuration, boxed to avoid bloating Container.
+/// Only allocated when `.scrollable()` is called.
+pub(super) struct ScrollData {
+    pub(super) scrollbar_visibility: ScrollbarVisibility,
+    pub(super) scrollbar_config: ScrollbarConfig,
+    pub(super) scroll_state: ScrollState,
+    pub(super) v_scrollbar_track_id: Option<WidgetId>,
+    pub(super) v_scrollbar_handle_id: Option<WidgetId>,
+    pub(super) v_scrollbar_scale_anim: Option<AnimationState<f32>>,
+    pub(super) h_scrollbar_track_id: Option<WidgetId>,
+    pub(super) h_scrollbar_handle_id: Option<WidgetId>,
+    pub(super) h_scrollbar_scale_anim: Option<AnimationState<f32>>,
+}
+
+impl Default for ScrollData {
+    fn default() -> Self {
+        Self {
+            scrollbar_visibility: ScrollbarVisibility::Always,
+            scrollbar_config: ScrollbarConfig::default(),
+            scroll_state: ScrollState::default(),
+            v_scrollbar_track_id: None,
+            v_scrollbar_handle_id: None,
+            v_scrollbar_scale_anim: None,
+            h_scrollbar_track_id: None,
+            h_scrollbar_handle_id: None,
+            h_scrollbar_scale_anim: None,
+        }
+    }
+}
+
 pub struct Container {
     // Layout and children
     pub(super) layout: Box<dyn Layout>,
@@ -176,19 +206,7 @@ pub struct Container {
 
     // Scroll configuration
     pub(super) scroll_axis: ScrollAxis,
-    pub(super) scrollbar_visibility: ScrollbarVisibility,
-    pub(super) scrollbar_config: ScrollbarConfig,
-    pub(super) scroll_state: ScrollState,
-
-    // Vertical scrollbar widget IDs (registered in Tree)
-    pub(super) v_scrollbar_track_id: Option<WidgetId>,
-    pub(super) v_scrollbar_handle_id: Option<WidgetId>,
-    pub(super) v_scrollbar_scale_anim: Option<AnimationState<f32>>,
-
-    // Horizontal scrollbar widget IDs (registered in Tree)
-    pub(super) h_scrollbar_track_id: Option<WidgetId>,
-    pub(super) h_scrollbar_handle_id: Option<WidgetId>,
-    pub(super) h_scrollbar_scale_anim: Option<AnimationState<f32>>,
+    pub(super) scroll_data: Option<Box<ScrollData>>,
 
     // Ripple animation state
     pub(super) ripple: RippleState,
@@ -235,17 +253,26 @@ impl Container {
             pressed_state: None,
             focused_state: None,
             scroll_axis: ScrollAxis::None,
-            scrollbar_visibility: ScrollbarVisibility::Always,
-            scrollbar_config: ScrollbarConfig::default(),
-            scroll_state: ScrollState::default(),
-            v_scrollbar_track_id: None,
-            v_scrollbar_handle_id: None,
-            v_scrollbar_scale_anim: None,
-            h_scrollbar_track_id: None,
-            h_scrollbar_handle_id: None,
-            h_scrollbar_scale_anim: None,
+            scroll_data: None,
             ripple: RippleState::new(),
         }
+    }
+
+    /// Get scroll data (panics if not scrollable — only call when scroll_axis != None)
+    fn scroll(&self) -> &ScrollData {
+        self.scroll_data.as_deref().expect("scroll_data not set")
+    }
+
+    /// Get mutable scroll data (panics if not scrollable)
+    fn scroll_mut(&mut self) -> &mut ScrollData {
+        self.scroll_data
+            .as_deref_mut()
+            .expect("scroll_data not set")
+    }
+
+    /// Get or create scroll data
+    fn scroll_or_init(&mut self) -> &mut ScrollData {
+        self.scroll_data.get_or_insert_with(Box::default)
     }
 
     /// Set the layout strategy for this container
@@ -409,12 +436,15 @@ impl Container {
     /// Enable scrolling on this container.
     pub fn scrollable(mut self, axis: ScrollAxis) -> Self {
         self.scroll_axis = axis;
+        if axis != ScrollAxis::None {
+            self.scroll_data = Some(Box::default());
+        }
         self
     }
 
     /// Configure scrollbar visibility.
     pub fn scrollbar_visibility(mut self, visibility: ScrollbarVisibility) -> Self {
-        self.scrollbar_visibility = visibility;
+        self.scroll_or_init().scrollbar_visibility = visibility;
         self
     }
 
@@ -424,7 +454,7 @@ impl Container {
         F: FnOnce(ScrollbarBuilder) -> ScrollbarBuilder,
     {
         let builder = f(ScrollbarBuilder::default());
-        self.scrollbar_config = builder.build();
+        self.scroll_or_init().scrollbar_config = builder.build();
         self
     }
 
@@ -948,15 +978,17 @@ impl Widget for Container {
         }
 
         // Advance kinetic scroll animation
-        let has_scroll_velocity =
-            self.scroll_state.velocity_x.abs() > 0.5 || self.scroll_state.velocity_y.abs() > 0.5;
-        if has_scroll_velocity {
-            let scroll_animating = self.scroll_state.advance_momentum();
-            if scroll_animating {
-                // Kinetic scroll is paint-only, request animation continuation with paint
-                request_job(id, JobRequest::Animation(RequiredJob::Paint));
+        if let Some(ref mut sd) = self.scroll_data {
+            let has_scroll_velocity =
+                sd.scroll_state.velocity_x.abs() > 0.5 || sd.scroll_state.velocity_y.abs() > 0.5;
+            if has_scroll_velocity {
+                let scroll_animating = sd.scroll_state.advance_momentum();
+                if scroll_animating {
+                    // Kinetic scroll is paint-only, request animation continuation with paint
+                    request_job(id, JobRequest::Animation(RequiredJob::Paint));
+                }
+                any_animating = any_animating || scroll_animating;
             }
-            any_animating = any_animating || scroll_animating;
         }
 
         // Update scrollbar handle positions based on current scroll offset
@@ -1100,10 +1132,11 @@ impl Widget for Container {
         let mut child_max_height = (child_layout_height - padding.vertical()).max(0.0);
 
         // Reserve gutter space for scrollbars
-        if self.scrollbar_config.reserve_gutter
-            && self.scrollbar_visibility != ScrollbarVisibility::Hidden
+        if let Some(ref sd) = self.scroll_data
+            && sd.scrollbar_config.reserve_gutter
+            && sd.scrollbar_visibility != ScrollbarVisibility::Hidden
         {
-            let gutter = self.scrollbar_config.width + self.scrollbar_config.margin * 2.0;
+            let gutter = sd.scrollbar_config.width + sd.scrollbar_config.margin * 2.0;
             if self.scroll_axis.allows_vertical() {
                 child_max_width = (child_max_width - gutter).max(0.0);
             }
@@ -1183,11 +1216,12 @@ impl Widget for Container {
 
         // Update scroll state with the viewport dimensions available for children.
         if scroll_axis != ScrollAxis::None {
-            self.scroll_state.content_width = content_size.width + padding.horizontal();
-            self.scroll_state.content_height = content_size.height + padding.vertical();
-            self.scroll_state.viewport_width = child_max_width;
-            self.scroll_state.viewport_height = child_max_height;
-            self.scroll_state.clamp_offsets();
+            let sd = self.scroll_mut();
+            sd.scroll_state.content_width = content_size.width + padding.horizontal();
+            sd.scroll_state.content_height = content_size.height + padding.vertical();
+            sd.scroll_state.viewport_width = child_max_width;
+            sd.scroll_state.viewport_height = child_max_height;
+            sd.scroll_state.clamp_offsets();
         }
 
         let content_width = content_size.width + padding.horizontal();
@@ -1464,9 +1498,10 @@ impl Widget for Container {
 
             // For scrollable containers, also add scroll offset
             let (child_x, child_y) = if self.scroll_axis != ScrollAxis::None {
+                let sd = self.scroll();
                 (
-                    local_x + self.scroll_state.offset_x,
-                    local_y + self.scroll_state.offset_y,
+                    local_x + sd.scroll_state.offset_x,
+                    local_y + sd.scroll_state.offset_y,
                 )
             } else {
                 (local_x, local_y)
@@ -1624,8 +1659,9 @@ impl Widget for Container {
                         let consumed = self.apply_scroll(*delta_x, *delta_y, *source);
                         if consumed {
                             // Kinetic scrolling needs Animation + Paint if has velocity
-                            let has_velocity = self.scroll_state.velocity_x.abs() > 0.5
-                                || self.scroll_state.velocity_y.abs() > 0.5;
+                            let sd = self.scroll();
+                            let has_velocity = sd.scroll_state.velocity_x.abs() > 0.5
+                                || sd.scroll_state.velocity_y.abs() > 0.5;
                             if has_velocity {
                                 request_job(id, JobRequest::Animation(RequiredJob::Paint));
                             } else {
@@ -1781,9 +1817,10 @@ impl Widget for Container {
         // For scrollable containers: viewport mapped to layout space (before scroll transform).
         // For non-scrollable containers: inherited from parent via PaintContext.
         let effective_cull_rect = if is_scrollable {
+            let sd = self.scroll();
             Some(Rect::new(
-                self.scroll_state.offset_x,
-                self.scroll_state.offset_y,
+                sd.scroll_state.offset_x,
+                sd.scroll_state.offset_y,
                 local_bounds.width,
                 local_bounds.height,
             ))
@@ -1812,9 +1849,10 @@ impl Widget for Container {
 
             // Child's position transform (may include scroll offset)
             let child_position = if is_scrollable {
+                let sd = self.scroll();
                 Transform::translate(
-                    child_offset_x - self.scroll_state.offset_x,
-                    child_offset_y - self.scroll_state.offset_y,
+                    child_offset_x - sd.scroll_state.offset_x,
+                    child_offset_y - sd.scroll_state.offset_y,
                 )
             } else {
                 Transform::translate(child_offset_x, child_offset_y)

--- a/src/widgets/container/scrollable.rs
+++ b/src/widgets/container/scrollable.rs
@@ -16,45 +16,45 @@ impl Container {
     /// Scrollbar containers are registered in Tree as real widgets.
     pub(super) fn ensure_scrollbar_containers(&mut self, tree: &mut Tree, id: WidgetId) {
         if self.scroll_axis == ScrollAxis::None
-            || self.scrollbar_visibility == ScrollbarVisibility::Hidden
+            || self.scroll().scrollbar_visibility == ScrollbarVisibility::Hidden
         {
             return;
         }
 
         // Create vertical scrollbar containers if needed
-        if self.scroll_axis.allows_vertical() && self.v_scrollbar_track_id.is_none() {
+        if self.scroll_axis.allows_vertical() && self.scroll().v_scrollbar_track_id.is_none() {
             let (track, handle, scale_anim) =
-                Self::create_scrollbar_components(&self.scrollbar_config);
+                Self::create_scrollbar_components(&self.scroll().scrollbar_config);
 
             // Register track in Tree
             let track_id = tree.register(Box::new(track));
             tree.set_parent(track_id, id);
-            self.v_scrollbar_track_id = Some(track_id);
+            self.scroll_mut().v_scrollbar_track_id = Some(track_id);
 
             // Register handle in Tree
             let handle_id = tree.register(Box::new(handle));
             tree.set_parent(handle_id, id);
-            self.v_scrollbar_handle_id = Some(handle_id);
+            self.scroll_mut().v_scrollbar_handle_id = Some(handle_id);
 
-            self.v_scrollbar_scale_anim = Some(scale_anim);
+            self.scroll_mut().v_scrollbar_scale_anim = Some(scale_anim);
         }
 
         // Create horizontal scrollbar containers if needed
-        if self.scroll_axis.allows_horizontal() && self.h_scrollbar_track_id.is_none() {
+        if self.scroll_axis.allows_horizontal() && self.scroll().h_scrollbar_track_id.is_none() {
             let (track, handle, scale_anim) =
-                Self::create_scrollbar_components(&self.scrollbar_config);
+                Self::create_scrollbar_components(&self.scroll().scrollbar_config);
 
             // Register track in Tree
             let track_id = tree.register(Box::new(track));
             tree.set_parent(track_id, id);
-            self.h_scrollbar_track_id = Some(track_id);
+            self.scroll_mut().h_scrollbar_track_id = Some(track_id);
 
             // Register handle in Tree
             let handle_id = tree.register(Box::new(handle));
             tree.set_parent(handle_id, id);
-            self.h_scrollbar_handle_id = Some(handle_id);
+            self.scroll_mut().h_scrollbar_handle_id = Some(handle_id);
 
-            self.h_scrollbar_scale_anim = Some(scale_anim);
+            self.scroll_mut().h_scrollbar_scale_anim = Some(scale_anim);
         }
     }
 
@@ -106,14 +106,15 @@ impl Container {
         size: crate::layout::Size,
     ) {
         if self.scroll_axis == ScrollAxis::None
-            || self.scrollbar_visibility == ScrollbarVisibility::Hidden
+            || self.scroll().scrollbar_visibility == ScrollbarVisibility::Hidden
         {
             return;
         }
 
-        let scale_factor = self.scrollbar_config.hover_width / self.scrollbar_config.width;
-        let needs_vertical = self.scroll_state.needs_vertical_scrollbar();
-        let needs_horizontal = self.scroll_state.needs_horizontal_scrollbar();
+        let sd = self.scroll();
+        let scale_factor = sd.scrollbar_config.hover_width / sd.scrollbar_config.width;
+        let needs_vertical = sd.scroll_state.needs_vertical_scrollbar();
+        let needs_horizontal = sd.scroll_state.needs_horizontal_scrollbar();
 
         // Use LOCAL bounds (0,0 origin) for scrollbar positioning.
         // Scrollbars are positioned relative to container origin, and paint
@@ -154,35 +155,37 @@ impl Container {
         needs_other_scrollbar: bool,
         local_bounds: Rect,
     ) {
-        let track_rect = self.scroll_state.scrollbar_track_rect(
+        let sd = self.scroll();
+        let track_rect = sd.scroll_state.scrollbar_track_rect(
             axis,
             local_bounds,
-            &self.scrollbar_config,
+            &sd.scrollbar_config,
             needs_other_scrollbar,
         );
-        let handle_rect = self.scroll_state.scrollbar_handle_rect(
+        let handle_rect = sd.scroll_state.scrollbar_handle_rect(
             axis,
             local_bounds,
-            &self.scrollbar_config,
+            &sd.scrollbar_config,
             needs_other_scrollbar,
         );
 
         // Update scale animation target based on hover state
-        let is_hovered = self.scroll_state.is_track_hovered(axis)
-            || self.scroll_state.is_handle_hovered(axis)
-            || self.scroll_state.is_dragging(axis);
+        let is_hovered = sd.scroll_state.is_track_hovered(axis)
+            || sd.scroll_state.is_handle_hovered(axis)
+            || sd.scroll_state.is_dragging(axis);
         let target_scale = if is_hovered { scale_factor } else { 1.0 };
 
+        let sd = self.scroll_mut();
         let (scale_anim, track_id, handle_id) = match axis {
             ScrollbarAxis::Vertical => (
-                &mut self.v_scrollbar_scale_anim,
-                self.v_scrollbar_track_id,
-                self.v_scrollbar_handle_id,
+                &mut sd.v_scrollbar_scale_anim,
+                sd.v_scrollbar_track_id,
+                sd.v_scrollbar_handle_id,
             ),
             ScrollbarAxis::Horizontal => (
-                &mut self.h_scrollbar_scale_anim,
-                self.h_scrollbar_track_id,
-                self.h_scrollbar_handle_id,
+                &mut sd.h_scrollbar_scale_anim,
+                sd.h_scrollbar_track_id,
+                sd.h_scrollbar_handle_id,
             ),
         };
 
@@ -229,14 +232,15 @@ impl Container {
     /// may not run during hover events.
     pub(super) fn advance_scrollbar_scale_animations_internal(&mut self, id: WidgetId) -> bool {
         if self.scroll_axis == ScrollAxis::None
-            || self.scrollbar_visibility == ScrollbarVisibility::Hidden
+            || self.scroll().scrollbar_visibility == ScrollbarVisibility::Hidden
         {
             return false;
         }
 
-        let scale_factor = self.scrollbar_config.hover_width / self.scrollbar_config.width;
-        let needs_vertical = self.scroll_state.needs_vertical_scrollbar();
-        let needs_horizontal = self.scroll_state.needs_horizontal_scrollbar();
+        let sd = self.scroll();
+        let scale_factor = sd.scrollbar_config.hover_width / sd.scrollbar_config.width;
+        let needs_vertical = sd.scroll_state.needs_vertical_scrollbar();
+        let needs_horizontal = sd.scroll_state.needs_horizontal_scrollbar();
         let mut any_animating = false;
 
         // Advance vertical scrollbar scale animation
@@ -261,14 +265,16 @@ impl Container {
         id: WidgetId,
     ) -> bool {
         // Determine target scale based on hover state
-        let is_hovered = self.scroll_state.is_track_hovered(axis)
-            || self.scroll_state.is_handle_hovered(axis)
-            || self.scroll_state.is_dragging(axis);
+        let sd = self.scroll();
+        let is_hovered = sd.scroll_state.is_track_hovered(axis)
+            || sd.scroll_state.is_handle_hovered(axis)
+            || sd.scroll_state.is_dragging(axis);
         let target_scale = if is_hovered { scale_factor } else { 1.0 };
 
+        let sd = self.scroll_mut();
         let scale_anim = match axis {
-            ScrollbarAxis::Vertical => &mut self.v_scrollbar_scale_anim,
-            ScrollbarAxis::Horizontal => &mut self.h_scrollbar_scale_anim,
+            ScrollbarAxis::Vertical => &mut sd.v_scrollbar_scale_anim,
+            ScrollbarAxis::Horizontal => &mut sd.h_scrollbar_scale_anim,
         };
 
         // Advance the animation and request continuation if still animating.
@@ -295,13 +301,14 @@ impl Container {
     /// even when layout doesn't run (scroll is paint-only).
     pub(super) fn update_scrollbar_handle_positions(&mut self, tree: &mut Tree, id: WidgetId) {
         if self.scroll_axis == ScrollAxis::None
-            || self.scrollbar_visibility == ScrollbarVisibility::Hidden
+            || self.scroll().scrollbar_visibility == ScrollbarVisibility::Hidden
         {
             return;
         }
 
-        let needs_vertical = self.scroll_state.needs_vertical_scrollbar();
-        let needs_horizontal = self.scroll_state.needs_horizontal_scrollbar();
+        let sd = self.scroll();
+        let needs_vertical = sd.scroll_state.needs_vertical_scrollbar();
+        let needs_horizontal = sd.scroll_state.needs_horizontal_scrollbar();
 
         // Get bounds from Tree (single source of truth)
         let bounds = tree.get_bounds(id).unwrap_or_default();
@@ -312,12 +319,13 @@ impl Container {
         // Update vertical scrollbar handle position
         if self.scroll_axis.allows_vertical()
             && needs_vertical
-            && let Some(handle_id) = self.v_scrollbar_handle_id
+            && let Some(handle_id) = self.scroll().v_scrollbar_handle_id
         {
-            let handle_rect = self.scroll_state.scrollbar_handle_rect(
+            let sd = self.scroll();
+            let handle_rect = sd.scroll_state.scrollbar_handle_rect(
                 ScrollbarAxis::Vertical,
                 local_bounds,
-                &self.scrollbar_config,
+                &sd.scrollbar_config,
                 needs_horizontal,
             );
             tree.set_origin(handle_id, handle_rect.x, handle_rect.y);
@@ -326,12 +334,13 @@ impl Container {
         // Update horizontal scrollbar handle position
         if self.scroll_axis.allows_horizontal()
             && needs_horizontal
-            && let Some(handle_id) = self.h_scrollbar_handle_id
+            && let Some(handle_id) = self.scroll().h_scrollbar_handle_id
         {
-            let handle_rect = self.scroll_state.scrollbar_handle_rect(
+            let sd = self.scroll();
+            let handle_rect = sd.scroll_state.scrollbar_handle_rect(
                 ScrollbarAxis::Horizontal,
                 local_bounds,
-                &self.scrollbar_config,
+                &sd.scrollbar_config,
                 needs_vertical,
             );
             tree.set_origin(handle_id, handle_rect.x, handle_rect.y);
@@ -350,30 +359,32 @@ impl Container {
     ) {
         use crate::transform::Transform;
 
-        if self.scrollbar_visibility == ScrollbarVisibility::Hidden {
+        let sd = self.scroll();
+
+        if sd.scrollbar_visibility == ScrollbarVisibility::Hidden {
             return;
         }
 
         // Get current scale for vertical scrollbar
-        let v_scale = self
+        let v_scale = sd
             .v_scrollbar_scale_anim
             .as_ref()
             .map(|a| *a.current())
             .unwrap_or(1.0);
 
         // Get current scale for horizontal scrollbar
-        let h_scale = self
+        let h_scale = sd
             .h_scrollbar_scale_anim
             .as_ref()
             .map(|a| *a.current())
             .unwrap_or(1.0);
 
         // Vertical scrollbar
-        if self.scroll_axis.allows_vertical() && self.scroll_state.needs_vertical_scrollbar() {
+        if self.scroll_axis.allows_vertical() && sd.scroll_state.needs_vertical_scrollbar() {
             // Vertical scrollbar scales horizontally (expands width on hover)
             let scale_transform = Transform::scale_xy(v_scale, 1.0);
 
-            if let Some(track_id) = self.v_scrollbar_track_id
+            if let Some(track_id) = sd.v_scrollbar_track_id
                 && let Some(track_bounds) = tree.get_bounds(track_id)
             {
                 // Scrollbar bounds are already in local coordinates (relative to 0,0)
@@ -394,7 +405,7 @@ impl Container {
                     widget.paint(tree, track_id, &mut track_ctx);
                 });
             }
-            if let Some(handle_id) = self.v_scrollbar_handle_id
+            if let Some(handle_id) = sd.v_scrollbar_handle_id
                 && let Some(handle_bounds) = tree.get_bounds(handle_id)
             {
                 let handle_local = Rect::new(0.0, 0.0, handle_bounds.width, handle_bounds.height);
@@ -416,11 +427,11 @@ impl Container {
         }
 
         // Horizontal scrollbar
-        if self.scroll_axis.allows_horizontal() && self.scroll_state.needs_horizontal_scrollbar() {
+        if self.scroll_axis.allows_horizontal() && sd.scroll_state.needs_horizontal_scrollbar() {
             // Horizontal scrollbar scales vertically (expands height on hover)
             let scale_transform = Transform::scale_xy(1.0, h_scale);
 
-            if let Some(track_id) = self.h_scrollbar_track_id
+            if let Some(track_id) = sd.h_scrollbar_track_id
                 && let Some(track_bounds) = tree.get_bounds(track_id)
             {
                 let track_local = Rect::new(0.0, 0.0, track_bounds.width, track_bounds.height);
@@ -439,7 +450,7 @@ impl Container {
                     widget.paint(tree, track_id, &mut track_ctx);
                 });
             }
-            if let Some(handle_id) = self.h_scrollbar_handle_id
+            if let Some(handle_id) = sd.h_scrollbar_handle_id
                 && let Some(handle_bounds) = tree.get_bounds(handle_id)
             {
                 let handle_local = Rect::new(0.0, 0.0, handle_bounds.width, handle_bounds.height);
@@ -470,7 +481,7 @@ impl Container {
         event: &Event,
     ) -> Option<EventResponse> {
         if self.scroll_axis == ScrollAxis::None
-            || self.scrollbar_visibility == ScrollbarVisibility::Hidden
+            || self.scroll().scrollbar_visibility == ScrollbarVisibility::Hidden
         {
             return None;
         }
@@ -479,7 +490,7 @@ impl Container {
             Event::MouseDown { x, y, button } if *button == MouseButton::Left => {
                 // Check vertical scrollbar
                 if self.scroll_axis.allows_vertical()
-                    && self.scroll_state.needs_vertical_scrollbar()
+                    && self.scroll().scroll_state.needs_vertical_scrollbar()
                     && let Some(response) = self.handle_scrollbar_click(
                         tree,
                         id,
@@ -495,7 +506,7 @@ impl Container {
 
                 // Check horizontal scrollbar
                 if self.scroll_axis.allows_horizontal()
-                    && self.scroll_state.needs_horizontal_scrollbar()
+                    && self.scroll().scroll_state.needs_horizontal_scrollbar()
                     && let Some(response) = self.handle_scrollbar_click(
                         tree,
                         id,
@@ -512,7 +523,7 @@ impl Container {
 
             Event::MouseMove { x, y } => {
                 // Handle dragging
-                if self.scroll_state.scrollbar_dragging {
+                if self.scroll().scroll_state.scrollbar_dragging {
                     return Some(self.handle_scrollbar_drag(
                         id,
                         bounds,
@@ -520,7 +531,7 @@ impl Container {
                         *y,
                     ));
                 }
-                if self.scroll_state.h_scrollbar_dragging {
+                if self.scroll().scroll_state.h_scrollbar_dragging {
                     return Some(self.handle_scrollbar_drag(
                         id,
                         bounds,
@@ -533,7 +544,7 @@ impl Container {
                 let mut needs_repaint = false;
 
                 if self.scroll_axis.allows_vertical()
-                    && self.scroll_state.needs_vertical_scrollbar()
+                    && self.scroll().scroll_state.needs_vertical_scrollbar()
                 {
                     needs_repaint |= self.update_scrollbar_hover(
                         tree,
@@ -547,7 +558,7 @@ impl Container {
                 }
 
                 if self.scroll_axis.allows_horizontal()
-                    && self.scroll_state.needs_horizontal_scrollbar()
+                    && self.scroll().scroll_state.needs_horizontal_scrollbar()
                 {
                     needs_repaint |= self.update_scrollbar_hover(
                         tree,
@@ -566,9 +577,9 @@ impl Container {
             }
 
             Event::MouseUp { button, .. } if *button == MouseButton::Left => {
-                if self.scroll_state.scrollbar_dragging {
-                    self.scroll_state.scrollbar_dragging = false;
-                    if let Some(handle_id) = self.v_scrollbar_handle_id {
+                if self.scroll().scroll_state.scrollbar_dragging {
+                    self.scroll_mut().scroll_state.scrollbar_dragging = false;
+                    if let Some(handle_id) = self.scroll().v_scrollbar_handle_id {
                         tree.with_widget_mut(handle_id, |widget, widget_id, tree| {
                             widget.event(tree, widget_id, event);
                         });
@@ -576,9 +587,9 @@ impl Container {
                     request_job(id, JobRequest::Paint);
                     return Some(EventResponse::Handled);
                 }
-                if self.scroll_state.h_scrollbar_dragging {
-                    self.scroll_state.h_scrollbar_dragging = false;
-                    if let Some(handle_id) = self.h_scrollbar_handle_id {
+                if self.scroll().scroll_state.h_scrollbar_dragging {
+                    self.scroll_mut().scroll_state.h_scrollbar_dragging = false;
+                    if let Some(handle_id) = self.scroll().h_scrollbar_handle_id {
                         tree.with_widget_mut(handle_id, |widget, widget_id, tree| {
                             widget.event(tree, widget_id, event);
                         });
@@ -590,15 +601,17 @@ impl Container {
 
             Event::MouseLeave => {
                 // Clear scrollbar hover state
-                if self.scroll_state.scrollbar_hovered || self.scroll_state.h_scrollbar_hovered {
-                    self.scroll_state.scrollbar_hovered = false;
-                    self.scroll_state.h_scrollbar_hovered = false;
-                    if let Some(handle_id) = self.v_scrollbar_handle_id {
+                let sd = self.scroll();
+                if sd.scroll_state.scrollbar_hovered || sd.scroll_state.h_scrollbar_hovered {
+                    let sd = self.scroll_mut();
+                    sd.scroll_state.scrollbar_hovered = false;
+                    sd.scroll_state.h_scrollbar_hovered = false;
+                    if let Some(handle_id) = self.scroll().v_scrollbar_handle_id {
                         tree.with_widget_mut(handle_id, |widget, widget_id, tree| {
                             widget.event(tree, widget_id, event);
                         });
                     }
-                    if let Some(handle_id) = self.h_scrollbar_handle_id {
+                    if let Some(handle_id) = self.scroll().h_scrollbar_handle_id {
                         tree.with_widget_mut(handle_id, |widget, widget_id, tree| {
                             widget.event(tree, widget_id, event);
                         });
@@ -606,9 +619,11 @@ impl Container {
                     request_job(id, JobRequest::Paint);
                 }
                 // Stop dragging
-                if self.scroll_state.scrollbar_dragging || self.scroll_state.h_scrollbar_dragging {
-                    self.scroll_state.scrollbar_dragging = false;
-                    self.scroll_state.h_scrollbar_dragging = false;
+                let sd = self.scroll();
+                if sd.scroll_state.scrollbar_dragging || sd.scroll_state.h_scrollbar_dragging {
+                    let sd = self.scroll_mut();
+                    sd.scroll_state.scrollbar_dragging = false;
+                    sd.scroll_state.h_scrollbar_dragging = false;
                     request_job(id, JobRequest::Paint);
                 }
             }
@@ -630,33 +645,34 @@ impl Container {
         y: f32,
         event: &Event,
     ) -> Option<EventResponse> {
+        let sd = self.scroll();
         let needs_other = match axis {
-            ScrollbarAxis::Vertical => self.scroll_state.needs_horizontal_scrollbar(),
-            ScrollbarAxis::Horizontal => self.scroll_state.needs_vertical_scrollbar(),
+            ScrollbarAxis::Vertical => sd.scroll_state.needs_horizontal_scrollbar(),
+            ScrollbarAxis::Horizontal => sd.scroll_state.needs_vertical_scrollbar(),
         };
-        let handle_rect = self.scroll_state.scrollbar_handle_rect(
-            axis,
-            bounds,
-            &self.scrollbar_config,
-            needs_other,
-        );
+        let handle_rect =
+            sd.scroll_state
+                .scrollbar_handle_rect(axis, bounds, &sd.scrollbar_config, needs_other);
         let hit_area =
-            self.scroll_state
-                .scrollbar_hit_area(axis, bounds, &self.scrollbar_config, needs_other);
+            sd.scroll_state
+                .scrollbar_hit_area(axis, bounds, &sd.scrollbar_config, needs_other);
 
         if handle_rect.contains(x, y) {
             // Start dragging handle
-            self.scroll_state.set_dragging(axis, true);
+            self.scroll_mut().scroll_state.set_dragging(axis, true);
+            let sd = self.scroll();
             let (pos, offset) = match axis {
-                ScrollbarAxis::Vertical => (y, self.scroll_state.offset_y),
-                ScrollbarAxis::Horizontal => (x, self.scroll_state.offset_x),
+                ScrollbarAxis::Vertical => (y, sd.scroll_state.offset_y),
+                ScrollbarAxis::Horizontal => (x, sd.scroll_state.offset_x),
             };
-            self.scroll_state.set_drag_start(axis, pos, offset);
+            self.scroll_mut()
+                .scroll_state
+                .set_drag_start(axis, pos, offset);
 
             // Forward event to handle container for pressed state
             let handle_id = match axis {
-                ScrollbarAxis::Vertical => self.v_scrollbar_handle_id,
-                ScrollbarAxis::Horizontal => self.h_scrollbar_handle_id,
+                ScrollbarAxis::Vertical => self.scroll().v_scrollbar_handle_id,
+                ScrollbarAxis::Horizontal => self.scroll().h_scrollbar_handle_id,
             };
             if let Some(handle_id) = handle_id {
                 tree.with_widget_mut(handle_id, |widget, widget_id, tree| {
@@ -668,18 +684,19 @@ impl Container {
             return Some(EventResponse::Handled);
         } else if hit_area.contains(x, y) {
             // Click on track - jump to position
-            let track_rect = self.scroll_state.scrollbar_track_rect(
+            let sd = self.scroll();
+            let track_rect = sd.scroll_state.scrollbar_track_rect(
                 axis,
                 bounds,
-                &self.scrollbar_config,
+                &sd.scrollbar_config,
                 needs_other,
             );
             let (track_size, handle_size, click_pos) = match axis {
                 ScrollbarAxis::Vertical => {
-                    let handle_size = self.scroll_state.scrollbar_handle_size(
+                    let handle_size = sd.scroll_state.scrollbar_handle_size(
                         axis,
                         track_rect.height,
-                        &self.scrollbar_config,
+                        &sd.scrollbar_config,
                     );
                     (
                         track_rect.height,
@@ -688,10 +705,10 @@ impl Container {
                     )
                 }
                 ScrollbarAxis::Horizontal => {
-                    let handle_size = self.scroll_state.scrollbar_handle_size(
+                    let handle_size = sd.scroll_state.scrollbar_handle_size(
                         axis,
                         track_rect.width,
-                        &self.scrollbar_config,
+                        &sd.scrollbar_config,
                     );
                     (
                         track_rect.width,
@@ -703,8 +720,9 @@ impl Container {
             let available = track_size - handle_size;
             if available > 0.0 {
                 let ratio = (click_pos / available).clamp(0.0, 1.0);
-                let offset = ratio * self.scroll_state.max_scroll(axis);
-                self.scroll_state.set_offset(axis, offset);
+                let sd = self.scroll_mut();
+                let offset = ratio * sd.scroll_state.max_scroll(axis);
+                sd.scroll_state.set_offset(axis, offset);
                 request_job(id, JobRequest::Paint);
             }
             return Some(EventResponse::Handled);
@@ -720,32 +738,30 @@ impl Container {
         axis: ScrollbarAxis,
         pos: f32,
     ) -> EventResponse {
+        let sd = self.scroll();
         let needs_other = match axis {
-            ScrollbarAxis::Vertical => self.scroll_state.needs_horizontal_scrollbar(),
-            ScrollbarAxis::Horizontal => self.scroll_state.needs_vertical_scrollbar(),
+            ScrollbarAxis::Vertical => sd.scroll_state.needs_horizontal_scrollbar(),
+            ScrollbarAxis::Horizontal => sd.scroll_state.needs_vertical_scrollbar(),
         };
-        let track = self.scroll_state.scrollbar_track_rect(
-            axis,
-            bounds,
-            &self.scrollbar_config,
-            needs_other,
-        );
+        let track =
+            sd.scroll_state
+                .scrollbar_track_rect(axis, bounds, &sd.scrollbar_config, needs_other);
         let track_size = match axis {
             ScrollbarAxis::Vertical => track.height,
             ScrollbarAxis::Horizontal => track.width,
         };
         let handle_size =
-            self.scroll_state
-                .scrollbar_handle_size(axis, track_size, &self.scrollbar_config);
+            sd.scroll_state
+                .scrollbar_handle_size(axis, track_size, &sd.scrollbar_config);
         let available = track_size - handle_size;
 
         if available > 0.0 {
-            let (drag_start, start_offset) = self.scroll_state.drag_start(axis);
+            let (drag_start, start_offset) = sd.scroll_state.drag_start(axis);
             let delta = pos - drag_start;
-            let scroll_delta = (delta / available) * self.scroll_state.max_scroll(axis);
-            let new_offset =
-                (start_offset + scroll_delta).clamp(0.0, self.scroll_state.max_scroll(axis));
-            self.scroll_state.set_offset(axis, new_offset);
+            let max_scroll = sd.scroll_state.max_scroll(axis);
+            let scroll_delta = (delta / available) * max_scroll;
+            let new_offset = (start_offset + scroll_delta).clamp(0.0, max_scroll);
+            self.scroll_mut().scroll_state.set_offset(axis, new_offset);
             // Scrollbar dragging needs Animation + Paint for smooth updates
             request_job(id, JobRequest::Animation(RequiredJob::Paint));
         }
@@ -764,34 +780,36 @@ impl Container {
         y: f32,
         _event: &Event,
     ) -> bool {
+        let sd = self.scroll();
         let needs_other = match axis {
-            ScrollbarAxis::Vertical => self.scroll_state.needs_horizontal_scrollbar(),
-            ScrollbarAxis::Horizontal => self.scroll_state.needs_vertical_scrollbar(),
+            ScrollbarAxis::Vertical => sd.scroll_state.needs_horizontal_scrollbar(),
+            ScrollbarAxis::Horizontal => sd.scroll_state.needs_vertical_scrollbar(),
         };
         let hit_area =
-            self.scroll_state
-                .scrollbar_hit_area(axis, bounds, &self.scrollbar_config, needs_other);
-        let handle_rect = self.scroll_state.scrollbar_handle_rect(
-            axis,
-            bounds,
-            &self.scrollbar_config,
-            needs_other,
-        );
+            sd.scroll_state
+                .scrollbar_hit_area(axis, bounds, &sd.scrollbar_config, needs_other);
+        let handle_rect =
+            sd.scroll_state
+                .scrollbar_handle_rect(axis, bounds, &sd.scrollbar_config, needs_other);
 
         let mut needs_repaint = false;
 
         // Track area hover (for expansion effect)
-        let was_track_hovered = self.scroll_state.is_track_hovered(axis);
+        let was_track_hovered = self.scroll().scroll_state.is_track_hovered(axis);
         let is_track_hovered = hit_area.contains(x, y);
-        self.scroll_state.set_track_hovered(axis, is_track_hovered);
+        self.scroll_mut()
+            .scroll_state
+            .set_track_hovered(axis, is_track_hovered);
         if was_track_hovered != is_track_hovered {
             needs_repaint = true;
         }
 
         // Handle hover (for color change)
-        let was_hovered = self.scroll_state.is_handle_hovered(axis);
+        let was_hovered = self.scroll().scroll_state.is_handle_hovered(axis);
         let is_hovered = handle_rect.contains(x, y);
-        self.scroll_state.set_handle_hovered(axis, is_hovered);
+        self.scroll_mut()
+            .scroll_state
+            .set_handle_hovered(axis, is_hovered);
         if was_hovered != is_hovered {
             needs_repaint = true;
         }
@@ -800,8 +818,8 @@ impl Container {
         // We can't forward raw MouseMove events because the Container's bounds check would fail
         // (coordinates are in parent space, not local to the handle widget).
         let handle_id = match axis {
-            ScrollbarAxis::Vertical => self.v_scrollbar_handle_id,
-            ScrollbarAxis::Horizontal => self.h_scrollbar_handle_id,
+            ScrollbarAxis::Vertical => self.scroll().v_scrollbar_handle_id,
+            ScrollbarAxis::Horizontal => self.scroll().h_scrollbar_handle_id,
         };
         if let Some(handle_id) = handle_id {
             if is_hovered && !was_hovered {
@@ -836,45 +854,52 @@ impl Container {
         delta_y: f32,
         source: ScrollSource,
     ) -> bool {
-        let old_x = self.scroll_state.offset_x;
-        let old_y = self.scroll_state.offset_y;
+        let sd = self.scroll_mut();
+        let old_x = sd.scroll_state.offset_x;
+        let old_y = sd.scroll_state.offset_y;
 
         match self.scroll_axis {
             ScrollAxis::Vertical => {
-                self.scroll_state.offset_y = (self.scroll_state.offset_y + delta_y)
-                    .clamp(0.0, self.scroll_state.max_scroll_y());
+                let sd = self.scroll_mut();
+                sd.scroll_state.offset_y =
+                    (sd.scroll_state.offset_y + delta_y).clamp(0.0, sd.scroll_state.max_scroll_y());
             }
             ScrollAxis::Horizontal => {
-                self.scroll_state.offset_x = (self.scroll_state.offset_x + delta_x)
-                    .clamp(0.0, self.scroll_state.max_scroll_x());
+                let sd = self.scroll_mut();
+                sd.scroll_state.offset_x =
+                    (sd.scroll_state.offset_x + delta_x).clamp(0.0, sd.scroll_state.max_scroll_x());
             }
             ScrollAxis::Both => {
-                self.scroll_state.offset_x = (self.scroll_state.offset_x + delta_x)
-                    .clamp(0.0, self.scroll_state.max_scroll_x());
-                self.scroll_state.offset_y = (self.scroll_state.offset_y + delta_y)
-                    .clamp(0.0, self.scroll_state.max_scroll_y());
+                let sd = self.scroll_mut();
+                sd.scroll_state.offset_x =
+                    (sd.scroll_state.offset_x + delta_x).clamp(0.0, sd.scroll_state.max_scroll_x());
+                sd.scroll_state.offset_y =
+                    (sd.scroll_state.offset_y + delta_y).clamp(0.0, sd.scroll_state.max_scroll_y());
             }
             ScrollAxis::None => return false,
         }
 
         // Track velocity for kinetic scrolling (touchpad/finger input only)
         if source == ScrollSource::Finger {
-            match self.scroll_axis {
+            let axis = self.scroll_axis;
+            let sd = self.scroll_mut();
+            match axis {
                 ScrollAxis::Vertical => {
-                    self.scroll_state.velocity_y = delta_y;
+                    sd.scroll_state.velocity_y = delta_y;
                 }
                 ScrollAxis::Horizontal => {
-                    self.scroll_state.velocity_x = delta_x;
+                    sd.scroll_state.velocity_x = delta_x;
                 }
                 ScrollAxis::Both => {
-                    self.scroll_state.velocity_x = delta_x;
-                    self.scroll_state.velocity_y = delta_y;
+                    sd.scroll_state.velocity_x = delta_x;
+                    sd.scroll_state.velocity_y = delta_y;
                 }
                 ScrollAxis::None => {}
             }
-            self.scroll_state.last_scroll_time = Some(std::time::Instant::now());
+            sd.scroll_state.last_scroll_time = Some(std::time::Instant::now());
         }
 
-        old_x != self.scroll_state.offset_x || old_y != self.scroll_state.offset_y
+        let sd = self.scroll();
+        old_x != sd.scroll_state.offset_x || old_y != sd.scroll_state.offset_y
     }
 }


### PR DESCRIPTION
## Summary

- **Fix O(n²) hotspots**: stress test item lookup (`iter().find()` → index access), remove redundant `set_parent` from layout hot path
- **Inline fill-flag check in flex layout**: avoid pre-scan `Vec<bool>` allocation, check `layout_hints()` inline during pass 1
- **Optimize subscriber registry**: replace `HashMap<usize, HashSet<Subscriber>>` with `Vec<SmallVec<[Subscriber; 2]>>` for O(1) signal-indexed lookup, add reverse index `HashMap<WidgetId, SmallVec<[usize; 4]>>` for O(1) widget cleanup
- **SmallVec for RenderNode commands**: `commands` (inline 2) and `overlay_commands` (inline 1) avoid heap allocation for typical nodes
- **Box Container sub-structs**: extract `ScrollData` (480 bytes), `ContainerAnims` (1408 bytes), and `InteractionState` (680 bytes) into `Option<Box<_>>` — only allocated when features are used. Reduces base Container from ~900+ bytes to **376 bytes**

### Measured struct sizes (after)
| Struct | Size |
|--------|------|
| Container | 376 bytes |
| InteractionState | 680 bytes (boxed, lazy) |
| ContainerAnims | 1408 bytes (boxed, lazy) |
| ScrollData | 480 bytes (boxed, lazy) |
| RenderNode | 312 bytes |

## Test plan
- [x] `cargo test` — all tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo check --example perf_stress_test` — compiles
- [ ] Run stress test with 10k items and verify startup + scroll performance
- [ ] Compare memory usage before/after with `/proc/self/status` VmRSS