### PR TITLE
Compositor background blur: container().background_blur() (ext-background-effect-v1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -384,6 +384,7 @@ This is a work-in-progress GUI library. Current implemented features:
 - Dynamic surface property modification (layer, keyboard interactivity, anchor, size, margins)
 - Multi-output support: reactive `outputs()` enumeration, per-output surface pinning, `surface_output()` tracking
 - Input regions: per-surface clickable rectangles / click-through surfaces (`input_region`, `click_through`, `set_input_region`)
+- Compositor background blur (`ext-background-effect-v1`) via `container().background_blur()`, shaped by bounds + corner radius
 - Text input widget with full editing support
 - Image widget with raster and SVG support
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,9 +378,9 @@ checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
 
 [[package]]
 name = "dlib"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
  "libloading",
 ]
@@ -704,6 +704,7 @@ dependencies = [
  "smithay-client-toolkit",
  "tokio",
  "wayland-backend",
+ "wayland-protocols",
  "wgpu",
 ]
 
@@ -1251,9 +1252,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -1947,9 +1948,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-backend"
-version = "0.3.12"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fee64194ccd96bf648f42a65a7e589547096dfa702f7cadef84347b66ad164f9"
+checksum = "016ccf01d1c58b6f8999612813e17c9b2390f7d70671428869913310f83f54b8"
 dependencies = [
  "cc",
  "downcast-rs",
@@ -1961,9 +1962,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-client"
-version = "0.31.12"
+version = "0.31.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e6faa537fbb6c186cb9f1d41f2f811a4120d1b57ec61f50da451a0c5122bec"
+checksum = "e3c36a0f861ad76d0901f2800b46321410d9f73f2ea88aac0650d86c32688073"
 dependencies = [
  "bitflags 2.10.0",
  "rustix",
@@ -1995,9 +1996,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.32.10"
+version = "0.32.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baeda9ffbcfc8cd6ddaade385eaf2393bd2115a69523c735f12242353c3df4f3"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
 dependencies = [
  "bitflags 2.10.0",
  "wayland-backend",
@@ -2046,9 +2047,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.8"
+version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5423e94b6a63e68e439803a3e153a9252d5ead12fd853334e2ad33997e3889e3"
+checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
 dependencies = [
  "proc-macro2",
  "quick-xml",
@@ -2057,9 +2058,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-sys"
-version = "0.31.8"
+version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6dbfc3ac5ef974c92a2235805cc0114033018ae1290a72e474aa8b28cbbdfd"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
 dependencies = [
  "dlib",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,8 @@ glyphon = "0.10"
 cosmic-text = "0.17"
 smithay-client-toolkit = { version = "0.20", default-features = false, features = ["calloop", "xkbcommon"] }
 wayland-backend = { version = "0.3", features = ["client_system"] }
+# Staging protocols not wrapped by sctk (ext-background-effect-v1 for blur)
+wayland-protocols = { version = "0.32.12", features = ["client", "staging"] }
 raw-window-handle = "0.6"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
 resvg = { version = "0.46", optional = true }

--- a/book/src/advanced/wayland.md
+++ b/book/src/advanced/wayland.md
@@ -497,6 +497,35 @@ create_effect(move || {
 Note: keyboard focus is unaffected — use `keyboard_interactivity` for
 that. Rectangles are rounded outward to whole pixels.
 
+## Background Blur
+
+Containers can ask the compositor to blur whatever is behind the
+surface (`ext-background-effect-v1`), shaped by their bounds and corner
+radius. Pair it with a translucent background so the blurred content
+shows through:
+
+```rust
+container()
+    .background(Color::rgba(0.12, 0.12, 0.18, 0.55))
+    .corner_radius(16.0)
+    .background_blur()
+    .child(text("Frosted glass"))
+```
+
+The blur region follows the container automatically: layout moves,
+resizes, and (animated) corner radius changes are picked up each frame.
+Rounded corners are tessellated into small rectangles because
+`wl_region` has no notion of curves.
+
+On compositors without the protocol or its blur capability this
+renders a plain translucent container — no error, no fallback blur.
+Surfaces that never use `background_blur()` are left untouched, so
+compositor-side blur rules (e.g. blur by namespace) keep working; once
+a surface has used blur, an empty region ("blur nothing") is reported
+instead of withdrawing, to keep the region authoritative.
+
+See `examples/blur_example.rs`.
+
 ## Complete Examples
 
 ### Status Bar

--- a/book/src/concepts/container.md
+++ b/book/src/concepts/container.md
@@ -65,6 +65,21 @@ container()
 
 See [Building UI](../building-ui/README.md) for complete styling reference.
 
+### Background Blur
+
+On Wayland compositors that support `ext-background-effect-v1`, a
+container can blur whatever is behind the surface, shaped by its bounds
+and corner radius:
+
+```rust
+container()
+    .background(Color::rgba(0.12, 0.12, 0.18, 0.55)) // translucent
+    .corner_radius(16.0)
+    .background_blur()
+```
+
+See [Wayland Layer Shell — Background Blur](../advanced/wayland.md#background-blur).
+
 ## Layout
 
 Control how children are arranged:

--- a/examples/blur_example.rs
+++ b/examples/blur_example.rs
@@ -1,0 +1,59 @@
+//! Compositor-side background blur behind translucent containers.
+//!
+//! Two floating cards with different corner radii blur whatever is behind
+//! the surface (`ext-background-effect-v1`). On compositors without the
+//! protocol or its blur capability this renders plain translucent cards.
+
+use guido::prelude::*;
+
+fn main() {
+    env_logger::init();
+
+    App::new().run(|app| {
+        let radius = create_signal(24.0f32);
+
+        app.add_surface(
+            SurfaceConfig::new()
+                .width(420)
+                .height(260)
+                .anchor(Anchor::TOP)
+                .margin(120, 0, 0, 0)
+                .layer(Layer::Overlay)
+                .exclusive_zone(Some(0))
+                .background_color(Color::TRANSPARENT),
+            move || {
+                container()
+                    .width(fill())
+                    .height(fill())
+                    .layout(
+                        Flex::column()
+                            .spacing(16.0)
+                            .main_alignment(MainAlignment::Center)
+                            .cross_alignment(CrossAlignment::Center),
+                    )
+                    .child(
+                        // Blurred card: translucent background + blur behind
+                        container()
+                            .background_blur()
+                            .background(Color::rgba(0.12, 0.12, 0.18, 0.55))
+                            .corner_radius(radius)
+                            .padding(24.0)
+                            .hover_state(|s| s.lighter(0.05))
+                            .on_click(move || {
+                                // Cycle the radius to show the region follows it
+                                radius.update(|r| *r = if *r >= 48.0 { 0.0 } else { *r + 12.0 });
+                            })
+                            .child(text("Blurred — click to change the corner radius")),
+                    )
+                    .child(
+                        // Control card without blur, for comparison
+                        container()
+                            .background(Color::rgba(0.12, 0.12, 0.18, 0.55))
+                            .corner_radius(16.0)
+                            .padding(24.0)
+                            .child(text("Same background, no blur")),
+                    )
+            },
+        );
+    });
+}

--- a/src/blur.rs
+++ b/src/blur.rs
@@ -1,0 +1,249 @@
+//! Compositor-side background blur (`ext-background-effect-v1`).
+//!
+//! Containers opt in via `.background_blur()`. During paint they register
+//! their id and corner radius here; each frame the surface sync reads the
+//! current bounds from the tree, tessellates rounded corners into
+//! axis-aligned rects (`wl_region` has no notion of curves), and hands them
+//! to the platform layer. No-ops when the compositor doesn't support the
+//! protocol or its blur capability.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+use crate::tree::{Tree, WidgetId};
+use crate::widgets::Rect;
+
+/// An axis-aligned rectangle of a blur region, in logical surface pixels.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct BlurRect {
+    pub x: i32,
+    pub y: i32,
+    pub width: i32,
+    pub height: i32,
+}
+
+thread_local! {
+    /// Widgets currently requesting background blur: id → corner radius.
+    /// Bounds are read fresh from the tree at collect time; entries whose
+    /// widget left the tree are pruned then too.
+    static BLUR_WIDGETS: RefCell<HashMap<WidgetId, f32>> = RefCell::new(HashMap::new());
+}
+
+/// Record a widget's blur request (called from `Container::paint`).
+pub(crate) fn register_blur(id: WidgetId, corner_radius: f32) {
+    BLUR_WIDGETS.with(|reg| {
+        reg.borrow_mut().insert(id, corner_radius);
+    });
+}
+
+/// Collect tessellated blur rects for every blur widget under `root`,
+/// sorted for deterministic change detection. Prunes stale entries.
+pub(crate) fn collect_for_surface(tree: &Tree, root: WidgetId) -> Vec<BlurRect> {
+    BLUR_WIDGETS.with(|reg| {
+        let mut reg = reg.borrow_mut();
+        let mut out = Vec::new();
+        reg.retain(|&id, &mut radius| {
+            if !tree.contains(id) {
+                return false;
+            }
+            // Only widgets belonging to this surface's subtree
+            if is_under(tree, id, root)
+                && let Some(bounds) = tree.get_surface_relative_bounds(id)
+            {
+                out.extend(rounded_rect_to_blur_rects(bounds, radius));
+            }
+            true
+        });
+        out.sort_unstable_by_key(|r| (r.y, r.x, r.width, r.height));
+        out
+    })
+}
+
+fn is_under(tree: &Tree, mut id: WidgetId, root: WidgetId) -> bool {
+    loop {
+        if id == root {
+            return true;
+        }
+        match tree.get_parent(id) {
+            Some(parent) => id = parent,
+            None => return false,
+        }
+    }
+}
+
+/// Reset blur state.
+///
+/// Called during `App::drop()`.
+pub(crate) fn reset_blur() {
+    BLUR_WIDGETS.with(|reg| reg.borrow_mut().clear());
+}
+
+/// Approximate a uniformly rounded rectangle as a union of axis-aligned
+/// rects that **inscribe** the shape. A zero radius or degenerate rectangle
+/// yields the bounding box.
+///
+/// `bounds` is in logical surface pixels, matching what `wl_region` expects.
+fn rounded_rect_to_blur_rects(bounds: Rect, radius: f32) -> Vec<BlurRect> {
+    if bounds.width <= 0.0 || bounds.height <= 0.0 {
+        return Vec::new();
+    }
+
+    let w = bounds.width;
+    let h = bounds.height;
+
+    // Clamp so two corners sharing an edge can never overlap.
+    let r = radius.clamp(0.0, w.min(h) / 2.0);
+
+    if r <= 0.5 {
+        return Vec::from_iter(to_blur_rect(bounds));
+    }
+
+    let mut out = Vec::new();
+
+    // Middle band spans the full width between the corner bands.
+    if h - r > r {
+        out.extend(to_blur_rect(Rect::new(
+            bounds.x,
+            bounds.y + r,
+            w,
+            h - 2.0 * r,
+        )));
+    }
+
+    let mut emit_band = |y_start: f32, y_end: f32| {
+        let band_h = y_end - y_start;
+        let steps = (band_h.ceil() as u32).clamp(4, 32);
+        let slab_h = band_h / steps as f32;
+        for i in 0..steps {
+            let y0 = y_start + i as f32 * slab_h;
+            let y1 = y0 + slab_h;
+            // Widest inset within the slab keeps it inside the curve.
+            let inset = corner_inset(y0, r, h).max(corner_inset(y1, r, h));
+            let slab_w = w - 2.0 * inset;
+            if slab_w <= 0.0 {
+                continue;
+            }
+            out.extend(to_blur_rect(Rect::new(
+                bounds.x + inset,
+                bounds.y + y0,
+                slab_w,
+                slab_h,
+            )));
+        }
+    };
+
+    emit_band(0.0, r);
+    emit_band(h - r, h);
+
+    out
+}
+
+/// Horizontal inset of a uniformly rounded edge at height `y`.
+fn corner_inset(y: f32, r: f32, h: f32) -> f32 {
+    if y < r {
+        let dy = r - y;
+        r - (r * r - dy * dy).max(0.0).sqrt()
+    } else if y > h - r {
+        let dy = y - (h - r);
+        r - (r * r - dy * dy).max(0.0).sqrt()
+    } else {
+        0.0
+    }
+}
+
+/// Round-to-nearest on all four edges so adjacent slabs tile without gaps
+/// (inward rounding would drop sub-pixel slabs). `None` when the rounding
+/// collapses the rectangle to nothing.
+fn to_blur_rect(b: Rect) -> Option<BlurRect> {
+    let x0 = b.x.round() as i32;
+    let y0 = b.y.round() as i32;
+    let x1 = (b.x + b.width).round() as i32;
+    let y1 = (b.y + b.height).round() as i32;
+    (x1 > x0 && y1 > y0).then_some(BlurRect {
+        x: x0,
+        y: y0,
+        width: x1 - x0,
+        height: y1 - y0,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn covers(rects: &[BlurRect], x: i32, y: i32) -> bool {
+        rects
+            .iter()
+            .any(|r| x >= r.x && x < r.x + r.width && y >= r.y && y < r.y + r.height)
+    }
+
+    #[test]
+    fn zero_radius_is_bounding_box() {
+        let rects = rounded_rect_to_blur_rects(Rect::new(10.0, 20.0, 100.0, 50.0), 0.0);
+        assert_eq!(
+            rects,
+            vec![BlurRect {
+                x: 10,
+                y: 20,
+                width: 100,
+                height: 50
+            }]
+        );
+    }
+
+    #[test]
+    fn degenerate_rect_is_empty() {
+        assert!(rounded_rect_to_blur_rects(Rect::new(0.0, 0.0, 0.0, 40.0), 8.0).is_empty());
+        assert!(rounded_rect_to_blur_rects(Rect::new(0.0, 0.0, 40.0, -1.0), 8.0).is_empty());
+    }
+
+    #[test]
+    fn rounded_corners_are_cut() {
+        let rects = rounded_rect_to_blur_rects(Rect::new(0.0, 0.0, 100.0, 60.0), 20.0);
+        // Corner pixels outside the curve are not covered…
+        assert!(!covers(&rects, 0, 0));
+        assert!(!covers(&rects, 99, 0));
+        assert!(!covers(&rects, 0, 59));
+        assert!(!covers(&rects, 99, 59));
+        // …while the center and edge midpoints are.
+        assert!(covers(&rects, 50, 30));
+        assert!(covers(&rects, 0, 30));
+        assert!(covers(&rects, 99, 30));
+        assert!(covers(&rects, 50, 0));
+        assert!(covers(&rects, 50, 59));
+    }
+
+    #[test]
+    fn slabs_stay_inside_the_curve() {
+        let r = 16.0f32;
+        let rects = rounded_rect_to_blur_rects(Rect::new(0.0, 0.0, 80.0, 80.0), r);
+        for rect in &rects {
+            // Every rect corner must be inside (or on) the rounded shape,
+            // with half-pixel tolerance for edge rounding.
+            for (px, py) in [
+                (rect.x, rect.y),
+                (rect.x + rect.width, rect.y),
+                (rect.x, rect.y + rect.height),
+                (rect.x + rect.width, rect.y + rect.height),
+            ] {
+                let (px, py) = (px as f32, py as f32);
+                let cx = px.clamp(r, 80.0 - r);
+                let cy = py.clamp(r, 80.0 - r);
+                let dist = ((px - cx).powi(2) + (py - cy).powi(2)).sqrt();
+                assert!(
+                    dist <= r + 0.75,
+                    "corner ({px}, {py}) is {dist} from the curve center, radius {r}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn radius_clamped_to_half_size() {
+        // Radius larger than half the shape: a circle-ish region, still non-empty
+        let rects = rounded_rect_to_blur_rects(Rect::new(0.0, 0.0, 40.0, 40.0), 100.0);
+        assert!(!rects.is_empty());
+        assert!(covers(&rects, 20, 20));
+        assert!(!covers(&rects, 0, 0));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod animation;
+mod blur;
 pub mod image_metadata;
 mod ingress;
 mod jobs;
@@ -497,12 +498,23 @@ fn render_surface(
             tree.mark_subtree_needs_paint(surface.widget_id);
         }
 
+        // Collect this surface's blur region from registered widgets (post
+        // layout, so bounds are current).
+        let blur_rects = blur::collect_for_surface(tree, surface.widget_id);
+
         // Skip frame if nothing needs paint
         if !tree.needs_paint(surface.widget_id) {
+            // A blur-region change without a repaint (e.g. the compositor's
+            // blur capability arriving) still needs its own commit.
+            wayland_state.sync_blur_region(id, blur_rects, qh, true);
             render_stats::record_frame_skipped();
             render_stats::end_frame(&DamageRegion::None);
             return;
         }
+
+        // Set the blur region now so it rides the buffer commit performed
+        // inside present() — region and content change in the same frame.
+        wayland_state.sync_blur_region(id, blur_rects, qh, false);
 
         // Clear and reuse the root node (preserves capacity)
         surface.root_node.clear();
@@ -959,6 +971,7 @@ impl Drop for App {
         surface::reset_surface_commands();
         widget_ref::reset_widget_refs();
         outputs::reset_outputs();
+        blur::reset_blur();
         FONTS_CONSUMED.with(|f| f.set(false));
     }
 }

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -36,10 +36,14 @@ use smithay_client_toolkit::reexports::client::{
         wl_data_device::WlDataDevice, wl_data_device_manager::DndAction,
         wl_data_source::WlDataSource, wl_keyboard, wl_output, wl_pointer, wl_seat, wl_surface,
     },
-    Connection, EventQueue, Proxy, QueueHandle,
+    Connection, Dispatch, EventQueue, Proxy, QueueHandle, WEnum, delegate_noop,
 };
 use smithay_client_toolkit::reexports::protocols::wp::cursor_shape::v1::client::wp_cursor_shape_device_v1::Shape as WpCursorShape;
 use wayland_backend::sys::client::ObjectId;
+use wayland_protocols::ext::background_effect::v1::client::{
+    ext_background_effect_manager_v1::{self, Capability as BgCapability, ExtBackgroundEffectManagerV1},
+    ext_background_effect_surface_v1::ExtBackgroundEffectSurfaceV1,
+};
 
 use std::collections::HashMap;
 use std::fs::File;
@@ -47,6 +51,7 @@ use std::io::{Read, Write};
 use std::os::fd::AsFd;
 use std::os::unix::io::OwnedFd;
 
+use crate::blur::BlurRect;
 use crate::outputs::{self, OutputId, OutputInfo};
 use crate::reactive::CursorIcon;
 use crate::surface::SurfaceId;
@@ -79,6 +84,13 @@ pub struct WaylandSurfaceState {
     pub frame_callback_pending: bool,
     /// Pending events for this surface
     pub pending_events: Vec<Event>,
+    /// Blur proxy for this surface, created lazily on first use (asking the
+    /// manager twice for the same surface is a protocol error).
+    bg_effect_surface: Option<ExtBackgroundEffectSurfaceV1>,
+    /// Last blur rects pushed to the compositor. `None` means nothing has
+    /// been pushed yet (also reset when the blur capability changes, so the
+    /// region is re-sent if it comes back).
+    blur_region: Option<Vec<BlurRect>>,
 }
 
 impl WaylandSurfaceState {
@@ -100,6 +112,8 @@ impl WaylandSurfaceState {
             first_frame_presented: false,
             frame_callback_pending: false,
             pending_events: Vec::new(),
+            bg_effect_surface: None,
+            blur_region: None,
         }
     }
 
@@ -135,6 +149,12 @@ pub struct WaylandState {
     output_ids: HashMap<ObjectId, OutputId>,
     /// Next OutputId to allocate.
     next_output_id: u32,
+
+    // Background effect (blur)
+    /// `None` where the protocol is unsupported — the feature simply no-ops.
+    bg_effect_manager: Option<ExtBackgroundEffectManagerV1>,
+    /// Whether the compositor currently advertises the Blur capability.
+    bg_effect_supports_blur: bool,
 
     // Pointer state
     pointer: Option<wl_pointer::WlPointer>,
@@ -244,6 +264,12 @@ pub fn create_wayland_app() -> Result<
         log::warn!("Cursor shape manager not available - cursor changes will not work");
     }
 
+    // Background effect manager (blur) — optional, no-ops when unsupported
+    let bg_effect_manager: Option<ExtBackgroundEffectManagerV1> = globals.bind(&qh, 1..=1, ()).ok();
+    if bg_effect_manager.is_none() {
+        log::info!("ext-background-effect-v1 not available - background blur will not work");
+    }
+
     let state = WaylandState {
         registry_state: RegistryState::new(&globals),
         compositor_state,
@@ -257,6 +283,8 @@ pub fn create_wayland_app() -> Result<
         current_keyboard_surface: None,
         output_ids: HashMap::new(),
         next_output_id: 0,
+        bg_effect_manager,
+        bg_effect_supports_blur: false,
         pointer: None,
         pointer_x: 0.0,
         pointer_y: 0.0,
@@ -345,6 +373,74 @@ impl WaylandState {
                     Some(r) => format!("{} rect(s)", r.len()),
                 }
             );
+        }
+    }
+
+    /// Push a surface's blur region to the compositor if it changed.
+    ///
+    /// The `set_blur_region` request is double-buffered: with `commit: false`
+    /// it rides the buffer commit performed inside the upcoming present, so
+    /// region and content change in the same frame. Pass `commit: true` on
+    /// paths that skip presenting (e.g. a capability change without repaint).
+    ///
+    /// Surfaces that never requested blur are left untouched — declaring an
+    /// empty region would override compositor-side blur rules (e.g. blur by
+    /// namespace). Once a surface has blurred, dropping to zero rects sends
+    /// an *empty* region, never NULL: NULL only withdraws our opinion and
+    /// lets such a rule blur the whole surface, where an empty region says
+    /// "blur exactly nothing".
+    pub(crate) fn sync_blur_region(
+        &mut self,
+        id: SurfaceId,
+        rects: Vec<BlurRect>,
+        qh: &QueueHandle<Self>,
+        commit: bool,
+    ) {
+        if !self.bg_effect_supports_blur {
+            return;
+        }
+        let Some(manager) = self.bg_effect_manager.clone() else {
+            return;
+        };
+        let Some(surface_state) = self.surfaces.get_mut(&id) else {
+            return;
+        };
+
+        // Never used blur and still doesn't — don't claim the surface.
+        if rects.is_empty()
+            && surface_state.blur_region.is_none()
+            && surface_state.bg_effect_surface.is_none()
+        {
+            return;
+        }
+
+        if surface_state.blur_region.as_deref() == Some(rects.as_slice()) {
+            return;
+        }
+
+        // Asking the manager twice for the same surface is a protocol error.
+        let effect = surface_state.bg_effect_surface.get_or_insert_with(|| {
+            manager.get_background_effect(&surface_state.wl_surface, qh, ())
+        });
+
+        let Ok(region) = Region::new(&self.compositor_state) else {
+            log::warn!("Failed to create wl_region for blur");
+            return;
+        };
+        for r in &rects {
+            region.add(r.x, r.y, r.width, r.height);
+        }
+        effect.set_blur_region(Some(region.wl_region()));
+
+        log::debug!(
+            "Surface {:?} blur region set to {} rect(s)",
+            id,
+            rects.len()
+        );
+        surface_state.blur_region = Some(rects);
+
+        if commit {
+            surface_state.wl_surface.commit();
         }
     }
 
@@ -464,6 +560,11 @@ impl WaylandState {
             // Remove from lookup table
             let object_id = surface_state.wl_surface.id();
             self.surface_lookup.remove(&object_id);
+
+            // Destroy the blur proxy before its wl_surface goes away
+            if let Some(effect) = surface_state.bg_effect_surface {
+                effect.destroy();
+            }
 
             // Clear pointer/keyboard focus if this surface had it
             if self.current_pointer_surface == Some(id) {
@@ -1393,6 +1494,41 @@ fn keysym_to_key(keysym: Keysym, utf8: Option<&str>, is_press: bool) -> Option<K
 
     None
 }
+
+impl Dispatch<ExtBackgroundEffectManagerV1, ()> for WaylandState {
+    fn event(
+        state: &mut Self,
+        _proxy: &ExtBackgroundEffectManagerV1,
+        event: ext_background_effect_manager_v1::Event,
+        _data: &(),
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+    ) {
+        if let ext_background_effect_manager_v1::Event::Capabilities { flags } = event {
+            let blur = match flags {
+                WEnum::Value(c) => c.contains(BgCapability::Blur),
+                WEnum::Unknown(_) => false,
+            };
+            if blur == state.bg_effect_supports_blur {
+                return;
+            }
+            log::info!(
+                "Compositor blur capability {}",
+                if blur { "available" } else { "lost" }
+            );
+            state.bg_effect_supports_blur = blur;
+
+            // The compositor drops its regions when the capability goes away:
+            // forget ours and wake the loop to push them again if it's back.
+            for surface_state in state.surfaces.values_mut() {
+                surface_state.blur_region = None;
+            }
+            crate::jobs::request_frame();
+        }
+    }
+}
+
+delegate_noop!(WaylandState: ignore ExtBackgroundEffectSurfaceV1);
 
 impl ProvidesRegistryState for WaylandState {
     fn registry(&mut self) -> &mut RegistryState {

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -231,6 +231,9 @@ pub struct Container {
     // Widget ref for reactive bounds tracking
     pub(super) widget_ref: Option<WidgetRef>,
 
+    // Compositor-side background blur (ext-background-effect-v1)
+    pub(super) background_blur: bool,
+
     // Animation state (boxed to save ~400 bytes per non-animated container)
     pub(super) anims: Option<Box<ContainerAnims>>,
 
@@ -261,6 +264,7 @@ impl Container {
             transform_origin: None,
             interaction: None,
             widget_ref: None,
+            background_blur: false,
             anims: None,
             scroll_axis: ScrollAxis::None,
             scroll_data: None,
@@ -375,6 +379,26 @@ impl Container {
     /// Set the corner curvature using CSS K-value system
     pub fn corner_curvature<M>(mut self, curvature: impl IntoSignal<f32, M>) -> Self {
         self.corner_curvature = Some(curvature.into_signal());
+        self
+    }
+
+    /// Blur the compositor background behind this container
+    /// (`ext-background-effect-v1`), shaped by its bounds and corner radius.
+    ///
+    /// Pair it with a translucent [`background()`](Self::background) so the
+    /// blurred content shows through. No-ops when the compositor doesn't
+    /// support the protocol.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// container()
+    ///     .background(Color::rgba(0.1, 0.1, 0.15, 0.6))
+    ///     .corner_radius(16.0)
+    ///     .background_blur()
+    /// ```
+    pub fn background_blur(mut self) -> Self {
+        self.background_blur = true;
         self
     }
 
@@ -1822,6 +1846,12 @@ impl Widget for Container {
                     let _ = s.get();
                 }
             });
+        }
+
+        // Publish the blur region: bounds are read fresh from the tree at
+        // frame sync, so only the (possibly animated) radius is recorded.
+        if self.background_blur {
+            crate::blur::register_blur(id, corner_radius);
         }
 
         let shadow = elevation_to_shadow(elevation_level);


### PR DESCRIPTION
## Summary

Third PR of the Wayland parity series (stacked on #110 → #109; merge in order, GitHub retargets automatically).

- New direct dependency on `wayland-protocols` 0.32 (`staging`) for **ext-background-effect-v1** — same protocol and approach as the iced_layershell fork's blur, adapted to guido's retained widget tree.
- **`container().background_blur()`**: blurs whatever is behind the surface, shaped by the container's bounds and corner radius. Pair with a translucent `.background(...)` for frosted glass.
- Blur widgets register during paint (id + animated corner radius); each frame the surface sync reads fresh bounds from the tree — so the region follows layout, resize, and radius animations even when paint is cache-skipped.
- Rounded corners tessellated into inscribed axis-aligned rects (`wl_region` has no curves) — unit-tested (5 new tests).
- Protocol care, learned from the fork's review cycle: capability handshake with region re-push on change; region only sent when changed, riding the present commit (region + content in the same frame); empty region instead of NULL when nothing blurs; surfaces that never blurred stay unclaimed so compositor-side namespace rules keep working; effect proxy created once and destroyed before its wl_surface.

## Testing

- 218 lib tests pass (5 new for tessellation); clippy 1.97.1 `-D warnings`, fmt, book build clean.
- Verified live on niri: `Compositor blur capability available` → `Surface SurfaceId(0) blur region set to 49 rect(s)` (24px-radius card).
