### PR TITLE
feat: snappier spring presets

### DIFF
--- a/book/src/animations/springs.md
+++ b/book/src/animations/springs.md
@@ -12,23 +12,31 @@ Transition::spring(SpringConfig::BOUNCY)
 
 ### DEFAULT
 
-Balanced spring - responsive without excessive bounce:
+Balanced spring - responsive without excessive bounce, settles in ~270ms:
 
 ```rust
 SpringConfig::DEFAULT
 ```
 
-### SMOOTH
+### SNAPPY
 
-Gentle spring - minimal overshoot:
+Quickest response with subtle overshoot, settles in ~185ms:
 
 ```rust
-SpringConfig::SMOOTH
+SpringConfig::SNAPPY
+```
+
+### GENTLE
+
+Slower and smooth - minimal overshoot, settles in ~325ms:
+
+```rust
+SpringConfig::GENTLE
 ```
 
 ### BOUNCY
 
-Energetic spring - visible bounce:
+Energetic spring - visible bounce, settles in ~410ms:
 
 ```rust
 SpringConfig::BOUNCY

--- a/src/animation/spring.rs
+++ b/src/animation/spring.rs
@@ -40,32 +40,36 @@ pub struct SpringConfig {
 }
 
 impl SpringConfig {
-    /// Default spring - fluid motion with moderate overshoot
+    /// Default spring - fluid motion with moderate overshoot.
+    /// Settles in ~270ms (damping ratio 0.66, ~6% overshoot).
     pub const DEFAULT: Self = Self {
         mass: 1.0,
-        stiffness: 150.0,
-        damping: 16.0,
+        stiffness: 500.0,
+        damping: 29.5,
     };
 
-    /// Bouncy spring with noticeable overshoot
+    /// Bouncy spring with noticeable overshoot.
+    /// Settles in ~410ms (damping ratio 0.49, ~17% overshoot).
     pub const BOUNCY: Self = Self {
         mass: 1.0,
-        stiffness: 150.0,
-        damping: 12.0,
+        stiffness: 400.0,
+        damping: 19.6,
     };
 
-    /// Snappy spring - quicker response, subtle overshoot
+    /// Snappy spring - quickest response, subtle overshoot.
+    /// Settles in ~185ms (damping ratio 0.72, ~4% overshoot).
     pub const SNAPPY: Self = Self {
         mass: 1.0,
-        stiffness: 250.0,
-        damping: 20.0,
+        stiffness: 900.0,
+        damping: 43.0,
     };
 
-    /// Gentle spring - slow and smooth, minimal overshoot
+    /// Gentle spring - slower and smooth, minimal overshoot.
+    /// Settles in ~325ms (damping ratio 0.78, ~3% overshoot).
     pub const GENTLE: Self = Self {
         mass: 1.0,
-        stiffness: 100.0,
-        damping: 15.0,
+        stiffness: 250.0,
+        damping: 24.7,
     };
 }
 


### PR DESCRIPTION
The spring presets settled far slower than contemporary UI motion: DEFAULT took ~500ms to rest, SNAPPY ~400ms, BOUNCY ~670ms — every animation built from the preset vocabulary felt sluggish next to e.g. iced's 100ms menu easings.

Each preset keeps its documented character — the damping ratio (and therefore the perceived overshoot) is nearly unchanged — but stiffness roughly triples, halving settle times:

| preset | before | after | overshoot |
|---|---|---|---|
| DEFAULT | ~500ms | **~270ms** | ~6% |
| SNAPPY | ~400ms | **~185ms** | ~4% |
| BOUNCY | ~670ms | **~410ms** | ~17% |
| GENTLE | ~530ms | **~325ms** | ~3% |

Settle times are now documented on each preset and in the book. The book's springs chapter also referenced a `SMOOTH` preset that never existed — it now documents `GENTLE` and `SNAPPY`.

Verified with the ashell-guido port: menus and submenus open with the retuned SNAPPY and close with a 120ms easeOutCubic, matching upstream's responsiveness while keeping the spring feel.