### PR TITLE
Core internals rework: identity, reactivity, rendering, and platform robustness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,13 +74,20 @@ cargo clippy
 cargo test
 ```
 
+### Cargo Features
+
+- `svg` (default) — SVG image support via resvg. Without it, `ImageSource::Svg*` sources fail to decode with a logged warning.
+- `webp` (default) — WebP raster decoding. PNG and JPEG are always available.
+- `gif` (opt-in) — GIF raster decoding.
+- `render-stats` (opt-in) — per-second rendering statistics on stdout; zero overhead when disabled.
+
 ## Architecture
 
 ### Core Modules
 
 **`reactive/`** - Single-threaded reactive system inspired by SolidJS
 - `RwSignal<T>`: Read-write reactive signal (8 bytes). Created via `create_signal` (requires Clone+PartialEq+Send). Has `.get()`, `.set()`, `.update()`, `.writer()`. Converts to `Signal<T>` via `.read_only()` or `.into()`
-- `Signal<T>`: Read-only reactive signal (16 bytes). Created via `create_stored` (static, requires Clone) or `create_derived` (closure-backed). Has `.get()`, `.with()` — no mutation methods. Widget props accept `Signal<T>` via `IntoSignal<T, M>` (marker-type disambiguation — integers accepted where `f32`/`Length`/`Padding` expected)
+- `Signal<T>`: Read-only reactive signal (12 bytes). Created via `create_stored` (static, requires Clone) or `create_derived` (closure-backed). Has `.get()`, `.with()` — no mutation methods. Widget props accept `Signal<T>` via `IntoSignal<T, M>` (marker-type disambiguation — integers accepted where `f32`/`Length`/`Padding` expected)
 - `Memo<T>`: Eager computed values that recompute when dependencies change, only notify on actual changes (`PartialEq`)
 - `Effect`: Side effects that re-run when tracked signals change
 - `Owner`: Ownership system for automatic resource cleanup (signals, effects, custom callbacks)
@@ -158,30 +165,25 @@ All widgets implement:
 
 ### Rendering Pipeline
 
-Each frame has two phases — per-surface rendering and centralized animation processing:
+Rendering is paced by the compositor's `wl_surface.frame` callbacks: an
+animating surface renders once per callback, an idle surface renders nothing.
 
-**Main loop (once per frame):**
+**Main loop (once per iteration):**
 1. `flush_bg_writes()` - Drain queued background-thread signal writes
 2. `take_frame_request()` - Check if a frame was requested
 
 **Per-surface rendering:**
-3. Dispatch events to widgets
-4. `drain_non_animation_jobs()` - Collect Paint/Layout/Reconcile/Unregister jobs (Animation jobs stay in queue)
-5. Process jobs: unregister dropped widgets, mark paint/layout dirty flags, reconcile dynamic children
+3. Dispatch events to widgets (queued `MouseMove`s are coalesced to the latest position)
+4. **Frame-pacing gate**: if the previous frame's callback hasn't fired yet, return
+   before draining jobs (animation continuations stay queued; init/resizes bypass)
+5. `drain_pending_jobs()` + `process_jobs()` - Unregister → advance animations → reconcile dynamic children → mark paint/layout dirty flags
 6. Partial layout from `layout_roots` - Only dirty subtrees re-layout
 7. **Skip frame** if root widget doesn't need paint
-8. `widget.paint(tree, ctx)` - Build render tree (clean children reuse cached `RenderNode`s)
-9. `cache_paint_results()` - Store paint output per widget, clear `needs_paint` flags
-10. `flatten_tree_into()` - Flatten render tree to draw commands (incremental: clean subtrees reuse cached commands)
-11. GPU rendering with instanced SDF shapes, HiDPI scaling, layer ordering (shapes → images → text → overlay)
-12. Report damage region to Wayland via `wl_surface.damage_buffer()`
-13. `wl_surface.commit()` - Present frame
-
-**After all surfaces render:**
-14. `drain_pending_jobs()` - Collect remaining Animation jobs
-15. `handle_animation_jobs()` - Advance animations once per frame
-
-Animation jobs are processed centrally to prevent cross-surface job loss in multi-surface apps.
+8. `widget.paint(tree, ctx)` - Build render tree (clean children reuse Rc-shared cached `RenderNode`s — reuse is a refcount bump, not a clone)
+9. `flatten_root_into()` - Flatten render tree to draw commands (incremental: clean subtrees reuse cached commands)
+10. Re-arm the frame callback and report per-surface damage via `wl_surface.damage_buffer()` — both BEFORE presenting so they ride the commit performed inside `present()`
+11. GPU rendering with instanced SDF shapes, HiDPI scaling, layer ordering (shapes → images → text → overlay); on a lost/outdated swapchain the dirty state is kept and a retry frame is requested
+12. `cache_paint_results()` - Rc-share paint output per widget, clear `needs_paint` flags (partial paints poison their ancestors and are never cached)
 
 ### Event System
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,6 +699,7 @@ dependencies = [
  "pollster",
  "raw-window-handle",
  "resvg",
+ "rustc-hash 2.1.1",
  "smallvec",
  "smithay-client-toolkit",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,15 @@ homepage.workspace = true
 license.workspace = true
 
 [features]
-default = []
+default = ["svg"]
 render-stats = []
+# SVG rendering via resvg (pulls a second text-shaping stack + software
+# rasterizer). Without it, ImageSource::Svg* sources fail to decode with a
+# warning instead of failing to compile.
+svg = ["dep:resvg"]
+# Additional raster decoders beyond the png/jpeg defaults
+webp = ["image/webp"]
+gif = ["image/gif"]
 
 [dependencies]
 guido-macros = { workspace = true }
@@ -40,11 +47,10 @@ cosmic-text = "0.17"
 smithay-client-toolkit = { version = "0.20", default-features = false, features = ["calloop", "xkbcommon"] }
 wayland-backend = { version = "0.3", features = ["client_system"] }
 raw-window-handle = "0.6"
-image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "webp"] }
-resvg = "0.46"
+image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
+resvg = { version = "0.46", optional = true }
 pollster = "0.4"
 log = "0.4"
-env_logger = "0.11"
 bitflags = "2.4"
 libc = "0.2"
 tokio = { version = "1", features = ["sync", "rt", "time"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ bitflags = "2.4"
 libc = "0.2"
 tokio = { version = "1", features = ["sync", "rt", "time"] }
 smallvec = "1"
+rustc-hash = "2"
 
 [dev-dependencies]
 env_logger = "0.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ homepage.workspace = true
 license.workspace = true
 
 [features]
-default = ["svg"]
+default = ["svg", "webp"]
 render-stats = []
 # SVG rendering via resvg (pulls a second text-shaping stack + software
 # rasterizer). Without it, ImageSource::Svg* sources fail to decode with a

--- a/book/src/advanced/app-lifecycle.md
+++ b/book/src/advanced/app-lifecycle.md
@@ -1,6 +1,6 @@
 # App Lifecycle
 
-Guido applications can programmatically quit or restart. `App::run()` returns an `ExitReason` so the caller knows why the loop exited.
+Guido applications can programmatically quit or restart. `App::run()` returns an `ExitReason` so the caller knows why the loop exited: `Quit`, `Restart`, or `Error(PlatformError)` when the platform layer fails (no Wayland session, a compositor without layer-shell support such as GNOME, or a lost connection) — these conditions are reported instead of panicking.
 
 ## Quitting
 

--- a/book/src/advanced/background-threads.md
+++ b/book/src/advanced/background-threads.md
@@ -2,7 +2,7 @@
 
 Guido signals (`RwSignal<T>` and `Signal<T>`) live on the main thread and are `!Send` — they cannot be captured directly in background tasks. To update signals from a background task, call `.writer()` on an `RwSignal<T>` to obtain a `WriteSignal<T>`, which **is** `Send`. Writes through a `WriteSignal` are queued and applied on the main thread during the next frame.
 
-The `create_service` API provides a convenient way to spawn async background tasks that are automatically cleaned up when the component unmounts. Services run as tokio tasks.
+The `create_service` API provides a convenient way to spawn async background tasks that are automatically cleaned up when the component unmounts. Services run as tokio tasks: if your `main` already runs inside a tokio runtime (e.g. `#[tokio::main]`), that runtime is used; otherwise guido lazily starts a small background runtime of its own, so a plain `fn main()` works too.
 
 ## Basic Pattern: Read-Only Service
 

--- a/book/src/architecture/overview.md
+++ b/book/src/architecture/overview.md
@@ -10,7 +10,7 @@ Single-threaded reactive primitives inspired by SolidJS.
 
 **Key Types:**
 - `RwSignal<T>` - Read-write reactive values (8 bytes, `Copy`). Created via `create_signal()`. Supports `.get()`, `.set()`, `.update()`, `.writer()`
-- `Signal<T>` - Read-only reactive values (16 bytes, `Copy`). Created via `create_stored()`, `create_derived()`, or `RwSignal::read_only()`. Supports `.get()`, `.with()` — no `.set()`
+- `Signal<T>` - Read-only reactive values (12 bytes, `Copy`). Created via `create_stored()`, `create_derived()`, or `RwSignal::read_only()`. Supports `.get()`, `.with()` — no `.set()`
 - `Memo<T>` - Eager derived values that only notify on actual changes
 - `Effect` - Side effects that re-run on changes
 
@@ -89,7 +89,7 @@ Built-in: `Flex` for row/column layouts.
 
 ### `transform.rs` - 2D Transforms
 
-4x4 matrices for 2D operations:
+2D affine transforms (6 floats, 24 bytes — exactly what the GPU shader consumes):
 
 ```rust
 Transform::translate(x, y)

--- a/book/src/architecture/rendering.md
+++ b/book/src/architecture/rendering.md
@@ -5,34 +5,32 @@ This page explains how Guido renders widgets to the screen.
 ## Pipeline Overview
 
 ```
-Main loop (once per frame):
+Main loop (once per iteration):
  1. flush_bg_writes()              → Drain queued background-thread signal writes
  2. take_frame_request()           → Check if a frame was requested
 
 Per-surface rendering:
- 3. Dispatch events                → Route input events to widgets
- 4. drain_non_animation_jobs()     → Collect non-animation jobs (Animation jobs stay in queue)
- 5. handle_unregister_jobs()       → Cleanup dropped widgets
- 6. handle_paint_jobs()            → Mark widgets needing paint, accumulate damage
- 7. handle_reconcile_jobs()        → Reconcile dynamic children
- 8. handle_layout_jobs()           → Collect layout roots
- 9. Partial layout                 → Only dirty subtrees re-layout
-10. Skip-frame check               → Skip paint if root is clean
-11. widget.paint(tree, ctx)        → Build render tree (cache reuse for clean children)
-12. cache_paint_results()          → Store rendered nodes, clear needs_paint flags
-13. flatten_tree_into()            → Flatten to draw commands (incremental for clean subtrees)
-14. GPU rendering                  → Instanced SDF shapes with HiDPI scaling
-15. damage_buffer()                → Report damage region to Wayland compositor
-16. wl_surface.commit()            → Present frame
-
-After all surfaces render:
-17. drain_pending_jobs()           → Collect remaining Animation jobs
-18. handle_animation_jobs()        → Advance animations once per frame
+ 3. Dispatch events                → Route input events (MouseMoves coalesced)
+ 4. Frame-pacing gate              → Return if the compositor hasn't shown the
+                                     previous frame yet (jobs stay queued)
+ 5. drain_pending_jobs()           → Process jobs: unregister, advance
+    + process_jobs()                 animations, reconcile children, mark dirty
+ 6. Partial layout                 → Only dirty subtrees re-layout
+ 7. Skip-frame check               → Skip paint if root is clean
+ 8. widget.paint(tree, ctx)        → Build render tree (Rc cache reuse for clean children)
+ 9. flatten_root_into()            → Flatten to draw commands (incremental for clean subtrees)
+10. frame() + damage_buffer()      → Re-arm the frame callback and report damage,
+                                     both BEFORE presenting
+11. GPU rendering + present()      → Instanced SDF shapes with HiDPI scaling;
+                                     present() commits the surface
+12. cache_paint_results()          → Rc-share rendered nodes into the cache,
+                                     clear needs_paint flags
 ```
 
-Animation jobs are processed centrally after all surfaces render. This prevents
-cross-surface job loss in multi-surface apps, where one surface's drain could
-swallow another surface's animation continuation jobs.
+Rendering is paced by the compositor's `wl_surface.frame` callbacks: after each
+present, a new callback is requested, and the surface won't render again until
+it fires. An animating surface renders exactly once per compositor frame; an
+idle surface renders nothing and the loop sleeps.
 
 ## Layout Pass
 
@@ -210,19 +208,15 @@ Clipping respects corner radius and curvature for proper rounded container clipp
 
 ## Animation Advancement
 
-Animations advance *after all surfaces render*, once per frame in the main loop:
+Animations advance during per-surface job processing, before layout and paint,
+so the frame being built always renders with up-to-date animation values. Each
+advance pushes a continuation job (`Animation` plus a `Paint` or `Layout`
+follow-up when the value changed), which schedules the next advancement.
 
-```rust
-// After all surfaces have rendered:
-let animation_jobs = drain_pending_jobs();  // Only Animation jobs remain
-handle_animation_jobs(&animation_jobs, &mut tree);
-```
-
-This ordering means the current frame renders with the current animation state,
-and `advance_animations()` prepares values for the next frame. Widgets like
-TextInput use `advance_animations()` to drive cursor blinking via `Animation(Paint)`
-jobs, which mark the widget for repaint on the next frame when the cursor
-visibility toggles.
+Continuation jobs are throttled by the frame-pacing gate: while the compositor
+hasn't shown the previous frame, they stay queued, so animations step once per
+displayed frame instead of once per loop iteration. Widgets like TextInput use
+this mechanism to drive cursor blinking.
 
 ## Performance Notes
 
@@ -269,17 +263,17 @@ The rendering pipeline includes several optimizations to avoid redundant work:
 **Partial Paint**: Each widget in the Tree has a `needs_paint` flag. When a widget's
 visual state changes (e.g., a signal update triggers a Paint job), the flag propagates
 upward to ancestors. During paint, Container checks each child's flag — clean children
-reuse their cached `RenderNode` from the previous frame, with only the parent position
-transform updated.
+reuse their cached `RenderNode` from the previous frame. The cache is `Rc`-shared with
+the render tree: reusing an unmoved child is a refcount bump, and a moved child clones
+only the node header (its subtree and draw commands stay shared).
 
 **Skip Frame**: If no widget needs paint after job processing and layout, the entire
-paint→flatten→render→commit cycle is skipped for that surface. Animation jobs are
-processed centrally in the main loop regardless, so they always advance.
+paint→flatten→render cycle is skipped for that surface.
 
 **Damage Regions**: As widgets are marked for paint, their surface-relative bounds are
-accumulated into a `DamageRegion` (None, Partial, or Full). Before presenting, the
-damage is reported to the Wayland compositor via `wl_surface.damage_buffer()`, allowing
-the compositor to optimize its own compositing.
+accumulated into a per-surface `DamageRegion` (None, Partial, or Full). The damage is
+set as pending Wayland state before presenting — `present()` commits it together with
+the new buffer — allowing the compositor to optimize its own compositing.
 
 **Incremental Flatten**: The flattener caches its output per `RenderNode`. Clean subtrees
 (where `repainted == false`) reuse their cached flattened commands with a translation

--- a/book/src/concepts/reactive-model.md
+++ b/book/src/concepts/reactive-model.md
@@ -30,7 +30,7 @@ count.update(|c| *c += 1);
 
 ## Signal (Read-Only)
 
-`Signal<T>` is a read-only reactive value (16 bytes, `Copy`). It cannot be written to — calling `.set()` is a compile-time error. There are two ways to create one:
+`Signal<T>` is a read-only reactive value (12 bytes, `Copy`). It cannot be written to — calling `.set()` is a compile-time error. There are two ways to create one:
 
 ```rust
 // Stored: wraps a static value

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -32,7 +32,7 @@ Single-threaded reactive primitives inspired by SolidJS and Floem.
 
 **Key Types:**
 - `RwSignal<T>` (8 bytes) - Read-write reactive values returned by `create_signal()`. Supports `.get()`, `.set()`, `.update()`, `.writer()`. `Copy`, `!Send`.
-- `Signal<T>` (16 bytes) - Read-only reactive wrapper. Created via `create_stored()` (static), `create_derived()` (closure-backed), or by coercing an `RwSignal<T>`. `Copy`, read-only (`.get()` only).
+- `Signal<T>` (12 bytes) - Read-only reactive wrapper. Created via `create_stored()` (static), `create_derived()` (closure-backed), or by coercing an `RwSignal<T>`. `Copy`, read-only (`.get()` only).
 - `Memo<T>` - Eager derived values that recompute when dependencies change, only notify on actual changes (`PartialEq`)
 - `Effect` - Side effects that re-run when tracked signals change
 - `WriteSignal<T>` - `Send` handle for background thread updates, obtained via `RwSignal::writer()`
@@ -47,6 +47,16 @@ count.set(5);                           // doubled automatically becomes 10
 ```
 
 The runtime uses thread-local storage for automatic dependency tracking. When a signal is read inside a `Memo`, `Effect`, or during widget `paint()`/`layout()`, it registers itself as a dependency.
+
+**Identity safety:** signal, effect, owner, and widget ids are all generational
+(`index + generation`). Slots are recycled, but a stale `Copy` handle held after
+disposal can never alias the slot's next occupant — reads of disposed signals
+fail loudly instead of silently reading unrelated state.
+
+**Effect execution:** effect callbacks run with no runtime borrow held, so
+writing signals inside an effect works and chains (effect → effect, memo →
+memo). Scope state (batch depth, owners, tracking contexts) is restored via
+Drop guards, so a caught panic cannot wedge the reactive system.
 
 ### `widgets/` - UI Components
 
@@ -98,36 +108,41 @@ Hardware-accelerated rendering using wgpu.
 **Components:**
 - `Renderer` - Main renderer managing GPU resources and render passes
 - `PaintContext` - Build render tree nodes during widget painting
-- `RenderTree` / `RenderNode` - Hierarchical render tree with local coordinates
+- `RenderNode` - Hierarchical render tree with local coordinates (one root per surface, children Rc-shared with the paint cache)
 - Custom WGSL shaders for SDF-based instanced rendering
 
 **Rendering Pipeline (per frame):**
 
-*Main loop (once per frame):*
+*Main loop (once per iteration):*
 1. `flush_bg_writes()` - Drain queued background-thread signal writes
 2. `take_frame_request()` - Check if a frame was requested
 
 *Per-surface rendering:*
-3. Dispatch events to widgets
-4. `drain_non_animation_jobs()` - Collect Paint/Layout/Reconcile/Unregister jobs (Animation jobs stay in queue)
-5. `handle_unregister_jobs()` - Cleanup dropped widgets
-6. `handle_paint_jobs()` - Mark widgets needing paint (propagates upward, accumulates damage)
-7. `handle_reconcile_jobs()` / `handle_layout_jobs()` - Collect layout roots
-8. Partial layout from `layout_roots` - Only dirty subtrees re-layout
-9. Force full repaint on resize, scale change, or initialization
-10. **Skip frame** if root widget doesn't need paint
-11. `widget.paint(tree, ctx)` - Build render tree via PaintContext (clean children reuse cached nodes)
-12. `cache_paint_results()` - Store paint output per widget, clear `needs_paint` flags
-13. `flatten_tree_into()` - Flatten render tree to draw commands (incremental: clean subtrees reuse cached commands)
-14. GPU rendering with instanced SDF shapes and HiDPI scaling
-15. Report damage region to Wayland via `wl_surface.damage_buffer()`
-16. `wl_surface.commit()` - Present frame
+3. Dispatch events to widgets (queued `MouseMove`s are coalesced to the latest position)
+4. **Frame-pacing gate**: if a `wl_surface.frame` callback is still in flight, return
+   before draining jobs — the compositor hasn't shown the previous frame yet.
+   Queued jobs (including animation continuations) stay pending until the
+   callback fires and wakes the loop. Init and resizes bypass the gate.
+5. `drain_pending_jobs()` + `process_jobs()` - Unregister → Animation (advance values) → Reconcile → Paint → Layout marking
+6. Process follow-up jobs pushed by animation advances and reconciliation
+7. Partial layout from `layout_roots` - Only dirty subtrees re-layout
+8. Force full repaint on resize, scale change, or initialization
+9. **Skip frame** if root widget doesn't need paint
+10. `widget.paint(tree, ctx)` - Build render tree via PaintContext (clean children reuse Rc-shared cached nodes)
+11. `flatten_root_into()` - Flatten render tree to draw commands (incremental: clean subtrees reuse cached commands)
+12. Re-arm the `wl_surface.frame` callback and report per-surface damage via
+    `wl_surface.damage_buffer()` — both BEFORE presenting, so they ride the
+    commit that `present()` performs internally
+13. GPU rendering with instanced SDF shapes and HiDPI scaling; `present()` commits.
+    If presentation fails (lost/outdated swapchain), dirty state is kept and a
+    retry frame is requested — no stale content
+14. `cache_paint_results()` - Rc-share paint output per widget into the cache,
+    clear `needs_paint`/`repainted` flags (skips already-clean subtrees)
 
-*After all surfaces render:*
-17. `drain_pending_jobs()` - Collect remaining Animation jobs
-18. `handle_animation_jobs()` - Advance animations once per frame
-
-Animation jobs are processed centrally to prevent cross-surface job loss in multi-surface apps, where one surface's drain could swallow another surface's animation continuation jobs.
+Rendering is paced by the compositor's frame callbacks: an animating surface
+renders once per callback, and an idle surface renders nothing at all. There is
+no post-loop animation phase — animations advance during job processing, and
+their continuation jobs are throttled by the pacing gate.
 
 **Shape Features:**
 - Rounded rectangles with configurable superellipse curvature
@@ -171,7 +186,8 @@ handle.set_size(400, 300);
 
 ### `transform.rs` - 2D Transforms
 
-4x4 transformation matrices for 2D operations.
+2D affine transforms stored as 6 floats `[a, b, tx, c, d, ty]` (24 bytes) —
+exactly the layout the GPU shader consumes.
 
 **Operations:**
 ```rust
@@ -330,14 +346,20 @@ The paint system tracks which widgets need repainting:
 
 - **`needs_paint` flag**: Each widget in the Tree has a `needs_paint` flag that propagates
   upward to ancestors (like `needs_layout`). Only widgets marked dirty are repainted.
-- **Cached paint**: After painting, each widget's `RenderNode` output is cached. On subsequent
-  frames, Container reuses cached nodes for clean children by cloning with an updated position
-  transform (decomposing parent position from user transform).
+- **Rc-shared paint cache**: After painting, each widget's `RenderNode` is cached as an
+  `Rc` to the same node in the frame's render tree — a refcount bump, not a clone. On
+  subsequent frames, a clean child whose position didn't change is reused via `Rc::clone`
+  (zero copies); if it moved, only the node header is cloned (children and commands stay
+  shared) with the position recomposed from the decomposed parent/user transforms.
+- **Partial propagation**: a node whose children were culled (`partial`) poisons its
+  ancestors in the cache walk — incomplete paints are never cached, so reuse can never
+  resurrect a subtree with missing children.
 - **Skip frame**: If the root widget doesn't need paint after job processing and layout,
-  the entire paint→flatten→render→commit cycle is skipped. Animation jobs still run.
+  the entire paint→flatten→render cycle is skipped.
 - **Damage regions**: `mark_needs_paint()` accumulates surface-relative bounds into a
-  `DamageRegion` (None/Partial/Full). Before commit, the damage is reported to the Wayland
-  compositor via `wl_surface.damage_buffer()`, enabling compositor-side optimizations.
+  per-surface `DamageRegion` (None/Partial/Full), keyed by the surface's root widget so
+  multi-surface apps can't consume each other's damage. Damage is set as pending state
+  BEFORE presenting, so it rides the commit that `present()` performs internally.
 - **Incremental flatten**: `RenderNode` caches its flattened commands. Clean subtrees
   (with `repainted == false`) reuse cached commands with a translation offset, skipping
   the full recursive flatten.
@@ -382,7 +404,7 @@ The feature has zero overhead when disabled (code is completely compiled out).
 | `src/renderer/mod.rs` | Module exports |
 | `src/renderer/render.rs` | Main renderer, GPU setup |
 | `src/renderer/paint_context.rs` | PaintContext API for building render tree |
-| `src/renderer/tree.rs` | RenderNode, RenderTree structures |
+| `src/renderer/tree.rs` | RenderNode structure and paint-cache sharing |
 | `src/renderer/flatten.rs` | Tree flattening with transform inheritance |
 | `src/renderer/shader.wgsl` | GPU shaders for instanced SDF rendering |
 | `src/reactive/signal.rs` | Signal implementation |

--- a/docs/REACTIVE.md
+++ b/docs/REACTIVE.md
@@ -25,7 +25,7 @@ count.update(|c| *c += 1);
 
 **Key types:**
 - `RwSignal<T>` (8 bytes) — read-write signal returned by `create_signal()`. Supports `.get()`, `.set()`, `.update()`, `.writer()`
-- `Signal<T>` (16 bytes) — read-only signal. Created via `create_stored()` (static), `create_derived()` (closure-backed), or by coercing an `RwSignal<T>`
+- `Signal<T>` (12 bytes) — read-only signal. Created via `create_stored()` (static), `create_derived()` (closure-backed), or by coercing an `RwSignal<T>`
 
 **Key properties:**
 - Both `Signal<T>` and `RwSignal<T>` are `Copy` — no cloning needed
@@ -260,16 +260,26 @@ pub struct RwSignal<T> {
 #[derive(Clone, Copy)]
 pub struct Signal<T> {
     id: SignalId,
-    kind: SignalKind,   // 16 bytes — read-only, supports stored/mutable/derived
+    kind: SignalKind,   // 12 bytes total — read-only, supports stored/mutable/derived
 }
 ```
+
+`SignalId` is generational — `{ index: u32, generation: u32 }`. Storage slots
+are recycled with a bumped generation, so a stale `Copy` handle held after its
+owner was disposed can never silently alias the slot's next occupant: reads of
+disposed signals fail loudly. Effect and owner ids use the same scheme.
 
 The actual value is stored in `thread_local! { RefCell<SignalStorage> }`, accessed by `id`. This design allows:
 - Both types to be `Copy`
 - Zero-lock access on the main thread (thread-local `RefCell` only)
 - Automatic dependency tracking via thread-local runtime
 
-`RwSignal<T>` is the compact read-write handle (8 bytes). `Signal<T>` is the read-only wrapper (16 bytes) that also supports static (`create_stored`) and derived (`create_derived`) values via its `SignalKind` discriminant.
+`RwSignal<T>` is the compact read-write handle (8 bytes). `Signal<T>` is the read-only wrapper (12 bytes) that also supports static (`create_stored`) and derived (`create_derived`) values via its `SignalKind` discriminant.
+
+Effect callbacks execute with no internal borrow held: writing a signal inside
+an effect notifies its subscribers normally, so effect → effect and memo → memo
+chains work. Panics inside effects or `batch()` are unwind-safe — scope state
+restores via Drop guards and the effect stays alive and re-runnable.
 
 `WriteSignal<T>` is a separate `Send` handle that queues writes through a thread-safe channel, which the main thread drains each frame:
 

--- a/docs/RENDERER.md
+++ b/docs/RENDERER.md
@@ -20,30 +20,40 @@ Each widget creates a `RenderNode` containing its visual output:
 
 ```rust
 pub struct RenderNode {
-    pub id: NodeId,                             // Unique identifier (matches widget ID)
-    pub bounds: Rect,                           // Local bounds for transform origin
-    pub local_transform: Transform,             // Transform relative to parent
-    pub parent_position: Transform,             // Position set by parent (for cache reuse)
-    pub transform_origin: TransformOrigin,      // Pivot point for transforms
-    pub commands: Vec<DrawCommand>,             // Draw commands (shapes, text, images)
-    pub children: Vec<RenderNode>,              // Child nodes
-    pub overlay_commands: Vec<DrawCommand>,     // Commands drawn after children
-    pub clip: Option<ClipRegion>,               // Clips this node and children
-    pub overlay_clip: Option<ClipRegion>,       // Clips only overlay commands
-    pub repainted: bool,                        // true = freshly painted, false = cache reused
-    pub cached_flatten: Option<CachedFlatten>,  // Cached flatten output for incremental reuse
+    pub id: NodeId,                          // Unique identifier (matches widget ID)
+    pub bounds: Rect,                        // Local bounds for transform origin
+    pub local_transform: Transform,          // Transform relative to parent
+    pub parent_position: Transform,          // Position set by parent (for cache reuse)
+    pub transform_origin: TransformOrigin,   // Pivot point for transforms
+    pub commands: SmallVec<[Rc<DrawCommand>; 2]>,        // Draw commands (shapes, text, images)
+    pub children: Vec<Rc<RenderNode>>,       // Child nodes, Rc-shared with the paint cache
+    pub overlay_commands: SmallVec<[Rc<DrawCommand>; 1]>, // Commands drawn after children
+    pub clip: Option<ClipRegion>,            // Clips this node and children
+    pub overlay_clip: Option<ClipRegion>,    // Clips only overlay commands
+    pub repainted: Cell<bool>,               // true = freshly painted this frame
+    pub partial: bool,                       // Some children were culled (do not cache)
+    pub cached_flatten: RefCell<Option<Rc<CachedFlatten>>>, // Cached flatten output
 }
 ```
 
-### RenderTree
+### Sharing Model
 
-The complete render tree for a frame:
+Children are `Rc`-shared. The paint cache (`Tree::cache_paint`) stores an `Rc`
+to the same node that sits in the frame's render tree:
 
-```rust
-pub struct RenderTree {
-    pub roots: Vec<RenderNode>,  // Root nodes (one per surface)
-}
-```
+- **Caching** a painted subtree is a refcount bump, not a deep clone.
+- **Reusing** a clean child whose position didn't change is `Rc::clone` —
+  zero copies. If it moved, only the node header is cloned (children and
+  commands stay shared).
+- The per-frame flags use interior mutability (`Cell` / `RefCell`) because
+  cached nodes are shared: `repainted` is cleared once the node's output has
+  been cached, and flatten writes `cached_flatten` through a `&RenderNode`.
+- `partial` propagates to ancestors during the cache walk: a subtree that
+  embeds a partially-painted node (culled children) is never cached, so a
+  later cache reuse cannot resurrect an incomplete paint.
+
+Each surface owns a single root `RenderNode` (`ManagedSurface::root_node`),
+cleared and rebuilt from dirty widgets every rendered frame.
 
 ### Local Coordinate System
 
@@ -149,7 +159,7 @@ ctx.draw_overlay_rounded_rect(rect, color, radius);
 
 ## Tree Flattening
 
-The `flatten_tree()` function converts the hierarchical `RenderTree` into a flat list of `FlattenedCommand`s ready for GPU submission.
+The `flatten_root_into()` function converts the hierarchical render tree into a flat list of `FlattenedCommand`s ready for GPU submission, reusing the output buffer's capacity across frames.
 
 ### World Transform Computation
 
@@ -180,7 +190,7 @@ The output of tree flattening:
 
 ```rust
 pub struct FlattenedCommand {
-    pub command: DrawCommand,
+    pub command: Rc<DrawCommand>,   // Shared with the render node — no deep clone
     pub world_transform: Transform,
     pub world_transform_origin: Option<(f32, f32)>,
     pub layer: RenderLayer,
@@ -205,7 +215,8 @@ cached and current world transforms are translation-only, the flattener reuses c
 commands with a (dx, dy) offset instead of recursing into children. After a full flatten,
 results are cached back onto the node for next frame.
 
-`flatten_tree_into()` takes `&mut RenderTree` to enable this caching.
+The cache lives in `RefCell<Option<Rc<CachedFlatten>>>` on the node, so flatten
+only needs `&RenderNode` and shallow node clones share the cached output.
 
 ## GPU Rendering Pipeline
 
@@ -300,7 +311,7 @@ fn paint(&self, tree: &Tree, id: WidgetId, ctx: &mut PaintContext) {
 
 | File | Purpose |
 |------|---------|
-| `src/renderer/tree.rs` | RenderNode, RenderTree, ClipRegion |
+| `src/renderer/tree.rs` | RenderNode, ClipRegion, CachedFlatten |
 | `src/renderer/paint_context.rs` | PaintContext API |
 | `src/renderer/commands.rs` | DrawCommand enum |
 | `src/renderer/flatten.rs` | Tree flattening with transform inheritance |

--- a/examples/bench_list.rs
+++ b/examples/bench_list.rs
@@ -1,0 +1,87 @@
+//! Benchmark: a long scrollable list of interactive rows.
+//!
+//! Each row has a checkbox (composed from a container — guido has no
+//! dedicated checkbox widget yet) and a text input. Intended for comparing
+//! performance and memory footprint against equivalent apps in other
+//! toolkits (see the iced twin of this example).
+//!
+//! Row count is the first CLI argument (default 1000):
+//!
+//! ```bash
+//! cargo run --release --example bench_list -- 1000
+//! ```
+
+use guido::prelude::*;
+
+fn main() {
+    let row_count: usize = std::env::args()
+        .nth(1)
+        .and_then(|a| a.parse().ok())
+        .unwrap_or(1000);
+
+    App::new().run(move |app| {
+        app.add_surface(
+            SurfaceConfig::new()
+                .width(600)
+                .height(800)
+                .anchor(Anchor::TOP | Anchor::LEFT)
+                .layer(Layer::Top)
+                .keyboard_interactivity(KeyboardInteractivity::OnDemand)
+                .namespace("guido-bench-list")
+                .background_color(Color::rgb(0.10, 0.10, 0.14)),
+            move || {
+                container()
+                    .background(Color::rgb(0.10, 0.10, 0.14))
+                    .scrollable(ScrollAxis::Vertical)
+                    .child(
+                        container()
+                            .layout(Flex::column().spacing(4.0))
+                            .padding(8.0)
+                            .children((0..row_count).map(bench_row).collect::<Vec<_>>()),
+                    )
+            },
+        );
+    });
+}
+
+fn bench_row(i: usize) -> Container {
+    let value = create_signal(format!("Item {i}"));
+    let checked = create_signal(i % 5 == 0);
+
+    container()
+        .layout(Flex::row().spacing(8.0))
+        .padding(4.0)
+        .background(Color::rgb(0.14, 0.14, 0.19))
+        .corner_radius(6.0)
+        .child(
+            // Checkbox composed from a container
+            container()
+                .width(18.0)
+                .height(18.0)
+                .corner_radius(4.0)
+                .border(1.5, Color::rgb(0.45, 0.45, 0.55))
+                .background(move || {
+                    if checked.get() {
+                        Color::rgb(0.30, 0.55, 0.95)
+                    } else {
+                        Color::rgb(0.18, 0.18, 0.24)
+                    }
+                })
+                .hover_state(|s| s.lighter(0.08))
+                .on_click(move || checked.update(|c| *c = !*c))
+                .child(
+                    text(move || (if checked.get() { "x" } else { "" }).to_string())
+                        .color(Color::WHITE)
+                        .font_size(12.0),
+                ),
+        )
+        .child(
+            container()
+                .width(fill())
+                .padding(6.0)
+                .background(Color::rgb(0.18, 0.18, 0.24))
+                .corner_radius(4.0)
+                .focused_state(|s| s.border(1.5, Color::rgb(0.4, 0.8, 1.0)))
+                .child(text_input(value).text_color(Color::WHITE).font_size(13.0)),
+        )
+}

--- a/examples/bench_list.rs
+++ b/examples/bench_list.rs
@@ -46,7 +46,7 @@ fn main() {
 
 fn bench_row(i: usize) -> Container {
     let value = create_signal(format!("Item {i}"));
-    let checked = create_signal(i % 5 == 0);
+    let checked = create_signal(i.is_multiple_of(5));
 
     container()
         .layout(Flex::row().spacing(8.0))

--- a/guido-macros/src/lib.rs
+++ b/guido-macros/src/lib.rs
@@ -336,7 +336,7 @@ pub fn component(_attr: TokenStream, input: TokenStream) -> TokenStream {
         #vis struct #struct_name {
             #(#field_defs,)*
             __inner: std::cell::RefCell<Option<Box<dyn ::guido::widgets::Widget>>>,
-            __owner_id: std::cell::Cell<usize>,
+            __owner_id: std::cell::Cell<Option<::guido::reactive::__internal::OwnerId>>,
         }
 
         impl #struct_name {
@@ -344,7 +344,7 @@ pub fn component(_attr: TokenStream, input: TokenStream) -> TokenStream {
                 Self {
                     #(#field_inits,)*
                     __inner: std::cell::RefCell::new(None),
-                    __owner_id: std::cell::Cell::new(0),
+                    __owner_id: std::cell::Cell::new(None),
                 }
             }
 
@@ -367,8 +367,7 @@ pub fn component(_attr: TokenStream, input: TokenStream) -> TokenStream {
                 let (widget, owner_id) = ::guido::reactive::__internal::with_owner(|| {
                     self.render()
                 });
-                // Store owner_id + 1 (0 means no owner)
-                self.__owner_id.set(owner_id + 1);
+                self.__owner_id.set(Some(owner_id));
                 *self.__inner.borrow_mut() = Some(Box::new(widget));
             }
         }
@@ -376,9 +375,8 @@ pub fn component(_attr: TokenStream, input: TokenStream) -> TokenStream {
         impl Drop for #struct_name {
             fn drop(&mut self) {
                 // Dispose the owner and all its signals/effects/cleanups
-                let stored = self.__owner_id.get();
-                if stored > 0 {
-                    ::guido::reactive::__internal::dispose_owner(stored - 1);
+                if let Some(owner_id) = self.__owner_id.get() {
+                    ::guido::reactive::__internal::dispose_owner(owner_id);
                 }
             }
         }

--- a/src/animation/animatable.rs
+++ b/src/animation/animatable.rs
@@ -65,7 +65,7 @@ impl Animatable for Padding {
 
 impl Animatable for Transform {
     fn lerp(from: &Self, to: &Self, t: f32) -> Self {
-        let mut data = [0.0f32; 16];
+        let mut data = [0.0f32; 6];
         for (i, val) in data.iter_mut().enumerate() {
             *val = from.data[i] + (to.data[i] - from.data[i]) * t;
         }

--- a/src/image_metadata.rs
+++ b/src/image_metadata.rs
@@ -28,14 +28,28 @@ pub fn get_intrinsic_size(source: &ImageSource) -> Option<(u32, u32)> {
 }
 
 /// Get SVG dimensions from a file path.
+#[cfg(feature = "svg")]
 fn get_svg_size_from_file(path: &Path) -> Option<(u32, u32)> {
     let data = std::fs::read(path).ok()?;
     get_svg_size_from_bytes(&data)
 }
 
 /// Get SVG dimensions from raw bytes.
+#[cfg(feature = "svg")]
 fn get_svg_size_from_bytes(bytes: &[u8]) -> Option<(u32, u32)> {
     let tree = resvg::usvg::Tree::from_data(bytes, &resvg::usvg::Options::default()).ok()?;
     let size = tree.size();
     Some((size.width() as u32, size.height() as u32))
+}
+
+#[cfg(not(feature = "svg"))]
+fn get_svg_size_from_file(_path: &Path) -> Option<(u32, u32)> {
+    log::warn!("SVG image used but the `svg` feature is disabled");
+    None
+}
+
+#[cfg(not(feature = "svg"))]
+fn get_svg_size_from_bytes(_bytes: &[u8]) -> Option<(u32, u32)> {
+    log::warn!("SVG image used but the `svg` feature is disabled");
+    None
 }

--- a/src/jobs.rs
+++ b/src/jobs.rs
@@ -23,7 +23,6 @@
 //! mechanism, ensuring the frame is processed promptly.
 
 use std::cell::RefCell;
-use std::collections::HashSet;
 use std::sync::{
     Mutex,
     atomic::{AtomicBool, AtomicU8, Ordering},
@@ -36,16 +35,24 @@ use crate::reactive::invalidation::clear_widget_subscribers;
 use crate::tree::{Tree, WidgetId};
 
 /// Job queue with O(1) dedup via HashSet + Vec for ordered iteration.
+///
+/// Drained buffers come from (and should be returned to, via
+/// [`recycle_job_buffer`]) a small spare pool so per-frame drains don't
+/// re-allocate from zero.
 struct JobQueue {
-    set: HashSet<Job>,
+    set: rustc_hash::FxHashSet<Job>,
     vec: Vec<Job>,
+    /// Spare buffers for capacity reuse across frames (at most 2: one per
+    /// drain flavor in flight).
+    spare: Vec<Vec<Job>>,
 }
 
 impl JobQueue {
     fn new() -> Self {
         Self {
-            set: HashSet::new(),
+            set: rustc_hash::FxHashSet::default(),
             vec: Vec::new(),
+            spare: Vec::new(),
         }
     }
 
@@ -57,11 +64,12 @@ impl JobQueue {
 
     fn drain_all(&mut self) -> Vec<Job> {
         self.set.clear();
-        std::mem::take(&mut self.vec)
+        let replacement = self.spare.pop().unwrap_or_default();
+        std::mem::replace(&mut self.vec, replacement)
     }
 
     fn drain_non_animation(&mut self) -> Vec<Job> {
-        let mut non_anim = Vec::new();
+        let mut non_anim = self.spare.pop().unwrap_or_default();
         self.vec.retain(|job| {
             if job.job_type == JobType::Animation {
                 true
@@ -72,6 +80,13 @@ impl JobQueue {
             }
         });
         non_anim
+    }
+
+    fn recycle(&mut self, mut buf: Vec<Job>) {
+        if self.spare.len() < 2 {
+            buf.clear();
+            self.spare.push(buf);
+        }
     }
 
     fn is_empty(&self) -> bool {
@@ -185,6 +200,11 @@ pub fn drain_pending_jobs() -> Vec<Job> {
 /// advances and reconciliation, without re-draining Animation jobs.
 pub fn drain_non_animation_jobs() -> Vec<Job> {
     PENDING_JOBS.with(|jobs| jobs.borrow_mut().drain_non_animation())
+}
+
+/// Return a drained job buffer for capacity reuse on later frames.
+pub fn recycle_job_buffer(buf: Vec<Job>) {
+    PENDING_JOBS.with(|jobs| jobs.borrow_mut().recycle(buf));
 }
 
 /// Process all jobs in a single pass, partitioned by type.

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -22,6 +22,15 @@ impl IntoF32 for f32 {
     }
 }
 
+/// Accepting f64 keeps bare float literals (which default to f64) working
+/// without relying on the deprecated f32 inference fallback
+/// (rust-lang/rust#154024).
+impl IntoF32 for f64 {
+    fn into_f32(self) -> f32 {
+        self as f32
+    }
+}
+
 impl IntoF32 for i32 {
     fn into_f32(self) -> f32 {
         self as f32
@@ -163,6 +172,14 @@ impl From<f32> for Length {
             exact: Some(value),
             fill: false,
         }
+    }
+}
+
+/// f64 converts to exact sizing — bare float literals default to f64, and
+/// accepting them avoids the deprecated f32 inference fallback.
+impl From<f64> for Length {
+    fn from(value: f64) -> Self {
+        Length::from(value as f32)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -490,32 +490,13 @@ fn render_surface(
             layer_boundaries =
                 flatten_root_into(&surface.root_node, &mut surface.flattened_commands);
         });
-        time_phase!(render_stats::Phase::GpuRender, {
-            renderer.render(
-                wgpu_surface,
-                &surface.flattened_commands,
-                layer_boundaries,
-                surface.config.background_color,
-            );
-        });
 
-        // Cache paint results AFTER flatten so cached_flatten data is preserved.
-        // This enables incremental flatten for paint-cached nodes on subsequent
-        // frames. The surface root itself is never cache-reused (it always
-        // repaints), so only its children are cached.
-        time_phase!(render_stats::Phase::CachePaintResults, {
-            for child in &surface.root_node.children {
-                cache_paint_results(tree, child);
-            }
-            tree.clear_needs_paint(surface.widget_id);
-        });
-
-        // Report damage region to Wayland compositor
-        let damage = tree.take_damage();
-
-        // Track render stats (when compiled with --features render-stats)
-        render_stats::record_frame_painted();
-        render_stats::end_frame(&damage);
+        // Report damage BEFORE presenting: presenting attaches the buffer and
+        // commits the wl_surface (inside wgpu/the driver's Wayland path), so
+        // pending damage set now is part of that commit. The previous code
+        // damaged + committed AFTER present, attaching the damage to an empty
+        // second commit the compositor could not use.
+        let damage = tree.take_damage(surface.widget_id);
         match damage {
             DamageRegion::None => {
                 // Shouldn't happen since we're rendering, but report full damage to be safe
@@ -535,8 +516,40 @@ fn render_surface(
             }
         }
 
-        // Commit surface
-        wl_surface.commit();
+        let presented;
+        time_phase!(render_stats::Phase::GpuRender, {
+            presented = renderer.render(
+                wgpu_surface,
+                &surface.flattened_commands,
+                layer_boundaries,
+                surface.config.background_color,
+            );
+        });
+
+        if !presented {
+            // Nothing reached the screen (lost/outdated swapchain — common
+            // right after a resize). Keep all dirty flags so the content is
+            // repainted next frame instead of staying stale, restore full
+            // damage, and request that frame.
+            tree.set_full_damage(surface.widget_id);
+            jobs::request_frame();
+            return;
+        }
+
+        // Cache paint results AFTER flatten so cached_flatten data is preserved.
+        // This enables incremental flatten for paint-cached nodes on subsequent
+        // frames. The surface root itself is never cache-reused (it always
+        // repaints), so only its children are cached.
+        time_phase!(render_stats::Phase::CachePaintResults, {
+            for child in &surface.root_node.children {
+                cache_paint_results(tree, child);
+            }
+            tree.clear_needs_paint(surface.widget_id);
+        });
+
+        // Track render stats (when compiled with --features render-stats)
+        render_stats::record_frame_painted();
+        render_stats::end_frame(&damage);
 
         // Request frame callback if not yet initialized
         if !first_frame_presented {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -407,12 +407,14 @@ fn render_surface(
     // jobs are deduped by the JobQueue HashSet.
     let jobs = drain_pending_jobs();
     process_jobs(&jobs, tree, layout_roots);
+    jobs::recycle_job_buffer(jobs);
 
     // Process follow-up jobs from animation advances and reconciliation
     let followup = drain_non_animation_jobs();
     if !followup.is_empty() {
         process_jobs(&followup, tree, layout_roots);
     }
+    jobs::recycle_job_buffer(followup);
 
     // Check render conditions
     let fully_initialized = first_frame_presented && scale_factor_received;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -322,6 +322,7 @@ fn render_surface(
     let height = wayland_surface.height;
     let first_frame_presented = wayland_surface.first_frame_presented;
     let scale_factor_received = wayland_surface.scale_factor_received;
+    let frame_callback_pending = wayland_surface.frame_callback_pending;
     let wl_surface = wayland_surface.wl_surface.clone();
 
     // Skip if GPU not ready (will be initialized next frame)
@@ -394,6 +395,21 @@ fn render_surface(
         surface.previous_scale_factor = scale_factor;
     }
 
+    // Frame pacing: while a wl_surface.frame callback is in flight the
+    // compositor hasn't shown the previous frame — rendering another one
+    // would only queue behind it (previously this was "throttled" by
+    // blocking the whole event loop on the Fifo swapchain). Return BEFORE
+    // draining jobs: animation continuations must stay queued, otherwise
+    // each loop iteration would advance them, re-ping the wakeup, and spin
+    // the loop flat-out between frame callbacks. Input events (dispatched
+    // above) are not delayed. Init and resizes bypass the gate.
+    let fully_initialized = first_frame_presented && scale_factor_received;
+    let force_render_surface = !fully_initialized;
+    if frame_callback_pending && !force_render_surface && !needs_resize && !scale_changed {
+        render_stats::record_frame_skipped();
+        return;
+    }
+
     // Process ALL pending jobs BEFORE paint.
     // This includes Animation jobs which were previously deferred to end-of-frame.
     // Processing animations here ensures hover/pressed state changes update animation
@@ -425,8 +441,6 @@ fn render_surface(
     jobs::recycle_job_buffer(followup);
 
     // Check render conditions
-    let fully_initialized = first_frame_presented && scale_factor_received;
-    let force_render_surface = !fully_initialized;
     let has_pending_layouts = !layout_roots.is_empty();
 
     // Only render if something changed (or during initialization)
@@ -501,6 +515,14 @@ fn render_surface(
                 flatten_root_into(&surface.root_node, &mut surface.flattened_commands);
         });
 
+        // Re-arm the frame callback BEFORE presenting so the request rides
+        // the same commit as the buffer (present() commits internally). The
+        // callback's arrival is the signal that this surface may render its
+        // next frame. Previously the callback was requested exactly once at
+        // startup and never again — the only pacing was the event loop
+        // blocking inside the Fifo swapchain.
+        wl_surface.frame(qh, wl_surface.clone());
+
         // Report damage BEFORE presenting: presenting attaches the buffer and
         // commits the wl_surface (inside wgpu/the driver's Wayland path), so
         // pending damage set now is part of that commit. The previous code
@@ -561,9 +583,10 @@ fn render_surface(
         render_stats::record_frame_painted();
         render_stats::end_frame(&damage);
 
-        // Request frame callback if not yet initialized
-        if !first_frame_presented {
-            wl_surface.frame(qh, wl_surface.clone());
+        // The frame callback requested before present is now committed;
+        // rendering for this surface is gated until it fires.
+        if let Some(ws) = wayland_state.get_surface_mut(id) {
+            ws.frame_callback_pending = true;
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,10 @@ pub enum ExitReason {
     Quit,
     /// Restart requested (e.g. config change). The caller should re-create `App` and run again.
     Restart,
+    /// The platform layer failed (no Wayland session, compositor without
+    /// layer-shell support, connection lost). Previously these ordinary
+    /// environmental conditions aborted the process with a panic.
+    Error(platform::PlatformError),
 }
 
 /// Request a clean application restart.
@@ -202,8 +206,12 @@ fn process_surface_commands(
             }
             SurfaceCommand::Close(id) => {
                 log::info!("Closing dynamic surface {:?}", id);
-                wayland_state.destroy_surface(id);
+                // Drop the managed surface FIRST: its wgpu Surface<'static>
+                // borrows the wl_surface through erased raw pointers, so the
+                // GPU surface must die before the Wayland surface it points
+                // at (previously a use-after-free during swapchain teardown).
                 surface_manager.remove(id);
+                wayland_state.destroy_surface(id);
 
                 // If no surfaces left, exit
                 if surface_manager.is_empty() {
@@ -667,7 +675,13 @@ impl App {
             panic!("No surfaces defined. Use add_surface() to add at least one surface.");
         }
 
-        let (connection, mut event_queue, mut wayland_state, qh) = create_wayland_app();
+        let (connection, mut event_queue, mut wayland_state, qh) = match create_wayland_app() {
+            Ok(app) => app,
+            Err(e) => {
+                log::error!("Cannot start: {e}");
+                return ExitReason::Error(e);
+            }
+        };
 
         // Create surfaces from add_surface() calls
         for def in &self.surface_definitions {
@@ -676,9 +690,10 @@ impl App {
 
         // Wait for all surfaces to configure
         while !wayland_state.all_surfaces_configured() && !wayland_state.exit {
-            event_queue
-                .blocking_dispatch(&mut wayland_state)
-                .expect("Failed to dispatch events");
+            if let Err(e) = event_queue.blocking_dispatch(&mut wayland_state) {
+                log::error!("Wayland dispatch failed during configure: {e}");
+                return ExitReason::Error(platform::PlatformError::ConnectionLost);
+            }
         }
 
         if wayland_state.exit {
@@ -772,9 +787,12 @@ impl App {
                 None // Block indefinitely until event
             };
 
-            event_loop
-                .dispatch(timeout, &mut wayland_state)
-                .expect("Failed to dispatch event loop");
+            if let Err(e) = event_loop.dispatch(timeout, &mut wayland_state) {
+                // The connection died (compositor exited, protocol error).
+                // Exit cleanly instead of panicking the process.
+                log::error!("Event loop dispatch failed: {e}");
+                return ExitReason::Error(platform::PlatformError::ConnectionLost);
+            }
 
             // Check for programmatic exit/restart requests
             match get_exit_request() {
@@ -833,7 +851,10 @@ impl App {
             }
 
             // Flush the connection once for all surfaces
-            connection.flush().expect("Failed to flush connection");
+            if let Err(e) = connection.flush() {
+                log::error!("Wayland connection flush failed: {e}");
+                return ExitReason::Error(platform::PlatformError::ConnectionLost);
+            }
         }
 
         ExitReason::Quit

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -667,8 +667,6 @@ impl App {
             panic!("No surfaces defined. Use add_surface() to add at least one surface.");
         }
 
-        let _ = env_logger::try_init();
-
         let (connection, mut event_queue, mut wayland_state, qh) = create_wayland_app();
 
         // Create surfaces from add_surface() calls

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ use layout::Constraints;
 use platform::create_wayland_app;
 use reactive::owner::with_owner;
 use reactive::{OwnerId, set_system_clipboard, take_clipboard_change, take_cursor_change};
-use renderer::{GpuContext, PaintContext, Renderer, flatten_tree_into};
+use renderer::{GpuContext, PaintContext, Renderer, flatten_root_into};
 use surface::{SurfaceCommand, SurfaceConfig, SurfaceId, drain_surface_commands};
 use surface_manager::{ManagedSurface, SurfaceManager};
 use widgets::Widget;
@@ -241,27 +241,47 @@ fn process_surface_commands(
 }
 
 /// Walk the render tree after painting and cache each node's output.
-/// Skips cache-reused nodes (repainted == false) since their tree cache is already valid.
-/// Also clears needs_paint flags for freshly painted widgets.
-fn cache_paint_results(tree: &mut Tree, node: &renderer::RenderNode) {
-    if node.repainted {
-        let widget_id = WidgetId::from_u64(node.id);
-        if tree.contains(widget_id) {
-            if !node.partial {
-                // Complete paint — safe to cache for future reuse.
-                tree.cache_paint(widget_id, node.clone());
-            }
-            // else: partial paint (children culled by cull_rect) — don't cache.
-            // Keep the previous complete cache (if any) so it can be reused
-            // when the widget becomes fully visible. If there's no previous
-            // cache, the widget will get a full paint next frame anyway
-            // (cached_paint returns None → falls through to full paint).
-            tree.clear_needs_paint(widget_id);
-        }
+///
+/// Caching is an `Rc::clone` of the node already sitting in the frame's
+/// render tree — O(1) per node instead of the previous deep subtree clone.
+///
+/// Returns whether the subtree is partial (this node or any descendant had
+/// children culled by cull_rect). Partial-ness propagates UP: an ancestor
+/// whose subtree embeds an incomplete paint must not be cached either, or a
+/// later cache reuse would permanently hide the culled grandchildren.
+///
+/// Also clears needs_paint flags and the per-frame `repainted` marker for
+/// freshly painted widgets (skipping already-clean subtrees entirely).
+fn cache_paint_results(tree: &mut Tree, node: &std::rc::Rc<renderer::RenderNode>) -> bool {
+    if !node.repainted.get() {
+        // Reused from cache: its subtree is by construction complete and its
+        // cache entries are already valid — nothing to do below it.
+        return false;
     }
+
+    let mut subtree_partial = node.partial;
     for child in &node.children {
-        cache_paint_results(tree, child);
+        subtree_partial |= cache_paint_results(tree, child);
     }
+
+    let widget_id = WidgetId::from_u64(node.id);
+    if tree.contains(widget_id) {
+        if !subtree_partial {
+            // Complete paint — safe to cache for future reuse.
+            tree.cache_paint(widget_id, std::rc::Rc::clone(node));
+        }
+        // else: partial subtree — don't cache. Keep the previous complete
+        // cache (if any) so it can be reused when the widget becomes fully
+        // visible. If there's no previous cache, the widget will get a full
+        // paint next frame anyway (cached_paint None → full paint).
+        tree.clear_needs_paint(widget_id);
+    }
+    // Mark as cached/clean for the flattener and future walks. The cache
+    // entry shares this Cell, so reused nodes come out with the flag
+    // already cleared.
+    node.repainted.set(false);
+
+    subtree_partial
 }
 
 /// Render a single surface using the hierarchical renderer.
@@ -453,8 +473,7 @@ fn render_surface(
             return;
         }
 
-        // Clear and reuse render tree (preserves capacity)
-        surface.render_tree.clear();
+        // Clear and reuse the root node (preserves capacity)
         surface.root_node.clear();
         surface.root_node.bounds = widgets::Rect::new(0.0, 0.0, width as f32, height as f32);
 
@@ -465,18 +484,11 @@ fn render_surface(
             });
         });
 
-        // Take ownership of root node temporarily, add to tree, then restore
-        let root = std::mem::replace(
-            &mut surface.root_node,
-            renderer::RenderNode::new(surface.widget_id.as_u64()),
-        );
-        surface.render_tree.add_root(root);
-
         // Flatten tree into reused buffer
         let layer_boundaries;
         time_phase!(render_stats::Phase::Flatten, {
             layer_boundaries =
-                flatten_tree_into(&mut surface.render_tree, &mut surface.flattened_commands);
+                flatten_root_into(&surface.root_node, &mut surface.flattened_commands);
         });
         time_phase!(render_stats::Phase::GpuRender, {
             renderer.render(
@@ -487,15 +499,15 @@ fn render_surface(
             );
         });
 
-        // Restore root_node for next frame (take it back from render_tree)
-        if let Some(root) = surface.render_tree.roots.pop() {
-            surface.root_node = root;
-        }
-
         // Cache paint results AFTER flatten so cached_flatten data is preserved.
-        // This enables incremental flatten for paint-cached nodes on subsequent frames.
+        // This enables incremental flatten for paint-cached nodes on subsequent
+        // frames. The surface root itself is never cache-reused (it always
+        // repaints), so only its children are cached.
         time_phase!(render_stats::Phase::CachePaintResults, {
-            cache_paint_results(tree, &surface.root_node);
+            for child in &surface.root_node.children {
+                cache_paint_results(tree, child);
+            }
+            tree.clear_needs_paint(surface.widget_id);
         });
 
         // Report damage region to Wayland compositor

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -1,5 +1,7 @@
 pub mod wayland;
 
-pub use wayland::{WaylandState, WaylandSurfaceState, WaylandWindowWrapper, create_wayland_app};
+pub use wayland::{
+    PlatformError, WaylandState, WaylandSurfaceState, WaylandWindowWrapper, create_wayland_app,
+};
 
 pub use smithay_client_toolkit::shell::wlr_layer::{Anchor, KeyboardInteractivity, Layer};

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -22,9 +22,12 @@ use smithay_client_toolkit::{
         },
         Capability, SeatHandler, SeatState,
     },
-    shell::wlr_layer::{
-        Anchor, KeyboardInteractivity, Layer, LayerShell, LayerShellHandler, LayerSurface,
-        LayerSurfaceConfigure,
+    shell::{
+        WaylandSurface,
+        wlr_layer::{
+            Anchor, KeyboardInteractivity, Layer, LayerShell, LayerShellHandler, LayerSurface,
+            LayerSurfaceConfigure,
+        },
     },
 };
 use smithay_client_toolkit::reexports::client::{
@@ -146,20 +149,73 @@ pub struct WaylandState {
     selection_offer: Option<SelectionOffer>,
 }
 
-pub fn create_wayland_app() -> (
-    Connection,
-    EventQueue<WaylandState>,
-    WaylandState,
-    QueueHandle<WaylandState>,
-) {
-    let connection = Connection::connect_to_env().expect("Failed to connect to Wayland");
-    let (globals, event_queue) =
-        registry_queue_init::<WaylandState>(&connection).expect("Failed to initialize registry");
+/// Why the platform layer could not start or continue.
+///
+/// These are ordinary environmental conditions (no Wayland session, a
+/// compositor without layer-shell such as GNOME, a dropped connection) —
+/// they are reported instead of panicking the process.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PlatformError {
+    /// Could not connect to a Wayland display (no session / wrong env).
+    Connect,
+    /// Wayland registry initialization failed.
+    Registry,
+    /// The compositor does not advertise `wl_compositor`.
+    MissingCompositor,
+    /// The compositor does not support `zwlr_layer_shell_v1` (e.g. GNOME).
+    MissingLayerShell,
+    /// The Wayland connection failed while the app was running.
+    ConnectionLost,
+}
+
+impl std::fmt::Display for PlatformError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Connect => write!(f, "failed to connect to a Wayland display"),
+            Self::Registry => write!(f, "failed to initialize the Wayland registry"),
+            Self::MissingCompositor => write!(f, "compositor does not advertise wl_compositor"),
+            Self::MissingLayerShell => {
+                write!(
+                    f,
+                    "compositor does not support zwlr_layer_shell_v1 (layer shell)"
+                )
+            }
+            Self::ConnectionLost => write!(f, "Wayland connection lost"),
+        }
+    }
+}
+
+impl std::error::Error for PlatformError {}
+
+#[allow(clippy::type_complexity)]
+pub fn create_wayland_app() -> Result<
+    (
+        Connection,
+        EventQueue<WaylandState>,
+        WaylandState,
+        QueueHandle<WaylandState>,
+    ),
+    PlatformError,
+> {
+    let connection = Connection::connect_to_env().map_err(|e| {
+        log::error!("Failed to connect to Wayland: {e}");
+        PlatformError::Connect
+    })?;
+    let (globals, event_queue) = registry_queue_init::<WaylandState>(&connection).map_err(|e| {
+        log::error!("Failed to initialize Wayland registry: {e}");
+        PlatformError::Registry
+    })?;
     let qh = event_queue.handle();
 
     let compositor_state =
-        CompositorState::bind(&globals, &qh).expect("wl_compositor not available");
-    let layer_shell = LayerShell::bind(&globals, &qh).expect("layer_shell not available");
+        CompositorState::bind(&globals, &qh).map_err(|_| PlatformError::MissingCompositor)?;
+    let layer_shell = LayerShell::bind(&globals, &qh).map_err(|_| {
+        log::error!(
+            "This compositor does not support the layer shell protocol; \
+             guido surfaces cannot be created"
+        );
+        PlatformError::MissingLayerShell
+    })?;
     let output_state = OutputState::new(&globals, &qh);
     let seat_state = SeatState::new(&globals, &qh);
 
@@ -204,7 +260,7 @@ pub fn create_wayland_app() -> (
         selection_offer: None,
     };
 
-    (connection, event_queue, state, qh)
+    Ok((connection, event_queue, state, qh))
 }
 
 impl WaylandState {
@@ -685,21 +741,17 @@ impl OutputHandler for WaylandState {
 
 impl LayerShellHandler for WaylandState {
     fn closed(&mut self, _conn: &Connection, _qh: &QueueHandle<Self>, layer: &LayerSurface) {
-        // Find which surface was closed
-        let closed_id = self
-            .surfaces
-            .iter()
-            .find(|(_, state)| &state.layer_surface == layer)
-            .map(|(id, _)| *id);
+        // O(1) lookup via the wl_surface object id
+        let closed_id = self.surface_lookup.get(&layer.wl_surface().id()).copied();
 
         if let Some(id) = closed_id {
             log::info!("Surface {:?} closed by compositor", id);
-            self.destroy_surface(id);
-
-            // If no surfaces left, exit
-            if self.surfaces.is_empty() {
-                self.exit = true;
-            }
+            // Route through the normal close command so the managed surface
+            // is fully cleaned up (widgets, reactive owner, wgpu surface —
+            // dropped BEFORE the wl_surface it borrows). Previously only the
+            // Wayland-side state was removed, leaking the widget tree and
+            // leaving a zombie surface iterated every frame.
+            crate::surface::push_surface_command(crate::surface::SurfaceCommand::Close(id));
         }
     }
 
@@ -711,12 +763,8 @@ impl LayerShellHandler for WaylandState {
         configure: LayerSurfaceConfigure,
         _serial: u32,
     ) {
-        // Find which surface this configure is for
-        let surface_id = self
-            .surfaces
-            .iter()
-            .find(|(_, state)| &state.layer_surface == layer)
-            .map(|(id, _)| *id);
+        // O(1) lookup via the wl_surface object id (fires on every resize)
+        let surface_id = self.surface_lookup.get(&layer.wl_surface().id()).copied();
 
         if let Some(id) = surface_id
             && let Some(surface_state) = self.surfaces.get_mut(&id)
@@ -762,20 +810,27 @@ impl SeatHandler for WaylandState {
         // Handle pointer capability
         if capability == Capability::Pointer && self.pointer.is_none() {
             log::info!("Pointer capability available, creating pointer");
-            let pointer = self
-                .seat_state
-                .get_pointer(qh, &seat)
-                .expect("Failed to get pointer");
-            self.pointer = Some(pointer);
+            match self.seat_state.get_pointer(qh, &seat) {
+                Ok(pointer) => self.pointer = Some(pointer),
+                Err(e) => {
+                    // A capability race at seat init is not fatal — the app
+                    // just runs without pointer input until the seat updates
+                    log::warn!("Failed to get pointer: {e}");
+                    return;
+                }
+            }
         }
 
         // Handle keyboard capability
         if capability == Capability::Keyboard && self.keyboard.is_none() {
             log::info!("Keyboard capability available, creating keyboard");
-            let keyboard = self
-                .seat_state
-                .get_keyboard(qh, &seat, None)
-                .expect("Failed to get keyboard");
+            let keyboard = match self.seat_state.get_keyboard(qh, &seat, None) {
+                Ok(keyboard) => keyboard,
+                Err(e) => {
+                    log::warn!("Failed to get keyboard: {e}");
+                    return;
+                }
+            };
             self.keyboard = Some(keyboard);
 
             // Create data device for clipboard when we have a seat
@@ -1266,12 +1321,22 @@ impl DataSourceHandler for WaylandState {
     ) {
         log::debug!("Clipboard send request for mime type: {}", mime);
 
-        // Write clipboard content to the file descriptor
+        // Write clipboard content on a short-lived thread: a payload larger
+        // than the pipe buffer with a slow reader would otherwise block the
+        // UI thread indefinitely inside write_all.
         if let Some(ref content) = self.clipboard_content {
+            let content = content.clone();
             let owned_fd = OwnedFd::from(fd);
-            let mut file = File::from(owned_fd);
-            if let Err(e) = file.write_all(content.as_bytes()) {
-                log::warn!("Failed to write clipboard content: {}", e);
+            if let Err(e) = std::thread::Builder::new()
+                .name("guido-clipboard-send".into())
+                .spawn(move || {
+                    let mut file = File::from(owned_fd);
+                    if let Err(e) = file.write_all(content.as_bytes()) {
+                        log::warn!("Failed to write clipboard content: {}", e);
+                    }
+                })
+            {
+                log::warn!("Failed to spawn clipboard writer thread: {e}");
             }
         }
     }

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -72,6 +72,10 @@ pub struct WaylandSurfaceState {
     pub scale_factor_received: bool,
     /// Whether the first frame has been presented
     pub first_frame_presented: bool,
+    /// Whether a wl_surface.frame callback is in flight. While true, the
+    /// compositor has not yet shown the last frame — rendering another one
+    /// would outpace it. Cleared by the frame-done handler.
+    pub frame_callback_pending: bool,
     /// Pending events for this surface
     pub pending_events: Vec<Event>,
 }
@@ -93,6 +97,7 @@ impl WaylandSurfaceState {
             scale_factor: 1.0,
             scale_factor_received: false,
             first_frame_presented: false,
+            frame_callback_pending: false,
             pending_events: Vec::new(),
         }
     }
@@ -695,16 +700,22 @@ impl CompositorHandler for WaylandState {
         surface: &wl_surface::WlSurface,
         _time: u32,
     ) {
-        // Find which surface this is for
+        // The compositor consumed the last frame: this surface may render
+        // again. Callbacks are re-armed on every present (see
+        // render_surface), so this is the pacing signal for the surface.
         if let Some(id) = self.surface_lookup.get(&surface.id()).copied()
             && let Some(surface_state) = self.surfaces.get_mut(&id)
-            && !surface_state.first_frame_presented
         {
-            log::info!(
-                "Surface {:?} first frame presented by compositor - initialization complete",
-                id
-            );
-            surface_state.first_frame_presented = true;
+            surface_state.frame_callback_pending = false;
+            if !surface_state.first_frame_presented {
+                log::info!(
+                    "Surface {:?} first frame presented by compositor - initialization complete",
+                    id
+                );
+                surface_state.first_frame_presented = true;
+            }
+            // Wake the loop so a dirty surface renders promptly
+            crate::jobs::request_frame();
         }
     }
 }
@@ -930,10 +941,20 @@ impl PointerHandler for WaylandState {
                     self.pointer_x = event.position.0 as f32;
                     self.pointer_y = event.position.1 as f32;
                     if let Some(events) = target_events {
-                        events.push(Event::MouseMove {
-                            x: self.pointer_x,
-                            y: self.pointer_y,
-                        });
+                        // Coalesce runs of MouseMove: only the latest position
+                        // matters for hover state, and every queued move costs
+                        // a full event-dispatch walk of the widget tree.
+                        if let Some(last @ Event::MouseMove { .. }) = events.last_mut() {
+                            *last = Event::MouseMove {
+                                x: self.pointer_x,
+                                y: self.pointer_y,
+                            };
+                        } else {
+                            events.push(Event::MouseMove {
+                                x: self.pointer_x,
+                                y: self.pointer_y,
+                            });
+                        }
                     }
                 }
                 PointerEventKind::Press { button, .. } => {

--- a/src/reactive/effect.rs
+++ b/src/reactive/effect.rs
@@ -1,5 +1,5 @@
 use super::owner::{effect_has_owner, register_effect};
-use super::runtime::{EffectId, with_runtime};
+use super::runtime::{EffectId, run_effect_by_id, with_runtime};
 
 pub struct Effect {
     id: EffectId,
@@ -10,11 +10,11 @@ impl Effect {
     where
         F: FnMut() + 'static,
     {
-        let id = with_runtime(|rt| {
-            let id = rt.allocate_effect(Box::new(f));
-            rt.run_effect(id);
-            id
-        });
+        let id = with_runtime(|rt| rt.allocate_effect(Box::new(f)));
+
+        // Initial run establishes dependencies. Runs outside the runtime
+        // borrow, so the callback can freely write signals or create new ones.
+        run_effect_by_id(id);
 
         // Register with current owner for automatic cleanup
         register_effect(id);
@@ -93,5 +93,83 @@ mod tests {
 
         // Effect should still be alive and re-run
         assert!(ran.load(Ordering::SeqCst));
+    }
+
+    /// Regression test: a signal write performed INSIDE an effect must
+    /// propagate to other effects. Previously the runtime RefCell was held
+    /// across effect callbacks, so the nested notify was silently dropped
+    /// and effect→effect chains never fired.
+    #[test]
+    fn test_write_inside_effect_triggers_other_effects() {
+        use std::cell::Cell;
+        use std::rc::Rc;
+
+        let source = create_signal(0);
+        let intermediate = create_signal(0);
+        let observed = Rc::new(Cell::new(-1));
+
+        // Effect A: writes `intermediate` whenever `source` changes
+        create_effect(move || {
+            intermediate.set(source.get() + 1);
+        })
+        .detach();
+
+        // Effect B: observes `intermediate`
+        let observed_b = observed.clone();
+        create_effect(move || {
+            observed_b.set(intermediate.get());
+        })
+        .detach();
+
+        assert_eq!(observed.get(), 1, "initial chain should have run");
+
+        source.set(10);
+        assert_eq!(
+            observed.get(),
+            11,
+            "write inside effect A must re-run effect B"
+        );
+    }
+
+    /// Signals created inside an effect must be fully reactive. Previously
+    /// runtime registration was silently skipped during effect execution,
+    /// leaving the signal permanently unable to notify — and arming an
+    /// out-of-bounds panic on the effect's next run.
+    #[test]
+    fn test_signal_created_inside_effect_is_reactive() {
+        use std::cell::{Cell, RefCell};
+        use std::rc::Rc;
+
+        let trigger = create_signal(0);
+        let created: Rc<RefCell<Option<crate::reactive::RwSignal<i32>>>> =
+            Rc::new(RefCell::new(None));
+
+        let created_in_effect = created.clone();
+        create_effect(move || {
+            let t = trigger.get();
+            if created_in_effect.borrow().is_none() {
+                *created_in_effect.borrow_mut() = Some(create_signal(t));
+            }
+        })
+        .detach();
+
+        // Re-run the effect a few times (previously panicked out-of-bounds)
+        trigger.set(1);
+        trigger.set(2);
+
+        let inner = created.borrow().expect("signal created inside effect");
+        let observed = Rc::new(Cell::new(-1));
+        let observed_c = observed.clone();
+        create_effect(move || {
+            observed_c.set(inner.get());
+        })
+        .detach();
+
+        inner.set(42);
+        assert_eq!(
+            observed.get(),
+            42,
+            "signal created inside an effect must notify its subscribers"
+        );
     }
 }

--- a/src/reactive/guard.rs
+++ b/src/reactive/guard.rs
@@ -1,0 +1,20 @@
+//! Minimal scope-guard utility for unwind-safe state restoration.
+//!
+//! The reactive system maintains several pieces of thread-local scope state
+//! (current owner, tracking contexts, batch depth). All of them must be
+//! restored when the scope exits — including via panic. A panic that escapes
+//! (or is caught by user code with `catch_unwind`) must never leave the
+//! reactive system permanently corrupted.
+
+/// Run `f` when the returned guard is dropped, including during unwind.
+pub(crate) fn defer<F: FnOnce()>(f: F) -> impl Drop {
+    struct Deferred<F: FnOnce()>(Option<F>);
+    impl<F: FnOnce()> Drop for Deferred<F> {
+        fn drop(&mut self) {
+            if let Some(f) = self.0.take() {
+                f();
+            }
+        }
+    }
+    Deferred(Some(f))
+}

--- a/src/reactive/into_signal.rs
+++ b/src/reactive/into_signal.rs
@@ -44,6 +44,15 @@ impl<T> IntoVal<T> for T {
     }
 }
 
+// Lossy f64 → f32: bare float literals in closures default to f64, and
+// accepting them avoids the deprecated f32 inference fallback
+// (rust-lang/rust#154024)
+impl IntoVal<f32> for f64 {
+    fn into_val(self) -> f32 {
+        self as f32
+    }
+}
+
 // Lossy integer → f32 conversions (no std From impl)
 impl IntoVal<f32> for i32 {
     fn into_val(self) -> f32 {
@@ -74,7 +83,15 @@ impl<T: Clone + 'static, I: Into<T>> IntoSignal<T, ValueMarker> for I {
     }
 }
 
-// 2. Lossy i32/u32 → f32 static conversions (no std From, can't use Into blanket)
+// 2. Lossy f64/i32/u32 → f32 static conversions (no std From, can't use the
+// Into blanket). f64 matters most: bare float literals default to f64, so
+// accepting them avoids the deprecated f32 inference fallback.
+impl IntoSignal<f32, LossyMarker> for f64 {
+    fn into_signal(self) -> Signal<f32> {
+        create_stored(self as f32)
+    }
+}
+
 impl IntoSignal<f32, LossyMarker> for i32 {
     fn into_signal(self) -> Signal<f32> {
         create_stored(self as f32)

--- a/src/reactive/invalidation.rs
+++ b/src/reactive/invalidation.rs
@@ -20,8 +20,8 @@
 //! subscribers. The jobs system deduplicates these and wakes the event loop.
 
 use std::cell::RefCell;
-use std::collections::HashMap;
 
+use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::SmallVec;
 
 use crate::jobs::{JobRequest, JobType, request_job};
@@ -114,14 +114,21 @@ struct SubscriberRegistry {
     /// recycled index always starts with an empty list).
     signal_to_widgets: Vec<SubscriberList>,
     /// Reverse index: widget_id → subscribed signal IDs. For O(1) widget cleanup.
-    widget_to_signals: HashMap<WidgetId, SignalList>,
+    widget_to_signals: FxHashMap<WidgetId, SignalList>,
+    /// All live (signal index, subscriber) pairs. This is the hot-path
+    /// dedup: widgets re-read their signals every frame, and without this
+    /// set each re-read paid a linear scan over the signal's subscriber
+    /// list — O(N²) per frame for a signal read by N widgets (e.g. a theme
+    /// color). With it, an already-registered read is one hash lookup.
+    active: FxHashSet<(usize, Subscriber)>,
 }
 
 impl SubscriberRegistry {
     fn new() -> Self {
         Self {
             signal_to_widgets: Vec::new(),
-            widget_to_signals: HashMap::new(),
+            widget_to_signals: FxHashMap::default(),
+            active: FxHashSet::default(),
         }
     }
 
@@ -132,6 +139,27 @@ impl SubscriberRegistry {
                 .resize_with(signal_id.index() + 1, SmallVec::new);
         }
     }
+
+    /// Remove a subscriber pair from the `active` set for every job type.
+    /// Used by widget cleanup, which knows the widget but not which job
+    /// types it registered with.
+    fn deactivate_widget_signal(&mut self, signal_index: usize, widget_id: WidgetId) {
+        for job_type in [
+            JobType::Layout,
+            JobType::Paint,
+            JobType::Reconcile,
+            JobType::Unregister,
+            JobType::Animation,
+        ] {
+            self.active.remove(&(
+                signal_index,
+                Subscriber {
+                    widget_id,
+                    job_type,
+                },
+            ));
+        }
+    }
 }
 
 thread_local! {
@@ -140,23 +168,28 @@ thread_local! {
     static REGISTRY: RefCell<SubscriberRegistry> = RefCell::new(SubscriberRegistry::new());
 }
 
-/// Register a widget as a subscriber for a signal with a specific job type
+/// Register a widget as a subscriber for a signal with a specific job type.
+///
+/// Called on every tracked signal read, so the already-registered case (the
+/// overwhelming majority — widgets re-read their signals every frame) is a
+/// single hash-set lookup.
 pub fn register_subscriber(widget_id: WidgetId, signal_id: SignalId, job_type: JobType) {
     REGISTRY.with(|reg| {
         let mut reg = reg.borrow_mut();
-        reg.ensure_signal_capacity(signal_id);
 
         let sub = Subscriber {
             widget_id,
             job_type,
         };
-
-        let subs = &mut reg.signal_to_widgets[signal_id.index()];
-        if !subs.contains(&sub) {
-            subs.push(sub);
+        if !reg.active.insert((signal_id.index(), sub)) {
+            return; // Already subscribed — the hot path
         }
 
-        // Update reverse index
+        reg.ensure_signal_capacity(signal_id);
+        reg.signal_to_widgets[signal_id.index()].push(sub);
+
+        // Update reverse index (deduped: the same widget/signal pair can
+        // arrive with several job types, but only one entry is needed)
         let signals = reg.widget_to_signals.entry(widget_id).or_default();
         if !signals.contains(&signal_id) {
             signals.push(signal_id);
@@ -164,32 +197,28 @@ pub fn register_subscriber(widget_id: WidgetId, signal_id: SignalId, job_type: J
     });
 }
 
-/// Notify all subscribers of a signal change by creating jobs
+/// Notify all subscribers of a signal change by creating jobs.
+///
+/// Iterates under the registry borrow: `request_job` only touches the job
+/// queue and frame-request state, never the registry, so no re-entrant
+/// borrow is possible and no snapshot allocation is needed.
 pub fn notify_signal_change(signal_id: SignalId) {
-    // Collect subscribers while holding the borrow, then release before calling request_job
-    // (which may trigger further signal reads/writes)
-    let subscribers: SmallVec<[Subscriber; 4]> = REGISTRY.with(|reg| {
+    REGISTRY.with(|reg| {
         let reg = reg.borrow();
-        if signal_id.index() < reg.signal_to_widgets.len() {
-            reg.signal_to_widgets[signal_id.index()]
-                .iter()
-                .copied()
-                .collect()
-        } else {
-            SmallVec::new()
+        let Some(subs) = reg.signal_to_widgets.get(signal_id.index()) else {
+            return;
+        };
+        for sub in subs {
+            let request = match sub.job_type {
+                JobType::Layout => JobRequest::Layout,
+                JobType::Paint => JobRequest::Paint,
+                JobType::Reconcile => JobRequest::Reconcile,
+                JobType::Unregister => JobRequest::Unregister,
+                JobType::Animation => JobRequest::Animation(crate::jobs::RequiredJob::None),
+            };
+            request_job(sub.widget_id, request);
         }
     });
-
-    for sub in &subscribers {
-        let request = match sub.job_type {
-            JobType::Layout => JobRequest::Layout,
-            JobType::Paint => JobRequest::Paint,
-            JobType::Reconcile => JobRequest::Reconcile,
-            JobType::Unregister => JobRequest::Unregister,
-            JobType::Animation => JobRequest::Animation(crate::jobs::RequiredJob::None),
-        };
-        request_job(sub.widget_id, request);
-    }
 }
 
 /// Clear signal subscribers for a specific signal (when signal is disposed)
@@ -200,6 +229,7 @@ pub fn clear_signal_subscribers(signal_id: SignalId) {
             // Remove this signal from the reverse index of each subscriber
             let subs = std::mem::take(&mut reg.signal_to_widgets[signal_id.index()]);
             for sub in &subs {
+                reg.active.remove(&(signal_id.index(), *sub));
                 if let Some(signals) = reg.widget_to_signals.get_mut(&sub.widget_id) {
                     signals.retain(|&mut s| s != signal_id);
                     if signals.is_empty() {
@@ -220,6 +250,7 @@ pub fn clear_widget_subscribers(widget_id: WidgetId) {
         // Use reverse index: only touch the signals this widget actually subscribes to
         if let Some(signal_ids) = reg.widget_to_signals.remove(&widget_id) {
             for signal_id in signal_ids {
+                reg.deactivate_widget_signal(signal_id.index(), widget_id);
                 if let Some(subs) = reg.signal_to_widgets.get_mut(signal_id.index()) {
                     subs.retain(|s| s.widget_id != widget_id);
                 }

--- a/src/reactive/invalidation.rs
+++ b/src/reactive/invalidation.rs
@@ -25,6 +25,7 @@ use std::collections::HashMap;
 use smallvec::SmallVec;
 
 use crate::jobs::{JobRequest, JobType, request_job};
+use crate::reactive::runtime::SignalId;
 use crate::tree::WidgetId;
 
 /// Context for tracking signal reads and associating them with a widget
@@ -78,7 +79,7 @@ where
 
 /// Record that a signal was read. Called from Signal::get().
 /// If tracking is active, registers the current widget as a subscriber.
-pub fn record_signal_read(signal_id: usize) {
+pub fn record_signal_read(signal_id: SignalId) {
     TRACKING_CONTEXT.with(|ctx| {
         if let Some(tracking) = ctx.borrow().last() {
             register_subscriber(tracking.widget_id, signal_id, tracking.job_type);
@@ -101,10 +102,12 @@ struct Subscriber {
 type SubscriberList = SmallVec<[Subscriber; 2]>;
 
 /// Most widgets subscribe to 2-6 signals (background, padding, etc.).
-type SignalList = SmallVec<[usize; 4]>;
+type SignalList = SmallVec<[SignalId; 4]>;
 
 struct SubscriberRegistry {
-    /// Forward index: signal_id → subscribers. Direct Vec indexing (signal IDs are dense).
+    /// Forward index: signal index → subscribers. Direct Vec indexing
+    /// (signal slot indices are dense; disposal clears the entry, so a
+    /// recycled index always starts with an empty list).
     signal_to_widgets: Vec<SubscriberList>,
     /// Reverse index: widget_id → subscribed signal IDs. For O(1) widget cleanup.
     widget_to_signals: HashMap<WidgetId, SignalList>,
@@ -119,10 +122,10 @@ impl SubscriberRegistry {
     }
 
     /// Ensure the forward index has capacity for the given signal ID.
-    fn ensure_signal_capacity(&mut self, signal_id: usize) {
-        if signal_id >= self.signal_to_widgets.len() {
+    fn ensure_signal_capacity(&mut self, signal_id: SignalId) {
+        if signal_id.index() >= self.signal_to_widgets.len() {
             self.signal_to_widgets
-                .resize_with(signal_id + 1, SmallVec::new);
+                .resize_with(signal_id.index() + 1, SmallVec::new);
         }
     }
 }
@@ -134,7 +137,7 @@ thread_local! {
 }
 
 /// Register a widget as a subscriber for a signal with a specific job type
-pub fn register_subscriber(widget_id: WidgetId, signal_id: usize, job_type: JobType) {
+pub fn register_subscriber(widget_id: WidgetId, signal_id: SignalId, job_type: JobType) {
     REGISTRY.with(|reg| {
         let mut reg = reg.borrow_mut();
         reg.ensure_signal_capacity(signal_id);
@@ -144,7 +147,7 @@ pub fn register_subscriber(widget_id: WidgetId, signal_id: usize, job_type: JobT
             job_type,
         };
 
-        let subs = &mut reg.signal_to_widgets[signal_id];
+        let subs = &mut reg.signal_to_widgets[signal_id.index()];
         if !subs.contains(&sub) {
             subs.push(sub);
         }
@@ -158,13 +161,16 @@ pub fn register_subscriber(widget_id: WidgetId, signal_id: usize, job_type: JobT
 }
 
 /// Notify all subscribers of a signal change by creating jobs
-pub fn notify_signal_change(signal_id: usize) {
+pub fn notify_signal_change(signal_id: SignalId) {
     // Collect subscribers while holding the borrow, then release before calling request_job
     // (which may trigger further signal reads/writes)
     let subscribers: SmallVec<[Subscriber; 4]> = REGISTRY.with(|reg| {
         let reg = reg.borrow();
-        if signal_id < reg.signal_to_widgets.len() {
-            reg.signal_to_widgets[signal_id].iter().copied().collect()
+        if signal_id.index() < reg.signal_to_widgets.len() {
+            reg.signal_to_widgets[signal_id.index()]
+                .iter()
+                .copied()
+                .collect()
         } else {
             SmallVec::new()
         }
@@ -183,12 +189,12 @@ pub fn notify_signal_change(signal_id: usize) {
 }
 
 /// Clear signal subscribers for a specific signal (when signal is disposed)
-pub fn clear_signal_subscribers(signal_id: usize) {
+pub fn clear_signal_subscribers(signal_id: SignalId) {
     REGISTRY.with(|reg| {
         let mut reg = reg.borrow_mut();
-        if signal_id < reg.signal_to_widgets.len() {
+        if signal_id.index() < reg.signal_to_widgets.len() {
             // Remove this signal from the reverse index of each subscriber
-            let subs = std::mem::take(&mut reg.signal_to_widgets[signal_id]);
+            let subs = std::mem::take(&mut reg.signal_to_widgets[signal_id.index()]);
             for sub in &subs {
                 if let Some(signals) = reg.widget_to_signals.get_mut(&sub.widget_id) {
                     signals.retain(|&mut s| s != signal_id);
@@ -210,8 +216,8 @@ pub fn clear_widget_subscribers(widget_id: WidgetId) {
         // Use reverse index: only touch the signals this widget actually subscribes to
         if let Some(signal_ids) = reg.widget_to_signals.remove(&widget_id) {
             for signal_id in signal_ids {
-                if signal_id < reg.signal_to_widgets.len() {
-                    reg.signal_to_widgets[signal_id].retain(|s| s.widget_id != widget_id);
+                if let Some(subs) = reg.signal_to_widgets.get_mut(signal_id.index()) {
+                    subs.retain(|s| s.widget_id != widget_id);
                 }
             }
         }
@@ -247,13 +253,17 @@ mod tests {
         WidgetId::from_u64(n)
     }
 
+    fn signal_id(n: u32) -> SignalId {
+        SignalId::new(n, 0)
+    }
+
     #[test]
     fn test_clear_signal_subscribers_removes_entry() {
         let wid = widget_id(100);
-        register_subscriber(wid, 42, JobType::Paint);
+        register_subscriber(wid, signal_id(42), JobType::Paint);
         assert!(subscriber_count() > 0);
 
-        clear_signal_subscribers(42);
+        clear_signal_subscribers(signal_id(42));
 
         // Signal 42 should have no subscribers
         REGISTRY.with(|reg| {
@@ -268,10 +278,10 @@ mod tests {
         let other = widget_id(201);
 
         // Widget 200 subscribes to signals 10 and 11
-        register_subscriber(wid, 10, JobType::Paint);
-        register_subscriber(wid, 11, JobType::Layout);
+        register_subscriber(wid, signal_id(10), JobType::Paint);
+        register_subscriber(wid, signal_id(11), JobType::Layout);
         // Widget 201 subscribes to signal 10
-        register_subscriber(other, 10, JobType::Paint);
+        register_subscriber(other, signal_id(10), JobType::Paint);
 
         clear_widget_subscribers(wid);
 
@@ -289,15 +299,15 @@ mod tests {
     #[test]
     fn test_with_signal_tracking_registers_subscriber() {
         let wid = widget_id(300);
-        let signal_id = 99;
+        let sid = signal_id(99);
 
         with_signal_tracking(wid, JobType::Paint, || {
-            record_signal_read(signal_id);
+            record_signal_read(sid);
         });
 
         REGISTRY.with(|reg| {
             let reg = reg.borrow();
-            let s = &reg.signal_to_widgets[signal_id];
+            let s = &reg.signal_to_widgets[sid.index()];
             assert!(s.contains(&Subscriber {
                 widget_id: wid,
                 job_type: JobType::Paint,
@@ -305,20 +315,20 @@ mod tests {
         });
 
         // Clean up
-        clear_signal_subscribers(signal_id);
+        clear_signal_subscribers(sid);
     }
 
     #[test]
     fn test_reverse_index_consistency() {
         let wid = widget_id(400);
-        register_subscriber(wid, 50, JobType::Paint);
-        register_subscriber(wid, 51, JobType::Layout);
+        register_subscriber(wid, signal_id(50), JobType::Paint);
+        register_subscriber(wid, signal_id(51), JobType::Layout);
 
         REGISTRY.with(|reg| {
             let reg = reg.borrow();
             let signals = reg.widget_to_signals.get(&wid).unwrap();
-            assert!(signals.contains(&50));
-            assert!(signals.contains(&51));
+            assert!(signals.contains(&signal_id(50)));
+            assert!(signals.contains(&signal_id(51)));
         });
 
         clear_widget_subscribers(wid);

--- a/src/reactive/invalidation.rs
+++ b/src/reactive/invalidation.rs
@@ -51,11 +51,14 @@ where
             job_type,
         });
     });
-    let result = f();
-    TRACKING_CONTEXT.with(|ctx| {
-        ctx.borrow_mut().pop();
+    // Pop on unwind too: a leaked frame would silently attribute every
+    // later signal read in the app to this widget.
+    let _guard = crate::reactive::guard::defer(|| {
+        TRACKING_CONTEXT.with(|ctx| {
+            ctx.borrow_mut().pop();
+        });
     });
-    result
+    f()
 }
 
 /// Suspend widget-level signal tracking during the given closure.
@@ -69,12 +72,13 @@ pub fn suspend_widget_tracking<F, R>(f: F) -> R
 where
     F: FnOnce() -> R,
 {
-    TRACKING_CONTEXT.with(|ctx| {
-        let saved: Vec<_> = ctx.borrow_mut().drain(..).collect();
-        let result = f();
-        *ctx.borrow_mut() = saved;
-        result
-    })
+    let saved: Vec<_> = TRACKING_CONTEXT.with(|ctx| ctx.borrow_mut().drain(..).collect());
+    // Restore on unwind too: losing the saved stack would permanently
+    // disable widget invalidation for every context that was active.
+    let _guard = crate::reactive::guard::defer(move || {
+        TRACKING_CONTEXT.with(|ctx| *ctx.borrow_mut() = saved);
+    });
+    f()
 }
 
 /// Record that a signal was read. Called from Signal::get().

--- a/src/reactive/memo.rs
+++ b/src/reactive/memo.rs
@@ -57,12 +57,19 @@ where
     // whenever any dependency changes. Signal::set() uses PartialEq to
     // skip notification when the value hasn't changed.
     //
-    // The effect is registered with the current owner via register_effect().
-    // Effect::Drop checks effect_has_owner() and skips disposal for owned
-    // effects, so the underscore-prefixed binding is safe here.
-    let _effect = create_effect(move || {
+    // Lifetime: when a current owner exists, the effect is registered with
+    // it and Effect::drop skips disposal (the owner cleans up). Without an
+    // owner (memo created outside App::run or any with_owner scope), the
+    // effect must be detached — otherwise dropping the binding would
+    // dispose it immediately and the memo would silently stop updating.
+    let effect = create_effect(move || {
         signal.set(f());
     });
+    if super::owner::current_owner().is_some() {
+        drop(effect); // owned: Drop skips disposal, owner controls cleanup
+    } else {
+        effect.detach();
+    }
     Memo { signal }
 }
 
@@ -123,5 +130,43 @@ mod tests {
         let memo = create_memo(move || signal.get() + 3);
         let sig: Signal<i32> = memo.into_signal();
         assert_eq!(sig.get(), 10);
+    }
+
+    /// Regression test: effects depending on a memo must re-run when the
+    /// memo recomputes. A memo is "set a signal inside an effect", which was
+    /// silently dropped while the runtime borrow was held across callbacks.
+    #[test]
+    fn test_effect_depending_on_memo_reruns() {
+        use std::cell::Cell;
+        use std::rc::Rc;
+
+        let count = create_signal(1);
+        let doubled = create_memo(move || count.get() * 2);
+
+        let observed = Rc::new(Cell::new(0));
+        let observed_c = observed.clone();
+        crate::reactive::create_effect(move || {
+            observed_c.set(doubled.get());
+        })
+        .detach();
+
+        assert_eq!(observed.get(), 2);
+
+        count.set(5);
+        assert_eq!(observed.get(), 10, "memo change must propagate to effects");
+    }
+
+    /// Memo-of-memo chains must propagate through both levels.
+    #[test]
+    fn test_memo_chains() {
+        let base = create_signal(1);
+        let doubled = create_memo(move || base.get() * 2);
+        let quadrupled = create_memo(move || doubled.get() * 2);
+
+        assert_eq!(quadrupled.get(), 4);
+
+        base.set(3);
+        assert_eq!(doubled.get(), 6);
+        assert_eq!(quadrupled.get(), 12, "second-level memo must recompute");
     }
 }

--- a/src/reactive/mod.rs
+++ b/src/reactive/mod.rs
@@ -3,6 +3,7 @@ pub mod context;
 pub mod cursor;
 pub mod effect;
 pub mod focus;
+pub(crate) mod guard;
 pub mod into_signal;
 pub mod invalidation;
 pub mod memo;

--- a/src/reactive/owner.rs
+++ b/src/reactive/owner.rs
@@ -282,9 +282,11 @@ pub fn dispose_owner(id: OwnerId) {
         with_runtime(|rt| rt.dispose_effect(effect_id));
     }
 
-    // Dispose signals (clear subscribers first to prevent stale notifications)
+    // Dispose signals (clear widget and effect subscriptions first to
+    // prevent stale notifications from a future occupant of the slot)
     for signal_id in owner.signals {
         clear_signal_subscribers(signal_id);
+        with_runtime(|rt| rt.dispose_signal_subscriptions(signal_id));
         dispose_signal(signal_id);
     }
 }

--- a/src/reactive/owner.rs
+++ b/src/reactive/owner.rs
@@ -208,13 +208,17 @@ pub fn with_owner<T>(f: impl FnOnce() -> T) -> (T, OwnerId) {
         prev
     });
 
+    // Restore on unwind too: a leaked owner scope would silently re-parent
+    // every reactive resource created afterwards.
+    let guard = crate::reactive::guard::defer(move || {
+        CURRENT_OWNER.with(|current| {
+            *current.borrow_mut() = prev_owner;
+        });
+    });
+
     // Execute the closure
     let result = f();
-
-    // Restore previous owner
-    CURRENT_OWNER.with(|current| {
-        *current.borrow_mut() = prev_owner;
-    });
+    drop(guard);
 
     (result, owner_id)
 }

--- a/src/reactive/owner.rs
+++ b/src/reactive/owner.rs
@@ -42,10 +42,21 @@ use super::runtime::{EffectId, SignalId, with_runtime};
 use super::storage::dispose_signal;
 
 /// Unique identifier for an owner in the owner arena.
-pub type OwnerId = usize;
+///
+/// Generational: the arena recycles slot indices and bumps the generation on
+/// every reuse, so a stale `OwnerId` held after disposal can never dispose or
+/// mutate an unrelated owner that later occupied the same slot.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub struct OwnerId {
+    index: u32,
+    generation: u32,
+}
 
 /// An owner that manages the lifecycle of reactive primitives.
 struct Owner {
+    /// The owner this one was created under, if any. Used to prune this
+    /// owner from the parent's `children` list on disposal.
+    parent: Option<OwnerId>,
     signals: Vec<SignalId>,
     effects: Vec<EffectId>,
     cleanups: Vec<Box<dyn FnOnce()>>,
@@ -53,8 +64,9 @@ struct Owner {
 }
 
 impl Owner {
-    fn new() -> Self {
+    fn new(parent: Option<OwnerId>) -> Self {
         Self {
+            parent,
             signals: Vec::new(),
             effects: Vec::new(),
             cleanups: Vec::new(),
@@ -63,37 +75,74 @@ impl Owner {
     }
 }
 
-/// Arena-based storage for owners.
+/// Slot in the owner arena. The generation survives vacancy so recycled
+/// indices can be distinguished from their previous occupants.
+struct OwnerSlot {
+    owner: Option<Owner>,
+    generation: u32,
+}
+
+/// Arena-based storage for owners with slot recycling.
 struct OwnerArena {
-    owners: Vec<Option<Owner>>,
+    slots: Vec<OwnerSlot>,
+    /// Vacant slot indices available for reuse.
+    free_indices: Vec<u32>,
     /// Reverse mapping from effect ID to owner ID for O(1) lookup.
     /// This avoids linear search through all owners when checking if an effect is owned.
     effect_owners: HashMap<EffectId, OwnerId>,
-    next_id: OwnerId,
 }
 
 impl OwnerArena {
     fn new() -> Self {
         Self {
-            owners: Vec::new(),
+            slots: Vec::new(),
+            free_indices: Vec::new(),
             effect_owners: HashMap::new(),
-            next_id: 0,
         }
     }
 
-    fn allocate(&mut self) -> OwnerId {
-        let id = self.next_id;
-        self.next_id += 1;
-        self.owners.push(Some(Owner::new()));
-        id
+    fn allocate(&mut self, parent: Option<OwnerId>) -> OwnerId {
+        let owner = Owner::new(parent);
+        if let Some(index) = self.free_indices.pop() {
+            let slot = &mut self.slots[index as usize];
+            slot.generation = slot.generation.wrapping_add(1);
+            slot.owner = Some(owner);
+            OwnerId {
+                index,
+                generation: slot.generation,
+            }
+        } else {
+            let index = self.slots.len() as u32;
+            self.slots.push(OwnerSlot {
+                owner: Some(owner),
+                generation: 0,
+            });
+            OwnerId {
+                index,
+                generation: 0,
+            }
+        }
     }
 
     fn get_mut(&mut self, id: OwnerId) -> Option<&mut Owner> {
-        self.owners.get_mut(id).and_then(|o| o.as_mut())
+        self.slots
+            .get_mut(id.index as usize)
+            .filter(|slot| slot.generation == id.generation)
+            .and_then(|slot| slot.owner.as_mut())
     }
 
     fn take(&mut self, id: OwnerId) -> Option<Owner> {
-        self.owners.get_mut(id).and_then(|o| o.take())
+        let slot = self
+            .slots
+            .get_mut(id.index as usize)
+            .filter(|slot| slot.generation == id.generation)?;
+        let owner = slot.owner.take();
+        if owner.is_some() {
+            // Recycle the slot. Any still-live OwnerId for it is now stale
+            // and will fail the generation check above.
+            self.free_indices.push(id.index);
+        }
+        owner
     }
 }
 
@@ -108,7 +157,7 @@ thread_local! {
 /// primitives created during setup. The root owner owns everything — when
 /// disposed, all signals, effects, and cleanup callbacks cascade.
 pub(crate) fn create_root_owner() -> OwnerId {
-    let id = OWNERS.with(|owners| owners.borrow_mut().allocate());
+    let id = OWNERS.with(|owners| owners.borrow_mut().allocate(None));
     CURRENT_OWNER.with(|current| *current.borrow_mut() = Some(id));
     id
 }
@@ -137,12 +186,13 @@ pub(crate) fn reset_owners() {
 /// Use `on_cleanup` for registering cleanup callbacks in user code.
 pub fn with_owner<T>(f: impl FnOnce() -> T) -> (T, OwnerId) {
     // Allocate new owner and register as child of current owner (if any)
+    let parent_id = CURRENT_OWNER.with(|current| *current.borrow());
     let owner_id = OWNERS.with(|owners| {
         let mut owners = owners.borrow_mut();
-        let id = owners.allocate();
+        let id = owners.allocate(parent_id);
 
         // Register as child of current owner
-        if let Some(parent_id) = CURRENT_OWNER.with(|current| *current.borrow())
+        if let Some(parent_id) = parent_id
             && let Some(parent_owner) = owners.get_mut(parent_id)
         {
             parent_owner.children.push(id);
@@ -190,8 +240,23 @@ pub fn current_owner() -> Option<OwnerId> {
 /// **Note:** This function is not part of the public API and may change.
 /// Cleanup is automatic when using dynamic children or components.
 pub fn dispose_owner(id: OwnerId) {
-    // Take the owner out of the arena
-    let owner = OWNERS.with(|owners| owners.borrow_mut().take(id));
+    // Take the owner out of the arena and prune it from its parent's
+    // children list. Without the pruning, long-lived parents (most notably
+    // the root owner) accumulate one dead child entry for every owner ever
+    // created under them. During recursive disposal the parent has already
+    // been taken from the arena, so `get_mut` fails and the prune is skipped.
+    let owner = OWNERS.with(|owners| {
+        let mut arena = owners.borrow_mut();
+        let owner = arena.take(id)?;
+        if let Some(parent_id) = owner.parent
+            && let Some(parent) = arena.get_mut(parent_id)
+            && let Some(pos) = parent.children.iter().position(|c| *c == id)
+        {
+            // Sibling disposal order is unspecified, so swap_remove is fine.
+            parent.children.swap_remove(pos);
+        }
+        Some(owner)
+    });
 
     let Some(owner) = owner else {
         return; // Already disposed
@@ -307,7 +372,58 @@ mod tests {
     fn test_with_owner_basic() {
         let (value, owner_id) = with_owner(|| 42);
         assert_eq!(value, 42);
-        assert!(owner_id < 100); // Just check it's a reasonable ID
+        dispose_owner(owner_id);
+    }
+
+    /// A disposed owner's slot is recycled with a bumped generation, so a
+    /// stale OwnerId must never resolve to (or dispose) the new occupant.
+    #[test]
+    fn test_stale_owner_id_cannot_alias_recycled_slot() {
+        let (_, first) = with_owner(|| ());
+        dispose_owner(first);
+
+        // Reuses the freed slot
+        let disposed = std::rc::Rc::new(std::cell::Cell::new(false));
+        let flag = disposed.clone();
+        let (_, second) = with_owner(move || {
+            on_cleanup(move || flag.set(true));
+        });
+        assert_eq!(first.index, second.index, "slot should be recycled");
+        assert_ne!(first.generation, second.generation);
+
+        // Disposing via the stale ID must be a no-op
+        dispose_owner(first);
+        assert!(!disposed.get(), "stale OwnerId disposed the new owner");
+
+        dispose_owner(second);
+        assert!(disposed.get());
+    }
+
+    /// Disposing a child owner must remove it from the parent's children
+    /// list; otherwise long-lived parents grow without bound.
+    #[test]
+    fn test_dispose_prunes_parent_children_list() {
+        let (child_ids, parent_id) = with_owner(|| {
+            (0..4)
+                .map(|_| with_owner(|| ()).1)
+                .collect::<Vec<OwnerId>>()
+        });
+
+        for child in &child_ids {
+            dispose_owner(*child);
+        }
+
+        OWNERS.with(|owners| {
+            let mut arena = owners.borrow_mut();
+            let parent = arena.get_mut(parent_id).expect("parent still live");
+            assert!(
+                parent.children.is_empty(),
+                "disposed children not pruned: {:?}",
+                parent.children
+            );
+        });
+
+        dispose_owner(parent_id);
     }
 
     #[test]

--- a/src/reactive/runtime.rs
+++ b/src/reactive/runtime.rs
@@ -450,18 +450,29 @@ pub(crate) fn run_effect_by_id(effect_id: EffectId) {
         return;
     };
 
-    // Phase 2 (no borrow): run the callback with read-tracking buffered
+    // Phase 2 (no borrow): run the callback with read-tracking buffered.
+    // A panicking callback must still reach phase 3: without it the slot
+    // would be stuck in Running with its callback lost, and the tracking
+    // frame would leak. Catch, restore state, then propagate the panic.
     EFFECT_TRACKING.with(|stack| {
         stack.borrow_mut().push((effect_id, EffectReads::new()));
     });
-    suspend_widget_tracking(&mut *callback);
+    let panic_payload = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        suspend_widget_tracking(&mut *callback);
+    }))
+    .err();
     let reads = EFFECT_TRACKING
         .with(|stack| stack.borrow_mut().pop())
         .map(|(_eid, reads)| reads)
         .unwrap_or_default();
 
     // Phase 3 (borrow): restore the callback and register dependencies
+    // (possibly partial if the callback panicked mid-run)
     with_runtime(|rt| rt.finish_effect(effect_id, callback, reads));
+
+    if let Some(payload) = panic_payload {
+        std::panic::resume_unwind(payload);
+    }
 }
 
 /// Drain the pending-effect queue, running each effect. No-op when already
@@ -531,13 +542,74 @@ pub(crate) fn reset_runtime() {
 /// jobs) is NOT batched — widgets still get per-field jobs immediately.
 pub fn batch<R>(f: impl FnOnce() -> R) -> R {
     BATCH_DEPTH.with(|d| d.set(d.get() + 1));
-    let result = f();
-    BATCH_DEPTH.with(|d| {
-        let new = d.get() - 1;
-        d.set(new);
-        if new == 0 {
-            flush_pending_effects();
-        }
+    // Restore the depth even if `f` panics: a caught panic must not leave
+    // BATCH_DEPTH stuck > 0 (which would stop every effect in the app from
+    // ever flushing again). Effects queued by the failed batch stay pending
+    // and run on the next notify — we deliberately don't flush during unwind.
+    let guard = super::guard::defer(|| {
+        BATCH_DEPTH.with(|d| d.set(d.get() - 1));
     });
+    let result = f();
+    drop(guard);
+    if BATCH_DEPTH.with(|d| d.get()) == 0 {
+        flush_pending_effects();
+    }
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::reactive::{create_effect, create_signal};
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    /// A panic caught inside batch() must not leave BATCH_DEPTH stuck > 0 —
+    /// that would silently stop every effect in the app from ever flushing.
+    #[test]
+    fn test_caught_panic_in_batch_does_not_wedge_effects() {
+        let sig = create_signal(0);
+        let observed = Rc::new(Cell::new(0));
+        let o = observed.clone();
+        create_effect(move || o.set(sig.get())).detach();
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            batch(|| {
+                sig.set(1);
+                panic!("boom");
+            })
+        }));
+        assert!(result.is_err());
+        assert_eq!(BATCH_DEPTH.with(|d| d.get()), 0, "batch depth must unwind");
+
+        // Effects must still flush on the next write
+        sig.set(2);
+        assert_eq!(observed.get(), 2);
+    }
+
+    /// A panicking effect callback must be restored into its slot so the
+    /// effect stays alive, and the flush machinery must stay usable.
+    #[test]
+    fn test_panicking_effect_survives_and_reruns() {
+        let sig = create_signal(0);
+        let observed = Rc::new(Cell::new(0));
+        let o = observed.clone();
+        create_effect(move || {
+            let v = sig.get();
+            o.set(v);
+            if v == 1 {
+                panic!("effect panic");
+            }
+        })
+        .detach();
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| sig.set(1)));
+        assert!(result.is_err(), "panic must propagate out of set()");
+        assert_eq!(observed.get(), 1);
+        assert!(!FLUSHING.with(|f| f.get()), "flush guard must have reset");
+
+        // The effect must still be alive, tracked, and re-runnable
+        sig.set(2);
+        assert_eq!(observed.get(), 2);
+    }
 }

--- a/src/reactive/runtime.rs
+++ b/src/reactive/runtime.rs
@@ -21,6 +21,7 @@
 //! interacting with the runtime directly.
 
 use std::cell::{Cell, RefCell};
+use std::collections::VecDeque;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -197,6 +198,25 @@ pub fn flush_bg_writes() {
     }
 }
 
+/// Lifecycle state of an effect slot.
+///
+/// `Running` exists because effect callbacks execute *outside* the runtime
+/// borrow (see [`run_effect_by_id`]): the callback is taken out of the slot
+/// while it runs, and disposal during execution must be remembered so
+/// [`Runtime::finish_effect`] can drop the callback instead of restoring it.
+#[derive(Clone, Copy, PartialEq, Eq, Default)]
+enum EffectState {
+    /// No live effect in this slot (never used, or disposed).
+    #[default]
+    Vacant,
+    /// Live effect, callback stored in the slot.
+    Idle,
+    /// Live effect, callback currently executing (taken out of the slot).
+    Running,
+    /// Disposed while its callback was executing; finalized in `finish_effect`.
+    DisposedWhileRunning,
+}
+
 /// Storage slot for one effect. The generation survives disposal so recycled
 /// indices can be told apart from their previous occupants.
 #[derive(Default)]
@@ -206,13 +226,14 @@ struct EffectSlot {
     /// 1–3 signals, making linear scan faster than HashSet.
     dependencies: Vec<SignalId>,
     generation: u32,
+    state: EffectState,
 }
 
 #[derive(Default)]
 pub struct Runtime {
-    current_effect: Option<EffectId>,
-    /// Pending effects to run. Uses Vec with dedup — most frames have 0–5 pending effects.
-    pending_effects: Vec<EffectId>,
+    /// Pending effects to run, in notification order. Deduplicated —
+    /// most frames have 0–5 pending effects.
+    pending_effects: VecDeque<EffectId>,
     /// Effect slots, indexed by `EffectId::index`.
     effects: Vec<EffectSlot>,
     /// Vacant effect slot indices available for reuse.
@@ -269,6 +290,7 @@ impl Runtime {
             slot.generation = slot.generation.wrapping_add(1);
             slot.callback = Some(callback);
             slot.dependencies.clear();
+            slot.state = EffectState::Idle;
             return EffectId {
                 index,
                 generation: slot.generation,
@@ -280,6 +302,7 @@ impl Runtime {
             callback: Some(callback),
             dependencies: Vec::new(),
             generation: 0,
+            state: EffectState::Idle,
         });
         EffectId {
             index,
@@ -287,85 +310,83 @@ impl Runtime {
         }
     }
 
-    pub fn notify_write(&mut self, signal_id: SignalId) {
-        // Check if this signal exists in our runtime (it might not if called from another thread)
-        if signal_id.index() >= self.signal_subscribers.len() {
+    /// Queue all effects subscribed to a signal. Does NOT run them — the
+    /// caller decides when to flush (immediately, or at batch end).
+    fn enqueue_subscribers(&mut self, signal_id: SignalId) {
+        let Some(subs) = self.signal_subscribers.get(signal_id.index()) else {
             return;
-        }
-
-        // Iterate subscribers by index — avoids temporary Vec allocation
-        for i in 0..self.signal_subscribers[signal_id.index()].len() {
+        };
+        for i in 0..subs.len() {
             let effect_id = self.signal_subscribers[signal_id.index()][i];
-            vec_insert(&mut self.pending_effects, effect_id);
-        }
-
-        // When inside a batch(), defer effect execution until the batch completes
-        let batching = BATCH_DEPTH.with(|d| d.get() > 0);
-        if !batching {
-            self.flush_effects();
+            if !self.pending_effects.contains(&effect_id) {
+                self.pending_effects.push_back(effect_id);
+            }
         }
     }
 
-    pub fn run_effect(&mut self, effect_id: EffectId) {
-        // Stale id (effect disposed, slot possibly recycled): nothing to run
-        let Some(slot) = self.effect_slot_mut(effect_id) else {
-            return;
-        };
+    /// Pop the next pending effect, if any.
+    fn pop_pending_effect(&mut self) -> Option<EffectId> {
+        self.pending_effects.pop_front()
+    }
 
-        // Clear old dependencies
+    /// Phase 1 of effect execution (under the runtime borrow): validate the
+    /// id, clear old dependencies, and hand the callback out so it can run
+    /// WITHOUT the runtime borrowed. Returns `None` for stale/disposed ids
+    /// or if the effect is already running (re-entrant trigger).
+    fn begin_effect(&mut self, effect_id: EffectId) -> Option<Box<dyn FnMut()>> {
+        let slot = self.effect_slot_mut(effect_id)?;
+        if slot.state != EffectState::Idle {
+            return None;
+        }
+        let callback = slot.callback.take()?;
+        slot.state = EffectState::Running;
+
+        // Clear old dependencies; they are re-established from this run's reads
         let old_deps = std::mem::take(&mut slot.dependencies);
         for signal_id in old_deps {
             if let Some(subs) = self.signal_subscribers.get_mut(signal_id.index()) {
                 vec_remove(subs, &effect_id);
             }
         }
+        Some(callback)
+    }
 
-        // Push tracking context (signal reads are buffered here since
-        // the Runtime RefCell is already borrowed during callback execution)
-        EFFECT_TRACKING.with(|stack| {
-            stack.borrow_mut().push((effect_id, EffectReads::new()));
-        });
-
-        // Run effect
-        let prev_effect = self.current_effect;
-        self.current_effect = Some(effect_id);
-
-        if let Some(callback) = self
-            .effect_slot_mut(effect_id)
-            .and_then(|slot| slot.callback.as_mut())
-        {
-            suspend_widget_tracking(callback);
-        }
-
-        self.current_effect = prev_effect;
-
-        // Pop tracking context and register buffered reads as dependencies
-        let reads = EFFECT_TRACKING.with(|stack| stack.borrow_mut().pop());
-        if let Some((_eid, signal_ids)) = reads {
-            // The callback may have disposed its own effect (owner disposal
-            // from within); re-validate before touching the slot.
-            if self.effect_slot_mut(effect_id).is_none() {
-                return;
-            }
-            for signal_id in signal_ids {
-                if signal_id.index() < self.signal_subscribers.len() {
-                    vec_insert(&mut self.signal_subscribers[signal_id.index()], effect_id);
-                    if let Some(slot) = self.effect_slot_mut(effect_id) {
-                        vec_insert(&mut slot.dependencies, signal_id);
+    /// Phase 3 of effect execution (under the runtime borrow): restore the
+    /// callback and register the reads buffered during the run as
+    /// dependencies. If the effect was disposed while running, finalize the
+    /// disposal instead.
+    fn finish_effect(
+        &mut self,
+        effect_id: EffectId,
+        callback: Box<dyn FnMut()>,
+        reads: EffectReads,
+    ) {
+        let Some(slot) = self.effect_slot_mut(effect_id) else {
+            return; // Cannot happen (slot recycles only after free), but stay safe
+        };
+        match slot.state {
+            EffectState::Running => {
+                slot.callback = Some(callback);
+                slot.state = EffectState::Idle;
+                for signal_id in reads {
+                    if signal_id.index() < self.signal_subscribers.len() {
+                        vec_insert(&mut self.signal_subscribers[signal_id.index()], effect_id);
+                        if let Some(slot) = self.effect_slot_mut(effect_id) {
+                            vec_insert(&mut slot.dependencies, signal_id);
+                        }
                     }
                 }
             }
-        }
-    }
-
-    pub fn flush_effects(&mut self) {
-        // Use swap + drain to preserve Vec capacity across frames.
-        // mem::take would replace with a 0-capacity Vec, forcing re-allocation next frame.
-        let mut to_run = Vec::new();
-        while !self.pending_effects.is_empty() {
-            std::mem::swap(&mut to_run, &mut self.pending_effects);
-            for effect_id in to_run.drain(..) {
-                self.run_effect(effect_id);
+            EffectState::DisposedWhileRunning => {
+                // The callback disposed its own effect (owner disposal from
+                // within). Drop the callback and complete the disposal.
+                drop(callback);
+                slot.state = EffectState::Vacant;
+                self.free_effect_indices.push(effect_id.index);
+            }
+            EffectState::Vacant | EffectState::Idle => {
+                // Unreachable by construction; drop the callback defensively.
+                drop(callback);
             }
         }
     }
@@ -375,18 +396,106 @@ impl Runtime {
         let Some(slot) = self.effect_slot_mut(effect_id) else {
             return;
         };
-        if slot.callback.is_none() {
-            return; // Already disposed (slot not yet recycled)
-        }
-        slot.callback = None;
-        let deps = std::mem::take(&mut slot.dependencies);
-        for signal_id in deps {
-            if let Some(subs) = self.signal_subscribers.get_mut(signal_id.index()) {
-                vec_remove(subs, &effect_id);
+        match slot.state {
+            EffectState::Idle => {
+                slot.callback = None;
+                slot.state = EffectState::Vacant;
+                let deps = std::mem::take(&mut slot.dependencies);
+                for signal_id in deps {
+                    if let Some(subs) = self.signal_subscribers.get_mut(signal_id.index()) {
+                        vec_remove(subs, &effect_id);
+                    }
+                }
+                if let Some(pos) = self.pending_effects.iter().position(|e| *e == effect_id) {
+                    self.pending_effects.remove(pos);
+                }
+                self.free_effect_indices.push(effect_id.index);
+            }
+            EffectState::Running => {
+                // The callback is currently executing outside the borrow.
+                // Mark for finalization in finish_effect (which pushes the
+                // free-list entry); clear what can be cleared now.
+                slot.state = EffectState::DisposedWhileRunning;
+                let deps = std::mem::take(&mut slot.dependencies);
+                for signal_id in deps {
+                    if let Some(subs) = self.signal_subscribers.get_mut(signal_id.index()) {
+                        vec_remove(subs, &effect_id);
+                    }
+                }
+                if let Some(pos) = self.pending_effects.iter().position(|e| *e == effect_id) {
+                    self.pending_effects.remove(pos);
+                }
+            }
+            EffectState::Vacant | EffectState::DisposedWhileRunning => {
+                // Already disposed
             }
         }
-        vec_remove(&mut self.pending_effects, &effect_id);
-        self.free_effect_indices.push(effect_id.index);
+    }
+}
+
+thread_local! {
+    /// Reentrancy guard for [`flush_pending_effects`]: when a write happens
+    /// inside an effect, the nested flush is skipped and the outermost flush
+    /// loop picks up the newly queued effects. This bounds stack depth for
+    /// effect chains (they become loop iterations, not recursion).
+    static FLUSHING: Cell<bool> = const { Cell::new(false) };
+}
+
+/// Run one effect: take its callback out of the runtime, execute it with NO
+/// runtime borrow held (so writes and signal creation inside the callback
+/// work), then restore it and register the tracked reads.
+pub(crate) fn run_effect_by_id(effect_id: EffectId) {
+    // Phase 1 (borrow): take the callback out
+    let Some(mut callback) = with_runtime(|rt| rt.begin_effect(effect_id)) else {
+        return;
+    };
+
+    // Phase 2 (no borrow): run the callback with read-tracking buffered
+    EFFECT_TRACKING.with(|stack| {
+        stack.borrow_mut().push((effect_id, EffectReads::new()));
+    });
+    suspend_widget_tracking(&mut *callback);
+    let reads = EFFECT_TRACKING
+        .with(|stack| stack.borrow_mut().pop())
+        .map(|(_eid, reads)| reads)
+        .unwrap_or_default();
+
+    // Phase 3 (borrow): restore the callback and register dependencies
+    with_runtime(|rt| rt.finish_effect(effect_id, callback, reads));
+}
+
+/// Drain the pending-effect queue, running each effect. No-op when already
+/// flushing higher up the stack (the outer loop drains everything).
+pub(crate) fn flush_pending_effects() {
+    if FLUSHING.with(|f| f.replace(true)) {
+        return;
+    }
+    // Reset the flag even if an effect callback panics; otherwise every
+    // future flush would silently no-op and all effects would stop running.
+    struct FlushGuard;
+    impl Drop for FlushGuard {
+        fn drop(&mut self) {
+            FLUSHING.with(|f| f.set(false));
+        }
+    }
+    let _guard = FlushGuard;
+
+    while let Some(effect_id) = with_runtime(|rt| rt.pop_pending_effect()) {
+        run_effect_by_id(effect_id);
+    }
+}
+
+/// Notify subscribers that a signal changed. Effects run immediately unless
+/// inside a `batch()` (deferred to batch end) or already inside an effect
+/// flush (picked up by the outer loop).
+///
+/// Safe to call from anywhere on the main thread, including from within
+/// effect callbacks — the runtime borrow is never held across user code.
+pub(crate) fn notify_write(signal_id: SignalId) {
+    with_runtime(|rt| rt.enqueue_subscribers(signal_id));
+    let batching = BATCH_DEPTH.with(|d| d.get() > 0);
+    if !batching {
+        flush_pending_effects();
     }
 }
 
@@ -395,21 +504,6 @@ where
     F: FnOnce(&mut Runtime) -> R,
 {
     RUNTIME.with(|rt| f(&mut rt.borrow_mut()))
-}
-
-/// Try to access the runtime. This is safe to call from any thread.
-/// On the main thread, runs the callback. On other threads, does nothing.
-/// This enables signals to be updated from background threads without panicking.
-pub fn try_with_runtime<F>(f: F)
-where
-    F: FnOnce(&mut Runtime),
-{
-    RUNTIME.with(|rt| {
-        if let Ok(mut runtime) = rt.try_borrow_mut() {
-            f(&mut runtime);
-        }
-        // If borrow fails (already borrowed), skip - this can happen during effect execution
-    });
 }
 
 /// Reset all runtime state (effects, tracking, batch depth, write queue).
@@ -421,6 +515,7 @@ pub(crate) fn reset_runtime() {
     RUNTIME.with(|rt| *rt.borrow_mut() = Runtime::new());
     EFFECT_TRACKING.with(|et| et.borrow_mut().clear());
     BATCH_DEPTH.with(|bd| bd.set(0));
+    FLUSHING.with(|f| f.set(false));
     // Increment epoch BEFORE clearing — writes queued between now and the next
     // flush_bg_writes() will carry the old epoch and be discarded.
     WRITE_EPOCH.fetch_add(1, Ordering::Release);
@@ -441,7 +536,7 @@ pub fn batch<R>(f: impl FnOnce() -> R) -> R {
         let new = d.get() - 1;
         d.set(new);
         if new == 0 {
-            try_with_runtime(|rt| rt.flush_effects());
+            flush_pending_effects();
         }
     });
     result

--- a/src/reactive/runtime.rs
+++ b/src/reactive/runtime.rs
@@ -57,8 +57,61 @@ type EpochWrite = (u64, Box<dyn FnOnce() + Send>);
 /// are discarded during flush.
 static WRITE_QUEUE: Mutex<Vec<EpochWrite>> = Mutex::new(Vec::new());
 
-pub type SignalId = usize;
-pub type EffectId = usize;
+/// Unique identifier for a signal.
+///
+/// Generational: storage recycles slot indices and bumps the generation on
+/// every reuse. Signal handles are `Copy` and freely captured in closures, so
+/// without the generation a stale handle would silently read/write whatever
+/// unrelated signal later recycled the same slot. With it, stale handles are
+/// reliably detected forever.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub struct SignalId {
+    index: u32,
+    generation: u32,
+}
+
+impl SignalId {
+    pub(crate) fn new(index: u32, generation: u32) -> Self {
+        Self { index, generation }
+    }
+
+    /// Slot index for direct Vec indexing in storage and subscriber registries.
+    #[inline]
+    pub(crate) fn index(self) -> usize {
+        self.index as usize
+    }
+
+    #[inline]
+    pub(crate) fn generation(self) -> u32 {
+        self.generation
+    }
+}
+
+impl std::fmt::Display for SignalId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}v{}", self.index, self.generation)
+    }
+}
+
+/// Unique identifier for an effect. Generational, like [`SignalId`].
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub struct EffectId {
+    index: u32,
+    generation: u32,
+}
+
+impl EffectId {
+    #[inline]
+    fn index(self) -> usize {
+        self.index as usize
+    }
+}
+
+impl std::fmt::Display for EffectId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}v{}", self.index, self.generation)
+    }
+}
 
 /// Insert into a Vec only if not already present (dedup).
 fn vec_insert<T: PartialEq>(vec: &mut Vec<T>, value: T) {
@@ -144,21 +197,29 @@ pub fn flush_bg_writes() {
     }
 }
 
+/// Storage slot for one effect. The generation survives disposal so recycled
+/// indices can be told apart from their previous occupants.
+#[derive(Default)]
+struct EffectSlot {
+    callback: Option<Box<dyn FnMut()>>,
+    /// Signals this effect reads. Vec with dedup — most effects depend on
+    /// 1–3 signals, making linear scan faster than HashSet.
+    dependencies: Vec<SignalId>,
+    generation: u32,
+}
+
 #[derive(Default)]
 pub struct Runtime {
     current_effect: Option<EffectId>,
     /// Pending effects to run. Uses Vec with dedup — most frames have 0–5 pending effects.
     pending_effects: Vec<EffectId>,
-    effect_callbacks: Vec<Option<Box<dyn FnMut()>>>,
-    /// Per-effect dependencies (which signals it reads). Vec with dedup — most effects
-    /// depend on 1–3 signals, making linear scan faster than HashSet.
-    effect_dependencies: Vec<Vec<SignalId>>,
-    /// Per-signal subscribers (which effects track it). Vec with dedup — most signals
-    /// have 1–5 subscribers.
+    /// Effect slots, indexed by `EffectId::index`.
+    effects: Vec<EffectSlot>,
+    /// Vacant effect slot indices available for reuse.
+    free_effect_indices: Vec<u32>,
+    /// Per-signal subscribers (which effects track it), indexed by
+    /// `SignalId::index`. Vec with dedup — most signals have 1–5 subscribers.
     signal_subscribers: Vec<Vec<EffectId>>,
-    next_effect_id: EffectId,
-    /// Free list of reusable effect IDs (from disposed effects).
-    free_effect_ids: Vec<EffectId>,
 }
 
 impl Runtime {
@@ -166,38 +227,75 @@ impl Runtime {
         Self::default()
     }
 
+    /// Get a generation-validated mutable reference to an effect slot.
+    /// Returns `None` for stale ids (slot recycled since the id was issued).
+    fn effect_slot_mut(&mut self, id: EffectId) -> Option<&mut EffectSlot> {
+        self.effects
+            .get_mut(id.index())
+            .filter(|slot| slot.generation == id.generation)
+    }
+
     /// Register a signal for subscriber tracking (called when signal is created)
     pub fn register_signal(&mut self, id: SignalId) {
         // Ensure we have space for subscribers
-        while self.signal_subscribers.len() <= id {
+        while self.signal_subscribers.len() <= id.index() {
             self.signal_subscribers.push(Vec::new());
+        }
+        // A signal index only recycles after the previous occupant was
+        // disposed, so any leftover subscribers at this index are stale.
+        self.signal_subscribers[id.index()].clear();
+    }
+
+    /// Remove all effect subscriptions for a signal being disposed, both from
+    /// the signal's subscriber list and from each subscriber's dependency list.
+    /// Without this, an effect could stay subscribed to a recycled slot index
+    /// and get spuriously re-run by an unrelated future signal.
+    pub fn dispose_signal_subscriptions(&mut self, id: SignalId) {
+        let Some(subs) = self.signal_subscribers.get_mut(id.index()) else {
+            return;
+        };
+        for effect_id in std::mem::take(subs) {
+            if let Some(slot) = self.effect_slot_mut(effect_id) {
+                vec_remove(&mut slot.dependencies, &id);
+            }
         }
     }
 
     pub fn allocate_effect(&mut self, callback: Box<dyn FnMut()>) -> EffectId {
-        // Reuse a freed slot if available
-        if let Some(id) = self.free_effect_ids.pop() {
-            self.effect_callbacks[id] = Some(callback);
-            self.effect_dependencies[id].clear();
-            return id;
+        // Reuse a freed slot if available, bumping its generation so stale
+        // ids for the previous occupant can never act on this effect
+        if let Some(index) = self.free_effect_indices.pop() {
+            let slot = &mut self.effects[index as usize];
+            slot.generation = slot.generation.wrapping_add(1);
+            slot.callback = Some(callback);
+            slot.dependencies.clear();
+            return EffectId {
+                index,
+                generation: slot.generation,
+            };
         }
         // Otherwise allocate new
-        let id = self.next_effect_id;
-        self.next_effect_id += 1;
-        self.effect_callbacks.push(Some(callback));
-        self.effect_dependencies.push(Vec::new());
-        id
+        let index = self.effects.len() as u32;
+        self.effects.push(EffectSlot {
+            callback: Some(callback),
+            dependencies: Vec::new(),
+            generation: 0,
+        });
+        EffectId {
+            index,
+            generation: 0,
+        }
     }
 
     pub fn notify_write(&mut self, signal_id: SignalId) {
         // Check if this signal exists in our runtime (it might not if called from another thread)
-        if signal_id >= self.signal_subscribers.len() {
+        if signal_id.index() >= self.signal_subscribers.len() {
             return;
         }
 
         // Iterate subscribers by index — avoids temporary Vec allocation
-        for i in 0..self.signal_subscribers[signal_id].len() {
-            let effect_id = self.signal_subscribers[signal_id][i];
+        for i in 0..self.signal_subscribers[signal_id.index()].len() {
+            let effect_id = self.signal_subscribers[signal_id.index()][i];
             vec_insert(&mut self.pending_effects, effect_id);
         }
 
@@ -209,10 +307,17 @@ impl Runtime {
     }
 
     pub fn run_effect(&mut self, effect_id: EffectId) {
+        // Stale id (effect disposed, slot possibly recycled): nothing to run
+        let Some(slot) = self.effect_slot_mut(effect_id) else {
+            return;
+        };
+
         // Clear old dependencies
-        let old_deps = std::mem::take(&mut self.effect_dependencies[effect_id]);
+        let old_deps = std::mem::take(&mut slot.dependencies);
         for signal_id in old_deps {
-            vec_remove(&mut self.signal_subscribers[signal_id], &effect_id);
+            if let Some(subs) = self.signal_subscribers.get_mut(signal_id.index()) {
+                vec_remove(subs, &effect_id);
+            }
         }
 
         // Push tracking context (signal reads are buffered here since
@@ -225,7 +330,10 @@ impl Runtime {
         let prev_effect = self.current_effect;
         self.current_effect = Some(effect_id);
 
-        if let Some(callback) = self.effect_callbacks[effect_id].as_mut() {
+        if let Some(callback) = self
+            .effect_slot_mut(effect_id)
+            .and_then(|slot| slot.callback.as_mut())
+        {
             suspend_widget_tracking(callback);
         }
 
@@ -234,11 +342,18 @@ impl Runtime {
         // Pop tracking context and register buffered reads as dependencies
         let reads = EFFECT_TRACKING.with(|stack| stack.borrow_mut().pop());
         if let Some((_eid, signal_ids)) = reads {
+            // The callback may have disposed its own effect (owner disposal
+            // from within); re-validate before touching the slot.
+            if self.effect_slot_mut(effect_id).is_none() {
+                return;
+            }
             for signal_id in signal_ids {
-                if signal_id < self.signal_subscribers.len() {
-                    vec_insert(&mut self.signal_subscribers[signal_id], effect_id);
+                if signal_id.index() < self.signal_subscribers.len() {
+                    vec_insert(&mut self.signal_subscribers[signal_id.index()], effect_id);
+                    if let Some(slot) = self.effect_slot_mut(effect_id) {
+                        vec_insert(&mut slot.dependencies, signal_id);
+                    }
                 }
-                vec_insert(&mut self.effect_dependencies[effect_id], signal_id);
             }
         }
     }
@@ -256,16 +371,22 @@ impl Runtime {
     }
 
     pub fn dispose_effect(&mut self, effect_id: EffectId) {
-        // Clear dependencies
-        let deps = std::mem::take(&mut self.effect_dependencies[effect_id]);
+        // Stale id: the slot was already recycled, nothing to dispose
+        let Some(slot) = self.effect_slot_mut(effect_id) else {
+            return;
+        };
+        if slot.callback.is_none() {
+            return; // Already disposed (slot not yet recycled)
+        }
+        slot.callback = None;
+        let deps = std::mem::take(&mut slot.dependencies);
         for signal_id in deps {
-            if signal_id < self.signal_subscribers.len() {
-                vec_remove(&mut self.signal_subscribers[signal_id], &effect_id);
+            if let Some(subs) = self.signal_subscribers.get_mut(signal_id.index()) {
+                vec_remove(subs, &effect_id);
             }
         }
-        self.effect_callbacks[effect_id] = None;
         vec_remove(&mut self.pending_effects, &effect_id);
-        self.free_effect_ids.push(effect_id);
+        self.free_effect_indices.push(effect_id.index);
     }
 }
 

--- a/src/reactive/service.rs
+++ b/src/reactive/service.rs
@@ -125,7 +125,7 @@ where
     let running_for_cleanup = running.clone();
 
     let ctx = ServiceContext { running };
-    let handle = tokio::spawn(f(rx, ctx));
+    let handle = service_runtime().spawn(f(rx, ctx));
 
     // Register cleanup to stop the task when component unmounts.
     // Setting is_running to false allows graceful shutdown, while abort()
@@ -139,12 +139,73 @@ where
     Service { sender: tx }
 }
 
+/// Get a runtime handle for spawning service tasks.
+///
+/// If the caller already runs inside a tokio runtime (e.g. `#[tokio::main]`),
+/// that runtime is used. Otherwise a small background runtime is created
+/// lazily on a dedicated thread — previously `create_service` simply called
+/// `tokio::spawn` and panicked in the documented plain-`fn main()` setup.
+fn service_runtime() -> tokio::runtime::Handle {
+    if let Ok(handle) = tokio::runtime::Handle::try_current() {
+        return handle;
+    }
+
+    static HANDLE: std::sync::OnceLock<tokio::runtime::Handle> = std::sync::OnceLock::new();
+    HANDLE
+        .get_or_init(|| {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_time()
+                .build()
+                .expect("failed to build guido service runtime");
+            let handle = runtime.handle().clone();
+            std::thread::Builder::new()
+                .name("guido-services".into())
+                .spawn(move || {
+                    // Drive the runtime forever; tasks spawned through the
+                    // handle run on this thread.
+                    runtime.block_on(std::future::pending::<()>());
+                })
+                .expect("failed to spawn guido service thread");
+            handle
+        })
+        .clone()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::reactive::owner::{dispose_owner, with_owner};
     use std::sync::atomic::AtomicI32;
     use std::time::Duration;
+
+    /// Regression test: create_service must work WITHOUT an ambient tokio
+    /// runtime (plain `fn main()`, the documented default setup). It
+    /// previously called tokio::spawn directly and panicked.
+    #[test]
+    fn test_service_without_ambient_runtime() {
+        let received = Arc::new(AtomicI32::new(0));
+        let received_clone = received.clone();
+
+        let (service, owner_id) = with_owner(|| {
+            create_service::<i32, _, _>(move |mut rx, _ctx| async move {
+                while let Some(v) = rx.recv().await {
+                    received_clone.fetch_add(v, Ordering::SeqCst);
+                }
+            })
+        });
+
+        service.send(5);
+
+        // The task runs on the lazily-created background thread
+        let mut waited = 0;
+        while received.load(Ordering::SeqCst) == 0 && waited < 2000 {
+            std::thread::sleep(Duration::from_millis(10));
+            waited += 10;
+        }
+        assert_eq!(received.load(Ordering::SeqCst), 5);
+
+        dispose_owner(owner_id);
+    }
 
     #[tokio::test]
     async fn test_service_stops_on_cleanup() {

--- a/src/reactive/signal.rs
+++ b/src/reactive/signal.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use super::invalidation::{notify_signal_change, record_signal_read};
 use super::owner::register_signal;
 use super::runtime::{
-    SignalId, current_write_epoch, queue_bg_write, record_effect_read, try_with_runtime,
+    SignalId, current_write_epoch, notify_write, queue_bg_write, record_effect_read, with_runtime,
 };
 use super::storage::{
     allocate_signal_slot, compare_and_set_signal_value, compare_and_update_signal_value,
@@ -87,7 +87,7 @@ fn tracked_with<T: Clone + 'static, R>(
 fn write_and_notify<T: Clone + PartialEq + 'static>(id: SignalId, value: T) {
     if compare_and_set_signal_value(id, value) {
         notify_signal_change(id);
-        try_with_runtime(|rt| rt.notify_write(id));
+        notify_write(id);
     }
 }
 
@@ -95,7 +95,7 @@ fn write_and_notify<T: Clone + PartialEq + 'static>(id: SignalId, value: T) {
 fn update_and_notify<T: Clone + PartialEq + 'static>(id: SignalId, f: impl FnOnce(&mut T)) {
     if compare_and_update_signal_value(id, f) {
         notify_signal_change(id);
-        try_with_runtime(|rt| rt.notify_write(id));
+        notify_write(id);
     }
 }
 
@@ -349,7 +349,9 @@ impl<T: Clone + PartialEq + Send + 'static> WriteSignal<T> {
 /// ```
 pub fn create_signal<T: Clone + PartialEq + Send + 'static>(value: T) -> RwSignal<T> {
     let id = create_signal_value(value);
-    try_with_runtime(|rt| rt.register_signal(id));
+    // Safe even inside effect callbacks: the runtime borrow is never held
+    // across user code anymore.
+    with_runtime(|rt| rt.register_signal(id));
     register_signal(id);
     RwSignal {
         id,
@@ -399,7 +401,7 @@ pub fn create_stored<T: Clone + 'static>(value: T) -> Signal<T> {
 pub fn create_derived<T: Clone + 'static>(f: impl Fn() -> T + 'static) -> Signal<T> {
     let id = allocate_signal_slot();
     store_derived_closure::<T>(id, f);
-    try_with_runtime(|rt| rt.register_signal(id));
+    with_runtime(|rt| rt.register_signal(id));
     register_signal(id);
     Signal {
         id,

--- a/src/reactive/signal.rs
+++ b/src/reactive/signal.rs
@@ -295,7 +295,15 @@ impl<T: Clone + PartialEq + Send + 'static> WriteSignal<T> {
             let id = self.id;
             let epoch = self.epoch;
             queue_bg_write(epoch, move || {
-                write_and_notify(id, value);
+                // The signal may have been disposed between queueing and this
+                // flush (e.g. a service outliving a removed dynamic child).
+                // That race is inherent to background writers, so drop the
+                // write instead of panicking the main loop.
+                if has_signal(id) {
+                    write_and_notify(id, value);
+                } else {
+                    log::debug!("dropping background write to disposed signal {id}");
+                }
             });
         }
     }
@@ -315,7 +323,12 @@ impl<T: Clone + PartialEq + Send + 'static> WriteSignal<T> {
             let id = self.id;
             let epoch = self.epoch;
             queue_bg_write(epoch, move || {
-                update_and_notify(id, f);
+                // See `set()`: disposal can race a queued write; drop it.
+                if has_signal(id) {
+                    update_and_notify(id, f);
+                } else {
+                    log::debug!("dropping background update to disposed signal {id}");
+                }
             });
         }
     }
@@ -532,8 +545,36 @@ mod tests {
 
     #[test]
     fn test_rw_signal_size() {
+        // SignalId is two u32s (index + generation), so alignment is 4:
+        // RwSignal is exactly the id, Signal adds the 1-byte kind + padding.
         assert_eq!(std::mem::size_of::<RwSignal<i32>>(), 8);
-        assert_eq!(std::mem::size_of::<Signal<i32>>(), 16);
+        assert_eq!(std::mem::size_of::<Signal<i32>>(), 12);
+    }
+
+    /// Regression test: a signal handle that outlives its owner must stay
+    /// invalid even after the storage slot is recycled by a same-typed
+    /// signal. With non-generational ids the stale handle silently read and
+    /// wrote the new signal's value.
+    #[test]
+    fn test_stale_handle_does_not_alias_recycled_slot() {
+        use super::super::owner::{dispose_owner, with_owner};
+
+        let (stale, owner_id) = with_owner(|| create_signal(1_i32));
+        dispose_owner(owner_id);
+
+        // Recycles the freed slot with the same value type
+        let fresh = create_signal(2_i32);
+        assert_eq!(
+            stale.id.index(),
+            fresh.id.index(),
+            "slot should be recycled"
+        );
+        assert_ne!(stale.id.generation(), fresh.id.generation());
+
+        // The stale handle must not resolve to the new signal
+        assert!(!has_signal(stale.id));
+        assert!(has_signal(fresh.id));
+        assert_eq!(fresh.get(), 2);
     }
 
     // ================================================================

--- a/src/reactive/storage.rs
+++ b/src/reactive/storage.rs
@@ -25,22 +25,28 @@ use super::runtime::SignalId;
 
 type SignalValue = Rc<dyn Any>;
 
+/// Storage slot for one signal. The generation survives disposal so recycled
+/// indices can be told apart from their previous occupants — a stale
+/// `SignalId` fails the generation check instead of silently aliasing.
+struct Slot {
+    value: Option<SignalValue>,
+    generation: u32,
+}
+
 struct SignalStorage {
-    values: Vec<Option<SignalValue>>,
-    /// Free list of reusable signal IDs (from disposed signals).
-    free_ids: Vec<SignalId>,
-    next_id: SignalId,
+    slots: Vec<Slot>,
+    /// Vacant slot indices available for reuse.
+    free_indices: Vec<u32>,
     /// Derived closures keyed by SignalId. When a signal has a derived closure,
-    /// `.get()` calls the closure instead of reading from `values`.
+    /// `.get()` calls the closure instead of reading from `slots`.
     derived: HashMap<SignalId, Rc<dyn Any>>,
 }
 
 impl SignalStorage {
     fn new() -> Self {
         Self {
-            values: Vec::new(),
-            free_ids: Vec::new(),
-            next_id: 0,
+            slots: Vec::new(),
+            free_indices: Vec::new(),
             derived: HashMap::new(),
         }
     }
@@ -58,25 +64,30 @@ thread_local! {
 fn clone_slot_rc(id: SignalId, operation: &str) -> Rc<dyn Any> {
     STORAGE.with(|storage| {
         let storage = storage.borrow();
-        let slot = storage
-            .values
-            .get(id)
-            .unwrap_or_else(|| {
-                panic!(
-                    "Invalid signal ID {}: out of bounds (max ID is {})",
-                    id,
-                    storage.values.len().saturating_sub(1)
-                )
-            })
-            .as_ref()
-            .unwrap_or_else(|| {
-                panic!(
-                    "Signal {} was disposed - cannot {} after owner cleanup. \
-                     This usually means the signal's owner was disposed while you still hold a reference to the signal.",
-                    id, operation
-                )
-            });
-        Rc::clone(slot)
+        let slot = storage.slots.get(id.index()).unwrap_or_else(|| {
+            panic!(
+                "Invalid signal ID {}: out of bounds (storage has {} slots)",
+                id,
+                storage.slots.len()
+            )
+        });
+        // A generation mismatch means the slot was recycled: the signal this
+        // handle referred to is gone, same as the vacant-slot case below.
+        if slot.generation != id.generation() {
+            panic!(
+                "Signal {} was disposed - cannot {} after owner cleanup. \
+                 This usually means the signal's owner was disposed while you still hold a reference to the signal.",
+                id, operation
+            );
+        }
+        let value = slot.value.as_ref().unwrap_or_else(|| {
+            panic!(
+                "Signal {} was disposed - cannot {} after owner cleanup. \
+                 This usually means the signal's owner was disposed while you still hold a reference to the signal.",
+                id, operation
+            )
+        });
+        Rc::clone(value)
     })
 }
 
@@ -97,18 +108,23 @@ fn with_signal_cell<T: 'static, R>(
     f(cell)
 }
 
-/// Allocate a slot and store the given value. Reuses IDs from disposed signals.
+/// Allocate a slot and store the given value. Reuses slot indices from
+/// disposed signals, bumping the generation so stale handles stay invalid.
 fn alloc_slot(value: Rc<dyn Any>) -> SignalId {
     STORAGE.with(|storage| {
         let mut storage = storage.borrow_mut();
-        if let Some(id) = storage.free_ids.pop() {
-            storage.values[id] = Some(value);
-            return id;
+        if let Some(index) = storage.free_indices.pop() {
+            let slot = &mut storage.slots[index as usize];
+            slot.generation = slot.generation.wrapping_add(1);
+            slot.value = Some(value);
+            return SignalId::new(index, slot.generation);
         }
-        let id = storage.next_id;
-        storage.next_id += 1;
-        storage.values.push(Some(value));
-        id
+        let index = storage.slots.len() as u32;
+        storage.slots.push(Slot {
+            value: Some(value),
+            generation: 0,
+        });
+        SignalId::new(index, 0)
     })
 }
 
@@ -174,10 +190,16 @@ pub fn try_call_derived<T: Clone + 'static>(id: SignalId) -> Option<T> {
 pub fn dispose_signal(id: SignalId) {
     STORAGE.with(|storage| {
         let mut storage = storage.borrow_mut();
-        if id < storage.values.len() {
-            storage.values[id] = None;
+        let Some(slot) = storage
+            .slots
+            .get_mut(id.index())
+            .filter(|slot| slot.generation == id.generation())
+        else {
+            return; // Stale id: slot already recycled, nothing to dispose
+        };
+        if slot.value.take().is_some() {
             storage.derived.remove(&id);
-            storage.free_ids.push(id);
+            storage.free_indices.push(id.index() as u32);
         }
     });
 }
@@ -276,6 +298,11 @@ pub(crate) fn reset_storage() {
 pub fn has_signal(id: SignalId) -> bool {
     STORAGE.with(|storage| {
         let storage = storage.borrow();
-        storage.values.get(id).and_then(|v| v.as_ref()).is_some()
+        storage
+            .slots
+            .get(id.index())
+            .filter(|slot| slot.generation == id.generation())
+            .and_then(|slot| slot.value.as_ref())
+            .is_some()
     })
 }

--- a/src/renderer/flatten.rs
+++ b/src/renderer/flatten.rs
@@ -6,7 +6,7 @@ use crate::transform::Transform;
 use crate::widgets::Rect;
 
 use super::commands::DrawCommand;
-use super::tree::{CachedFlatten, ClipRegion, RenderNode, RenderTree};
+use super::tree::{CachedFlatten, ClipRegion, RenderNode};
 
 /// Render layer for draw command ordering.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -55,16 +55,6 @@ pub struct FlattenedCommand {
     /// Whether the clip is in local coordinates (use frag_pos in shader instead of world_pos).
     /// This is true for overlay clips on transformed containers.
     pub clip_is_local: bool,
-}
-
-/// Flatten a render tree into a list of commands ready for GPU submission.
-///
-/// This walks the tree depth-first, computing world transforms as it goes.
-/// Commands are bucketed by layer for correct render order.
-pub fn flatten_tree(tree: &mut RenderTree) -> (Vec<FlattenedCommand>, LayerBoundaries) {
-    let mut commands = Vec::new();
-    let boundaries = flatten_tree_into(tree, &mut commands);
-    (commands, boundaries)
 }
 
 /// Layered command buffers that avoid post-flatten sorting.
@@ -157,24 +147,19 @@ pub struct LayerBoundaries {
 
 /// Flatten a render tree into an existing buffer (clears and reuses capacity).
 ///
-/// This is more efficient than `flatten_tree` when called repeatedly,
-/// as it avoids reallocating the output vector each frame.
-///
-/// Takes `&mut RenderTree` so that flatten results can be cached on nodes
-/// for incremental reuse in subsequent frames.
+/// Flatten results are cached on nodes (via interior mutability) for
+/// incremental reuse in subsequent frames.
 ///
 /// Returns `LayerBoundaries` with pre-computed offsets for each render layer,
 /// replacing the previous `partition_point` lookups in the renderer.
-pub fn flatten_tree_into(
-    tree: &mut RenderTree,
+pub fn flatten_root_into(
+    root: &RenderNode,
     commands: &mut Vec<FlattenedCommand>,
 ) -> LayerBoundaries {
     commands.clear();
 
     let mut layered = LayeredCommands::new();
-    for root in &mut tree.roots {
-        flatten_node(root, Transform::IDENTITY, None, None, &mut layered);
-    }
+    flatten_node(root, Transform::IDENTITY, None, None, &mut layered);
 
     layered.drain_into(commands)
 }
@@ -185,7 +170,7 @@ pub fn flatten_tree_into(
 /// reuse the cached commands with a translation offset instead of
 /// re-flattening the entire subtree.
 fn flatten_node(
-    node: &mut RenderNode,
+    node: &RenderNode,
     parent_world_transform: Transform,
     parent_world_origin: Option<(f32, f32)>,
     parent_clip: Option<&WorldClip>,
@@ -202,11 +187,16 @@ fn flatten_node(
     };
     let world_transform = parent_world_transform.then(&local_centered);
 
-    // Try cached flatten for clean subtrees (translation-only optimization)
-    if !node.repainted
-        && parent_clip.is_none()
+    // Try cached flatten for clean subtrees (translation-only optimization).
+    // Clone the Rc out of the RefCell so the borrow isn't held while pushing.
+    let cached_flatten = if !node.repainted.get() {
+        node.cached_flatten.borrow().clone()
+    } else {
+        None
+    };
+    if parent_clip.is_none()
         && node.clip.is_none()
-        && let Some(ref cached) = node.cached_flatten
+        && let Some(cached) = cached_flatten
         && cached.world_transform.is_translation_only()
         && world_transform.is_translation_only()
     {
@@ -284,7 +274,7 @@ fn flatten_node(
     }
 
     // Recurse to children with effective clip
-    for child in &mut node.children {
+    for child in &node.children {
         flatten_node(
             child,
             world_transform,
@@ -326,14 +316,12 @@ fn flatten_node(
     // Cache flatten results for next frame, but only when reuse is possible.
     // The snapshot captures everything added since the start of this node
     // (including all children), matching the original `out[start_idx..]` behavior.
-    if let Some(snap) = snap {
-        node.cached_flatten = Some(Box::new(CachedFlatten {
+    *node.cached_flatten.borrow_mut() = snap.map(|snap| {
+        Rc::new(CachedFlatten {
             commands: out.commands_since(&snap),
             world_transform,
-        }));
-    } else {
-        node.cached_flatten = None;
-    }
+        })
+    });
     crate::render_stats::record_flatten_full();
 }
 

--- a/src/renderer/gpu.rs
+++ b/src/renderer/gpu.rs
@@ -204,14 +204,11 @@ impl ShapeInstance {
     /// Set transform from a Transform struct, scaling translation by scale_factor.
     pub fn with_transform(mut self, transform: &crate::transform::Transform, scale: f32) -> Self {
         if !transform.is_identity() {
-            self.transform = [
-                transform.data[0],         // a
-                transform.data[1],         // b
-                transform.data[3] * scale, // tx (scaled)
-                transform.data[4],         // c
-                transform.data[5],         // d
-                transform.data[7] * scale, // ty (scaled)
-            ];
+            // Transform stores exactly the affine layout the shader expects
+            // ([a, b, tx, c, d, ty]); only the translation needs scaling.
+            self.transform = transform.data;
+            self.transform[2] *= scale;
+            self.transform[5] *= scale;
         }
         self
     }

--- a/src/renderer/image_quad.rs
+++ b/src/renderer/image_quad.rs
@@ -412,7 +412,23 @@ impl ImageQuadRenderer {
         })
     }
 
+    /// Fallback when the `svg` feature is disabled: SVG sources fail to
+    /// decode with a warning instead of failing to compile.
+    #[cfg(not(feature = "svg"))]
+    fn load_svg(
+        &self,
+        _device: &Device,
+        _queue: &Queue,
+        _format: &TextureFormat,
+        _bytes: &[u8],
+        _scale: f32,
+    ) -> Option<CachedTexture> {
+        log::warn!("SVG image used but the `svg` feature is disabled");
+        None
+    }
+
     /// Load and rasterize an SVG.
+    #[cfg(feature = "svg")]
     fn load_svg(
         &self,
         device: &Device,

--- a/src/renderer/image_quad.rs
+++ b/src/renderer/image_quad.rs
@@ -334,17 +334,38 @@ impl ImageQuadRenderer {
 
         match source {
             ImageSource::Path(path) => {
-                let img = image::open(path).ok()?;
+                // Decode failures must be loud: a missing decoder feature
+                // (e.g. `webp` disabled) or a bad file otherwise degrades to
+                // a silently empty box.
+                let img = match image::open(path) {
+                    Ok(img) => img,
+                    Err(e) => {
+                        log::warn!("Failed to decode image {}: {e}", path.display());
+                        return None;
+                    }
+                };
                 let rgba = img.to_rgba8();
                 self.upload_raster(device, queue, &format, &rgba)
             }
             ImageSource::Bytes(bytes) => {
-                let img = image::load_from_memory(bytes).ok()?;
+                let img = match image::load_from_memory(bytes) {
+                    Ok(img) => img,
+                    Err(e) => {
+                        log::warn!("Failed to decode in-memory image: {e}");
+                        return None;
+                    }
+                };
                 let rgba = img.to_rgba8();
                 self.upload_raster(device, queue, &format, &rgba)
             }
             ImageSource::SvgPath(path) => {
-                let data = std::fs::read(path).ok()?;
+                let data = match std::fs::read(path) {
+                    Ok(data) => data,
+                    Err(e) => {
+                        log::warn!("Failed to read SVG {}: {e}", path.display());
+                        return None;
+                    }
+                };
                 self.load_svg(device, queue, &format, &data, render_scale)
             }
             ImageSource::SvgBytes(bytes) => {

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -31,8 +31,8 @@ pub use gpu_context::{GpuContext, SurfaceState};
 pub use paint_context::PaintContext;
 pub use render::Renderer;
 pub use text_measurer::{
-    char_index_from_x, char_index_from_x_styled, measure_text, measure_text_styled,
-    measure_text_to_char, measure_text_to_char_styled,
+    char_index_from_x, char_index_from_x_styled, measure_char_positions_styled, measure_text,
+    measure_text_styled, measure_text_to_char, measure_text_to_char_styled,
 };
 pub use tree::{NodeId, RenderNode};
 pub use types::{Gradient, GradientDir, ImageEntry, Shadow, TextEntry};

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -26,7 +26,7 @@ mod tree;
 mod types;
 
 pub use commands::{Border, DrawCommand};
-pub use flatten::{FlattenedCommand, LayerBoundaries, flatten_tree, flatten_tree_into};
+pub use flatten::{FlattenedCommand, LayerBoundaries, flatten_root_into};
 pub use gpu_context::{GpuContext, SurfaceState};
 pub use paint_context::PaintContext;
 pub use render::Renderer;
@@ -34,5 +34,5 @@ pub use text_measurer::{
     char_index_from_x, char_index_from_x_styled, measure_text, measure_text_styled,
     measure_text_to_char, measure_text_to_char_styled,
 };
-pub use tree::{NodeId, RenderNode, RenderTree};
+pub use tree::{NodeId, RenderNode};
 pub use types::{Gradient, GradientDir, ImageEntry, Shadow, TextEntry};

--- a/src/renderer/paint_context.rs
+++ b/src/renderer/paint_context.rs
@@ -391,17 +391,24 @@ impl<'a> PaintContext<'a> {
     /// The child will inherit transforms from this node automatically
     /// during tree flattening.
     pub fn add_child(&mut self, id: NodeId, bounds: Rect) -> PaintContext<'_> {
-        self.node.children.push(RenderNode::with_bounds(id, bounds));
-        let child = self
-            .node
+        self.node
             .children
-            .last_mut()
-            .expect("child was just pushed");
+            .push(Rc::new(RenderNode::with_bounds(id, bounds)));
+        let child = Rc::get_mut(
+            self.node
+                .children
+                .last_mut()
+                .expect("child was just pushed"),
+        )
+        .expect("freshly created child Rc is unique");
         PaintContext::new(child)
     }
 
-    /// Add a child node with a pre-built node.
-    pub fn add_child_node(&mut self, node: RenderNode) {
+    /// Add a pre-built child node.
+    ///
+    /// Used by the paint cache: reusing a clean child is `Rc::clone` of its
+    /// cached node (or a shallow header clone when its position changed).
+    pub fn add_child_rc(&mut self, node: Rc<RenderNode>) {
         self.node.children.push(node);
     }
 

--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -249,26 +249,31 @@ impl Renderer {
     }
 
     /// Render flattened commands to a surface.
+    ///
+    /// Returns `true` if a frame was actually presented. On `false` (lost/
+    /// outdated swapchain, out of memory) nothing reached the screen — the
+    /// caller must keep its dirty state so the content is repainted on the
+    /// next frame instead of showing stale pixels.
     pub fn render(
         &mut self,
         surface: &mut SurfaceState,
         commands: &[FlattenedCommand],
         boundaries: super::flatten::LayerBoundaries,
         clear_color: Color,
-    ) {
+    ) -> bool {
         let output = match surface.surface.get_current_texture() {
             Ok(output) => output,
             Err(wgpu::SurfaceError::Lost) => {
                 surface.resize(surface.width(), surface.height());
-                return;
+                return false;
             }
             Err(wgpu::SurfaceError::OutOfMemory) => {
                 log::error!("Out of GPU memory");
-                return;
+                return false;
             }
             Err(e) => {
                 log::error!("Surface error: {:?}", e);
-                return;
+                return false;
             }
         };
 
@@ -465,6 +470,7 @@ impl Renderer {
 
         self.queue.submit(std::iter::once(encoder.finish()));
         output.present();
+        true
     }
 }
 

--- a/src/renderer/text.rs
+++ b/src/renderer/text.rs
@@ -97,7 +97,7 @@ impl TextRenderState {
         for (idx, entry) in texts.iter().enumerate() {
             // Skip text invisible due to zero scale — avoids all rendering work
             if !entry.transform.is_identity() && !entry.transform.is_translation_only() {
-                let (sx, sy) = (entry.transform.data[0], entry.transform.data[5]);
+                let (sx, sy) = (entry.transform.a(), entry.transform.d());
                 if sx.abs() < 1e-3 || sy.abs() < 1e-3 {
                     culled_indices.insert(idx);
                     continue;

--- a/src/renderer/text.rs
+++ b/src/renderer/text.rs
@@ -37,9 +37,13 @@ pub struct TextRenderState {
     text_renderer: TextRenderer,
     buffers: Vec<Buffer>,
     viewport: Viewport,
-    /// Cache of shaped text buffers from the previous frame, keyed by content+style hash.
-    /// Avoids expensive Unicode analysis and glyph shaping for unchanged text.
-    buffer_cache: HashMap<u64, Buffer>,
+    /// Cache of shaped text buffers from the previous frame, keyed by
+    /// content+style hash. Avoids expensive Unicode analysis and glyph
+    /// shaping for unchanged text. Multi-valued: the same label can appear
+    /// several times in a frame (e.g. repeated list items) — with a
+    /// single-entry cache the first occurrence consumed the only buffer and
+    /// every duplicate re-shaped from scratch, every frame, forever.
+    buffer_cache: HashMap<u64, Vec<Buffer>>,
     /// Keys for current frame's buffers (parallel to `self.buffers`), used to
     /// repopulate `buffer_cache` at the start of the next frame.
     frame_keys: Vec<u64>,
@@ -86,7 +90,7 @@ impl TextRenderState {
     ) -> Vec<usize> {
         // Move last frame's buffers into cache for reuse
         for (key, buffer) in self.frame_keys.drain(..).zip(self.buffers.drain(..)) {
-            self.buffer_cache.insert(key, buffer);
+            self.buffer_cache.entry(key).or_default().push(buffer);
         }
 
         // Collect indices of texts that have non-trivial transforms (for texture-based rendering)
@@ -145,7 +149,11 @@ impl TextRenderState {
 
             // Check buffer cache before expensive text shaping
             let key = text_buffer_key(entry, scale_factor);
-            let buffer = if let Some(cached) = self.buffer_cache.remove(&key) {
+            let cached = self
+                .buffer_cache
+                .get_mut(&key)
+                .and_then(|buffers| buffers.pop());
+            let buffer = if let Some(cached) = cached {
                 cached
             } else {
                 // Cache miss — create and shape a new buffer

--- a/src/renderer/text_measurer.rs
+++ b/src/renderer/text_measurer.rs
@@ -1,23 +1,56 @@
 use crate::layout::Size;
 use crate::widgets::font::{FontFamily, FontWeight};
 use cosmic_text::{Attrs, Buffer, FontSystem, Metrics, Shaping};
+use rustc_hash::FxHashMap;
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
 
 /// Cache key for measurement results.
-/// Uses f32::to_bits() for hashable floats.
-#[derive(Hash, Eq, PartialEq, Clone)]
+///
+/// The text and font family are folded into a 64-bit hash (plus the text
+/// length as a discriminator) instead of storing owned Strings: the previous
+/// key allocated a String on every lookup, hit or miss, and cursor
+/// positioning performs many lookups per keystroke.
+#[derive(Hash, Eq, PartialEq, Clone, Copy)]
 struct MeasureCacheKey {
-    text: String,
+    /// FxHash of (text, font_family)
+    content_hash: u64,
+    /// Text byte length — cheap extra collision discriminator
+    text_len: u32,
     font_size_bits: u32,
-    font_family: FontFamily,
     font_weight: FontWeight,
     max_width_bits: Option<u32>,
 }
 
+impl MeasureCacheKey {
+    fn new(
+        text: &str,
+        font_size: f32,
+        max_width: Option<f32>,
+        font_family: &FontFamily,
+        font_weight: FontWeight,
+    ) -> Self {
+        let mut hasher = rustc_hash::FxHasher::default();
+        text.hash(&mut hasher);
+        font_family.hash(&mut hasher);
+        Self {
+            content_hash: hasher.finish(),
+            text_len: text.len() as u32,
+            font_size_bits: font_size.to_bits(),
+            font_weight,
+            max_width_bits: max_width.map(|w| w.to_bits()),
+        }
+    }
+}
+
+/// Wholesale-eviction bound for the measurement cache. Entries are tiny
+/// (~40 bytes), but the cache previously grew without bound for the process
+/// lifetime (e.g. one entry per text-input prefix ever measured).
+const MEASURE_CACHE_CAP: usize = 8192;
+
 pub struct TextMeasurer {
     font_system: FontSystem,
-    measure_cache: HashMap<MeasureCacheKey, Size>,
+    measure_cache: FxHashMap<MeasureCacheKey, Size>,
 }
 
 impl TextMeasurer {
@@ -30,7 +63,7 @@ impl TextMeasurer {
         }
         Self {
             font_system,
-            measure_cache: HashMap::new(),
+            measure_cache: FxHashMap::default(),
         }
     }
 
@@ -52,21 +85,53 @@ impl TextMeasurer {
         font_family: &FontFamily,
         font_weight: FontWeight,
     ) -> Size {
-        // Build cache key
-        let cache_key = MeasureCacheKey {
-            text: text.to_string(),
-            font_size_bits: font_size.to_bits(),
-            font_family: font_family.clone(),
-            font_weight,
-            max_width_bits: max_width.map(|w| w.to_bits()),
-        };
+        let cache_key = MeasureCacheKey::new(text, font_size, max_width, font_family, font_weight);
 
-        // Check cache first
+        // Check cache first (no allocation on this path)
         if let Some(&cached_size) = self.measure_cache.get(&cache_key) {
             return cached_size;
         }
 
-        // Measure text
+        let size = {
+            let buffer = self.shape(text, font_size, max_width, font_family, font_weight);
+
+            let mut width = 0.0f32;
+            let mut height = 0.0f32;
+            for run in buffer.layout_runs() {
+                width = width.max(run.line_w);
+                height += run.line_height;
+            }
+
+            // Ensure minimum height for empty text
+            if height == 0.0 {
+                height = font_size * 1.2;
+            }
+
+            Size::new(width, height)
+        };
+
+        // Cache the result, with wholesale eviction at the cap
+        if self.measure_cache.len() >= MEASURE_CACHE_CAP {
+            self.measure_cache.clear();
+        }
+        self.measure_cache.insert(cache_key, size);
+
+        size
+    }
+
+    /// Shape text into a fresh buffer.
+    ///
+    /// Uses `Shaping::Advanced`, matching the renderer — measurement with
+    /// `Shaping::Basic` could disagree with rendered glyphs for ligatures
+    /// and complex scripts, making layout diverge from pixels.
+    fn shape(
+        &mut self,
+        text: &str,
+        font_size: f32,
+        max_width: Option<f32>,
+        font_family: &FontFamily,
+        font_weight: FontWeight,
+    ) -> Buffer {
         let metrics = Metrics::new(font_size, font_size * 1.2);
         let mut buffer = Buffer::new(&mut self.font_system, metrics);
 
@@ -77,29 +142,72 @@ impl TextMeasurer {
             &Attrs::new()
                 .family(font_family.to_cosmic())
                 .weight(font_weight.to_cosmic()),
-            Shaping::Basic,
+            Shaping::Advanced,
             None,
         );
         buffer.shape_until_scroll(&mut self.font_system, true);
+        buffer
+    }
 
-        let mut width = 0.0f32;
-        let mut height = 0.0f32;
+    /// Compute the cumulative x position of every character boundary by
+    /// shaping the text ONCE.
+    ///
+    /// Returns `char_count + 1` positions: `positions[i]` is the x offset of
+    /// the boundary before character `i`, and the last entry is the total
+    /// width. Characters swallowed into a ligature/cluster snap to the
+    /// cluster start. Assumes single-line LTR text (the text-input model).
+    ///
+    /// Text inputs previously rebuilt their cursor-position table by
+    /// measuring every prefix of the text — O(n) shaping passes of O(n)
+    /// text per keystroke.
+    pub fn char_positions_styled(
+        &mut self,
+        text: &str,
+        font_size: f32,
+        font_family: &FontFamily,
+        font_weight: FontWeight,
+    ) -> Vec<f32> {
+        let char_count = text.chars().count();
+        let mut positions = vec![0.0f32; char_count + 1];
+        if text.is_empty() {
+            return positions;
+        }
+
+        // Map byte offsets to character indices for glyph lookup
+        let mut char_index_at_byte = vec![usize::MAX; text.len() + 1];
+        for (char_idx, (byte_idx, _)) in text.char_indices().enumerate() {
+            char_index_at_byte[byte_idx] = char_idx;
+        }
+        char_index_at_byte[text.len()] = char_count;
+
+        let buffer = self.shape(text, font_size, None, font_family, font_weight);
+
+        let mut total_width = 0.0f32;
+        let mut any_glyphs = false;
         for run in buffer.layout_runs() {
-            width = width.max(run.line_w);
-            height += run.line_height;
+            for glyph in run.glyphs {
+                if let Some(&char_idx) = char_index_at_byte.get(glyph.start)
+                    && char_idx != usize::MAX
+                {
+                    positions[char_idx] = glyph.x;
+                    any_glyphs = true;
+                }
+            }
+            total_width = total_width.max(run.line_w);
+        }
+        positions[char_count] = total_width;
+
+        // Forward-fill boundaries that got no glyph (cluster continuations):
+        // they sit at the position of the cluster they belong to.
+        if any_glyphs {
+            for i in 1..char_count {
+                if positions[i] == 0.0 && positions[i - 1] > 0.0 {
+                    positions[i] = positions[i - 1];
+                }
+            }
         }
 
-        // Ensure minimum height for empty text
-        if height == 0.0 {
-            height = font_size * 1.2;
-        }
-
-        let size = Size::new(width, height);
-
-        // Cache the result
-        self.measure_cache.insert(cache_key, size);
-
-        size
+        positions
     }
 
     /// Measure text width up to a specific character index.
@@ -238,6 +346,18 @@ pub fn measure_text_to_char_styled(
     TEXT_MEASURER.with_borrow_mut(|m| {
         m.measure_to_char_styled(text, font_size, char_index, font_family, font_weight)
     })
+}
+
+/// Compute cumulative x positions of every character boundary in one
+/// shaping pass (for text-input cursor positioning).
+pub fn measure_char_positions_styled(
+    text: &str,
+    font_size: f32,
+    font_family: &FontFamily,
+    font_weight: FontWeight,
+) -> Vec<f32> {
+    TEXT_MEASURER
+        .with_borrow_mut(|m| m.char_positions_styled(text, font_size, font_family, font_weight))
 }
 
 /// Find the character index from an x-coordinate (for click-to-position)

--- a/src/renderer/tree.rs
+++ b/src/renderer/tree.rs
@@ -1,5 +1,6 @@
 //! Render tree data structures.
 
+use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
 use smallvec::SmallVec;
@@ -48,6 +49,20 @@ pub struct CachedFlatten {
 /// - Draw commands for this node
 /// - Child nodes (nested widgets)
 /// - Overlay commands rendered after children
+///
+/// # Sharing model
+///
+/// Children are `Rc`-shared. The paint cache (`Tree::cache_paint`) stores an
+/// `Rc` to the same node that sits in the frame's render tree, so caching a
+/// subtree is a refcount bump and "cloning" a cached node copies only the
+/// node header (child `Rc`s and `Rc<DrawCommand>`s are bumped, never deep-
+/// copied). This is what makes per-frame paint caching O(n) instead of
+/// O(n·depth).
+///
+/// Because cached nodes are shared, the per-frame flags use interior
+/// mutability: `repainted` is a `Cell` (flipped to false once the node's
+/// output has been cached) and `cached_flatten` is a `RefCell` (written
+/// during flatten, which otherwise only needs `&RenderNode`).
 #[derive(Debug, Clone)]
 pub struct RenderNode {
     /// Unique identifier for this node (matches widget ID)
@@ -73,8 +88,8 @@ pub struct RenderNode {
     /// SmallVec: most nodes have 1-2 commands (background + border).
     pub commands: SmallVec<[Rc<DrawCommand>; 2]>,
 
-    /// Child nodes (nested widgets)
-    pub children: Vec<RenderNode>,
+    /// Child nodes (nested widgets), Rc-shared with the paint cache.
+    pub children: Vec<Rc<RenderNode>>,
 
     /// Overlay commands - drawn AFTER all children (for ripples, effects).
     /// These are also in local coordinates.
@@ -90,19 +105,24 @@ pub struct RenderNode {
     /// without affecting child content.
     pub overlay_clip: Option<ClipRegion>,
 
-    /// Whether this node was freshly painted (true) or reused from cache (false).
-    /// The flattener uses this to decide whether to reuse cached flatten output.
-    pub repainted: bool,
+    /// Whether this node was freshly painted this frame (true) or reused
+    /// from cache (false). The flattener uses this to decide whether to
+    /// reuse cached flatten output. Cleared by `cache_paint_results` after
+    /// the node's output has been cached — which is why it is a `Cell`:
+    /// by then the node is already Rc-shared with the paint cache.
+    pub repainted: Cell<bool>,
 
     /// Whether some children were skipped (culled by cull_rect) during paint.
-    /// Partial nodes should not be cached because their paint is incomplete —
-    /// reusing them later (when fully visible) would permanently hide the
-    /// culled children.
+    /// Partial subtrees are not cached (see `cache_paint_results`, which
+    /// propagates partial-ness to ancestors) because their paint is
+    /// incomplete — reusing them later would permanently hide the culled
+    /// children.
     pub partial: bool,
 
-    /// Cached flattened commands from a previous flatten pass.
-    /// Boxed to reduce inline RenderNode size (CachedFlatten contains Vec + Transform).
-    pub cached_flatten: Option<Box<CachedFlatten>>,
+    /// Cached flattened commands from a previous flatten pass, shared via Rc
+    /// so shallow node clones inherit it for free. Interior-mutable because
+    /// flatten writes it while the tree is Rc-shared.
+    pub cached_flatten: RefCell<Option<Rc<CachedFlatten>>>,
 }
 
 impl RenderNode {
@@ -119,9 +139,9 @@ impl RenderNode {
             overlay_commands: SmallVec::new(),
             clip: None,
             overlay_clip: None,
-            repainted: true,
+            repainted: Cell::new(true),
             partial: false,
-            cached_flatten: None,
+            cached_flatten: RefCell::new(None),
         }
     }
 
@@ -143,39 +163,8 @@ impl RenderNode {
         self.overlay_commands.clear();
         self.clip = None;
         self.overlay_clip = None;
-        self.repainted = true;
+        self.repainted.set(true);
         self.partial = false;
-        self.cached_flatten = None;
-    }
-}
-
-/// The complete render tree for a frame.
-///
-/// Contains root nodes (one per surface or top-level widget).
-#[derive(Debug, Default)]
-pub struct RenderTree {
-    /// Root nodes
-    pub roots: Vec<RenderNode>,
-}
-
-impl RenderTree {
-    /// Create a new empty render tree.
-    pub fn new() -> Self {
-        Self { roots: Vec::new() }
-    }
-
-    /// Add a root node to the tree.
-    pub fn add_root(&mut self, node: RenderNode) {
-        self.roots.push(node);
-    }
-
-    /// Clear the tree for reuse (preserves capacity).
-    pub fn clear(&mut self) {
-        self.roots.clear();
-    }
-
-    /// Check if the tree is empty.
-    pub fn is_empty(&self) -> bool {
-        self.roots.is_empty()
+        *self.cached_flatten.borrow_mut() = None;
     }
 }

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -297,7 +297,7 @@ thread_local! {
 }
 
 /// Push a surface command to the thread-local queue.
-fn push_surface_command(cmd: SurfaceCommand) {
+pub(crate) fn push_surface_command(cmd: SurfaceCommand) {
     SURFACE_COMMANDS.with(|cmds| {
         cmds.borrow_mut().push(cmd);
     });

--- a/src/surface_manager.rs
+++ b/src/surface_manager.rs
@@ -10,7 +10,7 @@ use smithay_client_toolkit::reexports::client::Connection;
 use crate::layout::Constraints;
 use crate::platform::{WaylandState, WaylandWindowWrapper};
 use crate::reactive::owner::{OwnerId, dispose_owner};
-use crate::renderer::{FlattenedCommand, GpuContext, RenderNode, RenderTree, SurfaceState};
+use crate::renderer::{FlattenedCommand, GpuContext, RenderNode, SurfaceState};
 use crate::surface::{SurfaceConfig, SurfaceId};
 use crate::tree::{Tree, WidgetId};
 use crate::widgets::Widget;
@@ -32,8 +32,6 @@ pub struct ManagedSurface {
     pub wgpu_surface: Option<SurfaceState>,
     /// Previous scale factor for detecting changes
     pub previous_scale_factor: f32,
-    /// Render tree (reused across frames to avoid allocation)
-    pub render_tree: RenderTree,
     /// Root render node (reused across frames to avoid allocation)
     pub root_node: RenderNode,
     /// Flattened commands buffer (reused across frames to avoid allocation)
@@ -65,7 +63,6 @@ impl ManagedSurface {
             owner_id,
             wgpu_surface: None,
             previous_scale_factor: 1.0,
-            render_tree: RenderTree::new(),
             root_node: RenderNode::new(widget_id.as_u64()),
             flattened_commands: Vec::new(),
         }

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -1,22 +1,27 @@
-/// A 4x4 transformation matrix stored in row-major order.
+/// A 2D affine transformation.
 ///
-/// Used for 2D transformations (translate, rotate, scale) that compose
-/// parent→child and are passed to the GPU shader.
+/// Stored as 6 floats in the layout `[a, b, tx, c, d, ty]`, representing:
+///
+/// ```text
+/// | a  b  tx |   (x maps to a*x + b*y + tx)
+/// | c  d  ty |   (y maps to c*x + d*y + ty)
+/// ```
+///
+/// This is exactly the data the GPU shader consumes. The previous
+/// implementation stored a full 4×4 matrix (64 bytes) of which 8 of the 16
+/// floats were structurally constant; the affine form is 24 bytes, composes
+/// with 6 multiplies per output element instead of a 4×4 multiply, and cuts
+/// the size of every render node and flattened command that embeds one.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Transform {
-    /// Matrix data in row-major order: [row0, row1, row2, row3]
-    pub data: [f32; 16],
+    /// Affine coefficients: `[a, b, tx, c, d, ty]`
+    pub data: [f32; 6],
 }
 
 impl Transform {
-    /// Identity matrix (no transformation)
+    /// Identity transform (no transformation)
     pub const IDENTITY: Self = Self {
-        data: [
-            1.0, 0.0, 0.0, 0.0, // row 0
-            0.0, 1.0, 0.0, 0.0, // row 1
-            0.0, 0.0, 1.0, 0.0, // row 2
-            0.0, 0.0, 0.0, 1.0, // row 3
-        ],
+        data: [1.0, 0.0, 0.0, 0.0, 1.0, 0.0],
     };
 
     /// Create an identity transform
@@ -27,12 +32,7 @@ impl Transform {
     /// Create a translation transform
     pub fn translate(x: f32, y: f32) -> Self {
         Self {
-            data: [
-                1.0, 0.0, 0.0, x, // row 0
-                0.0, 1.0, 0.0, y, // row 1
-                0.0, 0.0, 1.0, 0.0, // row 2
-                0.0, 0.0, 0.0, 1.0, // row 3
-            ],
+            data: [1.0, 0.0, x, 0.0, 1.0, y],
         }
     }
 
@@ -41,12 +41,7 @@ impl Transform {
         let cos = angle_radians.cos();
         let sin = angle_radians.sin();
         Self {
-            data: [
-                cos, -sin, 0.0, 0.0, // row 0
-                sin, cos, 0.0, 0.0, // row 1
-                0.0, 0.0, 1.0, 0.0, // row 2
-                0.0, 0.0, 0.0, 1.0, // row 3
-            ],
+            data: [cos, -sin, 0.0, sin, cos, 0.0],
         }
     }
 
@@ -63,13 +58,32 @@ impl Transform {
     /// Create a non-uniform scale transform
     pub fn scale_xy(sx: f32, sy: f32) -> Self {
         Self {
-            data: [
-                sx, 0.0, 0.0, 0.0, // row 0
-                0.0, sy, 0.0, 0.0, // row 1
-                0.0, 0.0, 1.0, 0.0, // row 2
-                0.0, 0.0, 0.0, 1.0, // row 3
-            ],
+            data: [sx, 0.0, 0.0, 0.0, sy, 0.0],
         }
+    }
+
+    /// The `a` (x-from-x) coefficient.
+    #[inline]
+    pub fn a(&self) -> f32 {
+        self.data[0]
+    }
+
+    /// The `b` (x-from-y) coefficient.
+    #[inline]
+    pub fn b(&self) -> f32 {
+        self.data[1]
+    }
+
+    /// The `c` (y-from-x) coefficient.
+    #[inline]
+    pub fn c(&self) -> f32 {
+        self.data[3]
+    }
+
+    /// The `d` (y-from-y) coefficient.
+    #[inline]
+    pub fn d(&self) -> f32 {
+        self.data[4]
     }
 
     /// Create a transform that applies this transform centered around a point.
@@ -79,55 +93,43 @@ impl Transform {
     ///
     /// Useful for rotating or scaling around a specific point rather than the origin.
     pub fn center_at(self, cx: f32, cy: f32) -> Self {
-        let to_origin = Self::translate(-cx, -cy);
-        let from_origin = Self::translate(cx, cy);
-        from_origin.then(&self).then(&to_origin)
+        // Directly fold the two translations into the affine form instead of
+        // composing three transforms: only the translation column changes.
+        let [a, b, tx, c, d, ty] = self.data;
+        Self {
+            data: [
+                a,
+                b,
+                tx + cx - (a * cx + b * cy),
+                c,
+                d,
+                ty + cy - (c * cx + d * cy),
+            ],
+        }
     }
 
     /// Compose this transform with another: self * other
     /// Applies `other` first, then `self`.
     pub fn then(&self, other: &Transform) -> Transform {
-        let a = &self.data;
-        let b = &other.data;
-
-        // Matrix multiplication: result[i][j] = sum(a[i][k] * b[k][j])
-        // Row-major indexing: element at row i, col j is at index i*4 + j
-        let mut result = [0.0f32; 16];
-
-        for i in 0..4 {
-            for j in 0..4 {
-                let mut sum = 0.0;
-                for k in 0..4 {
-                    sum += a[i * 4 + k] * b[k * 4 + j];
-                }
-                result[i * 4 + j] = sum;
-            }
+        let [a1, b1, tx1, c1, d1, ty1] = self.data;
+        let [a2, b2, tx2, c2, d2, ty2] = other.data;
+        Transform {
+            data: [
+                a1 * a2 + b1 * c2,
+                a1 * b2 + b1 * d2,
+                a1 * tx2 + b1 * ty2 + tx1,
+                c1 * a2 + d1 * c2,
+                c1 * b2 + d1 * d2,
+                c1 * tx2 + d1 * ty2 + ty1,
+            ],
         }
-
-        Transform { data: result }
     }
 
     /// Compute the inverse of this transform.
-    /// For affine 2D transforms (translate, rotate, scale), this uses a simplified inverse.
+    ///
+    /// Returns the identity for degenerate (zero-determinant) transforms.
     pub fn inverse(&self) -> Transform {
-        // For a 2D affine transform, the matrix has the form:
-        // | a  b  0  tx |
-        // | c  d  0  ty |
-        // | 0  0  1  0  |
-        // | 0  0  0  1  |
-        //
-        // The inverse is:
-        // | d/det  -b/det  0  (-d*tx + b*ty)/det |
-        // | -c/det  a/det  0  (c*tx - a*ty)/det  |
-        // | 0       0      1  0                   |
-        // | 0       0      0  1                   |
-
-        let a = self.data[0];
-        let b = self.data[1];
-        let c = self.data[4];
-        let d = self.data[5];
-        let tx = self.data[3];
-        let ty = self.data[7];
+        let [a, b, tx, c, d, ty] = self.data;
 
         let det = a * d - b * c;
 
@@ -142,44 +144,23 @@ impl Transform {
             data: [
                 d * inv_det,
                 -b * inv_det,
-                0.0,
                 (-d * tx + b * ty) * inv_det,
                 -c * inv_det,
                 a * inv_det,
-                0.0,
                 (c * tx - a * ty) * inv_det,
-                0.0,
-                0.0,
-                1.0,
-                0.0,
-                0.0,
-                0.0,
-                0.0,
-                1.0,
             ],
         }
     }
 
-    /// Transform a 2D point by this matrix
+    /// Transform a 2D point by this transform
+    #[inline]
     pub fn transform_point(&self, x: f32, y: f32) -> (f32, f32) {
-        // Homogeneous coordinates: (x, y, 0, 1)
-        // Result: (a*x + b*y + tx, c*x + d*y + ty)
-        let new_x = self.data[0] * x + self.data[1] * y + self.data[3];
-        let new_y = self.data[4] * x + self.data[5] * y + self.data[7];
-        (new_x, new_y)
-    }
-
-    /// Get the rows of the matrix for passing to the shader
-    pub fn rows(&self) -> [[f32; 4]; 4] {
-        [
-            [self.data[0], self.data[1], self.data[2], self.data[3]],
-            [self.data[4], self.data[5], self.data[6], self.data[7]],
-            [self.data[8], self.data[9], self.data[10], self.data[11]],
-            [self.data[12], self.data[13], self.data[14], self.data[15]],
-        ]
+        let [a, b, tx, c, d, ty] = self.data;
+        (a * x + b * y + tx, c * x + d * y + ty)
     }
 
     /// Check if this is the identity transform
+    #[inline]
     pub fn is_identity(&self) -> bool {
         *self == Self::IDENTITY
     }
@@ -187,40 +168,40 @@ impl Transform {
     /// Check if this transform contains rotation.
     /// Rotation is present when the off-diagonal elements (b, c) are non-zero.
     pub fn has_rotation(&self) -> bool {
-        // Matrix layout:
-        // | a  b  0  tx |  indices: [0, 1, 2, 3]
-        // | c  d  0  ty |  indices: [4, 5, 6, 7]
-        // b is at index 1, c is at index 4
-        self.data[1].abs() > 1e-6 || self.data[4].abs() > 1e-6
+        self.b().abs() > 1e-6 || self.c().abs() > 1e-6
     }
 
     /// Get the X translation component
+    #[inline]
     pub fn tx(&self) -> f32 {
-        self.data[3]
+        self.data[2]
     }
 
     /// Get the Y translation component
+    #[inline]
     pub fn ty(&self) -> f32 {
-        self.data[7]
+        self.data[5]
     }
 
     /// Set the X translation component
+    #[inline]
     pub fn set_tx(&mut self, val: f32) {
-        self.data[3] = val;
+        self.data[2] = val;
     }
 
     /// Set the Y translation component
+    #[inline]
     pub fn set_ty(&mut self, val: f32) {
-        self.data[7] = val;
+        self.data[5] = val;
     }
 
     /// Scale the translation components by a factor (useful for HiDPI scaling)
     pub fn scale_translation(&mut self, factor: f32) {
-        self.data[3] *= factor;
-        self.data[7] *= factor;
+        self.data[2] *= factor;
+        self.data[5] *= factor;
     }
 
-    /// Extract the X and Y scale components from the transform matrix.
+    /// Extract the X and Y scale components from the transform.
     ///
     /// For transforms that contain rotation and/or scale:
     /// - sx = sqrt(a² + b²)
@@ -228,10 +209,7 @@ impl Transform {
     ///
     /// Returns `(scale_x, scale_y)` as a tuple.
     pub fn extract_scale_components(&self) -> (f32, f32) {
-        let a = self.data[0];
-        let b = self.data[1];
-        let c = self.data[4];
-        let d = self.data[5];
+        let (a, b, c, d) = (self.a(), self.b(), self.c(), self.d());
         ((a * a + b * b).sqrt(), (c * c + d * d).sqrt())
     }
 
@@ -252,49 +230,21 @@ impl Transform {
     /// Useful for render-to-texture workflows where text is pre-scaled.
     pub fn without_scale(&self) -> Transform {
         let (sx, sy) = self.extract_scale_components();
-        let tx = self.data[3];
-        let ty = self.data[7];
+        let [a, b, tx, c, d, ty] = self.data;
 
         // Avoid division by zero
         if sx < 1e-10 || sy < 1e-10 {
             return Transform::translate(tx, ty);
         }
 
-        let a = self.data[0];
-        let b = self.data[1];
-        let c = self.data[4];
-        let d = self.data[5];
-
-        // Normalize the rotation component
         Transform {
-            data: [
-                a / sx,
-                b / sx,
-                0.0,
-                tx,
-                c / sy,
-                d / sy,
-                0.0,
-                ty,
-                0.0,
-                0.0,
-                1.0,
-                0.0,
-                0.0,
-                0.0,
-                0.0,
-                1.0,
-            ],
+            data: [a / sx, b / sx, tx, c / sy, d / sy, ty],
         }
     }
 
     /// Check if this transform contains only translation (no rotation or scale).
     pub fn is_translation_only(&self) -> bool {
-        let a = self.data[0];
-        let b = self.data[1];
-        let c = self.data[4];
-        let d = self.data[5];
-
+        let (a, b, c, d) = (self.a(), self.b(), self.c(), self.d());
         // For pure translation: a=1, b=0, c=0, d=1
         (a - 1.0).abs() < 1e-6 && b.abs() < 1e-6 && c.abs() < 1e-6 && (d - 1.0).abs() < 1e-6
     }
@@ -316,31 +266,10 @@ impl Transform {
             return Transform::IDENTITY;
         }
 
-        let a = self.data[0];
-        let b = self.data[1];
-        let c = self.data[4];
-        let d = self.data[5];
+        let [a, b, _tx, c, d, _ty] = self.data;
 
-        // Extract normalized rotation (no translation)
         Transform {
-            data: [
-                a / sx,
-                b / sx,
-                0.0,
-                0.0, // No translation
-                c / sy,
-                d / sy,
-                0.0,
-                0.0, // No translation
-                0.0,
-                0.0,
-                1.0,
-                0.0,
-                0.0,
-                0.0,
-                0.0,
-                1.0,
-            ],
+            data: [a / sx, b / sx, 0.0, c / sy, d / sy, 0.0],
         }
     }
 }
@@ -451,16 +380,6 @@ mod tests {
     }
 
     #[test]
-    fn test_rows() {
-        let t = Transform::translate(1.0, 2.0);
-        let rows = t.rows();
-        assert_eq!(rows[0], [1.0, 0.0, 0.0, 1.0]);
-        assert_eq!(rows[1], [0.0, 1.0, 0.0, 2.0]);
-        assert_eq!(rows[2], [0.0, 0.0, 1.0, 0.0]);
-        assert_eq!(rows[3], [0.0, 0.0, 0.0, 1.0]);
-    }
-
-    #[test]
     fn test_center_at_rotation() {
         // Rotate 90 degrees around point (10, 10)
         let t = Transform::rotate_degrees(90.0).center_at(10.0, 10.0);
@@ -509,6 +428,23 @@ mod tests {
         let (x, y) = t.transform_point(50.0, 75.0);
         assert!(approx_eq(x, 50.0));
         assert!(approx_eq(y, 75.0));
+    }
+
+    /// center_at must agree with the composed definition:
+    /// translate(cx, cy) * self * translate(-cx, -cy)
+    #[test]
+    fn test_center_at_matches_composed_form() {
+        let t = Transform::rotate_degrees(30.0).then(&Transform::scale_xy(2.0, 0.5));
+        let (cx, cy) = (17.0, -4.0);
+
+        let direct = t.center_at(cx, cy);
+        let composed = Transform::translate(cx, cy)
+            .then(&t)
+            .then(&Transform::translate(-cx, -cy));
+
+        for (a, b) in direct.data.iter().zip(composed.data.iter()) {
+            assert!(approx_eq(*a, *b), "{direct:?} != {composed:?}");
+        }
     }
 
     #[test]

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -79,11 +79,15 @@ impl WidgetId {
     }
 }
 
-/// Entry in the sparse map, pointing to a dense array slot.
-struct SparseEntry {
-    /// Index into the dense array
-    dense_index: usize,
-    /// Generation of this entry (for validation)
+/// Slot in the sparse map, pointing to a dense array slot.
+///
+/// The generation survives vacancy: it is bumped when the slot is reused,
+/// so a stale `WidgetId` can never alias a widget that later recycled the
+/// same index.
+struct SparseSlot {
+    /// Index into the dense array; `None` while the slot is vacant
+    dense_index: Option<usize>,
+    /// Generation of this slot (for validation)
     generation: u32,
 }
 
@@ -122,7 +126,7 @@ pub struct Tree {
     /// Dense array of nodes (widgets + metadata)
     dense: Vec<Node>,
     /// Sparse map from index to dense position + generation
-    sparse: Vec<Option<SparseEntry>>,
+    sparse: Vec<SparseSlot>,
     /// Free list of reusable sparse indices
     free_indices: Vec<u32>,
     /// Accumulated damage region for the current frame
@@ -147,16 +151,17 @@ impl Tree {
     pub fn register(&mut self, widget: Box<dyn Widget>) -> WidgetId {
         // Allocate a sparse index (reuse from free list or allocate new)
         let (sparse_index, generation) = if let Some(idx) = self.free_indices.pop() {
-            // Reuse a freed slot - increment generation
-            let old_gen = self.sparse[idx as usize]
-                .as_ref()
-                .map(|e| e.generation)
-                .unwrap_or(0);
-            (idx, old_gen.wrapping_add(1))
+            // Reuse a freed slot - increment the surviving generation so
+            // stale IDs from the previous occupant can never match
+            let generation = self.sparse[idx as usize].generation.wrapping_add(1);
+            (idx, generation)
         } else {
             // Allocate new slot
             let idx = self.sparse.len() as u32;
-            self.sparse.push(None);
+            self.sparse.push(SparseSlot {
+                dense_index: None,
+                generation: 0,
+            });
             (idx, 0)
         };
 
@@ -181,10 +186,10 @@ impl Tree {
         });
 
         // Update sparse map
-        self.sparse[sparse_index as usize] = Some(SparseEntry {
-            dense_index,
+        self.sparse[sparse_index as usize] = SparseSlot {
+            dense_index: Some(dense_index),
             generation,
-        });
+        };
 
         id
     }
@@ -217,13 +222,11 @@ impl Tree {
         // Fix up the moved node's sparse entry (if we didn't remove the last element)
         if dense_index != last_dense_index && !self.dense.is_empty() {
             let moved_sparse_idx = self.dense[dense_index].sparse_index;
-            if let Some(ref mut entry) = self.sparse[moved_sparse_idx as usize] {
-                entry.dense_index = dense_index;
-            }
+            self.sparse[moved_sparse_idx as usize].dense_index = Some(dense_index);
         }
 
-        // Invalidate the sparse entry (keep generation for next allocation)
-        self.sparse[id.index as usize] = None;
+        // Vacate the sparse slot, keeping its generation for the next allocation
+        self.sparse[id.index as usize].dense_index = None;
         self.free_indices.push(id.index);
 
         // Now drop the removed widget (may trigger recursive unregisters)
@@ -234,9 +237,8 @@ impl Tree {
     fn get_dense_index(&self, id: WidgetId) -> Option<usize> {
         self.sparse
             .get(id.index as usize)
-            .and_then(|e| e.as_ref())
-            .filter(|e| e.generation == id.generation)
-            .map(|e| e.dense_index)
+            .filter(|slot| slot.generation == id.generation)
+            .and_then(|slot| slot.dense_index)
     }
 
     /// Access a widget via a closure.
@@ -629,6 +631,36 @@ mod tests {
         // They should have the same index but different generations
         assert_eq!(id1.index, id2.index);
         assert_ne!(id1.generation, id2.generation);
+    }
+
+    /// Regression test: the generation must keep advancing across repeated
+    /// recycles of the same slot. The old implementation read the generation
+    /// from a sparse entry that `unregister` had already cleared, so every
+    /// reuse produced generation 1 and a stale ID from cycle N aliased the
+    /// live widget of cycle N+2.
+    #[test]
+    fn test_tree_generation_advances_across_recycles() {
+        let mut tree = Tree::new();
+
+        let mut previous_ids = Vec::new();
+        let mut current = tree.register(Box::new(MockWidget::new()));
+
+        for _ in 0..5 {
+            tree.unregister(current);
+            let next = tree.register(Box::new(MockWidget::new()));
+            assert_eq!(next.index, current.index, "slot should be recycled");
+            previous_ids.push(current);
+            current = next;
+
+            // No previously issued ID may resolve to the new widget
+            for stale in &previous_ids {
+                assert!(
+                    !tree.contains(*stale),
+                    "stale id {stale:?} aliases live widget {current:?}"
+                );
+            }
+            assert!(tree.contains(current));
+        }
     }
 
     #[test]

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -129,8 +129,10 @@ pub struct Tree {
     sparse: Vec<SparseSlot>,
     /// Free list of reusable sparse indices
     free_indices: Vec<u32>,
-    /// Accumulated damage region for the current frame
-    damage: DamageRegion,
+    /// Accumulated damage region for the current frame, keyed by the
+    /// surface's root widget. Per-surface so that one surface's render
+    /// cannot consume (or misreport) damage accumulated by another.
+    damage: std::collections::HashMap<WidgetId, DamageRegion>,
 }
 
 impl Tree {
@@ -140,7 +142,7 @@ impl Tree {
             dense: Vec::new(),
             sparse: Vec::new(),
             free_indices: Vec::new(),
-            damage: DamageRegion::None,
+            damage: std::collections::HashMap::new(),
         }
     }
 
@@ -387,9 +389,10 @@ impl Tree {
     /// Also accumulates the widget's surface-relative bounds into the
     /// damage region for Wayland damage reporting.
     pub fn mark_needs_paint(&mut self, widget_id: WidgetId) {
-        // Accumulate damage for the actual dirty widget (before propagation)
-        if let Some(bounds) = self.get_surface_relative_bounds(widget_id) {
-            self.expand_damage_rect(bounds);
+        // Accumulate damage for the actual dirty widget (before propagation),
+        // attributed to the widget's surface root
+        if let Some((root, bounds)) = self.surface_relative_bounds_and_root(widget_id) {
+            self.expand_damage_rect(root, bounds);
         }
 
         let mut current = widget_id;
@@ -424,9 +427,12 @@ impl Tree {
 
     /// Mark a widget and all its descendants as needing paint.
     ///
-    /// Sets full damage since the entire subtree is being repainted.
+    /// Sets full damage for the widget's surface since the entire subtree
+    /// is being repainted.
     pub fn mark_subtree_needs_paint(&mut self, widget_id: WidgetId) {
-        self.damage = DamageRegion::Full;
+        if let Some(root) = self.surface_root_of(widget_id) {
+            self.damage.insert(root, DamageRegion::Full);
+        }
         self.mark_subtree_needs_paint_inner(widget_id);
     }
 
@@ -449,6 +455,13 @@ impl Tree {
     /// Get the surface-relative bounds of a widget by walking up the parent chain
     /// and summing origins.
     pub fn get_surface_relative_bounds(&self, id: WidgetId) -> Option<Rect> {
+        self.surface_relative_bounds_and_root(id)
+            .map(|(_, bounds)| bounds)
+    }
+
+    /// Walk to the surface root, returning it together with the widget's
+    /// surface-relative bounds (origins summed along the chain).
+    fn surface_relative_bounds_and_root(&self, id: WidgetId) -> Option<(WidgetId, Rect)> {
         let idx = self.get_dense_index(id)?;
         let size = self.dense[idx].cached_size?;
         let mut x = 0.0f32;
@@ -463,12 +476,25 @@ impl Tree {
                 None => break,
             }
         }
-        Some(Rect::new(x, y, size.width, size.height))
+        Some((current, Rect::new(x, y, size.width, size.height)))
     }
 
-    /// Union a rect into the accumulated damage region.
-    fn expand_damage_rect(&mut self, rect: Rect) {
-        self.damage = match &self.damage {
+    /// Find the surface root (topmost ancestor) of a widget.
+    fn surface_root_of(&self, id: WidgetId) -> Option<WidgetId> {
+        let mut current = id;
+        loop {
+            let dense_idx = self.get_dense_index(current)?;
+            match self.dense[dense_idx].parent {
+                Some(parent) => current = parent,
+                None => return Some(current),
+            }
+        }
+    }
+
+    /// Union a rect into the damage region of the given surface root.
+    fn expand_damage_rect(&mut self, root: WidgetId, rect: Rect) {
+        let entry = self.damage.entry(root).or_insert(DamageRegion::None);
+        *entry = match entry {
             DamageRegion::None => DamageRegion::Partial(rect),
             DamageRegion::Partial(existing) => {
                 let min_x = existing.x.min(rect.x);
@@ -481,14 +507,15 @@ impl Tree {
         };
     }
 
-    /// Set full-surface damage (e.g., on resize or initialization).
-    pub fn set_full_damage(&mut self) {
-        self.damage = DamageRegion::Full;
+    /// Set full-surface damage for a surface root (e.g., on resize,
+    /// initialization, or a failed present that must be retried).
+    pub fn set_full_damage(&mut self, root: WidgetId) {
+        self.damage.insert(root, DamageRegion::Full);
     }
 
-    /// Take the accumulated damage region, resetting it to None.
-    pub fn take_damage(&mut self) -> DamageRegion {
-        std::mem::replace(&mut self.damage, DamageRegion::None)
+    /// Take the accumulated damage region for a surface root, resetting it.
+    pub fn take_damage(&mut self, root: WidgetId) -> DamageRegion {
+        self.damage.remove(&root).unwrap_or(DamageRegion::None)
     }
 
     /// Set whether a widget is a relayout boundary.
@@ -569,6 +596,7 @@ impl Tree {
         self.dense.clear();
         self.sparse.clear();
         self.free_indices.clear();
+        self.damage.clear();
     }
 
     /// Get the number of registered widgets.

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -114,7 +114,7 @@ struct Node {
     /// Back-pointer to sparse array index (for swap-remove fixup)
     sparse_index: u32,
     /// Cached paint output from last frame
-    cached_paint: Option<crate::renderer::RenderNode>,
+    cached_paint: Option<std::rc::Rc<crate::renderer::RenderNode>>,
 }
 
 /// Central tree for widget storage using arena-based sparse-set architecture.
@@ -550,15 +550,16 @@ impl Tree {
         ))
     }
 
-    /// Cache a widget's paint output.
-    pub fn cache_paint(&mut self, id: WidgetId, node: crate::renderer::RenderNode) {
+    /// Cache a widget's paint output. The node is Rc-shared with the frame's
+    /// render tree, so this is a refcount bump, not a deep clone.
+    pub fn cache_paint(&mut self, id: WidgetId, node: std::rc::Rc<crate::renderer::RenderNode>) {
         if let Some(idx) = self.get_dense_index(id) {
             self.dense[idx].cached_paint = Some(node);
         }
     }
 
     /// Get a widget's cached paint output.
-    pub fn cached_paint(&self, id: WidgetId) -> Option<&crate::renderer::RenderNode> {
+    pub fn cached_paint(&self, id: WidgetId) -> Option<&std::rc::Rc<crate::renderer::RenderNode>> {
         self.get_dense_index(id)
             .and_then(|idx| self.dense[idx].cached_paint.as_ref())
     }

--- a/src/widgets/children.rs
+++ b/src/widgets/children.rs
@@ -3,6 +3,7 @@ use std::rc::Rc;
 
 use crate::jobs::{JobRequest, JobType, request_job};
 use crate::layout::{Constraints, Size};
+use crate::reactive::invalidation::clear_widget_subscribers;
 use crate::reactive::{OwnerId, dispose_owner, with_signal_tracking};
 use crate::renderer::PaintContext;
 use crate::tree::{Tree, WidgetId};
@@ -191,8 +192,12 @@ impl ChildrenSource {
                         // Update current keys
                         *current_keys = new_keys;
 
-                        // Unregister removed widgets from tree (triggers Drop/cleanup)
+                        // Unregister removed widgets from tree (triggers Drop/cleanup).
+                        // Clear their signal subscriptions first — otherwise the dead
+                        // WidgetId stays subscribed forever and every subsequent write
+                        // to those signals enqueues a job for a nonexistent widget.
                         for old_id in cached.values() {
+                            clear_widget_subscribers(*old_id);
                             tree.unregister(*old_id);
                         }
                         cached.clear();

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -1514,15 +1514,15 @@ impl Widget for Container {
                 }
             };
             match local_event.as_ref() {
-                Event::MouseEnter { x, y } => {
-                    if bounds.contains_rounded(*x, *y, corner_radius) && !ix.is_hovered {
-                        ix.is_hovered = true;
-                        if ix.hover_state.is_some() {
-                            request_repaint(id);
-                        }
-                        if let Some(ref callback) = ix.on_hover {
-                            callback(true);
-                        }
+                Event::MouseEnter { x, y }
+                    if bounds.contains_rounded(*x, *y, corner_radius) && !ix.is_hovered =>
+                {
+                    ix.is_hovered = true;
+                    if ix.hover_state.is_some() {
+                        request_repaint(id);
+                    }
+                    if let Some(ref callback) = ix.on_hover {
+                        callback(true);
                     }
                 }
                 Event::MouseMove { x, y } => {

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -2024,17 +2024,25 @@ impl Widget for Container {
                 && !tree.needs_paint(child_id)
                 && let Some(cached) = tree.cached_paint(child_id)
             {
-                let mut reused = cached.clone();
-                // Decompose: extract user transform, recompose with new position
-                let user_part = cached
-                    .parent_position
-                    .inverse()
-                    .then(&cached.local_transform);
-                reused.local_transform = child_position.then(&user_part);
-                reused.parent_position = child_position;
-                reused.bounds = child_local;
-                reused.repainted = false;
-                ctx.add_child_node(reused);
+                if cached.parent_position == child_position && cached.bounds == child_local {
+                    // Position unchanged: reuse the cached node wholesale.
+                    // Zero copies — the render tree and the cache share it.
+                    ctx.add_child_rc(std::rc::Rc::clone(cached));
+                } else {
+                    // Position changed: shallow header clone (children and
+                    // commands are Rc-shared, so this copies no subtree).
+                    // Decompose: extract user transform, recompose with new position.
+                    let mut reused = (**cached).clone();
+                    let user_part = cached
+                        .parent_position
+                        .inverse()
+                        .then(&cached.local_transform);
+                    reused.local_transform = child_position.then(&user_part);
+                    reused.parent_position = child_position;
+                    reused.bounds = child_local;
+                    reused.repainted.set(false);
+                    ctx.add_child_rc(std::rc::Rc::new(reused));
+                }
                 crate::render_stats::record_paint_child_cached();
                 continue;
             }

--- a/src/widgets/text_input.rs
+++ b/src/widgets/text_input.rs
@@ -18,7 +18,7 @@ use crate::reactive::{
     CursorIcon, IntoSignal, OptionSignalExt, RwSignal, Signal, clipboard_copy, clipboard_paste,
     has_focus, release_focus, request_focus, set_cursor, with_signal_tracking,
 };
-use crate::renderer::{PaintContext, char_index_from_x_styled, measure_text_styled};
+use crate::renderer::{PaintContext, char_index_from_x_styled};
 use crate::tree::{Tree, WidgetId};
 
 use super::font::{FontFamily, FontWeight};
@@ -408,32 +408,22 @@ impl TextInput {
         let font_family = &self.cached_font_family;
         let font_weight = self.cached_font_weight;
 
-        // Build cumulative position array: positions[i] = width of text[0..i]
-        // Length is char_count + 1 to include position 0 and position at end
-        let char_count = self.cached_char_count;
-        self.cached_glyph_positions.clear();
-        self.cached_glyph_positions.reserve(char_count + 1);
-        self.cached_glyph_positions.push(0.0); // Position at index 0
-
-        // Measure width at each character boundary
-        for (i, (byte_idx, _)) in display.char_indices().enumerate() {
-            // Width up to this character
-            let prefix = &display[..byte_idx];
-            let width = if prefix.is_empty() {
-                0.0
-            } else {
-                measure_text_styled(prefix, font_size, None, font_family, font_weight).width
-            };
-            // Update position for this index (already have 0 at index 0)
-            if i > 0 {
-                self.cached_glyph_positions.push(width);
-            }
-        }
-
-        // Add final position (total width)
-        self.cached_text_width =
-            measure_text_styled(display, font_size, None, font_family, font_weight).width;
-        self.cached_glyph_positions.push(self.cached_text_width);
+        // Build cumulative position array (positions[i] = x of the boundary
+        // before character i) by shaping the text ONCE. The previous
+        // implementation measured every prefix — O(n) shaping passes of
+        // O(n) text per keystroke — and flooded the measurement cache with
+        // one entry per prefix.
+        self.cached_glyph_positions = crate::renderer::measure_char_positions_styled(
+            display,
+            font_size,
+            font_family,
+            font_weight,
+        );
+        self.cached_text_width = self
+            .cached_glyph_positions
+            .last()
+            .copied()
+            .unwrap_or_default();
 
         self.measurements_dirty = false;
     }

--- a/src/widgets/text_input.rs
+++ b/src/widgets/text_input.rs
@@ -1102,21 +1102,21 @@ impl Widget for TextInput {
         let bounds = tree.get_bounds(id).unwrap_or_default();
 
         match event {
-            Event::MouseDown { x, y, button } => {
-                if bounds.contains(*x, *y) && *button == MouseButton::Left {
-                    // Request focus and start cursor blink animation
-                    request_focus(id);
-                    request_job(id, JobRequest::Animation(RequiredJob::Paint));
+            Event::MouseDown { x, y, button }
+                if bounds.contains(*x, *y) && *button == MouseButton::Left =>
+            {
+                // Request focus and start cursor blink animation
+                request_focus(id);
+                request_job(id, JobRequest::Animation(RequiredJob::Paint));
 
-                    // Set cursor position
-                    let char_index = self.char_index_at_x(*x, bounds);
-                    self.selection = Selection::new(char_index);
-                    self.is_dragging = true;
-                    self.reset_cursor_blink();
-                    self.ensure_cursor_visible(bounds.width);
+                // Set cursor position
+                let char_index = self.char_index_at_x(*x, bounds);
+                self.selection = Selection::new(char_index);
+                self.is_dragging = true;
+                self.reset_cursor_blink();
+                self.ensure_cursor_visible(bounds.width);
 
-                    return EventResponse::Handled;
-                }
+                return EventResponse::Handled;
             }
             Event::MouseMove { x, y, .. } => {
                 let in_bounds = bounds.contains(*x, *y);
@@ -1139,27 +1139,22 @@ impl Widget for TextInput {
                     return EventResponse::Handled;
                 }
             }
-            Event::MouseUp { button, .. } => {
-                if *button == MouseButton::Left && self.is_dragging {
-                    self.is_dragging = false;
-                    return EventResponse::Handled;
-                }
+            Event::MouseUp { button, .. } if *button == MouseButton::Left && self.is_dragging => {
+                self.is_dragging = false;
+                return EventResponse::Handled;
             }
-            Event::KeyDown { key, modifiers } => {
-                if has_focus(id) {
-                    // Track key for repeat
-                    let now = Instant::now();
-                    self.pressed_key = Some((*key, *modifiers));
-                    self.key_press_time = now;
-                    self.last_repeat_time = now;
+            Event::KeyDown { key, modifiers } if has_focus(id) => {
+                // Track key for repeat
+                let now = Instant::now();
+                self.pressed_key = Some((*key, *modifiers));
+                self.key_press_time = now;
+                self.last_repeat_time = now;
 
-                    let response =
-                        self.handle_key(key, modifiers.ctrl, modifiers.shift, bounds.width);
-                    if response == EventResponse::Handled {
-                        request_job(id, JobRequest::Paint);
-                    }
-                    return response;
+                let response = self.handle_key(key, modifiers.ctrl, modifiers.shift, bounds.width);
+                if response == EventResponse::Handled {
+                    request_job(id, JobRequest::Paint);
                 }
+                return response;
             }
             Event::KeyUp { key, .. } => {
                 // Stop repeating when key is released
@@ -1169,19 +1164,15 @@ impl Widget for TextInput {
                     self.pressed_key = None;
                 }
             }
-            Event::FocusOut => {
-                if has_focus(id) {
-                    release_focus(id);
-                    self.cursor_visible = false;
-                    self.is_dragging = false;
-                    request_job(id, JobRequest::Paint);
-                }
+            Event::FocusOut if has_focus(id) => {
+                release_focus(id);
+                self.cursor_visible = false;
+                self.is_dragging = false;
+                request_job(id, JobRequest::Paint);
             }
-            Event::MouseLeave => {
-                if self.is_hovered {
-                    self.is_hovered = false;
-                    set_cursor(CursorIcon::Default);
-                }
+            Event::MouseLeave if self.is_hovered => {
+                self.is_hovered = false;
+                set_cursor(CursorIcon::Default);
             }
             _ => {}
         }

--- a/src/widgets/widget.rs
+++ b/src/widgets/widget.rs
@@ -341,6 +341,14 @@ impl From<f32> for Padding {
     }
 }
 
+/// Bare float literals default to f64; accepting them avoids the deprecated
+/// f32 inference fallback.
+impl From<f64> for Padding {
+    fn from(v: f64) -> Self {
+        Padding::all(v as f32)
+    }
+}
+
 impl From<u16> for Padding {
     fn from(v: u16) -> Self {
         Padding::all(f32::from(v))


### PR DESCRIPTION
Large internals rework driven by a full-repo architecture review. The public API is unchanged — every example compiles and renders identically (verified with screenshots for status_bar, scroll, transforms, text styling, and dynamic children).

## Correctness

- **Generational IDs actually generate.** Widget slot recycling restarted at generation 1 forever (register read the generation from a slot unregister had already cleared), so stale WidgetIds aliased live widgets after two recycles. SignalId/EffectId/OwnerId had no generations at all — stale Copy handles silently read/wrote whatever recycled their slot. All four are now generational with regression tests.
- **Effect chaining works.** Effect callbacks ran under the runtime RefCell borrow, so writes inside effects (including every memo update) were silently dropped. Callbacks now run with no borrow held (take/restore protocol with an effect state machine); chains become flush-loop iterations. Also fixed: memos created without an owner were disposed on creation.
- **Unwind safety.** All reactive scope state restores via Drop guards; a caught panic can no longer permanently stop every effect in the app (stuck batch depth) or corrupt tracking stacks. Panicking effects are restored and stay re-runnable.
- **Leak fixes** for the long-running-panel use case: owner arena slots are recycled, parents prune disposed children (the root owner previously grew one entry per widget ever created), and keyed reconciliation clears signal subscriptions of removed widgets.
- **Presentation:** damage is reported before present (it previously rode an empty second commit the compositor couldn't use), damage is per-surface (first surface rendered no longer steals all surfaces' damage), and a lost/outdated swapchain no longer clears dirty flags (stale content after resize).
- **Platform:** no more panics on ordinary conditions (GNOME without layer-shell, dropped connection → ExitReason::Error); wgpu surface now drops before the wl_surface it borrows (was a use-after-free); compositor-initiated close cleans up widgets/owner/GPU surface instead of leaking a zombie; clipboard sends can't block the UI thread.

## Performance / memory

- **Render-tree sharing:** the paint cache deep-cloned every repainted node's subtree every frame — O(n·depth) allocations, with the root always repainted. Subtrees are now Rc-shared: caching is a refcount bump, unchanged-position reuse is zero-copy, and the partial-paint flag now propagates to ancestors (closes the remaining cache-poisoning hole from #106).
- **Frame pacing:** rendering is driven by re-armed wl_surface.frame callbacks instead of blocking the event loop inside the Fifo swapchain. Measured: animating surface renders once per compositor frame; static status bar presents twice at startup then goes fully idle; the animation-job busy-spin (~45k loop iterations/s) is gone. MouseMove events coalesce.
- **Transform** is a 24-byte 2D affine instead of a 64-byte 4×4 (half of which was structurally constant); composition is 12 multiplies instead of 64.
- **Reactive hot path:** subscription re-registration (every tracked read, every frame) is one hash lookup instead of hash + two linear scans (was O(N²)/frame for widely-read signals); notify no longer allocates a snapshot per write; job buffers recycle capacity.
- **Text:** measurement now uses the same shaping as rendering (layout matches pixels); the measurement cache is bounded and allocation-free on lookup; TextInput cursor tables are built from one shaping pass instead of shaping every prefix per keystroke (was O(n²)); duplicate labels no longer re-shape every frame.
- **Deps:** resvg behind a default-on svg feature, webp/gif decoders opt-in, env_logger removed from the library, and create_service no longer panics without an ambient tokio runtime (lazy background runtime; regression test).

## Test plan

- 228 tests pass (209 unit + integration/doc), including new regression tests for ID aliasing, effect chaining, panic recovery, ownerless services, and owner pruning.
- cargo clippy --all-targets --all-features: no new warnings; builds clean with --no-default-features.
- Visual verification on Wayland (grim screenshots): status bar, scroll (culling/clipping), transforms (rotation/scale/origins), text styling, dynamic children, animations (springs settle, app goes idle).
