### PR TITLE
Popups size to their content and reposition when it changes

### DIFF
--- a/book/src/advanced/wayland.md
+++ b/book/src/advanced/wayland.md
@@ -537,7 +537,7 @@ fullscreen overlay:
 ```rust
 let popup = spawn_popup(
     bar_id,
-    PopupConfig::new(250, 300)                 // size (required by xdg)
+    PopupConfig::new(250)                      // width; height sizes to content
         .anchor_rect(button_ref.rect().get())  // parent surface coords
         .anchor(PopupAnchor::Bottom)           // attach point on the rect
         .gravity(PopupGravity::Bottom)         // growth direction

--- a/examples/popup_example.rs
+++ b/examples/popup_example.rs
@@ -68,16 +68,17 @@ fn main() {
 
                                 let popup = spawn_popup(
                                     bar_id_for_click.borrow().unwrap(),
-                                    PopupConfig::new(220, 168)
+                                    PopupConfig::new(220)
                                         .anchor_rect(button_ref.rect().get())
                                         .anchor(PopupAnchor::Top)
                                         .gravity(PopupGravity::Top)
                                         .grab()
                                         .background_color(Color::TRANSPARENT),
                                     || {
+                                        // Auto-height popup: the content
+                                        // wraps, no fill-height here
                                         container()
                                             .width(fill())
-                                            .height(fill())
                                             .background(Color::rgb(0.13, 0.13, 0.2))
                                             .corner_radius(10.0)
                                             .padding(8.0)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,26 +263,69 @@ fn process_surface_commands(
                 widget_fn,
             } => {
                 log::info!("Creating popup {:?} anchored to {:?}", id, parent);
-                if wayland_state.create_popup_surface_with_id(&qh.clone(), id, parent, &config) {
-                    let (widget, owner_id) = with_owner(widget_fn);
-                    // Reuse the surface pipeline: only the background color
-                    // matters from the synthesized config (size arrives with
-                    // the popup configure)
-                    let surface_config = SurfaceConfig::new()
-                        .width(config.width)
-                        .height(config.height)
-                        .background_color(config.background_color);
-                    let managed = ManagedSurface::new(id, surface_config, widget, owner_id, tree);
+
+                // Build the widget tree FIRST: auto-height popups size to
+                // their content, so the content must exist to be measured
+                // before the xdg_positioner is created.
+                let (widget, owner_id) = with_owner(widget_fn);
+                let surface_config = SurfaceConfig::new()
+                    .width(config.width)
+                    .height(config.height.unwrap_or(1))
+                    .background_color(config.background_color);
+                let managed = ManagedSurface::new(id, surface_config, widget, owner_id, tree);
+
+                let height = config.height.unwrap_or_else(|| {
+                    measure_popup_height(tree, managed.widget_id, config.width, parent)
+                });
+
+                if wayland_state.create_popup_surface_with_id(
+                    qh,
+                    id,
+                    parent,
+                    &config,
+                    (config.width, height),
+                ) {
                     surface_manager.add(managed);
                 } else {
-                    // Creation failed (no xdg_wm_base, parent gone): report
-                    // as dismissed so the app can react.
+                    // Creation failed (no xdg_wm_base, parent gone): drop the
+                    // widget tree and report the popup as dismissed.
+                    drop(managed);
                     surface::mark_popup_dismissed(id);
                 }
             }
         }
     }
     true
+}
+
+/// Measure a popup's natural content height at the given width.
+///
+/// Capped at the parent surface's output height (minus a margin) so a
+/// runaway or `fill()`-height content can't request an absurd popup.
+fn measure_popup_height(tree: &mut Tree, root: WidgetId, width: u32, parent: SurfaceId) -> u32 {
+    let cap = outputs::surface_output(parent)
+        .and_then(|oid| {
+            outputs::current_outputs()
+                .into_iter()
+                .find(|o| o.id == oid)
+                .and_then(|o| o.logical_size)
+        })
+        .or_else(|| {
+            outputs::current_outputs()
+                .into_iter()
+                .find_map(|o| o.logical_size)
+        })
+        .map(|(_, h)| (h as f32 - 64.0).max(100.0))
+        .unwrap_or(800.0);
+
+    let constraints = Constraints::new(width as f32, 0.0, width as f32, cap);
+    let measured = tree
+        .with_widget_mut(root, |widget, id, tree| {
+            widget.layout(tree, id, constraints)
+        })
+        .map(|size| size.height)
+        .unwrap_or(100.0);
+    (measured.ceil() as u32).max(1)
 }
 
 /// Walk the render tree after painting and cache each node's output.
@@ -516,6 +559,19 @@ fn render_surface(
             tree.mark_subtree_needs_paint(surface.widget_id);
         }
         // If neither condition is true, skip layout entirely - nothing is dirty
+
+        // Auto-height popups follow their content: when this surface had
+        // layout activity, re-measure the natural height and ask the
+        // compositor to reposition if it changed (submenus expanding, lists
+        // growing). The measure pass runs under different constraints, so
+        // the real layout is restored right after.
+        if has_pending_layouts && let Some(popup_width) = wayland_state.popup_auto_width(id) {
+            let natural = measure_popup_height(tree, surface.widget_id, popup_width, id);
+            tree.with_widget_mut(surface.widget_id, |widget, wid, tree| {
+                widget.layout(tree, wid, constraints);
+            });
+            wayland_state.reposition_popup_if_changed(id, natural, qh);
+        }
 
         // Update widget ref signals with current bounds after layout
         widget_ref::update_widget_refs(tree);

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -87,8 +87,12 @@ pub enum SurfaceRole {
     /// Kept alive here — dropping it destroys the protocol object.
     Lock(SessionLockSurface),
     /// An xdg popup anchored to another surface. Kept alive here —
-    /// dropping it destroys the xdg objects.
-    Popup(Popup),
+    /// dropping it destroys the xdg objects. The config is retained to
+    /// rebuild positioners for repositioning (auto-height growth).
+    Popup {
+        popup: Popup,
+        config: crate::surface::PopupConfig,
+    },
 }
 
 /// Events from the session-lock protocol, drained by the main loop.
@@ -131,6 +135,9 @@ pub struct WaylandSurfaceState {
     /// been pushed yet (also reset when the blur capability changes, so the
     /// region is re-sent if it comes back).
     blur_region: Option<Vec<BlurRect>>,
+    /// Height sent in an in-flight popup reposition (cleared by the popup
+    /// configure), so repeated content measurements don't re-send it.
+    pending_popup_height: Option<u32>,
 }
 
 impl WaylandSurfaceState {
@@ -154,6 +161,7 @@ impl WaylandSurfaceState {
             pending_events: Vec::new(),
             bg_effect_surface: None,
             blur_region: None,
+            pending_popup_height: None,
         }
     }
 
@@ -199,6 +207,8 @@ pub struct WaylandState {
     // xdg shell (popups anchored to layer surfaces)
     /// `None` where xdg_wm_base is unavailable — popups then fail with a log.
     xdg_shell: Option<XdgShell>,
+    /// Monotonic token for xdg_popup.reposition requests.
+    reposition_token: u32,
 
     // Session lock (ext-session-lock-v1)
     session_lock_state: SessionLockState,
@@ -382,6 +392,7 @@ pub fn create_wayland_app() -> Result<
         bg_effect_manager,
         bg_effect_supports_blur: false,
         xdg_shell,
+        reposition_token: 0,
         session_lock_state,
         active_lock: None,
         lock_events: Vec::new(),
@@ -560,35 +571,20 @@ impl WaylandState {
         std::mem::take(&mut self.lock_events)
     }
 
-    /// Create an xdg popup anchored to `parent` with a specific SurfaceId.
-    ///
-    /// The popup's actual size/position arrive with the popup configure
-    /// (the compositor may flip/slide it to stay on screen). Returns false
-    /// when xdg_wm_base is missing or the parent can't host popups.
-    pub fn create_popup_surface_with_id(
-        &mut self,
-        qh: &QueueHandle<Self>,
-        id: SurfaceId,
-        parent: SurfaceId,
+    /// Build an xdg_positioner for a popup config at the given size.
+    fn build_popup_positioner(
+        xdg_shell: &XdgShell,
         config: &crate::surface::PopupConfig,
-    ) -> bool {
-        let Some(ref xdg_shell) = self.xdg_shell else {
-            log::error!("Cannot create popup: compositor lacks xdg_wm_base");
-            return false;
-        };
-        let Some(parent_state) = self.surfaces.get(&parent) else {
-            log::warn!("Cannot create popup: parent surface {:?} is gone", parent);
-            return false;
-        };
-
+        size: (u32, u32),
+    ) -> Option<XdgPositioner> {
         let positioner = match XdgPositioner::new(xdg_shell) {
             Ok(p) => p,
             Err(e) => {
                 log::error!("Failed to create xdg_positioner: {e}");
-                return false;
+                return None;
             }
         };
-        positioner.set_size(config.width.max(1) as i32, config.height.max(1) as i32);
+        positioner.set_size(size.0.max(1) as i32, size.1.max(1) as i32);
         let r = config.anchor_rect;
         positioner.set_anchor_rect(
             r.x.floor() as i32,
@@ -607,6 +603,36 @@ impl WaylandState {
                 | xdg_positioner::ConstraintAdjustment::SlideX
                 | xdg_positioner::ConstraintAdjustment::SlideY,
         );
+        Some(positioner)
+    }
+
+    /// Create an xdg popup anchored to `parent` with a specific SurfaceId.
+    ///
+    /// `size` is the resolved popup size (config height, or the measured
+    /// content height for auto-height popups). The actual size/position
+    /// arrive with the popup configure (the compositor may flip/slide it to
+    /// stay on screen). Returns false when xdg_wm_base is missing or the
+    /// parent can't host popups.
+    pub fn create_popup_surface_with_id(
+        &mut self,
+        qh: &QueueHandle<Self>,
+        id: SurfaceId,
+        parent: SurfaceId,
+        config: &crate::surface::PopupConfig,
+        size: (u32, u32),
+    ) -> bool {
+        let Some(ref xdg_shell) = self.xdg_shell else {
+            log::error!("Cannot create popup: compositor lacks xdg_wm_base");
+            return false;
+        };
+        let Some(parent_state) = self.surfaces.get(&parent) else {
+            log::warn!("Cannot create popup: parent surface {:?} is gone", parent);
+            return false;
+        };
+
+        let Some(positioner) = Self::build_popup_positioner(xdg_shell, config, size) else {
+            return false;
+        };
 
         let wl_surface = self.compositor_state.create_surface(qh);
         let popup = match &parent_state.role {
@@ -625,7 +651,10 @@ impl WaylandState {
                 layer_surface.get_popup(popup.xdg_popup());
                 popup
             }
-            SurfaceRole::Popup(parent_popup) => {
+            SurfaceRole::Popup {
+                popup: parent_popup,
+                ..
+            } => {
                 // Nested popup (submenu): ordinary xdg parent
                 let parent_xdg = parent_popup.xdg_surface().clone();
                 match Popup::from_surface(
@@ -660,10 +689,13 @@ impl WaylandState {
 
         self.surface_lookup.insert(wl_surface.id(), id);
         let surface_state = WaylandSurfaceState::new(
-            SurfaceRole::Popup(popup),
+            SurfaceRole::Popup {
+                popup,
+                config: config.clone(),
+            },
             wl_surface,
-            config.width,
-            config.height,
+            size.0,
+            size.1,
         );
         self.surfaces.insert(id, surface_state);
 
@@ -671,11 +703,58 @@ impl WaylandState {
             "Created popup {:?} on parent {:?} ({}x{}, grab: {})",
             id,
             parent,
-            config.width,
-            config.height,
+            size.0,
+            size.1,
             config.grab
         );
         true
+    }
+
+    /// For auto-height popups: the width to measure content at.
+    /// Returns `None` for non-popup surfaces or fixed-height popups.
+    pub(crate) fn popup_auto_width(&self, id: SurfaceId) -> Option<u32> {
+        match &self.surfaces.get(&id)?.role {
+            SurfaceRole::Popup { config, .. } if config.height.is_none() => Some(config.width),
+            _ => None,
+        }
+    }
+
+    /// Reposition an auto-height popup when its content height changed.
+    /// The compositor answers with a new configure carrying the final size.
+    pub(crate) fn reposition_popup_if_changed(
+        &mut self,
+        id: SurfaceId,
+        new_height: u32,
+        qh: &QueueHandle<Self>,
+    ) {
+        let _ = qh;
+        let Some(ref xdg_shell) = self.xdg_shell else {
+            return;
+        };
+        let Some(surface_state) = self.surfaces.get_mut(&id) else {
+            return;
+        };
+        if surface_state.height == new_height
+            || surface_state.pending_popup_height == Some(new_height)
+        {
+            return;
+        }
+        let SurfaceRole::Popup { popup, config } = &surface_state.role else {
+            return;
+        };
+        // xdg_popup.reposition needs protocol v3
+        if popup.xdg_popup().version() < 3 {
+            return;
+        }
+        let Some(positioner) =
+            Self::build_popup_positioner(xdg_shell, config, (config.width, new_height))
+        else {
+            return;
+        };
+        self.reposition_token = self.reposition_token.wrapping_add(1);
+        popup.reposition(&positioner, self.reposition_token);
+        surface_state.pending_popup_height = Some(new_height);
+        log::debug!("Popup {:?} repositioning to height {}", id, new_height);
     }
 
     /// Push a surface's blur region to the compositor if it changed.
@@ -900,7 +979,7 @@ impl WaylandState {
                     f(layer_surface);
                     surface_state.wl_surface.commit();
                 }
-                SurfaceRole::Lock(_) | SurfaceRole::Popup(_) => {
+                SurfaceRole::Lock(_) | SurfaceRole::Popup { .. } => {
                     log::warn!(
                         "Ignoring layer-shell property change on non-layer surface {:?}",
                         id
@@ -2175,6 +2254,7 @@ impl PopupHandler for WaylandState {
             if config.height > 0 {
                 surface_state.height = config.height as u32;
             }
+            surface_state.pending_popup_height = None;
             surface_state.configured = true;
             crate::jobs::request_frame();
         }

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -245,7 +245,7 @@ pub type PopupGravity = PopupAnchor;
 /// ```ignore
 /// spawn_popup(
 ///     bar_surface_id,
-///     PopupConfig::new(250, 300)
+///     PopupConfig::new(250)
 ///         .anchor_rect(button_rect)
 ///         .anchor(PopupAnchor::Bottom)
 ///         .gravity(PopupGravity::Bottom)
@@ -255,9 +255,15 @@ pub type PopupGravity = PopupAnchor;
 /// ```
 #[derive(Clone)]
 pub struct PopupConfig {
-    /// Popup size in logical pixels (required by xdg_positioner).
+    /// Popup width in logical pixels.
     pub width: u32,
-    pub height: u32,
+    /// Popup height in logical pixels. `None` (the default) sizes the popup
+    /// to its content: the widget is laid out at the given width before the
+    /// popup is created, and repositioned when its content height changes
+    /// (submenus expanding, lists growing). Content using `height(fill())`
+    /// resolves to the screen-height cap — give such popups an explicit
+    /// height instead.
+    pub height: Option<u32>,
     /// Rectangle the popup anchors to, in parent surface coordinates.
     pub anchor_rect: Rect,
     /// Which point of the anchor rect to attach to.
@@ -275,11 +281,12 @@ pub struct PopupConfig {
 }
 
 impl PopupConfig {
-    /// Create a popup configuration with the given size.
-    pub fn new(width: u32, height: u32) -> Self {
+    /// Create a popup configuration with the given width; the height sizes
+    /// to the content (see [`PopupConfig::height`] to fix it instead).
+    pub fn new(width: u32) -> Self {
         Self {
             width,
-            height,
+            height: None,
             anchor_rect: Rect::new(0.0, 0.0, 1.0, 1.0),
             anchor: PopupAnchor::Bottom,
             gravity: PopupGravity::Bottom,
@@ -287,6 +294,12 @@ impl PopupConfig {
             grab: false,
             background_color: Color::TRANSPARENT,
         }
+    }
+
+    /// Fix the popup height instead of sizing it to the content.
+    pub fn height(mut self, height: u32) -> Self {
+        self.height = Some(height);
+        self
     }
 
     /// Set the rectangle the popup anchors to (parent surface coordinates).
@@ -619,7 +632,7 @@ pub(crate) fn reset_popups() {
 /// let button_rect = button_ref.rect().get();
 /// let popup = spawn_popup(
 ///     bar_id,
-///     PopupConfig::new(250, 300)
+///     PopupConfig::new(250)
 ///         .anchor_rect(button_rect)
 ///         .grab(),
 ///     move || menu_widget(),


### PR DESCRIPTION
## Summary

First user feedback from the ashell menu adaptation: fixed popup heights leave dead space (or clip). Now:

- **`PopupConfig::new(width)`** — the popup's widget tree is built *before* the xdg surface and laid out at that width (capped at the output height − margin) to get the initial height. `.height(h)` pins it explicitly (content with `height(fill())` resolves to the cap, so fixed heights suit such popups).
- **Content growth → xdg reposition (v3+)**: when an auto-height popup's surface has layout activity, the natural height is re-measured (real layout restored afterwards — the measure pass runs under loose constraints); if changed, a rebuilt positioner is sent via `xdg_popup.reposition`, so expanding submenus and growing lists resize the popup instead of clipping. In-flight repositions dedupe via a pending height cleared by the popup configure.
- The popup role retains its `PopupConfig` to rebuild positioners.

Breaking: `PopupConfig::new(w, h)` → `PopupConfig::new(w)` (+`.height(h)`) — API introduced earlier today, only ashell-guido consumes it.

## Testing

221 lib tests, clippy 1.97.1 `-D warnings`, fmt, book updated. Interactive verification with ashell's settings menu follows in the port branch.
