### PR TITLE
Non-blocking clipboard paste + primary selection support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -387,6 +387,7 @@ This is a work-in-progress GUI library. Current implemented features:
 - Compositor background blur (`ext-background-effect-v1`) via `container().background_blur()`, shaped by bounds + corner radius
 - Session lock (`ext-session-lock-v1`): `lock_session(factory)` / `unlock_session()` / reactive `lock_state()`, one lock surface per output with hotplug handling
 - Touch input (`wl_touch`): first finger drives the pointer pipeline — tap = click, works with hover/pressed state layers
+- Clipboard: async prefetch (paste never blocks the UI thread) + primary selection (select-to-copy, middle-click paste)
 - Text input widget with full editing support
 - Image widget with raster and SVG support
 

--- a/book/src/building-ui/text-input.md
+++ b/book/src/building-ui/text-input.md
@@ -245,7 +245,12 @@ fn login_form() -> Container {
 ## Features
 
 - **Selection**: Click and drag to select text, or use Shift+Arrow keys
-- **Clipboard**: Full copy/cut/paste support via Ctrl+C/X/V
+- **Clipboard**: Full copy/cut/paste support via Ctrl+C/X/V. System
+  clipboard contents are prefetched asynchronously whenever another app
+  copies, so paste is instant and never blocks the UI
+- **Primary selection**: selecting text with the mouse sets the primary
+  selection (paste it elsewhere with middle click); middle-clicking the
+  input pastes the primary selection at the click position
 - **Undo/Redo**: History with intelligent coalescing of rapid edits
 - **Scrolling**: Long text scrolls horizontally to keep cursor visible
 - **Cursor Blinking**: Standard blinking cursor when focused

--- a/src/ingress.rs
+++ b/src/ingress.rs
@@ -27,6 +27,14 @@ pub(crate) enum IngressMessage {
     /// write queue and is drained at the loop's flush point). The message
     /// only guarantees the loop wakes up to run that flush.
     BgWritesQueued,
+    /// Prefetched clipboard/primary-selection content from a reader thread.
+    /// Applied by the channel callback (generation-checked against the
+    /// current offer in `WaylandState::apply_clipboard_update`).
+    ClipboardUpdate {
+        kind: crate::platform::wayland::SelectionKind,
+        generation: u64,
+        content: Option<String>,
+    },
 }
 
 static INGRESS_SENDER: Mutex<Option<Sender<IngressMessage>>> = Mutex::new(None);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -809,13 +809,19 @@ impl App {
         let (ingress_tx, ingress_channel) = calloop_channel::channel();
         ingress::install_ingress(ingress_tx);
         loop_handle
-            .insert_source(ingress_channel, |event, _, _wayland_state| {
+            .insert_source(ingress_channel, |event, _, wayland_state| {
                 if let calloop_channel::Event::Msg(message) = event {
                     match message {
                         // Doorbell only: the write payloads live in the
                         // reactive write queue, drained at the flush point
                         // later this same iteration.
                         ingress::IngressMessage::BgWritesQueued => {}
+                        // Prefetched selection content from a reader thread
+                        ingress::IngressMessage::ClipboardUpdate {
+                            kind,
+                            generation,
+                            content,
+                        } => wayland_state.apply_clipboard_update(kind, generation, content),
                     }
                 }
             })
@@ -909,19 +915,6 @@ impl App {
                     wgpu_surface.queue.clone(),
                     wgpu_surface.config.format,
                 ));
-            }
-
-            // Apply prefetched clipboard/primary contents from reader threads
-            for (kind, content) in wayland_state.drain_clipboard_updates() {
-                match kind {
-                    platform::wayland::SelectionKind::Clipboard => match content {
-                        Some(text) => reactive::set_system_clipboard(text),
-                        None => reactive::clear_system_clipboard(),
-                    },
-                    platform::wayland::SelectionKind::Primary => {
-                        reactive::set_system_primary(content)
-                    }
-                }
             }
 
             // Flush background-thread signal writes once per frame (queued via WriteSignal).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ use std::sync::Arc;
 use layout::Constraints;
 use platform::create_wayland_app;
 use reactive::owner::with_owner;
-use reactive::{OwnerId, set_system_clipboard, take_clipboard_change, take_cursor_change};
+use reactive::{OwnerId, take_clipboard_change, take_cursor_change};
 use renderer::{GpuContext, PaintContext, Renderer, flatten_root_into};
 use surface::{SurfaceCommand, SurfaceConfig, SurfaceId, drain_surface_commands};
 use surface_manager::{ManagedSurface, SurfaceManager};
@@ -169,7 +169,7 @@ pub mod prelude {
     };
 }
 
-use smithay_client_toolkit::reexports::client::{Connection, QueueHandle};
+use smithay_client_toolkit::reexports::client::QueueHandle;
 
 use crate::{
     jobs::{
@@ -311,7 +311,6 @@ fn render_surface(
     surface: &mut surface_manager::ManagedSurface,
     wayland_state: &mut platform::WaylandState,
     renderer: &mut Renderer,
-    connection: &Connection,
     qh: &QueueHandle<platform::WaylandState>,
     tree: &mut Tree,
     layout_roots: &mut Vec<WidgetId>,
@@ -342,21 +341,6 @@ fn render_surface(
         return;
     }
 
-    // Check for paste events
-    let has_paste_event = events.iter().any(|e| {
-        matches!(
-            e,
-            widgets::Event::KeyDown {
-                key: widgets::Key::Char('v'),
-                modifiers: widgets::Modifiers { ctrl: true, .. },
-                ..
-            }
-        )
-    });
-    if has_paste_event && let Some(text) = wayland_state.read_external_clipboard(connection) {
-        set_system_clipboard(text);
-    }
-
     // Dispatch events to widget
     for event in &events {
         tree.with_widget_mut(surface.widget_id, |widget, id, tree| {
@@ -367,6 +351,11 @@ fn render_surface(
     // Sync clipboard to Wayland if it changed (copy operations)
     if let Some(text) = take_clipboard_change() {
         wayland_state.set_clipboard(text, qh);
+    }
+
+    // Sync primary selection to Wayland if it changed (select-to-copy)
+    if let Some(text) = reactive::take_primary_change() {
+        wayland_state.set_primary(text, qh);
     }
 
     // Sync cursor to Wayland if it changed
@@ -922,6 +911,19 @@ impl App {
                 ));
             }
 
+            // Apply prefetched clipboard/primary contents from reader threads
+            for (kind, content) in wayland_state.drain_clipboard_updates() {
+                match kind {
+                    platform::wayland::SelectionKind::Clipboard => match content {
+                        Some(text) => reactive::set_system_clipboard(text),
+                        None => reactive::clear_system_clipboard(),
+                    },
+                    platform::wayland::SelectionKind::Primary => {
+                        reactive::set_system_primary(content)
+                    }
+                }
+            }
+
             // Flush background-thread signal writes once per frame (queued via WriteSignal).
             // Must run before take_frame_request() so that signal changes from bg writes
             // are processed into jobs before we check the frame request flag.
@@ -943,7 +945,6 @@ impl App {
                         surface,
                         &mut wayland_state,
                         renderer,
-                        &connection,
                         &qh,
                         &mut self.tree,
                         &mut self.layout_roots,

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -62,7 +62,6 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io::{Read, Write};
 use std::os::unix::io::OwnedFd;
-use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
 use crate::blur::BlurRect;
@@ -236,10 +235,8 @@ pub struct WaylandState {
     primary_source: Option<PrimarySelectionSource>,
 
     // Async clipboard prefetch: whenever a selection offer changes, a reader
-    // thread fetches its content and sends it here. Generation counters drop
-    // results made stale by a newer offer.
-    clipboard_updates_tx: mpsc::Sender<ClipboardUpdate>,
-    clipboard_updates_rx: mpsc::Receiver<ClipboardUpdate>,
+    // thread fetches its content and delivers it through the calloop ingress
+    // channel. Generation counters drop results made stale by a newer offer.
     selection_generation: u64,
     primary_generation: u64,
     /// Serial of the most recent input event, needed to claim selections.
@@ -253,12 +250,6 @@ pub enum SelectionKind {
     Clipboard,
     /// The primary selection (select-to-copy / middle-click paste).
     Primary,
-}
-
-struct ClipboardUpdate {
-    kind: SelectionKind,
-    generation: u64,
-    content: Option<String>,
 }
 
 /// Why the platform layer could not start or continue.
@@ -356,8 +347,6 @@ pub fn create_wayland_app() -> Result<
         log::info!("ext-background-effect-v1 not available - background blur will not work");
     }
 
-    let (clipboard_updates_tx, clipboard_updates_rx) = mpsc::channel();
-
     let state = WaylandState {
         registry_state: RegistryState::new(&globals),
         compositor_state,
@@ -397,8 +386,6 @@ pub fn create_wayland_app() -> Result<
         primary_selection_device: None,
         primary_content: None,
         primary_source: None,
-        clipboard_updates_tx,
-        clipboard_updates_rx,
         selection_generation: 0,
         primary_generation: 0,
         latest_input_serial: 0,
@@ -913,40 +900,36 @@ impl WaylandState {
         self.primary_source = Some(source);
     }
 
-    /// Drain prefetched clipboard/primary contents, newest generation per
-    /// kind (stale reads from superseded offers are dropped).
-    pub fn drain_clipboard_updates(&mut self) -> Vec<(SelectionKind, Option<String>)> {
-        let mut latest_clipboard: Option<ClipboardUpdate> = None;
-        let mut latest_primary: Option<ClipboardUpdate> = None;
-        while let Ok(update) = self.clipboard_updates_rx.try_recv() {
-            let slot = match update.kind {
-                SelectionKind::Clipboard => &mut latest_clipboard,
-                SelectionKind::Primary => &mut latest_primary,
-            };
-            if slot
-                .as_ref()
-                .is_none_or(|s| update.generation >= s.generation)
-            {
-                *slot = Some(update);
-            }
+    /// Apply a prefetched clipboard/primary content update (from the loop's
+    /// ingress channel callback). Reads made stale by a newer offer are
+    /// dropped via the generation check.
+    pub(crate) fn apply_clipboard_update(
+        &mut self,
+        kind: SelectionKind,
+        generation: u64,
+        content: Option<String>,
+    ) {
+        let current = match kind {
+            SelectionKind::Clipboard => self.selection_generation,
+            SelectionKind::Primary => self.primary_generation,
+        };
+        if generation != current {
+            log::debug!("Dropping stale {kind:?} content (gen {generation} != {current})");
+            return;
         }
-        // Drop reads that are older than the newest offer we've seen.
-        let mut out = Vec::new();
-        if let Some(update) = latest_clipboard
-            && update.generation == self.selection_generation
-        {
-            out.push((SelectionKind::Clipboard, update.content));
+        match kind {
+            SelectionKind::Clipboard => match content {
+                Some(text) => crate::reactive::set_system_clipboard(text),
+                None => crate::reactive::clear_system_clipboard(),
+            },
+            SelectionKind::Primary => crate::reactive::set_system_primary(content),
         }
-        if let Some(update) = latest_primary
-            && update.generation == self.primary_generation
-        {
-            out.push((SelectionKind::Primary, update.content));
-        }
-        out
     }
 
     /// Start an async prefetch of an offer's content on a reader thread.
-    /// `receive` turns a chosen mime type into a read pipe.
+    /// `receive` turns a chosen mime type into a read pipe. The result comes
+    /// back through the calloop ingress channel — the message itself wakes
+    /// the loop, no hand-rolled wakeup involved.
     fn prefetch_selection<R>(&mut self, kind: SelectionKind, mimes: Vec<String>, receive: R)
     where
         R: FnOnce(&str) -> Option<ReadPipe>,
@@ -961,7 +944,6 @@ impl WaylandState {
                 self.primary_generation
             }
         };
-        let tx = self.clipboard_updates_tx.clone();
 
         // Preferred mime order; take the first one offered.
         const PREFERRED: [&str; 5] = [
@@ -977,13 +959,15 @@ impl WaylandState {
             .copied();
 
         let Some(pipe) = mime.and_then(receive) else {
-            // Nothing readable as text — treat as cleared.
-            let _ = tx.send(ClipboardUpdate {
-                kind,
-                generation,
-                content: None,
-            });
-            crate::jobs::request_frame();
+            // Nothing readable as text — treat as cleared. We're on the main
+            // thread (called from a selection handler), so apply directly.
+            self.apply_clipboard_update(kind, generation, None);
+            return;
+        };
+
+        let Some(sender) = crate::ingress::sender() else {
+            // No running event loop to deliver the result to.
+            log::warn!("Selection prefetch skipped: no event loop running");
             return;
         };
 
@@ -991,13 +975,11 @@ impl WaylandState {
             .name("guido-clipboard-read".into())
             .spawn(move || {
                 let content = read_pipe_with_deadline(pipe, Duration::from_secs(3));
-                let _ = tx.send(ClipboardUpdate {
+                let _ = sender.send(crate::ingress::IngressMessage::ClipboardUpdate {
                     kind,
                     generation,
                     content,
                 });
-                // Wake the event loop so the main thread applies the update
-                crate::jobs::request_frame();
             })
         {
             log::warn!("Failed to spawn clipboard reader thread: {e}");
@@ -2090,12 +2072,10 @@ impl DataDeviceHandler for WaylandState {
             .and_then(|device| device.data().selection_offer());
         match offer {
             None => {
+                // Selection cleared — main thread, apply directly.
                 self.selection_generation += 1;
-                let _ = self.clipboard_updates_tx.send(ClipboardUpdate {
-                    kind: SelectionKind::Clipboard,
-                    generation: self.selection_generation,
-                    content: None,
-                });
+                let generation = self.selection_generation;
+                self.apply_clipboard_update(SelectionKind::Clipboard, generation, None);
             }
             Some(offer) => {
                 let mimes = offer.with_mime_types(|t| t.to_vec());
@@ -2126,12 +2106,10 @@ impl PrimarySelectionDeviceHandler for WaylandState {
             .and_then(|data| data.selection_offer());
         match offer {
             None => {
+                // Primary selection cleared — main thread, apply directly.
                 self.primary_generation += 1;
-                let _ = self.clipboard_updates_tx.send(ClipboardUpdate {
-                    kind: SelectionKind::Primary,
-                    generation: self.primary_generation,
-                    content: None,
-                });
+                let generation = self.primary_generation;
+                self.apply_clipboard_update(SelectionKind::Primary, generation, None);
             }
             Some(offer) => {
                 let mimes = offer.with_mime_types(|t| t.to_vec());

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -6,9 +6,15 @@ use smithay_client_toolkit::{
     compositor::{CompositorHandler, CompositorState, Region},
     data_device_manager::{
         data_device::{DataDevice, DataDeviceHandler},
-        data_offer::{DataOfferHandler, SelectionOffer},
+        data_offer::DataOfferHandler,
         data_source::{CopyPasteSource, DataSourceHandler},
         DataDeviceManagerState, ReadPipe,
+    },
+    delegate_primary_selection,
+    primary_selection::{
+        device::{PrimarySelectionDevice, PrimarySelectionDeviceHandler},
+        selection::{PrimarySelectionSource, PrimarySelectionSourceHandler},
+        PrimarySelectionManagerState,
     },
     delegate_compositor, delegate_data_device, delegate_keyboard, delegate_layer, delegate_output,
     delegate_pointer, delegate_registry, delegate_seat,
@@ -55,8 +61,9 @@ use wayland_protocols::ext::background_effect::v1::client::{
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::{Read, Write};
-use std::os::fd::AsFd;
 use std::os::unix::io::OwnedFd;
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
 
 use crate::blur::BlurRect;
 use crate::outputs::{self, OutputId, OutputInfo};
@@ -220,9 +227,38 @@ pub struct WaylandState {
     data_device_manager: Option<DataDeviceManagerState>,
     data_device: Option<DataDevice>,
     clipboard_content: Option<String>,
-    pending_clipboard_read: Option<ReadPipe>,
     clipboard_source: Option<CopyPasteSource>,
-    selection_offer: Option<SelectionOffer>,
+
+    // Primary selection (select-to-copy / middle-click paste)
+    primary_selection_manager: Option<PrimarySelectionManagerState>,
+    primary_selection_device: Option<PrimarySelectionDevice>,
+    primary_content: Option<String>,
+    primary_source: Option<PrimarySelectionSource>,
+
+    // Async clipboard prefetch: whenever a selection offer changes, a reader
+    // thread fetches its content and sends it here. Generation counters drop
+    // results made stale by a newer offer.
+    clipboard_updates_tx: mpsc::Sender<ClipboardUpdate>,
+    clipboard_updates_rx: mpsc::Receiver<ClipboardUpdate>,
+    selection_generation: u64,
+    primary_generation: u64,
+    /// Serial of the most recent input event, needed to claim selections.
+    latest_input_serial: u32,
+}
+
+/// Which system selection a prefetched content update belongs to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SelectionKind {
+    /// The regular clipboard (Ctrl+C / Ctrl+V).
+    Clipboard,
+    /// The primary selection (select-to-copy / middle-click paste).
+    Primary,
+}
+
+struct ClipboardUpdate {
+    kind: SelectionKind,
+    generation: u64,
+    content: Option<String>,
 }
 
 /// Why the platform layer could not start or continue.
@@ -302,6 +338,12 @@ pub fn create_wayland_app() -> Result<
         log::warn!("Data device manager not available - clipboard will not work");
     }
 
+    // Primary selection (select-to-copy / middle-click paste) — optional
+    let primary_selection_manager = PrimarySelectionManagerState::bind(&globals, &qh).ok();
+    if primary_selection_manager.is_none() {
+        log::info!("Primary selection manager not available - middle-click paste will not work");
+    }
+
     // Initialize cursor shape manager for cursor changes
     let cursor_shape_manager = CursorShapeManager::bind(&globals, &qh).ok();
     if cursor_shape_manager.is_none() {
@@ -313,6 +355,8 @@ pub fn create_wayland_app() -> Result<
     if bg_effect_manager.is_none() {
         log::info!("ext-background-effect-v1 not available - background blur will not work");
     }
+
+    let (clipboard_updates_tx, clipboard_updates_rx) = mpsc::channel();
 
     let state = WaylandState {
         registry_state: RegistryState::new(&globals),
@@ -348,9 +392,16 @@ pub fn create_wayland_app() -> Result<
         data_device_manager,
         data_device: None,
         clipboard_content: None,
-        pending_clipboard_read: None,
         clipboard_source: None,
-        selection_offer: None,
+        primary_selection_manager,
+        primary_selection_device: None,
+        primary_content: None,
+        primary_source: None,
+        clipboard_updates_tx,
+        clipboard_updates_rx,
+        selection_generation: 0,
+        primary_generation: 0,
+        latest_input_serial: 0,
     };
 
     Ok((connection, event_queue, state, qh))
@@ -844,90 +895,113 @@ impl WaylandState {
         self.clipboard_content.clone()
     }
 
-    /// Read clipboard content from external selection (from other applications)
-    /// This reads from the Wayland selection offer if available
-    pub fn read_external_clipboard(&mut self, connection: &Connection) -> Option<String> {
-        let offer = self.selection_offer.take()?;
+    /// Set the primary selection content (select-to-copy).
+    pub fn set_primary(&mut self, text: String, qh: &QueueHandle<Self>) {
+        let Some(ref manager) = self.primary_selection_manager else {
+            return;
+        };
+        let Some(ref device) = self.primary_selection_device else {
+            return;
+        };
 
-        // Try different mime types in order of preference
-        let mime_types = [
+        let source = manager.create_selection_source(
+            qh,
+            vec!["text/plain;charset=utf-8", "UTF8_STRING", "TEXT", "STRING"],
+        );
+        self.primary_content = Some(text);
+        source.set_selection(device, self.latest_input_serial);
+        self.primary_source = Some(source);
+    }
+
+    /// Drain prefetched clipboard/primary contents, newest generation per
+    /// kind (stale reads from superseded offers are dropped).
+    pub fn drain_clipboard_updates(&mut self) -> Vec<(SelectionKind, Option<String>)> {
+        let mut latest_clipboard: Option<ClipboardUpdate> = None;
+        let mut latest_primary: Option<ClipboardUpdate> = None;
+        while let Ok(update) = self.clipboard_updates_rx.try_recv() {
+            let slot = match update.kind {
+                SelectionKind::Clipboard => &mut latest_clipboard,
+                SelectionKind::Primary => &mut latest_primary,
+            };
+            if slot
+                .as_ref()
+                .is_none_or(|s| update.generation >= s.generation)
+            {
+                *slot = Some(update);
+            }
+        }
+        // Drop reads that are older than the newest offer we've seen.
+        let mut out = Vec::new();
+        if let Some(update) = latest_clipboard
+            && update.generation == self.selection_generation
+        {
+            out.push((SelectionKind::Clipboard, update.content));
+        }
+        if let Some(update) = latest_primary
+            && update.generation == self.primary_generation
+        {
+            out.push((SelectionKind::Primary, update.content));
+        }
+        out
+    }
+
+    /// Start an async prefetch of an offer's content on a reader thread.
+    /// `receive` turns a chosen mime type into a read pipe.
+    fn prefetch_selection<R>(&mut self, kind: SelectionKind, mimes: Vec<String>, receive: R)
+    where
+        R: FnOnce(&str) -> Option<ReadPipe>,
+    {
+        let generation = match kind {
+            SelectionKind::Clipboard => {
+                self.selection_generation += 1;
+                self.selection_generation
+            }
+            SelectionKind::Primary => {
+                self.primary_generation += 1;
+                self.primary_generation
+            }
+        };
+        let tx = self.clipboard_updates_tx.clone();
+
+        // Preferred mime order; take the first one offered.
+        const PREFERRED: [&str; 5] = [
             "text/plain;charset=utf-8",
             "UTF8_STRING",
             "text/plain",
             "TEXT",
             "STRING",
         ];
+        let mime = PREFERRED
+            .iter()
+            .find(|m| mimes.iter().any(|t| t == *m))
+            .copied();
 
-        for mime_type in mime_types {
-            // Check if this mime type is offered
-            if !offer.with_mime_types(|types| types.iter().any(|t| t == mime_type)) {
-                continue;
-            }
+        let Some(pipe) = mime.and_then(receive) else {
+            // Nothing readable as text — treat as cleared.
+            let _ = tx.send(ClipboardUpdate {
+                kind,
+                generation,
+                content: None,
+            });
+            crate::jobs::request_frame();
+            return;
+        };
 
-            // Try to receive data with this mime type
-            match offer.receive(mime_type.to_string()) {
-                Ok(pipe) => {
-                    // Flush the connection to send the receive request to the compositor
-                    // The compositor then notifies the source app to write data to the pipe
-                    let _ = connection.flush();
-
-                    // Convert to file for reading
-                    let fd = OwnedFd::from(pipe);
-                    let mut file = File::from(fd);
-
-                    // Use poll() to wait for data with a timeout
-                    #[cfg(unix)]
-                    {
-                        use std::os::unix::io::AsRawFd;
-                        let raw_fd = file.as_raw_fd();
-
-                        let mut poll_fd = libc::pollfd {
-                            fd: raw_fd,
-                            events: libc::POLLIN,
-                            revents: 0,
-                        };
-
-                        // Wait up to 500ms for data to be available
-                        let ret = unsafe { libc::poll(&mut poll_fd, 1, 500) };
-
-                        if ret > 0 && (poll_fd.revents & libc::POLLIN) != 0 {
-                            let mut contents = String::new();
-                            if file.read_to_string(&mut contents).is_ok() && !contents.is_empty() {
-                                self.selection_offer = Some(offer);
-                                return Some(contents);
-                            }
-                        }
-                    }
-                }
-                Err(e) => {
-                    log::debug!("Failed to receive clipboard data as {}: {:?}", mime_type, e);
-                }
-            }
+        if let Err(e) = std::thread::Builder::new()
+            .name("guido-clipboard-read".into())
+            .spawn(move || {
+                let content = read_pipe_with_deadline(pipe, Duration::from_secs(3));
+                let _ = tx.send(ClipboardUpdate {
+                    kind,
+                    generation,
+                    content,
+                });
+                // Wake the event loop so the main thread applies the update
+                crate::jobs::request_frame();
+            })
+        {
+            log::warn!("Failed to spawn clipboard reader thread: {e}");
         }
-
-        // Store back the offer even if we couldn't read
-        self.selection_offer = Some(offer);
-        None
-    }
-
-    /// Check if there's pending clipboard data to read
-    pub fn poll_clipboard(&mut self) -> Option<String> {
-        if let Some(ref mut pipe) = self.pending_clipboard_read.take() {
-            let mut contents = String::new();
-            // Read with a small timeout - this is blocking but typically fast
-            match pipe.as_fd().try_clone_to_owned() {
-                Ok(fd) => {
-                    let mut file = std::fs::File::from(fd);
-                    if file.read_to_string(&mut contents).is_ok() && !contents.is_empty() {
-                        return Some(contents);
-                    }
-                }
-                Err(e) => {
-                    log::warn!("Failed to clone clipboard fd: {}", e);
-                }
-            }
-        }
-        None
     }
 
     /// Set the cursor shape
@@ -967,6 +1041,61 @@ impl WaylandState {
         let device = manager.get_shape_device(pointer, qh);
         device.set_shape(self.pointer_enter_serial, shape);
     }
+}
+
+/// Read a selection pipe to EOF with a total deadline. Runs on a reader
+/// thread — never on the UI thread.
+fn read_pipe_with_deadline(pipe: ReadPipe, deadline: Duration) -> Option<String> {
+    use std::os::unix::io::AsRawFd;
+
+    let fd = OwnedFd::from(pipe);
+    let mut file = File::from(fd);
+    let raw_fd = file.as_raw_fd();
+    let mut buf = Vec::new();
+    let end = Instant::now() + deadline;
+
+    loop {
+        let remaining = end.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            log::warn!("Clipboard read timed out after {:?}", deadline);
+            return None;
+        }
+
+        let mut poll_fd = libc::pollfd {
+            fd: raw_fd,
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        let timeout_ms = remaining.as_millis().min(i32::MAX as u128) as i32;
+        let ret = unsafe { libc::poll(&mut poll_fd, 1, timeout_ms) };
+        if ret < 0 {
+            let err = std::io::Error::last_os_error();
+            if err.kind() == std::io::ErrorKind::Interrupted {
+                continue;
+            }
+            log::warn!("Clipboard read poll failed: {err}");
+            return None;
+        }
+        if ret == 0 {
+            log::warn!("Clipboard read timed out after {:?}", deadline);
+            return None;
+        }
+
+        // POLLIN or POLLHUP: data available or writer closed — read either way
+        let mut chunk = [0u8; 8192];
+        match file.read(&mut chunk) {
+            Ok(0) => break, // EOF
+            Ok(n) => buf.extend_from_slice(&chunk[..n]),
+            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(e) => {
+                log::warn!("Clipboard read failed: {e}");
+                return None;
+            }
+        }
+    }
+
+    let text = String::from_utf8_lossy(&buf).into_owned();
+    (!text.is_empty()).then_some(text)
 }
 
 pub struct WaylandWindowWrapper {
@@ -1259,6 +1388,14 @@ impl SeatHandler for WaylandState {
                 let data_device = manager.get_data_device(qh, &seat);
                 self.data_device = Some(data_device);
             }
+
+            // Create primary selection device alongside it
+            if self.primary_selection_device.is_none()
+                && let Some(ref manager) = self.primary_selection_manager
+            {
+                log::info!("Creating primary selection device");
+                self.primary_selection_device = Some(manager.get_selection_device(qh, &seat));
+            }
         }
     }
 
@@ -1301,12 +1438,13 @@ impl TouchHandler for WaylandState {
         _conn: &Connection,
         _qh: &QueueHandle<Self>,
         _touch: &wl_touch::WlTouch,
-        _serial: u32,
+        serial: u32,
         _time: u32,
         surface: wl_surface::WlSurface,
         id: i32,
         position: (f64, f64),
     ) {
+        self.latest_input_serial = serial;
         let Some(surface_id) = self.surface_lookup.get(&surface.id()).copied() else {
             return;
         };
@@ -1450,6 +1588,7 @@ impl PointerHandler for WaylandState {
                 PointerEventKind::Enter { serial } => {
                     self.pointer_over_surface = true;
                     self.pointer_enter_serial = serial;
+                    self.latest_input_serial = serial;
                     self.pointer_x = event.position.0 as f32;
                     self.pointer_y = event.position.1 as f32;
 
@@ -1501,7 +1640,8 @@ impl PointerHandler for WaylandState {
                         }
                     }
                 }
-                PointerEventKind::Press { button, .. } => {
+                PointerEventKind::Press { button, serial, .. } => {
+                    self.latest_input_serial = serial;
                     if let Some(mouse_button) = wayland_button_to_mouse_button(button)
                         && let Some(events) = target_events
                     {
@@ -1655,6 +1795,7 @@ impl KeyboardHandler for WaylandState {
     ) {
         // Track serial for clipboard operations
         self.keyboard_serial = serial;
+        self.latest_input_serial = serial;
 
         if let Some(key) = keysym_to_key(event.keysym, event.utf8.as_deref(), true) {
             // Store raw_code → Key mapping so release_key can emit the correct Key
@@ -1936,15 +2077,111 @@ impl DataDeviceHandler for WaylandState {
 
     fn selection(
         &mut self,
-        _conn: &Connection,
+        conn: &Connection,
         _qh: &QueueHandle<Self>,
         _data_device: &WlDataDevice,
     ) {
         log::debug!("Clipboard selection changed");
-        // Store the selection offer for later paste operations
-        if let Some(ref device) = self.data_device {
-            self.selection_offer = device.data().selection_offer();
+        // Prefetch the new selection's content on a reader thread so paste
+        // is instant and never blocks the UI thread.
+        let offer = self
+            .data_device
+            .as_ref()
+            .and_then(|device| device.data().selection_offer());
+        match offer {
+            None => {
+                self.selection_generation += 1;
+                let _ = self.clipboard_updates_tx.send(ClipboardUpdate {
+                    kind: SelectionKind::Clipboard,
+                    generation: self.selection_generation,
+                    content: None,
+                });
+            }
+            Some(offer) => {
+                let mimes = offer.with_mime_types(|t| t.to_vec());
+                self.prefetch_selection(SelectionKind::Clipboard, mimes, |mime| {
+                    offer
+                        .receive(mime.to_string())
+                        .map_err(|e| log::debug!("Failed to receive clipboard as {mime}: {e:?}"))
+                        .ok()
+                });
+                // Send the receive request out now so the source app starts
+                // writing before the next loop-iteration flush.
+                let _ = conn.flush();
+            }
         }
+    }
+}
+
+impl PrimarySelectionDeviceHandler for WaylandState {
+    fn selection(
+        &mut self,
+        conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        device: &smithay_client_toolkit::reexports::protocols::wp::primary_selection::zv1::client::zwp_primary_selection_device_v1::ZwpPrimarySelectionDeviceV1,
+    ) {
+        log::debug!("Primary selection changed");
+        let offer = device
+            .data::<smithay_client_toolkit::primary_selection::device::PrimarySelectionDeviceData>()
+            .and_then(|data| data.selection_offer());
+        match offer {
+            None => {
+                self.primary_generation += 1;
+                let _ = self.clipboard_updates_tx.send(ClipboardUpdate {
+                    kind: SelectionKind::Primary,
+                    generation: self.primary_generation,
+                    content: None,
+                });
+            }
+            Some(offer) => {
+                let mimes = offer.with_mime_types(|t| t.to_vec());
+                self.prefetch_selection(SelectionKind::Primary, mimes, |mime| {
+                    offer
+                        .receive(mime.to_string())
+                        .map_err(|e| log::debug!("Failed to receive primary as {mime}: {e:?}"))
+                        .ok()
+                });
+                let _ = conn.flush();
+            }
+        }
+    }
+}
+
+impl PrimarySelectionSourceHandler for WaylandState {
+    fn send_request(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _source: &smithay_client_toolkit::reexports::protocols::wp::primary_selection::zv1::client::zwp_primary_selection_source_v1::ZwpPrimarySelectionSourceV1,
+        mime: String,
+        write_pipe: smithay_client_toolkit::data_device_manager::WritePipe,
+    ) {
+        log::debug!("Primary selection send request for mime type: {mime}");
+        if let Some(ref content) = self.primary_content {
+            let content = content.clone();
+            let owned_fd = OwnedFd::from(write_pipe);
+            if let Err(e) = std::thread::Builder::new()
+                .name("guido-primary-send".into())
+                .spawn(move || {
+                    let mut file = File::from(owned_fd);
+                    if let Err(e) = file.write_all(content.as_bytes()) {
+                        log::warn!("Failed to write primary selection content: {e}");
+                    }
+                })
+            {
+                log::warn!("Failed to spawn primary selection writer thread: {e}");
+            }
+        }
+    }
+
+    fn cancelled(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _source: &smithay_client_toolkit::reexports::protocols::wp::primary_selection::zv1::client::zwp_primary_selection_source_v1::ZwpPrimarySelectionSourceV1,
+    ) {
+        log::debug!("Primary selection source cancelled");
+        self.primary_source = None;
     }
 }
 
@@ -2048,4 +2285,5 @@ delegate_pointer!(WaylandState);
 delegate_touch!(WaylandState);
 delegate_keyboard!(WaylandState);
 delegate_data_device!(WaylandState);
+delegate_primary_selection!(WaylandState);
 delegate_registry!(WaylandState);

--- a/src/reactive/clipboard.rs
+++ b/src/reactive/clipboard.rs
@@ -12,11 +12,17 @@ thread_local! {
     /// Flag indicating clipboard was changed and needs to be synced to Wayland
     static CLIPBOARD_CHANGED: RefCell<bool> = const { RefCell::new(false) };
 
-    /// Pending clipboard read request (for async clipboard reading from Wayland)
-    static CLIPBOARD_READ_REQUESTED: RefCell<bool> = const { RefCell::new(false) };
-
-    /// System clipboard contents (from Wayland selection offer)
+    /// System clipboard contents (prefetched from the Wayland selection offer)
     static SYSTEM_CLIPBOARD: RefCell<Option<String>> = const { RefCell::new(None) };
+
+    /// Internal primary-selection buffer (our outgoing content)
+    static PRIMARY: RefCell<Option<String>> = const { RefCell::new(None) };
+
+    /// Flag indicating the primary selection changed and needs syncing
+    static PRIMARY_CHANGED: RefCell<bool> = const { RefCell::new(false) };
+
+    /// System primary-selection contents (prefetched from other apps)
+    static SYSTEM_PRIMARY: RefCell<Option<String>> = const { RefCell::new(None) };
 }
 
 /// Copy text to the clipboard
@@ -80,10 +86,45 @@ pub fn clear_system_clipboard() {
     });
 }
 
-/// Request reading from system clipboard
-pub fn request_clipboard_read() {
-    CLIPBOARD_READ_REQUESTED.with(|r| {
-        *r.borrow_mut() = true;
+/// Copy text to the primary selection (select-to-copy).
+pub fn primary_copy(text: &str) {
+    PRIMARY.with(|c| {
+        *c.borrow_mut() = Some(text.to_string());
+    });
+    PRIMARY_CHANGED.with(|changed| {
+        *changed.borrow_mut() = true;
+    });
+}
+
+/// Take pending primary-selection change (for syncing to Wayland)
+pub(crate) fn take_primary_change() -> Option<String> {
+    let changed = PRIMARY_CHANGED.with(|c| {
+        let was_changed = *c.borrow();
+        *c.borrow_mut() = false;
+        was_changed
+    });
+
+    if changed {
+        PRIMARY.with(|c| c.borrow().clone())
+    } else {
+        None
+    }
+}
+
+/// Paste text from the primary selection (middle-click paste).
+pub fn primary_paste() -> Option<String> {
+    SYSTEM_PRIMARY.with(|sc| {
+        if let Some(text) = sc.borrow().as_ref() {
+            return Some(text.clone());
+        }
+        PRIMARY.with(|c| c.borrow().clone())
+    })
+}
+
+/// Set/clear system primary-selection contents (from Wayland)
+pub(crate) fn set_system_primary(text: Option<String>) {
+    SYSTEM_PRIMARY.with(|sc| {
+        *sc.borrow_mut() = text;
     });
 }
 
@@ -93,17 +134,8 @@ pub fn request_clipboard_read() {
 pub(crate) fn reset_clipboard() {
     CLIPBOARD.with(|c| *c.borrow_mut() = None);
     CLIPBOARD_CHANGED.with(|c| *c.borrow_mut() = false);
-    CLIPBOARD_READ_REQUESTED.with(|c| *c.borrow_mut() = false);
     SYSTEM_CLIPBOARD.with(|c| *c.borrow_mut() = None);
-}
-
-/// Check and clear clipboard read request
-pub fn take_clipboard_read_request() -> bool {
-    CLIPBOARD_READ_REQUESTED.with(|r| {
-        let requested = *r.borrow();
-        if requested {
-            *r.borrow_mut() = false;
-        }
-        requested
-    })
+    PRIMARY.with(|c| *c.borrow_mut() = None);
+    PRIMARY_CHANGED.with(|c| *c.borrow_mut() = false);
+    SYSTEM_PRIMARY.with(|c| *c.borrow_mut() = None);
 }

--- a/src/reactive/mod.rs
+++ b/src/reactive/mod.rs
@@ -14,7 +14,11 @@ pub mod signal;
 pub mod storage;
 
 pub(crate) use clipboard::{
-    clipboard_copy, clipboard_paste, set_system_clipboard, take_clipboard_change,
+    clear_system_clipboard, set_system_clipboard, set_system_primary, take_clipboard_change,
+    take_primary_change,
+};
+pub use clipboard::{
+    clipboard_copy, clipboard_has_content, clipboard_paste, primary_copy, primary_paste,
 };
 pub use context::{
     expect_context, has_context, provide_context, provide_signal_context, use_context, with_context,

--- a/src/widgets/text_input.rs
+++ b/src/widgets/text_input.rs
@@ -16,7 +16,8 @@ use crate::jobs::{JobRequest, JobType, RequiredJob, request_job};
 use crate::layout::{Constraints, Size};
 use crate::reactive::{
     CursorIcon, IntoSignal, OptionSignalExt, RwSignal, Signal, clipboard_copy, clipboard_paste,
-    has_focus, release_focus, request_focus, set_cursor, with_signal_tracking,
+    has_focus, primary_copy, primary_paste, release_focus, request_focus, set_cursor,
+    with_signal_tracking,
 };
 use crate::renderer::{PaintContext, char_index_from_x_styled};
 use crate::tree::{Tree, WidgetId};
@@ -1141,6 +1142,25 @@ impl Widget for TextInput {
             }
             Event::MouseUp { button, .. } if *button == MouseButton::Left && self.is_dragging => {
                 self.is_dragging = false;
+                // Select-to-copy: a completed mouse selection becomes the
+                // primary selection (middle-click paste elsewhere)
+                if let Some(text) = self.get_selected_text() {
+                    primary_copy(&text);
+                }
+                return EventResponse::Handled;
+            }
+            Event::MouseDown { x, y, button }
+                if bounds.contains(*x, *y) && *button == MouseButton::Middle =>
+            {
+                // Middle-click paste from the primary selection
+                request_focus(id);
+                let char_index = self.char_index_at_x(*x, bounds);
+                self.selection = Selection::new(char_index);
+                if let Some(text) = primary_paste() {
+                    self.insert_text(&text, bounds.width);
+                }
+                self.reset_cursor_blink();
+                request_job(id, JobRequest::Paint);
                 return EventResponse::Handled;
             }
             Event::KeyDown { key, modifiers } if has_focus(id) => {


### PR DESCRIPTION
## Summary

Seventh and last PR of the Wayland parity series (stacked on #114; the stack now sits on the #116 loop-ingress foundation).

**Non-blocking paste.** Paste used to do a synchronous 500 ms `libc::poll` on the UI thread, fired only by a hardcoded Ctrl+V sniff — widget-initiated pastes never refreshed the system clipboard, and a slow source app stalled the frame loop. Now every selection-offer change starts a reader thread that prefetches the content (3 s deadline) and delivers it through the **calloop ingress channel from #116** — the message's arrival is the wakeup, no hand-rolled ping. Generation counters drop reads made stale by a newer offer. `clipboard_paste()` consults the always-warm cache: instant, no UI-thread IO, works from any code path.

**Primary selection** (`zwp_primary_selection_v1`, prefetched the same way):
- `primary_copy()` / `primary_paste()` exposed from the reactive module
- TextInput: finishing a mouse selection publishes it as the primary selection; middle click pastes it at the click position
- selection claims use the latest input serial (pointer press/enter, key press, touch down)

## Testing

- 218 lib tests, clippy 1.97.1 `-D warnings`, fmt, book build — clean.
- Live on niri: clipboard + primary prefetch fire on `wl-copy`; three consecutive session lock/unlock cycles with exact timing on this stack (validating the #116 wakeup design end-to-end).
