### PR TITLE
feat: enter transitions and completion callbacks

### DIFF
--- a/src/animation/mod.rs
+++ b/src/animation/mod.rs
@@ -7,7 +7,7 @@ pub use spring::{SpringConfig, SpringState};
 pub use timing::TimingFunction;
 
 /// Configuration for how a property should animate when it changes
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct Transition {
     /// Duration of the animation in milliseconds
     pub duration_ms: f32,
@@ -15,6 +15,22 @@ pub struct Transition {
     pub timing: TimingFunction,
     /// Delay before animation starts in milliseconds
     pub delay_ms: f32,
+    /// Called once when an animation driven by this transition settles.
+    /// Direction-specific by construction: a callback on the `reverse`
+    /// transition fires exactly when the closing animation completes —
+    /// the lifecycle hook for "animate out, then destroy".
+    pub on_complete: Option<std::rc::Rc<dyn Fn()>>,
+}
+
+impl std::fmt::Debug for Transition {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Transition")
+            .field("duration_ms", &self.duration_ms)
+            .field("timing", &self.timing)
+            .field("delay_ms", &self.delay_ms)
+            .field("on_complete", &self.on_complete.as_ref().map(|_| "<fn>"))
+            .finish()
+    }
 }
 
 impl Transition {
@@ -24,6 +40,7 @@ impl Transition {
             duration_ms: duration_ms.into_f32(),
             timing,
             delay_ms: 0.0,
+            on_complete: None,
         }
     }
 
@@ -33,7 +50,16 @@ impl Transition {
             duration_ms: 1000.0, // Spring duration is dynamic, this is max
             timing: TimingFunction::Spring(config),
             delay_ms: 0.0,
+            on_complete: None,
         }
+    }
+
+    /// Run a callback (main thread) when an animation driven by this
+    /// transition settles. Fires once per completed run; a retarget that
+    /// completes again fires again.
+    pub fn on_complete(mut self, f: impl Fn() + 'static) -> Self {
+        self.on_complete = Some(std::rc::Rc::new(f));
+        self
     }
 
     /// Set the delay before the animation starts

--- a/src/widgets/container/animations.rs
+++ b/src/widgets/container/animations.rs
@@ -42,6 +42,9 @@ pub struct AnimationState<T: Animatable> {
     initialized: bool,
     /// Previous value for change detection
     prev_value: Option<T>,
+    /// Pending enter value: consumed at first layout to start an enter
+    /// animation instead of snapping to the target
+    enter_from: Option<T>,
 }
 
 impl<T: Animatable> AnimationState<T> {
@@ -67,6 +70,7 @@ impl<T: Animatable> AnimationState<T> {
             spring_state,
             initialized: false, // Not yet initialized with real content-based value
             prev_value: None,
+            enter_from: None,
         }
     }
 
@@ -112,6 +116,7 @@ impl<T: Animatable> AnimationState<T> {
         if self.progress >= 1.0 && self.spring_state.is_none() {
             return AdvanceResult::NoChange;
         }
+        let was_running = self.is_animating();
 
         // Extract scalar transition values upfront to avoid borrow conflicts
         // with self.spring_state. Copy SpringConfig (which is Copy) instead of
@@ -178,6 +183,17 @@ impl<T: Animatable> AnimationState<T> {
         self.current = new_value;
         self.prev_value = Some(new_value);
 
+        // Completion edge: fire the transition's callback once per run.
+        // The callback may write signals or push surface commands; it must
+        // not touch the widget tree synchronously (it runs inside
+        // advance_animations).
+        if was_running
+            && !self.is_animating()
+            && let Some(cb) = self.active_transition().on_complete.clone()
+        {
+            cb();
+        }
+
         if changed {
             AdvanceResult::Changed(new_value)
         } else {
@@ -198,6 +214,32 @@ impl<T: Animatable> AnimationState<T> {
     /// Get target value
     pub fn target(&self) -> &T {
         &self.target
+    }
+
+    /// Take the pending enter value, if any (consumed at first layout).
+    pub(crate) fn take_enter_from(&mut self) -> Option<T> {
+        self.enter_from.take()
+    }
+
+    /// Store an enter value: the first layout starts an animation from it
+    /// to the effective target instead of snapping (see
+    /// `Container::animate_transform_from`).
+    pub(crate) fn with_enter_from(mut self, from: T) -> Self {
+        self.enter_from = Some(from);
+        self
+    }
+
+    /// Begin animating from an explicit value (enter transitions): the
+    /// widget appears mid-animation instead of snapping to its target.
+    pub(crate) fn begin_from(&mut self, from: T, target: T) {
+        self.current = from;
+        self.start = from;
+        self.initialized = true;
+        // Reuse animate_to for direction selection and spring setup; it
+        // starts from `current`, which is now the enter value
+        let t = target;
+        self.target = from; // force the retarget below to fire
+        self.animate_to(t);
     }
 
     /// Set value immediately without animation (for initialization)
@@ -322,6 +364,36 @@ pub fn get_animated_value<T: Animatable + Copy>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// on_complete fires exactly once per completed run; a retarget that
+    /// completes again fires again.
+    #[test]
+    fn on_complete_fires_once_per_run() {
+        use crate::animation::TimingFunction;
+        use std::cell::Cell;
+        use std::rc::Rc;
+
+        let fired = Rc::new(Cell::new(0));
+        let counter = fired.clone();
+        let mut anim = AnimationState::new(
+            0.0_f32,
+            crate::animation::Transition::new(1, TimingFunction::Linear)
+                .on_complete(move || counter.set(counter.get() + 1)),
+        );
+        anim.set_immediate(0.0);
+
+        anim.animate_to(1.0);
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        anim.advance();
+        assert_eq!(fired.get(), 1, "settle must fire the callback once");
+        anim.advance();
+        assert_eq!(fired.get(), 1, "no refire after completion");
+
+        anim.animate_to(2.0);
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        anim.advance();
+        assert_eq!(fired.get(), 2, "a new completed run fires again");
+    }
     use crate::animation::TimingFunction;
 
     #[test]

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -706,6 +706,27 @@ impl Container {
         self
     }
 
+    /// Enable transform animation with an ENTER transition: on first
+    /// layout the transform animates from `enter_from` to its effective
+    /// value, so the widget appears mid-animation — no signal flip, no
+    /// timer. A menu that scales open declares it directly:
+    ///
+    /// ```ignore
+    /// .transform(move || if open.get() { Transform::IDENTITY } else { collapsed })
+    /// .animate_transform_from(collapsed, Transition::spring(SpringConfig::SNAPPY))
+    /// // `open` can simply start true: the enter plays from `collapsed`
+    /// ```
+    pub fn animate_transform_from(
+        mut self,
+        enter_from: Transform,
+        transition: impl Into<TransitionConfig>,
+    ) -> Self {
+        let initial = self.transform.get_or(Transform::IDENTITY);
+        self.anims_mut().transform =
+            Some(AnimationState::new(initial, transition).with_enter_from(enter_from));
+        self
+    }
+
     /// Set style overrides for the hover state.
     pub fn hover_state<F>(mut self, f: F) -> Self
     where
@@ -1456,7 +1477,14 @@ impl Widget for Container {
                     anim.set_immediate(target);
                 }
                 if let (Some(anim), Some(target)) = (&mut anims.transform, tf_target) {
-                    anim.set_immediate(target);
+                    // Enter transition: animate in from the declared value
+                    // instead of snapping to the target
+                    if let Some(enter) = anim.take_enter_from() {
+                        anim.begin_from(enter, target);
+                        request_job(id, JobRequest::Animation(RequiredJob::Paint));
+                    } else {
+                        anim.set_immediate(target);
+                    }
                 }
             }
         }
@@ -2326,6 +2354,46 @@ mod tests {
                 job_type: JobType::Animation,
             }),
             "paint must request an Animation job for the missed target change, got {drained:?}"
+        );
+    }
+
+    /// An enter transition starts animating at first layout — the widget
+    /// appears mid-animation, no signal flip or timer needed.
+    #[test]
+    fn enter_transition_starts_animating_at_first_layout() {
+        use crate::animation::TimingFunction;
+
+        let collapsed = Transform::scale_xy(1.0, 0.0);
+        let entering = container()
+            .transform(Transform::IDENTITY)
+            .animate_transform_from(collapsed, Transition::new(200, TimingFunction::EaseOut));
+        let plain = container()
+            .transform(Transform::IDENTITY)
+            .animate_transform(Transition::new(200, TimingFunction::EaseOut));
+
+        let mut tree = Tree::new();
+        let entering_id = tree.register(Box::new(entering));
+        let plain_id = tree.register(Box::new(plain));
+        let c = Constraints::new(0.0, 0.0, 100.0, 100.0);
+        for id in [entering_id, plain_id] {
+            tree.with_widget_mut(id, |w, id, tree| {
+                w.layout(tree, id, c);
+            });
+        }
+
+        let entering_animating = tree
+            .with_widget_mut(entering_id, |w, id, tree| w.advance_animations(tree, id))
+            .unwrap();
+        let plain_animating = tree
+            .with_widget_mut(plain_id, |w, id, tree| w.advance_animations(tree, id))
+            .unwrap();
+        assert!(
+            entering_animating,
+            "enter transition must be in flight right after the first layout"
+        );
+        assert!(
+            !plain_animating,
+            "a plain animation initializes settled at its target"
         );
     }
 


### PR DESCRIPTION
Audit cluster #2 (the menu machinery) reduced to two missing lifecycle primitives; together they compose the full transient-UI cycle (menus, dialogs, toasts) without a single timer:

## `animate_transform_from(from, transition)` — enter

Animations only play on *changes*: first appearance snaps (by design — new widgets must not flicker). So "appear by animating open" forced apps to start collapsed and flip a signal on a wall-clock delay — a bet on frame timing (ashell-guido's 30ms `MENU_OPEN_DELAY`). The `_from` variant starts the first layout at `from` and animates to the effective value: the widget appears mid-animation. CSS mount keyframes / SwiftUI `.transition` / Framer `initial=`, in guido's vocabulary.

## `Transition::on_complete(f)` — animate out, then destroy

Fires once per completed run at the settle edge. Direction-specific for free: a `TransitionConfig` already separates `forward`/`reverse`, so a callback on `reverse` fires exactly when the closing animation ends. Replaces the hand-duplicated duration in a sleep (`MENU_CLOSE_ANIM = 140ms` for a 120ms animation) that silently desyncs when the animation changes.

Downstream (next commit in ashell-guido): both menu timers deleted, plus the pending-close mailbox signal + effect + finish function — closing a menu is `open.set(false)` again; verified live: open (enter plays), toggle-close (collapse → on_complete destroys the popup), reopen, menu switch ordering intact.

Tests: enter is animating right after first layout vs plain settled; on_complete fires once per run, again after retarget.