### PR TITLE
feat: fractional lengths — fraction(f) resolves against available space

### DIFF
--- a/book/src/building-ui/styling.md
+++ b/book/src/building-ui/styling.md
@@ -112,6 +112,20 @@ container().width(at_most(400))              // At most 400px
 container().width(at_least(100).at_most(400)) // Range
 ```
 
+### Fraction of Available Space
+
+`fraction(f)` takes a fraction (0.0..=1.0) of the space offered by the
+parent, resolved at layout time. It is the natural tool for
+value-proportional bars — sliders, gauges, progress — because the width
+follows the value on the very first frame, with no measured-rect
+round-trip:
+
+```rust
+// A slider fill bar at the current volume
+let volume = create_signal(40);
+container().width(move || fraction(volume.get() as f32 / 100.0))
+```
+
 ## Complete Example
 
 ```rust

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -78,6 +78,11 @@ pub struct Length {
     pub exact: Option<f32>,
     /// When true, expand to fill all available space
     pub fill: bool,
+    /// Fraction (0.0..=1.0) of the available space, resolved against the
+    /// incoming constraints at layout time. Behaves like an `exact` length
+    /// whose value is only known during layout — a slider fill bar at 55%
+    /// is `fraction(0.55)` with no measure round-trip.
+    pub fraction: Option<f32>,
 }
 
 impl Length {
@@ -88,6 +93,7 @@ impl Length {
             max: None,
             exact: Some(value.into_f32()),
             fill: false,
+            fraction: None,
         }
     }
 
@@ -120,6 +126,7 @@ pub fn at_least(min: impl IntoF32) -> Length {
         max: None,
         exact: None,
         fill: false,
+        fraction: None,
     }
 }
 
@@ -139,6 +146,7 @@ pub fn at_most(max: impl IntoF32) -> Length {
         max: Some(max.into_f32()),
         exact: None,
         fill: false,
+        fraction: None,
     }
 }
 
@@ -160,6 +168,35 @@ pub fn fill() -> Length {
         max: None,
         exact: None,
         fill: true,
+        fraction: None,
+    }
+}
+
+/// Create a length that takes a fraction (0.0..=1.0) of the available
+/// space, resolved at layout time.
+///
+/// The natural tool for value-proportional bars (sliders, gauges,
+/// progress): the width follows the value on the very first frame, with
+/// no measured-rect round-trip.
+///
+/// # Examples
+/// ```
+/// use guido::prelude::*;
+///
+/// // A fill bar at 55% of the track width
+/// container().width(fraction(0.55));
+///
+/// // Reactive: follows the volume signal
+/// let volume = create_signal(40);
+/// container().width(move || fraction(volume.get() as f32 / 100.0));
+/// ```
+pub fn fraction(f: impl IntoF32) -> Length {
+    Length {
+        min: None,
+        max: None,
+        exact: None,
+        fill: false,
+        fraction: Some(f.into_f32()),
     }
 }
 
@@ -171,6 +208,7 @@ impl From<f32> for Length {
             max: None,
             exact: Some(value),
             fill: false,
+            fraction: None,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,7 @@ pub mod prelude {
     pub use crate::animation::{SpringConfig, TimingFunction, Transition, TransitionConfig};
     pub use crate::layout::{
         Axis, Constraints, CrossAlignment, Flex, IntoF32, Length, MainAlignment, Overlay, Size,
-        at_least, at_most, fill,
+        at_least, at_most, fill, fraction,
     };
     pub use crate::outputs::{OutputId, OutputInfo, outputs, surface_output};
     pub use crate::platform::{Anchor, KeyboardInteractivity, Layer};

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -1166,7 +1166,7 @@ impl Widget for Container {
         // Auto-track signal reads for layout properties.
         // Any signals read here (including closures) will register this widget
         // as a Layout subscriber so future changes trigger re-layout.
-        let (padding, width_length, height_length) =
+        let (padding, mut width_length, mut height_length) =
             with_signal_tracking(id, JobType::Layout, || {
                 (
                     self.animated_padding(),
@@ -1174,6 +1174,21 @@ impl Widget for Container {
                     self.height.as_ref().map(|h| h.get()).unwrap_or_default(),
                 )
             });
+
+        // Resolve fractional lengths against the incoming constraints: from
+        // here on a fraction is an exact length whose value became known at
+        // layout time, so everything downstream (flex sizing, animation
+        // targets, min/max clamping) works unchanged.
+        if let Some(f) = width_length.fraction
+            && constraints.max_width.is_finite()
+        {
+            width_length.exact = Some((constraints.max_width * f).max(0.0));
+        }
+        if let Some(f) = height_length.fraction
+            && constraints.max_height.is_finite()
+        {
+            height_length.exact = Some((constraints.max_height * f).max(0.0));
+        }
 
         // Calculate dimensions for child layout constraints.
         // When a layout animation is active and the width/height is exact, use


### PR DESCRIPTION
## What

`Length` gains a `fraction` field and a `fraction(f)` constructor: a fraction (0.0..=1.0) of the space offered by the parent, resolved at layout time.

```rust
// A slider fill bar at the current volume — correct on the very first frame
container().width(move || fraction(volume.get() as f32 / 100.0))
```

## How

Resolution happens at the top of `Container::layout`: a fraction becomes an `exact` length computed against the incoming constraints, so everything downstream (flex sizing, animation targets, min/max clamping) works unchanged. Infinite constraints (unbounded scroll axes) leave the fraction unresolved and the container falls back to content sizing.

## Why

The missing tool for value-proportional bars (sliders, gauges, progress). The workaround — computing the width from a WidgetRef-measured rect — lags one layout behind: when the widget is rebuilt (reactive menu content re-running) the rect signal reads zero for the first frame and the bar flashes empty before snapping to the real value. This was the settings-menu slider flicker in ashell-guido: submenu toggles rebuild the menu content, and every rebuild flashed the sliders to zero for one frame.

Verified in the port: sliders render at the correct value on the first frame with `fraction`, WidgetRef now only serves the pointer-math (event-time, no lag).

Docs: book styling chapter + doctests.