### PR TITLE
xdg popups: compositor-positioned menus anchored to surfaces

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -388,6 +388,7 @@ This is a work-in-progress GUI library. Current implemented features:
 - Session lock (`ext-session-lock-v1`): `lock_session(factory)` / `unlock_session()` / reactive `lock_state()`, one lock surface per output with hotplug handling
 - Touch input (`wl_touch`): first finger drives the pointer pipeline — tap = click, works with hover/pressed state layers
 - Clipboard: async prefetch (paste never blocks the UI thread) + primary selection (select-to-copy, middle-click paste)
+- xdg popups (`spawn_popup`): compositor-positioned menus anchored to a surface, grab semantics (outside click dismisses, reactive `dismissed()`), nested popups
 - Text input widget with full editing support
 - Image widget with raster and SVG support
 

--- a/book/src/advanced/wayland.md
+++ b/book/src/advanced/wayland.md
@@ -526,6 +526,47 @@ instead of withdrawing, to keep the region authoritative.
 
 See `examples/blur_example.rs`.
 
+## Popups (Menus, Dropdowns)
+
+`spawn_popup` creates an **xdg popup** anchored to a surface: the
+compositor positions it relative to an anchor rectangle, keeps it on
+screen (flipping/sliding at screen edges), and — with `.grab()` —
+dismisses it when the user clicks outside. Real menu semantics, no
+fullscreen overlay:
+
+```rust
+let popup = spawn_popup(
+    bar_id,
+    PopupConfig::new(250, 300)                 // size (required by xdg)
+        .anchor_rect(button_ref.rect().get())  // parent surface coords
+        .anchor(PopupAnchor::Bottom)           // attach point on the rect
+        .gravity(PopupGravity::Bottom)         // growth direction
+        .grab(),                               // dismiss on outside click
+    move || menu_widget(),
+);
+```
+
+Dismissal is reactive — reset your open/closed state when the
+compositor closes the popup:
+
+```rust
+create_effect(move || {
+    if popup.dismissed() {
+        menu_open.set(false);
+    }
+})
+.detach();
+```
+
+`popup.close()` closes it programmatically. Popups render their own
+widget tree and share the app's reactive state like any surface;
+anchoring a popup to another popup creates a nested popup (submenus).
+
+Note: for a bottom bar use `anchor(Top)` + `gravity(Top)` so the menu
+opens upward — or just rely on the compositor's flip adjustment.
+
+See `examples/popup_example.rs`.
+
 ## Session Lock (Lock Screens)
 
 `lock_session` asks the compositor to lock the session

--- a/examples/popup_example.rs
+++ b/examples/popup_example.rs
@@ -1,0 +1,116 @@
+//! xdg popups anchored to a bar: real menu semantics.
+//!
+//! Clicking the button opens a grabbed popup under it — the compositor
+//! positions it (flipping/sliding at screen edges) and dismisses it when
+//! you click anywhere outside. No fullscreen overlay involved.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use guido::prelude::*;
+
+fn menu_entry(label: &str) -> Container {
+    container()
+        .padding([8.0, 12.0])
+        .corner_radius(6.0)
+        .hover_state(|s| s.lighter(0.12))
+        .child(text(label).font_size(13))
+}
+
+fn main() {
+    env_logger::init();
+
+    App::new().run(|app| {
+        let button_ref = create_widget_ref();
+        let menu_open = create_signal(false);
+        let popup_slot: Rc<RefCell<Option<PopupHandle>>> = Rc::new(RefCell::new(None));
+        // The bar id is only known after add_surface returns; the click
+        // handler runs later, so a slot is enough.
+        let bar_id_slot: Rc<RefCell<Option<SurfaceId>>> = Rc::new(RefCell::new(None));
+        let bar_id_for_click = bar_id_slot.clone();
+
+        let bar_id = app.add_surface(
+            SurfaceConfig::new()
+                .height(36)
+                .anchor(Anchor::BOTTOM | Anchor::LEFT | Anchor::RIGHT)
+                .background_color(Color::rgb(0.1, 0.1, 0.15)),
+            move || {
+                let popup_slot = popup_slot.clone();
+                container()
+                    .width(fill())
+                    .layout(
+                        Flex::row()
+                            .spacing(12.0)
+                            .main_alignment(MainAlignment::Center)
+                            .cross_alignment(CrossAlignment::Center),
+                    )
+                    .child(
+                        container()
+                            .widget_ref(button_ref)
+                            .padding([6.0, 16.0])
+                            .background(move || {
+                                if menu_open.get() {
+                                    Color::rgb(0.35, 0.35, 0.5)
+                                } else {
+                                    Color::rgb(0.25, 0.25, 0.35)
+                                }
+                            })
+                            .corner_radius(6.0)
+                            .hover_state(|s| s.lighter(0.1))
+                            .on_click(move || {
+                                if menu_open.get() {
+                                    // Toggle closed
+                                    if let Some(popup) = popup_slot.borrow_mut().take() {
+                                        popup.close();
+                                    }
+                                    return;
+                                }
+
+                                let popup = spawn_popup(
+                                    bar_id_for_click.borrow().unwrap(),
+                                    PopupConfig::new(220, 168)
+                                        .anchor_rect(button_ref.rect().get())
+                                        .anchor(PopupAnchor::Top)
+                                        .gravity(PopupGravity::Top)
+                                        .grab()
+                                        .background_color(Color::TRANSPARENT),
+                                    || {
+                                        container()
+                                            .width(fill())
+                                            .height(fill())
+                                            .background(Color::rgb(0.13, 0.13, 0.2))
+                                            .corner_radius(10.0)
+                                            .padding(8.0)
+                                            .layout(Flex::column().spacing(2.0))
+                                            .child(menu_entry("Profile"))
+                                            .child(menu_entry("Settings"))
+                                            .child(menu_entry("About"))
+                                            .child(menu_entry("Quit"))
+                                    },
+                                );
+                                menu_open.set(true);
+
+                                // Reset state when the compositor dismisses
+                                // the popup (outside click) or close() runs
+                                create_effect(move || {
+                                    if popup.dismissed() {
+                                        menu_open.set(false);
+                                    }
+                                })
+                                .detach();
+
+                                *popup_slot.borrow_mut() = Some(popup);
+                            })
+                            .child(text(move || {
+                                if menu_open.get() {
+                                    "Menu ▾ (click outside to dismiss)".to_string()
+                                } else {
+                                    "Menu ▸".to_string()
+                                }
+                            })),
+                    )
+            },
+        );
+        *bar_id_slot.borrow_mut() = Some(bar_id);
+    });
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,7 +151,8 @@ pub mod prelude {
         LockState, lock_session, lock_state, session_locked, unlock_session,
     };
     pub use crate::surface::{
-        SurfaceConfig, SurfaceHandle, SurfaceId, spawn_surface, surface_handle,
+        PopupAnchor, PopupConfig, PopupGravity, PopupHandle, SurfaceConfig, SurfaceHandle,
+        SurfaceId, spawn_popup, spawn_surface, surface_handle,
     };
     pub use crate::transform::Transform;
     pub use crate::transform_origin::{HorizontalAnchor, TransformOrigin, VerticalAnchor};
@@ -212,6 +213,9 @@ fn process_surface_commands(
             }
             SurfaceCommand::Close(id) => {
                 log::info!("Closing dynamic surface {:?}", id);
+                // If this was a popup, make sure its dismissal signal fires
+                // (no-op for other surfaces or already-dismissed popups)
+                surface::mark_popup_dismissed(id);
                 // Drop the managed surface FIRST: its wgpu Surface<'static>
                 // borrows the wl_surface through erased raw pointers, so the
                 // GPU surface must die before the Wayland surface it points
@@ -251,6 +255,30 @@ fn process_surface_commands(
             }
             SurfaceCommand::SetInputRegion { id, rects } => {
                 wayland_state.set_surface_input_region(id, rects.as_deref());
+            }
+            SurfaceCommand::CreatePopup {
+                id,
+                parent,
+                config,
+                widget_fn,
+            } => {
+                log::info!("Creating popup {:?} anchored to {:?}", id, parent);
+                if wayland_state.create_popup_surface_with_id(&qh.clone(), id, parent, &config) {
+                    let (widget, owner_id) = with_owner(widget_fn);
+                    // Reuse the surface pipeline: only the background color
+                    // matters from the synthesized config (size arrives with
+                    // the popup configure)
+                    let surface_config = SurfaceConfig::new()
+                        .width(config.width)
+                        .height(config.height)
+                        .background_color(config.background_color);
+                    let managed = ManagedSurface::new(id, surface_config, widget, owner_id, tree);
+                    surface_manager.add(managed);
+                } else {
+                    // Creation failed (no xdg_wm_base, parent gone): report
+                    // as dismissed so the app can react.
+                    surface::mark_popup_dismissed(id);
+                }
             }
         }
     }
@@ -1011,6 +1039,7 @@ impl Drop for App {
         jobs::reset_jobs();
         ingress::reset_ingress();
         surface::reset_surface_commands();
+        surface::reset_popups();
         widget_ref::reset_widget_refs();
         outputs::reset_outputs();
         blur::reset_blur();

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -34,14 +34,20 @@ use smithay_client_toolkit::{
         SessionLock, SessionLockHandler, SessionLockState, SessionLockSurface,
         SessionLockSurfaceConfigure,
     },
+    delegate_xdg_popup,
     shell::{
         WaylandSurface,
         wlr_layer::{
             Anchor, KeyboardInteractivity, Layer, LayerShell, LayerShellHandler, LayerSurface,
             LayerSurfaceConfigure,
         },
+        xdg::{
+            XdgPositioner, XdgShell,
+            popup::{Popup, PopupConfigure, PopupHandler},
+        },
     },
 };
+use smithay_client_toolkit::reexports::protocols::xdg::shell::client::xdg_positioner;
 use smithay_client_toolkit::reexports::client::{
     globals::registry_queue_init,
     protocol::{
@@ -80,6 +86,9 @@ pub enum SurfaceRole {
     Layer(LayerSurface),
     /// Kept alive here — dropping it destroys the protocol object.
     Lock(SessionLockSurface),
+    /// An xdg popup anchored to another surface. Kept alive here —
+    /// dropping it destroys the xdg objects.
+    Popup(Popup),
 }
 
 /// Events from the session-lock protocol, drained by the main loop.
@@ -186,6 +195,10 @@ pub struct WaylandState {
     bg_effect_manager: Option<ExtBackgroundEffectManagerV1>,
     /// Whether the compositor currently advertises the Blur capability.
     bg_effect_supports_blur: bool,
+
+    // xdg shell (popups anchored to layer surfaces)
+    /// `None` where xdg_wm_base is unavailable — popups then fail with a log.
+    xdg_shell: Option<XdgShell>,
 
     // Session lock (ext-session-lock-v1)
     session_lock_state: SessionLockState,
@@ -323,6 +336,12 @@ pub fn create_wayland_app() -> Result<
     let seat_state = SeatState::new(&globals, &qh);
     let session_lock_state = SessionLockState::new(&globals, &qh);
 
+    // xdg shell for popups anchored to layer surfaces — optional
+    let xdg_shell = XdgShell::bind(&globals, &qh).ok();
+    if xdg_shell.is_none() {
+        log::warn!("xdg_wm_base not available - popups will not work");
+    }
+
     // Initialize data device manager for clipboard support
     let data_device_manager = DataDeviceManagerState::bind(&globals, &qh).ok();
     if data_device_manager.is_none() {
@@ -362,6 +381,7 @@ pub fn create_wayland_app() -> Result<
         next_output_id: 0,
         bg_effect_manager,
         bg_effect_supports_blur: false,
+        xdg_shell,
         session_lock_state,
         active_lock: None,
         lock_events: Vec::new(),
@@ -538,6 +558,124 @@ impl WaylandState {
     /// Drain pending session-lock lifecycle events.
     pub fn take_lock_events(&mut self) -> Vec<LockEvent> {
         std::mem::take(&mut self.lock_events)
+    }
+
+    /// Create an xdg popup anchored to `parent` with a specific SurfaceId.
+    ///
+    /// The popup's actual size/position arrive with the popup configure
+    /// (the compositor may flip/slide it to stay on screen). Returns false
+    /// when xdg_wm_base is missing or the parent can't host popups.
+    pub fn create_popup_surface_with_id(
+        &mut self,
+        qh: &QueueHandle<Self>,
+        id: SurfaceId,
+        parent: SurfaceId,
+        config: &crate::surface::PopupConfig,
+    ) -> bool {
+        let Some(ref xdg_shell) = self.xdg_shell else {
+            log::error!("Cannot create popup: compositor lacks xdg_wm_base");
+            return false;
+        };
+        let Some(parent_state) = self.surfaces.get(&parent) else {
+            log::warn!("Cannot create popup: parent surface {:?} is gone", parent);
+            return false;
+        };
+
+        let positioner = match XdgPositioner::new(xdg_shell) {
+            Ok(p) => p,
+            Err(e) => {
+                log::error!("Failed to create xdg_positioner: {e}");
+                return false;
+            }
+        };
+        positioner.set_size(config.width.max(1) as i32, config.height.max(1) as i32);
+        let r = config.anchor_rect;
+        positioner.set_anchor_rect(
+            r.x.floor() as i32,
+            r.y.floor() as i32,
+            (r.width.ceil() as i32).max(1),
+            (r.height.ceil() as i32).max(1),
+        );
+        positioner.set_anchor(popup_point_to_anchor(config.anchor));
+        positioner.set_gravity(popup_point_to_gravity(config.gravity));
+        positioner.set_offset(config.offset.0, config.offset.1);
+        // Let the compositor keep the popup on screen: flip at the screen
+        // edge on either axis, slide where flipping doesn't help.
+        positioner.set_constraint_adjustment(
+            xdg_positioner::ConstraintAdjustment::FlipX
+                | xdg_positioner::ConstraintAdjustment::FlipY
+                | xdg_positioner::ConstraintAdjustment::SlideX
+                | xdg_positioner::ConstraintAdjustment::SlideY,
+        );
+
+        let wl_surface = self.compositor_state.create_surface(qh);
+        let popup = match &parent_state.role {
+            SurfaceRole::Layer(layer_surface) => {
+                let popup =
+                    match Popup::from_surface(None, &positioner, qh, wl_surface.clone(), xdg_shell)
+                    {
+                        Ok(popup) => popup,
+                        Err(e) => {
+                            log::error!("Failed to create xdg popup: {e}");
+                            return false;
+                        }
+                    };
+                // Assign the layer surface as the popup parent BEFORE the
+                // initial commit (required for parentless xdg popups)
+                layer_surface.get_popup(popup.xdg_popup());
+                popup
+            }
+            SurfaceRole::Popup(parent_popup) => {
+                // Nested popup (submenu): ordinary xdg parent
+                let parent_xdg = parent_popup.xdg_surface().clone();
+                match Popup::from_surface(
+                    Some(&parent_xdg),
+                    &positioner,
+                    qh,
+                    wl_surface.clone(),
+                    xdg_shell,
+                ) {
+                    Ok(popup) => popup,
+                    Err(e) => {
+                        log::error!("Failed to create nested xdg popup: {e}");
+                        return false;
+                    }
+                }
+            }
+            SurfaceRole::Lock(_) => {
+                log::warn!("Cannot anchor a popup to a session-lock surface");
+                return false;
+            }
+        };
+
+        // Menu semantics: an input grab dismisses the popup on outside
+        // click. Must be requested before mapping, with a recent serial.
+        if config.grab
+            && let Some(seat) = self.seat_state.seats().next()
+        {
+            popup.xdg_popup().grab(&seat, self.latest_input_serial);
+        }
+
+        wl_surface.commit();
+
+        self.surface_lookup.insert(wl_surface.id(), id);
+        let surface_state = WaylandSurfaceState::new(
+            SurfaceRole::Popup(popup),
+            wl_surface,
+            config.width,
+            config.height,
+        );
+        self.surfaces.insert(id, surface_state);
+
+        log::info!(
+            "Created popup {:?} on parent {:?} ({}x{}, grab: {})",
+            id,
+            parent,
+            config.width,
+            config.height,
+            config.grab
+        );
+        true
     }
 
     /// Push a surface's blur region to the compositor if it changed.
@@ -762,9 +900,9 @@ impl WaylandState {
                     f(layer_surface);
                     surface_state.wl_surface.commit();
                 }
-                SurfaceRole::Lock(_) => {
+                SurfaceRole::Lock(_) | SurfaceRole::Popup(_) => {
                     log::warn!(
-                        "Ignoring layer-shell property change on lock surface {:?}",
+                        "Ignoring layer-shell property change on non-layer surface {:?}",
                         id
                     );
                 }
@@ -1706,6 +1844,38 @@ impl PointerHandler for WaylandState {
     }
 }
 
+/// Map guido's popup anchor point to the xdg_positioner anchor.
+fn popup_point_to_anchor(point: crate::surface::PopupAnchor) -> xdg_positioner::Anchor {
+    use crate::surface::PopupAnchor as P;
+    match point {
+        P::None => xdg_positioner::Anchor::None,
+        P::Top => xdg_positioner::Anchor::Top,
+        P::Bottom => xdg_positioner::Anchor::Bottom,
+        P::Left => xdg_positioner::Anchor::Left,
+        P::Right => xdg_positioner::Anchor::Right,
+        P::TopLeft => xdg_positioner::Anchor::TopLeft,
+        P::BottomLeft => xdg_positioner::Anchor::BottomLeft,
+        P::TopRight => xdg_positioner::Anchor::TopRight,
+        P::BottomRight => xdg_positioner::Anchor::BottomRight,
+    }
+}
+
+/// Map guido's popup gravity to the xdg_positioner gravity.
+fn popup_point_to_gravity(point: crate::surface::PopupAnchor) -> xdg_positioner::Gravity {
+    use crate::surface::PopupAnchor as P;
+    match point {
+        P::None => xdg_positioner::Gravity::None,
+        P::Top => xdg_positioner::Gravity::Top,
+        P::Bottom => xdg_positioner::Gravity::Bottom,
+        P::Left => xdg_positioner::Gravity::Left,
+        P::Right => xdg_positioner::Gravity::Right,
+        P::TopLeft => xdg_positioner::Gravity::TopLeft,
+        P::BottomLeft => xdg_positioner::Gravity::BottomLeft,
+        P::TopRight => xdg_positioner::Gravity::TopRight,
+        P::BottomRight => xdg_positioner::Gravity::BottomRight,
+    }
+}
+
 /// Convert Wayland button code to MouseButton
 fn wayland_button_to_mouse_button(button: u32) -> Option<MouseButton> {
     // Linux input event codes (from linux/input-event-codes.h)
@@ -1976,6 +2146,80 @@ impl SessionLockHandler for WaylandState {
 }
 
 delegate_session_lock!(WaylandState);
+
+impl PopupHandler for WaylandState {
+    fn configure(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        popup: &Popup,
+        config: PopupConfigure,
+    ) {
+        // Route to the matching surface state, like the layer-shell path.
+        // sctk has already acked; the compositor may have adjusted size and
+        // position to keep the popup on screen.
+        let surface_id = self.surface_lookup.get(&popup.wl_surface().id()).copied();
+        if let Some(id) = surface_id
+            && let Some(surface_state) = self.surfaces.get_mut(&id)
+        {
+            log::info!(
+                "Popup {:?} configure: {}x{} at {:?}",
+                id,
+                config.width,
+                config.height,
+                config.position
+            );
+            if config.width > 0 {
+                surface_state.width = config.width as u32;
+            }
+            if config.height > 0 {
+                surface_state.height = config.height as u32;
+            }
+            surface_state.configured = true;
+            crate::jobs::request_frame();
+        }
+    }
+
+    fn done(&mut self, _conn: &Connection, _qh: &QueueHandle<Self>, popup: &Popup) {
+        // Compositor dismissed the popup (outside click on a grab, parent
+        // gone). Flip the reactive dismissal signal and route through the
+        // normal close command for full teardown.
+        if let Some(id) = self.surface_lookup.get(&popup.wl_surface().id()).copied() {
+            log::info!("Popup {:?} dismissed by compositor", id);
+            crate::surface::mark_popup_dismissed(id);
+            crate::surface::push_surface_command(crate::surface::SurfaceCommand::Close(id));
+        }
+    }
+}
+
+// Not delegate_xdg_shell!: that macro (and sctk's decoration dispatches)
+// drag in WindowHandler bounds — guido has no toplevel windows. Popups need
+// only xdg_wm_base (ping/pong), plus an inert stub for the decoration
+// manager that XdgShell::bind insists on binding (the protocol object has
+// no events).
+smithay_client_toolkit::reexports::client::delegate_dispatch!(WaylandState: [
+    smithay_client_toolkit::reexports::protocols::xdg::shell::client::xdg_wm_base::XdgWmBase: smithay_client_toolkit::globals::GlobalData
+] => XdgShell);
+
+impl
+    Dispatch<
+        smithay_client_toolkit::reexports::protocols::xdg::decoration::zv1::client::zxdg_decoration_manager_v1::ZxdgDecorationManagerV1,
+        smithay_client_toolkit::globals::GlobalData,
+    > for WaylandState
+{
+    fn event(
+        _: &mut Self,
+        _: &smithay_client_toolkit::reexports::protocols::xdg::decoration::zv1::client::zxdg_decoration_manager_v1::ZxdgDecorationManagerV1,
+        _: smithay_client_toolkit::reexports::protocols::xdg::decoration::zv1::client::zxdg_decoration_manager_v1::Event,
+        _: &smithay_client_toolkit::globals::GlobalData,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        unreachable!("zxdg_decoration_manager_v1 has no events");
+    }
+}
+
+delegate_xdg_popup!(WaylandState);
 
 impl Dispatch<ExtBackgroundEffectManagerV1, ()> for WaylandState {
     fn event(

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -216,6 +216,117 @@ impl SurfaceConfig {
     }
 }
 
+/// Which point of the anchor rectangle a popup attaches to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PopupAnchor {
+    /// Center of the anchor rect.
+    #[default]
+    None,
+    Top,
+    Bottom,
+    Left,
+    Right,
+    TopLeft,
+    BottomLeft,
+    TopRight,
+    BottomRight,
+}
+
+/// Which direction a popup grows from its anchor point.
+///
+/// `Bottom` means "downwards" (typical menu under a bar button).
+pub type PopupGravity = PopupAnchor;
+
+/// Configuration for an xdg popup anchored to a parent surface.
+///
+/// The compositor positions the popup relative to `anchor_rect` (parent
+/// surface coordinates) and adjusts it to stay on screen (flip/slide).
+///
+/// ```ignore
+/// spawn_popup(
+///     bar_surface_id,
+///     PopupConfig::new(250, 300)
+///         .anchor_rect(button_rect)
+///         .anchor(PopupAnchor::Bottom)
+///         .gravity(PopupGravity::Bottom)
+///         .grab(),
+///     move || menu_widget(),
+/// );
+/// ```
+#[derive(Clone)]
+pub struct PopupConfig {
+    /// Popup size in logical pixels (required by xdg_positioner).
+    pub width: u32,
+    pub height: u32,
+    /// Rectangle the popup anchors to, in parent surface coordinates.
+    pub anchor_rect: Rect,
+    /// Which point of the anchor rect to attach to.
+    pub anchor: PopupAnchor,
+    /// Which direction the popup grows.
+    pub gravity: PopupGravity,
+    /// Extra offset from the anchor point.
+    pub offset: (i32, i32),
+    /// Take an input grab: clicking outside dismisses the popup (menu
+    /// semantics). The compositor reports the dismissal reactively — see
+    /// [`PopupHandle::dismissed`].
+    pub grab: bool,
+    /// Background color of the popup surface.
+    pub background_color: Color,
+}
+
+impl PopupConfig {
+    /// Create a popup configuration with the given size.
+    pub fn new(width: u32, height: u32) -> Self {
+        Self {
+            width,
+            height,
+            anchor_rect: Rect::new(0.0, 0.0, 1.0, 1.0),
+            anchor: PopupAnchor::Bottom,
+            gravity: PopupGravity::Bottom,
+            offset: (0, 0),
+            grab: false,
+            background_color: Color::TRANSPARENT,
+        }
+    }
+
+    /// Set the rectangle the popup anchors to (parent surface coordinates).
+    /// Typically a widget's bounds from a [`crate::widget_ref::WidgetRef`].
+    pub fn anchor_rect(mut self, rect: Rect) -> Self {
+        self.anchor_rect = rect;
+        self
+    }
+
+    /// Set which point of the anchor rect the popup attaches to.
+    pub fn anchor(mut self, anchor: PopupAnchor) -> Self {
+        self.anchor = anchor;
+        self
+    }
+
+    /// Set which direction the popup grows.
+    pub fn gravity(mut self, gravity: PopupGravity) -> Self {
+        self.gravity = gravity;
+        self
+    }
+
+    /// Set an extra offset from the anchor point.
+    pub fn offset(mut self, x: i32, y: i32) -> Self {
+        self.offset = (x, y);
+        self
+    }
+
+    /// Take an input grab: clicking outside dismisses the popup.
+    pub fn grab(mut self) -> Self {
+        self.grab = true;
+        self
+    }
+
+    /// Set the background color of the popup surface.
+    pub fn background_color(mut self, color: Color) -> Self {
+        self.background_color = color;
+        self
+    }
+}
+
 /// Handle to a spawned surface for controlling it from widget code.
 ///
 /// The handle can be cloned and shared between callbacks. It allows
@@ -353,6 +464,13 @@ pub(crate) enum SurfaceCommand {
         id: SurfaceId,
         rects: Option<Vec<Rect>>,
     },
+    /// Create an xdg popup anchored to a parent surface.
+    CreatePopup {
+        id: SurfaceId,
+        parent: SurfaceId,
+        config: PopupConfig,
+        widget_fn: Box<dyn FnOnce() -> Box<dyn Widget>>,
+    },
 }
 
 // Thread-local storage for the surface command queue.
@@ -429,6 +547,109 @@ where
     });
 
     SurfaceHandle { id }
+}
+
+/// Handle to a spawned popup.
+///
+/// Popups close either programmatically ([`PopupHandle::close`]) or by the
+/// compositor (grab + outside click, parent gone): watch that reactively
+/// via [`PopupHandle::dismissed`].
+#[derive(Clone, Copy)]
+pub struct PopupHandle {
+    id: SurfaceId,
+    dismissed: crate::reactive::RwSignal<bool>,
+}
+
+impl PopupHandle {
+    /// The popup's surface ID.
+    pub fn id(&self) -> SurfaceId {
+        self.id
+    }
+
+    /// Close the popup programmatically.
+    pub fn close(&self) {
+        self.dismissed.set(true);
+        push_surface_command(SurfaceCommand::Close(self.id));
+    }
+
+    /// Whether the popup has been dismissed (tracked read — reactive inside
+    /// tracked closures). True after `close()` or a compositor dismissal
+    /// (click outside a grabbed popup, parent closed).
+    pub fn dismissed(&self) -> bool {
+        self.dismissed.get()
+    }
+}
+
+// Registry of popup dismissal signals so the platform layer can flip them
+// when the compositor dismisses a popup (xdg_popup.popup_done).
+thread_local! {
+    static POPUP_DISMISSED: RefCell<std::collections::HashMap<SurfaceId, crate::reactive::RwSignal<bool>>> =
+        RefCell::new(std::collections::HashMap::new());
+}
+
+/// Mark a popup dismissed (called by the platform layer on popup_done, and
+/// on close). Removes the registry entry.
+pub(crate) fn mark_popup_dismissed(id: SurfaceId) {
+    let signal = POPUP_DISMISSED.with(|reg| reg.borrow_mut().remove(&id));
+    if let Some(signal) = signal {
+        signal.set(true);
+    }
+}
+
+/// Reset popup registry state.
+///
+/// Called during `App::drop()`.
+pub(crate) fn reset_popups() {
+    POPUP_DISMISSED.with(|reg| reg.borrow_mut().clear());
+}
+
+/// Spawn an xdg popup anchored to a parent surface.
+///
+/// The compositor positions the popup relative to `config.anchor_rect`
+/// (parent surface coordinates), keeps it on screen (flip/slide at screen
+/// edges), and — with [`PopupConfig::grab`] — dismisses it when the user
+/// clicks outside: real menu semantics, no fullscreen overlay needed.
+///
+/// The popup renders its own widget tree and shares the reactive state
+/// with the rest of the app, like any surface.
+///
+/// # Example
+///
+/// ```ignore
+/// let button_rect = button_ref.rect().get();
+/// let popup = spawn_popup(
+///     bar_id,
+///     PopupConfig::new(250, 300)
+///         .anchor_rect(button_rect)
+///         .grab(),
+///     move || menu_widget(),
+/// );
+/// // Reactively observe dismissal (e.g. reset the open/closed state):
+/// create_effect(move || {
+///     if popup.dismissed() {
+///         menu_open.set(false);
+///     }
+/// });
+/// ```
+pub fn spawn_popup<W, F>(parent: SurfaceId, config: PopupConfig, widget_fn: F) -> PopupHandle
+where
+    W: Widget + 'static,
+    F: FnOnce() -> W + 'static,
+{
+    let id = SurfaceId::next();
+    let dismissed = crate::reactive::create_signal(false);
+    POPUP_DISMISSED.with(|reg| {
+        reg.borrow_mut().insert(id, dismissed);
+    });
+
+    push_surface_command(SurfaceCommand::CreatePopup {
+        id,
+        parent,
+        config,
+        widget_fn: Box::new(move || Box::new(widget_fn())),
+    });
+
+    PopupHandle { id, dismissed }
 }
 
 /// Get a handle to control an existing surface.


### PR DESCRIPTION
## Summary

The biggest planned win for the ashell port: **real popups** instead of fullscreen overlay surfaces (ashell's own docs put that overlay at ~140 MB VRAM per 4K monitor).

- **`spawn_popup(parent, PopupConfig, widget_fn) -> PopupHandle`**: xdg popup via `zwlr_layer_surface_v1.get_popup` + `xdg_positioner` (size, anchor rect in parent coordinates, anchor point, gravity, offset). The compositor positions it and keeps it on screen (flip/slide).
- **`.grab()`** = menu semantics: outside click dismisses; dismissal is reactive via `PopupHandle::dismissed()` (and `popup_done` routes the normal close path). `close()` for programmatic closing.
- **Nested popups** (submenus) by anchoring a popup to a popup; `SurfaceRole::Popup` reuses the entire surface pipeline (widget tree, GPU, frame pacing, per-surface job scheduling from #119).
- `delegate_xdg_shell!` is *not* used: sctk's macro drags `WindowHandler` bounds in via the decoration dispatches and guido has no toplevel windows — `xdg_wm_base` is delegated by hand, the decoration manager gets an inert stub (the protocol object has no events).

## Testing

- 221 lib tests, clippy 1.97.1 `-D warnings`, fmt, book build — clean.
- Live on niri: popup created on a bottom bar, compositor-positioned above it (negative y in the popup configure), rendered with corner radius. Grab/dismiss path needs a real click — exercised next in the ashell-guido menu adaptation.
- `examples/popup_example.rs`: button toggling a grabbed menu with the reactive-dismissal pattern; documented in the book's Wayland chapter.
