### PR TITLE
feat: write-site equality — set_always, update_always, create_trigger

### DIFF
--- a/book/src/concepts/reactive-model.md
+++ b/book/src/concepts/reactive-model.md
@@ -28,6 +28,33 @@ count.update(|c| *c += 1);
 - **Automatic tracking** - Dependencies are tracked when reading inside reactive contexts
 - **Converts to Signal** - Call `.read_only()` or `.into()` to get a read-only `Signal<T>`
 
+## State vs. Triggers: `set` and `set_always`
+
+`set` publishes **state**: equal values are deduplicated (`PartialEq`),
+so republishing unchanged data costs nothing. `set_always` fires a
+**trigger**: every write notifies, no comparison, no `PartialEq` bound —
+the natural write for "something happened" values like an OSD flash:
+
+```rust
+volume.set(50);          // state: setting 50 twice notifies once
+osd.set_always(info);    // trigger: every flash notifies
+```
+
+For a data-less pulse there is `Trigger`:
+
+```rust
+let refresh = create_trigger();
+create_effect(move || {
+    refresh.track();
+    rebuild();
+});
+refresh.notify(); // rebuild() runs every time
+```
+
+Signals hold one value, so rapid `set_always` calls coalesce to the last
+one per frame — perfect for UI triggers, wrong for event streams that
+must not lose emissions (those belong in an async channel).
+
 ## Signal (Read-Only)
 
 `Signal<T>` is a read-only reactive value (12 bytes, `Copy`). It cannot be written to — calling `.set()` is a compile-time error. There are two ways to create one:

--- a/docs/REACTIVE.md
+++ b/docs/REACTIVE.md
@@ -261,6 +261,46 @@ let service = create_service(move |mut rx, ctx| async move {
 service.send(Cmd::Refresh);
 ```
 
+## State vs. Events (Write-Site Equality)
+
+A signal is **state**: a cell holding a current value, notifying when the
+value *changes*. `set` compares with `PartialEq` and deduplicates equal
+writes — that is what keeps an idle bar idle when services republish
+unchanged data.
+
+An **event** is different: two identical emissions are two emissions.
+Rather than a separate signal variant, equality is a property of the
+**write site** — the writer knows whether it is publishing state or
+firing a trigger:
+
+```rust
+volume.set(50);          // state: equal values deduplicate
+osd.set_always(info);    // trigger: every emission notifies
+refresh.notify();        // Trigger (create_trigger) = RwSignal<()> + set_always
+```
+
+`set_always` / `update_always` (and their `WriteSignal` counterparts)
+have no `PartialEq` bound — types without meaningful equality can only
+be written this way, and the compiler steers them there. `create_signal`
+itself requires only `Clone + Send`.
+
+Two caveats define the boundary of this tool:
+
+- A signal still holds ONE value: two `set_always` calls before the
+  consumer runs coalesce to the last value. That is correct for
+  frame-coalescing triggers (an OSD flash, an animation kick) — the
+  screen only shows the last frame anyway. **Event streams that must not
+  lose emissions belong in an async channel** (a service's command
+  queue), not in the reactive graph.
+- Never fake events by giving a type a lying `PartialEq` (a version
+  counter compared instead of the data): it breaks `==` for every other
+  use and hides the intent. `set_always` says the same thing honestly.
+
+For comparison: Solid deduplicates by default with per-signal opt-out
+(`equals: false`); Leptos and Floem never deduplicate on `set` and rely
+on `Memo` for cutoff. Guido keeps dedup as the default (idle cost
+matters here) and opts out per-write.
+
 ## Signal Internals
 
 Signals are lightweight handles that index into thread-local storage:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,10 +141,10 @@ pub mod prelude {
     pub use crate::outputs::{OutputId, OutputInfo, outputs, surface_output};
     pub use crate::platform::{Anchor, KeyboardInteractivity, Layer};
     pub use crate::reactive::{
-        CursorIcon, Memo, OptionSignalExt, RwSignal, Service, Signal, WriteSignal, create_derived,
-        create_effect, create_memo, create_service, create_signal, create_stored, expect_context,
-        has_context, on_cleanup, provide_context, provide_signal_context, set_cursor, use_context,
-        with_context,
+        CursorIcon, Memo, OptionSignalExt, RwSignal, Service, Signal, Trigger, WriteSignal,
+        create_derived, create_effect, create_memo, create_service, create_signal, create_stored,
+        create_trigger, expect_context, has_context, on_cleanup, provide_context,
+        provide_signal_context, set_cursor, use_context, with_context,
     };
     pub use crate::renderer::{PaintContext, Shadow, measure_text};
     pub use crate::session_lock::{

--- a/src/reactive/mod.rs
+++ b/src/reactive/mod.rs
@@ -12,6 +12,7 @@ pub mod runtime;
 pub mod service;
 pub mod signal;
 pub mod storage;
+mod trigger;
 
 pub(crate) use clipboard::{
     clear_system_clipboard, set_system_clipboard, set_system_primary, take_clipboard_change,
@@ -39,6 +40,7 @@ pub use memo::{Memo, create_memo};
 // call from anywhere), the synchronous engine stays crate-internal.
 pub(crate) use owner::{OwnerId, create_root_owner, dispose_owner_now, with_owner};
 pub use owner::{dispose_owner, on_cleanup};
+pub use trigger::{Trigger, create_trigger};
 
 /// Internal module for macro support. NOT PART OF PUBLIC API.
 /// Do not use directly - these are re-exported for proc macros only.

--- a/src/reactive/signal.rs
+++ b/src/reactive/signal.rs
@@ -99,6 +99,22 @@ fn update_and_notify<T: Clone + PartialEq + 'static>(id: SignalId, f: impl FnOnc
     }
 }
 
+/// Write without comparison: every write notifies (main thread only).
+fn write_and_notify_always<T: Clone + 'static>(id: SignalId, value: T) {
+    if crate::reactive::storage::set_signal_value_always(id, value) {
+        notify_signal_change(id);
+        notify_write(id);
+    }
+}
+
+/// Update without comparison: every update notifies (main thread only).
+fn update_and_notify_always<T: Clone + 'static>(id: SignalId, f: impl FnOnce(&mut T)) {
+    if crate::reactive::storage::update_signal_value_always(id, f) {
+        notify_signal_change(id);
+        notify_write(id);
+    }
+}
+
 /// A read-only reactive signal.
 ///
 /// `Signal<T>` provides read access to reactive values. It is returned by
@@ -216,7 +232,11 @@ impl<T: Clone + 'static> RwSignal<T> {
 }
 
 impl<T: Clone + PartialEq + 'static> RwSignal<T> {
-    /// Set a new value (notifies subscribers if changed)
+    /// Set a new value (notifies subscribers if changed).
+    ///
+    /// This is the STATE write: equal values are deduplicated. For
+    /// trigger-style writes where every emission must notify — or for
+    /// types with no meaningful `PartialEq` — use [`RwSignal::set_always`].
     pub fn set(&self, value: T) {
         write_and_notify(self.id, value);
     }
@@ -227,7 +247,31 @@ impl<T: Clone + PartialEq + 'static> RwSignal<T> {
     }
 }
 
-impl<T: Clone + PartialEq + Send + 'static> RwSignal<T> {
+impl<T: Clone + 'static> RwSignal<T> {
+    /// Set a new value, notifying subscribers unconditionally.
+    ///
+    /// Equality is a property of the WRITE SITE, not of the signal: `set`
+    /// publishes state (equal values deduplicate), `set_always` fires a
+    /// trigger (every emission notifies). No `PartialEq` bound — types
+    /// without meaningful equality can only be written this way, and the
+    /// compiler steers them here.
+    ///
+    /// Note that a signal still holds ONE value: two `set_always` calls
+    /// before the consumer runs coalesce to the last value (one
+    /// notification per flush). That is correct for frame-coalescing
+    /// triggers (an OSD flash, an animation kick); event streams that
+    /// must not lose emissions belong in an async channel, not a signal.
+    pub fn set_always(&self, value: T) {
+        write_and_notify_always(self.id, value);
+    }
+
+    /// Update the value using a closure, notifying unconditionally.
+    pub fn update_always<F: FnOnce(&mut T)>(&self, f: F) {
+        update_and_notify_always(self.id, f);
+    }
+}
+
+impl<T: Clone + Send + 'static> RwSignal<T> {
     /// Get a `WriteSignal<T>` for writing from background threads.
     ///
     /// `WriteSignal<T>` is `Send` and can be captured in `create_service` closures.
@@ -334,6 +378,51 @@ impl<T: Clone + PartialEq + Send + 'static> WriteSignal<T> {
     }
 }
 
+impl<T: Clone + Send + 'static> WriteSignal<T> {
+    /// Sets the signal's value, notifying subscribers unconditionally.
+    ///
+    /// The trigger-style counterpart of [`WriteSignal::set`]: no
+    /// comparison, no `PartialEq` bound. Same threading semantics
+    /// (immediate on the main thread, queued for the next frame from
+    /// background threads).
+    pub fn set_always(&self, value: T) {
+        if has_signal(self.id) {
+            write_and_notify_always(self.id, value);
+        } else {
+            let id = self.id;
+            let epoch = self.epoch;
+            queue_bg_write(epoch, move || {
+                // See `set()`: disposal can race a queued write; drop it.
+                if has_signal(id) {
+                    write_and_notify_always(id, value);
+                } else {
+                    log::debug!("dropping background write to disposed signal {id}");
+                }
+            });
+        }
+    }
+
+    /// Updates the signal's value using a closure, notifying unconditionally.
+    pub fn update_always<F>(&self, f: F)
+    where
+        F: FnOnce(&mut T) + Send + 'static,
+    {
+        if has_signal(self.id) {
+            update_and_notify_always(self.id, f);
+        } else {
+            let id = self.id;
+            let epoch = self.epoch;
+            queue_bg_write(epoch, move || {
+                if has_signal(id) {
+                    update_and_notify_always(id, f);
+                } else {
+                    log::debug!("dropping background update to disposed signal {id}");
+                }
+            });
+        }
+    }
+}
+
 /// Create a read-write reactive signal.
 ///
 /// Returns an [`RwSignal<T>`] that supports both reading and writing.
@@ -347,7 +436,7 @@ impl<T: Clone + PartialEq + Send + 'static> WriteSignal<T> {
 /// count.get();            // read
 /// container().padding(count) // auto-converts to Signal<T> via IntoSignal
 /// ```
-pub fn create_signal<T: Clone + PartialEq + Send + 'static>(value: T) -> RwSignal<T> {
+pub fn create_signal<T: Clone + Send + 'static>(value: T) -> RwSignal<T> {
     let id = create_signal_value(value);
     // Safe even inside effect callbacks: the runtime borrow is never held
     // across user code anymore.
@@ -597,5 +686,52 @@ mod tests {
         let writer = signal.writer();
         writer.update(|v| *v += 5);
         assert_eq!(signal.get(), 15);
+    }
+
+    /// Equality is a property of the write site: `set` deduplicates equal
+    /// values, `set_always` notifies unconditionally.
+    #[test]
+    fn set_dedups_but_set_always_notifies() {
+        use crate::reactive::create_effect;
+        use std::cell::Cell;
+        use std::rc::Rc;
+
+        let sig = create_signal(7);
+        let runs = Rc::new(Cell::new(0));
+        let counter = runs.clone();
+        create_effect(move || {
+            let _ = sig.get();
+            counter.set(counter.get() + 1);
+        })
+        .detach();
+        assert_eq!(runs.get(), 1);
+
+        sig.set(7); // equal: state write deduplicates
+        assert_eq!(runs.get(), 1, "set of an equal value must not notify");
+
+        sig.set_always(7); // equal, but trigger write
+        assert_eq!(runs.get(), 2, "set_always must notify unconditionally");
+    }
+
+    /// A type with no `PartialEq` can live in a signal — the compiler
+    /// steers it to the trigger-style writes.
+    #[test]
+    fn non_partialeq_type_uses_always_writes() {
+        #[derive(Clone)]
+        struct Snapshot {
+            value: u32,
+        }
+
+        let sig = create_signal(Snapshot { value: 1 });
+        sig.set_always(Snapshot { value: 2 });
+        assert_eq!(sig.with(|s| s.value), 2);
+
+        sig.update_always(|s| s.value += 1);
+        assert_eq!(sig.with(|s| s.value), 3);
+
+        // Background-writer path too (same-thread branch)
+        let w = sig.writer();
+        w.set_always(Snapshot { value: 10 });
+        assert_eq!(sig.with(|s| s.value), 10);
     }
 }

--- a/src/reactive/storage.rs
+++ b/src/reactive/storage.rs
@@ -308,6 +308,33 @@ pub fn compare_and_update_signal_value<T: Clone + PartialEq + 'static>(
     old != *current
 }
 
+/// Set unconditionally: no comparison, no `PartialEq` bound. Returns
+/// `true` if the write landed (`false` only when the slot is disposed).
+///
+/// Backs [`RwSignal::set_always`]: trigger-style writes where every
+/// emission must notify (or where the type has no meaningful equality).
+pub fn set_signal_value_always<T: 'static>(id: SignalId, value: T) -> bool {
+    let Some(rc) = try_clone_slot_rc(id) else {
+        log::warn!("ignoring write to disposed signal {id}");
+        return false;
+    };
+    let cell = downcast_cell::<T>(&rc, id);
+    *cell.borrow_mut() = value;
+    true
+}
+
+/// Update unconditionally: no comparison, no `PartialEq` bound. Returns
+/// `true` if the update ran (`false` only when the slot is disposed).
+pub fn update_signal_value_always<T: 'static>(id: SignalId, f: impl FnOnce(&mut T)) -> bool {
+    let Some(rc) = try_clone_slot_rc(id) else {
+        log::warn!("ignoring update of disposed signal {id}");
+        return false;
+    };
+    let cell = downcast_cell::<T>(&rc, id);
+    f(&mut cell.borrow_mut());
+    true
+}
+
 fn downcast_cell<T: 'static>(rc: &Rc<dyn Any>, id: SignalId) -> &RefCell<T> {
     rc.downcast_ref::<RefCell<T>>().unwrap_or_else(|| {
         panic!(

--- a/src/reactive/trigger.rs
+++ b/src/reactive/trigger.rs
@@ -1,0 +1,83 @@
+//! Data-less reactive notifier (Leptos/Floem-style `Trigger`).
+
+use super::signal::{RwSignal, create_signal};
+
+/// A data-less reactive notifier: `notify()` re-runs everything that
+/// `track()`ed it, unconditionally.
+///
+/// Sugar over an `RwSignal<()>` written with [`RwSignal::set_always`] —
+/// the trigger-style write with no equality semantics. Use it to push a
+/// "something happened" pulse through the reactive graph when there is no
+/// value to carry (external data changed, a cache was invalidated):
+///
+/// ```ignore
+/// let refresh = create_trigger();
+///
+/// create_effect(move || {
+///     refresh.track();
+///     rebuild_from_external_source();
+/// });
+///
+/// refresh.notify(); // effect re-runs, every time
+/// ```
+///
+/// `Copy` like every signal; owner-scoped like every signal (disposed with
+/// the scope that created it). Notifications coalesce per flush like any
+/// signal write — event streams that must not lose emissions belong in an
+/// async channel, not in the reactive graph.
+#[derive(Clone, Copy)]
+pub struct Trigger {
+    inner: RwSignal<()>,
+}
+
+/// Create a [`Trigger`], owned by the current owner scope.
+///
+/// Free-function constructor matching the rest of the reactive API
+/// (`create_signal`, `create_memo`, `create_effect`).
+pub fn create_trigger() -> Trigger {
+    Trigger {
+        inner: create_signal(()),
+    }
+}
+
+impl Trigger {
+    /// Notify every tracker, unconditionally.
+    pub fn notify(&self) {
+        self.inner.set_always(());
+    }
+
+    /// Track this trigger from reactive code (an effect, a widget
+    /// closure): the caller re-runs on every [`Trigger::notify`].
+    pub fn track(&self) {
+        self.inner.get();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::reactive::create_effect;
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    #[test]
+    fn notify_reruns_trackers_every_time() {
+        let trigger = create_trigger();
+        let runs = Rc::new(Cell::new(0));
+        let counter = runs.clone();
+        create_effect(move || {
+            trigger.track();
+            counter.set(counter.get() + 1);
+        })
+        .detach();
+        assert_eq!(runs.get(), 1, "initial run");
+
+        trigger.notify();
+        trigger.notify();
+        assert_eq!(
+            runs.get(),
+            3,
+            "every notify must re-run the tracker — no equality dedup on ()"
+        );
+    }
+}


### PR DESCRIPTION
Closes the "events squeezed into state primitives" class found by the ashell-guido audit. Peer survey (Solid: per-signal `equals: false`; Leptos/Floem: never dedup, Memo is the cutoff; Qt: properties vs signals as separate primitives) led to a middle road suited to an idle-cost-sensitive library:

## Equality is a property of the write site

```rust
volume.set(50);           // state: equal values deduplicate (unchanged)
osd.set_always(info);     // trigger: every emission notifies, no PartialEq bound
refresh.notify();         // Trigger = create_trigger(), sugar over RwSignal<()> + set_always
```

- `create_signal` bound relaxed to `Clone + Send`: the PartialEq bound moves to `set`/`update`. Types without meaningful equality (verbatim upstream service snapshots) live in ordinary signals; the compiler steers them to `set_always`/`update_always`. No new signal variant, no options struct.
- Same pair on `WriteSignal` over the existing background queue.
- `create_trigger()` — the Leptos/Floem data-less notifier, free-function named per the `create_*` convention.
- Docs: "State vs. Events" section (REACTIVE.md + book) states the two boundaries explicitly — always-writes coalesce per flush (event streams that must not lose emissions belong in async channels), and version-counter PartialEq lies are an antipattern with a named replacement.

Downstream: lets ashell-guido delete `Versioned<T>` and four hand-rolled version-only PartialEq impls (next PR).

Tests: dedup-vs-always effect-run counts, non-PartialEq type end-to-end incl. writer, trigger re-runs per notify.