### PR TITLE
Reactive children: closures rebuild on change, per-segment tracking, keyed() for lists

### DIFF
--- a/book/src/advanced/dynamic-children.md
+++ b/book/src/advanced/dynamic-children.md
@@ -4,182 +4,137 @@ Learn the different ways to add children to containers, from static to fully rea
 
 ![Children Example](../images/children_example.png)
 
-## Static Children
+## The Model
 
-### Single Child
-
-```rust
-container().child(text("Hello"))
-```
-
-### Multiple Children
+Children come in exactly four forms — two static, two reactive:
 
 ```rust
-container().children([
-    text("First"),
-    text("Second"),
-    text("Third"),
-])
+container()
+    .child(text("Hello"))                                  // static single
+    .children([text("A"), text("B")])                      // static list
+    .child(dynamic(move || data.get(), build_widget))      // reactive single
+    .children(keyed(move || items.get(), |i| i.id, row))   // reactive list
 ```
 
-## Dynamic Children with Keyed Reconciliation
+`dynamic()` and `keyed()` are values, not methods: they pair a **tracked data
+closure** with an **untracked builder**. The data closure is the only reactive
+part — the signals it reads decide when to re-evaluate, and its result is what
+the builder receives. Data the widget must react to has to flow through the
+data closure; that is what makes stale content unexpressible.
 
-For lists that change based on signals, use the keyed children API:
+Bare closures are **rejected at compile time**. With `.child(move || ...)`
+there would be no way to know which data the widget was built from, so content
+updates could be silently discarded — the compiler error points you to
+`dynamic()` / `keyed()` instead.
+
+## Reactive Single Child: `dynamic(data, build)`
 
 ```rust
-let items = create_signal(vec![1u64, 2, 3]);
-
-container().children(move || {
-    items.get().into_iter().map(|id| {
-        // Return (key, closure) - closure creates the widget
-        (id, move || {
-            container()
-                .padding(8.0)
-                .background(Color::rgb(0.2, 0.2, 0.3))
-                .child(text(format!("Item {}", id)))
-        })
-    })
-})
+// Content that re-renders when the data changes
+container().child(dynamic(
+    move || menu_entries.get(),   // tracked; T: Clone + PartialEq
+    |entries| build_menu(entries) // untracked; runs only when T changed
+))
 ```
 
-### The Closure Pattern
+The data result is compared with the previous value (`PartialEq`):
 
-The key insight is returning `(key, || widget)` instead of `(key, widget)`:
+- **unchanged** → the existing widget is kept untouched: inner state,
+  animations and subscriptions persist, the builder does not run
+- **changed** → the builder runs and the rebuilt widget replaces the old one
+  (its owner scope is disposed)
+
+The builder may return `Option<widget>` to also control presence:
 
 ```rust
-// The closure ensures:
-// 1. Widget is only created for NEW keys (not every frame)
-// 2. Signals/effects inside are automatically owned
-// 3. Cleanup runs when the child is removed
-
-(item.id, move || create_item_widget(item))
+// Shown only while there is an active window
+container().child(dynamic(
+    move || state.active_window.get(),
+    |window| window.map(title_widget),
+))
 ```
 
-### How Keys Work
-
-The key identifies each item for efficient updates:
+The builder runs with signal tracking suspended: reads inside it see current
+values but create no dependencies. Choose what goes through the data closure
+and what stays internally reactive:
 
 ```rust
-// Good: Unique, stable identifier
-(item.id, move || widget)
+// Rebuild the row when the label changes...
+dynamic(move || item.get(), |item| text(item.label))
 
-// Bad: Index changes when items reorder
-(index as u64, move || widget)
+// ...or keep the widget and let it track the label itself
+dynamic(move || item.with(|i| i.id), |_| text(move || item.with(|i| i.label.clone())))
 ```
 
-With proper keys:
-- **Reordering** preserves widget state
-- **Insertions** only create new widgets
-- **Deletions** only remove specific widgets
-
-## Single Reactive Child: Presence vs Content
-
-`.child()` accepts two reactive closure forms, and picking the wrong one is a
-subtle trap.
-
-The `Option<Widget>` form is **presence-only**. It always reconciles under the
-same internal key, so a `Some -> Some` transition keeps the first widget ever
-built and discards the rebuilt one. Use it to show or hide a widget whose own
-properties are reactive:
+## Reactive Lists: `keyed(data, key, build)`
 
 ```rust
-// Good: appears/disappears; the text widget itself tracks the signal
-container().child(move || {
-    logged_in.get().then(|| text(move || username.get()))
-})
+let items = create_signal(vec![
+    Item { id: 1, name: "First".into() },
+    Item { id: 2, name: "Second".into() },
+]);
+
+container().children(keyed(
+    move || items.get(),   // tracked; items: Clone + PartialEq
+    |item| item.id,        // stable identity (survives reorders)
+    |item| item_widget(item),
+))
 ```
 
-When the widget's *structure* depends on data — lists, branches, trees rebuilt
-from a snapshot — return `Option<(u64, Widget)>` instead. The key states which
-version of the content the widget renders: same key keeps the cached widget,
-a new key swaps the rebuilt one in (running owner cleanup for the old):
+Per item, identity (`key`) and content (`PartialEq`) are diffed separately:
+
+- **new key** → the builder runs
+- **known key, item unchanged** → the existing widget is kept, including
+  across reorders (state and animations persist)
+- **known key, item changed** → only that row is rebuilt
+- **key gone** → the widget is dropped with owner cleanup
+
+Keys must be unique and stable — never use the index:
 
 ```rust
-use std::hash::{DefaultHasher, Hash, Hasher};
-
-fn hash_key(value: impl Hash) -> u64 {
-    let mut hasher = DefaultHasher::new();
-    value.hash(&mut hasher);
-    hasher.finish()
-}
-
-container().child(move || {
-    let entries = menu_entries.get();
-    Some((hash_key(&entries), build_menu(entries)))
-})
+keyed(data, |item| item.id, build)        // Good: stable identity
+keyed(data, |(index, _)| *index as u64, build)  // Bad: reorder loses state
 ```
 
-If you ever write `.child(move || Some(...))` where the widget is built from
-signal data and it "never updates", this is why — key it.
+The item type chooses the update granularity, exactly like `dynamic()`:
+fields included in the item trigger a row rebuild when they change; fields
+left out can be read via signals inside the row for in-place updates.
 
 ## Automatic Ownership & Cleanup
 
-Signals and effects created inside the child closure are **automatically owned** and cleaned up when the child is removed:
+Builders run inside an **owner scope**: signals and effects created there are
+automatically owned and cleaned up when the child is removed or rebuilt.
 
 ```rust
-container().children(move || {
-    items.get().into_iter().map(|id| (id, move || {
-        // This signal is OWNED by this child
-        let local_count = create_signal(0);
+fn item_widget(item: Item) -> impl Widget {
+    // This signal is OWNED by this row
+    let clicks = create_signal(0);
 
-        // This effect is also owned
-        create_effect(move || {
-            println!("Count: {}", local_count.get());
-        });
+    // Register cleanup for non-reactive resources
+    on_cleanup(move || {
+        log::info!("Item {} removed", item.id);
+    });
 
-        // Register cleanup for non-reactive resources
-        on_cleanup(move || {
-            println!("Child {} removed!", id);
-        });
+    container()
+        .padding(8.0)
+        .hover_state(|s| s.lighter(0.1))
+        .on_click(move || clicks.update(|c| *c += 1))
+        .child(text(move || format!("{} (clicks: {})", item.name, clicks.get())))
+}
 
-        container()
-            .on_click(move || local_count.update(|c| *c += 1))
-            .child(text(move || local_count.get().to_string()))
-    }))
-})
+container().children(keyed(move || items.get(), |i| i.id, item_widget))
 ```
 
-When a child is removed:
+When a child is removed or rebuilt:
 1. The widget is dropped
 2. `on_cleanup` callbacks run
 3. Effects are disposed
 4. Signals are disposed
 
-### Extracting Widget Creation
-
-You can extract the widget creation into a function:
-
-```rust
-fn create_item_widget(id: u64, name: String) -> impl Widget {
-    // Everything here is automatically owned!
-    let hover = create_signal(false);
-
-    on_cleanup(move || {
-        log::info!("Item {} cleaned up", id);
-    });
-
-    container()
-        .padding(8.0)
-        .background(move || {
-            if hover.get() { Color::rgb(0.3, 0.3, 0.4) }
-            else { Color::rgb(0.2, 0.2, 0.3) }
-        })
-        .on_hover(move |h| hover.set(h))
-        .child(text(name).color(Color::WHITE))
-}
-
-// Use it with the closure wrapper
-container().children(move || {
-    items.get().into_iter().map(|item| {
-        (item.id, move || create_item_widget(item.id, item.name.clone()))
-    })
-})
-```
-
 ## Complete Example
 
 ```rust
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 struct Item {
     id: u64,
     name: String,
@@ -197,7 +152,6 @@ fn dynamic_list_demo() -> impl Widget {
         .padding(16.0)
         .layout(Flex::column().spacing(12.0))
         .child(
-            // Control buttons
             container()
                 .layout(Flex::row().spacing(8.0))
                 .children([
@@ -217,35 +171,9 @@ fn dynamic_list_demo() -> impl Widget {
                 ])
         )
         .child(
-            // Dynamic list with automatic cleanup
             container()
                 .layout(Flex::column().spacing(4.0))
-                .children(move || {
-                    items.get().into_iter().map(|item| {
-                        let id = item.id;
-                        let name = item.name.clone();
-                        (id, move || {
-                            // Local state for this item
-                            let clicks = create_signal(0);
-
-                            on_cleanup(move || {
-                                log::info!("Item {} removed", id);
-                            });
-
-                            container()
-                                .padding(8.0)
-                                .background(Color::rgb(0.2, 0.2, 0.3))
-                                .corner_radius(4.0)
-                                .hover_state(|s| s.lighter(0.1))
-                                .pressed_state(|s| s.ripple())
-                                .on_click(move || clicks.update(|c| *c += 1))
-                                .child(
-                                    text(move || format!("{} (clicks: {})", name, clicks.get()))
-                                        .color(Color::WHITE)
-                                )
-                        })
-                    })
-                })
+                .children(keyed(move || items.get(), |i| i.id, item_widget))
         )
 }
 
@@ -263,19 +191,15 @@ fn button(label: &str, on_click: impl Fn() + 'static) -> Container {
 
 ## Mixing Static and Dynamic
 
-Combine static and dynamic children freely:
+Combine static and dynamic children freely, in any order:
 
 ```rust
 container()
     .layout(Flex::column().spacing(8.0))
     // Static header
     .child(text("Items:").font_size(18.0).color(Color::WHITE))
-    // Dynamic list
-    .children(move || {
-        items.get().into_iter().map(|item| {
-            (item.id, move || item_view(item.clone()))
-        })
-    })
+    // Reactive list
+    .children(keyed(move || items.get(), |i| i.id, item_view))
     // Static footer
     .child(text("End of list").color(Color::rgb(0.6, 0.6, 0.7)))
 ```
@@ -284,36 +208,35 @@ container()
 
 ```rust
 impl Container {
-    // Single child
-    pub fn child(self, child: impl Widget + 'static) -> Self;
+    // A widget value, or dynamic(data, build)
+    pub fn child<M>(self, child: impl IntoChild<M>) -> Self;
 
-    // Single reactive child, presence-only (Some -> Some keeps the first widget)
-    pub fn child<F, W>(self, child: F) -> Self
-    where
-        F: Fn() -> Option<W> + 'static,
-        W: Widget + 'static;
-
-    // Single reactive child, content-keyed (new key swaps the widget in)
-    pub fn child<F, W>(self, child: F) -> Self
-    where
-        F: Fn() -> Option<(u64, W)> + 'static,
-        W: Widget + 'static;
-
-    // Multiple static children
-    pub fn children<W: Widget + 'static>(
-        self,
-        children: impl IntoIterator<Item = W>
-    ) -> Self;
-
-    // Dynamic keyed children with automatic ownership
-    pub fn children<F, I, G, W>(self, children: F) -> Self
-    where
-        F: Fn() -> I + 'static,
-        I: IntoIterator<Item = (u64, G)>,
-        G: FnOnce() -> W + 'static,
-        W: Widget + 'static;
+    // An iterator of widgets, or keyed(data, key, build)
+    pub fn children<M>(self, children: impl IntoChildren<M>) -> Self;
 }
 
-// Cleanup registration (use inside dynamic child closures)
+// Reactive single child: tracked data + untracked builder.
+// The builder may return a widget, or Option<widget> for presence.
+pub fn dynamic<T, C>(
+    data: impl Fn() -> T + 'static,
+    build: impl Fn(T) -> C + 'static,
+) -> DynChild<T, C>
+where
+    T: Clone + PartialEq + 'static,
+    C: IntoDynChild;
+
+// Reactive children list: tracked data, key-based identity,
+// untracked per-item builder with content diffing.
+pub fn keyed<T, I, W>(
+    data: impl Fn() -> I + 'static,
+    key: impl Fn(&T) -> u64 + 'static,
+    build: impl Fn(T) -> W + 'static,
+) -> KeyedChildren<T, I, W>
+where
+    T: Clone + PartialEq + 'static,
+    I: IntoIterator<Item = T>,
+    W: Widget + 'static;
+
+// Cleanup registration (use inside builders)
 pub fn on_cleanup(f: impl FnOnce() + 'static);
 ```

--- a/book/src/advanced/dynamic-children.md
+++ b/book/src/advanced/dynamic-children.md
@@ -6,74 +6,75 @@ Learn the different ways to add children to containers, from static to fully rea
 
 ## The Model
 
-Children come in exactly four forms — two static, two reactive:
+Children come in four forms — two static, two reactive, plus a keyed variant
+for lists:
 
 ```rust
 container()
     .child(text("Hello"))                                  // static single
+    .child(move || build_menu(entries.get()))              // reactive single
     .children([text("A"), text("B")])                      // static list
-    .child(dynamic(move || data.get(), build_widget))      // reactive single
-    .children(keyed(move || items.get(), |i| i.id, row))   // reactive list
+    .children(move || build_rows(items.get()))             // reactive list
+    .children(keyed(move || items.get(), |i| i.id, row))   // reactive keyed list
 ```
 
-`dynamic()` and `keyed()` are values, not methods: they pair a **tracked data
-closure** with an **untracked builder**. The data closure is the only reactive
-part — the signals it reads decide when to re-evaluate, and its result is what
-the builder receives. Data the widget must react to has to flow through the
-data closure; that is what makes stale content unexpressible.
+The rule is the one from SolidJS and Leptos: **a value is static, a closure
+is reactive**. A reactive closure re-runs when a signal it reads changes,
+and its result **replaces** the previous widget — always. There is no key
+comparison and no silently discarded rebuild.
 
-Bare closures are **rejected at compile time**. With `.child(move || ...)`
-there would be no way to know which data the widget was built from, so content
-updates could be silently discarded — the compiler error points you to
-`dynamic()` / `keyed()` instead.
+Tracking is per segment: each closure re-runs only when *its own* signals
+change, never because a sibling changed.
 
-## Reactive Single Child: `dynamic(data, build)`
+## Reactive Single Child
 
 ```rust
-// Content that re-renders when the data changes
-container().child(dynamic(
-    move || menu_entries.get(),   // tracked; T: Clone + PartialEq
-    |entries| build_menu(entries) // untracked; runs only when T changed
-))
+// Content rebuilt when the data changes
+container().child(move || build_menu(menu_entries.get()))
+
+// Presence: Option shows/hides — None removes the child
+container().child(move || {
+    state.active_window.get().map(|w| title_widget(w))
+})
 ```
 
-The data result is compared with the previous value (`PartialEq`):
+Because widget properties are themselves lazy closures (a `text(move || ...)`
+tracks its signal at paint time, not at construction), the reads tracked by a
+child closure are naturally the **structural** ones: the closure re-runs
+exactly when the shape of the content must change, while property-level
+updates keep flowing through the widgets without any rebuild.
 
-- **unchanged** → the existing widget is kept untouched: inner state,
-  animations and subscriptions persist, the builder does not run
-- **changed** → the builder runs and the rebuilt widget replaces the old one
-  (its owner scope is disposed)
+### Controlling granularity with memos
 
-The builder may return `Option<widget>` to also control presence:
+A closure re-runs whenever a tracked signal *changes value*. If your content
+depends on a reduction of the data (a count, a filtered subset), read a memo
+instead of the raw signal — memos notify only when the computed value
+actually changes:
 
 ```rust
-// Shown only while there is an active window
-container().child(dynamic(
-    move || state.active_window.get(),
-    |window| window.map(title_widget),
-))
+let count = create_memo(move || items.with(|l| l.len()));
+
+// Rebuilt only when the count changes, not on every list edit
+container().child(move || text(format!("{} items", count.get())))
 ```
 
-The builder runs with signal tracking suspended: reads inside it see current
-values but create no dependencies. Choose what goes through the data closure
-and what stays internally reactive:
+## Reactive Lists
+
+The unkeyed closure form replaces **all rows** when it re-runs:
 
 ```rust
-// Rebuild the row when the label changes...
-dynamic(move || item.get(), |item| text(item.label))
-
-// ...or keep the widget and let it track the label itself
-dynamic(move || item.with(|i| i.id), |_| text(move || item.with(|i| i.label.clone())))
+container().children(move || {
+    items.with(|list| {
+        list.iter().map(|item| row_widget(item)).collect::<Vec<_>>()
+    })
+})
 ```
 
-## Reactive Lists: `keyed(data, key, build)`
+Rows have no identity across runs: inner state (hover, animations, local
+signals) does not survive a re-run. That is fine for simple rows; for rows
+that carry state, use `keyed()`:
 
 ```rust
-let items = create_signal(vec![
-    Item { id: 1, name: "First".into() },
-    Item { id: 2, name: "Second".into() },
-]);
-
 container().children(keyed(
     move || items.get(),   // tracked; items: Clone + PartialEq
     |item| item.id,        // stable identity (survives reorders)
@@ -92,18 +93,19 @@ Per item, identity (`key`) and content (`PartialEq`) are diffed separately:
 Keys must be unique and stable — never use the index:
 
 ```rust
-keyed(data, |item| item.id, build)        // Good: stable identity
+keyed(data, |item| item.id, build)              // Good: stable identity
 keyed(data, |(index, _)| *index as u64, build)  // Bad: reorder loses state
 ```
 
-The item type chooses the update granularity, exactly like `dynamic()`:
-fields included in the item trigger a row rebuild when they change; fields
-left out can be read via signals inside the row for in-place updates.
+The item type chooses the update granularity: fields included in the item
+trigger a row rebuild when they change; fields left out can be read via
+signals inside the row for in-place updates.
 
 ## Automatic Ownership & Cleanup
 
-Builders run inside an **owner scope**: signals and effects created there are
-automatically owned and cleaned up when the child is removed or rebuilt.
+Reactive closures and keyed builders run inside an **owner scope**: signals
+and effects created there are automatically owned and cleaned up when the
+child is removed or rebuilt.
 
 ```rust
 fn item_widget(item: Item) -> impl Widget {
@@ -130,6 +132,9 @@ When a child is removed or rebuilt:
 2. `on_cleanup` callbacks run
 3. Effects are disposed
 4. Signals are disposed
+
+State that must survive a rebuild belongs in signals created *outside* the
+closure.
 
 ## Complete Example
 
@@ -198,7 +203,9 @@ container()
     .layout(Flex::column().spacing(8.0))
     // Static header
     .child(text("Items:").font_size(18.0).color(Color::WHITE))
-    // Reactive list
+    // Reactive middle
+    .child(move || warning.get().then(|| warning_banner()))
+    // Reactive keyed list
     .children(keyed(move || items.get(), |i| i.id, item_view))
     // Static footer
     .child(text("End of list").color(Color::rgb(0.6, 0.6, 0.7)))
@@ -208,24 +215,15 @@ container()
 
 ```rust
 impl Container {
-    // A widget value, or dynamic(data, build)
+    // A widget value, or a reactive closure returning a widget / Option<widget>
     pub fn child<M>(self, child: impl IntoChild<M>) -> Self;
 
-    // An iterator of widgets, or keyed(data, key, build)
+    // An iterator of widgets, a reactive closure returning one,
+    // or keyed(data, key, build)
     pub fn children<M>(self, children: impl IntoChildren<M>) -> Self;
 }
 
-// Reactive single child: tracked data + untracked builder.
-// The builder may return a widget, or Option<widget> for presence.
-pub fn dynamic<T, C>(
-    data: impl Fn() -> T + 'static,
-    build: impl Fn(T) -> C + 'static,
-) -> DynChild<T, C>
-where
-    T: Clone + PartialEq + 'static,
-    C: IntoDynChild;
-
-// Reactive children list: tracked data, key-based identity,
+// Reactive keyed children list: tracked data, key-based identity,
 // untracked per-item builder with content diffing.
 pub fn keyed<T, I, W>(
     data: impl Fn() -> I + 'static,
@@ -237,6 +235,6 @@ where
     I: IntoIterator<Item = T>,
     W: Widget + 'static;
 
-// Cleanup registration (use inside builders)
+// Cleanup registration (use inside reactive closures and builders)
 pub fn on_cleanup(f: impl FnOnce() + 'static);
 ```

--- a/book/src/concepts/reactive-model.md
+++ b/book/src/concepts/reactive-model.md
@@ -206,8 +206,10 @@ This is useful in effects where you want to read initial values without re-runni
 Signals and effects created inside dynamic children are automatically cleaned up when the child is removed. Use `on_cleanup` to register custom cleanup logic:
 
 ```rust
-container().children(move || {
-    items.get().into_iter().map(|id| (id, move || {
+container().children(keyed(
+    move || items.get(),
+    |id| *id,
+    |id| {
         // These are automatically owned and disposed
         let count = create_signal(0);
         create_effect(move || println!("Count: {}", count.get()));
@@ -218,8 +220,8 @@ container().children(move || {
         });
 
         container().child(text(move || count.get().to_string()))
-    }))
-})
+    },
+))
 ```
 
 See [Dynamic Children](../advanced/dynamic-children.md) for more details on automatic ownership.

--- a/docs/REACTIVE.md
+++ b/docs/REACTIVE.md
@@ -164,9 +164,9 @@ text(move || format!("Count: {}", count.get()))
 
 ### Reactive Children
 
-Reactive single children and lists take a tracked data closure plus an
-untracked builder (`dynamic()` / `keyed()`) — bare closures are a compile
-error:
+A closure child re-runs when a signal it reads changes, and its result
+**replaces** the previous widget (returning `None` removes it). Tracking is
+per segment: only the closure whose signals changed re-runs.
 
 ```rust
 let items = create_signal(vec![
@@ -174,13 +174,16 @@ let items = create_signal(vec![
     (2, "Item B".to_string()),
 ]);
 
-// Single child whose content depends on data
-container().child(dynamic(
-    move || items.with(|l| l.len()),
-    |len| text(format!("{len} items")),
-))
+// Single reactive child — rebuilt when `items` changes
+container().child(move || text(format!("{} items", items.with(|l| l.len()))))
 
-// Keyed list: identity via key, per-item content diffing via PartialEq
+// Reactive list, unkeyed — all rows replaced when `items` changes
+container().children(move || {
+    items.with(|l| l.iter().map(|(_, label)| text(label.clone())).collect::<Vec<_>>())
+})
+
+// Keyed list: identity via key, per-item content diffing via PartialEq —
+// rows keep their state across reorders, only changed rows rebuild
 container().children(keyed(
     move || items.get(),
     |(id, _)| *id,
@@ -188,9 +191,9 @@ container().children(keyed(
 ))
 ```
 
-Identity keys preserve widget state across reorders; a changed item rebuilds
-only its own row. See the book's Dynamic Children chapter for the full
-semantics.
+To narrow when a closure re-runs, read a `Memo` instead of the raw signal —
+memos notify only when their computed value actually changes. See the book's
+Dynamic Children chapter for the full semantics.
 
 ## IntoSignal Pattern
 
@@ -350,10 +353,10 @@ Signals and effects persist in memory by default. The **reactive owner** system 
 
 ### Automatic Ownership for Dynamic Children
 
-**Dynamic children automatically get owner scopes.** The `dynamic()` /
-`keyed()` builders run inside an owner scope: any signals, effects, or cleanup
-callbacks created there are automatically owned and cleaned up when the child
-is removed or rebuilt:
+**Dynamic children automatically get owner scopes.** Reactive child closures
+and `keyed()` builders run inside an owner scope: any signals, effects, or
+cleanup callbacks created there are automatically owned and cleaned up when
+the child is removed or rebuilt:
 
 ```rust
 let items = create_signal(vec![1u64, 2, 3]);

--- a/docs/REACTIVE.md
+++ b/docs/REACTIVE.md
@@ -164,24 +164,33 @@ text(move || format!("Count: {}", count.get()))
 
 ### Reactive Children
 
-Dynamic lists with keyed reconciliation:
+Reactive single children and lists take a tracked data closure plus an
+untracked builder (`dynamic()` / `keyed()`) — bare closures are a compile
+error:
 
 ```rust
 let items = create_signal(vec![
-    ("a", "Item A"),
-    ("b", "Item B"),
-    ("c", "Item C"),
+    (1u64, "Item A".to_string()),
+    (2, "Item B".to_string()),
 ]);
 
-container().children(move || {
-    items.get().into_iter().map(|(id, label)| {
-        let key = id.as_ptr() as u64;  // Use stable key
-        (key, move || text(label))     // Closure returns widget
-    })
-})
+// Single child whose content depends on data
+container().child(dynamic(
+    move || items.with(|l| l.len()),
+    |len| text(format!("{len} items")),
+))
+
+// Keyed list: identity via key, per-item content diffing via PartialEq
+container().children(keyed(
+    move || items.get(),
+    |(id, _)| *id,
+    |(_, label)| text(label),
+))
 ```
 
-The key ensures widget state is preserved when items are reordered.
+Identity keys preserve widget state across reorders; a changed item rebuilds
+only its own row. See the book's Dynamic Children chapter for the full
+semantics.
 
 ## IntoSignal Pattern
 
@@ -341,40 +350,42 @@ Signals and effects persist in memory by default. The **reactive owner** system 
 
 ### Automatic Ownership for Dynamic Children
 
-**Dynamic children automatically get owner scopes.** Return `(key, closure)` pairs where the closure produces the widget. Any signals, effects, or cleanup callbacks created inside the closure are automatically owned and cleaned up when the child is removed:
+**Dynamic children automatically get owner scopes.** The `dynamic()` /
+`keyed()` builders run inside an owner scope: any signals, effects, or cleanup
+callbacks created there are automatically owned and cleaned up when the child
+is removed or rebuilt:
 
 ```rust
 let items = create_signal(vec![1u64, 2, 3]);
 
-container().children(move || {
-    items.get().into_iter().map(|id| {
-        // Return (key, closure) - the closure runs inside an owner scope
-        (id, move || {
-            // ========================================================
-            // Everything created inside this closure is AUTOMATICALLY
-            // owned by the child's owner scope. When the child is
-            // removed, all these resources are automatically cleaned up!
-            // ========================================================
+container().children(keyed(
+    move || items.get(),
+    |id| *id,
+    |id| {
+        // ========================================================
+        // Everything created inside the builder is AUTOMATICALLY
+        // owned by the child's owner scope. When the child is
+        // removed, all these resources are automatically cleaned up!
+        // ========================================================
 
-            // This signal is owned by the child
-            let local_count = create_signal(0);
+        // This signal is owned by the child
+        let local_count = create_signal(0);
 
-            // This effect is also owned - disposed when child is removed
-            create_effect(move || {
-                println!("Child {} count: {}", id, local_count.get());
-            });
+        // This effect is also owned - disposed when child is removed
+        create_effect(move || {
+            println!("Child {} count: {}", id, local_count.get());
+        });
 
-            // Register cleanup for non-reactive resources
-            on_cleanup(move || {
-                println!("Child {} was removed!", id);
-            });
+        // Register cleanup for non-reactive resources
+        on_cleanup(move || {
+            println!("Child {} was removed!", id);
+        });
 
-            container()
-                .on_click(move || local_count.update(|c| *c += 1))
-                .child(text(move || format!("Child {} ({})", id, local_count.get())))
-        })
-    })
-});
+        container()
+            .on_click(move || local_count.update(|c| *c += 1))
+            .child(text(move || format!("Child {} ({})", id, local_count.get())))
+    },
+));
 
 // When an item is removed from the list:
 // 1. The child's OwnedWidget is dropped
@@ -384,20 +395,29 @@ container().children(move || {
 // 5. Signals are disposed
 ```
 
-**Important:** The closure syntax `(key, move || { ... })` is required for proper ownership. Signals created outside the closure won't be owned:
+**Important:** resources must be created inside the builder. Signals created
+while producing the data won't be owned:
 
 ```rust
-// WRONG - signal not owned (created outside closure)
-.map(|id| {
-    let signal = create_signal(0);  // NOT OWNED!
-    (id, container().child(...))
-})
+// WRONG - signal not owned (created in the data closure)
+keyed(
+    move || items.get().into_iter().map(|id| {
+        let signal = create_signal(0);  // NOT OWNED!
+        (id, signal)
+    }).collect::<Vec<_>>(),
+    |(id, _)| *id,
+    |(_, signal)| container().child(text(move || signal.get().to_string())),
+)
 
-// CORRECT - signal owned (created inside closure)
-.map(|id| (id, move || {
-    let signal = create_signal(0);  // OWNED!
-    container().child(...)
-}))
+// CORRECT - signal owned (created inside the builder)
+keyed(
+    move || items.get(),
+    |id| *id,
+    |id| {
+        let signal = create_signal(0);  // OWNED!
+        container().child(text(move || signal.get().to_string()))
+    },
+)
 ```
 
 You can also extract the child creation into a function:
@@ -408,10 +428,7 @@ fn create_child(id: u64) -> impl Widget {
     container().child(text(move || signal.get().to_string()))
 }
 
-// Call the function inside the closure
-container().children(move || {
-    items.get().into_iter().map(|id| (id, move || create_child(id)))
-})
+container().children(keyed(move || items.get(), |id| *id, create_child))
 ```
 
 ### Custom Cleanup Callbacks
@@ -475,15 +492,17 @@ Attempting to read or write a disposed signal will panic with a clear error mess
 // DON'T DO THIS - signal may be accessed after disposal
 let leaked_signal: Option<Signal<i32>> = None;
 
-container().children(move || {
-    items.get().into_iter().map(|id| {
+container().children(keyed(
+    move || items.get(),
+    |id| *id,
+    |id| {
         let signal = create_signal(0);
         // WRONG: Don't leak signals outside their owner
         // leaked_signal = Some(signal);
 
-        (id, container().child(text(move || signal.get().to_string())))
-    })
-});
+        container().child(text(move || signal.get().to_string()))
+    },
+));
 
 // If you access leaked_signal after the child is removed,
 // you'll get a panic: "Signal was disposed - cannot read after owner cleanup."

--- a/examples/children_example.rs
+++ b/examples/children_example.rs
@@ -214,20 +214,19 @@ fn main() {
                                 .color(Color::rgb(0.8, 0.8, 0.8))
                         )
                         .child(
-                            // Dynamic list with keyed reconciliation
+                            // Dynamic list: key by ID preserves widget state on
+                            // reorder; a changed item rebuilds only its row
                             container()
                                 .layout(Flex::row().spacing(4.0))
-                                .children(move || {
-                                    items.get().into_iter().map(|item| {
-                                        // Key by ID - preserves widget state on reorder!
-                                        // Return (key, closure) - closure runs in owner scope
-                                        (item.id, move || container()
-                                            .padding(8.0)
-                                            .background(item.color)
-                                            .corner_radius(4.0)
-                                            .child(text(item.name).color(Color::WHITE)))
-                                    })
-                                })
+                                .children(keyed(
+                                    move || items.get(),
+                                    |item| item.id,
+                                    |item| container()
+                                        .padding(8.0)
+                                        .background(item.color)
+                                        .corner_radius(4.0)
+                                        .child(text(item.name).color(Color::WHITE)),
+                                ))
                         )
                 )
                 )
@@ -282,19 +281,13 @@ fn main() {
                                 )
                                 .child(
                                     // Dynamic child in the middle!
-                                    move || {
-                                        if show_optional.get() {
-                                            Some(
-                                                container()
-                                                    .padding(8.0)
-                                                    .background(Color::rgb(0.5, 0.3, 0.5))
-                                                    .corner_radius(4.0)
-                                                    .child(text("Dynamic Middle!").color(Color::WHITE))
-                                            )
-                                        } else {
-                                            None
-                                        }
-                                    }
+                                    dynamic(move || show_optional.get(), |show| {
+                                        show.then(|| container()
+                                            .padding(8.0)
+                                            .background(Color::rgb(0.5, 0.3, 0.5))
+                                            .corner_radius(4.0)
+                                            .child(text("Dynamic Middle!").color(Color::WHITE)))
+                                    })
                                 )
                                 .child(
                                     container()
@@ -358,33 +351,21 @@ fn main() {
                             container()
                                 .layout(Flex::column().spacing(4.0))
                                 .child(text("Static 1").color(Color::WHITE))
-                                .child(move || {
-                                    if show_optional2.get() {
-                                        Some(
-                                            container()
-                                                .padding(6.0)
-                                                .background(Color::rgb(0.5, 0.2, 0.3))
-                                                .corner_radius(4.0)
-                                                .child(text("Dynamic 1").color(Color::WHITE))
-                                        )
-                                    } else {
-                                        None
-                                    }
-                                })
+                                .child(dynamic(move || show_optional2.get(), |show| {
+                                    show.then(|| container()
+                                        .padding(6.0)
+                                        .background(Color::rgb(0.5, 0.2, 0.3))
+                                        .corner_radius(4.0)
+                                        .child(text("Dynamic 1").color(Color::WHITE)))
+                                }))
                                 .child(text("Static 2").color(Color::WHITE))
-                                .child(move || {
-                                    if show_optional.get() {
-                                        Some(
-                                            container()
-                                                .padding(6.0)
-                                                .background(Color::rgb(0.3, 0.2, 0.5))
-                                                .corner_radius(4.0)
-                                                .child(text("Dynamic 2").color(Color::WHITE))
-                                        )
-                                    } else {
-                                        None
-                                    }
-                                })
+                                .child(dynamic(move || show_optional.get(), |show| {
+                                    show.then(|| container()
+                                        .padding(6.0)
+                                        .background(Color::rgb(0.3, 0.2, 0.5))
+                                        .corner_radius(4.0)
+                                        .child(text("Dynamic 2").color(Color::WHITE)))
+                                }))
                                 .child(text("Static 3").color(Color::WHITE))
                         )
                 )
@@ -411,19 +392,19 @@ fn main() {
                             container()
                                 .layout(Flex::column().spacing(4.0))
                                 .child(text("Static header before list").color(Color::rgb(0.8, 0.8, 0.8)))
-                                .children(move || {
-                                    vec!["Keyed Item 1", "Keyed Item 2"].into_iter().map(|content| {
+                                .children(keyed(
+                                    || vec!["Keyed Item 1", "Keyed Item 2"],
+                                    |content| {
                                         let mut hasher = DefaultHasher::new();
                                         content.hash(&mut hasher);
-                                        let key = hasher.finish();
-                                        // Return (key, closure) - closure runs in owner scope
-                                        (key, move || container()
-                                            .padding(8.0)
-                                            .background(Color::rgb(0.5, 0.3, 0.5))
-                                            .corner_radius(4.0)
-                                            .child(text(content).color(Color::WHITE)))
-                                    })
-                                })
+                                        hasher.finish()
+                                    },
+                                    |content| container()
+                                        .padding(8.0)
+                                        .background(Color::rgb(0.5, 0.3, 0.5))
+                                        .corner_radius(4.0)
+                                        .child(text(content).color(Color::WHITE)),
+                                ))
                                 .child(text("Static footer after list").color(Color::rgb(0.8, 0.8, 0.8)))
                         )
                 )

--- a/examples/children_example.rs
+++ b/examples/children_example.rs
@@ -281,13 +281,13 @@ fn main() {
                                 )
                                 .child(
                                     // Dynamic child in the middle!
-                                    dynamic(move || show_optional.get(), |show| {
-                                        show.then(|| container()
+                                    move || {
+                                        show_optional.get().then(|| container()
                                             .padding(8.0)
                                             .background(Color::rgb(0.5, 0.3, 0.5))
                                             .corner_radius(4.0)
                                             .child(text("Dynamic Middle!").color(Color::WHITE)))
-                                    })
+                                    }
                                 )
                                 .child(
                                     container()
@@ -351,21 +351,21 @@ fn main() {
                             container()
                                 .layout(Flex::column().spacing(4.0))
                                 .child(text("Static 1").color(Color::WHITE))
-                                .child(dynamic(move || show_optional2.get(), |show| {
-                                    show.then(|| container()
+                                .child(move || {
+                                    show_optional2.get().then(|| container()
                                         .padding(6.0)
                                         .background(Color::rgb(0.5, 0.2, 0.3))
                                         .corner_radius(4.0)
                                         .child(text("Dynamic 1").color(Color::WHITE)))
-                                }))
+                                })
                                 .child(text("Static 2").color(Color::WHITE))
-                                .child(dynamic(move || show_optional.get(), |show| {
-                                    show.then(|| container()
+                                .child(move || {
+                                    show_optional.get().then(|| container()
                                         .padding(6.0)
                                         .background(Color::rgb(0.3, 0.2, 0.5))
                                         .corner_radius(4.0)
                                         .child(text("Dynamic 2").color(Color::WHITE)))
-                                }))
+                                })
                                 .child(text("Static 3").color(Color::WHITE))
                         )
                 )

--- a/examples/effect_cleanup_test.rs
+++ b/examples/effect_cleanup_test.rs
@@ -202,16 +202,15 @@ fn main() {
                 .color(Color::WHITE),
             )
             .child(
-                // Children container with dynamic children
-                // The closure wrapper ensures create_child_widget runs inside owner scope
+                // Children container with dynamic children — the builder runs
+                // inside an owner scope, so per-child effects get cleaned up
                 container()
                     .layout(Flex::column().spacing(8.0))
-                    .children(move || {
-                        children_ids
-                            .get()
-                            .into_iter()
-                            .map(|id| (id, move || create_child_widget(id)))
-                    }),
+                    .children(keyed(
+                        move || children_ids.get(),
+                        |id| *id,
+                        create_child_widget,
+                    )),
             );
 
         app.add_surface(

--- a/examples/perf_stress_test.rs
+++ b/examples/perf_stress_test.rs
@@ -36,25 +36,26 @@ fn main() {
         let item_ids: RwSignal<Vec<u64>> = create_signal((0..INITIAL_ITEM_COUNT as u64).collect());
 
         let store_for_children = item_store.clone();
-        let dyn_container_view =
-            container()
-                .layout(Flex::column().spacing(10.0))
-                .children(move || {
+        let store_for_rows = item_store.clone();
+        let dyn_container_view = container()
+            .layout(Flex::column().spacing(10.0))
+            .children(keyed(
+                move || {
                     let store = store_for_children.borrow();
                     // Read item_ids to track reactivity
-                    let ids = item_ids.get();
-                    ids.iter()
-                        .filter_map(|&id| {
-                            store.get(id as usize).map(|item| {
-                                let enabled = item.enabled;
-                                let input_value = item.input_value;
-                                (id, move || {
-                                    create_item_row(enabled, input_value, id as usize)
-                                })
-                            })
-                        })
+                    item_ids
+                        .get()
+                        .into_iter()
+                        .filter(|&id| store.get(id as usize).is_some())
                         .collect::<Vec<_>>()
-                });
+                },
+                |id| *id,
+                move |id| {
+                    let store = store_for_rows.borrow();
+                    let item = store.get(id as usize).expect("row exists in store");
+                    create_item_row(item.enabled, item.input_value, id as usize)
+                },
+            ));
 
         let store_for_button = item_store.clone();
         let view = container()

--- a/examples/test_dynamic.rs
+++ b/examples/test_dynamic.rs
@@ -32,22 +32,17 @@ async fn main() {
             .child(
                 text("An item will be added after 2 seconds...").color(Color::rgb(0.7, 0.7, 0.7)),
             )
-            .child(
-                container()
-                    .layout(Flex::row().spacing(4.0))
-                    .children(move || {
-                        let list = items.get();
-                        list.into_iter().map(|id| {
-                            (id, move || {
-                                container()
-                                    .padding(8.0)
-                                    .background(Color::rgb(0.3 + id as f32 * 0.1, 0.3, 0.4))
-                                    .corner_radius(4.0)
-                                    .child(text(format!("Item {}", id)).color(Color::WHITE))
-                            })
-                        })
-                    }),
-            );
+            .child(container().layout(Flex::row().spacing(4.0)).children(keyed(
+                move || items.get(),
+                |id| *id,
+                |id| {
+                    container()
+                        .padding(8.0)
+                        .background(Color::rgb(0.3 + id as f32 * 0.1, 0.3, 0.4))
+                        .corner_radius(4.0)
+                        .child(text(format!("Item {}", id)).color(Color::WHITE))
+                },
+            )));
 
         app.add_surface(
             SurfaceConfig::new()

--- a/guido-macros/src/lib.rs
+++ b/guido-macros/src/lib.rs
@@ -270,14 +270,14 @@ pub fn component(_attr: TokenStream, input: TokenStream) -> TokenStream {
     // Generate children methods if needed
     let children_methods = if has_children {
         quote! {
-            #vis fn child(self, child: impl ::guido::widgets::IntoChild) -> Self {
+            #vis fn child<M>(self, child: impl ::guido::widgets::IntoChild<M>) -> Self {
                 child.add_to_container(&mut *self.__children.borrow_mut());
                 self
             }
 
-            #vis fn children<I>(self, children: I) -> Self
+            #vis fn children<M, I>(self, children: I) -> Self
             where
-                I: ::guido::widgets::IntoChildren,
+                I: ::guido::widgets::IntoChildren<M>,
             {
                 children.add_to_container(&mut *self.__children.borrow_mut());
                 self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,7 @@ pub mod prelude {
         FontWeight, GradientDirection, Image, ImageSource, IntoChildren, Key, LinearGradient,
         Modifiers, MouseButton, Overflow, Padding, Rect, ScrollAxis, ScrollSource,
         ScrollbarBuilder, ScrollbarVisibility, Selection, StateStyle, Text, TextInput, Widget,
-        container, image, text, text_input,
+        container, dynamic, image, keyed, text, text_input,
     };
     pub use crate::{
         App, ExitReason, SignalFields, component, default_font_family, load_font, quit_app,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,7 @@ pub mod prelude {
         FontWeight, GradientDirection, Image, ImageSource, IntoChildren, Key, LinearGradient,
         Modifiers, MouseButton, Overflow, Padding, Rect, ScrollAxis, ScrollSource,
         ScrollbarBuilder, ScrollbarVisibility, Selection, StateStyle, Text, TextInput, Widget,
-        container, dynamic, image, keyed, text, text_input,
+        container, image, keyed, text, text_input,
     };
     pub use crate::{
         App, ExitReason, SignalFields, component, default_font_family, load_font, quit_app,

--- a/src/reactive/invalidation.rs
+++ b/src/reactive/invalidation.rs
@@ -32,6 +32,10 @@ use crate::tree::WidgetId;
 struct SignalTrackingContext {
     widget_id: WidgetId,
     job_type: JobType,
+    /// For reconciliation: which dynamic-children segment of the widget is
+    /// reading. Lets a signal write dirty exactly one segment instead of
+    /// re-running every dynamic segment of the container.
+    segment: Option<u32>,
 }
 
 thread_local! {
@@ -45,10 +49,34 @@ pub fn with_signal_tracking<F, R>(widget_id: WidgetId, job_type: JobType, f: F) 
 where
     F: FnOnce() -> R,
 {
+    with_tracking_context(widget_id, job_type, None, f)
+}
+
+/// Run a closure while tracking signal reads for one dynamic-children
+/// segment of a widget. Reads register the widget for `Reconcile` jobs and
+/// additionally mark the segment, so reconciliation re-runs only the
+/// segments whose dependencies actually changed.
+pub(crate) fn with_segment_tracking<F, R>(widget_id: WidgetId, segment: u32, f: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    with_tracking_context(widget_id, JobType::Reconcile, Some(segment), f)
+}
+
+fn with_tracking_context<F, R>(
+    widget_id: WidgetId,
+    job_type: JobType,
+    segment: Option<u32>,
+    f: F,
+) -> R
+where
+    F: FnOnce() -> R,
+{
     TRACKING_CONTEXT.with(|ctx| {
         ctx.borrow_mut().push(SignalTrackingContext {
             widget_id,
             job_type,
+            segment,
         });
     });
     // Pop on unwind too: a leaked frame would silently attribute every
@@ -86,7 +114,12 @@ where
 pub fn record_signal_read(signal_id: SignalId) {
     TRACKING_CONTEXT.with(|ctx| {
         if let Some(tracking) = ctx.borrow().last() {
-            register_subscriber(tracking.widget_id, signal_id, tracking.job_type);
+            register_subscriber_impl(
+                tracking.widget_id,
+                signal_id,
+                tracking.job_type,
+                tracking.segment,
+            );
         }
     });
 }
@@ -95,11 +128,13 @@ pub fn record_signal_read(signal_id: SignalId) {
 // Unified Subscriber Registry
 // ============================================================================
 
-/// Subscriber entry with widget ID and job type
+/// Subscriber entry with widget ID, job type and (for reconciliation) the
+/// dynamic-children segment that performed the read.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 struct Subscriber {
     widget_id: WidgetId,
     job_type: JobType,
+    segment: Option<u32>,
 }
 
 /// Most signals have 1-2 widget subscribers (e.g. one paint, one layout).
@@ -139,33 +174,24 @@ impl SubscriberRegistry {
                 .resize_with(signal_id.index() + 1, SmallVec::new);
         }
     }
-
-    /// Remove a subscriber pair from the `active` set for every job type.
-    /// Used by widget cleanup, which knows the widget but not which job
-    /// types it registered with.
-    fn deactivate_widget_signal(&mut self, signal_index: usize, widget_id: WidgetId) {
-        for job_type in [
-            JobType::Layout,
-            JobType::Paint,
-            JobType::Reconcile,
-            JobType::Unregister,
-            JobType::Animation,
-        ] {
-            self.active.remove(&(
-                signal_index,
-                Subscriber {
-                    widget_id,
-                    job_type,
-                },
-            ));
-        }
-    }
 }
 
 thread_local! {
     /// Subscriber registry. All access is on the main thread — background writes go
     /// through `queue_bg_write()` → `flush_bg_writes()` which executes on the main thread.
     static REGISTRY: RefCell<SubscriberRegistry> = RefCell::new(SubscriberRegistry::new());
+
+    /// Dynamic-children segments dirtied by signal writes, per container.
+    /// Consumed by reconciliation via `take_dirty_segments()`.
+    static DIRTY_SEGMENTS: RefCell<FxHashMap<WidgetId, SmallVec<[u32; 4]>>> =
+        RefCell::new(FxHashMap::default());
+}
+
+/// Take (and clear) the set of dirty dynamic-children segments for a widget.
+/// `None` means no segment-tracked signal of this widget changed since the
+/// last call.
+pub(crate) fn take_dirty_segments(widget_id: WidgetId) -> Option<SmallVec<[u32; 4]>> {
+    DIRTY_SEGMENTS.with(|d| d.borrow_mut().remove(&widget_id))
 }
 
 /// Register a widget as a subscriber for a signal with a specific job type.
@@ -174,12 +200,22 @@ thread_local! {
 /// overwhelming majority — widgets re-read their signals every frame) is a
 /// single hash-set lookup.
 pub fn register_subscriber(widget_id: WidgetId, signal_id: SignalId, job_type: JobType) {
+    register_subscriber_impl(widget_id, signal_id, job_type, None);
+}
+
+fn register_subscriber_impl(
+    widget_id: WidgetId,
+    signal_id: SignalId,
+    job_type: JobType,
+    segment: Option<u32>,
+) {
     REGISTRY.with(|reg| {
         let mut reg = reg.borrow_mut();
 
         let sub = Subscriber {
             widget_id,
             job_type,
+            segment,
         };
         if !reg.active.insert((signal_id.index(), sub)) {
             return; // Already subscribed — the hot path
@@ -209,6 +245,15 @@ pub fn notify_signal_change(signal_id: SignalId) {
             return;
         };
         for sub in subs {
+            if let Some(segment) = sub.segment {
+                DIRTY_SEGMENTS.with(|d| {
+                    let mut d = d.borrow_mut();
+                    let dirty = d.entry(sub.widget_id).or_default();
+                    if !dirty.contains(&segment) {
+                        dirty.push(segment);
+                    }
+                });
+            }
             let request = match sub.job_type {
                 JobType::Layout => JobRequest::Layout,
                 JobType::Paint => JobRequest::Paint,
@@ -250,12 +295,26 @@ pub fn clear_widget_subscribers(widget_id: WidgetId) {
         // Use reverse index: only touch the signals this widget actually subscribes to
         if let Some(signal_ids) = reg.widget_to_signals.remove(&widget_id) {
             for signal_id in signal_ids {
-                reg.deactivate_widget_signal(signal_id.index(), widget_id);
-                if let Some(subs) = reg.signal_to_widgets.get_mut(signal_id.index()) {
-                    subs.retain(|s| s.widget_id != widget_id);
+                let Some(subs) = reg.signal_to_widgets.get_mut(signal_id.index()) else {
+                    continue;
+                };
+                // Collect the widget's exact entries first so `active` drops
+                // precisely what was registered (job types and segments are
+                // unknown to the caller).
+                let removed: SmallVec<[Subscriber; 2]> = subs
+                    .iter()
+                    .filter(|s| s.widget_id == widget_id)
+                    .copied()
+                    .collect();
+                subs.retain(|s| s.widget_id != widget_id);
+                for sub in removed {
+                    reg.active.remove(&(signal_id.index(), sub));
                 }
             }
         }
+    });
+    DIRTY_SEGMENTS.with(|d| {
+        d.borrow_mut().remove(&widget_id);
     });
 }
 
@@ -265,6 +324,7 @@ pub fn clear_widget_subscribers(widget_id: WidgetId) {
 pub(crate) fn reset_invalidation() {
     TRACKING_CONTEXT.with(|ctx| ctx.borrow_mut().clear());
     REGISTRY.with(|reg| *reg.borrow_mut() = SubscriberRegistry::new());
+    DIRTY_SEGMENTS.with(|d| d.borrow_mut().clear());
 }
 
 /// Get the number of signals with active subscribers (for testing).
@@ -346,6 +406,7 @@ mod tests {
             assert!(s.contains(&Subscriber {
                 widget_id: wid,
                 job_type: JobType::Paint,
+                segment: None,
             }));
         });
 

--- a/src/widgets/children.rs
+++ b/src/widgets/children.rs
@@ -1,10 +1,10 @@
 use std::collections::HashMap;
 use std::rc::Rc;
 
-use crate::jobs::{JobRequest, JobType, request_job};
+use crate::jobs::{JobRequest, request_job};
 use crate::layout::{Constraints, Size};
 use crate::reactive::invalidation::clear_widget_subscribers;
-use crate::reactive::{OwnerId, dispose_owner, with_signal_tracking};
+use crate::reactive::{OwnerId, dispose_owner};
 use crate::renderer::PaintContext;
 use crate::tree::{Tree, WidgetId};
 
@@ -22,6 +22,10 @@ enum SegmentType {
         cached: HashMap<u64, WidgetId>,
         /// Current keys in display order
         current_keys: Vec<u64>,
+        /// Whether items_fn has run at least once. After the first run the
+        /// segment only re-runs when a signal it tracks is written
+        /// (per-segment dirty marking in the invalidation registry).
+        has_run: bool,
     },
 }
 
@@ -92,6 +96,7 @@ impl ChildrenSource {
             items_fn: Rc::new(items_fn),
             cached: HashMap::new(),
             current_keys: Vec::new(),
+            has_run: false,
         });
     }
 
@@ -102,21 +107,40 @@ impl ChildrenSource {
             .any(|s| matches!(s, SegmentType::Dynamic { .. }))
     }
 
-    /// Reconcile all dynamic segments and rebuild merged list
+    /// Reconcile dynamic segments and rebuild the merged list.
+    ///
+    /// Each dynamic segment re-runs its items_fn only when a signal it read
+    /// was written (per-segment dirty marking) or on its first run. Reads
+    /// during the run are tracked to this (container, segment) pair.
     fn reconcile(&mut self, tree: &mut Tree, parent_id: WidgetId) {
-        // First pass: check if any dynamic segment needs reconciliation
+        let dirty = crate::reactive::invalidation::take_dirty_segments(parent_id);
+
+        // First pass: re-run dirty segments and collect those whose keys changed
         let mut segments_with_changes: Vec<(usize, Vec<DynItem>)> = Vec::new();
 
-        for (idx, segment) in self.segments.iter().enumerate() {
+        for (idx, segment) in self.segments.iter_mut().enumerate() {
             if let SegmentType::Dynamic {
                 items_fn,
                 current_keys,
+                has_run,
                 ..
             } = segment
             {
-                let new_items = items_fn();
-                let new_keys: Vec<u64> = new_items.iter().map(|i| i.key).collect();
+                let needs_run =
+                    !*has_run || dirty.as_ref().is_some_and(|d| d.contains(&(idx as u32)));
+                if !needs_run {
+                    continue;
+                }
 
+                let items_fn = Rc::clone(items_fn);
+                let new_items = crate::reactive::invalidation::with_segment_tracking(
+                    parent_id,
+                    idx as u32,
+                    || items_fn(),
+                );
+                *has_run = true;
+
+                let new_keys: Vec<u64> = new_items.iter().map(|i| i.key).collect();
                 if new_keys != *current_keys {
                     segments_with_changes.push((idx, new_items));
                 }
@@ -229,11 +253,8 @@ impl ChildrenSource {
 
         let prev_count = self.merged.len();
 
-        // Track signal reads during reconciliation
-        // This registers container as subscriber for any signals read
-        with_signal_tracking(container_id, JobType::Reconcile, || {
-            self.reconcile(tree, container_id);
-        });
+        // Signal reads are tracked per segment inside reconcile()
+        self.reconcile(tree, container_id);
         self.initial_reconcile_done = true;
 
         prev_count != self.merged.len()
@@ -245,9 +266,8 @@ impl ChildrenSource {
         // Lazy initial reconciliation (for first frame before any jobs exist)
         if self.has_dynamic() && !self.initial_reconcile_done {
             if let Some(container_id) = self.container_id {
-                with_signal_tracking(container_id, JobType::Reconcile, || {
-                    self.reconcile(tree, container_id);
-                });
+                // Signal reads are tracked per segment inside reconcile()
+                self.reconcile(tree, container_id);
                 self.initial_reconcile_done = true;
             } else {
                 // Fallback: reconcile without tracking (shouldn't happen in practice)
@@ -412,19 +432,67 @@ impl DynItem {
 /// ```
 pub struct OwnedWidget {
     inner: Box<dyn Widget>,
-    owner_id: OwnerId,
+    owner: OwnerHandle,
+}
+
+enum OwnerHandle {
+    /// This widget is the sole user of the owner scope.
+    Exclusive(OwnerId),
+    /// The owner scope is shared by several widgets (one closure run built
+    /// them all); it is disposed when the last of them drops.
+    Shared {
+        _guard: SharedOwner,
+    },
+}
+
+/// Reference-counted owner scope: disposes the owner when the last clone
+/// drops. Used by reactive list closures, where a single run builds every
+/// row inside one scope.
+#[derive(Clone)]
+pub struct SharedOwner {
+    _guard: Rc<OwnerGuard>,
+}
+
+struct OwnerGuard(OwnerId);
+
+impl Drop for OwnerGuard {
+    fn drop(&mut self) {
+        dispose_owner(self.0);
+    }
+}
+
+impl SharedOwner {
+    pub fn new(owner_id: OwnerId) -> Self {
+        Self {
+            _guard: Rc::new(OwnerGuard(owner_id)),
+        }
+    }
 }
 
 impl OwnedWidget {
     /// Create a new owned widget with the given inner widget and owner ID.
     pub fn new(inner: Box<dyn Widget>, owner_id: OwnerId) -> Self {
-        Self { inner, owner_id }
+        Self {
+            inner,
+            owner: OwnerHandle::Exclusive(owner_id),
+        }
+    }
+
+    /// Create an owned widget participating in a shared owner scope.
+    pub fn new_shared(inner: Box<dyn Widget>, shared: SharedOwner) -> Self {
+        Self {
+            inner,
+            owner: OwnerHandle::Shared { _guard: shared },
+        }
     }
 }
 
 impl Drop for OwnedWidget {
     fn drop(&mut self) {
-        dispose_owner(self.owner_id);
+        if let OwnerHandle::Exclusive(owner_id) = self.owner {
+            dispose_owner(owner_id);
+        }
+        // Shared: the SharedOwner guard disposes when its last clone drops
     }
 }
 

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -304,7 +304,8 @@ impl Container {
         self
     }
 
-    /// Add a single child (static or dynamic)
+    /// Add a single child: a widget value, or [`dynamic(data, build)`](crate::widgets::dynamic)
+    /// for reactive content.
     pub fn child<M>(mut self, child: impl IntoChild<M>) -> Self {
         child.add_to_container(&mut self.children_source);
         self

--- a/src/widgets/into_child.rs
+++ b/src/widgets/into_child.rs
@@ -1,31 +1,56 @@
+//! Child attachment forms for containers.
+//!
+//! Children come in four forms — two static, two reactive:
+//!
+//! ```ignore
+//! container()
+//!     .child(text("hi"))                                  // static single
+//!     .child(move || build_menu(entries.get()))           // reactive single
+//!     .children([a, b, c])                                // static list
+//!     .children(keyed(move || items.get(), |i| i.id, row)) // reactive keyed list
+//! ```
+//!
+//! A reactive closure re-runs when a signal it read is written, and its
+//! result **replaces** the previous widget — there is no key comparison and
+//! no silent discard. Tracking is per segment: only the closure whose
+//! signals changed re-runs, not every dynamic child of the container.
+//!
+//! State created inside a closure (signals, effects, `on_cleanup`) lives in
+//! an owner scope disposed on replacement. State that must survive a rebuild
+//! belongs in signals created outside the closure. To narrow *when* a
+//! closure re-runs, read a [`Memo`](crate::reactive::Memo) instead of the
+//! raw signal — memos notify only when their value actually changes.
+//!
+//! For lists, [`keyed()`] preserves per-row state through stable identity
+//! and rebuilds only rows whose item content changed.
+
 use std::cell::RefCell;
+use std::collections::HashMap;
 use std::rc::Rc;
 
 use crate::reactive::invalidation::suspend_widget_tracking;
 use crate::reactive::{OwnerId, dispose_owner, with_owner};
 
 use super::Widget;
-use super::children::{ChildrenSource, DynItem, OwnedWidget};
+use super::children::{ChildrenSource, DynItem, OwnedWidget, SharedOwner};
 
 /// Marker type for a static child (widget value)
 pub struct StaticChild;
 
-/// Marker type for a reactive child (built with [`dynamic()`])
+/// Marker type for a reactive child (closure)
 pub struct DynamicChild;
 
 /// Trait for values that can be added as a single child to a container.
 ///
 /// Accepted forms:
 /// - a widget value — static, evaluated once
-/// - [`dynamic(data, build)`](dynamic) — reactive content
-///
-/// Bare closures are rejected at compile time: with them, content updates
-/// could be silently discarded (there is no way to know which data the
-/// widget was built from). `dynamic()` makes that data explicit.
+/// - `move || widget` / `move || Option<widget>` — reactive: the closure
+///   re-runs when a signal it reads changes, and its result replaces the
+///   previous child (`None` removes it)
 #[diagnostic::on_unimplemented(
-    message = "`.child()` takes a widget or `dynamic(data, build)`, and `{Self}` is neither",
-    note = "for reactive content use `.child(dynamic(data, build))`: `data` is a tracked closure returning `Clone + PartialEq` data, `build` turns that data into the widget (return `Option<_>` to also control presence)",
-    note = "for reactive lists use `.children(keyed(data, key, build))`"
+    message = "`.child()` takes a widget or a reactive closure, and `{Self}` is neither",
+    note = "reactive forms: `.child(move || widget)` or `.child(move || Option<widget>)` — the closure re-runs and replaces the child when a signal it reads changes",
+    note = "for reactive lists use `.children(...)` with a closure or `keyed(data, key, build)`"
 )]
 pub trait IntoChild<Marker = StaticChild> {
     fn add_to_container(self, children_source: &mut ChildrenSource);
@@ -38,7 +63,7 @@ impl<W: Widget + 'static> IntoChild<StaticChild> for W {
     }
 }
 
-/// What a [`dynamic()`] builder may return: a widget (always present) or
+/// What a reactive child closure may return: a widget (always present) or
 /// `Option<widget>` (present when Some).
 pub trait IntoDynChild {
     fn into_dyn_child(self) -> Option<Box<dyn Widget>>;
@@ -56,153 +81,82 @@ impl<W: Widget + 'static> IntoDynChild for Option<W> {
     }
 }
 
-/// A reactive single child: tracked data + untracked builder.
-/// Built with [`dynamic()`], consumed by `.child()`.
-pub struct DynChild<T, C> {
-    data: Box<dyn Fn() -> T>,
-    build: Box<dyn Fn(T) -> C>,
-}
-
-/// Reactive single child: tracked data closure + untracked builder.
-///
-/// `data` runs inside the reconciliation tracking scope — the signals it
-/// reads are the ONLY thing that triggers a re-evaluation. Its result is
-/// compared with the previous value (`PartialEq`): unchanged data keeps the
-/// existing widget untouched (inner state, animations and subscriptions
-/// persist); changed data runs `build` and swaps the rebuilt widget in,
-/// disposing the old one's owner scope.
-///
-/// `build` runs with widget tracking suspended: signal reads inside it see
-/// current values but create no dependencies. Data the widget must react to
-/// has to flow through `data` — that is what makes staleness unexpressible.
-///
-/// The builder may return a widget, or `Option<widget>` to also control
-/// presence.
-///
-/// ```ignore
-/// // Content that re-renders when the data changes
-/// container().child(dynamic(move || menu.get(), build_menu))
-///
-/// // Presence: shown only while there is an active window
-/// container().child(dynamic(
-///     move || state.active_window.get(),
-///     |window| window.map(title_widget),
-/// ))
-/// ```
-pub fn dynamic<T, C>(
-    data: impl Fn() -> T + 'static,
-    build: impl Fn(T) -> C + 'static,
-) -> DynChild<T, C>
+/// Reactive single child: the closure runs inside its segment's tracking
+/// scope — the signals it reads are what trigger a re-run — and inside an
+/// owner scope, so signals/effects created during the build are disposed
+/// when the widget is replaced or removed. Every re-run replaces the child.
+impl<F, C> IntoChild<DynamicChild> for F
 where
-    T: Clone + PartialEq + 'static,
+    F: Fn() -> C + 'static,
     C: IntoDynChild,
-{
-    DynChild {
-        data: Box::new(data),
-        build: Box::new(build),
-    }
-}
-
-impl<T, C> IntoChild<DynamicChild> for DynChild<T, C>
-where
-    T: Clone + PartialEq + 'static,
-    C: IntoDynChild + 'static,
 {
     fn add_to_container(self, children_source: &mut ChildrenSource) {
-        add_dyn_child(children_source, self.data, self.build);
-    }
-}
+        struct State {
+            generation: u64,
+            /// Widget built by the latest run, adopted by the reconciler's
+            /// factory call in the same pass (the fresh generation key
+            /// guarantees the factory runs).
+            pending: Option<(Box<dyn Widget>, OwnerId)>,
+        }
 
-/// Wire a (tracked data, untracked builder) pair into a ChildrenSource as a
-/// single dynamic child. See [`dynamic()`] for the semantics.
-fn add_dyn_child<T, C>(
-    source: &mut ChildrenSource,
-    data_fn: impl Fn() -> T + 'static,
-    build_fn: impl Fn(T) -> C + 'static,
-) where
-    T: Clone + PartialEq + 'static,
-    C: IntoDynChild,
-{
-    struct DynChildState<T> {
-        prev: Option<T>,
-        generation: u64,
-        /// Widget built eagerly on data change, adopted by the reconciler's
-        /// factory call in the same pass (the new generation key guarantees
-        /// the factory runs whenever something is stashed here).
-        pending: Option<(Box<dyn Widget>, OwnerId)>,
-        present: bool,
-    }
+        let state = Rc::new(RefCell::new(State {
+            generation: 0,
+            pending: None,
+        }));
+        let child_fn = Rc::new(self);
 
-    let state = Rc::new(RefCell::new(DynChildState::<T> {
-        prev: None,
-        generation: 0,
-        pending: None,
-        present: false,
-    }));
+        let items_fn = move || {
+            let mut st = state.borrow_mut();
 
-    let items_fn = move || {
-        let data = data_fn(); // tracked: runs inside with_signal_tracking
-        let mut st = state.borrow_mut();
-
-        if st.prev.as_ref() != Some(&data) {
             // Defensive: a widget stashed by a previous pass that was never
             // adopted would leak its owner scope.
             if let Some((_, owner_id)) = st.pending.take() {
                 dispose_owner(owner_id);
             }
 
-            let (built, owner_id) =
-                with_owner(|| suspend_widget_tracking(|| build_fn(data.clone()).into_dyn_child()));
-            st.prev = Some(data);
-            st.generation += 1;
+            let child_fn = Rc::clone(&child_fn);
+            let (built, owner_id) = with_owner(move || child_fn().into_dyn_child());
             match built {
                 Some(widget) => {
+                    st.generation += 1;
                     st.pending = Some((widget, owner_id));
-                    st.present = true;
+                    let adopt_state = Rc::clone(&state);
+                    vec![DynItem::new(st.generation, move || {
+                        let (widget, owner_id) =
+                            adopt_state.borrow_mut().pending.take().expect(
+                                "reactive child factory ran without a freshly built widget",
+                            );
+                        OwnedWidget::new(widget, owner_id)
+                    })]
                 }
                 None => {
                     dispose_owner(owner_id);
-                    st.present = false;
+                    vec![]
                 }
             }
-        }
+        };
 
-        if st.present {
-            let adopt_state = Rc::clone(&state);
-            vec![DynItem::new(st.generation, move || {
-                let (widget, owner_id) = adopt_state
-                    .borrow_mut()
-                    .pending
-                    .take()
-                    .expect("dynamic child factory ran without a freshly built widget");
-                OwnedWidget::new(widget, owner_id)
-            })]
-        } else {
-            vec![]
-        }
-    };
-
-    source.add_dynamic(items_fn);
+        children_source.add_dynamic(items_fn);
+    }
 }
 
 /// Marker type for static children (iterator of widgets)
 pub struct StaticChildren;
 
-/// Marker type for reactive children (built with [`keyed()`])
+/// Marker type for reactive children (closure or [`keyed()`])
 pub struct DynamicChildren;
 
 /// Trait for values that can be added as children to a container.
 ///
 /// Accepted forms:
 /// - an iterator of widgets — static, evaluated once
-/// - [`keyed(data, key, build)`](keyed) — reactive list
-///
-/// Bare closures are rejected at compile time: with them, per-item content
-/// updates could be silently discarded. `keyed()` makes both the identity
-/// and the data of each row explicit.
+/// - `move || iterator_of_widgets` — reactive: re-runs when a signal it
+///   reads changes, replacing all rows
+/// - [`keyed(data, key, build)`](keyed) — reactive with stable identity:
+///   preserves per-row state, rebuilds only changed rows
 #[diagnostic::on_unimplemented(
-    message = "`.children()` takes an iterator of widgets or `keyed(data, key, build)`, and `{Self}` is neither",
-    note = "for reactive lists use `.children(keyed(data, key, build))`: `data` is a tracked closure returning an iterator of `Clone + PartialEq` items, `key` extracts each item's stable identity, `build` turns an item into its widget"
+    message = "`.children()` takes an iterator of widgets, a reactive closure returning one, or `keyed(data, key, build)` — and `{Self}` is none of those",
+    note = "`.children(move || widgets)` replaces all rows when a signal it reads changes; `keyed(data, key, build)` preserves per-row state via stable identity and rebuilds only rows whose item changed"
 )]
 pub trait IntoChildren<Marker = StaticChildren> {
     fn add_to_container(self, children_source: &mut ChildrenSource);
@@ -222,20 +176,90 @@ where
     }
 }
 
-/// A reactive children list: tracked data, key-based identity, untracked
-/// per-item builder. Built with [`keyed()`], consumed by `.children()`.
+/// Reactive unkeyed list: the closure re-runs when a signal it reads
+/// changes and its rows replace the previous ones wholesale. All rows of
+/// one run share a single owner scope, disposed when the last row drops.
+///
+/// Rows have no identity across runs — inner state does not survive a
+/// re-run. Use [`keyed()`] when rows carry state worth preserving.
+impl<F, I, W> IntoChildren<DynamicChildren> for F
+where
+    F: Fn() -> I + 'static,
+    I: IntoIterator<Item = W>,
+    W: Widget + 'static,
+{
+    fn add_to_container(self, children_source: &mut ChildrenSource) {
+        struct State {
+            next_generation: u64,
+            /// Rows built by the latest run, adopted by the reconciler's
+            /// factory calls in the same pass.
+            pending: HashMap<u64, Box<dyn Widget>>,
+        }
+
+        let state = Rc::new(RefCell::new(State {
+            next_generation: 0,
+            pending: HashMap::new(),
+        }));
+        let list_fn = Rc::new(self);
+
+        let items_fn = move || {
+            let mut st = state.borrow_mut();
+            // Defensive: unadopted rows from a previous pass (their shared
+            // owner guard was dropped with the unadopted factories).
+            st.pending.clear();
+
+            let list_fn = Rc::clone(&list_fn);
+            let (widgets, owner_id) = with_owner(move || {
+                list_fn()
+                    .into_iter()
+                    .map(|w| Box::new(w) as Box<dyn Widget>)
+                    .collect::<Vec<_>>()
+            });
+            if widgets.is_empty() {
+                dispose_owner(owner_id);
+                return vec![];
+            }
+
+            let shared = SharedOwner::new(owner_id);
+            let mut out = Vec::with_capacity(widgets.len());
+            for widget in widgets {
+                let generation = st.next_generation;
+                st.next_generation += 1;
+                st.pending.insert(generation, widget);
+
+                let adopt_state = Rc::clone(&state);
+                let shared = shared.clone();
+                out.push(DynItem::new(generation, move || {
+                    let widget = adopt_state
+                        .borrow_mut()
+                        .pending
+                        .remove(&generation)
+                        .expect("reactive children factory ran without a freshly built row");
+                    OwnedWidget::new_shared(widget, shared)
+                }));
+            }
+            out
+        };
+
+        children_source.add_dynamic(items_fn);
+    }
+}
+
+/// A reactive keyed children list: tracked data, key-based identity,
+/// untracked per-item builder. Built with [`keyed()`], consumed by
+/// `.children()`.
 pub struct KeyedChildren<T, I, W> {
     data: Box<dyn Fn() -> I>,
     key: Box<dyn Fn(&T) -> u64>,
     build: Box<dyn Fn(T) -> W>,
 }
 
-/// Reactive children list: tracked data, key-based identity, untracked
-/// per-item builder with content diffing.
+/// Reactive keyed children list: tracked data, key-based identity,
+/// untracked per-item builder with content diffing.
 ///
-/// `data` runs inside the reconciliation tracking scope and yields the
-/// items. `key` extracts each item's stable identity (it survives reorders).
-/// Per item:
+/// `data` runs inside the segment's tracking scope and yields the items.
+/// `key` extracts each item's stable identity (it survives reorders). Per
+/// item:
 ///
 /// - new key → `build` runs (untracked, in an owner scope)
 /// - known key, item `==` previous → the existing widget is kept untouched
@@ -279,14 +303,14 @@ where
     W: Widget + 'static,
 {
     fn add_to_container(self, children_source: &mut ChildrenSource) {
-        add_dyn_children(children_source, self.data, self.key, self.build);
+        add_keyed_children(children_source, self.data, self.key, self.build);
     }
 }
 
 /// Wire a (tracked data, key, untracked builder) triple into a
 /// ChildrenSource as a keyed dynamic list. See [`keyed()`] for the
 /// semantics.
-fn add_dyn_children<T, I, W>(
+fn add_keyed_children<T, I, W>(
     source: &mut ChildrenSource,
     data_fn: impl Fn() -> I + 'static,
     key_fn: impl Fn(&T) -> u64 + 'static,
@@ -302,22 +326,22 @@ fn add_dyn_children<T, I, W>(
         /// content version), stable while the item compares equal.
         generation: u64,
     }
-    struct DynChildrenState<T> {
-        rows: std::collections::HashMap<u64, Row<T>>,
+    struct KeyedState<T> {
+        rows: HashMap<u64, Row<T>>,
         next_generation: u64,
         /// Widgets built eagerly this pass, awaiting adoption by the
         /// reconciler's factory calls (keyed by generation).
-        pending: std::collections::HashMap<u64, (Box<dyn Widget>, OwnerId)>,
+        pending: HashMap<u64, (Box<dyn Widget>, OwnerId)>,
     }
 
-    let state = Rc::new(RefCell::new(DynChildrenState::<T> {
-        rows: std::collections::HashMap::new(),
+    let state = Rc::new(RefCell::new(KeyedState::<T> {
+        rows: HashMap::new(),
         next_generation: 0,
-        pending: std::collections::HashMap::new(),
+        pending: HashMap::new(),
     }));
 
     let items_fn = move || {
-        let items = data_fn(); // tracked: runs inside with_signal_tracking
+        let items = data_fn(); // tracked: runs inside the segment scope
         let mut st = state.borrow_mut();
 
         // Defensive: widgets stashed by a previous pass that were never
@@ -375,6 +399,7 @@ mod tests {
 
     use super::*;
     use crate::layout::{Constraints, Size};
+    use crate::reactive::{create_signal, on_cleanup};
     use crate::tree::{Tree, WidgetId};
 
     struct TestWidget;
@@ -395,81 +420,128 @@ mod tests {
     }
 
     #[test]
-    fn dynamic_child_rebuilds_only_when_data_changes() {
+    fn closure_child_replaces_on_tracked_change() {
         let (mut tree, mut source) = children_host();
-        let data = Rc::new(Cell::new(1u64));
+        let sig = create_signal(1u64);
+        let unrelated = create_signal(0u64);
         let builds = Rc::new(Cell::new(0usize));
 
-        let data_reader = data.clone();
         let builds_counter = builds.clone();
-        dynamic(
-            move || data_reader.get(),
-            move |_| {
-                builds_counter.set(builds_counter.get() + 1);
-                TestWidget
-            },
-        )
-        .add_to_container(&mut source);
+        let closure = move || {
+            sig.get();
+            builds_counter.set(builds_counter.get() + 1);
+            TestWidget
+        };
+        IntoChild::<DynamicChild>::add_to_container(closure, &mut source);
 
         let first = source.reconcile_and_get(&mut tree).clone();
         assert_eq!(first.len(), 1);
         assert_eq!(builds.get(), 1);
 
-        // Same data: widget kept, builder not called
+        // Untracked signal change: segment not dirty, widget untouched
+        unrelated.set(1);
         source.reconcile_with_tracking(&mut tree);
         assert_eq!(source.reconcile_and_get(&mut tree).clone(), first);
         assert_eq!(builds.get(), 1);
 
-        // Changed data: builder runs, widget replaced
-        data.set(2);
+        // Tracked signal change: closure re-runs, widget replaced
+        sig.set(2);
         source.reconcile_with_tracking(&mut tree);
         let second = source.reconcile_and_get(&mut tree).clone();
         assert_eq!(second.len(), 1);
         assert_ne!(second[0], first[0]);
         assert_eq!(builds.get(), 2);
+
+        // No-op write (same value): signals skip notification entirely
+        sig.set(2);
+        source.reconcile_with_tracking(&mut tree);
+        assert_eq!(source.reconcile_and_get(&mut tree).clone(), second);
+        assert_eq!(builds.get(), 2);
     }
 
     #[test]
-    fn dynamic_child_builder_controls_presence() {
+    fn segments_rerun_independently() {
         let (mut tree, mut source) = children_host();
-        let data = Rc::new(Cell::new(1u64));
+        let sig_a = create_signal(0u64);
+        let sig_b = create_signal(0u64);
 
-        let data_reader = data.clone();
-        dynamic(
-            move || data_reader.get(),
-            // Present only for even data
-            |n| (n % 2 == 0).then_some(TestWidget),
-        )
-        .add_to_container(&mut source);
+        let closure_a = move || {
+            sig_a.get();
+            TestWidget
+        };
+        let closure_b = move || {
+            sig_b.get();
+            TestWidget
+        };
+        IntoChild::<DynamicChild>::add_to_container(closure_a, &mut source);
+        IntoChild::<DynamicChild>::add_to_container(closure_b, &mut source);
+
+        let first = source.reconcile_and_get(&mut tree).clone();
+        assert_eq!(first.len(), 2);
+
+        // Only segment A's signal changes: B's widget must survive
+        sig_a.set(1);
+        source.reconcile_with_tracking(&mut tree);
+        let second = source.reconcile_and_get(&mut tree).clone();
+        assert_ne!(second[0], first[0]);
+        assert_eq!(second[1], first[1]);
+    }
+
+    #[test]
+    fn closure_child_controls_presence() {
+        let (mut tree, mut source) = children_host();
+        let show = create_signal(false);
+
+        let closure = move || show.get().then_some(TestWidget);
+        IntoChild::<DynamicChild>::add_to_container(closure, &mut source);
 
         assert!(source.reconcile_and_get(&mut tree).is_empty());
 
-        data.set(2);
+        show.set(true);
         source.reconcile_with_tracking(&mut tree);
-        let present = source.reconcile_and_get(&mut tree).clone();
-        assert_eq!(present.len(), 1);
+        assert_eq!(source.reconcile_and_get(&mut tree).len(), 1);
 
-        data.set(3);
+        show.set(false);
         source.reconcile_with_tracking(&mut tree);
         assert!(source.reconcile_and_get(&mut tree).is_empty());
+    }
 
-        data.set(4);
+    #[test]
+    fn closure_children_replace_all_rows_and_dispose_batch_owner() {
+        let (mut tree, mut source) = children_host();
+        let count = create_signal(2u64);
+        let cleanups = Rc::new(Cell::new(0usize));
+
+        let cleanups_counter = cleanups.clone();
+        let closure = move || {
+            let cleanups_counter = cleanups_counter.clone();
+            on_cleanup(move || cleanups_counter.set(cleanups_counter.get() + 1));
+            (0..count.get()).map(|_| TestWidget).collect::<Vec<_>>()
+        };
+        IntoChildren::<DynamicChildren>::add_to_container(closure, &mut source);
+
+        let first = source.reconcile_and_get(&mut tree).clone();
+        assert_eq!(first.len(), 2);
+        assert_eq!(cleanups.get(), 0);
+
+        count.set(3);
         source.reconcile_with_tracking(&mut tree);
-        let revived = source.reconcile_and_get(&mut tree).clone();
-        assert_eq!(revived.len(), 1);
-        assert_ne!(revived[0], present[0]);
+        let second = source.reconcile_and_get(&mut tree).clone();
+        assert_eq!(second.len(), 3);
+        // All rows replaced, previous batch owner disposed exactly once
+        assert!(first.iter().all(|id| !second.contains(id)));
+        assert_eq!(cleanups.get(), 1);
     }
 
     #[test]
     fn keyed_children_diff_by_identity_and_content() {
         let (mut tree, mut source) = children_host();
-        let items = Rc::new(RefCell::new(vec![(1u64, "a"), (2, "b")]));
+        let items = create_signal(vec![(1u64, "a".to_string()), (2, "b".to_string())]);
         let builds = Rc::new(Cell::new(0usize));
 
-        let items_reader = items.clone();
         let builds_counter = builds.clone();
         keyed(
-            move || items_reader.borrow().clone(),
+            move || items.get(),
             |(id, _)| *id,
             move |_| {
                 builds_counter.set(builds_counter.get() + 1);
@@ -483,14 +555,14 @@ mod tests {
         assert_eq!(builds.get(), 2);
 
         // Reorder with equal content: widgets reused, order follows data
-        *items.borrow_mut() = vec![(2, "b"), (1, "a")];
+        items.set(vec![(2, "b".to_string()), (1, "a".to_string())]);
         source.reconcile_with_tracking(&mut tree);
         let reordered = source.reconcile_and_get(&mut tree).clone();
         assert_eq!(reordered, vec![first[1], first[0]]);
         assert_eq!(builds.get(), 2);
 
         // Content change on one item: only that row rebuilds
-        *items.borrow_mut() = vec![(2, "B!"), (1, "a")];
+        items.set(vec![(2, "B!".to_string()), (1, "a".to_string())]);
         source.reconcile_with_tracking(&mut tree);
         let changed = source.reconcile_and_get(&mut tree).clone();
         assert_eq!(changed.len(), 2);
@@ -499,7 +571,7 @@ mod tests {
         assert_eq!(builds.get(), 3);
 
         // Removal drops only the removed row
-        *items.borrow_mut() = vec![(1, "a")];
+        items.set(vec![(1, "a".to_string())]);
         source.reconcile_with_tracking(&mut tree);
         let removed = source.reconcile_and_get(&mut tree).clone();
         assert_eq!(removed, vec![changed[1]]);

--- a/src/widgets/into_child.rs
+++ b/src/widgets/into_child.rs
@@ -1,25 +1,32 @@
-use crate::reactive::with_owner;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use crate::reactive::invalidation::suspend_widget_tracking;
+use crate::reactive::{OwnerId, dispose_owner, with_owner};
 
 use super::Widget;
 use super::children::{ChildrenSource, DynItem, OwnedWidget};
 
-/// Marker type for static child (widget value)
+/// Marker type for a static child (widget value)
 pub struct StaticChild;
 
-/// Marker type for dynamic child (closure)
+/// Marker type for a reactive child (built with [`dynamic()`])
 pub struct DynamicChild;
 
-/// Marker type for keyed dynamic child (closure returning `Option<(key, widget)>`)
-pub struct KeyedChild;
-
-/// Trait for types that can be added as a child to a container
+/// Trait for values that can be added as a single child to a container.
 ///
-/// This trait uses a marker type parameter to disambiguate between:
-/// - Static widgets (evaluated once at creation) - uses `StaticChild` marker
-/// - Dynamic closures returning `Option<Widget>` (presence-reactive) - uses `DynamicChild` marker
-/// - Dynamic closures returning `Option<(u64, Widget)>` (content-reactive) - uses `KeyedChild` marker
+/// Accepted forms:
+/// - a widget value — static, evaluated once
+/// - [`dynamic(data, build)`](dynamic) — reactive content
 ///
-/// The marker parameter defaults to `StaticChild` so `.child(widget)` works without annotation.
+/// Bare closures are rejected at compile time: with them, content updates
+/// could be silently discarded (there is no way to know which data the
+/// widget was built from). `dynamic()` makes that data explicit.
+#[diagnostic::on_unimplemented(
+    message = "`.child()` takes a widget or `dynamic(data, build)`, and `{Self}` is neither",
+    note = "for reactive content use `.child(dynamic(data, build))`: `data` is a tracked closure returning `Clone + PartialEq` data, `build` turns that data into the widget (return `Option<_>` to also control presence)",
+    note = "for reactive lists use `.children(keyed(data, key, build))`"
+)]
 pub trait IntoChild<Marker = StaticChild> {
     fn add_to_container(self, children_source: &mut ChildrenSource);
 }
@@ -31,97 +38,172 @@ impl<W: Widget + 'static> IntoChild<StaticChild> for W {
     }
 }
 
-/// Implementation for dynamic closures returning `Option<Widget>`.
-///
-/// **This form is presence-only.** The child always reconciles under the same
-/// key, so `Some -> Some` transitions keep the FIRST widget ever built and
-/// discard the rebuilt one — signals and state inside it persist, but a
-/// widget with different structure will never appear. Use it to show/hide a
-/// widget whose own properties are reactive.
-///
-/// When the widget's *structure* depends on data (lists, branches, rebuilt
-/// trees), return `Option<(key, widget)>` instead — see [`KeyedChild`] — with
-/// a key that changes alongside the content (typically a hash of the data).
-impl<F, W> IntoChild<DynamicChild> for F
-where
-    F: Fn() -> Option<W> + 'static,
-    W: Widget + 'static,
-{
-    fn add_to_container(self, children_source: &mut ChildrenSource) {
-        let child_fn = std::rc::Rc::new(self);
+/// What a [`dynamic()`] builder may return: a widget (always present) or
+/// `Option<widget>` (present when Some).
+pub trait IntoDynChild {
+    fn into_dyn_child(self) -> Option<Box<dyn Widget>>;
+}
 
-        let items_fn = move || {
-            let child_fn = child_fn.clone();
-            if let Some(widget) = child_fn() {
-                // For single optional child, wrap in owner at creation time
-                vec![DynItem::new(0, move || {
-                    let (widget, owner_id) = with_owner(|| widget);
-                    OwnedWidget::new(Box::new(widget), owner_id)
-                })]
-            } else {
-                vec![]
-            }
-        };
-
-        children_source.add_dynamic(items_fn);
+impl<W: Widget + 'static> IntoDynChild for W {
+    fn into_dyn_child(self) -> Option<Box<dyn Widget>> {
+        Some(Box::new(self))
     }
 }
 
-/// Implementation for dynamic closures returning `Option<(u64, Widget)>`.
+impl<W: Widget + 'static> IntoDynChild for Option<W> {
+    fn into_dyn_child(self) -> Option<Box<dyn Widget>> {
+        self.map(|w| Box::new(w) as Box<dyn Widget>)
+    }
+}
+
+/// A reactive single child: tracked data + untracked builder.
+/// Built with [`dynamic()`], consumed by `.child()`.
+pub struct DynChild<T, C> {
+    data: Box<dyn Fn() -> T>,
+    build: Box<dyn Fn(T) -> C>,
+}
+
+/// Reactive single child: tracked data closure + untracked builder.
 ///
-/// The content-reactive companion to the presence-only `Option<Widget>` form:
-/// the key states which version of the content the widget renders. Same key =
-/// the cached widget is kept (rebuilt value discarded, inner state persists);
-/// new key = the old widget is dropped (owner cleanup runs) and the rebuilt
-/// one is swapped in.
+/// `data` runs inside the reconciliation tracking scope — the signals it
+/// reads are the ONLY thing that triggers a re-evaluation. Its result is
+/// compared with the previous value (`PartialEq`): unchanged data keeps the
+/// existing widget untouched (inner state, animations and subscriptions
+/// persist); changed data runs `build` and swaps the rebuilt widget in,
+/// disposing the old one's owner scope.
 ///
-/// # Example
+/// `build` runs with widget tracking suspended: signal reads inside it see
+/// current values but create no dependencies. Data the widget must react to
+/// has to flow through `data` — that is what makes staleness unexpressible.
+///
+/// The builder may return a widget, or `Option<widget>` to also control
+/// presence.
 ///
 /// ```ignore
-/// let entries = create_signal(vec!["a".to_string()]);
-/// container().child(move || {
-///     let list = entries.get();
-///     let key = hash_of(&list); // any u64 that changes with the content
-///     Some((key, build_list_widget(list)))
-/// })
+/// // Content that re-renders when the data changes
+/// container().child(dynamic(move || menu.get(), build_menu))
+///
+/// // Presence: shown only while there is an active window
+/// container().child(dynamic(
+///     move || state.active_window.get(),
+///     |window| window.map(title_widget),
+/// ))
 /// ```
-impl<F, W> IntoChild<KeyedChild> for F
+pub fn dynamic<T, C>(
+    data: impl Fn() -> T + 'static,
+    build: impl Fn(T) -> C + 'static,
+) -> DynChild<T, C>
 where
-    F: Fn() -> Option<(u64, W)> + 'static,
-    W: Widget + 'static,
+    T: Clone + PartialEq + 'static,
+    C: IntoDynChild,
+{
+    DynChild {
+        data: Box::new(data),
+        build: Box::new(build),
+    }
+}
+
+impl<T, C> IntoChild<DynamicChild> for DynChild<T, C>
+where
+    T: Clone + PartialEq + 'static,
+    C: IntoDynChild + 'static,
 {
     fn add_to_container(self, children_source: &mut ChildrenSource) {
-        let child_fn = std::rc::Rc::new(self);
-
-        let items_fn = move || {
-            let child_fn = child_fn.clone();
-            if let Some((key, widget)) = child_fn() {
-                vec![DynItem::new(key, move || {
-                    let (widget, owner_id) = with_owner(|| widget);
-                    OwnedWidget::new(Box::new(widget), owner_id)
-                })]
-            } else {
-                vec![]
-            }
-        };
-
-        children_source.add_dynamic(items_fn);
+        add_dyn_child(children_source, self.data, self.build);
     }
+}
+
+/// Wire a (tracked data, untracked builder) pair into a ChildrenSource as a
+/// single dynamic child. See [`dynamic()`] for the semantics.
+fn add_dyn_child<T, C>(
+    source: &mut ChildrenSource,
+    data_fn: impl Fn() -> T + 'static,
+    build_fn: impl Fn(T) -> C + 'static,
+) where
+    T: Clone + PartialEq + 'static,
+    C: IntoDynChild,
+{
+    struct DynChildState<T> {
+        prev: Option<T>,
+        generation: u64,
+        /// Widget built eagerly on data change, adopted by the reconciler's
+        /// factory call in the same pass (the new generation key guarantees
+        /// the factory runs whenever something is stashed here).
+        pending: Option<(Box<dyn Widget>, OwnerId)>,
+        present: bool,
+    }
+
+    let state = Rc::new(RefCell::new(DynChildState::<T> {
+        prev: None,
+        generation: 0,
+        pending: None,
+        present: false,
+    }));
+
+    let items_fn = move || {
+        let data = data_fn(); // tracked: runs inside with_signal_tracking
+        let mut st = state.borrow_mut();
+
+        if st.prev.as_ref() != Some(&data) {
+            // Defensive: a widget stashed by a previous pass that was never
+            // adopted would leak its owner scope.
+            if let Some((_, owner_id)) = st.pending.take() {
+                dispose_owner(owner_id);
+            }
+
+            let (built, owner_id) =
+                with_owner(|| suspend_widget_tracking(|| build_fn(data.clone()).into_dyn_child()));
+            st.prev = Some(data);
+            st.generation += 1;
+            match built {
+                Some(widget) => {
+                    st.pending = Some((widget, owner_id));
+                    st.present = true;
+                }
+                None => {
+                    dispose_owner(owner_id);
+                    st.present = false;
+                }
+            }
+        }
+
+        if st.present {
+            let adopt_state = Rc::clone(&state);
+            vec![DynItem::new(st.generation, move || {
+                let (widget, owner_id) = adopt_state
+                    .borrow_mut()
+                    .pending
+                    .take()
+                    .expect("dynamic child factory ran without a freshly built widget");
+                OwnedWidget::new(widget, owner_id)
+            })]
+        } else {
+            vec![]
+        }
+    };
+
+    source.add_dynamic(items_fn);
 }
 
 /// Marker type for static children (iterator of widgets)
 pub struct StaticChildren;
 
-/// Marker type for dynamic children (closure returning keyed items)
+/// Marker type for reactive children (built with [`keyed()`])
 pub struct DynamicChildren;
 
-/// Trait for types that can be added as children to a container
+/// Trait for values that can be added as children to a container.
 ///
-/// This trait uses a marker type parameter to disambiguate between:
-/// - Static children (iterator of widgets) - uses `StaticChildren` marker
-/// - Dynamic children (closure returning keyed items) - uses `DynamicChildren` marker
+/// Accepted forms:
+/// - an iterator of widgets — static, evaluated once
+/// - [`keyed(data, key, build)`](keyed) — reactive list
 ///
-/// The marker parameter defaults to `StaticChildren` so `.children([...])` works without annotation.
+/// Bare closures are rejected at compile time: with them, per-item content
+/// updates could be silently discarded. `keyed()` makes both the identity
+/// and the data of each row explicit.
+#[diagnostic::on_unimplemented(
+    message = "`.children()` takes an iterator of widgets or `keyed(data, key, build)`, and `{Self}` is neither",
+    note = "for reactive lists use `.children(keyed(data, key, build))`: `data` is a tracked closure returning an iterator of `Clone + PartialEq` items, `key` extracts each item's stable identity, `build` turns an item into its widget"
+)]
 pub trait IntoChildren<Marker = StaticChildren> {
     fn add_to_container(self, children_source: &mut ChildrenSource);
 }
@@ -140,53 +222,150 @@ where
     }
 }
 
-/// Implementation for dynamic children with closures.
+/// A reactive children list: tracked data, key-based identity, untracked
+/// per-item builder. Built with [`keyed()`], consumed by `.children()`.
+pub struct KeyedChildren<T, I, W> {
+    data: Box<dyn Fn() -> I>,
+    key: Box<dyn Fn(&T) -> u64>,
+    build: Box<dyn Fn(T) -> W>,
+}
+
+/// Reactive children list: tracked data, key-based identity, untracked
+/// per-item builder with content diffing.
 ///
-/// Accepts `Fn() -> Iterator<Item = (key, FnOnce() -> Widget)>`.
+/// `data` runs inside the reconciliation tracking scope and yields the
+/// items. `key` extracts each item's stable identity (it survives reorders).
+/// Per item:
 ///
-/// Each child's closure runs inside an owner scope, so signals and effects
-/// created during widget construction are automatically owned and cleaned up
-/// when the child is removed.
+/// - new key → `build` runs (untracked, in an owner scope)
+/// - known key, item `==` previous → the existing widget is kept untouched
+///   (inner state and animations persist, including across reorders)
+/// - known key, item changed → `build` re-runs and the rebuilt widget
+///   replaces the old one (its owner scope is disposed)
+/// - key gone → widget dropped with owner cleanup
 ///
-/// **IMPORTANT:** The widget closure is only called for NEW keys. Existing keys
-/// reuse their cached widgets, so signals/effects persist across frames.
-///
-/// # Example
+/// The item type chooses the granularity: fields excluded from it can be
+/// read via signals inside the row for in-place updates, fields included
+/// trigger a row rebuild when they change.
 ///
 /// ```ignore
-/// let items = create_signal(vec![1, 2, 3]);
-/// container().children(move || {
-///     items.get().iter().map(|&id| {
-///         (id as u64, move || {
-///             text(format!("Item {}", id))
-///         })
-///     })
-/// })
+/// container().children(keyed(
+///     move || workspaces.get(),
+///     |ws| ws.id,
+///     workspace_pill,
+/// ))
 /// ```
-impl<F, I, G, W> IntoChildren<DynamicChildren> for F
+pub fn keyed<T, I, W>(
+    data: impl Fn() -> I + 'static,
+    key: impl Fn(&T) -> u64 + 'static,
+    build: impl Fn(T) -> W + 'static,
+) -> KeyedChildren<T, I, W>
 where
-    F: Fn() -> I + 'static,
-    I: IntoIterator<Item = (u64, G)>,
-    G: FnOnce() -> W + 'static,
+    T: Clone + PartialEq + 'static,
+    I: IntoIterator<Item = T>,
+    W: Widget + 'static,
+{
+    KeyedChildren {
+        data: Box::new(data),
+        key: Box::new(key),
+        build: Box::new(build),
+    }
+}
+
+impl<T, I, W> IntoChildren<DynamicChildren> for KeyedChildren<T, I, W>
+where
+    T: Clone + PartialEq + 'static,
+    I: IntoIterator<Item = T> + 'static,
     W: Widget + 'static,
 {
     fn add_to_container(self, children_source: &mut ChildrenSource) {
-        let items_fn = move || {
-            self()
-                .into_iter()
-                .map(|(key, widget_fn)| {
-                    // Return DynItem with a LAZY widget factory.
-                    // The closure is only called by reconciliation for NEW keys.
-                    // with_owner wraps the widget creation for automatic cleanup.
-                    DynItem::new(key, move || {
-                        let (widget, owner_id) = with_owner(widget_fn);
-                        OwnedWidget::new(Box::new(widget), owner_id)
-                    })
-                })
-                .collect()
-        };
-        children_source.add_dynamic(items_fn);
+        add_dyn_children(children_source, self.data, self.key, self.build);
     }
+}
+
+/// Wire a (tracked data, key, untracked builder) triple into a
+/// ChildrenSource as a keyed dynamic list. See [`keyed()`] for the
+/// semantics.
+fn add_dyn_children<T, I, W>(
+    source: &mut ChildrenSource,
+    data_fn: impl Fn() -> I + 'static,
+    key_fn: impl Fn(&T) -> u64 + 'static,
+    build_fn: impl Fn(T) -> W + 'static,
+) where
+    T: Clone + PartialEq + 'static,
+    I: IntoIterator<Item = T>,
+    W: Widget + 'static,
+{
+    struct Row<T> {
+        item: T,
+        /// Serves as the reconciliation key: globally unique per (identity,
+        /// content version), stable while the item compares equal.
+        generation: u64,
+    }
+    struct DynChildrenState<T> {
+        rows: std::collections::HashMap<u64, Row<T>>,
+        next_generation: u64,
+        /// Widgets built eagerly this pass, awaiting adoption by the
+        /// reconciler's factory calls (keyed by generation).
+        pending: std::collections::HashMap<u64, (Box<dyn Widget>, OwnerId)>,
+    }
+
+    let state = Rc::new(RefCell::new(DynChildrenState::<T> {
+        rows: std::collections::HashMap::new(),
+        next_generation: 0,
+        pending: std::collections::HashMap::new(),
+    }));
+
+    let items_fn = move || {
+        let items = data_fn(); // tracked: runs inside with_signal_tracking
+        let mut st = state.borrow_mut();
+
+        // Defensive: widgets stashed by a previous pass that were never
+        // adopted would leak their owner scopes.
+        for (_, (_, owner_id)) in st.pending.drain() {
+            dispose_owner(owner_id);
+        }
+
+        let mut seen = std::collections::HashSet::new();
+        let mut out = Vec::new();
+        for item in items {
+            let key = key_fn(&item);
+            if !seen.insert(key) {
+                log::warn!("keyed children: duplicate key {key}, skipping item");
+                continue;
+            }
+
+            let generation = match st.rows.get(&key) {
+                Some(row) if row.item == item => row.generation,
+                _ => {
+                    let generation = st.next_generation;
+                    st.next_generation += 1;
+                    let (widget, owner_id) = with_owner(|| {
+                        suspend_widget_tracking(|| {
+                            Box::new(build_fn(item.clone())) as Box<dyn Widget>
+                        })
+                    });
+                    st.pending.insert(generation, (widget, owner_id));
+                    st.rows.insert(key, Row { item, generation });
+                    generation
+                }
+            };
+
+            let adopt_state = Rc::clone(&state);
+            out.push(DynItem::new(generation, move || {
+                let (widget, owner_id) = adopt_state
+                    .borrow_mut()
+                    .pending
+                    .remove(&generation)
+                    .expect("keyed children factory ran without a freshly built widget");
+                OwnedWidget::new(widget, owner_id)
+            }));
+        }
+        st.rows.retain(|key, _| seen.contains(key));
+        out
+    };
+
+    source.add_dynamic(items_fn);
 }
 
 #[cfg(test)]
@@ -216,55 +395,129 @@ mod tests {
     }
 
     #[test]
-    fn keyed_child_swaps_widget_when_key_changes() {
+    fn dynamic_child_rebuilds_only_when_data_changes() {
         let (mut tree, mut source) = children_host();
-        let key = Rc::new(Cell::new(1u64));
+        let data = Rc::new(Cell::new(1u64));
+        let builds = Rc::new(Cell::new(0usize));
 
-        let key_reader = key.clone();
-        let closure = move || Some((key_reader.get(), TestWidget));
-        IntoChild::<KeyedChild>::add_to_container(closure, &mut source);
+        let data_reader = data.clone();
+        let builds_counter = builds.clone();
+        dynamic(
+            move || data_reader.get(),
+            move |_| {
+                builds_counter.set(builds_counter.get() + 1);
+                TestWidget
+            },
+        )
+        .add_to_container(&mut source);
 
         let first = source.reconcile_and_get(&mut tree).clone();
         assert_eq!(first.len(), 1);
+        assert_eq!(builds.get(), 1);
 
-        // Same key: the cached widget must be kept
+        // Same data: widget kept, builder not called
         source.reconcile_with_tracking(&mut tree);
         assert_eq!(source.reconcile_and_get(&mut tree).clone(), first);
+        assert_eq!(builds.get(), 1);
 
-        // New key: the widget must be replaced
-        key.set(2);
+        // Changed data: builder runs, widget replaced
+        data.set(2);
         source.reconcile_with_tracking(&mut tree);
         let second = source.reconcile_and_get(&mut tree).clone();
         assert_eq!(second.len(), 1);
         assert_ne!(second[0], first[0]);
+        assert_eq!(builds.get(), 2);
     }
 
     #[test]
-    fn option_child_is_presence_only() {
+    fn dynamic_child_builder_controls_presence() {
         let (mut tree, mut source) = children_host();
-        let present = Rc::new(Cell::new(true));
+        let data = Rc::new(Cell::new(1u64));
 
-        let present_reader = present.clone();
-        let closure = move || present_reader.get().then_some(TestWidget);
-        IntoChild::<DynamicChild>::add_to_container(closure, &mut source);
+        let data_reader = data.clone();
+        dynamic(
+            move || data_reader.get(),
+            // Present only for even data
+            |n| (n % 2 == 0).then_some(TestWidget),
+        )
+        .add_to_container(&mut source);
 
-        let first = source.reconcile_and_get(&mut tree).clone();
-        assert_eq!(first.len(), 1);
+        assert!(source.reconcile_and_get(&mut tree).is_empty());
 
-        // Some -> Some keeps the original widget: this form cannot express
-        // content changes, only presence
+        data.set(2);
         source.reconcile_with_tracking(&mut tree);
-        assert_eq!(source.reconcile_and_get(&mut tree).clone(), first);
+        let present = source.reconcile_and_get(&mut tree).clone();
+        assert_eq!(present.len(), 1);
 
-        // None removes it, Some builds a fresh one
-        present.set(false);
+        data.set(3);
         source.reconcile_with_tracking(&mut tree);
         assert!(source.reconcile_and_get(&mut tree).is_empty());
 
-        present.set(true);
+        data.set(4);
         source.reconcile_with_tracking(&mut tree);
         let revived = source.reconcile_and_get(&mut tree).clone();
         assert_eq!(revived.len(), 1);
-        assert_ne!(revived[0], first[0]);
+        assert_ne!(revived[0], present[0]);
+    }
+
+    #[test]
+    fn keyed_children_diff_by_identity_and_content() {
+        let (mut tree, mut source) = children_host();
+        let items = Rc::new(RefCell::new(vec![(1u64, "a"), (2, "b")]));
+        let builds = Rc::new(Cell::new(0usize));
+
+        let items_reader = items.clone();
+        let builds_counter = builds.clone();
+        keyed(
+            move || items_reader.borrow().clone(),
+            |(id, _)| *id,
+            move |_| {
+                builds_counter.set(builds_counter.get() + 1);
+                TestWidget
+            },
+        )
+        .add_to_container(&mut source);
+
+        let first = source.reconcile_and_get(&mut tree).clone();
+        assert_eq!(first.len(), 2);
+        assert_eq!(builds.get(), 2);
+
+        // Reorder with equal content: widgets reused, order follows data
+        *items.borrow_mut() = vec![(2, "b"), (1, "a")];
+        source.reconcile_with_tracking(&mut tree);
+        let reordered = source.reconcile_and_get(&mut tree).clone();
+        assert_eq!(reordered, vec![first[1], first[0]]);
+        assert_eq!(builds.get(), 2);
+
+        // Content change on one item: only that row rebuilds
+        *items.borrow_mut() = vec![(2, "B!"), (1, "a")];
+        source.reconcile_with_tracking(&mut tree);
+        let changed = source.reconcile_and_get(&mut tree).clone();
+        assert_eq!(changed.len(), 2);
+        assert_ne!(changed[0], reordered[0]); // row 2 rebuilt
+        assert_eq!(changed[1], reordered[1]); // row 1 untouched
+        assert_eq!(builds.get(), 3);
+
+        // Removal drops only the removed row
+        *items.borrow_mut() = vec![(1, "a")];
+        source.reconcile_with_tracking(&mut tree);
+        let removed = source.reconcile_and_get(&mut tree).clone();
+        assert_eq!(removed, vec![changed[1]]);
+        assert_eq!(builds.get(), 3);
+    }
+
+    #[test]
+    fn keyed_children_skip_duplicate_keys() {
+        let (mut tree, mut source) = children_host();
+
+        keyed(
+            move || vec![(7u64, "x"), (7, "y")],
+            |(id, _)| *id,
+            |_| TestWidget,
+        )
+        .add_to_container(&mut source);
+
+        // Only the first item with a given key is rendered
+        assert_eq!(source.reconcile_and_get(&mut tree).len(), 1);
     }
 }

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -13,7 +13,10 @@ pub use children::ChildrenSource;
 pub use container::{Border, Container, GradientDirection, LinearGradient, Overflow, container};
 pub use font::{FontFamily, FontWeight};
 pub use image::{ContentFit, Image, ImageSource, image};
-pub use into_child::{DynamicChildren, IntoChild, IntoChildren, StaticChildren};
+pub use into_child::{
+    DynChild, DynamicChildren, IntoChild, IntoChildren, IntoDynChild, KeyedChildren,
+    StaticChildren, dynamic, keyed,
+};
 pub use scroll::{ScrollAxis, ScrollbarBuilder, ScrollbarConfig, ScrollbarVisibility};
 pub use state_layer::{BackgroundOverride, RippleConfig, StateStyle};
 pub use text::{Text, text};

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -14,8 +14,7 @@ pub use container::{Border, Container, GradientDirection, LinearGradient, Overfl
 pub use font::{FontFamily, FontWeight};
 pub use image::{ContentFit, Image, ImageSource, image};
 pub use into_child::{
-    DynChild, DynamicChildren, IntoChild, IntoChildren, IntoDynChild, KeyedChildren,
-    StaticChildren, dynamic, keyed,
+    DynamicChildren, IntoChild, IntoChildren, IntoDynChild, KeyedChildren, StaticChildren, keyed,
 };
 pub use scroll::{ScrollAxis, ScrollbarBuilder, ScrollbarConfig, ScrollbarVisibility};
 pub use state_layer::{BackgroundOverride, RippleConfig, StateStyle};


### PR DESCRIPTION
## Summary

Definitive fix for the reactive-children API, converging (after design review) on the SolidJS/Leptos model: **a value is static, a closure is reactive** — no wrapper calls, no dedicated methods.

```rust
.child(text("hi"))                                  // static
.child(move || build_menu(entries.get()))            // reactive: re-run ⇒ replace
.child(move || cond.get().then(|| banner()))         // Option controls presence
.children([a, b, c])                                 // static
.children(move || rows(items.get()))                 // reactive: replaces all rows
.children(keyed(move || items.get(), |i| i.id, row)) // keyed: identity + per-row diffing
```

A closure re-runs when a signal it reads changes and its result **always replaces** the previous widget. The old semantics — closure re-runs but the rebuilt widget is discarded unless a reconciliation key changed — exists in no mainstream framework and shipped real bugs (frozen tray submenus/toggles).

## The enabling surgery: per-segment tracking

`Subscriber` and the tracking context now carry the dynamic-segment index; a signal write marks exactly that segment dirty and reconciliation re-runs only dirty segments. Previously any Reconcile job re-ran every dynamic segment of the container — the discard-by-key semantics was a patch around that coarseness. This is also a perf win: sibling segments no longer re-run on unrelated changes.

## Why this is safe/fast in guido specifically

- Widget props are lazy closures tracked at paint time → a child closure naturally tracks only **structural** reads; property updates never force a rebuild
- Signals skip no-op writes (PartialEq on set) → a re-run almost always means the data really changed
- For derived data, reading a `Memo` gives rebuild-only-on-real-change with an existing primitive (this is why the earlier `dynamic(data, build)` form was dropped)

## keyed() — the `<For>` equivalent

`keyed(data, key, build)` remains the opt-in for lists whose rows carry state: identity via key (state survives reorders), per-row content diffing via PartialEq (only changed rows rebuild), duplicate keys warn+skip, builders run untracked in owner scopes.

## Coverage

- 6 tests pin the semantics: replace-on-tracked-change, per-segment isolation, presence, batch-owner disposal for unkeyed lists, keyed identity+content diffing, duplicate keys
- Unkeyed closure lists share one owner scope per run via a new `SharedOwner` guard (disposed with the last row)
- `#[diagnostic::on_unimplemented]` on both traits documents the accepted forms at the error site
- Book chapter, docs/REACTIVE.md and examples rewritten; component-macro child slots accept the reactive forms

Breaking change, intentionally: no external users, and the previous semantics were an unfixable footgun.