### PR TITLE
fix: tear down popup chains in protocol order

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,6 +185,26 @@ struct SurfaceDefinition {
     widget_fn: Box<dyn FnOnce() -> Box<dyn Widget>>,
 }
 
+/// Close one surface synchronously: dismissal signal, widget-tree
+/// teardown, GPU surface, Wayland objects. The managed surface drops
+/// FIRST — its wgpu `Surface<'static>` borrows the wl_surface through
+/// erased raw pointers, so the GPU surface must die before the Wayland
+/// surface it points at.
+fn close_surface_now(
+    id: SurfaceId,
+    surface_manager: &mut SurfaceManager,
+    wayland_state: &mut platform::WaylandState,
+    tree: &mut Tree,
+) {
+    surface::mark_popup_dismissed(id);
+    if let Some(managed) = surface_manager.remove(id) {
+        // Unregister the widget tree and its signal subscribers before the
+        // drop disposes the reactive owner
+        surface_manager::teardown_widget_subtree(tree, managed.widget_id);
+    }
+    wayland_state.destroy_surface(id);
+}
+
 /// Process dynamic surface commands (create, close, property changes).
 /// Returns false if all surfaces have been closed and the app should exit.
 fn process_surface_commands(
@@ -213,19 +233,13 @@ fn process_surface_commands(
             }
             SurfaceCommand::Close(id) => {
                 log::info!("Closing dynamic surface {:?}", id);
-                // If this was a popup, make sure its dismissal signal fires
-                // (no-op for other surfaces or already-dismissed popups)
-                surface::mark_popup_dismissed(id);
-                // Drop the managed surface FIRST: its wgpu Surface<'static>
-                // borrows the wl_surface through erased raw pointers, so the
-                // GPU surface must die before the Wayland surface it points
-                // at (previously a use-after-free during swapchain teardown).
-                if let Some(managed) = surface_manager.remove(id) {
-                    // Unregister the widget tree and its signal subscribers
-                    // before the drop disposes the reactive owner
-                    surface_manager::teardown_widget_subtree(tree, managed.widget_id);
+                // Popup chains tear down children-first: destroying a popup
+                // that still has a live child raises not_the_topmost_popup
+                // and the compositor kills the connection.
+                for child in wayland_state.popup_descendants_bottom_up(id) {
+                    close_surface_now(child, surface_manager, wayland_state, tree);
                 }
-                wayland_state.destroy_surface(id);
+                close_surface_now(id, surface_manager, wayland_state, tree);
 
                 // If no surfaces left, exit
                 if surface_manager.is_empty() {
@@ -281,6 +295,19 @@ fn process_surface_commands(
                 let height = config.height.unwrap_or_else(|| {
                     measure_popup_height(tree, managed.widget_id, config.width, parent)
                 });
+
+                // A new grab must nest under the current grab holder:
+                // xdg-shell forbids a grabbing popup whose parent chain
+                // does not include the popup currently holding the grab
+                // (the compositor kills the connection with
+                // not_the_topmost_popup). Destroy conflicting grab chains
+                // before creating, children first.
+                if config.grab {
+                    for stale in wayland_state.conflicting_grab_popups(parent) {
+                        log::info!("Closing popup {:?} before new grab popup {:?}", stale, id);
+                        close_surface_now(stale, surface_manager, wayland_state, tree);
+                    }
+                }
 
                 if wayland_state.create_popup_surface_with_id(
                     qh,

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -92,6 +92,9 @@ pub enum SurfaceRole {
     Popup {
         popup: Popup,
         config: crate::surface::PopupConfig,
+        /// The surface this popup is anchored to — used to tear down popup
+        /// chains in protocol order (children before parents).
+        parent: crate::surface::SurfaceId,
     },
 }
 
@@ -692,6 +695,7 @@ impl WaylandState {
             SurfaceRole::Popup {
                 popup,
                 config: config.clone(),
+                parent,
             },
             wl_surface,
             size.0,
@@ -708,6 +712,69 @@ impl WaylandState {
             config.grab
         );
         true
+    }
+
+    /// Live popup descendants of `root`, deepest first — the order the
+    /// protocol demands for teardown (a popup must be destroyed before its
+    /// parent, or the compositor raises `not_the_topmost_popup`).
+    pub(crate) fn popup_descendants_bottom_up(&self, root: SurfaceId) -> Vec<SurfaceId> {
+        let mut out = Vec::new();
+        let mut frontier = vec![root];
+        while let Some(current) = frontier.pop() {
+            for (id, state) in &self.surfaces {
+                if let SurfaceRole::Popup { parent, .. } = &state.role
+                    && *parent == current
+                {
+                    out.push(*id);
+                    frontier.push(*id);
+                }
+            }
+        }
+        out.reverse(); // deepest first
+        out
+    }
+
+    /// Grabbing popups that would make a new grab on `new_parent` illegal:
+    /// xdg-shell requires a new grab to nest under the current grab holder,
+    /// so any live grabbing popup that is not `new_parent` itself (or one
+    /// of its ancestors) must be destroyed before the new popup is created.
+    /// Returned deepest-chain-first, ready for ordered teardown.
+    pub(crate) fn conflicting_grab_popups(&self, new_parent: SurfaceId) -> Vec<SurfaceId> {
+        // Ancestor chain of the new popup (surfaces a nested grab may sit on)
+        let mut ancestors = vec![new_parent];
+        let mut current = new_parent;
+        while let Some(state) = self.surfaces.get(&current) {
+            match &state.role {
+                SurfaceRole::Popup { parent, .. } => {
+                    ancestors.push(*parent);
+                    current = *parent;
+                }
+                _ => break,
+            }
+        }
+
+        let mut conflicts: Vec<SurfaceId> = self
+            .surfaces
+            .iter()
+            .filter(|(id, state)| {
+                matches!(&state.role, SurfaceRole::Popup { config, .. } if config.grab)
+                    && !ancestors.contains(id)
+            })
+            .map(|(id, _)| *id)
+            .collect();
+        // Close whole chains children-first: append descendants and dedup
+        let mut ordered = Vec::new();
+        for id in conflicts.drain(..) {
+            for d in self.popup_descendants_bottom_up(id) {
+                if !ordered.contains(&d) {
+                    ordered.push(d);
+                }
+            }
+            if !ordered.contains(&id) {
+                ordered.push(id);
+            }
+        }
+        ordered
     }
 
     /// For auto-height popups: the width to measure content at.
@@ -739,7 +806,7 @@ impl WaylandState {
         {
             return;
         }
-        let SurfaceRole::Popup { popup, config } = &surface_state.role else {
+        let SurfaceRole::Popup { popup, config, .. } = &surface_state.role else {
             return;
         };
         // xdg_popup.reposition needs protocol v3


### PR DESCRIPTION
`not_the_topmost_popup` is a fatal protocol error — the compositor kills the connection, which surfaced as ashell-guido dying with `Protocol error 2 on wl_surface` after rapid menu interactions. Two spec-mandated orderings are now enforced in the platform layer so no app-side sequence can trigger it:

## 1. Children before parents on close

Closing a surface now closes its popup descendants first, deepest-first. Destroying a popup that still has a live child is a protocol violation.

## 2. One grab chain at a time on create

Creating a grabbing popup first destroys any live grabbing popup that is not on the new popup's parent chain (xdg-shell requires a new grab to nest under the current grab holder). Conflicting chains are torn down children-first before the new popup's `get_popup`/`grab` hit the wire, so the compositor always sees destroy-then-create.

`SurfaceRole::Popup` now records its parent surface to make both walks possible, and surface teardown is extracted into `close_surface_now`, shared by every path.

Companion fix in ashell-guido: menu switches destroy the previous popup immediately instead of relying on the animated deferred close.