### PR TITLE
Pace animation jobs per surface: fix cross-surface busy-spin

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -123,6 +123,10 @@ Hardware-accelerated rendering using wgpu.
    before draining jobs — the compositor hasn't shown the previous frame yet.
    Queued jobs (including animation continuations) stay pending until the
    callback fires and wakes the loop. Init and resizes bypass the gate.
+   The gate is per-surface but the job queue is global, so a surface's drain
+   defers (quietly re-queues) animation jobs owned by *other, frame-gated*
+   surfaces: advancing them would outpace their callbacks and spin the loop
+   flat-out. Non-animation jobs are surface-agnostic and always run.
 5. `drain_pending_jobs()` + `process_jobs()` - Unregister → Animation (advance values) → Reconcile → Paint → Layout marking
 6. Process follow-up jobs pushed by animation advances and reconciliation
 7. Partial layout from `layout_roots` - Only dirty subtrees re-layout

--- a/src/jobs.rs
+++ b/src/jobs.rs
@@ -207,6 +207,21 @@ pub fn recycle_job_buffer(buf: Vec<Job>) {
     PENDING_JOBS.with(|jobs| jobs.borrow_mut().recycle(buf));
 }
 
+/// Re-queue jobs WITHOUT waking the loop.
+///
+/// Used to defer animation jobs belonging to a frame-gated surface that were
+/// drained by another surface's render pass: their wakeup is the owning
+/// surface's frame callback (plus the 16 ms animation poll), so pinging here
+/// would just spin the loop between callbacks.
+pub fn requeue_jobs_quiet(deferred: impl IntoIterator<Item = Job>) {
+    PENDING_JOBS.with(|jobs| {
+        let mut jobs = jobs.borrow_mut();
+        for job in deferred {
+            jobs.push(job);
+        }
+    });
+}
+
 /// Process all jobs in a single pass, partitioned by type.
 ///
 /// Order is preserved: Unregister → Animation → Reconcile → Paint → Layout.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -315,6 +315,7 @@ fn render_surface(
     tree: &mut Tree,
     layout_roots: &mut Vec<WidgetId>,
     frame_requested: bool,
+    gated_roots: &rustc_hash::FxHashSet<WidgetId>,
 ) {
     // Get wayland surface state
     let Some(wayland_surface) = wayland_state.get_surface_mut(id) else {
@@ -425,12 +426,34 @@ fn render_surface(
     // 4. Layout — needs updated animation values + reconciled children
     // 5. Paint — needs final layout positions
     //
-    // Cross-surface note: in multi-surface apps, one surface's drain may advance
-    // animations for widgets belonging to another surface. The second surface then
-    // picks up continuation jobs and re-advances. This is practically harmless —
-    // advance() is time-based (computes nearly the same value), and follow-up
-    // jobs are deduped by the JobQueue HashSet.
-    let jobs = drain_pending_jobs();
+    // Cross-surface note: the queue is global but the pacing gate above is
+    // per-surface, so this drain also picks up jobs belonging to OTHER
+    // surfaces. Animation jobs owned by a frame-gated surface must NOT be
+    // advanced here: each advance re-queues a continuation, and with this
+    // surface gate-open every loop iteration would advance them — the loop
+    // then spins flat-out (hundreds of thousands of iterations/s observed)
+    // until the other surface's callback fires. Defer them quietly instead;
+    // their wakeup is the owning surface's frame callback + the 16 ms
+    // animation poll. Non-animation jobs (unregister, reconcile, paint,
+    // layout) are surface-agnostic tree maintenance and always run.
+    let mut jobs = drain_pending_jobs();
+    if !gated_roots.is_empty() {
+        let mut deferred: smallvec::SmallVec<[jobs::Job; 8]> = smallvec::SmallVec::new();
+        let my_root = surface.widget_id;
+        jobs.retain(|job| {
+            if job.job_type != jobs::JobType::Animation {
+                return true;
+            }
+            match tree.surface_root_of(job.widget_id) {
+                Some(root) if root != my_root && gated_roots.contains(&root) => {
+                    deferred.push(*job);
+                    false
+                }
+                _ => true,
+            }
+        });
+        jobs::requeue_jobs_quiet(deferred);
+    }
     process_jobs(&jobs, tree, layout_roots);
     jobs::recycle_job_buffer(jobs);
 
@@ -929,6 +952,23 @@ impl App {
             // GPU state — nothing can be rendered this iteration)
             if let Some(renderer) = renderer.as_mut() {
                 let surface_ids: Vec<SurfaceId> = surface_manager.ids().collect();
+
+                // Surface roots whose frame callback is still in flight:
+                // their animation jobs must not be advanced by OTHER
+                // surfaces' render passes (see the cross-surface note in
+                // render_surface). Init-phase surfaces bypass their own
+                // gate, so they are never considered gated here either.
+                let gated_roots: rustc_hash::FxHashSet<WidgetId> = surface_ids
+                    .iter()
+                    .filter_map(|sid| {
+                        let ws = wayland_state.get_surface(*sid)?;
+                        let gated = ws.frame_callback_pending
+                            && ws.first_frame_presented
+                            && ws.scale_factor_received;
+                        gated.then(|| surface_manager.get(*sid).map(|s| s.widget_id))?
+                    })
+                    .collect();
+
                 for id in surface_ids {
                     let Some(surface) = surface_manager.get_mut(id) else {
                         continue;
@@ -942,6 +982,7 @@ impl App {
                         &mut self.tree,
                         &mut self.layout_roots,
                         frame_requested,
+                        &gated_roots,
                     );
                 }
             }

--- a/src/surface_manager.rs
+++ b/src/surface_manager.rs
@@ -156,6 +156,11 @@ impl SurfaceManager {
         self.surfaces.remove(&id)
     }
 
+    /// Get a surface by ID.
+    pub fn get(&self, id: SurfaceId) -> Option<&ManagedSurface> {
+        self.surfaces.get(&id)
+    }
+
     /// Get a mutable surface by ID.
     pub fn get_mut(&mut self, id: SurfaceId) -> Option<&mut ManagedSurface> {
         self.surfaces.get_mut(&id)

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -480,7 +480,7 @@ impl Tree {
     }
 
     /// Find the surface root (topmost ancestor) of a widget.
-    fn surface_root_of(&self, id: WidgetId) -> Option<WidgetId> {
+    pub(crate) fn surface_root_of(&self, id: WidgetId) -> Option<WidgetId> {
         let mut current = id;
         loop {
             let dense_idx = self.get_dense_index(current)?;


### PR DESCRIPTION
## Summary

Found while benchmarking the ashell→guido port: **the frame-pacing gate is per-surface but the job queue is global**. A gate-open surface (ashell's idle menu overlay) drained and advanced the animation jobs of the frame-gated bar on every loop iteration — each advance re-queued a continuation and re-pinged the wakeup, spinning the main loop **flat-out between frame callbacks**: ~260k iterations/s and ~1.1M reactive layouts/s (render-stats), ~30% CPU bursts while workspace pills ran `animate_width` springs. The old cross-surface comment called this "practically harmless"; it was not.

**Fix**: `render_surface` defers animation jobs whose surface root belongs to another, currently frame-gated surface — re-queued via the new `requeue_jobs_quiet` (no wakeup ping: the owning surface's frame callback + the 16 ms animation poll are the wakeup). Non-animation jobs (unregister, reconcile, paint, layout) are surface-agnostic tree maintenance and always run. Gated roots are computed once per loop iteration; a surface never defers its own jobs.

## Validation

- Real reproducer (ashell-guido: workspaces module with animated pills + hidden menu overlay): worst-case main-thread CPU over 96 s dropped **87 → 2 ticks/3s (~29% → ~0.7%)**, matching the single-surface control run.
- 218 lib tests, clippy 1.97.1 `-D warnings`, fmt — clean.
- ARCHITECTURE.md pipeline notes updated.
