### PR TITLE
Fix rustfmt violation in OwnerHandle

### DIFF
--- a/src/widgets/children.rs
+++ b/src/widgets/children.rs
@@ -440,9 +440,7 @@ enum OwnerHandle {
     Exclusive(OwnerId),
     /// The owner scope is shared by several widgets (one closure run built
     /// them all); it is disposed when the last of them drops.
-    Shared {
-        _guard: SharedOwner,
-    },
+    Shared { _guard: SharedOwner },
 }
 
 /// Reference-counted owner scope: disposes the owner when the last clone


### PR DESCRIPTION
One-line rustfmt fix: the `OwnerHandle::Shared` variant edit in #124 landed after the local fmt run, and I merged with the Format check red — this restores a green main.