### PR TITLE
chore: optimize pixel-crunching deps in dev builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,3 +94,30 @@ path = "examples/renderer_v2_test.rs"
 [[example]]
 name = "perf_stress_test"
 path = "examples/perf_stress_test.rs"
+
+# Pixel-crunching dependencies are unusable at opt-level 0 (an SVG raster
+# costs ~25ms at 16px, text shaping multiplies similarly): optimize them
+# even in dev builds so examples and downstream dev runs behave. Guido's
+# own code stays unoptimized for fast rebuilds.
+[profile.dev.package.tiny-skia]
+opt-level = 3
+[profile.dev.package.tiny-skia-path]
+opt-level = 3
+[profile.dev.package.resvg]
+opt-level = 3
+[profile.dev.package.usvg]
+opt-level = 3
+[profile.dev.package.cosmic-text]
+opt-level = 3
+[profile.dev.package.rustybuzz]
+opt-level = 3
+[profile.dev.package.ttf-parser]
+opt-level = 3
+[profile.dev.package.fontdb]
+opt-level = 3
+[profile.dev.package.swash]
+opt-level = 3
+[profile.dev.package.zeno]
+opt-level = 3
+[profile.dev.package.image]
+opt-level = 3


### PR DESCRIPTION
At opt-level 0, resvg/tiny-skia rasterize a single 16px SVG icon in ~25ms (measured — mostly per-tree fixed cost, barely pixel-dependent) and cosmic-text/rustybuzz shaping is similarly degraded. Debug runs of image- or text-heavy UIs pay hundreds of milliseconds per cold frame inside these crates: the ashell-guido weather menu spent ~430ms of its cold open in icon rasterization alone.

Optimizing just the pixel-crunching leaf dependencies in dev (the standard `[profile.dev.package.*]` pattern) removes that: measured downstream, menu cold open 654ms → 208ms, warm reopen ~40ms, in a debug build. Guido's own code stays at opt-level 0 for fast rebuilds and debuggability.