### PR TITLE
fix: prevent caching partial paint results and snap spring animations to target

### DIFF
--- a/src/layout/flex_layout.rs
+++ b/src/layout/flex_layout.rs
@@ -260,12 +260,21 @@ impl Flex {
         // up to recompute cross_size.
         if cross_align == CrossAlignment::Stretch && stretch_cross.is_none() && cross_size > 0.0 {
             children_main = 0.0;
+            let mut fill_cursor = 0;
             for (i, &child_id) in children.iter().enumerate() {
                 if (self.child_sizes[i].cross_axis(axis) - cross_size).abs() < 0.5 {
                     children_main += self.child_sizes[i].main_axis(axis);
+                    if fill_cursor < self.fill_indices.len() && self.fill_indices[fill_cursor] == i
+                    {
+                        fill_cursor += 1;
+                    }
                     continue;
                 }
-                let child_is_fill = self.fill_indices.binary_search(&i).is_ok();
+                let child_is_fill =
+                    fill_cursor < self.fill_indices.len() && self.fill_indices[fill_cursor] == i;
+                if child_is_fill {
+                    fill_cursor += 1;
+                }
                 let main_constraint = if child_is_fill { per_fill } else { main_max };
                 let stretch_constraints = match axis {
                     Axis::Horizontal => Constraints {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,7 +247,15 @@ fn cache_paint_results(tree: &mut Tree, node: &renderer::RenderNode) {
     if node.repainted {
         let widget_id = WidgetId::from_u64(node.id);
         if tree.contains(widget_id) {
-            tree.cache_paint(widget_id, node.clone());
+            if !node.partial {
+                // Complete paint — safe to cache for future reuse.
+                tree.cache_paint(widget_id, node.clone());
+            }
+            // else: partial paint (children culled by cull_rect) — don't cache.
+            // Keep the previous complete cache (if any) so it can be reused
+            // when the widget becomes fully visible. If there's no previous
+            // cache, the widget will get a full paint next frame anyway
+            // (cached_paint returns None → falls through to full paint).
             tree.clear_needs_paint(widget_id);
         }
     }

--- a/src/renderer/paint_context.rs
+++ b/src/renderer/paint_context.rs
@@ -82,6 +82,12 @@ impl<'a> PaintContext<'a> {
         self.cull_rect = Some(rect);
     }
 
+    /// Mark this node's paint as partial (some children were culled by cull_rect).
+    /// Partial nodes are not cached to prevent reusing incomplete paint results.
+    pub fn mark_partial(&mut self) {
+        self.node.partial = true;
+    }
+
     // -------------------------------------------------------------------------
     // Node Properties
     // -------------------------------------------------------------------------

--- a/src/renderer/tree.rs
+++ b/src/renderer/tree.rs
@@ -94,6 +94,12 @@ pub struct RenderNode {
     /// The flattener uses this to decide whether to reuse cached flatten output.
     pub repainted: bool,
 
+    /// Whether some children were skipped (culled by cull_rect) during paint.
+    /// Partial nodes should not be cached because their paint is incomplete —
+    /// reusing them later (when fully visible) would permanently hide the
+    /// culled children.
+    pub partial: bool,
+
     /// Cached flattened commands from a previous flatten pass.
     /// Boxed to reduce inline RenderNode size (CachedFlatten contains Vec + Transform).
     pub cached_flatten: Option<Box<CachedFlatten>>,
@@ -114,6 +120,7 @@ impl RenderNode {
             clip: None,
             overlay_clip: None,
             repainted: true,
+            partial: false,
             cached_flatten: None,
         }
     }
@@ -137,6 +144,7 @@ impl RenderNode {
         self.clip = None;
         self.overlay_clip = None;
         self.repainted = true;
+        self.partial = false;
         self.cached_flatten = None;
     }
 }

--- a/src/widgets/container/animations.rs
+++ b/src/widgets/container/animations.rs
@@ -151,13 +151,18 @@ impl<T: Animatable> AnimationState<T> {
         };
 
         // Interpolate
-        let new_value = T::lerp(&self.start, &self.target, eased_t);
+        let mut new_value = T::lerp(&self.start, &self.target, eased_t);
 
         // Update progress
         if let Some(ref state) = self.spring_state {
             // For spring animations, only mark complete when spring has settled
             if state.is_settled(0.01) {
                 self.progress = 1.0;
+                // Snap to exact target to avoid floating-point drift.
+                // The spring settles within 0.01 of the target, but downstream
+                // checks (e.g. Transform::is_translation_only) use much tighter
+                // tolerances (1e-6), so the lerped value must be exact.
+                new_value = self.target;
             } else {
                 // Keep progress < 1.0 to continue animating
                 self.progress = 0.5;

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -1994,6 +1994,11 @@ impl Widget for Container {
                 );
                 if !cull_rect.intersects(&child_rect) {
                     crate::render_stats::record_paint_child_culled();
+                    // Mark this node's paint as partial so it won't be cached.
+                    // Without this, the incomplete paint (missing culled children)
+                    // could be reused later when the node is fully visible,
+                    // permanently hiding the culled children.
+                    ctx.mark_partial();
                     continue;
                 }
             }

--- a/src/widgets/container/scrollable.rs
+++ b/src/widgets/container/scrollable.rs
@@ -600,30 +600,32 @@ impl Container {
             }
 
             Event::MouseLeave => {
-                // Clear scrollbar hover state
-                let sd = self.scroll();
-                if sd.scroll_state.scrollbar_hovered || sd.scroll_state.h_scrollbar_hovered {
-                    let sd = self.scroll_mut();
-                    sd.scroll_state.scrollbar_hovered = false;
-                    sd.scroll_state.h_scrollbar_hovered = false;
-                    if let Some(handle_id) = self.scroll().v_scrollbar_handle_id {
+                // Clear hover and drag state in one pass
+                let sd = self.scroll_mut();
+                let had_hover =
+                    sd.scroll_state.scrollbar_hovered || sd.scroll_state.h_scrollbar_hovered;
+                let had_drag =
+                    sd.scroll_state.scrollbar_dragging || sd.scroll_state.h_scrollbar_dragging;
+                sd.scroll_state.scrollbar_hovered = false;
+                sd.scroll_state.h_scrollbar_hovered = false;
+                sd.scroll_state.scrollbar_dragging = false;
+                sd.scroll_state.h_scrollbar_dragging = false;
+                let v_handle = sd.v_scrollbar_handle_id;
+                let h_handle = sd.h_scrollbar_handle_id;
+
+                if had_hover {
+                    if let Some(handle_id) = v_handle {
                         tree.with_widget_mut(handle_id, |widget, widget_id, tree| {
                             widget.event(tree, widget_id, event);
                         });
                     }
-                    if let Some(handle_id) = self.scroll().h_scrollbar_handle_id {
+                    if let Some(handle_id) = h_handle {
                         tree.with_widget_mut(handle_id, |widget, widget_id, tree| {
                             widget.event(tree, widget_id, event);
                         });
                     }
-                    request_job(id, JobRequest::Paint);
                 }
-                // Stop dragging
-                let sd = self.scroll();
-                if sd.scroll_state.scrollbar_dragging || sd.scroll_state.h_scrollbar_dragging {
-                    let sd = self.scroll_mut();
-                    sd.scroll_state.scrollbar_dragging = false;
-                    sd.scroll_state.h_scrollbar_dragging = false;
+                if had_hover || had_drag {
                     request_job(id, JobRequest::Paint);
                 }
             }
@@ -659,20 +661,18 @@ impl Container {
 
         if handle_rect.contains(x, y) {
             // Start dragging handle
-            self.scroll_mut().scroll_state.set_dragging(axis, true);
-            let sd = self.scroll();
+            let sd = self.scroll_mut();
+            sd.scroll_state.set_dragging(axis, true);
             let (pos, offset) = match axis {
                 ScrollbarAxis::Vertical => (y, sd.scroll_state.offset_y),
                 ScrollbarAxis::Horizontal => (x, sd.scroll_state.offset_x),
             };
-            self.scroll_mut()
-                .scroll_state
-                .set_drag_start(axis, pos, offset);
+            sd.scroll_state.set_drag_start(axis, pos, offset);
 
             // Forward event to handle container for pressed state
             let handle_id = match axis {
-                ScrollbarAxis::Vertical => self.scroll().v_scrollbar_handle_id,
-                ScrollbarAxis::Horizontal => self.scroll().h_scrollbar_handle_id,
+                ScrollbarAxis::Vertical => sd.v_scrollbar_handle_id,
+                ScrollbarAxis::Horizontal => sd.h_scrollbar_handle_id,
             };
             if let Some(handle_id) = handle_id {
                 tree.with_widget_mut(handle_id, |widget, widget_id, tree| {
@@ -793,23 +793,18 @@ impl Container {
                 .scrollbar_handle_rect(axis, bounds, &sd.scrollbar_config, needs_other);
 
         let mut needs_repaint = false;
-
-        // Track area hover (for expansion effect)
-        let was_track_hovered = self.scroll().scroll_state.is_track_hovered(axis);
         let is_track_hovered = hit_area.contains(x, y);
-        self.scroll_mut()
-            .scroll_state
-            .set_track_hovered(axis, is_track_hovered);
+        let is_hovered = handle_rect.contains(x, y);
+
+        // Update track and handle hover state in one borrow
+        let sd = self.scroll_mut();
+        let was_track_hovered = sd.scroll_state.is_track_hovered(axis);
+        sd.scroll_state.set_track_hovered(axis, is_track_hovered);
         if was_track_hovered != is_track_hovered {
             needs_repaint = true;
         }
-
-        // Handle hover (for color change)
-        let was_hovered = self.scroll().scroll_state.is_handle_hovered(axis);
-        let is_hovered = handle_rect.contains(x, y);
-        self.scroll_mut()
-            .scroll_state
-            .set_handle_hovered(axis, is_hovered);
+        let was_hovered = sd.scroll_state.is_handle_hovered(axis);
+        sd.scroll_state.set_handle_hovered(axis, is_hovered);
         if was_hovered != is_hovered {
             needs_repaint = true;
         }
@@ -818,8 +813,8 @@ impl Container {
         // We can't forward raw MouseMove events because the Container's bounds check would fail
         // (coordinates are in parent space, not local to the handle widget).
         let handle_id = match axis {
-            ScrollbarAxis::Vertical => self.scroll().v_scrollbar_handle_id,
-            ScrollbarAxis::Horizontal => self.scroll().h_scrollbar_handle_id,
+            ScrollbarAxis::Vertical => sd.v_scrollbar_handle_id,
+            ScrollbarAxis::Horizontal => sd.h_scrollbar_handle_id,
         };
         if let Some(handle_id) = handle_id {
             if is_hovered && !was_hovered {
@@ -854,23 +849,21 @@ impl Container {
         delta_y: f32,
         source: ScrollSource,
     ) -> bool {
+        let axis = self.scroll_axis;
         let sd = self.scroll_mut();
         let old_x = sd.scroll_state.offset_x;
         let old_y = sd.scroll_state.offset_y;
 
-        match self.scroll_axis {
+        match axis {
             ScrollAxis::Vertical => {
-                let sd = self.scroll_mut();
                 sd.scroll_state.offset_y =
                     (sd.scroll_state.offset_y + delta_y).clamp(0.0, sd.scroll_state.max_scroll_y());
             }
             ScrollAxis::Horizontal => {
-                let sd = self.scroll_mut();
                 sd.scroll_state.offset_x =
                     (sd.scroll_state.offset_x + delta_x).clamp(0.0, sd.scroll_state.max_scroll_x());
             }
             ScrollAxis::Both => {
-                let sd = self.scroll_mut();
                 sd.scroll_state.offset_x =
                     (sd.scroll_state.offset_x + delta_x).clamp(0.0, sd.scroll_state.max_scroll_x());
                 sd.scroll_state.offset_y =
@@ -879,17 +872,10 @@ impl Container {
             ScrollAxis::None => return false,
         }
 
-        // Track velocity for kinetic scrolling (touchpad/finger input only)
         if source == ScrollSource::Finger {
-            let axis = self.scroll_axis;
-            let sd = self.scroll_mut();
             match axis {
-                ScrollAxis::Vertical => {
-                    sd.scroll_state.velocity_y = delta_y;
-                }
-                ScrollAxis::Horizontal => {
-                    sd.scroll_state.velocity_x = delta_x;
-                }
+                ScrollAxis::Vertical => sd.scroll_state.velocity_y = delta_y,
+                ScrollAxis::Horizontal => sd.scroll_state.velocity_x = delta_x,
                 ScrollAxis::Both => {
                     sd.scroll_state.velocity_x = delta_x;
                     sd.scroll_state.velocity_y = delta_y;
@@ -899,7 +885,6 @@ impl Container {
             sd.scroll_state.last_scroll_time = Some(std::time::Instant::now());
         }
 
-        let sd = self.scroll();
         old_x != sd.scroll_state.offset_x || old_y != sd.scroll_state.offset_y
     }
 }


### PR DESCRIPTION
## Summary
- **Partial paint caching fix**: When children are culled by `cull_rect` during paint, mark the node as `partial` so the incomplete paint result isn't cached. Without this, a stale partial cache could be reused when the widget becomes fully visible (e.g., an edge item scrolling into the viewport), permanently hiding culled children.
- **Spring animation snap-to-target**: When a spring settles (within 0.01 tolerance), snap the value to the exact target. Prevents floating-point drift that broke tighter downstream checks like `Transform::is_translation_only` (1e-6 tolerance).

## Test plan
- [x] `cargo fmt --all` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test` — 198 tests pass
- [ ] Verify scrollable containers with nested children render correctly during scroll
- [ ] Verify spring animations settle cleanly without visual jitter