### PR TITLE
Content-keyed single reactive child

### DIFF
--- a/book/src/advanced/dynamic-children.md
+++ b/book/src/advanced/dynamic-children.md
@@ -72,6 +72,46 @@ With proper keys:
 - **Insertions** only create new widgets
 - **Deletions** only remove specific widgets
 
+## Single Reactive Child: Presence vs Content
+
+`.child()` accepts two reactive closure forms, and picking the wrong one is a
+subtle trap.
+
+The `Option<Widget>` form is **presence-only**. It always reconciles under the
+same internal key, so a `Some -> Some` transition keeps the first widget ever
+built and discards the rebuilt one. Use it to show or hide a widget whose own
+properties are reactive:
+
+```rust
+// Good: appears/disappears; the text widget itself tracks the signal
+container().child(move || {
+    logged_in.get().then(|| text(move || username.get()))
+})
+```
+
+When the widget's *structure* depends on data — lists, branches, trees rebuilt
+from a snapshot — return `Option<(u64, Widget)>` instead. The key states which
+version of the content the widget renders: same key keeps the cached widget,
+a new key swaps the rebuilt one in (running owner cleanup for the old):
+
+```rust
+use std::hash::{DefaultHasher, Hash, Hasher};
+
+fn hash_key(value: impl Hash) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    value.hash(&mut hasher);
+    hasher.finish()
+}
+
+container().child(move || {
+    let entries = menu_entries.get();
+    Some((hash_key(&entries), build_menu(entries)))
+})
+```
+
+If you ever write `.child(move || Some(...))` where the widget is built from
+signal data and it "never updates", this is why — key it.
+
 ## Automatic Ownership & Cleanup
 
 Signals and effects created inside the child closure are **automatically owned** and cleaned up when the child is removed:
@@ -246,6 +286,18 @@ container()
 impl Container {
     // Single child
     pub fn child(self, child: impl Widget + 'static) -> Self;
+
+    // Single reactive child, presence-only (Some -> Some keeps the first widget)
+    pub fn child<F, W>(self, child: F) -> Self
+    where
+        F: Fn() -> Option<W> + 'static,
+        W: Widget + 'static;
+
+    // Single reactive child, content-keyed (new key swaps the widget in)
+    pub fn child<F, W>(self, child: F) -> Self
+    where
+        F: Fn() -> Option<(u64, W)> + 'static,
+        W: Widget + 'static;
 
     // Multiple static children
     pub fn children<W: Widget + 'static>(

--- a/src/widgets/into_child.rs
+++ b/src/widgets/into_child.rs
@@ -9,11 +9,15 @@ pub struct StaticChild;
 /// Marker type for dynamic child (closure)
 pub struct DynamicChild;
 
+/// Marker type for keyed dynamic child (closure returning `Option<(key, widget)>`)
+pub struct KeyedChild;
+
 /// Trait for types that can be added as a child to a container
 ///
 /// This trait uses a marker type parameter to disambiguate between:
 /// - Static widgets (evaluated once at creation) - uses `StaticChild` marker
-/// - Dynamic closures returning `Option<Widget>` (reactive) - uses `DynamicChild` marker
+/// - Dynamic closures returning `Option<Widget>` (presence-reactive) - uses `DynamicChild` marker
+/// - Dynamic closures returning `Option<(u64, Widget)>` (content-reactive) - uses `KeyedChild` marker
 ///
 /// The marker parameter defaults to `StaticChild` so `.child(widget)` works without annotation.
 pub trait IntoChild<Marker = StaticChild> {
@@ -27,9 +31,17 @@ impl<W: Widget + 'static> IntoChild<StaticChild> for W {
     }
 }
 
-// Implementation for dynamic closures returning Option<Widget>
-// Note: For single optional children, ownership is handled at the item level.
-// Use keyed .children() for proper ownership with dynamic lists.
+/// Implementation for dynamic closures returning `Option<Widget>`.
+///
+/// **This form is presence-only.** The child always reconciles under the same
+/// key, so `Some -> Some` transitions keep the FIRST widget ever built and
+/// discard the rebuilt one — signals and state inside it persist, but a
+/// widget with different structure will never appear. Use it to show/hide a
+/// widget whose own properties are reactive.
+///
+/// When the widget's *structure* depends on data (lists, branches, rebuilt
+/// trees), return `Option<(key, widget)>` instead — see [`KeyedChild`] — with
+/// a key that changes alongside the content (typically a hash of the data).
 impl<F, W> IntoChild<DynamicChild> for F
 where
     F: Fn() -> Option<W> + 'static,
@@ -43,6 +55,48 @@ where
             if let Some(widget) = child_fn() {
                 // For single optional child, wrap in owner at creation time
                 vec![DynItem::new(0, move || {
+                    let (widget, owner_id) = with_owner(|| widget);
+                    OwnedWidget::new(Box::new(widget), owner_id)
+                })]
+            } else {
+                vec![]
+            }
+        };
+
+        children_source.add_dynamic(items_fn);
+    }
+}
+
+/// Implementation for dynamic closures returning `Option<(u64, Widget)>`.
+///
+/// The content-reactive companion to the presence-only `Option<Widget>` form:
+/// the key states which version of the content the widget renders. Same key =
+/// the cached widget is kept (rebuilt value discarded, inner state persists);
+/// new key = the old widget is dropped (owner cleanup runs) and the rebuilt
+/// one is swapped in.
+///
+/// # Example
+///
+/// ```ignore
+/// let entries = create_signal(vec!["a".to_string()]);
+/// container().child(move || {
+///     let list = entries.get();
+///     let key = hash_of(&list); // any u64 that changes with the content
+///     Some((key, build_list_widget(list)))
+/// })
+/// ```
+impl<F, W> IntoChild<KeyedChild> for F
+where
+    F: Fn() -> Option<(u64, W)> + 'static,
+    W: Widget + 'static,
+{
+    fn add_to_container(self, children_source: &mut ChildrenSource) {
+        let child_fn = std::rc::Rc::new(self);
+
+        let items_fn = move || {
+            let child_fn = child_fn.clone();
+            if let Some((key, widget)) = child_fn() {
+                vec![DynItem::new(key, move || {
                     let (widget, owner_id) = with_owner(|| widget);
                     OwnedWidget::new(Box::new(widget), owner_id)
                 })]
@@ -132,5 +186,85 @@ where
                 .collect()
         };
         children_source.add_dynamic(items_fn);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    use super::*;
+    use crate::layout::{Constraints, Size};
+    use crate::tree::{Tree, WidgetId};
+
+    struct TestWidget;
+    impl Widget for TestWidget {
+        fn layout(&mut self, _: &mut Tree, _: WidgetId, _: Constraints) -> Size {
+            Size::zero()
+        }
+        fn paint(&self, _: &Tree, _: WidgetId, _: &mut crate::renderer::PaintContext) {}
+    }
+
+    /// A parented ChildrenSource ready for reconciliation.
+    fn children_host() -> (Tree, ChildrenSource) {
+        let mut tree = Tree::new();
+        let parent = tree.register(Box::new(TestWidget));
+        let mut source = ChildrenSource::default();
+        source.set_container_id(parent);
+        (tree, source)
+    }
+
+    #[test]
+    fn keyed_child_swaps_widget_when_key_changes() {
+        let (mut tree, mut source) = children_host();
+        let key = Rc::new(Cell::new(1u64));
+
+        let key_reader = key.clone();
+        let closure = move || Some((key_reader.get(), TestWidget));
+        IntoChild::<KeyedChild>::add_to_container(closure, &mut source);
+
+        let first = source.reconcile_and_get(&mut tree).clone();
+        assert_eq!(first.len(), 1);
+
+        // Same key: the cached widget must be kept
+        source.reconcile_with_tracking(&mut tree);
+        assert_eq!(source.reconcile_and_get(&mut tree).clone(), first);
+
+        // New key: the widget must be replaced
+        key.set(2);
+        source.reconcile_with_tracking(&mut tree);
+        let second = source.reconcile_and_get(&mut tree).clone();
+        assert_eq!(second.len(), 1);
+        assert_ne!(second[0], first[0]);
+    }
+
+    #[test]
+    fn option_child_is_presence_only() {
+        let (mut tree, mut source) = children_host();
+        let present = Rc::new(Cell::new(true));
+
+        let present_reader = present.clone();
+        let closure = move || present_reader.get().then_some(TestWidget);
+        IntoChild::<DynamicChild>::add_to_container(closure, &mut source);
+
+        let first = source.reconcile_and_get(&mut tree).clone();
+        assert_eq!(first.len(), 1);
+
+        // Some -> Some keeps the original widget: this form cannot express
+        // content changes, only presence
+        source.reconcile_with_tracking(&mut tree);
+        assert_eq!(source.reconcile_and_get(&mut tree).clone(), first);
+
+        // None removes it, Some builds a fresh one
+        present.set(false);
+        source.reconcile_with_tracking(&mut tree);
+        assert!(source.reconcile_and_get(&mut tree).is_empty());
+
+        present.set(true);
+        source.reconcile_with_tracking(&mut tree);
+        let revived = source.reconcile_and_get(&mut tree).clone();
+        assert_eq!(revived.len(), 1);
+        assert_ne!(revived[0], first[0]);
     }
 }


### PR DESCRIPTION
## Summary

`.child(closure)` had one reactive form: `Fn() -> Option<W>`. It reconciles under a hardcoded key, so a `Some -> Some` transition keeps the first widget ever built and discards the rebuilt one. That is the right semantic for presence toggling around internally-reactive widgets — and a silent correctness trap for content that must re-render: the ashell tray menu shipped with frozen submenus/toggles because of exactly this.

This adds the content-reactive companion: closures returning `Option<(u64, W)>` reconcile under the returned key.

- Same key → cached widget kept (inner state persists, rebuilt value discarded)
- New key → old widget dropped with owner cleanup, rebuilt widget swapped in
- Typical usage: `Some((hash_of(&data), build_widget(data)))`

No call-site changes for existing code; the marker type disambiguates the two closure shapes.

## Coverage

- Both semantics documented on the `IntoChild` impls (the presence-only form now carries an explicit warning)
- Two tests pin the behaviors: keyed child swaps on key change, Option child is presence-only
- Book: `advanced/dynamic-children.md` gains a "Single Reactive Child: Presence vs Content" section + API reference entries