### PR TITLE
Input regions: clickable rectangles and click-through surfaces

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -383,6 +383,7 @@ This is a work-in-progress GUI library. Current implemented features:
 - Multi-surface support with shared reactive state
 - Dynamic surface property modification (layer, keyboard interactivity, anchor, size, margins)
 - Multi-output support: reactive `outputs()` enumeration, per-output surface pinning, `surface_output()` tracking
+- Input regions: per-surface clickable rectangles / click-through surfaces (`input_region`, `click_through`, `set_input_region`)
 - Text input widget with full editing support
 - Image widget with raster and SVG support
 

--- a/book/src/advanced/wayland.md
+++ b/book/src/advanced/wayland.md
@@ -453,6 +453,50 @@ text(move || match surface_output(my_surface_id) {
 For a surface spanning multiple outputs, this reports the one entered
 most recently.
 
+## Input Regions
+
+By default the whole surface accepts pointer and touch input. An input
+region limits input to a set of rectangles (logical surface
+coordinates) — everything outside them lets clicks pass through to the
+windows below. This is how transparent overlays avoid stealing clicks:
+
+```rust
+// Only the given rectangle is clickable:
+SurfaceConfig::new()
+    .background_color(Color::TRANSPARENT)
+    .input_region([Rect::new(16.0, 20.0, 200.0, 40.0)])
+
+// Fully click-through (e.g. a HUD or wallpaper widget):
+SurfaceConfig::new().click_through()
+```
+
+At runtime, use the handle — `None` restores full-surface input, an
+empty list is fully click-through:
+
+```rust
+surface_handle(id).set_input_region(Some(vec![rect]));
+surface_handle(id).set_input_region(None);
+```
+
+The idiomatic pattern glues the region to a widget's bounds with a
+`WidgetRef`, so it follows layout changes automatically (full version
+in `examples/input_region.rs`):
+
+```rust
+let pill_ref = create_widget_ref();
+// ...build the surface with .click_through() and .widget_ref(pill_ref)...
+
+create_effect(move || {
+    let rect = pill_ref.rect().get();
+    if rect.width > 0.0 {
+        surface_handle(id).set_input_region(Some(vec![rect]));
+    }
+});
+```
+
+Note: keyboard focus is unaffected — use `keyboard_interactivity` for
+that. Rectangles are rounded outward to whole pixels.
+
 ## Complete Examples
 
 ### Status Bar
@@ -563,6 +607,8 @@ impl SurfaceConfig {
     pub fn background_color(self, color: Color) -> Self;
     pub fn margin(self, top: i32, right: i32, bottom: i32, left: i32) -> Self;
     pub fn output(self, output: OutputId) -> Self;
+    pub fn input_region(self, rects: impl Into<Vec<Rect>>) -> Self;
+    pub fn click_through(self) -> Self;
 }
 ```
 
@@ -625,5 +671,6 @@ impl SurfaceHandle {
     pub fn set_size(&self, width: u32, height: u32);
     pub fn set_exclusive_zone(&self, zone: i32);
     pub fn set_margin(&self, top: i32, right: i32, bottom: i32, left: i32);
+    pub fn set_input_region(&self, rects: Option<Vec<Rect>>);
 }
 ```

--- a/examples/input_region.rs
+++ b/examples/input_region.rs
@@ -1,0 +1,63 @@
+//! Click-through overlay: only the centered pill accepts input.
+//!
+//! The surface spans the whole top edge without reserving space, but its
+//! input region is glued to the pill's bounds via a `WidgetRef` — clicks
+//! anywhere else pass through to the windows below.
+
+use guido::prelude::*;
+
+fn main() {
+    env_logger::init();
+
+    App::new().run(|app| {
+        let pill_ref = create_widget_ref();
+        let count = create_signal(0);
+
+        let id = app.add_surface(
+            SurfaceConfig::new()
+                .height(80)
+                .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+                .layer(Layer::Overlay)
+                .exclusive_zone(Some(0))
+                .background_color(Color::TRANSPARENT)
+                // Start fully click-through; the effect below narrows the
+                // region to the pill once it has been laid out.
+                .click_through(),
+            move || {
+                container()
+                    .width(fill())
+                    .height(fill())
+                    .layout(
+                        Flex::row()
+                            .main_alignment(MainAlignment::Center)
+                            .cross_alignment(CrossAlignment::Center),
+                    )
+                    .child(
+                        container()
+                            .widget_ref(pill_ref)
+                            .padding([10.0, 24.0])
+                            .background(Color::rgba(0.15, 0.15, 0.25, 0.95))
+                            .corner_radius(20.0)
+                            .hover_state(|s| s.lighter(0.1))
+                            .pressed_state(|s| s.ripple())
+                            .on_click(move || count.update(|c| *c += 1))
+                            .child(text(move || {
+                                format!(
+                                    "Clicks: {} — everything around me passes through",
+                                    count.get()
+                                )
+                            })),
+                    )
+            },
+        );
+
+        // Keep the input region glued to the pill's bounds (re-runs whenever
+        // layout moves or resizes it).
+        create_effect(move || {
+            let rect = pill_ref.rect().get();
+            if rect.width > 0.0 {
+                surface_handle(id).set_input_region(Some(vec![rect]));
+            }
+        });
+    });
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,6 +247,9 @@ fn process_surface_commands(
             } => {
                 wayland_state.set_surface_margin(id, top, right, bottom, left);
             }
+            SurfaceCommand::SetInputRegion { id, rects } => {
+                wayland_state.set_surface_input_region(id, rects.as_deref());
+            }
         }
     }
     true

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -3,7 +3,7 @@ use raw_window_handle::{
     RawWindowHandle, WaylandDisplayHandle, WaylandWindowHandle, WindowHandle,
 };
 use smithay_client_toolkit::{
-    compositor::{CompositorHandler, CompositorState},
+    compositor::{CompositorHandler, CompositorState, Region},
     data_device_manager::{
         data_device::{DataDevice, DataDeviceHandler},
         data_offer::{DataOfferHandler, SelectionOffer},
@@ -50,7 +50,7 @@ use std::os::unix::io::OwnedFd;
 use crate::outputs::{self, OutputId, OutputInfo};
 use crate::reactive::CursorIcon;
 use crate::surface::SurfaceId;
-use crate::widgets::{Event, Key, Modifiers, MouseButton, ScrollSource};
+use crate::widgets::{Event, Key, Modifiers, MouseButton, Rect, ScrollSource};
 
 /// Pixels per line for discrete scroll (mouse wheel)
 const SCROLL_PIXELS_PER_LINE: f32 = 40.0;
@@ -298,6 +298,56 @@ impl WaylandState {
             .find(|o| self.output_ids.get(&o.id()) == Some(&id))
     }
 
+    /// Build a wl_region from logical-coordinate rects, rounded outward so a
+    /// fractional widget bound never loses its edge pixels.
+    fn build_region(&self, rects: &[Rect]) -> Option<Region> {
+        let region = Region::new(&self.compositor_state)
+            .map_err(|e| log::warn!("Failed to create wl_region: {e}"))
+            .ok()?;
+        for r in rects {
+            let x = r.x.floor() as i32;
+            let y = r.y.floor() as i32;
+            let width = (r.x + r.width).ceil() as i32 - x;
+            let height = (r.y + r.height).ceil() as i32 - y;
+            region.add(x, y, width, height);
+        }
+        Some(region)
+    }
+
+    /// Apply an input region to a wl_surface. `None` restores the default
+    /// (the whole surface accepts input); an empty slice is fully
+    /// click-through.
+    ///
+    /// The `Region` is dropped (and the wl_region destroyed) right away:
+    /// the protocol copies the region state at `set_input_region` time.
+    fn apply_input_region(&self, wl_surface: &wl_surface::WlSurface, rects: Option<&[Rect]>) {
+        match rects {
+            None => wl_surface.set_input_region(None),
+            Some(rects) => {
+                let Some(region) = self.build_region(rects) else {
+                    return;
+                };
+                wl_surface.set_input_region(Some(region.wl_region()));
+            }
+        }
+    }
+
+    /// Set the input region for a surface at runtime.
+    pub fn set_surface_input_region(&mut self, id: SurfaceId, rects: Option<&[Rect]>) {
+        if let Some(surface_state) = self.surfaces.get(&id) {
+            self.apply_input_region(&surface_state.wl_surface, rects);
+            surface_state.wl_surface.commit();
+            log::info!(
+                "Surface {:?} input region set to {}",
+                id,
+                match rects {
+                    None => "full surface".to_string(),
+                    Some(r) => format!("{} rect(s)", r.len()),
+                }
+            );
+        }
+    }
+
     /// Rebuild the reactive output list from current compositor state.
     fn sync_outputs(&mut self) {
         let wl_outputs: Vec<wl_output::WlOutput> = self.output_state.outputs().collect();
@@ -380,6 +430,10 @@ impl WaylandState {
         let (top, right, bottom, left) = config.margin;
         if (top, right, bottom, left) != (0, 0, 0, 0) {
             layer_surface.set_margin(top, right, bottom, left);
+        }
+
+        if let Some(rects) = &config.input_region {
+            self.apply_input_region(&wl_surface, Some(rects));
         }
 
         wl_surface.commit();

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -40,7 +40,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::outputs::OutputId;
 use crate::platform::{Anchor, KeyboardInteractivity, Layer};
-use crate::widgets::{Color, Widget};
+use crate::widgets::{Color, Rect, Widget};
 
 /// Unique identifier for each surface in the application.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -95,6 +95,10 @@ pub struct SurfaceConfig {
     pub margin: (i32, i32, i32, i32),
     /// Output (monitor) to show the surface on. None lets the compositor choose.
     pub output: Option<OutputId>,
+    /// Input region in logical surface coordinates. `None` means the whole
+    /// surface accepts input; `Some(rects)` limits input to those rectangles
+    /// (an empty list makes the surface fully click-through).
+    pub input_region: Option<Vec<Rect>>,
 }
 
 impl Default for SurfaceConfig {
@@ -110,6 +114,7 @@ impl Default for SurfaceConfig {
             exclusive_zone: None,
             margin: (0, 0, 0, 0),
             output: None,
+            input_region: None,
         }
     }
 }
@@ -189,6 +194,24 @@ impl SurfaceConfig {
     /// creation (a layer surface is bound to its output for its lifetime).
     pub fn output(mut self, output: OutputId) -> Self {
         self.output = Some(output);
+        self
+    }
+
+    /// Limit pointer/touch input to the given rectangles (logical surface
+    /// coordinates). Everything outside them lets clicks pass through to
+    /// whatever is below. An empty list makes the surface fully
+    /// click-through.
+    ///
+    /// Use `SurfaceHandle::set_input_region` to change it at runtime.
+    pub fn input_region(mut self, rects: impl Into<Vec<Rect>>) -> Self {
+        self.input_region = Some(rects.into());
+        self
+    }
+
+    /// Make the whole surface click-through: pointer and touch input passes
+    /// to whatever is below. Shorthand for `input_region([])`.
+    pub fn click_through(mut self) -> Self {
+        self.input_region = Some(Vec::new());
         self
     }
 }
@@ -276,6 +299,17 @@ impl SurfaceHandle {
             left,
         });
     }
+
+    /// Set the input region for this surface.
+    ///
+    /// `None` restores the default (the whole surface accepts input).
+    /// `Some(rects)` limits pointer/touch input to those rectangles in
+    /// logical surface coordinates — everything outside them lets clicks
+    /// pass through to whatever is below. `Some(vec![])` makes the surface
+    /// fully click-through.
+    pub fn set_input_region(&self, rects: Option<Vec<Rect>>) {
+        push_surface_command(SurfaceCommand::SetInputRegion { id: self.id, rects });
+    }
 }
 
 /// Commands for dynamic surface creation/destruction and property modification.
@@ -313,6 +347,11 @@ pub(crate) enum SurfaceCommand {
         right: i32,
         bottom: i32,
         left: i32,
+    },
+    /// Set the input region for a surface.
+    SetInputRegion {
+        id: SurfaceId,
+        rects: Option<Vec<Rect>>,
     },
 }
 


### PR DESCRIPTION
## Summary

Second PR of the Wayland parity series (stacked on #109 — merge that first; GitHub will retarget this to `main`).

- `wl_surface.set_input_region` via sctk `Region`: limit pointer/touch input to a set of rectangles in logical surface coordinates, everything else passes through to the windows below.
- **`SurfaceConfig::input_region(rects)`** and **`.click_through()`** — applied before the surface's first commit.
- **`SurfaceHandle::set_input_region(Option<Vec<Rect>>)`** — runtime changes; `None` restores full-surface input, `Some(vec![])` is fully click-through.
- Rects are rounded outward to whole pixels so fractional widget bounds keep their edges.
- `examples/input_region.rs`: transparent full-width overlay whose region is glued to a centered pill via `WidgetRef` + effect — the idiomatic "region follows the widget" pattern, also documented in the book.

## Testing

- 213 lib tests, clippy 1.97.1 `-D warnings`, fmt, book build — all clean.
- Example verified on Hyprland: pill renders centered over other windows, log confirms the 1-rect region lands after layout ( `Surface SurfaceId(0) input region set to 1 rect(s)`).
