### PR TITLE
feat: content-sized layer surfaces and intent-based exclusive zones

### DIFF
--- a/examples/blur_example.rs
+++ b/examples/blur_example.rs
@@ -19,7 +19,7 @@ fn main() {
                 .anchor(Anchor::TOP)
                 .margin(120, 0, 0, 0)
                 .layer(Layer::Overlay)
-                .exclusive_zone(Some(0))
+                .exclusive_zone(ExclusiveZone::None)
                 .background_color(Color::TRANSPARENT),
             move || {
                 container()

--- a/examples/input_region.rs
+++ b/examples/input_region.rs
@@ -18,7 +18,7 @@ fn main() {
                 .height(80)
                 .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
                 .layer(Layer::Overlay)
-                .exclusive_zone(Some(0))
+                .exclusive_zone(ExclusiveZone::None)
                 .background_color(Color::TRANSPARENT)
                 // Start fully click-through; the effect below narrows the
                 // region to the pill once it has been laid out.

--- a/examples/multi_output.rs
+++ b/examples/multi_output.rs
@@ -51,6 +51,7 @@ fn main() {
                     SurfaceConfig::new()
                         .height(32)
                         .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+                        .exclusive_zone(ExclusiveZone::Auto)
                         .layer(Layer::Top)
                         .namespace("guido-multi-output")
                         .output(info.id),

--- a/examples/status_bar.rs
+++ b/examples/status_bar.rs
@@ -6,6 +6,7 @@ fn main() {
             SurfaceConfig::new()
                 .height(32)
                 .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+                .exclusive_zone(ExclusiveZone::Auto)
                 .background_color(Color::rgb(0.1, 0.1, 0.15)),
             || {
                 container()

--- a/examples/surface_properties_example.rs
+++ b/examples/surface_properties_example.rs
@@ -23,6 +23,7 @@ fn main() {
                 .width(500)
                 .height(300)
                 .anchor(Anchor::TOP | Anchor::LEFT)
+                .exclusive_zone(ExclusiveZone::Auto)
                 .layer(Layer::Top)
                 .keyboard_interactivity(KeyboardInteractivity::OnDemand)
                 .namespace("surface-properties-example")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,8 +151,9 @@ pub mod prelude {
         LockState, lock_session, lock_state, session_locked, unlock_session,
     };
     pub use crate::surface::{
-        PopupAnchor, PopupConfig, PopupGravity, PopupHandle, SurfaceConfig, SurfaceHandle,
-        SurfaceId, spawn_popup, spawn_surface, surface_handle,
+        ExclusiveZone, PopupAnchor, PopupConfig, PopupGravity, PopupHandle, SurfaceConfig,
+        SurfaceExtent, SurfaceHandle, SurfaceId, content, spawn_popup, spawn_surface,
+        surface_handle,
     };
     pub use crate::transform::Transform;
     pub use crate::transform_origin::{HorizontalAnchor, TransformOrigin, VerticalAnchor};
@@ -330,11 +331,23 @@ fn process_surface_commands(
 }
 
 /// Measure a popup's natural content height at the given width.
-///
-/// Capped at the parent surface's output height (minus a margin) so a
-/// runaway or `fill()`-height content can't request an absurd popup.
 fn measure_popup_height(tree: &mut Tree, root: WidgetId, width: u32, parent: SurfaceId) -> u32 {
-    let cap = outputs::surface_output(parent)
+    measure_natural_size(tree, root, Some(width), None, parent).1
+}
+
+/// Measure a widget tree's natural size. `fixed_w`/`fixed_h` pin an axis;
+/// `None` measures it loose, capped at the surface's output size (minus a
+/// margin) so a runaway or `fill()` content can't request an absurd
+/// surface. Runs under the measure-final flag: animation TARGETS, not
+/// in-flight values, so the result is animation-invariant.
+fn measure_natural_size(
+    tree: &mut Tree,
+    root: WidgetId,
+    fixed_w: Option<u32>,
+    fixed_h: Option<u32>,
+    surface: SurfaceId,
+) -> (u32, u32) {
+    let output_size = outputs::surface_output(surface)
         .and_then(|oid| {
             outputs::current_outputs()
                 .into_iter()
@@ -345,18 +358,33 @@ fn measure_popup_height(tree: &mut Tree, root: WidgetId, width: u32, parent: Sur
             outputs::current_outputs()
                 .into_iter()
                 .find_map(|o| o.logical_size)
-        })
-        .map(|(_, h)| (h as f32 - 64.0).max(100.0))
-        .unwrap_or(800.0);
+        });
+    let cap = |v: i32| (v as f32 - 64.0).max(100.0);
+    let (cap_w, cap_h) = match output_size {
+        Some((w, h)) => (cap(w), cap(h)),
+        None => (800.0, 800.0),
+    };
 
-    let constraints = Constraints::new(width as f32, 0.0, width as f32, cap);
-    let measured = tree
-        .with_widget_mut(root, |widget, id, tree| {
+    let (min_w, max_w) = match fixed_w {
+        Some(w) => (w as f32, w as f32),
+        None => (0.0, cap_w),
+    };
+    let (min_h, max_h) = match fixed_h {
+        Some(h) => (h as f32, h as f32),
+        None => (0.0, cap_h),
+    };
+
+    let constraints = Constraints::new(min_w, min_h, max_w, max_h);
+    let measured = widgets::container::with_measure_final(|| {
+        tree.with_widget_mut(root, |widget, id, tree| {
             widget.layout(tree, id, constraints)
         })
-        .map(|size| size.height)
-        .unwrap_or(100.0);
-    (measured.ceil() as u32).max(1)
+    })
+    .unwrap_or(layout::Size::new(100.0, 100.0));
+
+    let w = fixed_w.unwrap_or_else(|| (measured.width.ceil() as u32).max(1));
+    let h = fixed_h.unwrap_or_else(|| (measured.height.ceil() as u32).max(1));
+    (w, h)
 }
 
 /// Walk the render tree after painting and cache each node's output.
@@ -602,6 +630,41 @@ fn render_surface(
                 widget.layout(tree, wid, constraints);
             });
             wayland_state.reposition_popup_if_changed(id, natural, qh);
+        } else if (has_pending_layouts || force_render_surface)
+            && (surface.config.width.is_content() || surface.config.height.is_content())
+        {
+            // Initialization included: a freshly spawned surface reaches
+            // its first frames through the full-layout path, not
+            // layout_roots — without measuring here a single-toast spawn
+            // would stay at its 1px initial size until the NEXT content
+            // change.
+            // Content-sized layer surface (toast stacks, OSDs): measure
+            // the natural size and follow it — the layer counterpart of
+            // the popup reposition above. Without this a content-sized
+            // surface is stuck at its initial size: the real layout
+            // clamps to the surface, so a measured rect can never exceed
+            // it. The measure reads animation TARGETS, so an animated
+            // growth resizes once and the animation plays inside.
+            let fixed_w = (!surface.config.width.is_content()).then_some(width);
+            let fixed_h = (!surface.config.height.is_content()).then_some(height);
+            let (nw, nh) = measure_natural_size(tree, surface.widget_id, fixed_w, fixed_h, id);
+            tree.with_widget_mut(surface.widget_id, |widget, wid, tree| {
+                widget.layout(tree, wid, constraints);
+            });
+            if (nw, nh) != (width, height) {
+                wayland_state.set_surface_size(id, nw, nh);
+                // Auto reservations follow automatic resizes too; every
+                // other policy never moves
+                if surface.config.exclusive_zone == surface::ExclusiveZone::Auto {
+                    let zone = surface.config.exclusive_zone.resolve(
+                        surface.config.anchor,
+                        surface.config.margin,
+                        nw,
+                        nh,
+                    );
+                    wayland_state.set_surface_exclusive_zone(id, zone);
+                }
+            }
         }
 
         // Update widget ref signals with current bounds after layout

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -949,26 +949,32 @@ impl WaylandState {
 
         layer_surface.set_anchor(config.anchor);
 
-        // When anchored to both edges on an axis, set that dimension to 0
-        // to let the compositor stretch the surface to fill
-        let use_width =
-            if config.anchor.contains(Anchor::LEFT) && config.anchor.contains(Anchor::RIGHT) {
-                0 // Let compositor decide
-            } else {
-                config.width
-            };
-        let use_height =
-            if config.anchor.contains(Anchor::TOP) && config.anchor.contains(Anchor::BOTTOM) {
-                0 // Let compositor decide
-            } else {
-                config.height
-            };
+        // When anchored to both edges on an axis, the compositor owns
+        // that dimension: set it to 0 so it stretches. Content sizing on
+        // such an axis can never take effect — warn loudly.
+        let stretch_w =
+            config.anchor.contains(Anchor::LEFT) && config.anchor.contains(Anchor::RIGHT);
+        let stretch_h =
+            config.anchor.contains(Anchor::TOP) && config.anchor.contains(Anchor::BOTTOM);
+        if (stretch_w && config.width.is_content()) || (stretch_h && config.height.is_content()) {
+            log::warn!(
+                "Surface {id:?}: content() sizing on an axis anchored to both                  screen edges is compositor-owned and will be ignored"
+            );
+        }
+        let initial_width = config.width.initial();
+        let initial_height = config.height.initial();
+        let use_width = if stretch_w { 0 } else { initial_width };
+        let use_height = if stretch_h { 0 } else { initial_height };
 
         layer_surface.set_size(use_width, use_height);
         layer_surface.set_keyboard_interactivity(config.keyboard_interactivity);
 
-        // Set exclusive zone: None means use height, Some(0) means no exclusive zone
-        let zone = config.exclusive_zone.unwrap_or(config.height as i32);
+        let zone = config.exclusive_zone.resolve(
+            config.anchor,
+            config.margin,
+            initial_width,
+            initial_height,
+        );
         layer_surface.set_exclusive_zone(zone);
 
         let (top, right, bottom, left) = config.margin;
@@ -990,16 +996,16 @@ impl WaylandState {
         let surface_state = WaylandSurfaceState::new(
             SurfaceRole::Layer(layer_surface),
             wl_surface,
-            config.width,
-            config.height,
+            initial_width,
+            initial_height,
         );
         self.surfaces.insert(id, surface_state);
 
         log::info!(
             "Created surface {:?} with size {}x{}, anchor {:?}, layer {:?}, keyboard {:?}",
             id,
-            config.width,
-            config.height,
+            initial_width,
+            initial_height,
             config.anchor,
             config.layer,
             config.keyboard_interactivity

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -75,10 +75,10 @@ impl SurfaceId {
 /// ```
 #[derive(Clone)]
 pub struct SurfaceConfig {
-    /// Width of the surface in logical pixels.
-    pub width: u32,
-    /// Height of the surface in logical pixels.
-    pub height: u32,
+    /// Width of the surface (fixed pixels or content-following).
+    pub width: SurfaceExtent,
+    /// Height of the surface (fixed pixels or content-following).
+    pub height: SurfaceExtent,
     /// Anchor edges for the surface position.
     pub anchor: Anchor,
     /// Layer shell layer (background, bottom, top, overlay).
@@ -89,8 +89,8 @@ pub struct SurfaceConfig {
     pub namespace: String,
     /// Background color for the surface.
     pub background_color: Color,
-    /// Exclusive zone (reserves screen space). None means use height.
-    pub exclusive_zone: Option<i32>,
+    /// Screen-space reservation policy (see [`ExclusiveZone`]).
+    pub exclusive_zone: ExclusiveZone,
     /// Margins from the anchored screen edges (top, right, bottom, left).
     pub margin: (i32, i32, i32, i32),
     /// Output (monitor) to show the surface on. None lets the compositor choose.
@@ -101,17 +101,181 @@ pub struct SurfaceConfig {
     pub input_region: Option<Vec<Rect>>,
 }
 
+/// Per-axis sizing for layer surfaces.
+///
+/// `Fixed` is a size in logical pixels (plain integers convert into it).
+/// `Content` follows the content's natural size on that axis — the
+/// [`content()`] constructor reads like [`fill()`](crate::layout::fill)
+/// and friends:
+///
+/// ```ignore
+/// SurfaceConfig::new()
+///     .width(360)             // fixed
+///     .height(content())      // follows the toast stack
+/// ```
+///
+/// Content semantics, designed to stay footgun-free:
+/// - Resizing is asynchronous (one compositor round trip per change) and
+///   happens on CONTENT changes, not per animation frame: the natural
+///   size is measured against animation **targets**, so an animated
+///   growth resizes once up front and the animation plays inside the
+///   final-size surface.
+/// - On an axis anchored to both screen edges the compositor owns the
+///   size; `Content` there is ignored with a warning at creation.
+/// - An exclusive zone of [`ExclusiveZone::FollowHeight`] follows content
+///   resizes; every other policy never moves.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SurfaceExtent {
+    /// Fixed size in logical pixels.
+    Fixed(u32),
+    /// Follow the content's natural size on this axis.
+    Content,
+}
+
+impl SurfaceExtent {
+    /// The initial protocol size (`Content` starts at 1px until the first
+    /// measure lands).
+    pub(crate) fn initial(self) -> u32 {
+        match self {
+            SurfaceExtent::Fixed(v) => v,
+            SurfaceExtent::Content => 1,
+        }
+    }
+
+    pub(crate) fn is_content(self) -> bool {
+        matches!(self, SurfaceExtent::Content)
+    }
+}
+
+impl From<u32> for SurfaceExtent {
+    fn from(v: u32) -> Self {
+        SurfaceExtent::Fixed(v)
+    }
+}
+
+impl From<i32> for SurfaceExtent {
+    fn from(v: i32) -> Self {
+        SurfaceExtent::Fixed(v.max(0) as u32)
+    }
+}
+
+/// A [`SurfaceExtent`] that follows the content's natural size.
+pub fn content() -> SurfaceExtent {
+    SurfaceExtent::Content
+}
+
+/// Screen-space reservation for layer surfaces, mapping the layer-shell
+/// exclusive-zone semantics to intent. Reserving is **opt-in**: the
+/// default is [`ExclusiveZone::None`] — a bar declares its reservation
+/// explicitly:
+///
+/// ```ignore
+/// .exclusive_zone(ExclusiveZone::Auto)    // a bar reserving itself
+/// .exclusive_zone(34)                     // fixed reservation
+/// .exclusive_zone(ExclusiveZone::None)    // reserve nothing (toasts, OSD)
+/// .exclusive_zone(ExclusiveZone::Ignore)  // overlap panels too
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExclusiveZone {
+    /// Reserve the surface's own extent on the anchored axis, plus the
+    /// margin on that edge (gtk-layer-shell's "auto exclusive zone"): the
+    /// height of a top/bottom bar, the width of a left/right dock — the
+    /// axis follows from the anchor, it is never a choice. Content-sized
+    /// surfaces keep the reservation in sync when they resize. Per the
+    /// layer-shell spec a zone is only meaningful anchored to one edge
+    /// (plus optionally both perpendicular ones); on other anchors this
+    /// resolves to no reservation.
+    Auto,
+    /// Reserve exactly this many logical pixels.
+    Fixed(u32),
+    /// Reserve nothing; the surface is moved by other surfaces' zones.
+    None,
+    /// Reserve nothing and ignore other surfaces' zones (the surface may
+    /// overlap panels; protocol value -1).
+    Ignore,
+}
+
+impl ExclusiveZone {
+    /// Protocol value. [`Auto`](ExclusiveZone::Auto) resolves against the
+    /// surface extent on the anchored axis plus that edge's margin.
+    pub(crate) fn resolve(
+        self,
+        anchor: Anchor,
+        margin: (i32, i32, i32, i32),
+        width: u32,
+        height: u32,
+    ) -> i32 {
+        match self {
+            ExclusiveZone::Auto => match Self::follow_axis(anchor) {
+                Some(FollowAxis::Height) => {
+                    let edge_margin = if anchor.contains(Anchor::TOP) {
+                        margin.0
+                    } else {
+                        margin.2
+                    };
+                    height as i32 + edge_margin
+                }
+                Some(FollowAxis::Width) => {
+                    let edge_margin = if anchor.contains(Anchor::LEFT) {
+                        margin.3
+                    } else {
+                        margin.1
+                    };
+                    width as i32 + edge_margin
+                }
+                None => {
+                    log::warn!(
+                        "ExclusiveZone::Auto on a corner/full anchor has no \
+                         meaningful axis (layer-shell spec); reserving nothing"
+                    );
+                    0
+                }
+            },
+            ExclusiveZone::Fixed(z) => z as i32,
+            ExclusiveZone::None => 0,
+            ExclusiveZone::Ignore => -1,
+        }
+    }
+
+    /// The axis an `Auto` reservation tracks, from the anchor — the
+    /// layer-shell rule: a zone is meaningful anchored to one edge, or
+    /// one edge plus both perpendicular ones.
+    pub(crate) fn follow_axis(anchor: Anchor) -> Option<FollowAxis> {
+        let vertical_edge = anchor.contains(Anchor::TOP) != anchor.contains(Anchor::BOTTOM);
+        let horizontal_edge = anchor.contains(Anchor::LEFT) != anchor.contains(Anchor::RIGHT);
+        match (vertical_edge, horizontal_edge) {
+            (true, false) => Some(FollowAxis::Height),
+            (false, true) => Some(FollowAxis::Width),
+            // Corner (one edge of each axis) or no meaningful anchor
+            _ => None,
+        }
+    }
+}
+
+/// The axis an [`ExclusiveZone::Auto`] reservation tracks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FollowAxis {
+    Width,
+    Height,
+}
+
+impl From<u32> for ExclusiveZone {
+    fn from(z: u32) -> Self {
+        ExclusiveZone::Fixed(z)
+    }
+}
+
 impl Default for SurfaceConfig {
     fn default() -> Self {
         Self {
-            width: 400,
-            height: 300,
+            width: SurfaceExtent::Fixed(400),
+            height: SurfaceExtent::Fixed(300),
             anchor: Anchor::empty(),
             layer: Layer::Top,
             keyboard_interactivity: KeyboardInteractivity::OnDemand,
             namespace: "guido-surface".to_string(),
             background_color: Color::rgb(0.1, 0.1, 0.15),
-            exclusive_zone: None,
+            exclusive_zone: ExclusiveZone::None,
             margin: (0, 0, 0, 0),
             output: None,
             input_region: None,
@@ -126,14 +290,14 @@ impl SurfaceConfig {
     }
 
     /// Set the width of the surface.
-    pub fn width(mut self, width: u32) -> Self {
-        self.width = width;
+    pub fn width(mut self, width: impl Into<SurfaceExtent>) -> Self {
+        self.width = width.into();
         self
     }
 
     /// Set the height of the surface.
-    pub fn height(mut self, height: u32) -> Self {
-        self.height = height;
+    pub fn height(mut self, height: impl Into<SurfaceExtent>) -> Self {
+        self.height = height.into();
         self
     }
 
@@ -163,8 +327,8 @@ impl SurfaceConfig {
 
     /// Set the exclusive zone (reserves screen space).
     /// Pass Some(0) for no exclusive zone, None to use the surface height.
-    pub fn exclusive_zone(mut self, zone: Option<i32>) -> Self {
-        self.exclusive_zone = zone;
+    pub fn exclusive_zone(mut self, zone: impl Into<ExclusiveZone>) -> Self {
+        self.exclusive_zone = zone.into();
         self
     }
 

--- a/src/widgets/container/animations.rs
+++ b/src/widgets/container/animations.rs
@@ -280,6 +280,27 @@ macro_rules! advance_anim {
     };
 }
 
+thread_local! {
+    /// While set, layout reads animation TARGETS instead of current
+    /// values. Content-sized surfaces measure under this flag so their
+    /// natural size is animation-invariant: an animated growth resizes
+    /// the surface once, to the final size, and the animation plays
+    /// inside it — never one compositor configure per frame.
+    static MEASURE_FINAL: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+/// Run `f` with layout reading animation targets instead of current values.
+pub(crate) fn with_measure_final<R>(f: impl FnOnce() -> R) -> R {
+    MEASURE_FINAL.with(|m| m.set(true));
+    let out = f();
+    MEASURE_FINAL.with(|m| m.set(false));
+    out
+}
+
+pub(crate) fn measuring_final() -> bool {
+    MEASURE_FINAL.with(|m| m.get())
+}
+
 /// Helper to get an animated value or a fallback
 #[inline]
 pub fn get_animated_value<T: Animatable + Copy>(
@@ -287,7 +308,13 @@ pub fn get_animated_value<T: Animatable + Copy>(
     fallback: impl FnOnce() -> T,
 ) -> T {
     match anim {
-        Some(a) => *a.current(),
+        Some(a) => {
+            if measuring_final() {
+                *a.target()
+            } else {
+                *a.current()
+            }
+        }
         None => fallback(),
     }
 }

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -4,6 +4,7 @@ mod animations;
 mod ripple;
 mod scrollable;
 
+pub(crate) use animations::with_measure_final;
 pub use animations::{AdvanceResult, AnimationState, get_animated_value};
 pub use ripple::RippleState;
 
@@ -1199,7 +1200,11 @@ impl Widget for Container {
         let child_layout_width =
             if let Some(anim) = self.anims.as_ref().and_then(|a| a.width.as_ref()) {
                 if !anim.is_initial() && width_length.exact.is_some() {
-                    *anim.current()
+                    if animations::measuring_final() {
+                        *anim.target()
+                    } else {
+                        *anim.current()
+                    }
                 } else {
                     width_length.exact.unwrap_or(constraints.max_width)
                 }
@@ -1217,7 +1222,11 @@ impl Widget for Container {
         let child_layout_height =
             if let Some(anim) = self.anims.as_ref().and_then(|a| a.height.as_ref()) {
                 if !anim.is_initial() && height_length.exact.is_some() {
-                    *anim.current()
+                    if animations::measuring_final() {
+                        *anim.target()
+                    } else {
+                        *anim.current()
+                    }
                 } else {
                     height_length.exact.unwrap_or(constraints.max_height)
                 }
@@ -1474,12 +1483,18 @@ impl Widget for Container {
             || has_exact_height
             || self.scroll_axis.allows_vertical();
 
-        // Calculate final dimensions
+        // Calculate final dimensions (measure-final: report animation
+        // targets so content-sized surfaces size once, not per frame)
         let mut width = if let Some(anim) = self.anims.as_ref().and_then(|a| a.width.as_ref()) {
-            if allow_shrink_width {
-                *anim.current()
+            let animated = if animations::measuring_final() {
+                *anim.target()
             } else {
-                content_width.max(*anim.current())
+                *anim.current()
+            };
+            if allow_shrink_width {
+                animated
+            } else {
+                content_width.max(animated)
             }
         } else if let Some(exact) = width_length.exact {
             exact
@@ -1498,10 +1513,15 @@ impl Widget for Container {
         }
 
         let mut height = if let Some(anim) = self.anims.as_ref().and_then(|a| a.height.as_ref()) {
-            if allow_shrink_height {
-                *anim.current()
+            let animated = if animations::measuring_final() {
+                *anim.target()
             } else {
-                content_height.max(*anim.current())
+                *anim.current()
+            };
+            if allow_shrink_height {
+                animated
+            } else {
+                content_height.max(animated)
             }
         } else if let Some(exact) = height_length.exact {
             exact
@@ -2306,6 +2326,51 @@ mod tests {
                 job_type: JobType::Animation,
             }),
             "paint must request an Animation job for the missed target change, got {drained:?}"
+        );
+    }
+
+    /// Content-sized surfaces measure under the measure-final flag: layout
+    /// must report animation TARGETS, not in-flight values, so a growth
+    /// animation resizes the surface once instead of once per frame.
+    #[test]
+    fn measure_final_reads_animation_targets() {
+        let height_sig = create_signal(100.0_f32);
+        let widget = container()
+            .width(50.0)
+            .height(move || height_sig.get())
+            .animate_height(Transition::new(200, TimingFunction::EaseOut));
+
+        let mut tree = Tree::new();
+        let id = tree.register(Box::new(widget));
+        // The real flow measures under DIFFERENT constraints than the
+        // render layout (loose caps vs the exact surface size), which is
+        // also what defeats the layout cache here
+        let render = Constraints::new(0.0, 0.0, 400.0, 400.0);
+        let measure = Constraints::new(0.0, 0.0, 500.0, 500.0);
+
+        // First layout initializes the animation at 100
+        tree.with_widget_mut(id, |w, id, tree| {
+            w.layout(tree, id, render);
+        });
+
+        // Retarget to 180: the animation starts from ~100
+        height_sig.set(180.0);
+        let mid = tree
+            .with_widget_mut(id, |w, id, tree| w.layout(tree, id, render))
+            .unwrap();
+        assert!(
+            mid.height < 180.0,
+            "mid-animation layout should not have reached the target yet (got {})",
+            mid.height
+        );
+
+        let fin = super::animations::with_measure_final(|| {
+            tree.with_widget_mut(id, |w, id, tree| w.layout(tree, id, measure))
+        })
+        .unwrap();
+        assert_eq!(
+            fin.height, 180.0,
+            "measure-final must report the animation target"
         );
     }
 


### PR DESCRIPTION
Two related surface-API reworks, both born from the ashell-guido toast layer (which turned out to have never been visible: the app-side measured-rect sizing pattern can't work — content layout clamps to the surface, so the measured height can never exceed it).

## `SurfaceExtent` — `.height(content())`

Per-axis sizing in the `fill()`/`fraction()` vocabulary: `Fixed(u32)` (plain integers convert) or `Content`, which measures the content with loose constraints (output-capped, same measure as popups) and follows it through the normal set_size/configure cycle — at initialization and on every content change. Dynamic layer resizing is standard practice (mako's notification stack) and the request→configure→ack cycle is already guido's bread and butter.

Footgun elimination, by construction:
- The measure reads **animation targets** (measure-final flag honored at every animated-dimension read in layout): an animated growth resizes once, up front, and the animation plays inside the final-size surface. Regression test included — writing it also surfaced and documented the layout-cache subtlety (measure constraints differ from render constraints).
- `content()` on an axis anchored to both screen edges warns at creation: the compositor owns that axis (spec).

## `ExclusiveZone` — reserving is opt-in

`Option<i32>` had `None` meaning "use the height" — the opposite of what `None` reads as. Now:

| variant | meaning |
|---|---|
| `Auto` | surface extent on the **anchored axis** + that edge's margin — gtk-layer-shell's "auto exclusive zone"; the axis derives from the anchor per the layer-shell spec (top/bottom bar → height, left/right dock → width), never a user choice; follows `content()` resizes |
| `Fixed(u32)` | exact pixels (`From<u32>`) |
| `None` | nothing reserved — **the default** |
| `Ignore` | protocol -1: reserve nothing and overlap other zones |

Bar examples declare `Auto` explicitly (pedagogically right); demo examples stop displacing the user's windows.

Verified live with the ashell-guido toast stack: grows 1→180 on first toast, shrinks 180→86 per expiry, closes when empty; explicit zones untouched by resizes.