### PR TITLE
Drop spurious Cmd: Clone bound from Service::clone

### DIFF
--- a/src/reactive/service.rs
+++ b/src/reactive/service.rs
@@ -47,9 +47,18 @@ impl ServiceContext {
 /// Handle to a background service for sending commands.
 ///
 /// Clone this handle to send commands from multiple places.
-#[derive(Clone)]
 pub struct Service<Cmd> {
     sender: mpsc::UnboundedSender<Cmd>,
+}
+
+// Manual impl: the derive would add a spurious `Cmd: Clone` bound, but only
+// the sender is cloned.
+impl<Cmd> Clone for Service<Cmd> {
+    fn clone(&self) -> Self {
+        Self {
+            sender: self.sender.clone(),
+        }
+    }
 }
 
 impl<Cmd> Service<Cmd> {


### PR DESCRIPTION
`#[derive(Clone)]` on `Service<Cmd>` conditions the impl on `Cmd: Clone`, but cloning only copies the mpsc sender. Manual impl removes the bound.

Surfaced by the ashell-guido port adopting upstream ashell services verbatim — their command enums don't all derive Clone.