### PR TITLE
feat: retire_owner — deferred owner disposal for self-closing scopes

### DIFF
--- a/docs/REACTIVE.md
+++ b/docs/REACTIVE.md
@@ -460,6 +460,38 @@ fn create_child(id: u64) -> impl Widget {
 container().children(keyed(move || items.get(), |id| *id, create_child))
 ```
 
+### Self-Closing Scopes: `retire_owner`
+
+Self-closing UI must dispose an owner **from code the owner itself owns**
+— an effect observing a popup's dismissal, a dialog's own close button.
+Synchronous disposal there would free the closure currently executing.
+`retire_owner(id)` queues the disposal instead; the main loop drains the
+queue once per iteration, when no user closure is on the stack:
+
+```rust
+use guido::reactive::retire_owner;
+
+// The owner id only exists after with_owner returns, so code inside the
+// scope reaches it through app state (a slot, a thread-local registry):
+let owner_slot = Rc::new(Cell::new(None));
+let slot = owner_slot.clone();
+let (popup, owner_id) = guido::reactive::owner::with_owner(move || {
+    spawn_popup(bar, config, move || {
+        menu_view(move || {
+            // Close button: this callback is owned by the very scope it
+            // is about to tear down — dispose_owner here would free the
+            // closure currently executing. Retiring is safe:
+            if let Some(id) = slot.get() {
+                retire_owner(id);
+            }
+        })
+    })
+});
+owner_slot.set(Some(owner_id));
+```
+
+Retiring twice, or retiring an already-disposed owner, is harmless.
+
 ### Custom Cleanup Callbacks
 
 Use `on_cleanup` inside dynamic children or component render methods to register cleanup logic for non-reactive resources:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1009,6 +1009,10 @@ impl App {
                 &mut self.tree,
             );
 
+            // Dispose owners retired from inside their own computations
+            // (retire_owner). Safe here: no user closure is on the stack.
+            reactive::owner::dispose_retired_owners();
+
             // Process dynamic surface commands
             if !process_surface_commands(
                 &mut surface_manager,

--- a/src/reactive/mod.rs
+++ b/src/reactive/mod.rs
@@ -36,8 +36,8 @@ pub(crate) use invalidation::with_signal_tracking;
 pub use memo::{Memo, create_memo};
 // Only on_cleanup is public API - with_owner, dispose_owner, and OwnerId are
 // internal and automatically used by the dynamic children system
-pub use owner::on_cleanup;
 pub(crate) use owner::{OwnerId, create_root_owner, dispose_owner, with_owner};
+pub use owner::{on_cleanup, retire_owner};
 
 /// Internal module for macro support. NOT PART OF PUBLIC API.
 /// Do not use directly - these are re-exported for proc macros only.

--- a/src/reactive/owner.rs
+++ b/src/reactive/owner.rs
@@ -241,6 +241,10 @@ pub fn current_owner() -> Option<OwnerId> {
 /// After disposal, any attempt to access the disposed signals will panic
 /// with a clear error message.
 ///
+/// **Safety note:** disposal is synchronous — never call this from code
+/// the owner itself owns (an effect observing "close myself" would free
+/// its own running closure). Use [`retire_owner`] there instead.
+///
 /// **Note:** This function is not part of the public API and may change.
 /// Cleanup is automatic when using dynamic children or components.
 pub fn dispose_owner(id: OwnerId) {
@@ -370,6 +374,46 @@ pub(crate) fn effect_has_owner(id: EffectId) -> bool {
     OWNERS.with(|owners| owners.borrow().effect_owners.contains_key(&id))
 }
 
+// Owners scheduled for deferred disposal (see `retire_owner`).
+thread_local! {
+    static RETIRED_OWNERS: std::cell::RefCell<Vec<OwnerId>> =
+        const { std::cell::RefCell::new(Vec::new()) };
+}
+
+/// Schedule an owner for disposal at a safe point.
+///
+/// Self-closing UI has to dispose an owner from code that the owner
+/// itself owns: an effect observing a popup's dismissal, a dialog's own
+/// close button. Calling [`dispose_owner`] there would free the closure
+/// currently executing. `retire_owner` queues the disposal instead; the
+/// main loop drains the queue once per iteration, when no user closure
+/// is on the stack.
+///
+/// Retiring the same owner twice (or an already-disposed owner) is
+/// harmless — disposal is idempotent.
+pub fn retire_owner(id: OwnerId) {
+    RETIRED_OWNERS.with(|v| v.borrow_mut().push(id));
+    // Wake the loop so a retirement from a quiet moment (compositor
+    // dismissal with no other activity) is not postponed indefinitely
+    crate::jobs::request_frame();
+}
+
+/// Dispose every retired owner. Called by the main loop at a safe point —
+/// never call from inside reactive computations.
+pub(crate) fn dispose_retired_owners() {
+    // split_off keeps draining safe even if a cleanup callback retires
+    // another owner while running (it lands in the next drain)
+    loop {
+        let batch = RETIRED_OWNERS.with(|v| v.borrow_mut().split_off(0));
+        if batch.is_empty() {
+            return;
+        }
+        for id in batch {
+            dispose_owner(id);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -379,6 +423,53 @@ mod tests {
         let (value, owner_id) = with_owner(|| 42);
         assert_eq!(value, 42);
         dispose_owner(owner_id);
+    }
+
+    /// retire_owner defers: nothing is disposed until the main loop drains
+    /// the queue, so an owned computation can safely retire its own owner
+    /// ("close myself" UI). Double-retiring is harmless.
+    #[test]
+    fn test_retire_owner_defers_disposal() {
+        let cleaned = std::rc::Rc::new(std::cell::Cell::new(false));
+        let flag = cleaned.clone();
+        let (_, owner_id) = with_owner(move || {
+            on_cleanup(move || flag.set(true));
+        });
+
+        retire_owner(owner_id);
+        retire_owner(owner_id); // idempotent
+        assert!(
+            !cleaned.get(),
+            "retire_owner must not dispose synchronously"
+        );
+
+        dispose_retired_owners();
+        assert!(cleaned.get(), "drain must dispose the retired owner");
+
+        // Draining again (and a stale retire) must be a no-op
+        retire_owner(owner_id);
+        dispose_retired_owners();
+    }
+
+    /// A cleanup callback that retires ANOTHER owner while the queue is
+    /// being drained must not be lost.
+    #[test]
+    fn test_retire_owner_during_drain_is_processed() {
+        let cleaned_b = std::rc::Rc::new(std::cell::Cell::new(false));
+        let flag_b = cleaned_b.clone();
+        let (_, owner_b) = with_owner(move || {
+            on_cleanup(move || flag_b.set(true));
+        });
+        let (_, owner_a) = with_owner(move || {
+            on_cleanup(move || retire_owner(owner_b));
+        });
+
+        retire_owner(owner_a);
+        dispose_retired_owners();
+        assert!(
+            cleaned_b.get(),
+            "an owner retired during the drain must be disposed in the same drain"
+        );
     }
 
     /// A disposed owner's slot is recycled with a bumped generation, so a


### PR DESCRIPTION
## Problem

Self-closing UI must dispose an owner **from code that the owner itself owns** — an effect observing a popup's dismissal, a dialog's own close button. `dispose_owner` is synchronous: calling it there frees the closure currently executing.

ashell-guido was forced to hand-roll the workaround (a `RETIRED_POPUP_OWNERS` thread-local drained at the next menu interaction). Deferred, but leak-prone — the last retired owner lives until the next interaction, and every downstream app would have to reinvent the same trick. This is a primitive the runtime should own.

## API

`guido::reactive::retire_owner(id)` queues the disposal and wakes the loop; the main loop drains the queue once per iteration at a safe point (no user closure on the stack). Owners retired by cleanup callbacks *during* the drain are disposed in the same drain; double-retiring or retiring an already-disposed owner is harmless.

`dispose_owner` gains a safety note pointing here.

## Tests

- `test_retire_owner_defers_disposal` — nothing disposed until the drain; idempotent.
- `test_retire_owner_during_drain_is_processed` — a cleanup that retires another owner mid-drain is not lost.

Companion ashell-guido change deletes the hand-rolled list in favor of this.