### PR TITLE
Multi-output support: reactive outputs(), surface pinning, creation margins

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -382,6 +382,7 @@ This is a work-in-progress GUI library. Current implemented features:
 - Mouse event handling with proper transform hit testing
 - Multi-surface support with shared reactive state
 - Dynamic surface property modification (layer, keyboard interactivity, anchor, size, margins)
+- Multi-output support: reactive `outputs()` enumeration, per-output surface pinning, `surface_output()` tracking
 - Text input widget with full editing support
 - Image widget with raster and SVG support
 

--- a/book/src/advanced/wayland.md
+++ b/book/src/advanced/wayland.md
@@ -350,6 +350,109 @@ App::new().run(|app| {
 });
 ```
 
+## Multiple Outputs (Monitors)
+
+Connected outputs are exposed as a reactive list. Reading it inside a
+tracked closure (an effect, a dynamic child, a reactive property)
+re-runs the closure when monitors are plugged in, unplugged, or
+reconfigured:
+
+```rust
+use guido::prelude::*;
+
+create_effect(move || {
+    for info in outputs().get() {
+        println!(
+            "{:?}: {:?} {} ({}x{:?})",
+            info.id, info.name, info.model, info.scale_factor, info.logical_size
+        );
+    }
+});
+```
+
+Each `OutputInfo` carries a stable `OutputId` plus the connector name
+(`"DP-1"`, `"eDP-1"`, …), description, make/model, integer scale factor,
+and logical size/position when the compositor reports them. Ids are never
+reused: a monitor that is unplugged and reconnected gets a fresh id.
+
+### Pinning a Surface to an Output
+
+By default the compositor picks the output a surface appears on. Pass an
+`OutputId` to pin it:
+
+```rust
+spawn_surface(
+    SurfaceConfig::new()
+        .height(32)
+        .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+        .output(info.id),
+    move || bar_widget(),
+);
+```
+
+The output cannot be changed after creation — a layer surface is bound to
+its output for its lifetime. If the output disconnects before the surface
+is created, the compositor chooses one instead (a warning is logged).
+
+### One Bar per Monitor
+
+An app can start with **zero surfaces** and spawn one per output from an
+effect — the classic multi-monitor status bar. See
+`examples/multi_output.rs` for the full version:
+
+```rust
+App::new().run(|_app| {
+    let bars: Rc<RefCell<HashMap<OutputId, SurfaceHandle>>> =
+        Rc::new(RefCell::new(HashMap::new()));
+
+    create_effect(move || {
+        let current = outputs().get();
+        let mut bars = bars.borrow_mut();
+
+        // Drop bars for disconnected outputs
+        bars.retain(|id, handle| {
+            let alive = current.iter().any(|o| o.id == *id);
+            if !alive {
+                handle.close();
+            }
+            alive
+        });
+
+        // Spawn a bar on every new output
+        for info in current {
+            if !bars.contains_key(&info.id) {
+                let handle = spawn_surface(
+                    SurfaceConfig::new().height(32).output(info.id),
+                    move || bar_widget(),
+                );
+                bars.insert(info.id, handle);
+            }
+        }
+    });
+});
+```
+
+When the compositor closes the surfaces of an unplugged monitor, the
+bars keep working on the remaining outputs. Note that the app exits when
+its last surface closes, so an all-monitors-disconnected event ends the
+app.
+
+### Tracking Which Output a Surface Is On
+
+`surface_output(surface_id)` reports the output a surface is currently
+shown on (`None` until the compositor maps it). It is a tracked read —
+reactive inside any tracked closure:
+
+```rust
+text(move || match surface_output(my_surface_id) {
+    Some(out) => format!("shown on output {}", out.raw()),
+    None => "not mapped yet".to_string(),
+})
+```
+
+For a surface spanning multiple outputs, this reports the one entered
+most recently.
+
 ## Complete Examples
 
 ### Status Bar
@@ -458,6 +561,29 @@ impl SurfaceConfig {
     pub fn exclusive_zone(self, zone: Option<i32>) -> Self;
     pub fn namespace(self, namespace: impl Into<String>) -> Self;
     pub fn background_color(self, color: Color) -> Self;
+    pub fn margin(self, top: i32, right: i32, bottom: i32, left: i32) -> Self;
+    pub fn output(self, output: OutputId) -> Self;
+}
+```
+
+### Outputs
+
+```rust
+/// Reactive list of connected outputs, sorted by id
+pub fn outputs() -> Signal<Vec<OutputInfo>>;
+
+/// The output a surface is currently shown on (tracked read)
+pub fn surface_output(id: SurfaceId) -> Option<OutputId>;
+
+pub struct OutputInfo {
+    pub id: OutputId,
+    pub name: Option<String>,        // connector, e.g. "DP-1"
+    pub description: Option<String>,
+    pub make: String,
+    pub model: String,
+    pub scale_factor: i32,
+    pub logical_size: Option<(i32, i32)>,
+    pub logical_position: Option<(i32, i32)>,
 }
 ```
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -161,7 +161,10 @@ Layer shell protocol implementation for desktop widgets.
 - Layer shell positioning (Top, Bottom, Overlay, Background)
 - Anchor edges (TOP, BOTTOM, LEFT, RIGHT combinations)
 - Keyboard interactivity modes (None, OnDemand, Exclusive)
-- Exclusive zones for panels
+- Exclusive zones and margins for panels
+- Reactive output (monitor) enumeration via `outputs()`, per-output surface
+  pinning via `SurfaceConfig::output`, per-surface output tracking via
+  `surface_output()` (see `src/outputs.rs`)
 - Event loop via calloop
 - Dynamic surface property modification via `SurfaceHandle`
 

--- a/examples/multi_output.rs
+++ b/examples/multi_output.rs
@@ -1,0 +1,86 @@
+//! One bar per connected monitor, reacting to hotplug.
+//!
+//! The app starts with zero surfaces: an effect reads the reactive
+//! `outputs()` list and spawns a bar pinned to each monitor via
+//! `SurfaceConfig::output`. Plugging a monitor in creates its bar,
+//! unplugging it removes it (the compositor closes the surface; the
+//! effect also drops its handle).
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use guido::prelude::*;
+
+fn main() {
+    env_logger::init();
+
+    App::new().run(|_app| {
+        let bars: Rc<RefCell<HashMap<OutputId, SurfaceHandle>>> =
+            Rc::new(RefCell::new(HashMap::new()));
+
+        create_effect(move || {
+            let current = outputs().get();
+            let mut bars = bars.borrow_mut();
+
+            // Close bars whose output disappeared (usually already closed by
+            // the compositor — this just keeps the map tidy)
+            bars.retain(|id, handle| {
+                let alive = current.iter().any(|o| o.id == *id);
+                if !alive {
+                    handle.close();
+                }
+                alive
+            });
+
+            // Spawn a bar on every newly connected output
+            for info in current {
+                if bars.contains_key(&info.id) {
+                    continue;
+                }
+
+                let label = info
+                    .name
+                    .clone()
+                    .unwrap_or_else(|| format!("output-{}", info.id.raw()));
+                let model = info.model.clone();
+                let surface_id = Rc::new(RefCell::new(None::<SurfaceId>));
+                let surface_id_for_widget = surface_id.clone();
+
+                let handle = spawn_surface(
+                    SurfaceConfig::new()
+                        .height(32)
+                        .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+                        .layer(Layer::Top)
+                        .namespace("guido-multi-output")
+                        .output(info.id),
+                    move || {
+                        let my_id = surface_id_for_widget.borrow().unwrap();
+                        container()
+                            .layout(
+                                Flex::row()
+                                    .spacing(8.0)
+                                    .cross_alignment(CrossAlignment::Center)
+                                    .main_alignment(MainAlignment::SpaceBetween),
+                            )
+                            .padding(8.0)
+                            .child(text(format!("{label} — {model}")))
+                            .child(text(move || {
+                                // Reactive reads: re-renders on hotplug and
+                                // when the compositor maps the surface
+                                let total = outputs().get().len();
+                                match surface_output(my_id) {
+                                    Some(out) => {
+                                        format!("on output {} of {total}", out.raw())
+                                    }
+                                    None => format!("{total} output(s)"),
+                                }
+                            }))
+                    },
+                );
+                *surface_id.borrow_mut() = Some(handle.id());
+                bars.insert(info.id, handle);
+            }
+        });
+    });
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod image_metadata;
 mod ingress;
 mod jobs;
 pub mod layout;
+pub mod outputs;
 pub mod reactive;
 pub mod render_stats;
 pub mod surface;
@@ -135,6 +136,7 @@ pub mod prelude {
         Axis, Constraints, CrossAlignment, Flex, IntoF32, Length, MainAlignment, Overlay, Size,
         at_least, at_most, fill,
     };
+    pub use crate::outputs::{OutputId, OutputInfo, outputs, surface_output};
     pub use crate::platform::{Anchor, KeyboardInteractivity, Layer};
     pub use crate::reactive::{
         CursorIcon, Memo, OptionSignalExt, RwSignal, Service, Signal, WriteSignal, create_derived,
@@ -697,7 +699,14 @@ impl App {
         setup(&mut self);
 
         if self.surface_definitions.is_empty() {
-            panic!("No surfaces defined. Use add_surface() to add at least one surface.");
+            // Not an error: outputs-driven apps start with zero surfaces and
+            // spawn one per monitor from an effect once the compositor
+            // reports its outputs. An app that never spawns anything will
+            // just idle in the event loop.
+            log::info!(
+                "No static surfaces defined; waiting for dynamic surfaces \
+                 (spawn_surface, e.g. from an outputs() effect)"
+            );
         }
 
         let (connection, mut event_queue, mut wayland_state, qh) = match create_wayland_app() {
@@ -769,8 +778,6 @@ impl App {
 
             surface_manager.add(managed);
         }
-
-        let mut renderer = renderer.expect("At least one surface should exist");
 
         // Create calloop event loop for event-driven execution
         let mut event_loop: EventLoop<platform::WaylandState> =
@@ -874,6 +881,19 @@ impl App {
                 &mut self.tree,
             );
 
+            // Lazily create the shared renderer once the first surface has a
+            // GPU state (apps may start with zero surfaces and spawn them
+            // dynamically, e.g. one bar per output).
+            if renderer.is_none()
+                && let Some(wgpu_surface) = surface_manager.first_gpu_surface()
+            {
+                renderer = Some(Renderer::new(
+                    wgpu_surface.device.clone(),
+                    wgpu_surface.queue.clone(),
+                    wgpu_surface.config.format,
+                ));
+            }
+
             // Flush background-thread signal writes once per frame (queued via WriteSignal).
             // Must run before take_frame_request() so that signal changes from bg writes
             // are processed into jobs before we check the frame request flag.
@@ -882,23 +902,26 @@ impl App {
             // Check frame request once for all surfaces (not per-surface)
             let frame_requested = take_frame_request();
 
-            // Render each surface
-            let surface_ids: Vec<SurfaceId> = surface_manager.ids().collect();
-            for id in surface_ids {
-                let Some(surface) = surface_manager.get_mut(id) else {
-                    continue;
-                };
-                render_surface(
-                    id,
-                    surface,
-                    &mut wayland_state,
-                    &mut renderer,
-                    &connection,
-                    &qh,
-                    &mut self.tree,
-                    &mut self.layout_roots,
-                    frame_requested,
-                );
+            // Render each surface (no renderer yet means no surface has a
+            // GPU state — nothing can be rendered this iteration)
+            if let Some(renderer) = renderer.as_mut() {
+                let surface_ids: Vec<SurfaceId> = surface_manager.ids().collect();
+                for id in surface_ids {
+                    let Some(surface) = surface_manager.get_mut(id) else {
+                        continue;
+                    };
+                    render_surface(
+                        id,
+                        surface,
+                        &mut wayland_state,
+                        renderer,
+                        &connection,
+                        &qh,
+                        &mut self.tree,
+                        &mut self.layout_roots,
+                        frame_requested,
+                    );
+                }
             }
 
             // Flush the connection once for all surfaces
@@ -932,6 +955,7 @@ impl Drop for App {
         ingress::reset_ingress();
         surface::reset_surface_commands();
         widget_ref::reset_widget_refs();
+        outputs::reset_outputs();
         FONTS_CONSUMED.with(|f| f.set(false));
     }
 }

--- a/src/outputs.rs
+++ b/src/outputs.rs
@@ -1,0 +1,157 @@
+//! Output (monitor) enumeration and per-surface output tracking.
+//!
+//! The compositor's outputs are exposed as a reactive list: read it inside any
+//! tracked closure (effects, dynamic children, reactive properties) and the
+//! closure re-runs when monitors are added, removed, or reconfigured.
+//!
+//! ```ignore
+//! // One bar per monitor, reacting to hotplug:
+//! create_effect(move || {
+//!     for info in outputs().get() {
+//!         spawn_surface(
+//!             SurfaceConfig::new().height(32).output(info.id),
+//!             move || bar_widget(),
+//!         );
+//!     }
+//! });
+//! ```
+//!
+//! `surface_output(id)` reports which output a surface is currently shown on
+//! (tracked read — reactive when called inside a tracked closure).
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+use crate::reactive::{RwSignal, Signal, create_signal};
+use crate::surface::SurfaceId;
+
+/// Stable identifier for a connected output (monitor).
+///
+/// Ids are unique for the lifetime of the app and never reused: an output
+/// that is unplugged and reconnected gets a fresh id.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct OutputId(u32);
+
+impl OutputId {
+    pub(crate) fn from_raw(raw: u32) -> Self {
+        Self(raw)
+    }
+
+    /// Get the raw id value (for debugging/logging).
+    pub fn raw(&self) -> u32 {
+        self.0
+    }
+}
+
+/// Information about a connected output (monitor).
+#[derive(Debug, Clone, PartialEq)]
+pub struct OutputInfo {
+    /// Stable identifier, usable with [`crate::surface::SurfaceConfig::output`].
+    pub id: OutputId,
+    /// Connector name such as `"DP-1"` or `"eDP-1"`. `None` when the
+    /// compositor doesn't support wl_output v4.
+    pub name: Option<String>,
+    /// Human-readable description such as `"Dell U2720Q"`.
+    pub description: Option<String>,
+    /// Monitor manufacturer as advertised by the server.
+    pub make: String,
+    /// Monitor model as advertised by the server.
+    pub model: String,
+    /// Integer scale factor of the output.
+    pub scale_factor: i32,
+    /// Logical size in compositor coordinates, if known.
+    pub logical_size: Option<(i32, i32)>,
+    /// Logical position in the global compositor space, if known.
+    pub logical_position: Option<(i32, i32)>,
+}
+
+thread_local! {
+    /// Reactive list of connected outputs. Lazily created so it works both
+    /// before and after platform init; wiped by `reset_outputs()`.
+    static OUTPUTS: RefCell<Option<RwSignal<Vec<OutputInfo>>>> = const { RefCell::new(None) };
+
+    /// Which output each surface is currently shown on (latest entered).
+    static SURFACE_OUTPUTS: RefCell<Option<RwSignal<HashMap<SurfaceId, OutputId>>>> =
+        const { RefCell::new(None) };
+}
+
+fn outputs_signal() -> RwSignal<Vec<OutputInfo>> {
+    OUTPUTS.with(|cell| {
+        *cell
+            .borrow_mut()
+            .get_or_insert_with(|| create_signal(Vec::new()))
+    })
+}
+
+fn surface_outputs_signal() -> RwSignal<HashMap<SurfaceId, OutputId>> {
+    SURFACE_OUTPUTS.with(|cell| {
+        *cell
+            .borrow_mut()
+            .get_or_insert_with(|| create_signal(HashMap::new()))
+    })
+}
+
+/// Reactive list of connected outputs (monitors), sorted by [`OutputId`].
+///
+/// Reading the returned signal inside a tracked closure subscribes it to
+/// monitor hotplug and configuration changes.
+pub fn outputs() -> Signal<Vec<OutputInfo>> {
+    outputs_signal().read_only()
+}
+
+/// The output a surface is currently shown on (tracked read).
+///
+/// Returns `None` until the compositor maps the surface onto an output. For a
+/// surface spanning multiple outputs this reports the one entered most
+/// recently. Reactive when called inside a tracked closure.
+pub fn surface_output(id: SurfaceId) -> Option<OutputId> {
+    surface_outputs_signal().with(|m| m.get(&id).copied())
+}
+
+/// Replace the reactive output list. Called by the platform layer whenever
+/// the compositor adds, removes, or reconfigures an output.
+pub(crate) fn sync_outputs(list: Vec<OutputInfo>) {
+    outputs_signal().set(list);
+}
+
+/// Record that `surface` entered `output`. Called by the platform layer.
+pub(crate) fn surface_entered_output(surface: SurfaceId, output: OutputId) {
+    surface_outputs_signal().update(|m| {
+        m.insert(surface, output);
+    });
+}
+
+/// Record that `surface` left `output`. Only clears the entry if that output
+/// is still the current one (a surface spanning two outputs enters the second
+/// before leaving the first).
+pub(crate) fn surface_left_output(surface: SurfaceId, output: OutputId) {
+    surface_outputs_signal().update(|m| {
+        if m.get(&surface) == Some(&output) {
+            m.remove(&surface);
+        }
+    });
+}
+
+/// Drop all tracking for a surface (closed) or an output (disconnected
+/// without per-surface leave events).
+pub(crate) fn surface_closed(surface: SurfaceId) {
+    surface_outputs_signal().update(|m| {
+        m.remove(&surface);
+    });
+}
+
+/// Remove entries pointing at a destroyed output.
+pub(crate) fn output_removed(output: OutputId) {
+    surface_outputs_signal().update(|m| {
+        m.retain(|_, o| *o != output);
+    });
+}
+
+/// Reset output state.
+///
+/// Called during `App::drop()`; the signals themselves die with the reactive
+/// storage reset, this just drops the stale handles.
+pub(crate) fn reset_outputs() {
+    OUTPUTS.with(|cell| *cell.borrow_mut() = None);
+    SURFACE_OUTPUTS.with(|cell| *cell.borrow_mut() = None);
+}

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -47,6 +47,7 @@ use std::io::{Read, Write};
 use std::os::fd::AsFd;
 use std::os::unix::io::OwnedFd;
 
+use crate::outputs::{self, OutputId, OutputInfo};
 use crate::reactive::CursorIcon;
 use crate::surface::SurfaceId;
 use crate::widgets::{Event, Key, Modifiers, MouseButton, ScrollSource};
@@ -127,6 +128,13 @@ pub struct WaylandState {
     pub current_pointer_surface: Option<SurfaceId>,
     /// Which surface currently has keyboard focus
     pub current_keyboard_surface: Option<SurfaceId>,
+
+    // Output tracking
+    /// Stable OutputId for each wl_output global. Ids are never reused: a
+    /// reconnected monitor gets a fresh id.
+    output_ids: HashMap<ObjectId, OutputId>,
+    /// Next OutputId to allocate.
+    next_output_id: u32,
 
     // Pointer state
     pointer: Option<wl_pointer::WlPointer>,
@@ -247,6 +255,8 @@ pub fn create_wayland_app() -> Result<
         surface_lookup: HashMap::new(),
         current_pointer_surface: None,
         current_keyboard_surface: None,
+        output_ids: HashMap::new(),
+        next_output_id: 0,
         pointer: None,
         pointer_x: 0.0,
         pointer_y: 0.0,
@@ -269,6 +279,49 @@ pub fn create_wayland_app() -> Result<
 }
 
 impl WaylandState {
+    /// Get (or allocate) the stable OutputId for a wl_output.
+    fn ensure_output_id(&mut self, output: &wl_output::WlOutput) -> OutputId {
+        let object_id = output.id();
+        if let Some(id) = self.output_ids.get(&object_id) {
+            return *id;
+        }
+        let id = OutputId::from_raw(self.next_output_id);
+        self.next_output_id += 1;
+        self.output_ids.insert(object_id, id);
+        id
+    }
+
+    /// Find the wl_output for a stable OutputId, if still connected.
+    fn wl_output_for(&self, id: OutputId) -> Option<wl_output::WlOutput> {
+        self.output_state
+            .outputs()
+            .find(|o| self.output_ids.get(&o.id()) == Some(&id))
+    }
+
+    /// Rebuild the reactive output list from current compositor state.
+    fn sync_outputs(&mut self) {
+        let wl_outputs: Vec<wl_output::WlOutput> = self.output_state.outputs().collect();
+        let mut list: Vec<OutputInfo> = wl_outputs
+            .iter()
+            .filter_map(|o| {
+                let id = self.ensure_output_id(o);
+                let info = self.output_state.info(o)?;
+                Some(OutputInfo {
+                    id,
+                    name: info.name,
+                    description: info.description,
+                    make: info.make,
+                    model: info.model,
+                    scale_factor: info.scale_factor,
+                    logical_size: info.logical_size,
+                    logical_position: info.logical_position,
+                })
+            })
+            .collect();
+        list.sort_by_key(|o| o.id);
+        outputs::sync_outputs(list);
+    }
+
     /// Create a layer surface with a specific SurfaceId.
     pub fn create_surface_with_id(
         &mut self,
@@ -276,13 +329,28 @@ impl WaylandState {
         id: SurfaceId,
         config: &crate::surface::SurfaceConfig,
     ) {
+        // Resolve the requested output; fall back to letting the compositor
+        // choose if it was disconnected in the meantime.
+        let target_output = config.output.and_then(|oid| {
+            let found = self.wl_output_for(oid);
+            if found.is_none() {
+                log::warn!(
+                    "Surface {:?} requested output {:?} which is not connected; \
+                     letting the compositor choose",
+                    id,
+                    oid
+                );
+            }
+            found
+        });
+
         let wl_surface = self.compositor_state.create_surface(qh);
         let layer_surface = self.layer_shell.create_layer_surface(
             qh,
             wl_surface.clone(),
             config.layer,
             Some(config.namespace.clone()),
-            None,
+            target_output.as_ref(),
         );
 
         layer_surface.set_anchor(config.anchor);
@@ -308,6 +376,11 @@ impl WaylandState {
         // Set exclusive zone: None means use height, Some(0) means no exclusive zone
         let zone = config.exclusive_zone.unwrap_or(config.height as i32);
         layer_surface.set_exclusive_zone(zone);
+
+        let (top, right, bottom, left) = config.margin;
+        if (top, right, bottom, left) != (0, 0, 0, 0) {
+            layer_surface.set_margin(top, right, bottom, left);
+        }
 
         wl_surface.commit();
 
@@ -345,6 +418,9 @@ impl WaylandState {
             if self.current_keyboard_surface == Some(id) {
                 self.current_keyboard_surface = None;
             }
+
+            // Drop reactive output tracking for the closed surface
+            outputs::surface_closed(id);
 
             // The LayerSurface and WlSurface will be destroyed when dropped
             log::info!("Destroyed surface {:?}", id);
@@ -679,18 +755,29 @@ impl CompositorHandler for WaylandState {
         &mut self,
         _conn: &Connection,
         _qh: &QueueHandle<Self>,
-        _surface: &wl_surface::WlSurface,
-        _output: &wl_output::WlOutput,
+        surface: &wl_surface::WlSurface,
+        output: &wl_output::WlOutput,
     ) {
+        if let Some(surface_id) = self.surface_lookup.get(&surface.id()).copied() {
+            let output_id = self.ensure_output_id(output);
+            log::debug!("Surface {:?} entered output {:?}", surface_id, output_id);
+            outputs::surface_entered_output(surface_id, output_id);
+        }
     }
 
     fn surface_leave(
         &mut self,
         _conn: &Connection,
         _qh: &QueueHandle<Self>,
-        _surface: &wl_surface::WlSurface,
-        _output: &wl_output::WlOutput,
+        surface: &wl_surface::WlSurface,
+        output: &wl_output::WlOutput,
     ) {
+        if let Some(surface_id) = self.surface_lookup.get(&surface.id()).copied()
+            && let Some(output_id) = self.output_ids.get(&output.id()).copied()
+        {
+            log::debug!("Surface {:?} left output {:?}", surface_id, output_id);
+            outputs::surface_left_output(surface_id, output_id);
+        }
     }
 
     fn frame(
@@ -729,8 +816,15 @@ impl OutputHandler for WaylandState {
         &mut self,
         _conn: &Connection,
         _qh: &QueueHandle<Self>,
-        _output: wl_output::WlOutput,
+        output: wl_output::WlOutput,
     ) {
+        let id = self.ensure_output_id(&output);
+        log::info!(
+            "Output {:?} connected: {:?}",
+            id,
+            self.output_state.info(&output).and_then(|i| i.name)
+        );
+        self.sync_outputs();
     }
 
     fn update_output(
@@ -739,14 +833,20 @@ impl OutputHandler for WaylandState {
         _qh: &QueueHandle<Self>,
         _output: wl_output::WlOutput,
     ) {
+        self.sync_outputs();
     }
 
     fn output_destroyed(
         &mut self,
         _conn: &Connection,
         _qh: &QueueHandle<Self>,
-        _output: wl_output::WlOutput,
+        output: wl_output::WlOutput,
     ) {
+        if let Some(id) = self.output_ids.remove(&output.id()) {
+            log::info!("Output {:?} disconnected", id);
+            outputs::output_removed(id);
+        }
+        self.sync_outputs();
     }
 }
 

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -38,6 +38,7 @@
 use std::cell::RefCell;
 use std::sync::atomic::{AtomicU64, Ordering};
 
+use crate::outputs::OutputId;
 use crate::platform::{Anchor, KeyboardInteractivity, Layer};
 use crate::widgets::{Color, Widget};
 
@@ -90,6 +91,10 @@ pub struct SurfaceConfig {
     pub background_color: Color,
     /// Exclusive zone (reserves screen space). None means use height.
     pub exclusive_zone: Option<i32>,
+    /// Margins from the anchored screen edges (top, right, bottom, left).
+    pub margin: (i32, i32, i32, i32),
+    /// Output (monitor) to show the surface on. None lets the compositor choose.
+    pub output: Option<OutputId>,
 }
 
 impl Default for SurfaceConfig {
@@ -103,6 +108,8 @@ impl Default for SurfaceConfig {
             namespace: "guido-surface".to_string(),
             background_color: Color::rgb(0.1, 0.1, 0.15),
             exclusive_zone: None,
+            margin: (0, 0, 0, 0),
+            output: None,
         }
     }
 }
@@ -163,6 +170,25 @@ impl SurfaceConfig {
     /// - `KeyboardInteractivity::Exclusive`: Surface grabs keyboard focus exclusively.
     pub fn keyboard_interactivity(mut self, mode: KeyboardInteractivity) -> Self {
         self.keyboard_interactivity = mode;
+        self
+    }
+
+    /// Set the margins from the anchored screen edges, applied at creation.
+    ///
+    /// Use `SurfaceHandle::set_margin` to change them at runtime.
+    pub fn margin(mut self, top: i32, right: i32, bottom: i32, left: i32) -> Self {
+        self.margin = (top, right, bottom, left);
+        self
+    }
+
+    /// Pin the surface to a specific output (monitor).
+    ///
+    /// Get output ids from the reactive [`crate::outputs::outputs`] list. If
+    /// the output is disconnected before the surface is created, the
+    /// compositor chooses one instead. The output cannot be changed after
+    /// creation (a layer surface is bound to its output for its lifetime).
+    pub fn output(mut self, output: OutputId) -> Self {
+        self.output = Some(output);
         self
     }
 }

--- a/src/surface_manager.rs
+++ b/src/surface_manager.rs
@@ -171,6 +171,14 @@ impl SurfaceManager {
         self.surfaces.is_empty()
     }
 
+    /// First initialized wgpu surface, if any.
+    ///
+    /// Used to create the shared `Renderer` lazily: apps may start with zero
+    /// surfaces and spawn them dynamically (e.g. one bar per output).
+    pub fn first_gpu_surface(&self) -> Option<&SurfaceState> {
+        self.surfaces.values().find_map(|s| s.wgpu_surface.as_ref())
+    }
+
     /// Initialize GPU for surfaces that need it.
     ///
     /// This iterates over all surfaces and initializes GPU for any


### PR DESCRIPTION
## Summary

First feature PR of the Wayland parity series, now stacked on **#116** (loop-ingress foundation — merge that first; GitHub retargets this to `main`).

- **New `src/outputs.rs`**: connected monitors exposed as a reactive list — `outputs() -> Signal<Vec<OutputInfo>>` (stable `OutputId`, connector name, description, make/model, scale factor, logical size/position). The previously-stubbed `OutputHandler` now maintains it on hotplug and reconfiguration.
- **`surface_output(SurfaceId)`**: tracked read of the output a surface is currently mapped on, driven by `wl_surface` enter/leave (previously empty stubs).
- **`SurfaceConfig::output(OutputId)`**: pin a layer surface to a monitor — the `wl_output` is finally passed to `get_layer_surface` instead of the hardcoded `None`. Falls back to compositor choice (with a warning) if the output disconnected.
- **`SurfaceConfig::margin(t, r, b, l)`**: margins at creation, no more post-creation `SurfaceHandle::set_margin` reposition.
- **Zero-surface startup**: `App::run` no longer panics without static surfaces; the renderer is created lazily from the first GPU-ready surface. This enables the canonical multi-monitor pattern — an effect that spawns one bar per output (see `examples/multi_output.rs`).

This is also a prerequisite for session-lock support (`ext-session-lock-v1` needs one lock surface per output).

## Testing

- 213+ lib tests pass; clippy 1.97.1 `--all-targets --all-features -D warnings` clean; `cargo fmt` clean; book builds.
- `examples/multi_output.rs` run on niri: starts with zero surfaces, detects `eDP-1`, spawns a pinned bar, `surface_output()` reports the mapping (verified with screenshot).
