### PR TITLE
perf: scroll performance optimizations and render-stats timing

### DIFF
--- a/src/jobs.rs
+++ b/src/jobs.rs
@@ -29,6 +29,7 @@ use std::sync::{
     atomic::{AtomicBool, AtomicU8, Ordering},
 };
 
+use smallvec::SmallVec;
 use smithay_client_toolkit::reexports::calloop::ping::Ping;
 
 use crate::reactive::invalidation::clear_widget_subscribers;
@@ -186,47 +187,57 @@ pub fn drain_non_animation_jobs() -> Vec<Job> {
     PENDING_JOBS.with(|jobs| jobs.borrow_mut().drain_non_animation())
 }
 
-pub fn handle_unregister_jobs(jobs: &[Job], tree: &mut Tree) {
-    for job in jobs.iter().filter(|j| j.job_type == JobType::Unregister) {
-        clear_widget_subscribers(job.widget_id);
-        tree.unregister(job.widget_id);
-    }
-}
+/// Process all jobs in a single pass, partitioned by type.
+///
+/// Order is preserved: Unregister → Animation → Reconcile → Paint → Layout.
+/// Uses two passes (partition then process) instead of 5 separate filter scans.
+pub fn process_jobs(jobs: &[Job], tree: &mut Tree, layout_roots: &mut Vec<WidgetId>) {
+    // Single pass: partition into type buckets
+    let mut unregister = SmallVec::<[WidgetId; 4]>::new();
+    let mut animation = SmallVec::<[WidgetId; 8]>::new();
+    let mut reconcile = SmallVec::<[WidgetId; 4]>::new();
+    let mut paint = SmallVec::<[WidgetId; 8]>::new();
+    let mut layout = SmallVec::<[WidgetId; 8]>::new();
 
-pub fn handle_reconcile_jobs(jobs: &[Job], tree: &mut Tree, layout_roots: &mut Vec<WidgetId>) {
-    for job in jobs.iter().filter(|j| j.job_type == JobType::Reconcile) {
-        tree.with_widget_mut(job.widget_id, |widget, id, tree| {
-            widget.reconcile_children(tree, id);
+    for job in jobs {
+        match job.job_type {
+            JobType::Unregister => unregister.push(job.widget_id),
+            JobType::Animation => animation.push(job.widget_id),
+            JobType::Reconcile => reconcile.push(job.widget_id),
+            JobType::Paint => paint.push(job.widget_id),
+            JobType::Layout => layout.push(job.widget_id),
+        }
+    }
+
+    // Process in required order
+    for id in unregister {
+        clear_widget_subscribers(id);
+        tree.unregister(id);
+    }
+    for id in animation {
+        tree.with_widget_mut(id, |widget, wid, tree| {
+            widget.advance_animations(tree, wid);
         });
-        if let Some(root) = tree.mark_needs_layout(job.widget_id)
+    }
+    for id in reconcile {
+        tree.with_widget_mut(id, |widget, wid, tree| {
+            widget.reconcile_children(tree, wid);
+        });
+        if let Some(root) = tree.mark_needs_layout(id)
             && !layout_roots.contains(&root)
         {
             layout_roots.push(root);
         }
     }
-}
-
-pub fn handle_layout_jobs(jobs: &[Job], tree: &mut Tree, layout_roots: &mut Vec<WidgetId>) {
-    for job in jobs.iter().filter(|j| j.job_type == JobType::Layout) {
-        if let Some(root) = tree.mark_needs_layout(job.widget_id)
+    for id in paint {
+        tree.mark_needs_paint(id);
+    }
+    for id in layout {
+        if let Some(root) = tree.mark_needs_layout(id)
             && !layout_roots.contains(&root)
         {
             layout_roots.push(root);
         }
-    }
-}
-
-pub fn handle_paint_jobs(jobs: &[Job], tree: &mut Tree) {
-    for job in jobs.iter().filter(|j| j.job_type == JobType::Paint) {
-        tree.mark_needs_paint(job.widget_id);
-    }
-}
-
-pub fn handle_animation_jobs(jobs: &[Job], tree: &mut Tree) {
-    for job in jobs.iter().filter(|j| j.job_type == JobType::Animation) {
-        tree.with_widget_mut(job.widget_id, |widget, id, tree| {
-            widget.advance_animations(tree, id);
-        });
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -453,9 +453,11 @@ fn render_surface(
         surface.root_node.clear();
         surface.root_node.bounds = widgets::Rect::new(0.0, 0.0, width as f32, height as f32);
 
-        tree.with_widget_mut(surface.widget_id, |widget, id, tree| {
-            let mut ctx = PaintContext::new(&mut surface.root_node);
-            widget.paint(tree, id, &mut ctx);
+        time_phase!(render_stats::Phase::Paint, {
+            tree.with_widget_mut(surface.widget_id, |widget, id, tree| {
+                let mut ctx = PaintContext::new(&mut surface.root_node);
+                widget.paint(tree, id, &mut ctx);
+            });
         });
 
         // Take ownership of root node temporarily, add to tree, then restore
@@ -466,12 +468,16 @@ fn render_surface(
         surface.render_tree.add_root(root);
 
         // Flatten tree into reused buffer
-        flatten_tree_into(&mut surface.render_tree, &mut surface.flattened_commands);
-        renderer.render(
-            wgpu_surface,
-            &surface.flattened_commands,
-            surface.config.background_color,
-        );
+        time_phase!(render_stats::Phase::Flatten, {
+            flatten_tree_into(&mut surface.render_tree, &mut surface.flattened_commands);
+        });
+        time_phase!(render_stats::Phase::GpuRender, {
+            renderer.render(
+                wgpu_surface,
+                &surface.flattened_commands,
+                surface.config.background_color,
+            );
+        });
 
         // Restore root_node for next frame (take it back from render_tree)
         if let Some(root) = surface.render_tree.roots.pop() {
@@ -480,7 +486,9 @@ fn render_surface(
 
         // Cache paint results AFTER flatten so cached_flatten data is preserved.
         // This enables incremental flatten for paint-cached nodes on subsequent frames.
-        cache_paint_results(tree, &surface.root_node);
+        time_phase!(render_stats::Phase::CachePaintResults, {
+            cache_paint_results(tree, &surface.root_node);
+        });
 
         // Report damage region to Wayland compositor
         let damage = tree.take_damage();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,9 +160,8 @@ use smithay_client_toolkit::reexports::client::{Connection, QueueHandle};
 
 use crate::{
     jobs::{
-        drain_non_animation_jobs, drain_pending_jobs, get_exit_request, handle_animation_jobs,
-        handle_layout_jobs, handle_paint_jobs, handle_reconcile_jobs, handle_unregister_jobs,
-        has_pending_jobs, init_wakeup, take_frame_request,
+        drain_non_animation_jobs, drain_pending_jobs, get_exit_request, has_pending_jobs,
+        init_wakeup, process_jobs, take_frame_request,
     },
     tree::{DamageRegion, Tree, WidgetId},
 };
@@ -378,16 +377,14 @@ fn render_surface(
     // picks up continuation jobs and re-advances. This is practically harmless —
     // advance() is time-based (computes nearly the same value), and follow-up
     // jobs are deduped by the JobQueue HashSet.
-    let mut jobs = drain_pending_jobs();
-    handle_unregister_jobs(&jobs, tree);
-    handle_animation_jobs(&jobs, tree);
-    handle_reconcile_jobs(&jobs, tree, layout_roots);
+    let jobs = drain_pending_jobs();
+    process_jobs(&jobs, tree, layout_roots);
 
-    // Merge follow-up jobs from animation advances and reconciliation
-    jobs.extend(drain_non_animation_jobs());
-
-    handle_paint_jobs(&jobs, tree);
-    handle_layout_jobs(&jobs, tree, layout_roots);
+    // Process follow-up jobs from animation advances and reconciliation
+    let followup = drain_non_animation_jobs();
+    if !followup.is_empty() {
+        process_jobs(&followup, tree, layout_roots);
+    }
 
     // Check render conditions
     let fully_initialized = first_frame_presented && scale_factor_received;
@@ -468,13 +465,16 @@ fn render_surface(
         surface.render_tree.add_root(root);
 
         // Flatten tree into reused buffer
+        let layer_boundaries;
         time_phase!(render_stats::Phase::Flatten, {
-            flatten_tree_into(&mut surface.render_tree, &mut surface.flattened_commands);
+            layer_boundaries =
+                flatten_tree_into(&mut surface.render_tree, &mut surface.flattened_commands);
         });
         time_phase!(render_stats::Phase::GpuRender, {
             renderer.render(
                 wgpu_surface,
                 &surface.flattened_commands,
+                layer_boundaries,
                 surface.config.background_color,
             );
         });

--- a/src/render_stats.rs
+++ b/src/render_stats.rs
@@ -11,6 +11,7 @@
 //! - Paint child cache hits/misses
 //! - Flatten cache hits/misses
 //! - Damage region distribution
+//! - Per-phase timing (paint, flatten, GPU render, cache)
 
 /// Reasons why a layout was executed (can be multiple).
 /// Note: Animations and property changes flow through the reactive system via mark_needs_layout(),
@@ -19,6 +20,23 @@
 pub struct LayoutReasons {
     pub constraints_changed: bool,
     pub reactive_changed: bool,
+}
+
+/// Render pipeline phase for timing measurements.
+#[derive(Debug, Clone, Copy)]
+pub enum Phase {
+    Paint,
+    Flatten,
+    GpuRender,
+    CachePaintResults,
+}
+
+/// Per-phase timing statistics (microseconds).
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct PhaseTiming {
+    pub avg_us: f64,
+    pub min_us: f64,
+    pub max_us: f64,
 }
 
 /// Snapshot of accumulated render statistics.
@@ -39,17 +57,87 @@ pub struct StatsSnapshot {
     pub damage_none: u64,
     pub damage_partial: u64,
     pub damage_full: u64,
+    // Timing
+    pub paint_timing: PhaseTiming,
+    pub flatten_timing: PhaseTiming,
+    pub gpu_render_timing: PhaseTiming,
+    pub cache_paint_timing: PhaseTiming,
+    // Scroll
+    pub scroll_children_total: u64,
+    pub scroll_children_iterated: u64,
+}
+
+/// Zero-cost timing macro. Wraps a block with `Instant::now()` / `.elapsed()`
+/// when `render-stats` is enabled; expands to just the body when disabled.
+#[cfg(feature = "render-stats")]
+#[macro_export]
+macro_rules! time_phase {
+    ($phase:expr, $body:expr) => {{
+        let _t = std::time::Instant::now();
+        let result = $body;
+        $crate::render_stats::record_phase_duration($phase, _t.elapsed());
+        result
+    }};
+}
+
+#[cfg(not(feature = "render-stats"))]
+#[macro_export]
+macro_rules! time_phase {
+    ($phase:expr, $body:expr) => {
+        $body
+    };
 }
 
 #[cfg(feature = "render-stats")]
 mod inner {
-    use super::LayoutReasons;
+    use super::{LayoutReasons, Phase, PhaseTiming};
     use crate::tree::DamageRegion;
     use std::cell::RefCell;
-    use std::time::Instant;
+    use std::time::{Duration, Instant};
 
     thread_local! {
         static STATS: RefCell<RenderStats> = RefCell::new(RenderStats::new());
+    }
+
+    /// Per-phase duration accumulator.
+    struct PhaseAccum {
+        total: Duration,
+        min: Duration,
+        max: Duration,
+        count: u64,
+    }
+
+    impl PhaseAccum {
+        fn new() -> Self {
+            Self {
+                total: Duration::ZERO,
+                min: Duration::MAX,
+                max: Duration::ZERO,
+                count: 0,
+            }
+        }
+
+        fn record(&mut self, d: Duration) {
+            self.total += d;
+            self.min = self.min.min(d);
+            self.max = self.max.max(d);
+            self.count += 1;
+        }
+
+        fn to_timing(&self) -> PhaseTiming {
+            if self.count == 0 {
+                return PhaseTiming::default();
+            }
+            PhaseTiming {
+                avg_us: self.total.as_micros() as f64 / self.count as f64,
+                min_us: self.min.as_micros() as f64,
+                max_us: self.max.as_micros() as f64,
+            }
+        }
+
+        fn reset(&mut self) {
+            *self = Self::new();
+        }
     }
 
     struct RenderStats {
@@ -73,7 +161,15 @@ mod inner {
         damage_none: u64,
         damage_partial: u64,
         damage_full: u64,
-        // Timing
+        // Phase timing
+        paint_phase: PhaseAccum,
+        flatten_phase: PhaseAccum,
+        gpu_render_phase: PhaseAccum,
+        cache_paint_phase: PhaseAccum,
+        // Scroll
+        scroll_children_total: u64,
+        scroll_children_iterated: u64,
+        // Report timing
         last_print: Instant,
     }
 
@@ -95,6 +191,12 @@ mod inner {
                 damage_none: 0,
                 damage_partial: 0,
                 damage_full: 0,
+                paint_phase: PhaseAccum::new(),
+                flatten_phase: PhaseAccum::new(),
+                gpu_render_phase: PhaseAccum::new(),
+                cache_paint_phase: PhaseAccum::new(),
+                scroll_children_total: 0,
+                scroll_children_iterated: 0,
                 last_print: Instant::now(),
             }
         }
@@ -115,6 +217,12 @@ mod inner {
             self.damage_none = 0;
             self.damage_partial = 0;
             self.damage_full = 0;
+            self.paint_phase.reset();
+            self.flatten_phase.reset();
+            self.gpu_render_phase.reset();
+            self.cache_paint_phase.reset();
+            self.scroll_children_total = 0;
+            self.scroll_children_iterated = 0;
             self.last_print = Instant::now();
         }
     }
@@ -201,6 +309,30 @@ mod inner {
         });
     }
 
+    /// Record a render pipeline phase duration.
+    #[inline]
+    pub fn record_phase_duration(phase: Phase, duration: Duration) {
+        STATS.with(|s| {
+            let mut stats = s.borrow_mut();
+            match phase {
+                Phase::Paint => stats.paint_phase.record(duration),
+                Phase::Flatten => stats.flatten_phase.record(duration),
+                Phase::GpuRender => stats.gpu_render_phase.record(duration),
+                Phase::CachePaintResults => stats.cache_paint_phase.record(duration),
+            }
+        });
+    }
+
+    /// Record scroll paint iteration stats.
+    #[inline]
+    pub fn record_scroll_paint_range(total_children: u64, iterated: u64) {
+        STATS.with(|s| {
+            let mut stats = s.borrow_mut();
+            stats.scroll_children_total += total_children;
+            stats.scroll_children_iterated += iterated;
+        });
+    }
+
     /// Return a snapshot of the current stats (for testing).
     pub fn get_stats() -> super::StatsSnapshot {
         STATS.with(|s| {
@@ -221,6 +353,12 @@ mod inner {
                 damage_none: stats.damage_none,
                 damage_partial: stats.damage_partial,
                 damage_full: stats.damage_full,
+                paint_timing: stats.paint_phase.to_timing(),
+                flatten_timing: stats.flatten_phase.to_timing(),
+                gpu_render_timing: stats.gpu_render_phase.to_timing(),
+                cache_paint_timing: stats.cache_paint_phase.to_timing(),
+                scroll_children_total: stats.scroll_children_total,
+                scroll_children_iterated: stats.scroll_children_iterated,
             }
         })
     }
@@ -307,6 +445,27 @@ mod inner {
                     stats.damage_none, stats.damage_partial, stats.damage_full
                 );
 
+                // Timing output
+                let pt = stats.paint_phase.to_timing();
+                let ft = stats.flatten_phase.to_timing();
+                let gt = stats.gpu_render_phase.to_timing();
+                let ct = stats.cache_paint_phase.to_timing();
+                eprintln!(
+                    "  timing (avg/min/max us): paint={:.0}/{:.0}/{:.0} flatten={:.0}/{:.0}/{:.0} gpu={:.0}/{:.0}/{:.0} cache={:.0}/{:.0}/{:.0}",
+                    pt.avg_us, pt.min_us, pt.max_us,
+                    ft.avg_us, ft.min_us, ft.max_us,
+                    gt.avg_us, gt.min_us, gt.max_us,
+                    ct.avg_us, ct.min_us, ct.max_us,
+                );
+
+                // Scroll stats (only if scroll activity occurred)
+                if stats.scroll_children_total > 0 {
+                    eprintln!(
+                        "  scroll: total_children={} iterated={}",
+                        stats.scroll_children_total, stats.scroll_children_iterated
+                    );
+                }
+
                 stats.reset();
             }
         });
@@ -363,6 +522,14 @@ pub fn record_flatten_cached() {}
 #[cfg(not(feature = "render-stats"))]
 #[inline(always)]
 pub fn record_flatten_full() {}
+
+#[cfg(not(feature = "render-stats"))]
+#[inline(always)]
+pub fn record_phase_duration(_phase: Phase, _duration: std::time::Duration) {}
+
+#[cfg(not(feature = "render-stats"))]
+#[inline(always)]
+pub fn record_scroll_paint_range(_total_children: u64, _iterated: u64) {}
 
 #[cfg(not(feature = "render-stats"))]
 #[inline(always)]
@@ -550,5 +717,33 @@ mod tests {
         assert_eq!(s.damage_none, 0);
         assert_eq!(s.damage_partial, 0);
         assert_eq!(s.damage_full, 0);
+    }
+
+    #[test]
+    fn test_phase_duration_recording() {
+        setup();
+        use std::time::Duration;
+
+        record_phase_duration(Phase::Paint, Duration::from_micros(100));
+        record_phase_duration(Phase::Paint, Duration::from_micros(200));
+        record_phase_duration(Phase::Paint, Duration::from_micros(150));
+
+        record_phase_duration(Phase::Flatten, Duration::from_micros(50));
+
+        let s = get_stats();
+        assert!((s.paint_timing.avg_us - 150.0).abs() < 1.0);
+        assert!((s.paint_timing.min_us - 100.0).abs() < 1.0);
+        assert!((s.paint_timing.max_us - 200.0).abs() < 1.0);
+        assert!((s.flatten_timing.avg_us - 50.0).abs() < 1.0);
+    }
+
+    #[test]
+    fn test_scroll_paint_range() {
+        setup();
+        record_scroll_paint_range(10000, 52);
+        record_scroll_paint_range(10000, 48);
+        let s = get_stats();
+        assert_eq!(s.scroll_children_total, 20000);
+        assert_eq!(s.scroll_children_iterated, 100);
     }
 }

--- a/src/renderer/flatten.rs
+++ b/src/renderer/flatten.rs
@@ -60,11 +60,99 @@ pub struct FlattenedCommand {
 /// Flatten a render tree into a list of commands ready for GPU submission.
 ///
 /// This walks the tree depth-first, computing world transforms as it goes.
-/// Commands are sorted by layer for correct render order.
-pub fn flatten_tree(tree: &mut RenderTree) -> Vec<FlattenedCommand> {
+/// Commands are bucketed by layer for correct render order.
+pub fn flatten_tree(tree: &mut RenderTree) -> (Vec<FlattenedCommand>, LayerBoundaries) {
     let mut commands = Vec::new();
-    flatten_tree_into(tree, &mut commands);
-    commands
+    let boundaries = flatten_tree_into(tree, &mut commands);
+    (commands, boundaries)
+}
+
+/// Layered command buffers that avoid post-flatten sorting.
+///
+/// Commands are emitted directly into per-layer buckets during flattening,
+/// then concatenated in layer order. This replaces the O(n log n) sort with O(n) append.
+struct LayeredCommands {
+    shapes: Vec<FlattenedCommand>,
+    images: Vec<FlattenedCommand>,
+    text: Vec<FlattenedCommand>,
+    overlay: Vec<FlattenedCommand>,
+}
+
+impl LayeredCommands {
+    fn new() -> Self {
+        Self {
+            shapes: Vec::new(),
+            images: Vec::new(),
+            text: Vec::new(),
+            overlay: Vec::new(),
+        }
+    }
+
+    fn push(&mut self, cmd: FlattenedCommand) {
+        match cmd.layer {
+            RenderLayer::Shapes => self.shapes.push(cmd),
+            RenderLayer::Images => self.images.push(cmd),
+            RenderLayer::Text => self.text.push(cmd),
+            RenderLayer::Overlay => self.overlay.push(cmd),
+        }
+    }
+
+    /// Take a snapshot of current lengths across all layer buckets.
+    /// Used with `commands_since()` to capture everything added by a subtree.
+    fn snapshot(&self) -> LayerSnapshot {
+        LayerSnapshot {
+            shapes: self.shapes.len(),
+            images: self.images.len(),
+            text: self.text.len(),
+            overlay: self.overlay.len(),
+        }
+    }
+
+    /// Collect all commands added since a snapshot (across all layers).
+    /// Used to populate `CachedFlatten` which stores a flat mixed-layer Vec.
+    fn commands_since(&self, snap: &LayerSnapshot) -> Vec<FlattenedCommand> {
+        let mut result = Vec::new();
+        result.extend_from_slice(&self.shapes[snap.shapes..]);
+        result.extend_from_slice(&self.images[snap.images..]);
+        result.extend_from_slice(&self.text[snap.text..]);
+        result.extend_from_slice(&self.overlay[snap.overlay..]);
+        result
+    }
+
+    /// Drain all layers into the output buffer in correct render order.
+    /// Returns the boundary offsets: (images_start, text_start, overlay_start).
+    fn drain_into(self, out: &mut Vec<FlattenedCommand>) -> LayerBoundaries {
+        let images_start = self.shapes.len();
+        let text_start = images_start + self.images.len();
+        let overlay_start = text_start + self.text.len();
+
+        out.extend(self.shapes);
+        out.extend(self.images);
+        out.extend(self.text);
+        out.extend(self.overlay);
+
+        LayerBoundaries {
+            images_start,
+            text_start,
+            overlay_start,
+        }
+    }
+}
+
+/// Snapshot of `LayeredCommands` lengths for capturing subtree output.
+struct LayerSnapshot {
+    shapes: usize,
+    images: usize,
+    text: usize,
+    overlay: usize,
+}
+
+/// Pre-computed layer boundary offsets, eliminating the need for `partition_point` calls.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct LayerBoundaries {
+    pub images_start: usize,
+    pub text_start: usize,
+    pub overlay_start: usize,
 }
 
 /// Flatten a render tree into an existing buffer (clears and reuses capacity).
@@ -74,15 +162,21 @@ pub fn flatten_tree(tree: &mut RenderTree) -> Vec<FlattenedCommand> {
 ///
 /// Takes `&mut RenderTree` so that flatten results can be cached on nodes
 /// for incremental reuse in subsequent frames.
-pub fn flatten_tree_into(tree: &mut RenderTree, commands: &mut Vec<FlattenedCommand>) {
+///
+/// Returns `LayerBoundaries` with pre-computed offsets for each render layer,
+/// replacing the previous `partition_point` lookups in the renderer.
+pub fn flatten_tree_into(
+    tree: &mut RenderTree,
+    commands: &mut Vec<FlattenedCommand>,
+) -> LayerBoundaries {
     commands.clear();
 
+    let mut layered = LayeredCommands::new();
     for root in &mut tree.roots {
-        flatten_node(root, Transform::IDENTITY, None, None, commands);
+        flatten_node(root, Transform::IDENTITY, None, None, &mut layered);
     }
 
-    // Sort by layer for correct render order
-    commands.sort_by_key(|c| c.layer);
+    layered.drain_into(commands)
 }
 
 /// Recursively flatten a node and its children.
@@ -95,7 +189,7 @@ fn flatten_node(
     parent_world_transform: Transform,
     parent_world_origin: Option<(f32, f32)>,
     parent_clip: Option<&WorldClip>,
-    out: &mut Vec<FlattenedCommand>,
+    out: &mut LayeredCommands,
 ) {
     // Compute this node's world transform
     let (origin_x, origin_y) = node.transform_origin.resolve(node.bounds);
@@ -139,7 +233,16 @@ fn flatten_node(
     }
 
     // Full flatten — existing logic
-    let start_idx = out.len();
+    // Track if we should cache this node's flatten output.
+    // Snapshot captures lengths across all layer buckets so we can collect
+    // everything added by this subtree (including children) for caching.
+    let should_cache =
+        node.clip.is_none() && parent_clip.is_none() && world_transform.is_translation_only();
+    let snap = if should_cache {
+        Some(out.snapshot())
+    } else {
+        None
+    };
 
     // Compute world transform origin (for shapes that need it)
     let world_origin = if !node.local_transform.is_identity() {
@@ -221,11 +324,11 @@ fn flatten_node(
     }
 
     // Cache flatten results for next frame, but only when reuse is possible.
-    // The cache reuse path requires no clips and translation-only transforms,
-    // so skip caching for nodes that would never hit it.
-    if node.clip.is_none() && parent_clip.is_none() && world_transform.is_translation_only() {
+    // The snapshot captures everything added since the start of this node
+    // (including all children), matching the original `out[start_idx..]` behavior.
+    if let Some(snap) = snap {
         node.cached_flatten = Some(Box::new(CachedFlatten {
-            commands: out[start_idx..].to_vec(),
+            commands: out.commands_since(&snap),
             world_transform,
         }));
     } else {

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -26,7 +26,7 @@ mod tree;
 mod types;
 
 pub use commands::{Border, DrawCommand};
-pub use flatten::{FlattenedCommand, flatten_tree, flatten_tree_into};
+pub use flatten::{FlattenedCommand, LayerBoundaries, flatten_tree, flatten_tree_into};
 pub use gpu_context::{GpuContext, SurfaceState};
 pub use paint_context::PaintContext;
 pub use render::Renderer;

--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -11,7 +11,7 @@ use wgpu::{
 };
 
 use super::commands::DrawCommand;
-use super::flatten::{FlattenedCommand, RenderLayer};
+use super::flatten::FlattenedCommand;
 use super::gpu::{QUAD_INDICES, QUAD_VERTICES, QuadVertex, ShaderUniforms, ShapeInstance};
 use super::gpu_context::SurfaceState;
 use super::image_quad::{ImageQuadRenderer, PreparedImageQuad};
@@ -253,6 +253,7 @@ impl Renderer {
         &mut self,
         surface: &mut SurfaceState,
         commands: &[FlattenedCommand],
+        boundaries: super::flatten::LayerBoundaries,
         clear_color: Color,
     ) {
         let output = match surface.surface.get_current_texture() {
@@ -281,11 +282,11 @@ impl Renderer {
         self.queue
             .write_buffer(&self.uniform_buffer, 0, bytemuck::cast_slice(&[uniforms]));
 
-        // Commands are sorted by layer (Shapes < Images < Text < Overlay).
-        // Use partition_point to find layer boundaries as slice ranges — no allocations.
-        let images_start = commands.partition_point(|c| c.layer < RenderLayer::Images);
-        let text_start = commands.partition_point(|c| c.layer < RenderLayer::Text);
-        let overlay_start = commands.partition_point(|c| c.layer < RenderLayer::Overlay);
+        // Commands are pre-sorted by layer via LayeredCommands bucketing.
+        // Use pre-computed boundaries instead of partition_point scans.
+        let images_start = boundaries.images_start;
+        let text_start = boundaries.text_start;
+        let overlay_start = boundaries.overlay_start;
 
         let shape_commands = &commands[..images_start];
         let image_commands = &commands[images_start..text_start];

--- a/src/renderer/text.rs
+++ b/src/renderer/text.rs
@@ -1,4 +1,5 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
+use std::hash::{Hash, Hasher};
 
 use glyphon::{
     Attrs, Buffer, Cache, Color as GlyphonColor, ColorMode, FontSystem, Metrics, Resolution,
@@ -10,6 +11,23 @@ use crate::widgets::font::FontWeight;
 
 use super::types::TextEntry;
 
+/// Compute a cache key for a text buffer based on content and styling.
+/// Two entries with the same key produce identical glyphon Buffers.
+fn text_buffer_key(entry: &TextEntry, scale_factor: f32) -> u64 {
+    let mut hasher = std::hash::DefaultHasher::new();
+    entry.text.hash(&mut hasher);
+    (entry.font_size * scale_factor).to_bits().hash(&mut hasher);
+    entry.font_weight.hash(&mut hasher);
+    entry.font_family.hash(&mut hasher);
+    ((entry.rect.width.max(200.0)) * scale_factor)
+        .to_bits()
+        .hash(&mut hasher);
+    ((entry.rect.height.max(50.0)) * scale_factor)
+        .to_bits()
+        .hash(&mut hasher);
+    hasher.finish()
+}
+
 pub struct TextRenderState {
     font_system: FontSystem,
     swash_cache: SwashCache,
@@ -19,6 +37,12 @@ pub struct TextRenderState {
     text_renderer: TextRenderer,
     buffers: Vec<Buffer>,
     viewport: Viewport,
+    /// Cache of shaped text buffers from the previous frame, keyed by content+style hash.
+    /// Avoids expensive Unicode analysis and glyph shaping for unchanged text.
+    buffer_cache: HashMap<u64, Buffer>,
+    /// Keys for current frame's buffers (parallel to `self.buffers`), used to
+    /// repopulate `buffer_cache` at the start of the next frame.
+    frame_keys: Vec<u64>,
 }
 
 impl TextRenderState {
@@ -44,6 +68,8 @@ impl TextRenderState {
             text_renderer,
             buffers: Vec::new(),
             viewport,
+            buffer_cache: HashMap::new(),
+            frame_keys: Vec::new(),
         }
     }
 
@@ -58,7 +84,10 @@ impl TextRenderState {
         screen_height: u32,
         scale_factor: f32,
     ) -> Vec<usize> {
-        self.buffers.clear();
+        // Move last frame's buffers into cache for reuse
+        for (key, buffer) in self.frame_keys.drain(..).zip(self.buffers.drain(..)) {
+            self.buffer_cache.insert(key, buffer);
+        }
 
         // Collect indices of texts that have non-trivial transforms (for texture-based rendering)
         let mut transformed_indices = Vec::new();
@@ -114,37 +143,45 @@ impl TextRenderState {
                 continue; // Skip transformed text in direct rendering
             }
 
-            // Scale the font size for HiDPI rendering
-            let scaled_font_size = entry.font_size * scale_factor;
-
-            let mut buffer = Buffer::new(
-                &mut self.font_system,
-                Metrics::new(scaled_font_size, scaled_font_size * 1.2),
-            );
-            // Give more space for the text buffer, scaled
-            buffer.set_size(
-                &mut self.font_system,
-                Some((entry.rect.width.max(200.0)) * scale_factor),
-                Some((entry.rect.height.max(50.0)) * scale_factor),
-            );
-            // Use entry's font properties, defaulting to NORMAL weight if default (0)
-            let weight = if entry.font_weight == FontWeight::default() {
-                FontWeight::NORMAL
+            // Check buffer cache before expensive text shaping
+            let key = text_buffer_key(entry, scale_factor);
+            let buffer = if let Some(cached) = self.buffer_cache.remove(&key) {
+                cached
             } else {
-                entry.font_weight
+                // Cache miss — create and shape a new buffer
+                let scaled_font_size = entry.font_size * scale_factor;
+                let mut buffer = Buffer::new(
+                    &mut self.font_system,
+                    Metrics::new(scaled_font_size, scaled_font_size * 1.2),
+                );
+                buffer.set_size(
+                    &mut self.font_system,
+                    Some((entry.rect.width.max(200.0)) * scale_factor),
+                    Some((entry.rect.height.max(50.0)) * scale_factor),
+                );
+                let weight = if entry.font_weight == FontWeight::default() {
+                    FontWeight::NORMAL
+                } else {
+                    entry.font_weight
+                };
+                buffer.set_text(
+                    &mut self.font_system,
+                    &entry.text,
+                    &Attrs::new()
+                        .family(entry.font_family.to_cosmic())
+                        .weight(weight.to_cosmic()),
+                    Shaping::Advanced,
+                    None,
+                );
+                buffer.shape_until_scroll(&mut self.font_system, true);
+                buffer
             };
-            buffer.set_text(
-                &mut self.font_system,
-                &entry.text,
-                &Attrs::new()
-                    .family(entry.font_family.to_cosmic())
-                    .weight(weight.to_cosmic()),
-                Shaping::Advanced,
-                None,
-            );
-            buffer.shape_until_scroll(&mut self.font_system, true);
+            self.frame_keys.push(key);
             self.buffers.push(buffer);
         }
+
+        // Evict unused cache entries (anything still in buffer_cache was not used this frame)
+        self.buffer_cache.clear();
 
         // Filter to only non-transformed, non-culled texts for TextArea creation
         // Use HashSet for O(1) lookup instead of Vec::contains which is O(n)

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -429,13 +429,14 @@ impl Tree {
     }
 
     fn mark_subtree_needs_paint_inner(&mut self, widget_id: WidgetId) {
-        let Some(dense_idx) = self.get_dense_index(widget_id) else {
-            return;
-        };
-        self.dense[dense_idx].needs_paint = true;
-        let children = self.dense[dense_idx].children.clone();
-        for child_id in children {
-            self.mark_subtree_needs_paint_inner(child_id);
+        // Iterative DFS to avoid cloning children SmallVecs for borrow checker
+        let mut stack = vec![widget_id];
+        while let Some(id) = stack.pop() {
+            let Some(dense_idx) = self.get_dense_index(id) else {
+                continue;
+            };
+            self.dense[dense_idx].needs_paint = true;
+            stack.extend_from_slice(&self.dense[dense_idx].children);
         }
     }
 

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -1910,8 +1910,57 @@ impl Widget for Container {
             return;
         }
 
-        // Draw children - each gets its own node with position transform
-        for &child_id in self.children_source.get() {
+        // Draw children - each gets its own node with position transform.
+        //
+        // For scrollable containers with a single-axis layout, use binary search
+        // to find the visible range (O(log n)) instead of iterating all children (O(n)).
+        let all_children = self.children_source.get();
+        let visible_children: &[WidgetId] = if is_scrollable {
+            let sd = self.scroll();
+            match self.scroll_axis {
+                ScrollAxis::Vertical => {
+                    let vp_top = sd.scroll_state.offset_y;
+                    let vp_bottom = vp_top + local_bounds.height;
+                    let first = all_children.partition_point(|&cid| {
+                        tree.get_bounds(cid)
+                            .is_some_and(|b| b.y + b.height <= vp_top)
+                    });
+                    let last = all_children.partition_point(|&cid| {
+                        tree.get_bounds(cid).is_some_and(|b| b.y < vp_bottom)
+                    });
+                    let start = first.saturating_sub(1);
+                    let end = (last + 1).min(all_children.len());
+                    crate::render_stats::record_scroll_paint_range(
+                        all_children.len() as u64,
+                        (end - start) as u64,
+                    );
+                    &all_children[start..end]
+                }
+                ScrollAxis::Horizontal => {
+                    let vp_left = sd.scroll_state.offset_x;
+                    let vp_right = vp_left + local_bounds.width;
+                    let first = all_children.partition_point(|&cid| {
+                        tree.get_bounds(cid)
+                            .is_some_and(|b| b.x + b.width <= vp_left)
+                    });
+                    let last = all_children.partition_point(|&cid| {
+                        tree.get_bounds(cid).is_some_and(|b| b.x < vp_right)
+                    });
+                    let start = first.saturating_sub(1);
+                    let end = (last + 1).min(all_children.len());
+                    crate::render_stats::record_scroll_paint_range(
+                        all_children.len() as u64,
+                        (end - start) as u64,
+                    );
+                    &all_children[start..end]
+                }
+                _ => all_children, // Both/None: fall back to full iteration
+            }
+        } else {
+            all_children
+        };
+
+        for &child_id in visible_children {
             // Get child bounds from Tree - these are in LOCAL coordinates (relative to parent)
             let child_bounds = tree
                 .get_bounds(child_id)
@@ -1950,9 +1999,23 @@ impl Widget for Container {
             }
 
             // Try cached paint for clean children.
-            // For scrollable containers, skip cached paint for direct children so their
-            // paint method runs and can cull grandchildren using the propagated cull_rect.
-            if !is_scrollable
+            // For scrollable containers, allow cache reuse when the child is fully
+            // within the viewport — cull_rect propagation is unnecessary since all
+            // grandchildren are visible. Only partially visible edge items need full
+            // repaint for proper cull_rect propagation.
+            let can_use_cache = if is_scrollable {
+                if let Some(ref cull) = effective_cull_rect {
+                    child_offset_y >= cull.y
+                        && child_offset_y + child_bounds.height <= cull.y + cull.height
+                        && child_offset_x >= cull.x
+                        && child_offset_x + child_bounds.width <= cull.x + cull.width
+                } else {
+                    false
+                }
+            } else {
+                true
+            };
+            if can_use_cache
                 && !tree.needs_paint(child_id)
                 && let Some(cached) = tree.cached_paint(child_id)
             {
@@ -1971,7 +2034,7 @@ impl Widget for Container {
                 continue;
             }
 
-            // Full paint (child is dirty, no cache, or scrollable container child)
+            // Full paint (child is dirty, no cache, or partially visible scrollable child)
             let mut child_ctx = ctx.add_child(child_id.as_u64(), child_local);
             child_ctx.set_transform(child_position);
 


### PR DESCRIPTION
## Summary

- **Render-stats timing**: Add per-phase duration measurements (paint, flatten, GPU render, cache) with min/max/avg output. Uses a zero-cost `time_phase!` macro that compiles to nothing when the feature is disabled. Also adds scroll iteration counter.
- **Binary search for visible children**: In scrollable containers, replace O(n) linear scan with O(log n + visible) binary search using `partition_point` on sorted child positions. With 10k children and ~50 visible, this reduces iteration from ~10k to ~50.
- **Paint cache for scrollable children**: Allow clean, fully-visible children inside scrollable containers to reuse cached paint results. Only the 1-2 partially visible items at scroll edges need full repaint. Previously ALL scrollable children were always repainted.

## Test plan
- [x] `cargo test` — all 214 tests pass
- [x] `cargo test --features render-stats` — all 13 render-stats tests pass (including 2 new)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [ ] Run `cargo run --example perf_stress_test --features render-stats` and verify timing output + scroll stats
- [ ] Visual verification: scroll the list, confirm rendering is correct