### PR TITLE
Core: lost-wakeup fix + calloop ingress channel for cross-thread wakeups

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -243,6 +243,38 @@ The jobs system connects reactive signals to widget invalidation.
 - Main loop drains jobs and processes by type in order
 - Animation jobs run after paint to advance state for next frame
 
+## Event Loop Wakeup Contract
+
+The main loop blocks in `calloop::EventLoop::dispatch` when idle. Anything
+that queues work for the loop must guarantee a wakeup that survives until
+its consumer runs. Two mechanisms exist, and which one to use depends on
+the producer's thread:
+
+**Background threads → calloop ingress channel (`src/ingress.rs`).**
+Cross-thread producers (services via `WriteSignal`, reader threads) send an
+`IngressMessage` through a calloop channel registered as an event source.
+calloop guarantees a send wakes the next dispatch — the message's existence
+*is* the wakeup, so a lost-wakeup is impossible by construction. Messages
+either carry their payload or act as doorbells for data queued elsewhere
+(e.g. `BgWritesQueued` for the reactive write queue, drained at the loop's
+flush point). Never call `jobs::request_frame()` directly from a background
+thread as the *only* wakeup for queued work.
+
+**Main thread → `jobs::request_frame()`.**
+The frame-request ping is coalesced per loop iteration through a dedicated
+`PING_SENT` flag cleared once per wakeup (`mark_loop_awake`, right after
+dispatch returns). It is intentionally NOT coalesced via `FRAME_REQUESTED`:
+that flag is consumed mid-iteration by `take_frame_request()`, and gating
+the ping on it once lost wakeups entirely (a request landing while the flag
+was set sent no ping and was then absorbed by the take — the loop blocked
+with work queued until an unrelated Wayland event arrived). Additionally,
+the loop refuses to block indefinitely while `FRAME_REQUESTED` is still set
+at iteration start (`frame_request_pending`).
+
+When adding a new deferred-work queue, either drain it in the loop after
+the flush point AND wake through one of the two mechanisms above, or make
+it a calloop source of its own.
+
 ## Widget Trait
 
 All widgets implement this trait:

--- a/src/ingress.rs
+++ b/src/ingress.rs
@@ -1,0 +1,69 @@
+//! Cross-thread ingress into the main event loop.
+//!
+//! Background threads must never hand-roll wakeups for the main loop: they
+//! send an [`IngressMessage`] through a calloop channel registered as an
+//! event source. calloop guarantees that a send wakes the next dispatch and
+//! delivers the message before the loop can block again — the message's
+//! existence *is* the wakeup, so the lost-wakeup class of bugs (a ping
+//! suppressed because some flag was already set, then absorbed by an
+//! unrelated consumer) cannot occur by construction.
+//!
+//! Main-thread code keeps using `jobs::request_frame()`, whose ping is
+//! coalesced once per loop iteration (see `jobs::mark_loop_awake`).
+//!
+//! When no loop is running (setup phase, tests, teardown) [`notify`] falls
+//! back to the frame-request ping, which degrades to a plain flag there.
+
+use std::sync::Mutex;
+
+use smithay_client_toolkit::reexports::calloop::channel::Sender;
+
+/// Messages background threads can push into the main loop.
+///
+/// Variants either carry their payload directly (applied by the loop's
+/// channel callback) or act as doorbells for data queued elsewhere.
+pub(crate) enum IngressMessage {
+    /// Background signal writes were queued (the data lives in the reactive
+    /// write queue and is drained at the loop's flush point). The message
+    /// only guarantees the loop wakes up to run that flush.
+    BgWritesQueued,
+}
+
+static INGRESS_SENDER: Mutex<Option<Sender<IngressMessage>>> = Mutex::new(None);
+
+/// Install the loop's channel sender. Called by `App::run` when the event
+/// loop is created.
+pub(crate) fn install_ingress(sender: Sender<IngressMessage>) {
+    if let Ok(mut guard) = INGRESS_SENDER.lock() {
+        *guard = Some(sender);
+    }
+}
+
+/// Get a sender clone for a background thread, if a loop is running.
+pub(crate) fn sender() -> Option<Sender<IngressMessage>> {
+    INGRESS_SENDER.lock().ok().and_then(|g| g.as_ref().cloned())
+}
+
+/// Send a message to the main loop, falling back to the frame-request ping
+/// when no loop is running.
+pub(crate) fn notify(message: IngressMessage) {
+    match sender() {
+        Some(tx) => {
+            if tx.send(message).is_err() {
+                // Receiver died (loop shutting down) — fall back so pending
+                // work is at least flagged for a future loop.
+                crate::jobs::request_frame();
+            }
+        }
+        None => crate::jobs::request_frame(),
+    }
+}
+
+/// Reset ingress state.
+///
+/// Called during `App::drop()`.
+pub(crate) fn reset_ingress() {
+    if let Ok(mut guard) = INGRESS_SENDER.lock() {
+        *guard = None;
+    }
+}

--- a/src/jobs.rs
+++ b/src/jobs.rs
@@ -313,6 +313,9 @@ pub(crate) fn get_exit_request() -> ExitRequest {
 
 /// Global flag to indicate a frame is requested
 static FRAME_REQUESTED: AtomicBool = AtomicBool::new(false);
+/// Whether a wakeup ping is already in flight for the current blocked/idle
+/// period. Cleared by `mark_loop_awake()` right after dispatch returns.
+static PING_SENT: AtomicBool = AtomicBool::new(false);
 
 /// Global wakeup handle for signaling the event loop.
 /// Uses `Mutex<Option<Ping>>` instead of `OnceLock` so it can be reset on App drop.
@@ -327,16 +330,30 @@ pub fn init_wakeup(ping: Ping) {
 
 /// Request that the main event loop process a frame
 pub(crate) fn request_frame() {
-    // Only ping on first request - avoids redundant syscalls when multiple signals update
-    let was_requested = FRAME_REQUESTED.swap(true, Ordering::Relaxed);
-    if !was_requested {
-        // Wake up the event loop immediately
-        if let Ok(guard) = WAKEUP_PING.lock()
-            && let Some(ref ping) = *guard
-        {
-            ping.ping();
-        }
+    FRAME_REQUESTED.store(true, Ordering::Relaxed);
+    // Coalesce pings per loop iteration via a dedicated flag, NOT via
+    // FRAME_REQUESTED: the frame flag is consumed mid-iteration by
+    // take_frame_request(), so gating the ping on it lost wakeups — a
+    // request landing while the flag happened to be set sent no ping, the
+    // take then cleared the flag, and the loop blocked indefinitely with
+    // work queued (only an unrelated Wayland event like mouse movement
+    // would revive it). PING_SENT is instead cleared exactly once per
+    // wakeup (mark_loop_awake), so during any blocked period the first
+    // request always pings.
+    let already_pinged = PING_SENT.swap(true, Ordering::Relaxed);
+    if !already_pinged
+        && let Ok(guard) = WAKEUP_PING.lock()
+        && let Some(ref ping) = *guard
+    {
+        ping.ping();
     }
+}
+
+/// Reset ping coalescing after the event loop woke up. Any `request_frame`
+/// from here until the next dispatch sends (at most) one fresh ping, which
+/// keeps the eventfd readable so that dispatch returns immediately.
+pub(crate) fn mark_loop_awake() {
+    PING_SENT.store(false, Ordering::Relaxed);
 }
 
 /// Reset all job state (pending jobs, frame request flag, wakeup ping).
@@ -347,6 +364,7 @@ pub(crate) fn reset_jobs() {
         jobs.borrow_mut().drain_all();
     });
     FRAME_REQUESTED.store(false, Ordering::Relaxed);
+    PING_SENT.store(false, Ordering::Relaxed);
     EXIT_REQUEST.store(ExitRequest::Running as u8, Ordering::Relaxed);
     if let Ok(mut guard) = WAKEUP_PING.lock() {
         *guard = None;
@@ -356,6 +374,18 @@ pub(crate) fn reset_jobs() {
 /// Check if a frame has been requested and clear the flag
 pub fn take_frame_request() -> bool {
     FRAME_REQUESTED.swap(false, Ordering::Relaxed)
+}
+
+/// Peek the frame-request flag without clearing it.
+///
+/// Used by the main loop before blocking: a request that landed after this
+/// iteration's `take_frame_request()` (e.g. from a background thread) leaves
+/// the flag set, and `request_frame`'s ping-on-first-request optimization
+/// then suppresses every later ping — blocking indefinitely on a set flag
+/// would make the app deaf to background wakeups until an unrelated Wayland
+/// event (mouse movement) arrives.
+pub fn frame_request_pending() -> bool {
+    FRAME_REQUESTED.load(Ordering::Relaxed)
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod animation;
 pub mod image_metadata;
+mod ingress;
 mod jobs;
 pub mod layout;
 pub mod reactive;
@@ -34,6 +35,7 @@ use widgets::font::FontFamily;
 
 // Calloop imports for event-driven main loop (via smithay-client-toolkit re-exports)
 use smithay_client_toolkit::reexports::calloop::EventLoop;
+use smithay_client_toolkit::reexports::calloop::channel as calloop_channel;
 use smithay_client_toolkit::reexports::calloop::ping::make_ping;
 use smithay_client_toolkit::reexports::calloop_wayland_source::WaylandSource;
 
@@ -786,6 +788,24 @@ impl App {
             })
             .expect("Failed to insert ping source");
 
+        // Cross-thread ingress channel: background threads send messages
+        // here instead of hand-rolling wakeups. calloop guarantees a send
+        // wakes the next dispatch — see the ingress module.
+        let (ingress_tx, ingress_channel) = calloop_channel::channel();
+        ingress::install_ingress(ingress_tx);
+        loop_handle
+            .insert_source(ingress_channel, |event, _, _wayland_state| {
+                if let calloop_channel::Event::Msg(message) = event {
+                    match message {
+                        // Doorbell only: the write payloads live in the
+                        // reactive write queue, drained at the flush point
+                        // later this same iteration.
+                        ingress::IngressMessage::BgWritesQueued => {}
+                    }
+                }
+            })
+            .expect("Failed to insert ingress channel");
+
         // Insert Wayland source - this handles all Wayland protocol events
         WaylandSource::new(connection.clone(), event_queue)
             .insert(loop_handle.clone())
@@ -909,6 +929,7 @@ impl Drop for App {
         // Reset all thread-local and static state so the next App can start clean.
         reactive::reset_reactive();
         jobs::reset_jobs();
+        ingress::reset_ingress();
         surface::reset_surface_commands();
         widget_ref::reset_widget_refs();
         FONTS_CONSUMED.with(|f| f.set(false));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -797,9 +797,12 @@ impl App {
             let any_surface_needs_init = wayland_state.any_surface_needs_render();
             let force_render = any_surface_needs_init;
 
-            // Check if we need to actively poll (jobs pushed during previous frame)
+            // Check if we need to actively poll: jobs pushed during the
+            // previous frame, or a frame request that landed after this
+            // iteration consumed the flag (blocking on a set flag would
+            // suppress all later pings — see frame_request_pending).
             let has_pending = has_pending_jobs();
-            let needs_polling = has_pending || force_render;
+            let needs_polling = has_pending || force_render || jobs::frame_request_pending();
 
             // Dispatch events from calloop:
             // - If polling needed (animations/callbacks/init), use timeout
@@ -816,6 +819,11 @@ impl App {
                 log::error!("Event loop dispatch failed: {e}");
                 return ExitReason::Error(platform::PlatformError::ConnectionLost);
             }
+
+            // Reset ping coalescing: the first request_frame from here on
+            // sends a fresh ping so the next dispatch can't block on
+            // work queued during this iteration.
+            jobs::mark_loop_awake();
 
             // Check for programmatic exit/restart requests
             match get_exit_request() {

--- a/src/reactive/runtime.rs
+++ b/src/reactive/runtime.rs
@@ -159,8 +159,10 @@ pub fn queue_bg_write(epoch: u64, f: impl FnOnce() + Send + 'static) {
     if let Ok(mut q) = WRITE_QUEUE.lock() {
         q.push((epoch, Box::new(f)));
     }
-    // Wake the event loop so flush_bg_writes() runs on the next frame
-    crate::jobs::request_frame();
+    // Wake the event loop so flush_bg_writes() runs on the next frame.
+    // Routed through the calloop ingress channel: its readiness guarantees
+    // the loop wakes no matter where in its iteration the write landed.
+    crate::ingress::notify(crate::ingress::IngressMessage::BgWritesQueued);
 }
 
 /// Drain queued background writes and execute them on the main thread.


### PR DESCRIPTION
## Summary

New foundation PR at the bottom of the Wayland parity stack (#109–#115 will be rebased on top).

**1. Lost-wakeup fix** (found live while testing session lock — lock/unlock only progressed when the mouse moved): `request_frame()` coalesced its wakeup ping via `FRAME_REQUESTED`, which `take_frame_request()` consumes mid-iteration. A request landing while the flag was set sent no ping and was absorbed by the take: the loop blocked indefinitely with work queued. Ping coalescing now uses a dedicated `PING_SENT` flag cleared once per wakeup, and the loop refuses to block while a frame request is pending.

**2. Structural hardening — calloop ingress channel** (`src/ingress.rs`): background threads no longer hand-roll wakeups at all. They send an `IngressMessage` through a calloop channel registered as an event source; calloop guarantees a send wakes the next dispatch, so the lost-wakeup class of bugs becomes impossible by construction rather than avoided by convention. Background signal writes (`WriteSignal`/services) are the first user (doorbell message, data drained at the existing flush point); the clipboard prefetch in #115 will be the second. Falls back to the ping when no loop runs (setup/tests/teardown).

The wakeup contract is documented in ARCHITECTURE.md for anyone adding future queues.

## Testing

- 213 lib tests, clippy 1.97.1 `-D warnings`, fmt — clean.
- The lost-wakeup fix was validated live at the top of the stack: three consecutive session lock/unlock cycles with exact timing (before: stalled until mouse movement).
