### PR TITLE
perf: optimize create_stored() to skip reactive overhead

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,8 +79,8 @@ cargo test
 ### Core Modules
 
 **`reactive/`** - Single-threaded reactive system inspired by SolidJS
-- `Signal<T>`: Main-thread reactive values with automatic dependency tracking. `!Send` — use `.writer()` for background thread updates
-- `Signal<T>`: Copy type that wraps reactive or static values. Created via `create_signal` (read-write, requires Clone+PartialEq+Send), `create_stored` (read-only, requires Clone), or `create_derived` (closure-backed). `IntoSignal<T, M>` uses marker-type disambiguation for blanket impls — integers are accepted where `f32`/`Length`/`Padding` is expected
+- `RwSignal<T>`: Read-write reactive signal (8 bytes). Created via `create_signal` (requires Clone+PartialEq+Send). Has `.get()`, `.set()`, `.update()`, `.writer()`. Converts to `Signal<T>` via `.read_only()` or `.into()`
+- `Signal<T>`: Read-only reactive signal (16 bytes). Created via `create_stored` (static, requires Clone) or `create_derived` (closure-backed). Has `.get()`, `.with()` — no mutation methods. Widget props accept `Signal<T>` via `IntoSignal<T, M>` (marker-type disambiguation — integers accepted where `f32`/`Length`/`Padding` expected)
 - `Memo<T>`: Eager computed values that recompute when dependencies change, only notify on actual changes (`PartialEq`)
 - `Effect`: Side effects that re-run when tracked signals change
 - `Owner`: Ownership system for automatic resource cleanup (signals, effects, custom callbacks)
@@ -131,7 +131,7 @@ The reactive system allows widget properties to be either static or dynamic:
 // Static value
 container().background(Color::rgb(0.2, 0.2, 0.3))
 
-// Reactive signal
+// Reactive signal (RwSignal auto-converts to Signal via IntoSignal)
 let color = create_signal(Color::rgb(0.2, 0.2, 0.3));
 container().background(color)
 
@@ -145,7 +145,7 @@ container().background(move || {
 })
 ```
 
-Signals are main-thread only. Background threads use `.writer()` to get a `WriteSignal<T>` that queues writes for the next frame. The main render loop re-layouts and re-paints each frame, reading current signal values.
+Both `Signal<T>` and `RwSignal<T>` are main-thread only (`!Send`). Background threads use `rw_signal.writer()` to get a `WriteSignal<T>` that queues writes for the next frame. The main render loop re-layouts and re-paints each frame, reading current signal values.
 
 ### Widget Trait
 

--- a/book/src/advanced/background-threads.md
+++ b/book/src/advanced/background-threads.md
@@ -1,6 +1,6 @@
 # Background Tasks
 
-Guido signals (`Signal<T>`) live on the main thread and are `!Send` — they cannot be captured directly in background tasks. To update signals from a background task, call `.writer()` to obtain a `WriteSignal<T>`, which **is** `Send`. Writes through a `WriteSignal` are queued and applied on the main thread during the next frame.
+Guido signals (`RwSignal<T>` and `Signal<T>`) live on the main thread and are `!Send` — they cannot be captured directly in background tasks. To update signals from a background task, call `.writer()` on an `RwSignal<T>` to obtain a `WriteSignal<T>`, which **is** `Send`. Writes through a `WriteSignal` are queued and applied on the main thread during the next frame.
 
 The `create_service` API provides a convenient way to spawn async background tasks that are automatically cleaned up when the component unmounts. Services run as tokio tasks.
 

--- a/book/src/advanced/components.md
+++ b/book/src/advanced/components.md
@@ -97,7 +97,7 @@ button()
 
 ## Accessing Props
 
-In the function body, each prop is a `Signal<T>` (which is `Copy`). Pass the signal directly to widget methods — this preserves reactivity so props update automatically when the caller provides reactive values:
+In the function body, each prop is a read-only `Signal<T>` (which is `Copy`). Pass the signal directly to widget methods — this preserves reactivity so props update automatically when the caller provides reactive values (both `RwSignal<T>` and `Signal<T>` work as prop values via `IntoSignal`):
 
 ```rust
 #[component]

--- a/book/src/advanced/context.md
+++ b/book/src/advanced/context.md
@@ -71,11 +71,11 @@ For mutable shared state, store a `Signal<T>` as context. This is the most power
 
 ### provide_signal_context
 
-Creates a signal and provides it as context in one step:
+Creates an `RwSignal` and provides it as context in one step:
 
 ```rust
 App::new().run(|app| {
-    // Creates Signal<Theme> and stores it as context
+    // Creates RwSignal<Theme> and stores it as context
     let theme = provide_signal_context(Theme::default());
 
     app.add_surface(config, || build_ui());
@@ -86,7 +86,7 @@ App::new().run(|app| {
 
 ```rust
 fn themed_box() -> Container {
-    let theme = expect_context::<Signal<Theme>>();
+    let theme = expect_context::<RwSignal<Theme>>();
 
     container()
         .background(move || theme.get().bg_color)
@@ -163,5 +163,5 @@ pub fn has_context<T: 'static>() -> bool;
 // Create signal + provide as context
 pub fn provide_signal_context<T: Clone + PartialEq + Send + 'static>(
     value: T
-) -> Signal<T>;
+) -> RwSignal<T>;
 ```

--- a/book/src/architecture/overview.md
+++ b/book/src/architecture/overview.md
@@ -9,10 +9,10 @@ This page details Guido's module structure and key types.
 Single-threaded reactive primitives inspired by SolidJS.
 
 **Key Types:**
-- `Signal<T>` - Reactive values with automatic dependency tracking
+- `RwSignal<T>` - Read-write reactive values (8 bytes, `Copy`). Created via `create_signal()`. Supports `.get()`, `.set()`, `.update()`, `.writer()`
+- `Signal<T>` - Read-only reactive values (16 bytes, `Copy`). Created via `create_stored()`, `create_derived()`, or `RwSignal::read_only()`. Supports `.get()`, `.with()` — no `.set()`
 - `Memo<T>` - Eager derived values that only notify on actual changes
 - `Effect` - Side effects that re-run on changes
-- `Signal<T>` - Copy wrapper for reactive values
 
 **How It Works:**
 

--- a/book/src/concepts/reactive-model.md
+++ b/book/src/concepts/reactive-model.md
@@ -2,14 +2,14 @@
 
 Guido uses a fine-grained reactive system inspired by SolidJS. This enables efficient updates where only the affected parts of the UI change.
 
-## Signals
+## RwSignal (Read-Write)
 
-Signals are reactive values that notify dependents when they change:
+`create_signal()` returns an `RwSignal<T>` — a read-write reactive value (8 bytes, `Copy`):
 
 ```rust
 use guido::prelude::*;
 
-let count = create_signal(0);
+let count = create_signal(0); // RwSignal<i32>
 
 // Read the current value
 let value = count.get();
@@ -23,9 +23,29 @@ count.update(|c| *c += 1);
 
 ### Key Properties
 
-- **Copy** - Signals implement `Copy`, so you can use them in multiple closures without cloning
+- **Copy** - `RwSignal` implements `Copy`, so you can use it in multiple closures without cloning
 - **Background updates** - Use `.writer()` to get a `WriteSignal<T>` for background task updates
 - **Automatic tracking** - Dependencies are tracked when reading inside reactive contexts
+- **Converts to Signal** - Call `.read_only()` or `.into()` to get a read-only `Signal<T>`
+
+## Signal (Read-Only)
+
+`Signal<T>` is a read-only reactive value (16 bytes, `Copy`). It cannot be written to — calling `.set()` is a compile-time error. There are two ways to create one:
+
+```rust
+// Stored: wraps a static value
+let name = create_stored("hello".to_string()); // Signal<String>
+
+// Derived: closure-backed, re-evaluates on each read
+let doubled = create_derived(move || count.get() * 2); // Signal<i32>
+```
+
+You can also convert an `RwSignal` to a `Signal`:
+
+```rust
+let count = create_signal(0);
+let read_only: Signal<i32> = count.read_only(); // or count.into()
+```
 
 ## Memos
 
@@ -102,11 +122,12 @@ The text automatically updates when `count` changes.
 
 ## The IntoSignal Pattern
 
-Under the hood, Guido uses `Signal<T>` to represent all reactive values. The `IntoSignal<T>` trait accepts:
+Widget properties accept `Signal<T>` via the `IntoSignal<T>` trait. Both `RwSignal<T>` and `Signal<T>` work, along with raw values and closures:
 
-- **Static values** → creates a read-only stored signal via `create_stored()`
-- **Closures** → creates a derived signal via `create_derived()`
-- **Existing `Signal<T>`** → passed through directly (Signal is Copy)
+- **Static values** → creates a stored `Signal<T>` via `create_stored()`
+- **Closures** → creates a derived `Signal<T>` via `create_derived()`
+- **`Signal<T>`** → passed through directly
+- **`RwSignal<T>`** → automatically converted to `Signal<T>`
 
 You don't need to create signals manually for widget properties — just pass values, closures, or signals directly.
 
@@ -252,9 +273,24 @@ let doubled = create_memo(move || count.get() * 2);
 ### Signal Creation
 
 ```rust
-pub fn create_signal<T: Clone + 'static>(value: T) -> Signal<T>;
+pub fn create_signal<T: Clone + PartialEq + Send + 'static>(value: T) -> RwSignal<T>;
+pub fn create_stored<T: Clone + 'static>(value: T) -> Signal<T>;
+pub fn create_derived<T: Clone + 'static>(f: impl Fn() -> T + 'static) -> Signal<T>;
 pub fn create_memo<T: Clone + PartialEq + 'static>(f: impl Fn() -> T + 'static) -> Memo<T>;
 pub fn create_effect(f: impl Fn() + 'static);
+```
+
+### RwSignal Methods
+
+```rust
+impl<T: Clone> RwSignal<T> {
+    pub fn get(&self) -> T;           // Read with tracking
+    pub fn get_untracked(&self) -> T; // Read without tracking
+    pub fn set(&self, value: T);      // Set new value
+    pub fn update(&self, f: impl FnOnce(&mut T)); // Update in place
+    pub fn writer(&self) -> WriteSignal<T>; // Get Send handle for background threads
+    pub fn read_only(&self) -> Signal<T>;   // Convert to read-only Signal
+}
 ```
 
 ### Signal Methods
@@ -265,9 +301,7 @@ impl<T: Clone> Signal<T> {
     pub fn get_untracked(&self) -> T; // Read without tracking
     pub fn with<R>(&self, f: impl FnOnce(&T) -> R) -> R; // Borrow with tracking
     pub fn with_untracked<R>(&self, f: impl FnOnce(&T) -> R) -> R; // Borrow without tracking
-    pub fn set(&self, value: T);      // Set new value
-    pub fn update(&self, f: impl FnOnce(&mut T)); // Update in place
-    pub fn writer(&self) -> WriteSignal<T>; // Get Send handle for background threads
+    // No set/update/writer — Signal is read-only
 }
 ```
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -31,14 +31,15 @@ This document provides an overview of Guido's architecture for developers workin
 Single-threaded reactive primitives inspired by SolidJS and Floem.
 
 **Key Types:**
-- `Signal<T>` - Reactive values with automatic dependency tracking. Signals are `Copy` (backed by thread-local storage), so no cloning needed. `!Send` — use `.writer()` for background thread updates.
+- `RwSignal<T>` (8 bytes) - Read-write reactive values returned by `create_signal()`. Supports `.get()`, `.set()`, `.update()`, `.writer()`. `Copy`, `!Send`.
+- `Signal<T>` (16 bytes) - Read-only reactive wrapper. Created via `create_stored()` (static), `create_derived()` (closure-backed), or by coercing an `RwSignal<T>`. `Copy`, read-only (`.get()` only).
 - `Memo<T>` - Eager derived values that recompute when dependencies change, only notify on actual changes (`PartialEq`)
 - `Effect` - Side effects that re-run when tracked signals change
-- `Signal<T>` - Copy wrapper for reactive values (static, derived, or read-write)
+- `WriteSignal<T>` - `Send` handle for background thread updates, obtained via `RwSignal::writer()`
 
 **How it works:**
 ```rust
-let count = create_signal(0);           // Create a signal
+let count = create_signal(0);           // Returns RwSignal<T> (read-write)
 let doubled = create_memo(move ||      // Create derived value
     count.get() * 2
 );

--- a/docs/REACTIVE.md
+++ b/docs/REACTIVE.md
@@ -11,7 +11,7 @@ Signals are reactive values that notify dependents when they change:
 ```rust
 use guido::prelude::*;
 
-let count = create_signal(0);
+let count = create_signal(0);  // Returns RwSignal<T> (read-write)
 
 // Read the current value
 let value = count.get();
@@ -23,9 +23,13 @@ count.set(5);
 count.update(|c| *c += 1);
 ```
 
+**Key types:**
+- `RwSignal<T>` (8 bytes) — read-write signal returned by `create_signal()`. Supports `.get()`, `.set()`, `.update()`, `.writer()`
+- `Signal<T>` (16 bytes) — read-only signal. Created via `create_stored()` (static), `create_derived()` (closure-backed), or by coercing an `RwSignal<T>`
+
 **Key properties:**
-- Signals are `Copy` - no cloning needed
-- Main-thread only reads/writes — use `.writer()` to get a `WriteSignal<T>` for background thread updates
+- Both `Signal<T>` and `RwSignal<T>` are `Copy` — no cloning needed
+- Main-thread only reads/writes — use `.writer()` on `RwSignal<T>` to get a `WriteSignal<T>` for background thread updates
 - Automatic dependency tracking
 
 ### Memos
@@ -185,13 +189,13 @@ The `IntoSignal<T>` trait allows properties to accept any of:
 
 - **Static values**: `container().background(Color::RED)` → calls `create_stored()`
 - **Closures**: `container().background(move || if dark { Color::BLACK } else { Color::WHITE })` → calls `create_derived()`
-- **Signals**: `container().background(my_signal)` → passed through directly
+- **Signals**: `container().background(my_signal)` → passed through directly (accepts both `Signal<T>` and `RwSignal<T>`)
 
-All produce a `Signal<T>` (which is `Copy`). The distinction between `create_stored` (read-only, Clone only) and `create_signal` (read-write, Clone+PartialEq+Send) only matters when you need to call `.set()` or `.writer()`.
+All produce a `Signal<T>` (which is `Copy`). `create_signal` returns `RwSignal<T>` (read-write, Clone+PartialEq+Send) which has `.set()`, `.update()`, and `.writer()`. `Signal<T>` is read-only — use it when you only need to read values.
 
 ## Background Task Updates
 
-`Signal<T>` is `!Send` — it can only be read and written on the main thread. To update a signal from a background task, use `.writer()` to obtain a `WriteSignal<T>`, which is `Send`. Writes from `WriteSignal` are queued and applied on the next frame.
+`RwSignal<T>` is `!Send` — it can only be read and written on the main thread. To update a signal from a background task, use `.writer()` on `RwSignal<T>` to obtain a `WriteSignal<T>`, which is `Send`. Writes from `WriteSignal` are queued and applied on the next frame.
 
 Use `create_service` to spawn an async background service that is automatically cleaned up when the component unmounts:
 
@@ -209,7 +213,7 @@ let _ = create_service::<(), _, _>(move |_rx, ctx| async move {
 });
 ```
 
-**Note:** Capturing `data` (a `Signal`) directly in a service closure will **not compile** because `Signal` is `!Send`. Always use `.writer()` to get a `WriteSignal` for background tasks.
+**Note:** Capturing `data` (an `RwSignal`) directly in a service closure will **not compile** because `RwSignal` is `!Send`. Always use `.writer()` to get a `WriteSignal` for background tasks.
 
 For bidirectional communication (sending commands to the service):
 
@@ -249,15 +253,23 @@ Signals are lightweight handles that index into thread-local storage:
 
 ```rust
 #[derive(Clone, Copy)]
+pub struct RwSignal<T> {
+    id: SignalId,       // 8 bytes — read-write handle
+}
+
+#[derive(Clone, Copy)]
 pub struct Signal<T> {
     id: SignalId,
+    kind: SignalKind,   // 16 bytes — read-only, supports stored/mutable/derived
 }
 ```
 
 The actual value is stored in `thread_local! { RefCell<SignalStorage> }`, accessed by `id`. This design allows:
-- Signals to be `Copy`
+- Both types to be `Copy`
 - Zero-lock access on the main thread (thread-local `RefCell` only)
 - Automatic dependency tracking via thread-local runtime
+
+`RwSignal<T>` is the compact read-write handle (8 bytes). `Signal<T>` is the read-only wrapper (16 bytes) that also supports static (`create_stored`) and derived (`create_derived`) values via its `SignalKind` discriminant.
 
 `WriteSignal<T>` is a separate `Send` handle that queues writes through a thread-safe channel, which the main thread drains each frame:
 
@@ -472,12 +484,12 @@ This behavior helps catch bugs where signals are used after their owner has been
 ### Signal Creation
 
 ```rust
-pub fn create_signal<T: Clone + PartialEq + Send + 'static>(value: T) -> Signal<T>;
+pub fn create_signal<T: Clone + PartialEq + Send + 'static>(value: T) -> RwSignal<T>;
 pub fn create_memo<T: Clone + PartialEq + 'static>(f: impl Fn() -> T + 'static) -> Memo<T>;
 pub fn create_effect(f: impl Fn() + 'static);
 ```
 
-`create_signal` requires `Send` because `WriteSignal<T>` must be able to queue values from background threads.
+`create_signal` returns `RwSignal<T>` (8 bytes, read-write). It requires `Send` because `WriteSignal<T>` must be able to queue values from background threads.
 
 ### Cleanup Functions
 
@@ -490,10 +502,10 @@ pub fn on_cleanup(f: impl FnOnce() + 'static);
 
 **Note:** `with_owner` and `dispose_owner` are internal functions used by the framework. User code should rely on automatic ownership via dynamic children and the `#[component]` macro.
 
-### Signal Methods (main-thread only)
+### RwSignal Methods (main-thread only)
 
 ```rust
-impl<T: Clone> Signal<T> {
+impl<T: Clone> RwSignal<T> {
     pub fn get(&self) -> T;                // Read with tracking
     pub fn get_untracked(&self) -> T;      // Read without tracking
     pub fn set(&self, value: T);           // Set immediately
@@ -502,7 +514,18 @@ impl<T: Clone> Signal<T> {
 }
 ```
 
-`Signal<T>` is `!Send` — all methods above must be called on the main thread.
+`RwSignal<T>` is `!Send` — all methods above must be called on the main thread.
+
+### Signal Methods (read-only, main-thread only)
+
+```rust
+impl<T: Clone> Signal<T> {
+    pub fn get(&self) -> T;                // Read with tracking
+    pub fn get_untracked(&self) -> T;      // Read without tracking
+}
+```
+
+`Signal<T>` is read-only — no `.set()`, `.update()`, or `.writer()` methods.
 
 ### WriteSignal Methods (Send — background threads)
 

--- a/examples/animation_example.rs
+++ b/examples/animation_example.rs
@@ -34,7 +34,7 @@ fn main() {
 }
 
 /// Card demonstrating width animation with spring physics
-fn create_width_animation_card(expanded: Signal<bool>) -> Container {
+fn create_width_animation_card(expanded: RwSignal<bool>) -> Container {
     container()
         .width(move || at_least(if expanded.get() { 600.0 } else { 50.0 }))
         .animate_width(Transition::spring(SpringConfig::DEFAULT))

--- a/examples/perf_stress_test.rs
+++ b/examples/perf_stress_test.rs
@@ -16,8 +16,8 @@ use std::rc::Rc;
 const INITIAL_ITEM_COUNT: usize = 10000;
 
 struct ItemData {
-    enabled: Signal<bool>,
-    input_value: Signal<String>,
+    enabled: RwSignal<bool>,
+    input_value: RwSignal<String>,
 }
 
 fn main() {
@@ -33,7 +33,7 @@ fn main() {
         ));
 
         // Signal that tracks the list of item IDs (u64 is Send)
-        let item_ids: Signal<Vec<u64>> = create_signal((0..INITIAL_ITEM_COUNT as u64).collect());
+        let item_ids: RwSignal<Vec<u64>> = create_signal((0..INITIAL_ITEM_COUNT as u64).collect());
 
         let store_for_children = item_store.clone();
         let dyn_container_view =
@@ -96,7 +96,7 @@ fn get_item_description(id: usize) -> String {
 }
 
 fn create_add_button(
-    item_ids: Signal<Vec<u64>>,
+    item_ids: RwSignal<Vec<u64>>,
     item_store: Rc<RefCell<Vec<ItemData>>>,
 ) -> Container {
     container()
@@ -116,7 +116,11 @@ fn create_add_button(
         .child(text("Add Item").color(Color::WHITE).font_size(14.0))
 }
 
-fn create_item_row(enabled: Signal<bool>, input_value: Signal<String>, index: usize) -> Container {
+fn create_item_row(
+    enabled: RwSignal<bool>,
+    input_value: RwSignal<String>,
+    index: usize,
+) -> Container {
     let name = get_item_name(index);
     let description = get_item_description(index);
 
@@ -135,7 +139,7 @@ fn create_item_row(enabled: Signal<bool>, input_value: Signal<String>, index: us
     // .child(create_status_indicator(enabled))
 }
 
-fn create_toggle_button(enabled: Signal<bool>) -> Container {
+fn create_toggle_button(enabled: RwSignal<bool>) -> Container {
     container()
         .width(100.0)
         .height(30.0) // Fixed dimensions make this a relayout boundary
@@ -169,7 +173,7 @@ fn create_toggle_button(enabled: Signal<bool>) -> Container {
 fn create_info_section(
     name: String,
     description: String,
-    input_value: Signal<String>,
+    input_value: RwSignal<String>,
 ) -> Container {
     container()
         .width(at_least(200.0))
@@ -187,7 +191,7 @@ fn create_info_section(
         )
 }
 
-fn create_text_input_field(input_value: Signal<String>) -> Container {
+fn create_text_input_field(input_value: RwSignal<String>) -> Container {
     container()
         .width(200.0)
         .padding(8.0)

--- a/examples/rounded_hitbox_test.rs
+++ b/examples/rounded_hitbox_test.rs
@@ -64,7 +64,7 @@ fn make_box(
     label: &'static str,
     corner_radius: f32,
     base_color: Color,
-    click_count: Signal<i32>,
+    click_count: RwSignal<i32>,
 ) -> Container {
     container()
         .width(100.0)

--- a/examples/rounded_transform_test.rs
+++ b/examples/rounded_transform_test.rs
@@ -70,7 +70,7 @@ fn main() {
     });
 }
 
-fn make_box(label: &'static str, base_color: Color, click_count: Signal<i32>) -> Container {
+fn make_box(label: &'static str, base_color: Color, click_count: RwSignal<i32>) -> Container {
     container()
         .width(100.0)
         .height(100.0)

--- a/examples/scroll_mixed_content.rs
+++ b/examples/scroll_mixed_content.rs
@@ -16,7 +16,7 @@ fn main() {
         let bio = create_signal(String::new());
 
         // Helper to create a form field
-        fn form_field(label: &'static str, input_signal: Signal<String>) -> Container {
+        fn form_field(label: &'static str, input_signal: RwSignal<String>) -> Container {
             container()
                 .layout(Flex::column().spacing(4.0))
                 .child(text(label).color(Color::rgb(0.7, 0.7, 0.8)).font_size(12.0))

--- a/examples/surface_properties_example.rs
+++ b/examples/surface_properties_example.rs
@@ -165,8 +165,8 @@ fn main() {
 fn layer_button(
     label: &'static str,
     layer: Layer,
-    surface_id_signal: Signal<Option<SurfaceId>>,
-    current_layer: Signal<&'static str>,
+    surface_id_signal: RwSignal<Option<SurfaceId>>,
+    current_layer: RwSignal<&'static str>,
 ) -> Container {
     container()
         .padding([8.0, 12.0])
@@ -187,8 +187,8 @@ fn layer_button(
 fn keyboard_button(
     label: &'static str,
     mode: KeyboardInteractivity,
-    surface_id_signal: Signal<Option<SurfaceId>>,
-    current_keyboard: Signal<&'static str>,
+    surface_id_signal: RwSignal<Option<SurfaceId>>,
+    current_keyboard: RwSignal<&'static str>,
 ) -> Container {
     container()
         .padding([8.0, 12.0])

--- a/examples/transform_events_test.rs
+++ b/examples/transform_events_test.rs
@@ -109,7 +109,7 @@ fn main() {
     });
 }
 
-fn make_box(label: &'static str, base_color: Color, click_count: Signal<i32>) -> Container {
+fn make_box(label: &'static str, base_color: Color, click_count: RwSignal<i32>) -> Container {
     container()
         .width(70.0)
         .height(70.0)

--- a/guido-macros/src/lib.rs
+++ b/guido-macros/src/lib.rs
@@ -541,7 +541,7 @@ pub fn derive_signal_fields(input: TokenStream) -> TokenStream {
         .iter()
         .zip(field_types.iter())
         .map(|(name, ty)| {
-            quote! { pub #name: ::guido::reactive::signal::Signal<#ty> }
+            quote! { pub #name: ::guido::reactive::signal::RwSignal<#ty> }
         });
 
     // Generate {Name}Writers struct fields

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,7 @@ pub mod prelude {
     };
     pub use crate::platform::{Anchor, KeyboardInteractivity, Layer};
     pub use crate::reactive::{
-        CursorIcon, Memo, OptionSignalExt, Service, Signal, WriteSignal, create_derived,
+        CursorIcon, Memo, OptionSignalExt, RwSignal, Service, Signal, WriteSignal, create_derived,
         create_effect, create_memo, create_service, create_signal, create_stored, expect_context,
         has_context, on_cleanup, provide_context, provide_signal_context, set_cursor, use_context,
         with_context,

--- a/src/reactive/context.rs
+++ b/src/reactive/context.rs
@@ -27,7 +27,7 @@
 use std::any::{Any, TypeId};
 use std::cell::RefCell;
 
-use super::signal::{Signal, create_signal};
+use super::signal::{RwSignal, create_signal};
 
 thread_local! {
     static CONTEXTS: RefCell<Vec<(TypeId, Box<dyn Any>)>> = const { RefCell::new(Vec::new()) };
@@ -179,7 +179,7 @@ pub fn has_context<T: 'static>() -> bool {
 /// let theme = expect_context::<Signal<Theme>>();
 /// container().background(move || theme.get().bg_color)
 /// ```
-pub fn provide_signal_context<T: Clone + PartialEq + Send + 'static>(value: T) -> Signal<T> {
+pub fn provide_signal_context<T: Clone + PartialEq + Send + 'static>(value: T) -> RwSignal<T> {
     let signal = create_signal(value);
     provide_context(signal);
     signal
@@ -289,8 +289,8 @@ mod tests {
         let signal = provide_signal_context(100i32);
         assert_eq!(signal.get(), 100);
 
-        // Retrieve via use_context
-        let retrieved = use_context::<Signal<i32>>().unwrap();
+        // Retrieve via use_context (stored as RwSignal)
+        let retrieved = use_context::<RwSignal<i32>>().unwrap();
         assert_eq!(retrieved.get(), 100);
 
         // Signal set propagates

--- a/src/reactive/into_signal.rs
+++ b/src/reactive/into_signal.rs
@@ -1,4 +1,4 @@
-use super::signal::{Signal, create_derived, create_stored};
+use super::signal::{RwSignal, Signal, create_derived, create_stored};
 
 // ============================================================================
 // Marker types for IntoSignal disambiguation
@@ -12,6 +12,8 @@ pub struct LossyMarker;
 pub struct ClosureMarker;
 #[doc(hidden)]
 pub struct SignalMarker;
+#[doc(hidden)]
+pub struct RwSignalMarker;
 #[doc(hidden)]
 pub struct MemoMarker;
 
@@ -104,6 +106,13 @@ impl<T: Clone + 'static> IntoSignal<T, SignalMarker> for Signal<T> {
     }
 }
 
+// 5. RwSignal<T> → Signal<T> via read_only()
+impl<T: Clone + 'static> IntoSignal<T, RwSignalMarker> for RwSignal<T> {
+    fn into_signal(self) -> Signal<T> {
+        self.read_only()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -145,12 +154,19 @@ mod tests {
 
     #[test]
     fn test_signal_into_signal() {
-        let signal = create_signal(42);
-        let sig: Signal<i32> = signal.into_signal();
+        let rw = create_signal(42);
+        let sig: Signal<i32> = rw.into_signal();
 
         assert_eq!(sig.get(), 42);
-        signal.set(100);
+        rw.set(100);
         assert_eq!(sig.get(), 100);
+    }
+
+    #[test]
+    fn test_rw_signal_into_signal() {
+        let rw = create_signal(42);
+        let sig: Signal<i32> = rw.into_signal();
+        assert_eq!(sig.get(), 42);
     }
 
     #[test]

--- a/src/reactive/memo.rs
+++ b/src/reactive/memo.rs
@@ -1,6 +1,6 @@
 use super::effect::create_effect;
 use super::into_signal::{IntoSignal, MemoMarker};
-use super::signal::{Signal, create_signal};
+use super::signal::{RwSignal, Signal, create_signal};
 
 /// Eager computed value that recomputes immediately when dependencies change.
 ///
@@ -22,7 +22,7 @@ use super::signal::{Signal, create_signal};
 /// })
 /// ```
 pub struct Memo<T: Clone + PartialEq + Send + 'static> {
-    signal: Signal<T>,
+    signal: RwSignal<T>,
 }
 
 // Manually implement Clone and Copy to avoid unnecessary bounds on T
@@ -77,15 +77,15 @@ impl<T: Clone + PartialEq + Send + 'static> Memo<T> {
         self.signal.with(f)
     }
 
-    /// Extract the inner signal.
+    /// Extract as a read-only signal.
     pub fn into_signal(self) -> Signal<T> {
-        self.signal
+        self.signal.read_only()
     }
 }
 
 impl<T: Clone + PartialEq + Send + 'static> IntoSignal<T, MemoMarker> for Memo<T> {
     fn into_signal(self) -> Signal<T> {
-        self.signal
+        self.signal.read_only()
     }
 }
 

--- a/src/reactive/mod.rs
+++ b/src/reactive/mod.rs
@@ -23,7 +23,9 @@ pub use cursor::{CursorIcon, set_cursor};
 pub use effect::{Effect, create_effect};
 pub(crate) use focus::{focused_widget, has_focus, release_focus, request_focus};
 #[doc(hidden)]
-pub use into_signal::{ClosureMarker, LossyMarker, MemoMarker, SignalMarker, ValueMarker};
+pub use into_signal::{
+    ClosureMarker, LossyMarker, MemoMarker, RwSignalMarker, SignalMarker, ValueMarker,
+};
 pub use into_signal::{IntoSignal, IntoVal};
 pub(crate) use invalidation::with_signal_tracking;
 pub use memo::{Memo, create_memo};
@@ -42,7 +44,7 @@ pub mod __internal {
 pub(crate) use runtime::flush_bg_writes;
 pub use service::{Service, ServiceContext, create_service};
 pub use signal::{
-    OptionSignalExt, Signal, WriteSignal, create_derived, create_signal, create_stored,
+    OptionSignalExt, RwSignal, Signal, WriteSignal, create_derived, create_signal, create_stored,
 };
 
 /// Reset all reactive system state.

--- a/src/reactive/signal.rs
+++ b/src/reactive/signal.rs
@@ -11,6 +11,24 @@ use super::storage::{
     store_derived_closure, try_call_derived, with_signal_value, with_stored_value,
 };
 
+/// Implement Clone (via Copy), Copy, PartialEq (by SignalId), and Eq for a signal type.
+macro_rules! impl_signal_id_traits {
+    ($ty:ident) => {
+        impl<T> Clone for $ty<T> {
+            fn clone(&self) -> Self {
+                *self
+            }
+        }
+        impl<T> Copy for $ty<T> {}
+        impl<T> PartialEq for $ty<T> {
+            fn eq(&self, other: &Self) -> bool {
+                self.id == other.id
+            }
+        }
+        impl<T> Eq for $ty<T> {}
+    };
+}
+
 /// Internal discriminant for the three signal kinds.
 /// Same size as `bool` (1 byte) so `Signal<T>` stays at 16 bytes.
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -28,6 +46,7 @@ pub(crate) enum SignalKind {
 /// - Stored: no tracking (value never changes), reads `Rc<T>` directly
 /// - Mutable: full effect + widget tracking, reads `Rc<RefCell<T>>`
 /// - Derived: calls the closure (which tracks its own reads internally)
+#[inline]
 fn tracked_get<T: Clone + 'static>(id: SignalId, kind: SignalKind) -> T {
     match kind {
         SignalKind::Stored => get_stored_value(id),
@@ -44,6 +63,7 @@ fn tracked_get<T: Clone + 'static>(id: SignalId, kind: SignalKind) -> T {
 /// - Stored: no tracking, borrows `Rc<T>` directly
 /// - Mutable: full tracking, borrows through `Rc<RefCell<T>>`
 /// - Derived: calls the closure and passes the result to `f`
+#[inline]
 fn tracked_with<T: Clone + 'static, R>(
     id: SignalId,
     kind: SignalKind,
@@ -100,23 +120,7 @@ pub struct Signal<T> {
     _not_send: PhantomData<*const ()>,
 }
 
-// Manually implement Clone and Copy to avoid unnecessary bounds on T
-impl<T> Clone for Signal<T> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-
-impl<T> Copy for Signal<T> {}
-
-// Implement PartialEq by comparing SignalId.
-impl<T> PartialEq for Signal<T> {
-    fn eq(&self, other: &Self) -> bool {
-        self.id == other.id
-    }
-}
-
-impl<T> Eq for Signal<T> {}
+impl_signal_id_traits!(Signal);
 
 impl<T: Clone + 'static> Signal<T> {
     /// Get the current value (tracks as dependency for effects)
@@ -169,39 +173,33 @@ pub struct RwSignal<T> {
     _not_send: PhantomData<*const ()>,
 }
 
-impl<T> Clone for RwSignal<T> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-
-impl<T> Copy for RwSignal<T> {}
-
-impl<T> PartialEq for RwSignal<T> {
-    fn eq(&self, other: &Self) -> bool {
-        self.id == other.id
-    }
-}
-
-impl<T> Eq for RwSignal<T> {}
+impl_signal_id_traits!(RwSignal);
 
 impl<T: Clone + 'static> RwSignal<T> {
     /// Get the current value (tracks as dependency for effects)
+    #[inline]
     pub fn get(&self) -> T {
-        tracked_get(self.id, SignalKind::Mutable)
+        record_effect_read(self.id);
+        record_signal_read(self.id);
+        get_signal_value(self.id)
     }
 
     /// Get the current value without tracking
+    #[inline]
     pub fn get_untracked(&self) -> T {
         get_signal_value(self.id)
     }
 
     /// Borrow the value for reading
+    #[inline]
     pub fn with<R>(&self, f: impl FnOnce(&T) -> R) -> R {
-        tracked_with(self.id, SignalKind::Mutable, f)
+        record_effect_read(self.id);
+        record_signal_read(self.id);
+        with_signal_value(self.id, f)
     }
 
     /// Borrow the value without tracking
+    #[inline]
     pub fn with_untracked<R>(&self, f: impl FnOnce(&T) -> R) -> R {
         with_signal_value(self.id, f)
     }
@@ -277,13 +275,11 @@ pub struct WriteSignal<T> {
     _marker: PhantomData<T>,
 }
 
-// Manually implement Clone and Copy to avoid unnecessary bounds on T
 impl<T> Clone for WriteSignal<T> {
     fn clone(&self) -> Self {
         *self
     }
 }
-
 impl<T> Copy for WriteSignal<T> {}
 
 impl<T: Clone + PartialEq + Send + 'static> WriteSignal<T> {

--- a/src/reactive/signal.rs
+++ b/src/reactive/signal.rs
@@ -7,33 +7,68 @@ use super::runtime::{
 };
 use super::storage::{
     allocate_signal_slot, compare_and_set_signal_value, compare_and_update_signal_value,
-    create_signal_value, get_signal_value, has_signal, store_derived_closure, try_call_derived,
-    with_signal_value,
+    create_signal_value, create_stored_value, get_signal_value, get_stored_value, has_signal,
+    store_derived_closure, try_call_derived, with_signal_value, with_stored_value,
 };
 
+/// Internal discriminant for the three signal kinds.
+/// Same size as `bool` (1 byte) so `Signal<T>` stays at 16 bytes.
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub(crate) enum SignalKind {
+    /// Immutable stored value (`Rc<T>`, no RefCell, no tracking).
+    Stored = 0,
+    /// Reactive read-write value (`Rc<RefCell<T>>`, tracked).
+    Mutable = 1,
+    /// Closure-backed derived signal (HashMap lookup).
+    Derived = 2,
+}
+
 /// Common read operations for signal types.
-/// Tracks reads for effect dependencies and widget invalidation.
-/// For derived signals, calls the closure (which tracks its own reads) and
-/// does NOT self-track to avoid double-tracking.
-fn tracked_get<T: Clone + 'static>(id: SignalId, derived: bool) -> T {
-    if derived && let Some(val) = try_call_derived::<T>(id) {
-        return val;
+/// - Stored: no tracking (value never changes), reads `Rc<T>` directly
+/// - Mutable: full effect + widget tracking, reads `Rc<RefCell<T>>`
+/// - Derived: calls the closure (which tracks its own reads internally)
+fn tracked_get<T: Clone + 'static>(id: SignalId, kind: SignalKind) -> T {
+    match kind {
+        SignalKind::Stored => get_stored_value(id),
+        SignalKind::Derived => {
+            if let Some(val) = try_call_derived::<T>(id) {
+                return val;
+            }
+            // Fallback (shouldn't happen for properly constructed derived signals)
+            record_effect_read(id);
+            record_signal_read(id);
+            get_signal_value(id)
+        }
+        SignalKind::Mutable => {
+            record_effect_read(id);
+            record_signal_read(id);
+            get_signal_value(id)
+        }
     }
-    record_effect_read(id);
-    record_signal_read(id);
-    get_signal_value(id)
 }
 
 /// Common read-with-borrow operation for signal types.
-/// For derived signals, calls the closure and passes the result to `f`.
-fn tracked_with<T: Clone + 'static, R>(id: SignalId, derived: bool, f: impl FnOnce(&T) -> R) -> R {
-    if derived {
-        let val = try_call_derived::<T>(id).unwrap();
-        return f(&val);
+/// - Stored: no tracking, borrows `Rc<T>` directly
+/// - Mutable: full tracking, borrows through `Rc<RefCell<T>>`
+/// - Derived: calls the closure and passes the result to `f`
+fn tracked_with<T: Clone + 'static, R>(
+    id: SignalId,
+    kind: SignalKind,
+    f: impl FnOnce(&T) -> R,
+) -> R {
+    match kind {
+        SignalKind::Stored => with_stored_value(id, f),
+        SignalKind::Derived => {
+            let val = try_call_derived::<T>(id).unwrap();
+            f(&val)
+        }
+        SignalKind::Mutable => {
+            record_effect_read(id);
+            record_signal_read(id);
+            with_signal_value(id, f)
+        }
     }
-    record_effect_read(id);
-    record_signal_read(id);
-    with_signal_value(id, f)
 }
 
 /// Perform a signal write with change detection and notification (main thread only).
@@ -66,9 +101,9 @@ fn update_and_notify<T: Clone + PartialEq + 'static>(id: SignalId, f: impl FnOnc
 /// to get a [`WriteSignal<T>`] which is `Send`.
 pub struct Signal<T> {
     id: SignalId,
-    /// True for derived signals (closure-backed). Stored signals skip
-    /// the HashMap lookup in `try_call_derived()` when this is false.
-    derived: bool,
+    /// Discriminant for the three signal kinds (Stored, Mutable, Derived).
+    /// Same size as the old `derived: bool` — Signal<T> stays at 16 bytes.
+    kind: SignalKind,
     _marker: PhantomData<T>,
     _not_send: PhantomData<*const ()>, // makes Signal !Send !Sync
 }
@@ -94,36 +129,38 @@ impl<T> Eq for Signal<T> {}
 impl<T: Clone + 'static> Signal<T> {
     /// Get the current value (tracks as dependency for effects)
     pub fn get(&self) -> T {
-        tracked_get(self.id, self.derived)
+        tracked_get(self.id, self.kind)
     }
 
     /// Get the current value without tracking
     pub fn get_untracked(&self) -> T {
-        if self.derived
-            && let Some(val) = try_call_derived::<T>(self.id)
-        {
-            return val;
+        match self.kind {
+            SignalKind::Stored => get_stored_value(self.id),
+            SignalKind::Derived => try_call_derived::<T>(self.id).unwrap(),
+            SignalKind::Mutable => get_signal_value(self.id),
         }
-        get_signal_value(self.id)
     }
 
     /// Borrow the value for reading
     pub fn with<R>(&self, f: impl FnOnce(&T) -> R) -> R {
-        tracked_with(self.id, self.derived, f)
+        tracked_with(self.id, self.kind, f)
     }
 
     /// Borrow the value without tracking
     pub fn with_untracked<R>(&self, f: impl FnOnce(&T) -> R) -> R {
-        if self.derived {
-            let val = try_call_derived::<T>(self.id).unwrap();
-            return f(&val);
+        match self.kind {
+            SignalKind::Stored => with_stored_value(self.id, f),
+            SignalKind::Derived => {
+                let val = try_call_derived::<T>(self.id).unwrap();
+                f(&val)
+            }
+            SignalKind::Mutable => with_signal_value(self.id, f),
         }
-        with_signal_value(self.id, f)
     }
 
     /// Check if this signal is derived (backed by a closure, not a stored value).
     pub fn is_derived(&self) -> bool {
-        self.derived
+        self.kind == SignalKind::Derived
     }
 }
 
@@ -230,7 +267,7 @@ impl<T: Clone + PartialEq + Send + 'static> WriteSignal<T> {
 }
 
 pub fn create_signal<T: Clone + PartialEq + Send + 'static>(value: T) -> Signal<T> {
-    // Create value in thread-local storage
+    // Create value in thread-local storage (Rc<RefCell<T>> for read-write access)
     let id = create_signal_value(value);
     // Register with thread-local runtime for subscriber tracking
     try_with_runtime(|rt| rt.register_signal(id));
@@ -238,7 +275,7 @@ pub fn create_signal<T: Clone + PartialEq + Send + 'static>(value: T) -> Signal<
     register_signal(id);
     Signal {
         id,
-        derived: false,
+        kind: SignalKind::Mutable,
         _marker: PhantomData,
         _not_send: PhantomData,
     }
@@ -257,12 +294,14 @@ pub fn create_signal<T: Clone + PartialEq + Send + 'static>(value: T) -> Signal<
 /// container().background(color) // Copy, no clone needed
 /// ```
 pub fn create_stored<T: Clone + 'static>(value: T) -> Signal<T> {
-    let id = create_signal_value(value);
-    try_with_runtime(|rt| rt.register_signal(id));
+    // Store as Rc<T> (no RefCell) — value is immutable, no tracking needed.
+    let id = create_stored_value(value);
+    // Skip runtime registration — value never changes, no subscribers needed.
+    // Still register with owner for slot cleanup when owner is disposed.
     register_signal(id);
     Signal {
         id,
-        derived: false,
+        kind: SignalKind::Stored,
         _marker: PhantomData,
         _not_send: PhantomData,
     }
@@ -290,7 +329,7 @@ pub fn create_derived<T: Clone + 'static>(f: impl Fn() -> T + 'static) -> Signal
     register_signal(id);
     Signal {
         id,
-        derived: true,
+        kind: SignalKind::Derived,
         _marker: PhantomData,
         _not_send: PhantomData,
     }

--- a/src/reactive/signal.rs
+++ b/src/reactive/signal.rs
@@ -31,15 +31,7 @@ pub(crate) enum SignalKind {
 fn tracked_get<T: Clone + 'static>(id: SignalId, kind: SignalKind) -> T {
     match kind {
         SignalKind::Stored => get_stored_value(id),
-        SignalKind::Derived => {
-            if let Some(val) = try_call_derived::<T>(id) {
-                return val;
-            }
-            // Fallback (shouldn't happen for properly constructed derived signals)
-            record_effect_read(id);
-            record_signal_read(id);
-            get_signal_value(id)
-        }
+        SignalKind::Derived => try_call_derived::<T>(id).expect("derived closure missing"),
         SignalKind::Mutable => {
             record_effect_read(id);
             record_signal_read(id);
@@ -87,25 +79,25 @@ fn update_and_notify<T: Clone + PartialEq + 'static>(id: SignalId, f: impl FnOnc
     }
 }
 
-/// A reactive signal that can be read and written on the main thread.
+/// A read-only reactive signal.
 ///
-/// Signals are the core primitive of the reactive system. When a signal's
-/// value changes, any effects that depend on it will be re-run.
+/// `Signal<T>` provides read access to reactive values. It is returned by
+/// [`create_stored`] (static values) and [`create_derived`] (closure-backed).
+/// Widget properties accept `Signal<T>` via the [`IntoSignal`] trait.
 ///
-/// Signals are Copy - they can be freely passed into closures without cloning.
+/// To create a read-write signal, use [`create_signal`] which returns [`RwSignal<T>`].
+///
+/// Signals are `Copy` — they can be freely passed into closures without cloning.
 ///
 /// # Thread Safety
 ///
-/// `Signal<T>` is `!Send` — it can only be used on the main thread where it
-/// was created. To write from a background thread, use [`Signal::writer()`]
-/// to get a [`WriteSignal<T>`] which is `Send`.
+/// `Signal<T>` is `!Send` — it can only be used on the main thread.
 pub struct Signal<T> {
     id: SignalId,
     /// Discriminant for the three signal kinds (Stored, Mutable, Derived).
-    /// Same size as the old `derived: bool` — Signal<T> stays at 16 bytes.
     kind: SignalKind,
     _marker: PhantomData<T>,
-    _not_send: PhantomData<*const ()>, // makes Signal !Send !Sync
+    _not_send: PhantomData<*const ()>,
 }
 
 // Manually implement Clone and Copy to avoid unnecessary bounds on T
@@ -157,14 +149,87 @@ impl<T: Clone + 'static> Signal<T> {
             SignalKind::Mutable => with_signal_value(self.id, f),
         }
     }
+}
 
-    /// Check if this signal is derived (backed by a closure, not a stored value).
-    pub fn is_derived(&self) -> bool {
-        self.kind == SignalKind::Derived
+/// A read-write reactive signal.
+///
+/// Created by [`create_signal`]. Provides both read and write access.
+/// Can be converted to a read-only [`Signal<T>`] via [`read_only()`](RwSignal::read_only)
+/// or the [`From`] impl. Widget properties accept `RwSignal<T>` via [`IntoSignal`].
+///
+/// `RwSignal<T>` is `Copy` (8 bytes — just a signal ID).
+///
+/// # Thread Safety
+///
+/// `RwSignal<T>` is `!Send`. Use [`.writer()`](RwSignal::writer) to get a
+/// [`WriteSignal<T>`] which is `Send` for background thread writes.
+pub struct RwSignal<T> {
+    id: SignalId,
+    _marker: PhantomData<T>,
+    _not_send: PhantomData<*const ()>,
+}
+
+impl<T> Clone for RwSignal<T> {
+    fn clone(&self) -> Self {
+        *self
     }
 }
 
-impl<T: Clone + PartialEq + Send + 'static> Signal<T> {
+impl<T> Copy for RwSignal<T> {}
+
+impl<T> PartialEq for RwSignal<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+
+impl<T> Eq for RwSignal<T> {}
+
+impl<T: Clone + 'static> RwSignal<T> {
+    /// Get the current value (tracks as dependency for effects)
+    pub fn get(&self) -> T {
+        tracked_get(self.id, SignalKind::Mutable)
+    }
+
+    /// Get the current value without tracking
+    pub fn get_untracked(&self) -> T {
+        get_signal_value(self.id)
+    }
+
+    /// Borrow the value for reading
+    pub fn with<R>(&self, f: impl FnOnce(&T) -> R) -> R {
+        tracked_with(self.id, SignalKind::Mutable, f)
+    }
+
+    /// Borrow the value without tracking
+    pub fn with_untracked<R>(&self, f: impl FnOnce(&T) -> R) -> R {
+        with_signal_value(self.id, f)
+    }
+
+    /// Convert to a read-only [`Signal<T>`].
+    pub fn read_only(self) -> Signal<T> {
+        Signal {
+            id: self.id,
+            kind: SignalKind::Mutable,
+            _marker: PhantomData,
+            _not_send: PhantomData,
+        }
+    }
+}
+
+impl<T: Clone + PartialEq + 'static> RwSignal<T> {
+    /// Set a new value (notifies subscribers if changed)
+    pub fn set(&self, value: T) {
+        write_and_notify(self.id, value);
+    }
+
+    /// Update the value using a closure
+    pub fn update<F: FnOnce(&mut T)>(&self, f: F) {
+        update_and_notify(self.id, f);
+    }
+}
+
+impl<T: Clone + PartialEq + Send + 'static> RwSignal<T> {
     /// Get a `WriteSignal<T>` for writing from background threads.
     ///
     /// `WriteSignal<T>` is `Send` and can be captured in `create_service` closures.
@@ -179,15 +244,9 @@ impl<T: Clone + PartialEq + Send + 'static> Signal<T> {
     }
 }
 
-impl<T: Clone + PartialEq + 'static> Signal<T> {
-    /// Set a new value (notifies subscribers if changed)
-    pub fn set(&self, value: T) {
-        write_and_notify(self.id, value);
-    }
-
-    /// Update the value using a closure
-    pub fn update<F: FnOnce(&mut T)>(&self, f: F) {
-        update_and_notify(self.id, f);
+impl<T: Clone + 'static> From<RwSignal<T>> for Signal<T> {
+    fn from(rw: RwSignal<T>) -> Self {
+        rw.read_only()
     }
 }
 
@@ -266,16 +325,25 @@ impl<T: Clone + PartialEq + Send + 'static> WriteSignal<T> {
     }
 }
 
-pub fn create_signal<T: Clone + PartialEq + Send + 'static>(value: T) -> Signal<T> {
-    // Create value in thread-local storage (Rc<RefCell<T>> for read-write access)
+/// Create a read-write reactive signal.
+///
+/// Returns an [`RwSignal<T>`] that supports both reading and writing.
+/// Converts to [`Signal<T>`] (read-only) via `.read_only()` or `Into`.
+///
+/// # Example
+///
+/// ```ignore
+/// let count = create_signal(0);
+/// count.set(1);           // write
+/// count.get();            // read
+/// container().padding(count) // auto-converts to Signal<T> via IntoSignal
+/// ```
+pub fn create_signal<T: Clone + PartialEq + Send + 'static>(value: T) -> RwSignal<T> {
     let id = create_signal_value(value);
-    // Register with thread-local runtime for subscriber tracking
     try_with_runtime(|rt| rt.register_signal(id));
-    // Register with current owner for automatic cleanup
     register_signal(id);
-    Signal {
+    RwSignal {
         id,
-        kind: SignalKind::Mutable,
         _marker: PhantomData,
         _not_send: PhantomData,
     }
@@ -294,10 +362,7 @@ pub fn create_signal<T: Clone + PartialEq + Send + 'static>(value: T) -> Signal<
 /// container().background(color) // Copy, no clone needed
 /// ```
 pub fn create_stored<T: Clone + 'static>(value: T) -> Signal<T> {
-    // Store as Rc<T> (no RefCell) — value is immutable, no tracking needed.
     let id = create_stored_value(value);
-    // Skip runtime registration — value never changes, no subscribers needed.
-    // Still register with owner for slot cleanup when owner is disposed.
     register_signal(id);
     Signal {
         id,
@@ -453,12 +518,26 @@ mod tests {
     }
 
     #[test]
-    fn test_signal_is_copy() {
+    fn test_rw_signal_is_copy() {
         let signal = create_signal(42);
         let _copy1 = signal;
         let _copy2 = signal;
-        // If Signal wasn't Copy, this wouldn't compile
         assert_eq!(signal.get(), 42);
+    }
+
+    #[test]
+    fn test_rw_signal_to_signal() {
+        let rw = create_signal(42);
+        let read_only: Signal<i32> = rw.into();
+        assert_eq!(read_only.get(), 42);
+        rw.set(100);
+        assert_eq!(read_only.get(), 100);
+    }
+
+    #[test]
+    fn test_rw_signal_size() {
+        assert_eq!(std::mem::size_of::<RwSignal<i32>>(), 8);
+        assert_eq!(std::mem::size_of::<Signal<i32>>(), 16);
     }
 
     // ================================================================

--- a/src/reactive/storage.rs
+++ b/src/reactive/storage.rs
@@ -50,18 +50,13 @@ thread_local! {
     static STORAGE: RefCell<SignalStorage> = RefCell::new(SignalStorage::new());
 }
 
-/// Get a reference to the signal's RefCell, handling errors consistently.
+/// Briefly borrow storage to Rc::clone a signal's value handle.
 ///
-/// Leptos-style: briefly borrow storage to Rc::clone the handle (O(1)),
-/// release the storage borrow, then work with the value through the Rc.
-/// This prevents re-entrant borrow panics when user callbacks create new signals.
-fn with_signal_cell<T: 'static, R>(
-    id: SignalId,
-    operation: &str,
-    f: impl FnOnce(&RefCell<T>) -> R,
-) -> R {
-    // Phase 1: briefly borrow storage to clone the Rc handle
-    let rc = STORAGE.with(|storage| {
+/// Leptos-style: clone the Rc (O(1)), release the storage borrow, then let
+/// the caller work with the value. Prevents re-entrant borrow panics when
+/// user callbacks create new signals.
+fn clone_slot_rc(id: SignalId, operation: &str) -> Rc<dyn Any> {
+    STORAGE.with(|storage| {
         let storage = storage.borrow();
         let slot = storage
             .values
@@ -82,8 +77,16 @@ fn with_signal_cell<T: 'static, R>(
                 )
             });
         Rc::clone(slot)
-    });
-    // Phase 2: storage borrow released — work with value through the Rc
+    })
+}
+
+/// Get a reference to the signal's RefCell, handling errors consistently.
+fn with_signal_cell<T: 'static, R>(
+    id: SignalId,
+    operation: &str,
+    f: impl FnOnce(&RefCell<T>) -> R,
+) -> R {
+    let rc = clone_slot_rc(id, operation);
     let cell = rc.downcast_ref::<RefCell<T>>().unwrap_or_else(|| {
         panic!(
             "Signal {} type mismatch: stored type does not match requested type {}",
@@ -94,23 +97,24 @@ fn with_signal_cell<T: 'static, R>(
     f(cell)
 }
 
-/// Create a new mutable signal value (`Rc<RefCell<T>>`) and return its ID.
-/// Reuses IDs from disposed signals when available to prevent unbounded growth.
-pub fn create_signal_value<T: 'static>(value: T) -> SignalId {
+/// Allocate a slot and store the given value. Reuses IDs from disposed signals.
+fn alloc_slot(value: Rc<dyn Any>) -> SignalId {
     STORAGE.with(|storage| {
         let mut storage = storage.borrow_mut();
-        let boxed: Rc<dyn Any> = Rc::new(RefCell::new(value));
-        // Reuse a freed slot if available
         if let Some(id) = storage.free_ids.pop() {
-            storage.values[id] = Some(boxed);
+            storage.values[id] = Some(value);
             return id;
         }
-        // Otherwise allocate new
         let id = storage.next_id;
         storage.next_id += 1;
-        storage.values.push(Some(boxed));
+        storage.values.push(Some(value));
         id
     })
+}
+
+/// Create a new mutable signal value (`Rc<RefCell<T>>`) and return its ID.
+pub fn create_signal_value<T: 'static>(value: T) -> SignalId {
+    alloc_slot(Rc::new(RefCell::new(value)))
 }
 
 /// Create a new immutable stored value (`Rc<T>`, no RefCell) and return its ID.
@@ -121,36 +125,14 @@ pub fn create_signal_value<T: 'static>(value: T) -> SignalId {
 /// - One `Vec::push` in runtime's `signal_subscribers`
 /// - `record_effect_read()` + `record_signal_read()` on every `.get()` call
 pub fn create_stored_value<T: 'static>(value: T) -> SignalId {
-    STORAGE.with(|storage| {
-        let mut storage = storage.borrow_mut();
-        let boxed: Rc<dyn Any> = Rc::new(value); // No RefCell!
-        if let Some(id) = storage.free_ids.pop() {
-            storage.values[id] = Some(boxed);
-            return id;
-        }
-        let id = storage.next_id;
-        storage.next_id += 1;
-        storage.values.push(Some(boxed));
-        id
-    })
+    alloc_slot(Rc::new(value))
 }
 
 /// Allocate a signal ID slot without storing a value.
 /// Used by `create_derived` — the ID exists in the runtime/owner system,
 /// but reads go through the derived closure map instead.
 pub fn allocate_signal_slot() -> SignalId {
-    STORAGE.with(|storage| {
-        let mut storage = storage.borrow_mut();
-        if let Some(id) = storage.free_ids.pop() {
-            // Mark slot as occupied (None means disposed, Some means alive)
-            storage.values[id] = Some(Rc::new(()));
-            return id;
-        }
-        let id = storage.next_id;
-        storage.next_id += 1;
-        storage.values.push(Some(Rc::new(())));
-        id
-    })
+    alloc_slot(Rc::new(()))
 }
 
 /// Store a derived closure for the given signal ID.
@@ -215,31 +197,9 @@ pub fn with_stored_value<T: 'static, R>(id: SignalId, f: impl FnOnce(&T) -> R) -
     with_stored_ref(id, f)
 }
 
-/// Internal: borrow the Rc<T> for a stored signal and apply `f`.
-///
-/// Like `with_signal_cell` but for immutable stored values (no RefCell).
+/// Borrow the Rc<T> for a stored (immutable) signal and apply `f`.
 fn with_stored_ref<T: 'static, R>(id: SignalId, f: impl FnOnce(&T) -> R) -> R {
-    let rc = STORAGE.with(|storage| {
-        let storage = storage.borrow();
-        let slot = storage
-            .values
-            .get(id)
-            .unwrap_or_else(|| {
-                panic!(
-                    "Invalid signal ID {}: out of bounds (max ID is {})",
-                    id,
-                    storage.values.len().saturating_sub(1)
-                )
-            })
-            .as_ref()
-            .unwrap_or_else(|| {
-                panic!(
-                    "Signal {} was disposed - cannot read after owner cleanup.",
-                    id
-                )
-            });
-        Rc::clone(slot)
-    });
+    let rc = clone_slot_rc(id, "read");
     let val = rc.downcast_ref::<T>().unwrap_or_else(|| {
         panic!(
             "Signal {} type mismatch: stored type does not match requested type {}",

--- a/src/reactive/storage.rs
+++ b/src/reactive/storage.rs
@@ -94,7 +94,7 @@ fn with_signal_cell<T: 'static, R>(
     f(cell)
 }
 
-/// Create a new signal and return its ID.
+/// Create a new mutable signal value (`Rc<RefCell<T>>`) and return its ID.
 /// Reuses IDs from disposed signals when available to prevent unbounded growth.
 pub fn create_signal_value<T: 'static>(value: T) -> SignalId {
     STORAGE.with(|storage| {
@@ -106,6 +106,28 @@ pub fn create_signal_value<T: 'static>(value: T) -> SignalId {
             return id;
         }
         // Otherwise allocate new
+        let id = storage.next_id;
+        storage.next_id += 1;
+        storage.values.push(Some(boxed));
+        id
+    })
+}
+
+/// Create a new immutable stored value (`Rc<T>`, no RefCell) and return its ID.
+///
+/// This is the cheap path for `create_stored()`: no RefCell wrapping, and the
+/// caller skips runtime registration and dependency tracking. Saves per-signal:
+/// - 8 bytes (no RefCell borrow flag)
+/// - One `Vec::push` in runtime's `signal_subscribers`
+/// - `record_effect_read()` + `record_signal_read()` on every `.get()` call
+pub fn create_stored_value<T: 'static>(value: T) -> SignalId {
+    STORAGE.with(|storage| {
+        let mut storage = storage.borrow_mut();
+        let boxed: Rc<dyn Any> = Rc::new(value); // No RefCell!
+        if let Some(id) = storage.free_ids.pop() {
+            storage.values[id] = Some(boxed);
+            return id;
+        }
         let id = storage.next_id;
         storage.next_id += 1;
         storage.values.push(Some(boxed));
@@ -163,11 +185,6 @@ pub fn try_call_derived<T: Clone + 'static>(id: SignalId) -> Option<T> {
     })
 }
 
-/// Check if a signal has a derived closure.
-pub fn is_derived(id: SignalId) -> bool {
-    STORAGE.with(|storage| storage.borrow().derived.contains_key(&id))
-}
-
 /// Dispose a signal, marking it as unavailable and adding its ID to the free list.
 ///
 /// After disposal, any attempt to read or write the signal will panic
@@ -183,7 +200,57 @@ pub fn dispose_signal(id: SignalId) {
     });
 }
 
-/// Get a signal's value (clones it)
+/// Get a stored (immutable) value by cloning it.
+///
+/// Reads `Rc<T>` directly — no RefCell borrow needed since the value is immutable.
+/// Used by `Signal::get()` for `SignalKind::Stored` signals.
+pub fn get_stored_value<T: Clone + 'static>(id: SignalId) -> T {
+    with_stored_ref(id, |v: &T| v.clone())
+}
+
+/// Borrow a stored (immutable) value for reading.
+///
+/// Reads `Rc<T>` directly — no RefCell borrow needed.
+pub fn with_stored_value<T: 'static, R>(id: SignalId, f: impl FnOnce(&T) -> R) -> R {
+    with_stored_ref(id, f)
+}
+
+/// Internal: borrow the Rc<T> for a stored signal and apply `f`.
+///
+/// Like `with_signal_cell` but for immutable stored values (no RefCell).
+fn with_stored_ref<T: 'static, R>(id: SignalId, f: impl FnOnce(&T) -> R) -> R {
+    let rc = STORAGE.with(|storage| {
+        let storage = storage.borrow();
+        let slot = storage
+            .values
+            .get(id)
+            .unwrap_or_else(|| {
+                panic!(
+                    "Invalid signal ID {}: out of bounds (max ID is {})",
+                    id,
+                    storage.values.len().saturating_sub(1)
+                )
+            })
+            .as_ref()
+            .unwrap_or_else(|| {
+                panic!(
+                    "Signal {} was disposed - cannot read after owner cleanup.",
+                    id
+                )
+            });
+        Rc::clone(slot)
+    });
+    let val = rc.downcast_ref::<T>().unwrap_or_else(|| {
+        panic!(
+            "Signal {} type mismatch: stored type does not match requested type {}",
+            id,
+            std::any::type_name::<T>()
+        )
+    });
+    f(val)
+}
+
+/// Get a mutable signal's value (clones it)
 pub fn get_signal_value<T: Clone + 'static>(id: SignalId) -> T {
     with_signal_cell(id, "read", |cell: &RefCell<T>| cell.borrow().clone())
 }

--- a/src/widget_ref.rs
+++ b/src/widget_ref.rs
@@ -7,7 +7,7 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
 
-use crate::reactive::{Signal, create_signal};
+use crate::reactive::{RwSignal, Signal, create_signal};
 use crate::tree::{Tree, WidgetId};
 use crate::widgets::Rect;
 
@@ -17,12 +17,17 @@ use crate::widgets::Rect;
 /// `.widget_ref(r)` and read bounds reactively via `.rect().get()`.
 #[derive(Clone, Copy)]
 pub struct WidgetRef {
-    signal: Signal<Rect>,
+    signal: RwSignal<Rect>,
 }
 
 impl WidgetRef {
-    /// The reactive signal holding this widget's surface-relative bounds.
+    /// The reactive signal holding this widget's surface-relative bounds (read-only).
     pub fn rect(&self) -> Signal<Rect> {
+        self.signal.read_only()
+    }
+
+    /// Internal: get the read-write signal for updating bounds after layout.
+    pub(crate) fn rw_signal(&self) -> RwSignal<Rect> {
         self.signal
     }
 }
@@ -35,11 +40,11 @@ pub fn create_widget_ref() -> WidgetRef {
 }
 
 // ---------------------------------------------------------------------------
-// Thread-local registry: WidgetId → Signal<Rect>
+// Thread-local registry: WidgetId → RwSignal<Rect>
 // ---------------------------------------------------------------------------
 
 thread_local! {
-    static WIDGET_REF_REGISTRY: RefCell<HashMap<WidgetId, Signal<Rect>>> =
+    static WIDGET_REF_REGISTRY: RefCell<HashMap<WidgetId, RwSignal<Rect>>> =
         RefCell::new(HashMap::new());
 }
 
@@ -47,7 +52,7 @@ thread_local! {
 ///
 /// Called from `Container::layout` each time a container with a `WidgetRef`
 /// is laid out. Idempotent — HashMap insert overwrites.
-pub(crate) fn register_widget_ref(id: WidgetId, signal: Signal<Rect>) {
+pub(crate) fn register_widget_ref(id: WidgetId, signal: RwSignal<Rect>) {
     WIDGET_REF_REGISTRY.with(|reg| {
         reg.borrow_mut().insert(id, signal);
     });

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -1463,7 +1463,7 @@ impl Widget for Container {
 
         // Register widget ref so update_widget_refs() can refresh bounds
         if let Some(ref wr) = self.widget_ref {
-            register_widget_ref(id, wr.rect());
+            register_widget_ref(id, wr.rw_signal());
         }
 
         size

--- a/src/widgets/text_input.rs
+++ b/src/widgets/text_input.rs
@@ -15,8 +15,8 @@ use crate::default_font_family;
 use crate::jobs::{JobRequest, JobType, RequiredJob, request_job};
 use crate::layout::{Constraints, Size};
 use crate::reactive::{
-    CursorIcon, IntoSignal, OptionSignalExt, Signal, clipboard_copy, clipboard_paste, has_focus,
-    release_focus, request_focus, set_cursor, with_signal_tracking,
+    CursorIcon, IntoSignal, OptionSignalExt, RwSignal, Signal, clipboard_copy, clipboard_paste,
+    has_focus, release_focus, request_focus, set_cursor, with_signal_tracking,
 };
 use crate::renderer::{PaintContext, char_index_from_x_styled, measure_text_styled};
 use crate::tree::{Tree, WidgetId};
@@ -191,7 +191,7 @@ impl Selection {
 pub struct TextInput {
     // Content (actual value, never masked)
     /// Signal for two-way binding
-    value: Signal<String>,
+    value: RwSignal<String>,
     cached_value: String,
     cached_char_count: usize,
     cached_display_text: String,
@@ -253,7 +253,7 @@ pub struct TextInput {
 impl TextInput {
     /// Create a TextInput with a Signal for two-way binding.
     /// Changes made in the TextInput will be written back to the signal.
-    pub fn new(signal: Signal<String>) -> Self {
+    pub fn new(signal: RwSignal<String>) -> Self {
         // Use get_untracked() to avoid registering layout dependencies during widget creation.
         // Layout dependencies should only be registered during the widget's own layout phase.
         let cached_value = signal.get_untracked();
@@ -1207,6 +1207,6 @@ impl Widget for TextInput {
 /// let username = create_signal(String::new());
 /// text_input(username)
 /// ```
-pub fn text_input(signal: Signal<String>) -> TextInput {
+pub fn text_input(signal: RwSignal<String>) -> TextInput {
     TextInput::new(signal)
 }


### PR DESCRIPTION
## Summary
- Optimize `create_stored()` to skip reactive runtime registration, making it a lightweight `Rc<T>` wrapper instead of going through the full signal machinery
- Stored values are read-only and never change, so they don't need dependency tracking or subscriber notification

## Test plan
- [x] `cargo clippy` passes
- [x] `cargo test` passes
- [x] Verify with `perf_stress_test` example that rendering is correct