### PR TITLE
Session lock support: lock_session() / unlock_session() (ext-session-lock-v1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -385,6 +385,7 @@ This is a work-in-progress GUI library. Current implemented features:
 - Multi-output support: reactive `outputs()` enumeration, per-output surface pinning, `surface_output()` tracking
 - Input regions: per-surface clickable rectangles / click-through surfaces (`input_region`, `click_through`, `set_input_region`)
 - Compositor background blur (`ext-background-effect-v1`) via `container().background_blur()`, shaped by bounds + corner radius
+- Session lock (`ext-session-lock-v1`): `lock_session(factory)` / `unlock_session()` / reactive `lock_state()`, one lock surface per output with hotplug handling
 - Text input widget with full editing support
 - Image widget with raster and SVG support
 

--- a/book/src/advanced/wayland.md
+++ b/book/src/advanced/wayland.md
@@ -526,6 +526,55 @@ instead of withdrawing, to keep the region authoritative.
 
 See `examples/blur_example.rs`.
 
+## Session Lock (Lock Screens)
+
+`lock_session` asks the compositor to lock the session
+(`ext-session-lock-v1`). Once granted, guido creates one lock surface
+per output using your widget factory — the compositor blanks every
+output, shows the lock surfaces, and routes all input to them, so a
+`text_input` password field works out of the box:
+
+```rust
+lock_session(|output: OutputInfo| {
+    let attempt = create_signal(String::new());
+    container()
+        .width(fill())
+        .height(fill())
+        .background(Color::rgb(0.07, 0.07, 0.1))
+        .layout(Flex::column().main_alignment(MainAlignment::Center))
+        .child(text(format!("Locked — {:?}", output.name)))
+        .child(text_input(attempt).password(true).on_submit(|s| {
+            if verify_password(s) {
+                unlock_session();
+            }
+        }))
+});
+```
+
+The lifecycle is reactive:
+
+```rust
+text(move || format!("{:?}", lock_state().get()))
+// Unlocked → Locking → Locked, back to Unlocked on unlock/denial
+```
+
+Details worth knowing:
+
+- Outputs plugged in **while locked** get a lock surface automatically
+  (the factory is called again); the compositor blanks any output
+  without one.
+- If the compositor refuses the lock (no protocol support, or another
+  lock client is active), `lock_state` returns to `Unlocked`.
+- Unlike ordinary surfaces, closing lock surfaces never exits the app:
+  a lock daemon whose only surfaces are lock surfaces keeps running
+  after unlocking, idle until the next `lock_session` call.
+- Layer-shell properties (anchor, margins, exclusive zone…) don't
+  apply to lock surfaces; their size always comes from the compositor.
+
+See `examples/simple_lock.rs` — note that running it really locks your
+session (it has a 30-second auto-unlock safety net; the password is
+`guido`).
+
 ## Complete Examples
 
 ### Status Bar

--- a/examples/simple_lock.rs
+++ b/examples/simple_lock.rs
@@ -1,0 +1,121 @@
+//! Session lock example (`ext-session-lock-v1`).
+//!
+//! **WARNING: running this locks your session.** Unlock by typing the
+//! password `guido` (plus Enter) in the password field, or wait for the
+//! 30-second auto-unlock safety timer.
+//!
+//! A small bar hosts a "Lock session" button. Locking creates one lock
+//! surface per output with a password field; the compositor blanks every
+//! output and routes keyboard input to the lock surfaces.
+
+use std::time::Duration;
+
+use guido::prelude::*;
+
+const PASSWORD: &str = "guido";
+
+fn lock_screen(output: OutputInfo) -> Container {
+    let attempt = create_signal(String::new());
+    let error = create_signal(false);
+
+    // Safety net for an example: never leave the user locked out.
+    let auto_unlock = create_signal(false);
+    let auto_unlock_w = auto_unlock.writer();
+    let _ = create_service::<(), _, _>(move |_rx, ctx| async move {
+        tokio::time::sleep(Duration::from_secs(30)).await;
+        if ctx.is_running() {
+            auto_unlock_w.set(true);
+        }
+    });
+    create_effect(move || {
+        if auto_unlock.get() {
+            unlock_session();
+        }
+    });
+
+    container()
+        .width(fill())
+        .height(fill())
+        .background(Color::rgb(0.07, 0.07, 0.1))
+        .layout(
+            Flex::column()
+                .spacing(16.0)
+                .main_alignment(MainAlignment::Center)
+                .cross_alignment(CrossAlignment::Center),
+        )
+        .child(
+            text(format!(
+                "Locked — {}",
+                output.name.unwrap_or_else(|| "output".into())
+            ))
+            .color(Color::WHITE)
+            .font_size(24.0),
+        )
+        .child(
+            text("password: guido (auto-unlocks after 30s)")
+                .color(Color::rgb(0.6, 0.6, 0.7))
+                .font_size(13.0),
+        )
+        .child(
+            container()
+                .width(at_least(280.0))
+                .padding(10.0)
+                .background(Color::rgb(0.15, 0.15, 0.2))
+                .corner_radius(8.0)
+                .focused_state(|s| s.border(2.0, Color::rgb(0.4, 0.8, 1.0)))
+                .child(
+                    text_input(attempt)
+                        .password(true)
+                        .text_color(Color::WHITE)
+                        .cursor_color(Color::rgb(0.4, 0.8, 1.0))
+                        .on_submit(move |s| {
+                            if s == PASSWORD {
+                                unlock_session();
+                            } else {
+                                error.set(true);
+                            }
+                        }),
+                ),
+        )
+        .child(text(move || {
+            if error.get() {
+                "Wrong password".to_string()
+            } else {
+                String::new()
+            }
+        }))
+}
+
+fn main() {
+    env_logger::init();
+
+    App::new().run(|app| {
+        app.add_surface(
+            SurfaceConfig::new()
+                .height(40)
+                .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+                .background_color(Color::rgb(0.1, 0.1, 0.15)),
+            || {
+                container()
+                    .width(fill())
+                    .layout(
+                        Flex::row()
+                            .spacing(12.0)
+                            .main_alignment(MainAlignment::Center)
+                            .cross_alignment(CrossAlignment::Center),
+                    )
+                    .child(
+                        container()
+                            .padding([6.0, 16.0])
+                            .background(Color::rgb(0.3, 0.2, 0.2))
+                            .corner_radius(6.0)
+                            .hover_state(|s| s.lighter(0.1))
+                            .pressed_state(|s| s.ripple())
+                            .on_click(|| lock_session(lock_screen))
+                            .child(text("Lock session")),
+                    )
+                    .child(text(move || format!("state: {:?}", lock_state().get())))
+            },
+        );
+    });
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod layout;
 pub mod outputs;
 pub mod reactive;
 pub mod render_stats;
+pub mod session_lock;
 pub mod surface;
 mod surface_manager;
 pub mod transform;
@@ -146,6 +147,9 @@ pub mod prelude {
         with_context,
     };
     pub use crate::renderer::{PaintContext, Shadow, measure_text};
+    pub use crate::session_lock::{
+        LockState, lock_session, lock_state, session_locked, unlock_session,
+    };
     pub use crate::surface::{
         SurfaceConfig, SurfaceHandle, SurfaceId, spawn_surface, surface_handle,
     };
@@ -878,6 +882,15 @@ impl App {
                 break;
             }
 
+            // Drive the session-lock state machine (lock/unlock requests,
+            // grant/denial events, per-output lock surfaces)
+            session_lock::process_session_lock(
+                &mut surface_manager,
+                &mut wayland_state,
+                &qh,
+                &mut self.tree,
+            );
+
             // Process dynamic surface commands
             if !process_surface_commands(
                 &mut surface_manager,
@@ -972,6 +985,7 @@ impl Drop for App {
         widget_ref::reset_widget_refs();
         outputs::reset_outputs();
         blur::reset_blur();
+        session_lock::reset_session_lock();
         FONTS_CONSUMED.with(|f| f.set(false));
     }
 }

--- a/src/outputs.rs
+++ b/src/outputs.rs
@@ -108,6 +108,12 @@ pub fn surface_output(id: SurfaceId) -> Option<OutputId> {
     surface_outputs_signal().with(|m| m.get(&id).copied())
 }
 
+/// Untracked snapshot of the current outputs (for main-loop code that must
+/// not subscribe).
+pub(crate) fn current_outputs() -> Vec<OutputInfo> {
+    outputs_signal().with_untracked(|v| v.clone())
+}
+
 /// Replace the reactive output list. Called by the platform layer whenever
 /// the compositor adds, removes, or reconfigures an output.
 pub(crate) fn sync_outputs(list: Vec<OutputInfo>) {

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -1,7 +1,8 @@
 pub mod wayland;
 
 pub use wayland::{
-    PlatformError, WaylandState, WaylandSurfaceState, WaylandWindowWrapper, create_wayland_app,
+    LockEvent, PlatformError, SurfaceRole, WaylandState, WaylandSurfaceState, WaylandWindowWrapper,
+    create_wayland_app,
 };
 
 pub use smithay_client_toolkit::shell::wlr_layer::{Anchor, KeyboardInteractivity, Layer};

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -22,6 +22,11 @@ use smithay_client_toolkit::{
         },
         Capability, SeatHandler, SeatState,
     },
+    delegate_session_lock,
+    session_lock::{
+        SessionLock, SessionLockHandler, SessionLockState, SessionLockSurface,
+        SessionLockSurfaceConfigure,
+    },
     shell::{
         WaylandSurface,
         wlr_layer::{
@@ -60,10 +65,28 @@ use crate::widgets::{Event, Key, Modifiers, MouseButton, Rect, ScrollSource};
 /// Pixels per line for discrete scroll (mouse wheel)
 const SCROLL_PIXELS_PER_LINE: f32 = 40.0;
 
+/// The shell role of a surface: an ordinary layer-shell surface or an
+/// ext-session-lock-v1 lock surface. Both share the same widget tree, GPU
+/// and input pipeline; only creation, configure, and shell requests differ.
+pub enum SurfaceRole {
+    Layer(LayerSurface),
+    /// Kept alive here — dropping it destroys the protocol object.
+    Lock(SessionLockSurface),
+}
+
+/// Events from the session-lock protocol, drained by the main loop.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LockEvent {
+    /// The compositor granted the lock; lock surfaces may be created.
+    Locked,
+    /// The lock ended: denied outright, or unlocked/aborted later.
+    Finished,
+}
+
 /// Per-surface state for multi-surface support.
 pub struct WaylandSurfaceState {
-    /// The layer surface protocol object
-    pub layer_surface: LayerSurface,
+    /// The shell role (layer surface or session-lock surface)
+    pub role: SurfaceRole,
     /// The underlying wl_surface
     pub wl_surface: wl_surface::WlSurface,
     /// Whether the surface has been configured
@@ -96,13 +119,13 @@ pub struct WaylandSurfaceState {
 impl WaylandSurfaceState {
     /// Create a new surface state.
     pub fn new(
-        layer_surface: LayerSurface,
+        role: SurfaceRole,
         wl_surface: wl_surface::WlSurface,
         width: u32,
         height: u32,
     ) -> Self {
         Self {
-            layer_surface,
+            role,
             wl_surface,
             configured: false,
             width,
@@ -155,6 +178,15 @@ pub struct WaylandState {
     bg_effect_manager: Option<ExtBackgroundEffectManagerV1>,
     /// Whether the compositor currently advertises the Blur capability.
     bg_effect_supports_blur: bool,
+
+    // Session lock (ext-session-lock-v1)
+    session_lock_state: SessionLockState,
+    /// The active lock grant. Written when `start_session_lock` succeeds so a
+    /// synchronous double-lock check can reject a second call; cleared by
+    /// `finished` or `unlock_session`.
+    active_lock: Option<SessionLock>,
+    /// Lock lifecycle events, drained by the main loop.
+    lock_events: Vec<LockEvent>,
 
     // Pointer state
     pointer: Option<wl_pointer::WlPointer>,
@@ -251,6 +283,7 @@ pub fn create_wayland_app() -> Result<
     })?;
     let output_state = OutputState::new(&globals, &qh);
     let seat_state = SeatState::new(&globals, &qh);
+    let session_lock_state = SessionLockState::new(&globals, &qh);
 
     // Initialize data device manager for clipboard support
     let data_device_manager = DataDeviceManagerState::bind(&globals, &qh).ok();
@@ -285,6 +318,9 @@ pub fn create_wayland_app() -> Result<
         next_output_id: 0,
         bg_effect_manager,
         bg_effect_supports_blur: false,
+        session_lock_state,
+        active_lock: None,
+        lock_events: Vec::new(),
         pointer: None,
         pointer_x: 0.0,
         pointer_y: 0.0,
@@ -374,6 +410,82 @@ impl WaylandState {
                 }
             );
         }
+    }
+
+    /// Request a session lock from the compositor.
+    ///
+    /// Returns false when a lock is already active or the compositor lacks
+    /// ext-session-lock-v1. The grant (or denial) arrives asynchronously as
+    /// a [`LockEvent`].
+    pub fn start_session_lock(&mut self, qh: &QueueHandle<Self>) -> bool {
+        if self.active_lock.is_some() {
+            log::warn!("Session lock requested while a lock is already active");
+            return false;
+        }
+        match self.session_lock_state.lock(qh) {
+            Ok(lock) => {
+                self.active_lock = Some(lock);
+                log::info!("Session lock requested");
+                true
+            }
+            Err(e) => {
+                log::error!("Compositor does not support ext-session-lock-v1: {e}");
+                false
+            }
+        }
+    }
+
+    /// Unlock the session (no-op when not locked).
+    pub fn unlock_session(&mut self) {
+        if let Some(lock) = self.active_lock.take() {
+            lock.unlock();
+            log::info!("Session unlocked");
+        }
+    }
+
+    /// Whether a session lock is currently held and granted.
+    pub fn is_session_locked(&self) -> bool {
+        self.active_lock.as_ref().is_some_and(|l| l.is_locked())
+    }
+
+    /// Create a lock surface for `output` with a specific SurfaceId.
+    ///
+    /// The surface starts at 0×0 — its real size arrives with the first
+    /// lock-surface configure. Returns false without an active lock or when
+    /// the output disconnected.
+    pub fn create_lock_surface_with_id(
+        &mut self,
+        qh: &QueueHandle<Self>,
+        id: SurfaceId,
+        output: OutputId,
+    ) -> bool {
+        let Some(lock) = self.active_lock.clone() else {
+            log::warn!("Cannot create lock surface without an active session lock");
+            return false;
+        };
+        let Some(wl_output) = self.wl_output_for(output) else {
+            log::warn!(
+                "Cannot create lock surface: output {:?} is not connected",
+                output
+            );
+            return false;
+        };
+
+        let wl_surface = self.compositor_state.create_surface(qh);
+        let lock_surface = lock.create_lock_surface(wl_surface.clone(), &wl_output, qh);
+
+        self.surface_lookup.insert(wl_surface.id(), id);
+        let surface_state =
+            WaylandSurfaceState::new(SurfaceRole::Lock(lock_surface), wl_surface, 0, 0);
+        self.surfaces.insert(id, surface_state);
+
+        log::info!("Created lock surface {:?} on output {:?}", id, output);
+        true
+    }
+
+    /// Drain pending session-lock lifecycle events.
+    pub fn take_lock_events(&mut self) -> Vec<LockEvent> {
+        std::mem::take(&mut self.lock_events)
     }
 
     /// Push a surface's blur region to the compositor if it changed.
@@ -539,8 +651,12 @@ impl WaylandState {
         self.surface_lookup.insert(object_id, id);
 
         // Create and store surface state
-        let surface_state =
-            WaylandSurfaceState::new(layer_surface, wl_surface, config.width, config.height);
+        let surface_state = WaylandSurfaceState::new(
+            SurfaceRole::Layer(layer_surface),
+            wl_surface,
+            config.width,
+            config.height,
+        );
         self.surfaces.insert(id, surface_state);
 
         log::info!(
@@ -583,13 +699,24 @@ impl WaylandState {
     }
 
     /// Helper to modify a surface's layer shell properties and commit.
+    /// No-ops (with a warning) on session-lock surfaces, which have none.
     fn with_layer_surface<F>(&mut self, id: SurfaceId, f: F)
     where
         F: FnOnce(&LayerSurface),
     {
         if let Some(surface_state) = self.surfaces.get_mut(&id) {
-            f(&surface_state.layer_surface);
-            surface_state.wl_surface.commit();
+            match &surface_state.role {
+                SurfaceRole::Layer(layer_surface) => {
+                    f(layer_surface);
+                    surface_state.wl_surface.commit();
+                }
+                SurfaceRole::Lock(_) => {
+                    log::warn!(
+                        "Ignoring layer-shell property change on lock surface {:?}",
+                        id
+                    );
+                }
+            }
         }
     }
 
@@ -1494,6 +1621,63 @@ fn keysym_to_key(keysym: Keysym, utf8: Option<&str>, is_press: bool) -> Option<K
 
     None
 }
+
+impl SessionLockHandler for WaylandState {
+    fn locked(&mut self, _conn: &Connection, _qh: &QueueHandle<Self>, _session_lock: SessionLock) {
+        log::info!("Session lock granted by compositor");
+        self.lock_events.push(LockEvent::Locked);
+        crate::jobs::request_frame();
+    }
+
+    fn finished(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _session_lock: SessionLock,
+    ) {
+        log::info!("Session lock finished (denied or ended)");
+        self.active_lock = None;
+        self.lock_events.push(LockEvent::Finished);
+        crate::jobs::request_frame();
+    }
+
+    fn configure(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        surface: SessionLockSurface,
+        configure: SessionLockSurfaceConfigure,
+        _serial: u32,
+    ) {
+        // Route to the matching surface state, mirroring the layer-shell
+        // configure path so the same render machinery applies. sctk has
+        // already acked the configure.
+        let surface_id = self.surface_lookup.get(&surface.wl_surface().id()).copied();
+        if let Some(id) = surface_id
+            && let Some(surface_state) = self.surfaces.get_mut(&id)
+        {
+            let (width, height) = configure.new_size;
+            log::info!(
+                "Lock surface {:?} configure: {}x{} (current {}x{})",
+                id,
+                width,
+                height,
+                surface_state.width,
+                surface_state.height
+            );
+            if width > 0 {
+                surface_state.width = width;
+            }
+            if height > 0 {
+                surface_state.height = height;
+            }
+            surface_state.configured = true;
+            crate::jobs::request_frame();
+        }
+    }
+}
+
+delegate_session_lock!(WaylandState);
 
 impl Dispatch<ExtBackgroundEffectManagerV1, ()> for WaylandState {
     fn event(

--- a/src/session_lock.rs
+++ b/src/session_lock.rs
@@ -1,0 +1,242 @@
+//! Session lock (`ext-session-lock-v1`) — build lock screens.
+//!
+//! [`lock_session`] asks the compositor to lock the session and, once the
+//! lock is granted, creates one lock surface per output using the provided
+//! widget factory (new outputs plugged in while locked get one too). The
+//! compositor blanks all outputs and routes input to the lock surfaces, so
+//! a `text_input` password field works out of the box.
+//!
+//! ```ignore
+//! lock_session(|output| lock_screen_widget(output));
+//! // …later, e.g. after password verification:
+//! unlock_session();
+//! ```
+//!
+//! [`lock_state`] exposes the lifecycle reactively. When the compositor
+//! refuses or aborts the lock (another lock client active, protocol
+//! missing), the state returns to `Unlocked` and the surfaces are dropped.
+//!
+//! An app whose only surfaces are lock surfaces keeps running after
+//! unlocking (it idles waiting for the next [`lock_session`] call) — unlike
+//! ordinary surfaces, closing lock surfaces never exits the app.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+use smithay_client_toolkit::reexports::client::QueueHandle;
+
+use crate::outputs::{self, OutputId, OutputInfo};
+use crate::platform::{LockEvent, WaylandState};
+use crate::reactive::owner::with_owner;
+use crate::reactive::{RwSignal, Signal, create_signal};
+use crate::surface::{SurfaceConfig, SurfaceId};
+use crate::surface_manager::{ManagedSurface, SurfaceManager};
+use crate::tree::Tree;
+use crate::widgets::Widget;
+
+/// Lifecycle of the session lock.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum LockState {
+    /// No lock held (also after a denied or finished lock).
+    #[default]
+    Unlocked,
+    /// Lock requested, waiting for the compositor to grant it.
+    Locking,
+    /// Lock granted — lock surfaces are shown on every output.
+    Locked,
+}
+
+type LockWidgetFn = Box<dyn Fn(OutputInfo) -> Box<dyn Widget>>;
+
+#[derive(Default)]
+struct LockData {
+    /// Builds the lock screen widget for an output. Kept across lock
+    /// cycles so hotplugged outputs get surfaces while locked.
+    factory: Option<LockWidgetFn>,
+    /// Lock surface per output.
+    surfaces: HashMap<OutputId, SurfaceId>,
+    state: Option<RwSignal<LockState>>,
+    lock_requested: bool,
+    unlock_requested: bool,
+}
+
+thread_local! {
+    static LOCK: RefCell<LockData> = RefCell::new(LockData::default());
+}
+
+fn state_signal() -> RwSignal<LockState> {
+    LOCK.with(|lock| {
+        *lock
+            .borrow_mut()
+            .state
+            .get_or_insert_with(|| create_signal(LockState::default()))
+    })
+}
+
+fn set_state(state: LockState) {
+    state_signal().set(state);
+}
+
+/// Reactive session-lock lifecycle.
+pub fn lock_state() -> Signal<LockState> {
+    state_signal().read_only()
+}
+
+/// Lock the session (tracked read convenience: `lock_state` == `Locked`).
+pub fn session_locked() -> bool {
+    lock_state().get() == LockState::Locked
+}
+
+/// Ask the compositor to lock the session.
+///
+/// `widget_fn` builds the lock screen for each output — it is called once
+/// per connected output when the lock is granted, and again for outputs
+/// plugged in while locked. Does nothing if a lock is already active or
+/// pending. Watch [`lock_state`] for the outcome: `Locking` → `Locked`, or
+/// back to `Unlocked` when the compositor refuses (e.g. no
+/// ext-session-lock-v1, or another lock client is active).
+pub fn lock_session<W, F>(widget_fn: F)
+where
+    W: Widget + 'static,
+    F: Fn(OutputInfo) -> W + 'static,
+{
+    LOCK.with(|lock| {
+        let mut lock = lock.borrow_mut();
+        if lock.lock_requested || lock.state.map(|s| s.get_untracked()) == Some(LockState::Locked) {
+            log::warn!("lock_session() called while already locked or locking");
+            return;
+        }
+        lock.factory = Some(Box::new(move |info| Box::new(widget_fn(info))));
+        lock.lock_requested = true;
+    });
+    crate::jobs::request_frame();
+}
+
+/// Unlock the session and drop all lock surfaces.
+pub fn unlock_session() {
+    LOCK.with(|lock| lock.borrow_mut().unlock_requested = true);
+    crate::jobs::request_frame();
+}
+
+/// Drive the session-lock state machine. Called once per main-loop
+/// iteration, before surface commands are processed.
+pub(crate) fn process_session_lock(
+    surface_manager: &mut SurfaceManager,
+    wayland_state: &mut WaylandState,
+    qh: &QueueHandle<WaylandState>,
+    tree: &mut Tree,
+) {
+    // 1. Pending lock request
+    let lock_requested = LOCK.with(|l| std::mem::take(&mut l.borrow_mut().lock_requested));
+    if lock_requested {
+        if wayland_state.start_session_lock(qh) {
+            set_state(LockState::Locking);
+        } else {
+            LOCK.with(|l| l.borrow_mut().factory = None);
+            set_state(LockState::Unlocked);
+        }
+    }
+
+    // 2. Lock lifecycle events from the compositor
+    for event in wayland_state.take_lock_events() {
+        match event {
+            LockEvent::Locked => set_state(LockState::Locked),
+            LockEvent::Finished => {
+                // Denied, or the lock ended without our unlock_session().
+                teardown_lock_surfaces(surface_manager, wayland_state);
+                LOCK.with(|l| l.borrow_mut().factory = None);
+                set_state(LockState::Unlocked);
+            }
+        }
+    }
+
+    // 3. Pending unlock request
+    let unlock_requested = LOCK.with(|l| std::mem::take(&mut l.borrow_mut().unlock_requested));
+    if unlock_requested && state_signal().get_untracked() != LockState::Unlocked {
+        wayland_state.unlock_session();
+        teardown_lock_surfaces(surface_manager, wayland_state);
+        LOCK.with(|l| l.borrow_mut().factory = None);
+        set_state(LockState::Unlocked);
+    }
+
+    // 4. While locked: one lock surface per connected output (covers both
+    // the initial grant and hotplug while locked)
+    if state_signal().get_untracked() == LockState::Locked {
+        let current = outputs::current_outputs();
+
+        // Drop surfaces for disconnected outputs
+        let stale: Vec<(OutputId, SurfaceId)> = LOCK.with(|l| {
+            let mut lock = l.borrow_mut();
+            let stale: Vec<(OutputId, SurfaceId)> = lock
+                .surfaces
+                .iter()
+                .filter(|(out, _)| !current.iter().any(|o| o.id == **out))
+                .map(|(out, sid)| (*out, *sid))
+                .collect();
+            for (out, _) in &stale {
+                lock.surfaces.remove(out);
+            }
+            stale
+        });
+        for (_, sid) in stale {
+            surface_manager.remove(sid);
+            wayland_state.destroy_surface(sid);
+        }
+
+        // Create surfaces for new outputs
+        for info in current {
+            let already = LOCK.with(|l| l.borrow().surfaces.contains_key(&info.id));
+            if already {
+                continue;
+            }
+
+            let id = SurfaceId::next();
+            if !wayland_state.create_lock_surface_with_id(qh, id, info.id) {
+                continue;
+            }
+
+            let output_id = info.id;
+            let widget = LOCK.with(|l| {
+                l.borrow()
+                    .factory
+                    .as_ref()
+                    .map(|f| with_owner(|| f(info.clone())))
+            });
+            let Some((widget, owner_id)) = widget else {
+                log::error!("Session locked but no lock widget factory is set");
+                wayland_state.destroy_surface(id);
+                continue;
+            };
+
+            // Size arrives with the first configure; the config only
+            // contributes the clear color behind the widget tree.
+            let config = SurfaceConfig::new().width(0).height(0);
+            let managed = ManagedSurface::new(id, config, widget, owner_id, tree);
+            surface_manager.add(managed);
+            LOCK.with(|l| l.borrow_mut().surfaces.insert(output_id, id));
+        }
+    }
+}
+
+fn teardown_lock_surfaces(surface_manager: &mut SurfaceManager, wayland_state: &mut WaylandState) {
+    let surfaces: Vec<SurfaceId> = LOCK.with(|l| {
+        l.borrow_mut()
+            .surfaces
+            .drain()
+            .map(|(_, sid)| sid)
+            .collect()
+    });
+    for sid in surfaces {
+        // Removed directly — not via SurfaceCommand::Close — so an app whose
+        // only surfaces were lock surfaces keeps running after unlock.
+        surface_manager.remove(sid);
+        wayland_state.destroy_surface(sid);
+    }
+}
+
+/// Reset session-lock state.
+///
+/// Called during `App::drop()`.
+pub(crate) fn reset_session_lock() {
+    LOCK.with(|lock| *lock.borrow_mut() = LockData::default());
+}


### PR DESCRIPTION
## Summary

Fourth PR of the Wayland parity series (stacked on #111 → #110 → #109; merge in order).

Ports the approach from iced_layershell's `feature/ext-session-lock-v1` draft (PR #18 there) to guido's reactive API:

- **`SurfaceRole` enum (Layer | Lock)**: both roles share the widget tree, GPU, input, and frame-pacing pipeline; layer-shell setters warn+no-op on lock surfaces, whose size comes from the lock configure (sctk auto-acks).
- **`lock_session(factory)`**: requests the lock; once granted, one lock surface per output is created from the widget factory — including outputs hotplugged while locked. `text_input` password fields work out of the box since the compositor routes input to lock surfaces.
- **`unlock_session()`**: `unlock_and_destroy` + surface teardown.
- **`lock_state() -> Signal<LockState>`** (`Unlocked → Locking → Locked`), reactive; denial or external finish falls back to `Unlocked`.
- Lock-surface teardown bypasses the exit-on-last-surface logic, so a lock daemon with no other surfaces keeps running after unlock — combined with zero-surface startup (#109), a pure lock app needs no static surfaces at all.
- Double-lock rejected synchronously via the held grant.

## Testing

- 218 lib tests, clippy 1.97.1 `-D warnings`, fmt, book build — clean; `examples/simple_lock.rs` compiles.
- **Not run live**: locking the session on this machine while it's in use wasn't an option. The example has a 30s auto-unlock safety net (password `guido`) for when you want to try it: `cargo run --example simple_lock`.
