### PR TITLE
refactor: one public disposal API — dispose_owner is deferred everywhere

### DIFF
--- a/docs/REACTIVE.md
+++ b/docs/REACTIVE.md
@@ -460,16 +460,21 @@ fn create_child(id: u64) -> impl Widget {
 container().children(keyed(move || items.get(), |id| *id, create_child))
 ```
 
-### Self-Closing Scopes: `retire_owner`
+### Disposing Owner Scopes: `dispose_owner`
 
-Self-closing UI must dispose an owner **from code the owner itself owns**
-— an effect observing a popup's dismissal, a dialog's own close button.
-Synchronous disposal there would free the closure currently executing.
-`retire_owner(id)` queues the disposal instead; the main loop drains the
-queue once per iteration, when no user closure is on the stack:
+`guido::reactive::dispose_owner(id)` disposes an owner created with
+`with_owner`: all its signals, effects, and cleanup callbacks.
+
+Disposal is **deferred**: the main loop runs pending disposals once per
+iteration, at a point where no user closure is on the stack. That makes
+it safe to call from anywhere — including code the owner itself owns
+(an effect observing a popup's dismissal, a dialog's own close button)
+and code whose widgets outlive the current instant (a popup surface that
+lives until its Close command is processed). Deferral is a mechanism,
+not a second API: there is nothing to choose between.
 
 ```rust
-use guido::reactive::retire_owner;
+use guido::reactive::dispose_owner;
 
 // The owner id only exists after with_owner returns, so code inside the
 // scope reaches it through app state (a slot, a thread-local registry):
@@ -479,10 +484,10 @@ let (popup, owner_id) = guido::reactive::owner::with_owner(move || {
     spawn_popup(bar, config, move || {
         menu_view(move || {
             // Close button: this callback is owned by the very scope it
-            // is about to tear down — dispose_owner here would free the
-            // closure currently executing. Retiring is safe:
+            // is tearing down — safe, disposal runs at the next loop
+            // iteration:
             if let Some(id) = slot.get() {
-                retire_owner(id);
+                dispose_owner(id);
             }
         })
     })
@@ -490,7 +495,10 @@ let (popup, owner_id) = guido::reactive::owner::with_owner(move || {
 owner_slot.set(Some(owner_id));
 ```
 
-Retiring twice, or retiring an already-disposed owner, is harmless.
+Disposing twice, or disposing an already-disposed owner, is harmless.
+(The library's own teardown paths — surface close, reconcile discard,
+component Drop — use an internal synchronous variant whose ordering
+guarantees they control.)
 
 ### Custom Cleanup Callbacks
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1009,9 +1009,9 @@ impl App {
                 &mut self.tree,
             );
 
-            // Dispose owners retired from inside their own computations
-            // (retire_owner). Safe here: no user closure is on the stack.
-            reactive::owner::dispose_retired_owners();
+            // Run deferred owner disposals (public dispose_owner). Safe
+            // here: no user closure is on the stack.
+            reactive::owner::flush_pending_disposals();
 
             // Process dynamic surface commands
             if !process_surface_commands(
@@ -1116,7 +1116,7 @@ impl Drop for App {
         // Dispose the root owner first — cascades cleanup through the entire
         // reactive graph (signals, effects, cleanup callbacks).
         if let Some(root_id) = self.root_owner_id {
-            reactive::dispose_owner(root_id);
+            reactive::dispose_owner_now(root_id);
         }
 
         // Clear the tree BEFORE resetting jobs. Dropping widgets triggers

--- a/src/reactive/mod.rs
+++ b/src/reactive/mod.rs
@@ -34,16 +34,17 @@ pub use into_signal::{
 pub use into_signal::{IntoSignal, IntoVal};
 pub(crate) use invalidation::with_signal_tracking;
 pub use memo::{Memo, create_memo};
-// Only on_cleanup is public API - with_owner, dispose_owner, and OwnerId are
-// internal and automatically used by the dynamic children system
-pub(crate) use owner::{OwnerId, create_root_owner, dispose_owner, with_owner};
-pub use owner::{on_cleanup, retire_owner};
+// with_owner and OwnerId are internal and automatically used by the
+// dynamic children system; the public dispose_owner is deferred (safe to
+// call from anywhere), the synchronous engine stays crate-internal.
+pub(crate) use owner::{OwnerId, create_root_owner, dispose_owner_now, with_owner};
+pub use owner::{dispose_owner, on_cleanup};
 
 /// Internal module for macro support. NOT PART OF PUBLIC API.
 /// Do not use directly - these are re-exported for proc macros only.
 #[doc(hidden)]
 pub mod __internal {
-    pub use super::owner::{OwnerId, dispose_owner, with_owner};
+    pub use super::owner::{OwnerId, dispose_owner_now as dispose_owner, with_owner};
     pub use super::runtime::batch;
 }
 pub(crate) use runtime::flush_bg_writes;

--- a/src/reactive/owner.rs
+++ b/src/reactive/owner.rs
@@ -241,13 +241,15 @@ pub fn current_owner() -> Option<OwnerId> {
 /// After disposal, any attempt to access the disposed signals will panic
 /// with a clear error message.
 ///
-/// **Safety note:** disposal is synchronous — never call this from code
-/// the owner itself owns (an effect observing "close myself" would free
-/// its own running closure). Use [`retire_owner`] there instead.
-///
-/// **Note:** This function is not part of the public API and may change.
-/// Cleanup is automatic when using dynamic children or components.
-pub fn dispose_owner(id: OwnerId) {
+/// Internal engine: synchronous disposal, used by the library's own
+/// teardown paths (surface close, reconcile discard, component Drop)
+/// where ordering invariants are controlled. A running effect that
+/// disposes its own owner is protected by the runtime's take/put-back
+/// callback pattern (`EffectState::DisposedWhileRunning`), but code
+/// after the call must not touch the owner's signals — public callers
+/// get the deferred [`dispose_owner`] instead, which is safe anywhere.
+#[doc(hidden)]
+pub fn dispose_owner_now(id: OwnerId) {
     // Take the owner out of the arena and prune it from its parent's
     // children list. Without the pruning, long-lived parents (most notably
     // the root owner) accumulate one dead child entry for every owner ever
@@ -272,7 +274,7 @@ pub fn dispose_owner(id: OwnerId) {
 
     // Dispose children first (depth-first)
     for child_id in owner.children {
-        dispose_owner(child_id);
+        dispose_owner_now(child_id);
     }
 
     // Run cleanup callbacks in reverse order (LIFO)
@@ -374,42 +376,42 @@ pub(crate) fn effect_has_owner(id: EffectId) -> bool {
     OWNERS.with(|owners| owners.borrow().effect_owners.contains_key(&id))
 }
 
-// Owners scheduled for deferred disposal (see `retire_owner`).
+// Owners scheduled for deferred disposal (see `dispose_owner`).
 thread_local! {
-    static RETIRED_OWNERS: std::cell::RefCell<Vec<OwnerId>> =
+    static PENDING_DISPOSALS: std::cell::RefCell<Vec<OwnerId>> =
         const { std::cell::RefCell::new(Vec::new()) };
 }
 
-/// Schedule an owner for disposal at a safe point.
+/// Dispose an owner: all its signals, effects, and cleanup callbacks.
 ///
-/// Self-closing UI has to dispose an owner from code that the owner
-/// itself owns: an effect observing a popup's dismissal, a dialog's own
-/// close button. Calling [`dispose_owner`] there would free the closure
-/// currently executing. `retire_owner` queues the disposal instead; the
-/// main loop drains the queue once per iteration, when no user closure
-/// is on the stack.
+/// Disposal is **deferred**: the main loop drains pending disposals once
+/// per iteration, at a point where no user closure is on the stack. That
+/// makes this safe to call from anywhere — including code the owner
+/// itself owns (an effect observing a popup's dismissal, a dialog's own
+/// close button) and code whose widgets outlive the current instant
+/// (a popup surface that lives until its Close command is processed).
 ///
-/// Retiring the same owner twice (or an already-disposed owner) is
-/// harmless — disposal is idempotent.
-pub fn retire_owner(id: OwnerId) {
-    RETIRED_OWNERS.with(|v| v.borrow_mut().push(id));
-    // Wake the loop so a retirement from a quiet moment (compositor
+/// Disposing the same owner twice (or an already-disposed owner) is
+/// harmless.
+pub fn dispose_owner(id: OwnerId) {
+    PENDING_DISPOSALS.with(|v| v.borrow_mut().push(id));
+    // Wake the loop so a disposal requested in a quiet moment (compositor
     // dismissal with no other activity) is not postponed indefinitely
     crate::jobs::request_frame();
 }
 
-/// Dispose every retired owner. Called by the main loop at a safe point —
-/// never call from inside reactive computations.
-pub(crate) fn dispose_retired_owners() {
-    // split_off keeps draining safe even if a cleanup callback retires
-    // another owner while running (it lands in the next drain)
+/// Run every pending deferred disposal. Called by the main loop at a safe
+/// point — never call from inside reactive computations.
+pub(crate) fn flush_pending_disposals() {
+    // split_off keeps draining safe even if a cleanup callback disposes
+    // another owner while running (it lands in the next batch)
     loop {
-        let batch = RETIRED_OWNERS.with(|v| v.borrow_mut().split_off(0));
+        let batch = PENDING_DISPOSALS.with(|v| v.borrow_mut().split_off(0));
         if batch.is_empty() {
             return;
         }
         for id in batch {
-            dispose_owner(id);
+            dispose_owner_now(id);
         }
     }
 }
@@ -422,53 +424,53 @@ mod tests {
     fn test_with_owner_basic() {
         let (value, owner_id) = with_owner(|| 42);
         assert_eq!(value, 42);
-        dispose_owner(owner_id);
+        dispose_owner_now(owner_id);
     }
 
-    /// retire_owner defers: nothing is disposed until the main loop drains
-    /// the queue, so an owned computation can safely retire its own owner
-    /// ("close myself" UI). Double-retiring is harmless.
+    /// The public dispose_owner defers: nothing is disposed until the main
+    /// loop flushes, so an owned computation can safely dispose its own
+    /// owner ("close myself" UI). Double-disposing is harmless.
     #[test]
-    fn test_retire_owner_defers_disposal() {
+    fn test_dispose_owner_defers_disposal() {
         let cleaned = std::rc::Rc::new(std::cell::Cell::new(false));
         let flag = cleaned.clone();
         let (_, owner_id) = with_owner(move || {
             on_cleanup(move || flag.set(true));
         });
 
-        retire_owner(owner_id);
-        retire_owner(owner_id); // idempotent
+        dispose_owner(owner_id);
+        dispose_owner(owner_id); // idempotent
         assert!(
             !cleaned.get(),
-            "retire_owner must not dispose synchronously"
+            "public dispose_owner must not dispose synchronously"
         );
 
-        dispose_retired_owners();
-        assert!(cleaned.get(), "drain must dispose the retired owner");
+        flush_pending_disposals();
+        assert!(cleaned.get(), "flush must dispose the pending owner");
 
-        // Draining again (and a stale retire) must be a no-op
-        retire_owner(owner_id);
-        dispose_retired_owners();
+        // Flushing again (and a stale dispose) must be a no-op
+        dispose_owner(owner_id);
+        flush_pending_disposals();
     }
 
-    /// A cleanup callback that retires ANOTHER owner while the queue is
-    /// being drained must not be lost.
+    /// A cleanup callback that disposes ANOTHER owner while the queue is
+    /// being flushed must not be lost.
     #[test]
-    fn test_retire_owner_during_drain_is_processed() {
+    fn test_dispose_during_flush_is_processed() {
         let cleaned_b = std::rc::Rc::new(std::cell::Cell::new(false));
         let flag_b = cleaned_b.clone();
         let (_, owner_b) = with_owner(move || {
             on_cleanup(move || flag_b.set(true));
         });
         let (_, owner_a) = with_owner(move || {
-            on_cleanup(move || retire_owner(owner_b));
+            on_cleanup(move || dispose_owner(owner_b));
         });
 
-        retire_owner(owner_a);
-        dispose_retired_owners();
+        dispose_owner(owner_a);
+        flush_pending_disposals();
         assert!(
             cleaned_b.get(),
-            "an owner retired during the drain must be disposed in the same drain"
+            "an owner disposed during the flush must be handled in the same flush"
         );
     }
 
@@ -477,7 +479,7 @@ mod tests {
     #[test]
     fn test_stale_owner_id_cannot_alias_recycled_slot() {
         let (_, first) = with_owner(|| ());
-        dispose_owner(first);
+        dispose_owner_now(first);
 
         // Reuses the freed slot
         let disposed = std::rc::Rc::new(std::cell::Cell::new(false));
@@ -489,10 +491,10 @@ mod tests {
         assert_ne!(first.generation, second.generation);
 
         // Disposing via the stale ID must be a no-op
-        dispose_owner(first);
+        dispose_owner_now(first);
         assert!(!disposed.get(), "stale OwnerId disposed the new owner");
 
-        dispose_owner(second);
+        dispose_owner_now(second);
         assert!(disposed.get());
     }
 
@@ -507,7 +509,7 @@ mod tests {
         });
 
         for child in &child_ids {
-            dispose_owner(*child);
+            dispose_owner_now(*child);
         }
 
         OWNERS.with(|owners| {
@@ -520,7 +522,7 @@ mod tests {
             );
         });
 
-        dispose_owner(parent_id);
+        dispose_owner_now(parent_id);
     }
 
     #[test]
@@ -565,7 +567,7 @@ mod tests {
         });
 
         // Dispose the outer owner
-        dispose_owner(outer_id);
+        dispose_owner_now(outer_id);
 
         // Children should be disposed first
         let order = cleanup_order.lock().unwrap();
@@ -594,7 +596,7 @@ mod tests {
             });
         });
 
-        dispose_owner(owner_id);
+        dispose_owner_now(owner_id);
 
         // Should be reverse order (LIFO)
         let order = cleanup_order.lock().unwrap();
@@ -606,8 +608,8 @@ mod tests {
         let (_, owner_id) = with_owner(|| {});
 
         // Should not panic
-        dispose_owner(owner_id);
-        dispose_owner(owner_id);
+        dispose_owner_now(owner_id);
+        dispose_owner_now(owner_id);
     }
 
     #[test]
@@ -634,7 +636,7 @@ mod tests {
         );
 
         // Dispose the owner
-        dispose_owner(owner_id);
+        dispose_owner_now(owner_id);
 
         // Effect should no longer be owned (removed from reverse mapping)
         assert!(
@@ -653,7 +655,7 @@ mod tests {
         assert_eq!(signal.get(), 42);
 
         // Dispose the owner
-        dispose_owner(owner_id);
+        dispose_owner_now(owner_id);
 
         // Note: accessing disposed signal should panic, but we don't test that
         // here since it would terminate the test. The storage.rs tests cover
@@ -685,7 +687,7 @@ mod tests {
         assert!(effect_has_owner(effect_ids.2));
 
         // Dispose
-        dispose_owner(owner_id);
+        dispose_owner_now(owner_id);
 
         // None should be owned anymore
         assert!(!effect_has_owner(effect_ids.0));
@@ -718,7 +720,7 @@ mod tests {
         assert!(effect_has_owner(outer_effect));
 
         // Dispose outer (which should dispose inner first due to depth-first)
-        dispose_owner(outer_id);
+        dispose_owner_now(outer_id);
 
         // Both should be disposed
         assert!(!effect_has_owner(inner_effect));
@@ -737,7 +739,7 @@ mod tests {
         assert_eq!(signal.get(), 42);
 
         // Dispose root owner — cascades signal disposal
-        dispose_owner(root_id);
+        dispose_owner_now(root_id);
 
         // Signal should be disposed (reading would panic)
         let panicked = std::panic::catch_unwind(|| signal.get()).is_err();
@@ -754,7 +756,7 @@ mod tests {
         assert_eq!(signal2.get(), 99);
 
         // Cleanup
-        dispose_owner(new_root);
+        dispose_owner_now(new_root);
         reset_owners();
     }
 }

--- a/src/reactive/service.rs
+++ b/src/reactive/service.rs
@@ -183,7 +183,7 @@ fn service_runtime() -> tokio::runtime::Handle {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::reactive::owner::{dispose_owner, with_owner};
+    use crate::reactive::owner::{dispose_owner_now, with_owner};
     use std::sync::atomic::AtomicI32;
     use std::time::Duration;
 
@@ -213,7 +213,7 @@ mod tests {
         }
         assert_eq!(received.load(Ordering::SeqCst), 5);
 
-        dispose_owner(owner_id);
+        dispose_owner_now(owner_id);
     }
 
     #[tokio::test]
@@ -236,7 +236,7 @@ mod tests {
         assert!(count_before > 0, "Service should have run at least once");
 
         // Dispose the owner
-        dispose_owner(owner_id);
+        dispose_owner_now(owner_id);
 
         // Wait for service to notice and stop
         tokio::time::sleep(Duration::from_millis(50)).await;
@@ -283,7 +283,7 @@ mod tests {
         assert_eq!(received.load(Ordering::SeqCst), 60);
 
         // Cleanup
-        dispose_owner(owner_id);
+        dispose_owner_now(owner_id);
     }
 
     #[tokio::test]
@@ -315,6 +315,6 @@ mod tests {
 
         assert_eq!(received.load(Ordering::SeqCst), 12);
 
-        dispose_owner(owner_id);
+        dispose_owner_now(owner_id);
     }
 }

--- a/src/reactive/signal.rs
+++ b/src/reactive/signal.rs
@@ -559,10 +559,10 @@ mod tests {
     /// wrote the new signal's value.
     #[test]
     fn test_stale_handle_does_not_alias_recycled_slot() {
-        use super::super::owner::{dispose_owner, with_owner};
+        use super::super::owner::{dispose_owner_now, with_owner};
 
         let (stale, owner_id) = with_owner(|| create_signal(1_i32));
-        dispose_owner(owner_id);
+        dispose_owner_now(owner_id);
 
         // Recycles the freed slot with the same value type
         let fresh = create_signal(2_i32);

--- a/src/reactive/storage.rs
+++ b/src/reactive/storage.rs
@@ -343,14 +343,14 @@ pub fn has_signal(id: SignalId) -> bool {
 #[cfg(test)]
 mod dispose_write_tests {
     use crate::reactive::create_signal;
-    use crate::reactive::owner::{dispose_owner, with_owner};
+    use crate::reactive::owner::{dispose_owner_now, with_owner};
 
     /// Writes race disposal by design (queued WriteSignal flushes, delayed
     /// timers): they must be dropped, not panic.
     #[test]
     fn write_to_disposed_signal_is_a_noop() {
         let (sig, owner) = with_owner(|| create_signal(1u32));
-        dispose_owner(owner);
+        dispose_owner_now(owner);
         sig.set(2); // must not panic
         sig.update(|v| *v += 1); // must not panic
     }

--- a/src/surface_manager.rs
+++ b/src/surface_manager.rs
@@ -9,7 +9,7 @@ use smithay_client_toolkit::reexports::client::Connection;
 
 use crate::layout::Constraints;
 use crate::platform::{WaylandState, WaylandWindowWrapper};
-use crate::reactive::owner::{OwnerId, dispose_owner};
+use crate::reactive::owner::{OwnerId, dispose_owner_now};
 use crate::renderer::{FlattenedCommand, GpuContext, RenderNode, SurfaceState};
 use crate::surface::{SurfaceConfig, SurfaceId};
 use crate::tree::{Tree, WidgetId};
@@ -129,7 +129,7 @@ impl ManagedSurface {
 
 impl Drop for ManagedSurface {
     fn drop(&mut self) {
-        dispose_owner(self.owner_id);
+        dispose_owner_now(self.owner_id);
     }
 }
 
@@ -254,7 +254,7 @@ mod tests {
 
     use super::*;
     use crate::layout::{Constraints, Size};
-    use crate::reactive::owner::{dispose_owner as dispose, with_owner};
+    use crate::reactive::owner::{dispose_owner_now as dispose, with_owner};
     use crate::reactive::{create_memo, create_signal};
     use crate::widgets::Widget;
     use crate::widgets::children::ChildrenSource;

--- a/src/widgets/children.rs
+++ b/src/widgets/children.rs
@@ -3,7 +3,7 @@ use std::rc::Rc;
 
 use crate::jobs::{JobRequest, request_job};
 use crate::layout::{Constraints, Size};
-use crate::reactive::{OwnerId, dispose_owner};
+use crate::reactive::{OwnerId, dispose_owner_now};
 use crate::renderer::PaintContext;
 use crate::tree::{Tree, WidgetId};
 
@@ -456,7 +456,7 @@ struct OwnerGuard(OwnerId);
 
 impl Drop for OwnerGuard {
     fn drop(&mut self) {
-        dispose_owner(self.0);
+        dispose_owner_now(self.0);
     }
 }
 
@@ -489,7 +489,7 @@ impl OwnedWidget {
 impl Drop for OwnedWidget {
     fn drop(&mut self) {
         if let OwnerHandle::Exclusive(owner_id) = self.owner {
-            dispose_owner(owner_id);
+            dispose_owner_now(owner_id);
         }
         // Shared: the SharedOwner guard disposes when its last clone drops
     }

--- a/src/widgets/into_child.rs
+++ b/src/widgets/into_child.rs
@@ -29,7 +29,7 @@ use std::collections::HashMap;
 use std::rc::Rc;
 
 use crate::reactive::invalidation::suspend_widget_tracking;
-use crate::reactive::{OwnerId, dispose_owner, with_owner};
+use crate::reactive::{OwnerId, dispose_owner_now, with_owner};
 
 use super::Widget;
 use super::children::{ChildrenSource, DynItem, OwnedWidget, SharedOwner};
@@ -111,7 +111,7 @@ where
             // Defensive: a widget stashed by a previous pass that was never
             // adopted would leak its owner scope.
             if let Some((_, owner_id)) = st.pending.take() {
-                dispose_owner(owner_id);
+                dispose_owner_now(owner_id);
             }
 
             let child_fn = Rc::clone(&child_fn);
@@ -130,7 +130,7 @@ where
                     })]
                 }
                 None => {
-                    dispose_owner(owner_id);
+                    dispose_owner_now(owner_id);
                     vec![]
                 }
             }
@@ -216,7 +216,7 @@ where
                     .collect::<Vec<_>>()
             });
             if widgets.is_empty() {
-                dispose_owner(owner_id);
+                dispose_owner_now(owner_id);
                 return vec![];
             }
 
@@ -347,7 +347,7 @@ fn add_keyed_children<T, I, W>(
         // Defensive: widgets stashed by a previous pass that were never
         // adopted would leak their owner scopes.
         for (_, (_, owner_id)) in st.pending.drain() {
-            dispose_owner(owner_id);
+            dispose_owner_now(owner_id);
         }
 
         let mut seen = std::collections::HashSet::new();


### PR DESCRIPTION
Follow-up to #140 after an API review: two public disposal functions with a doc comment deciding which one is safe is bad design. Survey of peer libraries:

- **SolidJS**: one synchronous dispose; safe because GC keeps the running closure alive. Not transferable to Rust.
- **Leptos**: safety via Arc-refcounted owners; still ships three cleanup entry points because immediate-vs-deferred is a real semantic axis — but safety never depends on docs.
- **Floem** (closest cousin: Rust, arena, single-threaded): **one** `dispose`; deferral exists as an internal mechanism (cross-thread enqueue), not as a second public API.

This adopts the Floem shape:

- Public `dispose_owner(id)` **always defers** — the main loop flushes pending disposals once per iteration with no user closure on the stack. Safe from anywhere: self-closing scopes, and scopes whose widgets outlive the current instant (popups alive until their Close command processes). `retire_owner` is gone.
- The synchronous engine survives as doc-hidden `dispose_owner_now` for the library's own teardown paths (surface close, reconcile discard, component-macro Drop) where ordering invariants are controlled.
- Corrected a wrong claim from #140's safety note: a running effect disposing its own owner never freed the running closure — the runtime's take/put-back pattern (`EffectState::DisposedWhileRunning`) already guards that. The docs now say what is actually true.

Tests updated: engine tests exercise `dispose_owner_now`; deferred-semantics tests exercise the public API (defer-until-flush, idempotence, dispose-during-flush).