### PR TITLE
Tear down closed surfaces' widget trees and signal subscribers

### DIFF
--- a/src/jobs.rs
+++ b/src/jobs.rs
@@ -246,6 +246,28 @@ pub fn request_job(widget_id: WidgetId, request: JobRequest) {
 /// no longer active are retired into the orphan lane too, so a closed
 /// surface's deferred Unregister jobs still run and nothing keeps
 /// `has_pending_jobs` true forever.
+/// Synchronously tear down a widget subtree: clear each widget's signal
+/// subscribers (and dirty segments) and unregister it from the tree,
+/// children first.
+///
+/// Used wherever a subtree is discarded while the app keeps running — a
+/// closed surface, or an old dynamic/keyed child replaced during
+/// reconciliation. The deferred Drop→Unregister cascade is NOT enough
+/// there: the discarded root's exclusive owner is disposed immediately,
+/// but its descendants would stay in the tree (subscribers live, queued
+/// reconciles runnable) until their deferred jobs ran — and a reconcile
+/// executing in that window reads owner-disposed state and panics.
+///
+/// Children-first order means each widget Drop's deferred Unregister
+/// requests target already-removed ids and no-op; stale queued jobs no-op
+/// too via the tree's generation check.
+pub(crate) fn teardown_widget_subtree(tree: &mut crate::tree::Tree, root: WidgetId) {
+    for id in tree.collect_subtree_post_order(root) {
+        clear_widget_subscribers(id);
+        tree.unregister(id);
+    }
+}
+
 pub fn distribute_jobs(tree: &Tree, active_roots: &rustc_hash::FxHashSet<WidgetId>) {
     PENDING_JOBS.with(|jobs| {
         let mut jobs = jobs.borrow_mut();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,7 +220,11 @@ fn process_surface_commands(
                 // borrows the wl_surface through erased raw pointers, so the
                 // GPU surface must die before the Wayland surface it points
                 // at (previously a use-after-free during swapchain teardown).
-                surface_manager.remove(id);
+                if let Some(managed) = surface_manager.remove(id) {
+                    // Unregister the widget tree and its signal subscribers
+                    // before the drop disposes the reactive owner
+                    surface_manager::teardown_widget_subtree(tree, managed.widget_id);
+                }
                 wayland_state.destroy_surface(id);
 
                 // If no surfaces left, exit

--- a/src/session_lock.rs
+++ b/src/session_lock.rs
@@ -143,7 +143,7 @@ pub(crate) fn process_session_lock(
             LockEvent::Locked => set_state(LockState::Locked),
             LockEvent::Finished => {
                 // Denied, or the lock ended without our unlock_session().
-                teardown_lock_surfaces(surface_manager, wayland_state);
+                teardown_lock_surfaces(surface_manager, wayland_state, tree);
                 LOCK.with(|l| l.borrow_mut().factory = None);
                 set_state(LockState::Unlocked);
             }
@@ -154,7 +154,7 @@ pub(crate) fn process_session_lock(
     let unlock_requested = LOCK.with(|l| std::mem::take(&mut l.borrow_mut().unlock_requested));
     if unlock_requested && state_signal().get_untracked() != LockState::Unlocked {
         wayland_state.unlock_session();
-        teardown_lock_surfaces(surface_manager, wayland_state);
+        teardown_lock_surfaces(surface_manager, wayland_state, tree);
         LOCK.with(|l| l.borrow_mut().factory = None);
         set_state(LockState::Unlocked);
     }
@@ -179,7 +179,9 @@ pub(crate) fn process_session_lock(
             stale
         });
         for (_, sid) in stale {
-            surface_manager.remove(sid);
+            if let Some(managed) = surface_manager.remove(sid) {
+                crate::surface_manager::teardown_widget_subtree(tree, managed.widget_id);
+            }
             wayland_state.destroy_surface(sid);
         }
 
@@ -218,7 +220,11 @@ pub(crate) fn process_session_lock(
     }
 }
 
-fn teardown_lock_surfaces(surface_manager: &mut SurfaceManager, wayland_state: &mut WaylandState) {
+fn teardown_lock_surfaces(
+    surface_manager: &mut SurfaceManager,
+    wayland_state: &mut WaylandState,
+    tree: &mut crate::tree::Tree,
+) {
     let surfaces: Vec<SurfaceId> = LOCK.with(|l| {
         l.borrow_mut()
             .surfaces
@@ -229,7 +235,9 @@ fn teardown_lock_surfaces(surface_manager: &mut SurfaceManager, wayland_state: &
     for sid in surfaces {
         // Removed directly — not via SurfaceCommand::Close — so an app whose
         // only surfaces were lock surfaces keeps running after unlock.
-        surface_manager.remove(sid);
+        if let Some(managed) = surface_manager.remove(sid) {
+            crate::surface_manager::teardown_widget_subtree(tree, managed.widget_id);
+        }
         wayland_state.destroy_surface(sid);
     }
 }

--- a/src/surface_manager.rs
+++ b/src/surface_manager.rs
@@ -148,10 +148,7 @@ impl Drop for ManagedSurface {
 /// Call this BEFORE dropping the `ManagedSurface`: subscribers must be
 /// gone before the owner (and the signals it holds) is disposed.
 pub(crate) fn teardown_widget_subtree(tree: &mut Tree, root: WidgetId) {
-    for id in tree.collect_subtree_post_order(root) {
-        crate::reactive::invalidation::clear_widget_subscribers(id);
-        tree.unregister(id);
-    }
+    crate::jobs::teardown_widget_subtree(tree, root);
 }
 
 /// Manages all surfaces in the application.

--- a/src/surface_manager.rs
+++ b/src/surface_manager.rs
@@ -133,6 +133,27 @@ impl Drop for ManagedSurface {
     }
 }
 
+/// Tear down a closed surface's widget tree synchronously.
+///
+/// Removing a `ManagedSurface` only disposes its reactive owner; without
+/// this, the widget subtree stays registered in the [`Tree`] forever (a
+/// leak that grows with every closed popup) and its signal subscribers
+/// stay live — the next write to a subscribed signal reconciles a dead
+/// dynamic child whose closure reads owner-disposed state and panics.
+///
+/// Widgets are unregistered children-first, so each Drop's deferred
+/// Unregister requests target already-removed ids and no-op; any stale
+/// queued job no-ops too because the ids fail the tree's generation check.
+///
+/// Call this BEFORE dropping the `ManagedSurface`: subscribers must be
+/// gone before the owner (and the signals it holds) is disposed.
+pub(crate) fn teardown_widget_subtree(tree: &mut Tree, root: WidgetId) {
+    for id in tree.collect_subtree_post_order(root) {
+        crate::reactive::invalidation::clear_widget_subscribers(id);
+        tree.unregister(id);
+    }
+}
+
 /// Manages all surfaces in the application.
 pub struct SurfaceManager {
     surfaces: HashMap<SurfaceId, ManagedSurface>,
@@ -226,5 +247,70 @@ impl SurfaceManager {
 impl Default for SurfaceManager {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    use super::*;
+    use crate::layout::{Constraints, Size};
+    use crate::reactive::owner::{dispose_owner as dispose, with_owner};
+    use crate::reactive::{create_memo, create_signal};
+    use crate::widgets::Widget;
+    use crate::widgets::children::ChildrenSource;
+    use crate::widgets::into_child::{DynamicChild, IntoChild};
+
+    struct TestWidget;
+    impl Widget for TestWidget {
+        fn layout(&mut self, _: &mut Tree, _: crate::tree::WidgetId, _: Constraints) -> Size {
+            Size::zero()
+        }
+        fn paint(&self, _: &Tree, _: crate::tree::WidgetId, _: &mut crate::renderer::PaintContext) {
+        }
+    }
+
+    /// The surface-close crash scenario: a dynamic child reads a memo owned
+    /// by the surface factory's owner scope; the surface closes (owner
+    /// disposed); a later write to the tracked signal must NOT re-run the
+    /// dead closure (which would read the disposed memo and panic) — and the
+    /// subtree must actually leave the tree (the popup leak).
+    #[test]
+    fn teardown_clears_subscribers_and_empties_tree() {
+        let mut tree = Tree::new();
+        let parent = tree.register(Box::new(TestWidget));
+        let mut source = ChildrenSource::default();
+        source.set_container_id(parent);
+
+        let sig = create_signal(0u64);
+        let builds = Rc::new(Cell::new(0usize));
+
+        // Mimic the surface factory: reactive state owned by a scope that
+        // dies with the surface
+        let (memo, owner_id) = with_owner(|| create_memo(move || sig.get() + 1));
+
+        let counter = builds.clone();
+        let closure = move || {
+            let _ = memo.get();
+            counter.set(counter.get() + 1);
+            TestWidget
+        };
+        IntoChild::<DynamicChild>::add_to_container(closure, &mut source);
+        source.reconcile_and_get(&mut tree);
+        assert_eq!(builds.get(), 1);
+        assert!(tree.widget_count() > 1);
+
+        // Surface close: subtree teardown, THEN owner disposal
+        teardown_widget_subtree(&mut tree, parent);
+        dispose(owner_id);
+
+        // The write that used to reconcile the dead child into a panic
+        sig.set(1);
+        source.reconcile_with_tracking(&mut tree);
+
+        assert_eq!(builds.get(), 1, "dead closure must not re-run");
+        assert_eq!(tree.widget_count(), 0, "subtree must leave the tree");
     }
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -325,6 +325,26 @@ impl Tree {
             .unwrap_or(&[])
     }
 
+    /// Collect a subtree in post-order (children before parents).
+    ///
+    /// Used for surface teardown: unregistering in this order means each
+    /// widget's Drop finds its children already gone, so the deferred
+    /// Unregister jobs it schedules become no-ops.
+    pub fn collect_subtree_post_order(&self, root: WidgetId) -> Vec<WidgetId> {
+        let mut ordered = Vec::new();
+        // Pre-order DFS, then reverse: yields children before parents
+        let mut stack = vec![root];
+        while let Some(id) = stack.pop() {
+            if self.get_dense_index(id).is_none() {
+                continue;
+            }
+            ordered.push(id);
+            stack.extend_from_slice(self.get_children(id));
+        }
+        ordered.reverse();
+        ordered
+    }
+
     /// Mark a widget as needing layout, returning the layout root.
     ///
     /// The needs_layout flag bubbles up to the nearest relayout boundary or root.

--- a/src/widgets/children.rs
+++ b/src/widgets/children.rs
@@ -3,7 +3,6 @@ use std::rc::Rc;
 
 use crate::jobs::{JobRequest, request_job};
 use crate::layout::{Constraints, Size};
-use crate::reactive::invalidation::clear_widget_subscribers;
 use crate::reactive::{OwnerId, dispose_owner};
 use crate::renderer::PaintContext;
 use crate::tree::{Tree, WidgetId};
@@ -216,13 +215,15 @@ impl ChildrenSource {
                         // Update current keys
                         *current_keys = new_keys;
 
-                        // Unregister removed widgets from tree (triggers Drop/cleanup).
-                        // Clear their signal subscriptions first — otherwise the dead
-                        // WidgetId stays subscribed forever and every subsequent write
-                        // to those signals enqueues a job for a nonexistent widget.
+                        // Discard replaced widgets: the WHOLE subtree comes out of
+                        // the tree synchronously (subscribers + dirty segments
+                        // cleared, children first). The root's exclusive owner is
+                        // disposed by its Drop right here, so any state it owned
+                        // (memos captured by descendant closures) dies with it —
+                        // a descendant left behind for deferred cleanup could
+                        // still reconcile this batch and read that disposed state.
                         for old_id in cached.values() {
-                            clear_widget_subscribers(*old_id);
-                            tree.unregister(*old_id);
+                            crate::jobs::teardown_widget_subtree(tree, *old_id);
                         }
                         cached.clear();
                     } else {

--- a/src/widgets/into_child.rs
+++ b/src/widgets/into_child.rs
@@ -459,6 +459,47 @@ mod tests {
         assert_eq!(builds.get(), 2);
     }
 
+    /// A replaced dynamic child's WHOLE subtree must leave the tree during
+    /// the reconcile itself. If descendants lingered for deferred cleanup,
+    /// their queued reconciles could still run in the same batch and read
+    /// state owned (and just disposed) by the replaced root.
+    #[test]
+    fn replaced_child_subtree_is_torn_down_synchronously() {
+        struct ParentWidget;
+        impl Widget for ParentWidget {
+            fn layout(&mut self, _: &mut Tree, _: WidgetId, _: Constraints) -> Size {
+                Size::zero()
+            }
+            fn paint(&self, _: &Tree, _: WidgetId, _: &mut crate::renderer::PaintContext) {}
+            fn register_children(&mut self, tree: &mut Tree, id: WidgetId) {
+                let child = tree.register(Box::new(TestWidget));
+                tree.set_parent(child, id);
+            }
+        }
+
+        let (mut tree, mut source) = children_host();
+        let sig = create_signal(0u64);
+
+        let closure = move || {
+            sig.get();
+            ParentWidget
+        };
+        IntoChild::<DynamicChild>::add_to_container(closure, &mut source);
+        source.reconcile_and_get(&mut tree);
+
+        // host + row root + row's registered child
+        let count_after_build = tree.widget_count();
+        assert_eq!(count_after_build, 3);
+
+        // Tracked change: the row is replaced by a fresh build
+        sig.set(1);
+        source.reconcile_with_tracking(&mut tree);
+
+        // Same shape, and the OLD subtree is fully gone already — no
+        // deferred leftovers
+        assert_eq!(tree.widget_count(), count_after_build);
+    }
+
     #[test]
     fn segments_rerun_independently() {
         let (mut tree, mut source) = children_host();


### PR DESCRIPTION
## Problem

Closing a surface (dynamic surface, popup, lock surface) only disposed the widget factory's reactive owner. Two consequences:

1. **Leak**: the widget subtree stayed registered in the `Tree` forever — every closed popup/menu left its whole tree behind.
2. **Crash**: the dead widgets' signal subscribers stayed live. The next write to a subscribed signal marked the dead dynamic child dirty, the orphan job lane reconciled it, and the closure read owner-disposed state:

   ```
   Signal 173v0 was disposed - cannot read after owner cleanup
   ```

   Hit in ashell-guido: the multi-output fallback→pinned bar handover closed the first bar; the first notification afterwards touched the dead bell closure and panicked.

## Fix

`teardown_widget_subtree()` walks the closed surface's subtree children-first, clearing each widget's subscribers + dirty segments and unregistering it from the tree — **before** the `ManagedSurface` drop disposes the owner. Children-first order means each widget Drop's deferred Unregister requests target already-removed ids and no-op; stale queued jobs no-op too via the tree's generation check.

Wired into: `SurfaceCommand::Close`, session-lock teardown, and the locked-output-unplugged path.

## Test

Regression test reproduces the exact scenario: dynamic child reading a memo owned by the factory scope, surface teardown, then a tracked write — asserts the dead closure doesn't re-run and the tree actually empties.