### PR TITLE
Add ImageSource::Rgba for raw pre-decoded pixel data

### DIFF
--- a/book/src/building-ui/images.md
+++ b/book/src/building-ui/images.md
@@ -36,9 +36,14 @@ ImageSource::SvgPath("./icon.svg".into())
 
 // From memory (SVG)
 ImageSource::SvgBytes(svg_string.as_bytes().into())
+
+// Raw pre-decoded RGBA8 pixels (width * height * 4 bytes, row-major)
+ImageSource::Rgba { width: 22, height: 22, pixels: rgba_bytes.into() }
 ```
 
 When using a string path with `image()`, the file extension determines the type automatically: `.svg` files use SVG rendering, all others use raster decoding.
+
+`ImageSource::Rgba` skips decoding entirely — use it for pixel data that never existed in an encoded format, such as tray icon pixmaps or album art received over D-Bus.
 
 ## Sizing
 

--- a/src/image_metadata.rs
+++ b/src/image_metadata.rs
@@ -22,6 +22,7 @@ pub fn get_intrinsic_size(source: &ImageSource) -> Option<(u32, u32)> {
         ImageSource::Bytes(bytes) => image::load_from_memory(bytes)
             .ok()
             .map(|img| img.dimensions()),
+        ImageSource::Rgba { width, height, .. } => Some((*width, *height)),
         ImageSource::SvgPath(path) => get_svg_size_from_file(path),
         ImageSource::SvgBytes(bytes) => get_svg_size_from_bytes(bytes),
     }

--- a/src/renderer/image_quad.rs
+++ b/src/renderer/image_quad.rs
@@ -266,6 +266,16 @@ impl ImageQuadRenderer {
                 "bytes".hash(&mut hasher);
                 Self::hash_bytes(bytes, &mut hasher);
             }
+            ImageSource::Rgba {
+                width,
+                height,
+                pixels,
+            } => {
+                "rgba".hash(&mut hasher);
+                width.hash(&mut hasher);
+                height.hash(&mut hasher);
+                Self::hash_bytes(pixels, &mut hasher);
+            }
             ImageSource::SvgPath(path) => {
                 "svg_path".hash(&mut hasher);
                 path.hash(&mut hasher);
@@ -345,7 +355,8 @@ impl ImageQuadRenderer {
                     }
                 };
                 let rgba = img.to_rgba8();
-                self.upload_raster(device, queue, &format, &rgba)
+                let (width, height) = rgba.dimensions();
+                self.upload_raster(device, queue, &format, width, height, rgba.as_raw())
             }
             ImageSource::Bytes(bytes) => {
                 let img = match image::load_from_memory(bytes) {
@@ -356,7 +367,28 @@ impl ImageQuadRenderer {
                     }
                 };
                 let rgba = img.to_rgba8();
-                self.upload_raster(device, queue, &format, &rgba)
+                let (width, height) = rgba.dimensions();
+                self.upload_raster(device, queue, &format, width, height, rgba.as_raw())
+            }
+            ImageSource::Rgba {
+                width,
+                height,
+                pixels,
+            } => {
+                let expected = (*width as usize)
+                    .checked_mul(*height as usize)
+                    .and_then(|v| v.checked_mul(4));
+                if Some(pixels.len()) != expected {
+                    log::warn!(
+                        "Rgba image source size mismatch: {}x{} expects {:?} bytes, got {}",
+                        width,
+                        height,
+                        expected,
+                        pixels.len()
+                    );
+                    return None;
+                }
+                self.upload_raster(device, queue, &format, *width, *height, pixels)
             }
             ImageSource::SvgPath(path) => {
                 let data = match std::fs::read(path) {
@@ -374,15 +406,16 @@ impl ImageQuadRenderer {
         }
     }
 
-    /// Upload a raster image to GPU.
+    /// Upload raw RGBA8 pixel data to GPU.
     fn upload_raster(
         &self,
         device: &Device,
         queue: &Queue,
         format: &TextureFormat,
-        rgba: &image::RgbaImage,
+        width: u32,
+        height: u32,
+        rgba: &[u8],
     ) -> Option<CachedTexture> {
-        let (width, height) = rgba.dimensions();
         if width == 0 || height == 0 {
             return None;
         }
@@ -409,7 +442,7 @@ impl ImageQuadRenderer {
                 origin: wgpu::Origin3d::ZERO,
                 aspect: wgpu::TextureAspect::All,
             },
-            rgba.as_raw(),
+            rgba,
             wgpu::TexelCopyBufferLayout {
                 offset: 0,
                 bytes_per_row: Some(4 * width),

--- a/src/widgets/image.rs
+++ b/src/widgets/image.rs
@@ -21,6 +21,15 @@ pub enum ImageSource {
     Path(PathBuf),
     /// Raster image from in-memory bytes
     Bytes(Arc<[u8]>),
+    /// Raw pre-decoded RGBA8 pixels (row-major, `width * height * 4` bytes).
+    ///
+    /// Skips the decode step entirely — for pixel data that never existed in
+    /// an encoded format, like tray icon pixmaps or album art from D-Bus.
+    Rgba {
+        width: u32,
+        height: u32,
+        pixels: Arc<[u8]>,
+    },
     /// SVG from a file path
     SvgPath(PathBuf),
     /// SVG from in-memory bytes


### PR DESCRIPTION
## Summary

Adds an `ImageSource::Rgba { width, height, pixels }` variant for raw RGBA8 pixel buffers.

Tray icon pixmaps (StatusNotifierItem) and album art arrive over D-Bus as raw ARGB/RGBA buffers. Without this variant a consumer would have to PNG-encode them only for guido to decode them again. The new variant validates `pixels.len() == width * height * 4` (mismatches log a warning and skip rendering, matching the existing decode-failure behavior) and uploads straight to the texture cache.

- `upload_raster` refactored to take `(width, height, &[u8])` so the Path/Bytes/Rgba paths share one upload
- Cache key hashes dimensions + sampled pixel bytes
- `get_intrinsic_size` returns the declared dimensions without touching the pixels
- Book: images chapter updated

First consumer: the ashell tray module port.