### PR TITLE
feat: per-corner radii (CornerRadii) for rounded rectangles

### DIFF
--- a/docs/STYLING.md
+++ b/docs/STYLING.md
@@ -88,6 +88,28 @@ container()
 container().corner_radius(8.0)  // 8px radius on all corners
 ```
 
+### Per-Corner Radii
+
+Round each corner independently with `corner_radii` — accordion-style
+lists round only the top of the first row and only the bottom of the last:
+
+```rust
+use guido::prelude::CornerRadii;
+
+container().corner_radii(CornerRadii::top(16.0))     // first row
+container().corner_radii(CornerRadii::bottom(16.0))  // last row
+container().corner_radii(CornerRadii {
+    top_left: 16.0,
+    top_right: 4.0,
+    bottom_right: 16.0,
+    bottom_left: 4.0,
+})
+```
+
+`corner_radii` overrides `corner_radius` for drawing (background, border,
+shadow, gradient). Child clipping, blur regions and rounded hit testing
+keep using a uniform radius — the largest of the four.
+
 ### Corner Curvature (Superellipse)
 
 Control the shape of corners using CSS K-values:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,9 +158,9 @@ pub mod prelude {
     pub use crate::transform_origin::{HorizontalAnchor, TransformOrigin, VerticalAnchor};
     pub use crate::widget_ref::{WidgetRef, create_widget_ref};
     pub use crate::widgets::{
-        AnyWidget, Border, Color, Container, ContentFit, Event, EventResponse, FontFamily,
-        FontWeight, GradientDirection, Image, ImageSource, IntoChildren, Key, LinearGradient,
-        Modifiers, MouseButton, Overflow, Padding, Rect, ScrollAxis, ScrollSource,
+        AnyWidget, Border, Color, Container, ContentFit, CornerRadii, Event, EventResponse,
+        FontFamily, FontWeight, GradientDirection, Image, ImageSource, IntoChildren, Key,
+        LinearGradient, Modifiers, MouseButton, Overflow, Padding, Rect, ScrollAxis, ScrollSource,
         ScrollbarBuilder, ScrollbarVisibility, Selection, StateStyle, Text, TextInput, Widget,
         container, image, keyed, text, text_input,
     };

--- a/src/renderer/commands.rs
+++ b/src/renderer/commands.rs
@@ -21,6 +21,110 @@ impl Border {
     }
 }
 
+/// Per-corner radii for rounded rectangles (logical pixels).
+///
+/// Most shapes use a uniform radius — `f32` converts directly. Per-corner
+/// values enable accordion-style lists where the first row rounds only its
+/// top corners and the last only its bottom ones.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct CornerRadii {
+    pub top_left: f32,
+    pub top_right: f32,
+    pub bottom_right: f32,
+    pub bottom_left: f32,
+}
+
+impl CornerRadii {
+    /// The same radius on all four corners.
+    pub fn uniform(radius: f32) -> Self {
+        Self {
+            top_left: radius,
+            top_right: radius,
+            bottom_right: radius,
+            bottom_left: radius,
+        }
+    }
+
+    /// `radius` on the top corners, zero on the bottom ones.
+    pub fn top(radius: f32) -> Self {
+        Self {
+            top_left: radius,
+            top_right: radius,
+            bottom_right: 0.0,
+            bottom_left: 0.0,
+        }
+    }
+
+    /// `radius` on the bottom corners, zero on the top ones.
+    pub fn bottom(radius: f32) -> Self {
+        Self {
+            top_left: 0.0,
+            top_right: 0.0,
+            bottom_right: radius,
+            bottom_left: radius,
+        }
+    }
+
+    /// The largest of the four radii (uniform approximations: clip, blur).
+    pub fn max(&self) -> f32 {
+        self.top_left
+            .max(self.top_right)
+            .max(self.bottom_right)
+            .max(self.bottom_left)
+    }
+
+    /// As `[top_left, top_right, bottom_right, bottom_left]`.
+    pub fn to_array(self) -> [f32; 4] {
+        [
+            self.top_left,
+            self.top_right,
+            self.bottom_right,
+            self.bottom_left,
+        ]
+    }
+
+    /// Multiply every radius (logical → physical pixels).
+    pub fn scaled(self, factor: f32) -> Self {
+        Self {
+            top_left: self.top_left * factor,
+            top_right: self.top_right * factor,
+            bottom_right: self.bottom_right * factor,
+            bottom_left: self.bottom_left * factor,
+        }
+    }
+}
+
+impl From<f32> for CornerRadii {
+    fn from(radius: f32) -> Self {
+        Self::uniform(radius)
+    }
+}
+
+impl From<[f32; 4]> for CornerRadii {
+    /// `[top_left, top_right, bottom_right, bottom_left]` — clockwise from
+    /// the top left, CSS `border-radius` order.
+    fn from(r: [f32; 4]) -> Self {
+        Self {
+            top_left: r[0],
+            top_right: r[1],
+            bottom_right: r[2],
+            bottom_left: r[3],
+        }
+    }
+}
+
+impl From<(f32, f32, f32, f32)> for CornerRadii {
+    /// `(top_left, top_right, bottom_right, bottom_left)`.
+    fn from(r: (f32, f32, f32, f32)) -> Self {
+        Self {
+            top_left: r.0,
+            top_right: r.1,
+            bottom_right: r.2,
+            bottom_left: r.3,
+        }
+    }
+}
+
 /// A single draw operation in local coordinates.
 ///
 /// All coordinates and sizes are in the node's local coordinate space.
@@ -33,8 +137,8 @@ pub enum DrawCommand {
         rect: Rect,
         /// Fill color
         color: Color,
-        /// Corner radius in logical pixels
-        radius: f32,
+        /// Corner radii in logical pixels
+        radius: CornerRadii,
         /// Superellipse curvature (K-value: 1.0 = circle, 2.0 = squircle)
         curvature: f32,
         /// Optional border
@@ -84,11 +188,11 @@ pub enum DrawCommand {
 
 impl DrawCommand {
     /// Create a simple rounded rectangle.
-    pub fn rounded_rect(rect: Rect, color: Color, radius: f32) -> Self {
+    pub fn rounded_rect(rect: Rect, color: Color, radius: impl Into<CornerRadii>) -> Self {
         Self::RoundedRect {
             rect,
             color,
-            radius,
+            radius: radius.into(),
             curvature: 1.0,
             border: None,
             shadow: None,
@@ -100,13 +204,13 @@ impl DrawCommand {
     pub fn rounded_rect_with_curvature(
         rect: Rect,
         color: Color,
-        radius: f32,
+        radius: impl Into<CornerRadii>,
         curvature: f32,
     ) -> Self {
         Self::RoundedRect {
             rect,
             color,
-            radius,
+            radius: radius.into(),
             curvature,
             border: None,
             shadow: None,

--- a/src/renderer/gpu.rs
+++ b/src/renderer/gpu.rs
@@ -93,12 +93,9 @@ pub struct ShapeInstance {
     /// Rectangle bounds: [x, y, width, height]
     pub rect: [f32; 4],
 
-    /// Corner radius in logical pixels
-    pub corner_radius: f32,
-    /// Superellipse curvature (K-value: 1.0=circle, 2.0=squircle)
-    pub shape_curvature: f32,
-    /// Padding for 16-byte alignment (wgpu uniform buffer requirement)
-    pub _pad0: [f32; 2],
+    /// Corner radii in physical pixels:
+    /// [top_left, top_right, bottom_right, bottom_left]
+    pub corner_radii: [f32; 4],
 
     // === Colors ===
     /// Fill color RGBA
@@ -109,8 +106,10 @@ pub struct ShapeInstance {
     // === Border ===
     /// Border width in logical pixels
     pub border_width: f32,
+    /// Superellipse curvature (K-value: 1.0=circle, 2.0=squircle)
+    pub shape_curvature: f32,
     /// Padding for 16-byte alignment
-    pub _pad1: [f32; 3],
+    pub _pad1: [f32; 2],
 
     // === Shadow ===
     /// Shadow offset in logical pixels (x, y)
@@ -158,13 +157,12 @@ impl Default for ShapeInstance {
     fn default() -> Self {
         Self {
             rect: [0.0, 0.0, 0.0, 0.0],
-            corner_radius: 0.0,
-            shape_curvature: 1.0,
-            _pad0: [0.0, 0.0],
+            corner_radii: [0.0; 4],
             fill_color: [0.0, 0.0, 0.0, 0.0],
             border_color: [0.0, 0.0, 0.0, 0.0],
             border_width: 0.0,
-            _pad1: [0.0, 0.0, 0.0],
+            shape_curvature: 1.0,
+            _pad1: [0.0, 0.0],
             shadow_offset: [0.0, 0.0],
             shadow_blur: 0.0,
             shadow_spread: 0.0,
@@ -189,12 +187,12 @@ impl ShapeInstance {
     pub fn from_rect(
         rect: [f32; 4],
         fill_color: [f32; 4],
-        corner_radius: f32,
+        corner_radii: [f32; 4],
         curvature: f32,
     ) -> Self {
         Self {
             rect,
-            corner_radius,
+            corner_radii,
             shape_curvature: curvature,
             fill_color,
             ..Default::default()
@@ -293,7 +291,7 @@ impl ShapeInstance {
                     shader_location: 1,
                     format: VertexFormat::Float32x4,
                 },
-                // corner_radius, shape_curvature, _pad0[0], _pad0[1]
+                // corner_radii: [top_left, top_right, bottom_right, bottom_left]
                 VertexAttribute {
                     offset: 16,
                     shader_location: 2,
@@ -311,7 +309,7 @@ impl ShapeInstance {
                     shader_location: 4,
                     format: VertexFormat::Float32x4,
                 },
-                // border_width, _pad1[0], _pad1[1], _pad1[2]
+                // border_width, shape_curvature, _pad1[0], _pad1[1]
                 VertexAttribute {
                     offset: 64,
                     shader_location: 5,

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -25,7 +25,7 @@ mod textured_vertex;
 mod tree;
 mod types;
 
-pub use commands::{Border, DrawCommand};
+pub use commands::{Border, CornerRadii, DrawCommand};
 pub use flatten::{FlattenedCommand, LayerBoundaries, flatten_root_into};
 pub use gpu_context::{GpuContext, SurfaceState};
 pub use paint_context::PaintContext;

--- a/src/renderer/paint_context.rs
+++ b/src/renderer/paint_context.rs
@@ -2,7 +2,7 @@
 
 use std::rc::Rc;
 
-use super::commands::{Border, DrawCommand};
+use super::commands::{Border, CornerRadii, DrawCommand};
 use super::tree::{ClipRegion, NodeId, RenderNode};
 use super::types::{Gradient, Shadow};
 use crate::transform::Transform;
@@ -188,11 +188,11 @@ impl<'a> PaintContext<'a> {
     // -------------------------------------------------------------------------
 
     /// Draw a rounded rectangle in local coordinates.
-    pub fn draw_rounded_rect(&mut self, rect: Rect, color: Color, radius: f32) {
+    pub fn draw_rounded_rect(&mut self, rect: Rect, color: Color, radius: impl Into<CornerRadii>) {
         self.node.commands.push(Rc::new(DrawCommand::RoundedRect {
             rect,
             color,
-            radius,
+            radius: radius.into(),
             curvature: 1.0,
             border: None,
             shadow: None,
@@ -205,13 +205,13 @@ impl<'a> PaintContext<'a> {
         &mut self,
         rect: Rect,
         color: Color,
-        radius: f32,
+        radius: impl Into<CornerRadii>,
         curvature: f32,
     ) {
         self.node.commands.push(Rc::new(DrawCommand::RoundedRect {
             rect,
             color,
-            radius,
+            radius: radius.into(),
             curvature,
             border: None,
             shadow: None,
@@ -224,13 +224,13 @@ impl<'a> PaintContext<'a> {
         &mut self,
         rect: Rect,
         gradient: Gradient,
-        radius: f32,
+        radius: impl Into<CornerRadii>,
         curvature: f32,
     ) {
         self.node.commands.push(Rc::new(DrawCommand::RoundedRect {
             rect,
             color: gradient.start_color, // Fallback color
-            radius,
+            radius: radius.into(),
             curvature,
             border: None,
             shadow: None,
@@ -243,13 +243,13 @@ impl<'a> PaintContext<'a> {
         &mut self,
         rect: Rect,
         border_color: Color,
-        radius: f32,
+        radius: impl Into<CornerRadii>,
         border_width: f32,
     ) {
         self.node.commands.push(Rc::new(DrawCommand::RoundedRect {
             rect,
             color: Color::TRANSPARENT,
-            radius,
+            radius: radius.into(),
             curvature: 1.0,
             border: Some(Border::new(border_width, border_color)),
             shadow: None,
@@ -262,14 +262,14 @@ impl<'a> PaintContext<'a> {
         &mut self,
         rect: Rect,
         border_color: Color,
-        radius: f32,
+        radius: impl Into<CornerRadii>,
         border_width: f32,
         curvature: f32,
     ) {
         self.node.commands.push(Rc::new(DrawCommand::RoundedRect {
             rect,
             color: Color::TRANSPARENT,
-            radius,
+            radius: radius.into(),
             curvature,
             border: Some(Border::new(border_width, border_color)),
             shadow: None,
@@ -282,14 +282,14 @@ impl<'a> PaintContext<'a> {
         &mut self,
         rect: Rect,
         color: Color,
-        radius: f32,
+        radius: impl Into<CornerRadii>,
         curvature: f32,
         shadow: Shadow,
     ) {
         self.node.commands.push(Rc::new(DrawCommand::RoundedRect {
             rect,
             color,
-            radius,
+            radius: radius.into(),
             curvature,
             border: None,
             shadow: Some(shadow),
@@ -303,7 +303,7 @@ impl<'a> PaintContext<'a> {
         &mut self,
         rect: Rect,
         color: Color,
-        radius: f32,
+        radius: impl Into<CornerRadii>,
         curvature: f32,
         border: Option<Border>,
         shadow: Option<Shadow>,
@@ -312,7 +312,7 @@ impl<'a> PaintContext<'a> {
         self.node.commands.push(Rc::new(DrawCommand::RoundedRect {
             rect,
             color,
-            radius,
+            radius: radius.into(),
             curvature,
             border,
             shadow,
@@ -429,13 +429,18 @@ impl<'a> PaintContext<'a> {
     }
 
     /// Draw a rounded rectangle as overlay (rendered after children).
-    pub fn draw_overlay_rounded_rect(&mut self, rect: Rect, color: Color, radius: f32) {
+    pub fn draw_overlay_rounded_rect(
+        &mut self,
+        rect: Rect,
+        color: Color,
+        radius: impl Into<CornerRadii>,
+    ) {
         self.node
             .overlay_commands
             .push(Rc::new(DrawCommand::RoundedRect {
                 rect,
                 color,
-                radius,
+                radius: radius.into(),
                 curvature: 1.0,
                 border: None,
                 shadow: None,

--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -494,7 +494,7 @@ fn command_to_instance(cmd: &FlattenedCommand, scale: f32) -> Option<ShapeInstan
                     rect.height * scale,
                 ],
                 [color.r, color.g, color.b, color.a],
-                radius * scale,
+                radius.scaled(scale).to_array(),
                 *curvature,
             )
             .with_transform(&cmd.world_transform, scale);
@@ -527,8 +527,8 @@ fn command_to_instance(cmd: &FlattenedCommand, scale: f32) -> Option<ShapeInstan
             let mut instance = ShapeInstance::from_rect(
                 [rect_x, rect_y, size, size],
                 [color.r, color.g, color.b, color.a],
-                radius * scale, // Full radius = circle
-                1.0,            // Circular corners
+                [radius * scale; 4], // Full radius = circle
+                1.0,                 // Circular corners
             )
             .with_transform(&cmd.world_transform, scale);
 

--- a/src/renderer/shader.wgsl
+++ b/src/renderer/shader.wgsl
@@ -25,13 +25,13 @@ struct VertexInput {
 struct InstanceInput {
     // rect: [x, y, width, height] in logical pixels
     @location(1) rect: vec4<f32>,
-    // corner_radius, shape_curvature, _pad, _pad
-    @location(2) shape_params: vec4<f32>,
+    // corner radii: [top_left, top_right, bottom_right, bottom_left]
+    @location(2) shape_radii: vec4<f32>,
     // fill_color RGBA
     @location(3) fill_color: vec4<f32>,
     // border_color RGBA
     @location(4) border_color: vec4<f32>,
-    // border_width, _pad, _pad, _pad
+    // border_width, shape_curvature, _pad, _pad
     @location(5) border_params: vec4<f32>,
     // shadow_offset.xy, shadow_blur, shadow_spread
     @location(6) shadow_params: vec4<f32>,
@@ -63,10 +63,10 @@ struct VertexOutput {
     @location(2) frag_pos: vec2<f32>,
     // Shape rect in logical pixels [x, y, width, height]
     @location(3) shape_rect: vec4<f32>,
-    // corner_radius, shape_curvature
-    @location(4) shape_params: vec2<f32>,
-    // border_width
-    @location(5) border_width: f32,
+    // corner radii: [top_left, top_right, bottom_right, bottom_left]
+    @location(4) shape_radii: vec4<f32>,
+    // border_width, shape_curvature
+    @location(5) border_params: vec2<f32>,
     // shadow_offset.xy, shadow_blur, shadow_spread
     @location(6) shadow_params: vec4<f32>,
     // shadow_color
@@ -171,8 +171,8 @@ fn vs_main(vertex: VertexInput, instance: InstanceInput) -> VertexOutput {
     out.fill_color = instance.fill_color;
     out.border_color = instance.border_color;
     out.shape_rect = instance.rect;
-    out.shape_params = instance.shape_params.xy;  // corner_radius, curvature
-    out.border_width = instance.border_params.x;
+    out.shape_radii = instance.shape_radii;
+    out.border_params = instance.border_params.xy;  // border_width, curvature
     out.shadow_params = instance.shadow_params;
     out.shadow_color = instance.shadow_color;
 
@@ -208,10 +208,18 @@ fn superellipse_length(p: vec2<f32>, n: f32) -> f32 {
 }
 
 // Unified SDF for rounded rectangle with superellipse corners
-// rect: [x, y, width, height], radius: corner radius, k: curvature
-fn rounded_rect_sdf(pos: vec2<f32>, rect: vec4<f32>, radius: f32, k: f32) -> f32 {
+// rect: [x, y, width, height], k: curvature
+// radii: [top_left, top_right, bottom_right, bottom_left] — the quadrant
+// the fragment falls in selects its radius, then the math is identical to
+// the uniform case (the abs() below folds everything into one quadrant).
+fn rounded_rect_sdf(pos: vec2<f32>, rect: vec4<f32>, radii: vec4<f32>, k: f32) -> f32 {
     let center = vec2<f32>(rect.x + rect.z * 0.5, rect.y + rect.w * 0.5);
     let half_size = vec2<f32>(rect.z * 0.5, rect.w * 0.5);
+
+    // Select this quadrant's radius
+    let rel = pos - center;
+    let top = select(vec2<f32>(radii.y, radii.z), vec2<f32>(radii.x, radii.w), rel.x < 0.0);
+    let radius = select(top.y, top.x, rel.y < 0.0);
 
     // Clamp radius to half the smaller dimension
     let r = min(radius, min(half_size.x, half_size.y));
@@ -271,11 +279,12 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     }
 
     let pos = in.frag_pos;
-    let radius = in.shape_params.x;
-    let curvature = in.shape_params.y;
+    let radii = in.shape_radii;
+    let curvature = in.border_params.y;
+    let border_width = in.border_params.x;
 
     // Compute SDF for the shape
-    let dist = rounded_rect_sdf(pos, in.shape_rect, radius, curvature);
+    let dist = rounded_rect_sdf(pos, in.shape_rect, radii, curvature);
 
     // Anti-aliasing using fwidth
     let aa = fwidth(dist) * 1.0;
@@ -302,7 +311,7 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
         let shadow_pos = pos - shadow_offset;
 
         // Compute shadow SDF (expanded by spread)
-        let shadow_dist = rounded_rect_sdf(shadow_pos, in.shape_rect, radius, curvature) - shadow_spread;
+        let shadow_dist = rounded_rect_sdf(shadow_pos, in.shape_rect, radii, curvature) - shadow_spread;
 
         // Convert to alpha with blur falloff
         let shadow_alpha = in.shadow_color.a * (1.0 - smoothstep(-shadow_blur, shadow_blur * 2.0, shadow_dist));
@@ -312,14 +321,14 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     // === Main Shape ===
     var shape_result: vec4<f32>;
 
-    if (in.border_width <= 0.0) {
+    if (border_width <= 0.0) {
         // No border - simple filled shape
         let alpha = 1.0 - smoothstep(-aa, aa, dist);
         shape_result = vec4<f32>(fill_color.rgb, fill_color.a * alpha);
     } else {
         // With border
         let outer_edge = dist;
-        let inner_edge = dist + in.border_width;
+        let inner_edge = dist + border_width;
 
         let shape_alpha = 1.0 - smoothstep(-aa, aa, outer_edge);
         let fill_alpha = 1.0 - smoothstep(-aa, aa, inner_edge);
@@ -363,12 +372,12 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
         // world_pos for world clips (regular clipping)
         let clip_pos = select(in.world_pos, in.frag_pos, in.clip_params.z > 0.5);
 
-        // Compute clip SDF
+        // Compute clip SDF (clips stay uniform-radius)
         let clip_dist = rounded_rect_sdf(
             clip_pos,
             in.clip_rect,
-            in.clip_params.x,  // corner_radius
-            in.clip_params.y   // curvature
+            vec4<f32>(in.clip_params.x),  // corner_radius, all corners
+            in.clip_params.y              // curvature
         );
 
         // Smooth clip edge (anti-aliased)

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -213,6 +213,7 @@ pub struct Container {
     pub(super) background: Option<Signal<Color>>,
     pub(super) gradient: Option<LinearGradient>,
     pub(super) corner_radius: Option<Signal<f32>>,
+    pub(super) corner_radii: Option<Signal<crate::renderer::CornerRadii>>,
     pub(super) corner_curvature: Option<Signal<f32>>,
     pub(super) border_width: Option<Signal<f32>>,
     pub(super) border_color: Option<Signal<Color>>,
@@ -252,6 +253,7 @@ impl Container {
             background: None,
             gradient: None,
             corner_radius: None,
+            corner_radii: None,
             corner_curvature: None,
             border_width: None,
             border_color: None,
@@ -374,6 +376,26 @@ impl Container {
     /// ```
     pub fn corner_radius<M>(mut self, radius: impl IntoSignal<f32, M>) -> Self {
         self.corner_radius = Some(radius.into_signal());
+        self
+    }
+
+    /// Set per-corner radii (overrides `corner_radius` for drawing).
+    ///
+    /// Enables accordion-style lists where the first row rounds only its
+    /// top corners and the last row only its bottom ones:
+    ///
+    /// ```ignore
+    /// container().corner_radii(CornerRadii::top(16.0))     // first row
+    /// container().corner_radii(CornerRadii::bottom(16.0))  // last row
+    /// ```
+    ///
+    /// Child clipping, blur regions and rounded hit testing keep using a
+    /// uniform radius (the largest of the four).
+    pub fn corner_radii<M>(
+        mut self,
+        radii: impl IntoSignal<crate::renderer::CornerRadii, M>,
+    ) -> Self {
+        self.corner_radii = Some(radii.into_signal());
         self
     }
 
@@ -1904,6 +1926,17 @@ impl Widget for Container {
             }
         }
 
+        // Per-corner radii override the uniform (animated) radius for
+        // drawing. Clip, blur region and rounded hit testing stay uniform,
+        // approximated by the largest corner.
+        let corner_radii = with_signal_tracking(id, JobType::Paint, || {
+            self.corner_radii
+                .as_ref()
+                .map(|s| s.get())
+                .unwrap_or_else(|| crate::renderer::CornerRadii::uniform(corner_radius))
+        });
+        let corner_radius = corner_radius.max(corner_radii.max());
+
         // Publish the blur region: bounds are read fresh from the tree at
         // frame sync, so only the (possibly animated) radius is recorded.
         if self.background_blur {
@@ -1932,7 +1965,7 @@ impl Widget for Container {
                     end_color: gradient.end_color,
                     direction: gradient.direction.into(),
                 },
-                corner_radius,
+                corner_radii,
                 corner_curvature,
             );
         } else if background.a > 0.0 {
@@ -1940,7 +1973,7 @@ impl Widget for Container {
                 ctx.draw_rounded_rect_with_shadow(
                     local_bounds,
                     background,
-                    corner_radius,
+                    corner_radii,
                     corner_curvature,
                     shadow,
                 );
@@ -1948,7 +1981,7 @@ impl Widget for Container {
                 ctx.draw_rounded_rect_with_curvature(
                     local_bounds,
                     background,
-                    corner_radius,
+                    corner_radii,
                     corner_curvature,
                 );
             }
@@ -1959,7 +1992,7 @@ impl Widget for Container {
             ctx.draw_border_frame_with_curvature(
                 local_bounds,
                 border_color,
-                corner_radius,
+                corner_radii,
                 border_width,
                 corner_curvature,
             );

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -9,6 +9,7 @@ pub mod text;
 pub mod text_input;
 pub mod widget;
 
+pub use crate::renderer::CornerRadii;
 pub use children::ChildrenSource;
 pub use container::{Border, Container, GradientDirection, LinearGradient, Overflow, container};
 pub use font::{FontFamily, FontWeight};


### PR DESCRIPTION
## What

Each corner of a rounded rectangle can now have its own radius:

```rust
container().corner_radii(CornerRadii::top(16.0))     // round only the top
container().corner_radii(CornerRadii::bottom(16.0))  // round only the bottom
container().corner_radii(CornerRadii { top_left: 16.0, top_right: 4.0, .. })
```

## How

- **Shader**: the SDF picks the fragment's quadrant radius, then the math is unchanged — superellipse curvature (squircle/bevel/scoop), borders and shadows follow per-corner for free.
- **Instance layout unchanged (224 B)**: the four radii take the old `radius + padding` vec4 slot; curvature moves beside `border_width` into its padding. Same attributes, same locations, same size.
- **API**: new `CornerRadii` type (uniform/top/bottom constructors, `From<f32>`, array/tuple conversions in CSS clockwise order). `PaintContext` draw methods widen `radius: f32` to `impl Into<CornerRadii>` — every existing f32 call site compiles untouched.
- **Uniform approximations**: child clipping, blur regions and rounded hit testing use the largest of the four radii.

## Why

Upstream ashell's accordion lists (weather daily forecast) round only the top corners of the first row and the bottom corners of the last — impossible to render faithfully with a single radius. Verified with the ashell-guido port: the daily list now matches upstream pixel-for-pixel (16/4 accordion).

Docs updated: `docs/STYLING.md` + book borders chapter.