### PR TITLE
Support f64 float literals in IntoSignal<f32>

### DIFF
--- a/book/src/building-ui/text.md
+++ b/book/src/building-ui/text.md
@@ -236,7 +236,7 @@ All properties accept static values, signals, or closures.
 text(content: impl IntoSignal<String, M>) -> Text
 
 impl Text {
-    pub fn font_size<M>(self, size: impl IntoSignal<f32, M>) -> Self;  // integers work: .font_size(16)
+    pub fn font_size<M>(self, size: impl IntoSignal<f32, M>) -> Self;  // numbers work: .font_size(16) or .font_size(16.5)
     pub fn color<M>(self, color: impl IntoSignal<Color, M>) -> Self;
     pub fn font_family<M>(self, family: impl IntoSignal<FontFamily, M>) -> Self;
     pub fn font_weight<M>(self, weight: impl IntoSignal<FontWeight, M>) -> Self;

--- a/docs/REACTIVE.md
+++ b/docs/REACTIVE.md
@@ -191,6 +191,8 @@ The `IntoSignal<T>` trait allows properties to accept any of:
 - **Closures**: `container().background(move || if dark { Color::BLACK } else { Color::WHITE })` → calls `create_derived()`
 - **Signals**: `container().background(my_signal)` → passed through directly (accepts both `Signal<T>` and `RwSignal<T>`)
 
+For numeric properties (`f32`, `Length`, `Padding`), integer and float literals both coerce to the target type: `container().corner_radius(12)` and `.corner_radius(12.5)` are equivalent to `12.0_f32`. Float coercion is lossy (`f64 as f32`), matching the precision of the destination.
+
 All produce a `Signal<T>` (which is `Copy`). `create_signal` returns `RwSignal<T>` (read-write, Clone+PartialEq+Send) which has `.set()`, `.update()`, and `.writer()`. `Signal<T>` is read-only — use it when you only need to read values.
 
 ## Background Task Updates

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -228,6 +228,12 @@ impl IntoVal<Length> for f32 {
     }
 }
 
+impl IntoVal<Length> for f64 {
+    fn into_val(self) -> Length {
+        Length::from(self as f32)
+    }
+}
+
 /// Trait for layout strategies that position multiple children
 pub trait Layout {
     /// Perform layout on children and return the total size.

--- a/src/reactive/into_signal.rs
+++ b/src/reactive/into_signal.rs
@@ -213,6 +213,12 @@ mod tests {
     }
 
     #[test]
+    fn test_closure_f64_conversion() {
+        let sig: Signal<f32> = (|| 8.5).into_signal();
+        assert_eq!(sig.get(), 8.5);
+    }
+
+    #[test]
     fn test_stored_is_copy() {
         let sig = create_stored(42);
         let sig2 = sig; // Copy

--- a/src/reactive/into_signal.rs
+++ b/src/reactive/into_signal.rs
@@ -151,6 +151,25 @@ mod tests {
     }
 
     #[test]
+    fn test_into_signal_for_f64_literal() {
+        let sig: Signal<f32> = 2.5.into_signal();
+        assert_eq!(sig.get(), 2.5);
+    }
+
+    #[test]
+    fn test_into_signal_for_f64_runtime_value() {
+        let value: f64 = 2.5;
+        let sig: Signal<f32> = value.into_signal();
+        assert_eq!(sig.get(), 2.5);
+    }
+
+    #[test]
+    fn test_into_signal_f64_narrows_to_f32() {
+        let sig: Signal<f32> = 0.1_f64.into_signal();
+        assert_eq!(sig.get(), 0.1_f32);
+    }
+
+    #[test]
     fn test_into_signal_for_bool() {
         let sig: Signal<bool> = true.into_signal();
         assert!(sig.get());

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -49,3 +49,9 @@ impl IntoVal<Padding> for f32 {
         Padding::from(self)
     }
 }
+
+impl IntoVal<Padding> for f64 {
+    fn into_val(self) -> Padding {
+        Padding::from(self as f32)
+    }
+}


### PR DESCRIPTION
Bare float literals default to `f64`, but the reactive prop system had no `f64` conversion. A literal like `.corner_radius(8.0)` compiled only because the type checker fell back to typing it as `f32` — the `float_literal_f32_fallback` future-incompatibility lint (rust-lang/rust#154024), a warning today and a hard error later. CI runs `clippy --all-targets --all-features -- -D warnings`, so it already fails on every example that passes a plain float.

## Changes

- Add `f64` to the lossy numeric conversions: `IntoVal<f32>` and `IntoSignal<f32, LossyMarker>` for `f32` props, and `IntoVal<Length>` / `IntoVal<Padding>` for the closure path, mirroring the existing `i32`/`u32`/`u16` coercions. The `f64 -> f32` cast is lossy by nature; the destination is `f32`, so this matches the precision of the integer impls already in place.
- Collapse the `TextInput` `MouseLeave` handler into a match guard, clearing a separate `collapsible_match` lint that also fails `-D warnings` on current stable.
- Tests for the runtime `f64` path and the lossy narrowing; docs note that float literals coerce alongside integers.

## Why both fixes are in one PR

Neither passes CI alone: a `text_input`-only change fails the float lint in the examples, and an `f64`-only change fails `collapsible_match` in the lib. No merge order gives a green intermediate, so they land together.
