### PR TITLE
Surface-owned job scheduling: per-surface queues, single ownership resolution

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -121,12 +121,11 @@ Hardware-accelerated rendering using wgpu.
 3. Dispatch events to widgets (queued `MouseMove`s are coalesced to the latest position)
 4. **Frame-pacing gate**: if a `wl_surface.frame` callback is still in flight, return
    before draining jobs — the compositor hasn't shown the previous frame yet.
-   Queued jobs (including animation continuations) stay pending until the
-   callback fires and wakes the loop. Init and resizes bypass the gate.
-   The gate is per-surface but the job queue is global, so a surface's drain
-   defers (quietly re-queues) animation jobs owned by *other, frame-gated*
-   surfaces: advancing them would outpace their callbacks and spin the loop
-   flat-out. Non-animation jobs are surface-agnostic and always run.
+   The gate and the job queues have the same per-surface granularity
+   (surface-owned scheduling, see Jobs System): a gated surface's queued
+   jobs — including animation continuations — sit untouched in its own
+   queue until the callback fires and wakes the loop. Init and resizes
+   bypass the gate.
 5. `drain_pending_jobs()` + `process_jobs()` - Unregister → Animation (advance values) → Reconcile → Paint → Layout marking
 6. Process follow-up jobs pushed by animation advances and reconciliation
 7. Partial layout from `layout_roots` - Only dirty subtrees re-layout
@@ -243,12 +242,24 @@ The jobs system connects reactive signals to widget invalidation.
 - `Unregister` - Widget needs cleanup (deferred Drop)
 - `Animation` - Widget has active animations
 
-**How It Works:**
-- Signals push jobs to a global queue when values change
-- `request_job()` is thread-safe and wakes the event loop
-- For animations, `request_job()` with `JobRequest::Animation(RequiredJob)` adds both the Animation job and any required follow-up job (Paint or Layout)
-- Main loop drains jobs and processes by type in order
-- Animation jobs run after paint to advance state for next frame
+**How It Works — surface-owned scheduling:**
+- Jobs are keyed by widget, but their *scheduling domain* is the surface:
+  the frame-pacing gate is per-surface, so the queues are too.
+- `request_job()` pushes into a global **inbox** (push sites have no `Tree`
+  access) and wakes the event loop. For animations,
+  `JobRequest::Animation(RequiredJob)` adds both the Animation job and any
+  required follow-up job (Paint or Layout).
+- `distribute_jobs(tree, active_roots)` is the **single place where
+  ownership is resolved**: it sorts the inbox into per-surface queues keyed
+  by surface root (topmost ancestor). Jobs with no live owning surface go
+  to the **orphan lane**, processed once per loop iteration (deferred
+  Unregister cleanup); queues of destroyed surfaces are retired there too.
+- Each surface's render pass drains **only its own queue** and processes by
+  type in order. A frame-gated surface's animation continuations sit in its
+  own queue until its callback fires — no other surface can advance them
+  (this exact bug once spun the loop at ~260k iterations/s).
+- `layout_roots` are per-surface as well, so one surface's render pass
+  never lays out another surface's subtrees.
 
 ## Event Loop Wakeup Contract
 

--- a/src/jobs.rs
+++ b/src/jobs.rs
@@ -42,9 +42,6 @@ use crate::tree::{Tree, WidgetId};
 struct JobQueue {
     set: rustc_hash::FxHashSet<Job>,
     vec: Vec<Job>,
-    /// Spare buffers for capacity reuse across frames (at most 2: one per
-    /// drain flavor in flight).
-    spare: Vec<Vec<Job>>,
 }
 
 impl JobQueue {
@@ -52,7 +49,6 @@ impl JobQueue {
         Self {
             set: rustc_hash::FxHashSet::default(),
             vec: Vec::new(),
-            spare: Vec::new(),
         }
     }
 
@@ -62,31 +58,24 @@ impl JobQueue {
         }
     }
 
-    fn drain_all(&mut self) -> Vec<Job> {
+    /// Drain everything, installing `replacement` as the new backing buffer.
+    fn drain_all(&mut self, replacement: Vec<Job>) -> Vec<Job> {
         self.set.clear();
-        let replacement = self.spare.pop().unwrap_or_default();
         std::mem::replace(&mut self.vec, replacement)
     }
 
-    fn drain_non_animation(&mut self) -> Vec<Job> {
-        let mut non_anim = self.spare.pop().unwrap_or_default();
+    /// Drain everything except Animation jobs into `buf`.
+    fn drain_non_animation(&mut self, mut buf: Vec<Job>) -> Vec<Job> {
         self.vec.retain(|job| {
             if job.job_type == JobType::Animation {
                 true
             } else {
                 self.set.remove(job);
-                non_anim.push(*job);
+                buf.push(*job);
                 false
             }
         });
-        non_anim
-    }
-
-    fn recycle(&mut self, mut buf: Vec<Job>) {
-        if self.spare.len() < 2 {
-            buf.clear();
-            self.spare.push(buf);
-        }
+        buf
     }
 
     fn is_empty(&self) -> bool {
@@ -94,11 +83,67 @@ impl JobQueue {
     }
 }
 
-// Thread-local job queue for pending reactive updates.
+/// Surface-owned scheduling.
+///
+/// Jobs are keyed by widget, but their *scheduling domain* is the surface:
+/// the frame-pacing gate is per-surface, so the queues must be too — a
+/// global queue drained by whichever surface renders first let a gate-open
+/// surface advance another surface's animations unpaced (a busy-spin at
+/// hundreds of thousands of iterations/s).
+///
+/// Push sites (`request_job`) have no `Tree` access, so jobs land in a
+/// global `inbox` first. [`distribute_jobs`] — the single place where
+/// ownership is resolved — sorts them into per-surface queues keyed by the
+/// surface root widget. Each surface's render pass drains only its own
+/// queue: a frame-gated surface's animation jobs simply sit in its queue
+/// until its callback fires. Jobs whose widget has no live surface (mid-
+/// teardown, or their surface was destroyed) go to the `orphans` lane,
+/// processed once per loop iteration so deferred Unregister cleanup always
+/// runs.
+struct JobQueues {
+    /// Push-side inbox (no ownership resolved yet).
+    inbox: JobQueue,
+    /// Per-surface queues, keyed by surface root widget.
+    per_root: rustc_hash::FxHashMap<WidgetId, JobQueue>,
+    /// Jobs with no live owning surface.
+    orphans: JobQueue,
+    /// Spare buffers for capacity reuse across frames.
+    spare: Vec<Vec<Job>>,
+}
+
+impl JobQueues {
+    fn new() -> Self {
+        Self {
+            inbox: JobQueue::new(),
+            per_root: rustc_hash::FxHashMap::default(),
+            orphans: JobQueue::new(),
+            spare: Vec::new(),
+        }
+    }
+
+    fn spare_buf(&mut self) -> Vec<Job> {
+        self.spare.pop().unwrap_or_default()
+    }
+
+    fn recycle(&mut self, mut buf: Vec<Job>) {
+        if self.spare.len() < 4 {
+            buf.clear();
+            self.spare.push(buf);
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.inbox.is_empty()
+            && self.orphans.is_empty()
+            && self.per_root.values().all(JobQueue::is_empty)
+    }
+}
+
+// Thread-local job queues for pending reactive updates.
 // All job producers (signal writes, animations) run on the main thread,
 // so no Mutex is needed.
 thread_local! {
-    static PENDING_JOBS: RefCell<JobQueue> = RefCell::new(JobQueue::new());
+    static PENDING_JOBS: RefCell<JobQueues> = RefCell::new(JobQueues::new());
 }
 
 /// Job types for reactive invalidation (stored in the queue)
@@ -150,22 +195,23 @@ pub struct Job {
 pub fn request_job(widget_id: WidgetId, request: JobRequest) {
     PENDING_JOBS.with(|jobs| {
         let mut jobs = jobs.borrow_mut();
+        let inbox = &mut jobs.inbox;
         match request {
             JobRequest::Animation(required) => {
-                jobs.push(Job {
+                inbox.push(Job {
                     widget_id,
                     job_type: JobType::Animation,
                 });
                 match required {
                     RequiredJob::None => {}
                     RequiredJob::Paint => {
-                        jobs.push(Job {
+                        inbox.push(Job {
                             widget_id,
                             job_type: JobType::Paint,
                         });
                     }
                     RequiredJob::Layout => {
-                        jobs.push(Job {
+                        inbox.push(Job {
                             widget_id,
                             job_type: JobType::Layout,
                         });
@@ -180,7 +226,7 @@ pub fn request_job(widget_id: WidgetId, request: JobRequest) {
                     JobRequest::Unregister => JobType::Unregister,
                     JobRequest::Animation(_) => unreachable!(),
                 };
-                jobs.push(Job {
+                inbox.push(Job {
                     widget_id,
                     job_type,
                 });
@@ -190,36 +236,95 @@ pub fn request_job(widget_id: WidgetId, request: JobRequest) {
     request_frame();
 }
 
-/// Drain all pending jobs
-pub fn drain_pending_jobs() -> Vec<Job> {
-    PENDING_JOBS.with(|jobs| jobs.borrow_mut().drain_all())
+/// Resolve job ownership: sort the inbox into per-surface queues.
+///
+/// This is the ONLY place where a job's owning surface is determined
+/// (topmost ancestor walk — parent links are complete between loop phases,
+/// which is when this runs). `active_roots` is the set of live surface
+/// roots: jobs resolving anywhere else — widget already gone, surface
+/// destroyed, never parented — go to the orphan lane. Queues whose root is
+/// no longer active are retired into the orphan lane too, so a closed
+/// surface's deferred Unregister jobs still run and nothing keeps
+/// `has_pending_jobs` true forever.
+pub fn distribute_jobs(tree: &Tree, active_roots: &rustc_hash::FxHashSet<WidgetId>) {
+    PENDING_JOBS.with(|jobs| {
+        let mut jobs = jobs.borrow_mut();
+
+        // Retire queues for surfaces that no longer exist.
+        let dead: SmallVec<[WidgetId; 2]> = jobs
+            .per_root
+            .keys()
+            .filter(|root| !active_roots.contains(root))
+            .copied()
+            .collect();
+        for root in dead {
+            if let Some(mut queue) = jobs.per_root.remove(&root) {
+                for job in queue.vec.drain(..) {
+                    jobs.orphans.push(job);
+                }
+            }
+        }
+
+        // Sort the inbox.
+        if jobs.inbox.is_empty() {
+            return;
+        }
+        let buf = jobs.spare_buf();
+        let pending = jobs.inbox.drain_all(buf);
+        for job in &pending {
+            match tree.surface_root_of(job.widget_id) {
+                Some(root) if active_roots.contains(&root) => {
+                    jobs.per_root
+                        .entry(root)
+                        .or_insert_with(JobQueue::new)
+                        .push(*job);
+                }
+                _ => jobs.orphans.push(*job),
+            }
+        }
+        jobs.recycle(pending);
+    });
 }
 
-/// Drain all pending jobs EXCEPT Animation jobs.
+/// Drain all jobs owned by the given surface root.
+pub fn drain_surface_jobs(root: WidgetId) -> Vec<Job> {
+    PENDING_JOBS.with(|jobs| {
+        let mut jobs = jobs.borrow_mut();
+        let buf = jobs.spare_buf();
+        match jobs.per_root.get_mut(&root) {
+            Some(queue) => queue.drain_all(buf),
+            None => buf,
+        }
+    })
+}
+
+/// Drain the given surface's jobs EXCEPT Animation jobs.
 /// Used to collect follow-up jobs (Paint/Layout) pushed by animation
 /// advances and reconciliation, without re-draining Animation jobs.
-pub fn drain_non_animation_jobs() -> Vec<Job> {
-    PENDING_JOBS.with(|jobs| jobs.borrow_mut().drain_non_animation())
+pub fn drain_surface_non_animation_jobs(root: WidgetId) -> Vec<Job> {
+    PENDING_JOBS.with(|jobs| {
+        let mut jobs = jobs.borrow_mut();
+        let buf = jobs.spare_buf();
+        match jobs.per_root.get_mut(&root) {
+            Some(queue) => queue.drain_non_animation(buf),
+            None => buf,
+        }
+    })
+}
+
+/// Drain the orphan lane (jobs with no live owning surface — deferred
+/// Unregister cleanup, mostly). Processed once per loop iteration.
+pub fn drain_orphan_jobs() -> Vec<Job> {
+    PENDING_JOBS.with(|jobs| {
+        let mut jobs = jobs.borrow_mut();
+        let buf = jobs.spare_buf();
+        jobs.orphans.drain_all(buf)
+    })
 }
 
 /// Return a drained job buffer for capacity reuse on later frames.
 pub fn recycle_job_buffer(buf: Vec<Job>) {
     PENDING_JOBS.with(|jobs| jobs.borrow_mut().recycle(buf));
-}
-
-/// Re-queue jobs WITHOUT waking the loop.
-///
-/// Used to defer animation jobs belonging to a frame-gated surface that were
-/// drained by another surface's render pass: their wakeup is the owning
-/// surface's frame callback (plus the 16 ms animation poll), so pinging here
-/// would just spin the loop between callbacks.
-pub fn requeue_jobs_quiet(deferred: impl IntoIterator<Item = Job>) {
-    PENDING_JOBS.with(|jobs| {
-        let mut jobs = jobs.borrow_mut();
-        for job in deferred {
-            jobs.push(job);
-        }
-    });
 }
 
 /// Process all jobs in a single pass, partitioned by type.
@@ -286,7 +391,7 @@ pub fn has_pending_jobs() -> bool {
 #[cfg(test)]
 fn clear_pending_jobs() {
     PENDING_JOBS.with(|jobs| {
-        jobs.borrow_mut().drain_all();
+        *jobs.borrow_mut() = JobQueues::new();
     });
 }
 
@@ -376,7 +481,7 @@ pub(crate) fn mark_loop_awake() {
 /// Called during `App::drop()` to clear stale jobs and allow re-initialization.
 pub(crate) fn reset_jobs() {
     PENDING_JOBS.with(|jobs| {
-        jobs.borrow_mut().drain_all();
+        *jobs.borrow_mut() = JobQueues::new();
     });
     FRAME_REQUESTED.store(false, Ordering::Relaxed);
     PING_SENT.store(false, Ordering::Relaxed);
@@ -406,98 +511,152 @@ pub fn frame_request_pending() -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tree::WidgetId;
+    use crate::layout::{Constraints, Size};
+    use crate::widgets::Widget;
 
-    fn widget_id(n: u64) -> WidgetId {
-        WidgetId::from_u64(n)
+    struct TestWidget;
+    impl Widget for TestWidget {
+        fn layout(&mut self, _: &mut Tree, _: WidgetId, _: Constraints) -> Size {
+            Size::zero()
+        }
+        fn paint(&self, _: &Tree, _: WidgetId, _: &mut crate::renderer::PaintContext) {}
     }
 
-    /// Helper: directly push jobs into PENDING_JOBS for testing.
-    fn push_test_jobs(jobs: &[Job]) {
-        PENDING_JOBS.with(|pending| {
-            let mut pending = pending.borrow_mut();
-            for job in jobs {
-                pending.push(*job);
-            }
-        });
+    /// Two surfaces (roots), one child each. Returns (tree, roots, children).
+    fn two_surface_tree() -> (Tree, [WidgetId; 2], [WidgetId; 2]) {
+        let mut tree = Tree::new();
+        let root_a = tree.register(Box::new(TestWidget));
+        let root_b = tree.register(Box::new(TestWidget));
+        let child_a = tree.register(Box::new(TestWidget));
+        let child_b = tree.register(Box::new(TestWidget));
+        tree.set_parent(child_a, root_a);
+        tree.set_parent(child_b, root_b);
+        (tree, [root_a, root_b], [child_a, child_b])
+    }
+
+    fn roots_set(roots: &[WidgetId]) -> rustc_hash::FxHashSet<WidgetId> {
+        roots.iter().copied().collect()
+    }
+
+    fn push(widget_id: WidgetId, job_type: JobType) -> Job {
+        let job = Job {
+            widget_id,
+            job_type,
+        };
+        PENDING_JOBS.with(|pending| pending.borrow_mut().inbox.push(job));
+        job
     }
 
     #[test]
-    fn drain_non_animation_keeps_animation_jobs() {
-        // Clear any leftover state from other tests
+    fn jobs_are_routed_to_their_owning_surface() {
         clear_pending_jobs();
+        let (tree, roots, children) = two_surface_tree();
+        let active = roots_set(&roots);
 
-        let anim_job = Job {
-            widget_id: widget_id(1),
-            job_type: JobType::Animation,
-        };
-        let paint_job = Job {
-            widget_id: widget_id(2),
-            job_type: JobType::Paint,
-        };
-        let layout_job = Job {
-            widget_id: widget_id(3),
-            job_type: JobType::Layout,
-        };
+        let job_a = push(children[0], JobType::Paint);
+        let job_b = push(children[1], JobType::Layout);
+        distribute_jobs(&tree, &active);
 
-        push_test_jobs(&[anim_job, paint_job, layout_job]);
+        let drained_a = drain_surface_jobs(roots[0]);
+        assert_eq!(drained_a, vec![job_a]);
+        let drained_b = drain_surface_jobs(roots[1]);
+        assert_eq!(drained_b, vec![job_b]);
 
-        // drain_non_animation_jobs should return Paint + Layout, keep Animation
-        let drained = drain_non_animation_jobs();
+        // A second drain returns nothing — queues are per surface and empty
+        assert!(drain_surface_jobs(roots[0]).is_empty());
+        assert!(!has_pending_jobs() || drain_orphan_jobs().is_empty());
+    }
+
+    #[test]
+    fn gated_surface_animations_survive_other_surfaces_drains() {
+        // The core invariant behind the pacing fix: draining surface B can
+        // never touch surface A's animation continuations.
+        clear_pending_jobs();
+        let (tree, roots, children) = two_surface_tree();
+        let active = roots_set(&roots);
+
+        let anim_a = push(children[0], JobType::Animation);
+        distribute_jobs(&tree, &active);
+
+        // Surface B renders (A is frame-gated and never drains)
+        assert!(drain_surface_jobs(roots[1]).is_empty());
+        assert!(drain_surface_non_animation_jobs(roots[1]).is_empty());
+
+        // A's animation is still queued, untouched
+        let drained_a = drain_surface_jobs(roots[0]);
+        assert_eq!(drained_a, vec![anim_a]);
+    }
+
+    #[test]
+    fn drain_surface_non_animation_keeps_animation_jobs() {
+        clear_pending_jobs();
+        let (tree, roots, children) = two_surface_tree();
+        let active = roots_set(&roots);
+
+        let anim = push(children[0], JobType::Animation);
+        let paint = push(children[0], JobType::Paint);
+        let layout = push(roots[0], JobType::Layout);
+        distribute_jobs(&tree, &active);
+
+        let drained = drain_surface_non_animation_jobs(roots[0]);
         assert_eq!(drained.len(), 2);
-        assert!(drained.contains(&paint_job));
-        assert!(drained.contains(&layout_job));
+        assert!(drained.contains(&paint));
+        assert!(drained.contains(&layout));
 
-        // Animation job should still be in PENDING_JOBS
-        let remaining = drain_pending_jobs();
-        assert_eq!(remaining.len(), 1);
-        assert_eq!(remaining[0], anim_job);
+        let remaining = drain_surface_jobs(roots[0]);
+        assert_eq!(remaining, vec![anim]);
     }
 
     #[test]
-    fn drain_non_animation_with_no_animations() {
+    fn jobs_without_a_live_surface_go_to_the_orphan_lane() {
         clear_pending_jobs();
+        let (mut tree, roots, children) = two_surface_tree();
+        let active = roots_set(&roots);
 
-        let paint_job = Job {
-            widget_id: widget_id(1),
-            job_type: JobType::Paint,
-        };
-        let unregister_job = Job {
-            widget_id: widget_id(2),
-            job_type: JobType::Unregister,
-        };
+        // Widget removed from the tree before distribution (deferred
+        // Unregister after teardown)
+        let ghost = children[1];
+        tree.unregister(ghost);
+        let orphan_job = push(ghost, JobType::Unregister);
+        distribute_jobs(&tree, &active);
 
-        push_test_jobs(&[paint_job, unregister_job]);
-
-        let drained = drain_non_animation_jobs();
-        assert_eq!(drained.len(), 2);
-
-        // Nothing should remain
-        let remaining = drain_pending_jobs();
-        assert!(remaining.is_empty());
+        assert_eq!(drain_orphan_jobs(), vec![orphan_job]);
+        assert!(drain_surface_jobs(roots[1]).is_empty());
     }
 
     #[test]
-    fn drain_non_animation_with_only_animations() {
+    fn dead_surface_queues_are_retired_into_the_orphan_lane() {
         clear_pending_jobs();
+        let (tree, roots, children) = two_surface_tree();
+        let active = roots_set(&roots);
 
-        let anim1 = Job {
-            widget_id: widget_id(1),
-            job_type: JobType::Animation,
-        };
-        let anim2 = Job {
-            widget_id: widget_id(2),
-            job_type: JobType::Animation,
-        };
+        let job_a = push(children[0], JobType::Unregister);
+        distribute_jobs(&tree, &active);
 
-        push_test_jobs(&[anim1, anim2]);
+        // Surface A closes: its root disappears from the active set. The
+        // queued job must not be stranded (it would keep has_pending_jobs
+        // true forever with no render pass to drain it).
+        let only_b = roots_set(&roots[1..]);
+        distribute_jobs(&tree, &only_b);
 
-        // Should return empty — all jobs are animations
-        let drained = drain_non_animation_jobs();
-        assert!(drained.is_empty());
+        assert_eq!(drain_orphan_jobs(), vec![job_a]);
+        assert!(!has_pending_jobs());
+    }
 
-        // Both should remain
-        let remaining = drain_pending_jobs();
-        assert_eq!(remaining.len(), 2);
+    #[test]
+    fn inbox_dedup_survives_distribution() {
+        clear_pending_jobs();
+        let (tree, roots, children) = two_surface_tree();
+        let active = roots_set(&roots);
+
+        let job = push(children[0], JobType::Paint);
+        // Same job pushed twice — deduped in the inbox
+        push(children[0], JobType::Paint);
+        distribute_jobs(&tree, &active);
+        // ...and pushing again after distribution dedups in the surface queue
+        push(children[0], JobType::Paint);
+        distribute_jobs(&tree, &active);
+
+        assert_eq!(drain_surface_jobs(roots[0]), vec![job]);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,10 +172,7 @@ pub mod prelude {
 use smithay_client_toolkit::reexports::client::QueueHandle;
 
 use crate::{
-    jobs::{
-        drain_non_animation_jobs, drain_pending_jobs, get_exit_request, has_pending_jobs,
-        init_wakeup, process_jobs, take_frame_request,
-    },
+    jobs::{get_exit_request, has_pending_jobs, init_wakeup, process_jobs, take_frame_request},
     tree::{DamageRegion, Tree, WidgetId},
 };
 
@@ -315,7 +312,7 @@ fn render_surface(
     tree: &mut Tree,
     layout_roots: &mut Vec<WidgetId>,
     frame_requested: bool,
-    gated_roots: &rustc_hash::FxHashSet<WidgetId>,
+    active_roots: &rustc_hash::FxHashSet<WidgetId>,
 ) {
     // Get wayland surface state
     let Some(wayland_surface) = wayland_state.get_surface_mut(id) else {
@@ -348,6 +345,11 @@ fn render_surface(
             widget.event(tree, id, event);
         });
     }
+
+    // Jobs pushed by the event handlers above (hover/pressed state changes,
+    // clicks) land in the inbox: distribute now so this surface's drain
+    // below picks them up in the same frame (no 1-frame hover delay).
+    jobs::distribute_jobs(tree, active_roots);
 
     // Sync clipboard to Wayland if it changed (copy operations)
     if let Some(text) = take_clipboard_change() {
@@ -426,39 +428,20 @@ fn render_surface(
     // 4. Layout — needs updated animation values + reconciled children
     // 5. Paint — needs final layout positions
     //
-    // Cross-surface note: the queue is global but the pacing gate above is
-    // per-surface, so this drain also picks up jobs belonging to OTHER
-    // surfaces. Animation jobs owned by a frame-gated surface must NOT be
-    // advanced here: each advance re-queues a continuation, and with this
-    // surface gate-open every loop iteration would advance them — the loop
-    // then spins flat-out (hundreds of thousands of iterations/s observed)
-    // until the other surface's callback fires. Defer them quietly instead;
-    // their wakeup is the owning surface's frame callback + the 16 ms
-    // animation poll. Non-animation jobs (unregister, reconcile, paint,
-    // layout) are surface-agnostic tree maintenance and always run.
-    let mut jobs = drain_pending_jobs();
-    if !gated_roots.is_empty() {
-        let mut deferred: smallvec::SmallVec<[jobs::Job; 8]> = smallvec::SmallVec::new();
-        let my_root = surface.widget_id;
-        jobs.retain(|job| {
-            if job.job_type != jobs::JobType::Animation {
-                return true;
-            }
-            match tree.surface_root_of(job.widget_id) {
-                Some(root) if root != my_root && gated_roots.contains(&root) => {
-                    deferred.push(*job);
-                    false
-                }
-                _ => true,
-            }
-        });
-        jobs::requeue_jobs_quiet(deferred);
-    }
+    // Scheduling is surface-owned: distribute_jobs resolved ownership and
+    // this drain returns ONLY jobs belonging to this surface's subtree, so
+    // the pacing gate above and the queue have the same granularity — a
+    // gated surface's animation continuations sit untouched in its own
+    // queue until its frame callback fires, regardless of what other
+    // surfaces do in between.
+    let jobs = jobs::drain_surface_jobs(surface.widget_id);
     process_jobs(&jobs, tree, layout_roots);
     jobs::recycle_job_buffer(jobs);
 
     // Process follow-up jobs from animation advances and reconciliation
-    let followup = drain_non_animation_jobs();
+    // (they land in the inbox — re-distribute before draining)
+    jobs::distribute_jobs(tree, active_roots);
+    let followup = jobs::drain_surface_non_animation_jobs(surface.widget_id);
     if !followup.is_empty() {
         process_jobs(&followup, tree, layout_roots);
     }
@@ -631,8 +614,10 @@ pub struct App {
     surface_definitions: Vec<SurfaceDefinition>,
     /// The layout tree for widget storage (owned by App)
     tree: Tree,
-    /// Layout roots that need re-layout (Vec with dedup — typically 1–3 per frame)
-    layout_roots: Vec<WidgetId>,
+    /// Layout roots that need re-layout, keyed by surface root so one
+    /// surface's render pass never lays out another surface's subtrees
+    /// (each inner Vec is deduped — typically 1–3 entries per frame)
+    layout_roots: rustc_hash::FxHashMap<WidgetId, Vec<WidgetId>>,
     /// Root owner for the reactive graph. When disposed, cascades cleanup
     /// through all signals, effects, and cleanup callbacks.
     root_owner_id: Option<OwnerId>,
@@ -643,7 +628,7 @@ impl App {
         Self {
             surface_definitions: Vec::new(),
             tree: Tree::new(),
-            layout_roots: Vec::new(),
+            layout_roots: rustc_hash::FxHashMap::default(),
             root_owner_id: None,
         }
     }
@@ -953,26 +938,35 @@ impl App {
             if let Some(renderer) = renderer.as_mut() {
                 let surface_ids: Vec<SurfaceId> = surface_manager.ids().collect();
 
-                // Surface roots whose frame callback is still in flight:
-                // their animation jobs must not be advanced by OTHER
-                // surfaces' render passes (see the cross-surface note in
-                // render_surface). Init-phase surfaces bypass their own
-                // gate, so they are never considered gated here either.
-                let gated_roots: rustc_hash::FxHashSet<WidgetId> = surface_ids
+                // Live surface roots: the ownership domain for job
+                // scheduling. Computed after surface commands/session-lock
+                // processing so closed surfaces are already gone.
+                let active_roots: rustc_hash::FxHashSet<WidgetId> = surface_ids
                     .iter()
-                    .filter_map(|sid| {
-                        let ws = wayland_state.get_surface(*sid)?;
-                        let gated = ws.frame_callback_pending
-                            && ws.first_frame_presented
-                            && ws.scale_factor_received;
-                        gated.then(|| surface_manager.get(*sid).map(|s| s.widget_id))?
-                    })
+                    .filter_map(|sid| surface_manager.get(*sid).map(|s| s.widget_id))
                     .collect();
+
+                // Resolve job ownership, then run the orphan lane: jobs
+                // whose widget has no live surface (deferred Unregister
+                // cleanup from closed surfaces, mostly) must not wait for
+                // a render pass that will never come.
+                jobs::distribute_jobs(&self.tree, &active_roots);
+                let orphans = jobs::drain_orphan_jobs();
+                if !orphans.is_empty() {
+                    let mut scratch_layout_roots = Vec::new();
+                    process_jobs(&orphans, &mut self.tree, &mut scratch_layout_roots);
+                }
+                jobs::recycle_job_buffer(orphans);
+
+                // Drop layout roots of surfaces that no longer exist.
+                self.layout_roots
+                    .retain(|root, _| active_roots.contains(root));
 
                 for id in surface_ids {
                     let Some(surface) = surface_manager.get_mut(id) else {
                         continue;
                     };
+                    let layout_roots = self.layout_roots.entry(surface.widget_id).or_default();
                     render_surface(
                         id,
                         surface,
@@ -980,9 +974,9 @@ impl App {
                         renderer,
                         &qh,
                         &mut self.tree,
-                        &mut self.layout_roots,
+                        layout_roots,
                         frame_requested,
-                        &gated_roots,
+                        &active_roots,
                     );
                 }
             }


### PR DESCRIPTION
## Summary

Structural follow-up to #118, replacing its defer-and-requeue patch with architecture. Jobs are keyed by widget but their *scheduling domain* is the surface — the frame-pacing gate is per-surface, so the queues now are too:

- **`request_job` → global inbox** (push sites have no `Tree` access; external API unchanged).
- **`distribute_jobs(tree, active_roots)`** is the *single place where ownership is resolved*: sorts the inbox into per-surface queues keyed by surface root; jobs with no live owning surface go to an **orphan lane**; queues of destroyed surfaces are retired there too (deferred Unregister cleanup always runs, nothing strands `has_pending_jobs`).
- **`render_surface` drains only its own queue** — the gate and the queue have the same granularity, so a gated surface's animation continuations cannot be advanced by other surfaces *by construction*. The #118 filter/requeue dance is deleted.
- **`layout_roots` are per-surface** as well (one surface's render never lays out another's subtrees), swept per iteration.
- Events distribute before the drain, preserving same-frame hover/pressed updates.

## Testing

- **6 new unit tests** encode the invariants: per-surface routing, gated-surface animation survival, non-animation drain, orphan lane, dead-queue retirement, dedup across distribution. 221 lib tests total, clippy 1.97.1 `-D warnings`, fmt clean.
- Real reproducer (ashell workspaces pills + hidden menu overlay, 96 s): worst-case main-thread CPU **1 tick/3s** (original bug: 87; #118 patch: 2).
- `multi_surface` example smoke-tested live.
- ARCHITECTURE.md rewritten for the new model (Jobs System + pipeline notes).
