### PR TITLE
ZStack: rename the Overlay layout and size followers to their siblings

### DIFF
--- a/book/src/advanced/widget-ref.md
+++ b/book/src/advanced/widget-ref.md
@@ -65,6 +65,20 @@ let popup = container()
     .child(popup_content());
 ```
 
+## When Not to Use It
+
+A `WidgetRef` rect is written *after* layout, so a property derived from one
+lags a frame — and reads zero on the first frame, before any layout has run.
+That is fine for positioning a popup, and wrong for sizing. Two common cases
+have direct layout support instead:
+
+- **A bar proportional to a value** (slider fill, gauge, progress): use
+  [`fraction()`](../concepts/layout.md#size-constraints), resolved against the
+  real constraints during layout.
+- **A widget sized to a sibling** (background, badge, decoration): stack them
+  with [`ZStack`](../concepts/layout.md#stacking-children-zstack) and give the
+  follower `fill()`.
+
 ## Edge Cases
 
 - **Before first layout**: The signal returns `Rect::default()` (all zeros)

--- a/book/src/concepts/layout.md
+++ b/book/src/concepts/layout.md
@@ -219,15 +219,96 @@ container()
 
 ## Layout Without Explicit Flex
 
-Containers without `.layout()` stack children (each child fills the container):
+Containers without `.layout()` use `Flex::column()`:
 
 ```rust
-// Children overlap, each filling the container
+// Same as .layout(Flex::column())
 container()
     .children([
-        background_image(),
-        overlay_content(),
+        text("first"),
+        text("second"),
     ])
+```
+
+## Stacking Children (ZStack)
+
+`ZStack` places every child at the same position, stacked along the Z axis —
+later children paint on top:
+
+```rust
+container()
+    .layout(ZStack::new())
+    .child(background())
+    .child(content())   // drawn on top
+```
+
+### Leaders and Followers
+
+The stack takes the size of its largest child, but a child that declares
+`fill()` on an axis **follows** the stack instead of leading it: it never
+contributes to that axis and is laid out against the size the other children
+established.
+
+That is how a decoration is sized to its sibling without measuring anything:
+
+```rust
+container()
+    .layout(ZStack::new())
+    // Follower: exactly as wide and tall as the card below it
+    .child(
+        container()
+            .width(fill())
+            .height(fill())
+            .background(Color::rgb(0.2, 0.2, 0.3))
+    )
+    // Leader: the stack is as big as this card
+    .child(card_content())
+```
+
+Without this rule the background would expand to all the available space,
+and sizing it to its sibling would need a [WidgetRef](../advanced/widget-ref.md)
+round-trip — one frame behind, and zero on the first frame.
+
+The two axes are decided independently, which is what makes the status-bar
+case work: a child with only `.height(fill())` fills the bar height and still
+leads the width.
+
+```rust
+container()
+    .height(fill())
+    .layout(ZStack::new())
+    // Follows both axes
+    .child(container().width(fill()).height(fill()).child(visualizer()))
+    // Fills the bar height, leads the width
+    .child(container().height(fill()).child(now_playing()))
+```
+
+When *every* child fills an axis there is no size to follow, and the stack
+takes all the space it was offered on that axis.
+
+### Positioning Inside the Stack
+
+Every child sits at the stack's origin. To place a follower elsewhere, let it
+fill both axes and use its own layout:
+
+```rust
+container()
+    .layout(ZStack::new())
+    .child(icon_widget())
+    // Alert dot pinned to the icon's top-right corner
+    .child(
+        container()
+            .width(fill())
+            .height(fill())
+            .layout(Flex::row().main_alignment(MainAlignment::End))
+            .child(
+                container()
+                    .width(4)
+                    .height(4)
+                    .corner_radius(2)
+                    .background(Color::RED)
+            )
+    )
 ```
 
 ## API Reference
@@ -260,4 +341,10 @@ CrossAlignment::Start
 CrossAlignment::Center
 CrossAlignment::End
 CrossAlignment::Stretch
+```
+
+### ZStack
+
+```rust
+ZStack::new() -> ZStack                // Children stacked at the same origin
 ```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -84,7 +84,7 @@ Text rendering with:
 - `AnyWidget` type alias (`Box<dyn Widget>`) for type-erased widgets
 - `Widget::into_any()` method for boxing widgets in conditional branches
 
-**Layout System** (`widgets/layout.rs`)
+**Layout System** (`layout/`)
 Pluggable layouts via the `Layout` trait:
 ```rust
 pub trait Layout {
@@ -98,8 +98,11 @@ pub trait Layout {
 }
 ```
 
-Built-in implementation:
+Built-in implementations:
 - `Flex` - Flexbox-style row/column layout with spacing and alignment
+- `ZStack` - Children share an origin and stack along the Z axis. Children
+  that don't `fill()` an axis lead it (the stack takes their size); children
+  that do fill it follow, laid out against the size the others established
 
 ### `renderer/` - GPU Rendering
 

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -1,10 +1,10 @@
 pub mod flex;
 pub mod flex_layout;
-pub mod overlay;
+pub mod zstack;
 
 pub use flex::{Constraints, Size};
 pub use flex_layout::Flex;
-pub use overlay::Overlay;
+pub use zstack::ZStack;
 
 use crate::tree::{Tree, WidgetId};
 

--- a/src/layout/zstack.rs
+++ b/src/layout/zstack.rs
@@ -1,29 +1,29 @@
-//! Overlay layout that stacks children on top of each other.
+//! ZStack layout that stacks children on top of each other.
 
 use crate::tree::{Tree, WidgetId};
 
 use super::{Constraints, Layout, Size};
 
-/// Overlay layout that places all children at the same position,
-/// stacking them on top of each other. Later children appear on top.
+/// Layout that places all children at the same position, stacking them along
+/// the Z axis. Later children appear on top.
 ///
-/// The size of the overlay is determined by the largest child.
-pub struct Overlay;
+/// The size of the stack is determined by the largest child.
+pub struct ZStack;
 
-impl Overlay {
-    /// Create a new overlay layout
+impl ZStack {
+    /// Create a new z-stack layout
     pub fn new() -> Self {
         Self
     }
 }
 
-impl Default for Overlay {
+impl Default for ZStack {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl Layout for Overlay {
+impl Layout for ZStack {
     fn layout(
         &mut self,
         tree: &mut Tree,

--- a/src/layout/zstack.rs
+++ b/src/layout/zstack.rs
@@ -1,25 +1,71 @@
 //! ZStack layout that stacks children on top of each other.
 
 use crate::tree::{Tree, WidgetId};
+use crate::widgets::LayoutHints;
 
 use super::{Constraints, Layout, Size};
 
 /// Layout that places all children at the same position, stacking them along
 /// the Z axis. Later children appear on top.
 ///
-/// The size of the stack is determined by the largest child.
-pub struct ZStack;
+/// # Sizing
+///
+/// The stack takes the size of its largest child — but a child that declares
+/// [`fill()`](super::fill) on an axis **follows** the stack instead of leading
+/// it: it never contributes to that axis, and it is laid out against the size
+/// the other children established.
+///
+/// That is how a decoration is sized to its sibling without measuring
+/// anything:
+///
+/// ```
+/// use guido::prelude::*;
+///
+/// container()
+///     .layout(ZStack::new())
+///     // Background: exactly as wide and tall as the label below
+///     .child(container().width(fill()).height(fill()).background(Color::RED))
+///     // Content: leads, so the stack is as big as this text
+///     .child(text("hello"));
+/// ```
+///
+/// Both axes are decided independently, which is what makes the common bar
+/// case work: a child with only `.height(fill())` still leads the width.
+///
+/// When *every* child fills an axis there is nothing to follow, and the stack
+/// takes all the space it was offered on that axis.
+///
+/// # Positioning
+///
+/// Every child is placed at the stack's origin. To align a follower inside
+/// the stack, give it `fill()` on both axes and let its own layout do the
+/// positioning:
+///
+/// ```
+/// use guido::prelude::*;
+///
+/// container()
+///     .layout(ZStack::new())
+///     .child(text("content"))
+///     // Badge pinned to the top-right corner of the content
+///     .child(
+///         container()
+///             .width(fill())
+///             .height(fill())
+///             .layout(Flex::row().main_alignment(MainAlignment::End))
+///             .child(container().width(4).height(4).corner_radius(2)),
+///     );
+/// ```
+#[derive(Default)]
+pub struct ZStack {
+    /// Scratch buffer for per-child fill hints, reused across layouts.
+    hints: Vec<LayoutHints>,
+}
 
 impl ZStack {
     /// Create a new z-stack layout
     pub fn new() -> Self {
-        Self
-    }
-}
-
-impl Default for ZStack {
-    fn default() -> Self {
-        Self::new()
+        Self::default()
     }
 }
 
@@ -31,21 +77,199 @@ impl Layout for ZStack {
         constraints: Constraints,
         origin: (f32, f32),
     ) -> Size {
-        let mut max_width: f32 = 0.0;
-        let mut max_height: f32 = 0.0;
+        self.hints.clear();
+        self.hints.extend(children.iter().map(|&child_id| {
+            tree.with_widget(child_id, |w| w.layout_hints())
+                .unwrap_or_default()
+        }));
 
-        // Layout all children at the same origin, giving them the full constraints
-        for &child_id in children.iter() {
-            if let Some(child_size) = tree.with_widget_mut(child_id, |widget, id, tree| {
+        // Pass 1: children that don't fill an axis establish the stack size on
+        // that axis. A child that fills both can only follow, so it is left
+        // for pass 2 — laying it out here would just be thrown away.
+        let mut stack = Size::zero();
+        let (mut led_width, mut led_height) = (false, false);
+
+        for (i, &child_id) in children.iter().enumerate() {
+            let hints = self.hints[i];
+            if hints.fill_width && hints.fill_height {
+                continue;
+            }
+            let Some(child_size) = tree.with_widget_mut(child_id, |widget, id, tree| {
                 widget.layout(tree, id, constraints)
-            }) {
-                tree.set_origin(child_id, origin.0, origin.1);
-                max_width = max_width.max(child_size.width);
-                max_height = max_height.max(child_size.height);
+            }) else {
+                continue;
+            };
+            if !hints.fill_width {
+                stack.width = stack.width.max(child_size.width);
+                led_width = true;
+            }
+            if !hints.fill_height {
+                stack.height = stack.height.max(child_size.height);
+                led_height = true;
             }
         }
 
-        // Return the size of the largest child, constrained
-        constraints.constrain(Size::new(max_width, max_height))
+        // Nothing leads this axis: there is no sibling size to follow, so the
+        // stack takes the space it was offered.
+        if !led_width {
+            stack.width = constraints.max_width;
+        }
+        if !led_height {
+            stack.height = constraints.max_height;
+        }
+        let size = constraints.constrain(stack);
+
+        // Pass 2: followers resolve against the stack size — tight on the axes
+        // they fill, unchanged on the axes they lead.
+        for (i, &child_id) in children.iter().enumerate() {
+            let hints = self.hints[i];
+            if !hints.fill_width && !hints.fill_height {
+                continue;
+            }
+            // A child that leads one axis was already laid out in pass 1.
+            // Only a change on the axis it follows can alter its layout: on
+            // the axis it leads, the max shrinks at most down to the size it
+            // reported, which cannot change a layout that already fit.
+            let leads_an_axis = !hints.fill_width || !hints.fill_height;
+            let followed_size_changed = (hints.fill_width && size.width != constraints.max_width)
+                || (hints.fill_height && size.height != constraints.max_height);
+            if leads_an_axis && !followed_size_changed {
+                continue;
+            }
+            let child_constraints = Constraints {
+                min_width: if hints.fill_width {
+                    size.width
+                } else {
+                    constraints.min_width.min(size.width)
+                },
+                min_height: if hints.fill_height {
+                    size.height
+                } else {
+                    constraints.min_height.min(size.height)
+                },
+                max_width: size.width,
+                max_height: size.height,
+            };
+            tree.with_widget_mut(child_id, |widget, id, tree| {
+                widget.layout(tree, id, child_constraints)
+            });
+        }
+
+        for &child_id in children.iter() {
+            tree.set_origin(child_id, origin.0, origin.1);
+        }
+
+        size
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::layout::{Flex, fill};
+    use crate::widgets::container;
+
+    /// Lay out `widget` and return the tree plus the root id.
+    fn layout_root(
+        widget: crate::widgets::Container,
+        constraints: Constraints,
+    ) -> (Tree, WidgetId) {
+        let mut tree = Tree::new();
+        let id = tree.register(Box::new(widget));
+        tree.with_widget_mut(id, |w, id, tree| {
+            w.register_children(tree, id);
+            w.layout(tree, id, constraints);
+        });
+        (tree, id)
+    }
+
+    fn child_size(tree: &Tree, root: WidgetId, index: usize) -> Size {
+        let child = tree.get_children(root)[index];
+        tree.cached_size(child).expect("child was laid out")
+    }
+
+    /// A filling child follows the size its sibling established instead of
+    /// expanding to all the available space — the whole point of the layout:
+    /// decorations sized to their sibling without a measure round-trip.
+    #[test]
+    fn filling_child_follows_its_sibling() {
+        let root = container()
+            .layout(ZStack::new())
+            .child(container().width(fill()).height(fill()))
+            .child(container().width(80).height(20));
+
+        let (tree, id) = layout_root(root, Constraints::new(0.0, 0.0, 400.0, 400.0));
+
+        assert_eq!(tree.cached_size(id), Some(Size::new(80.0, 20.0)));
+        assert_eq!(
+            child_size(&tree, id, 0),
+            Size::new(80.0, 20.0),
+            "the follower must take the leader's size, not the 400x400 offered"
+        );
+        assert_eq!(tree.get_origin(tree.get_children(id)[0]), Some((0.0, 0.0)));
+        assert_eq!(tree.get_origin(tree.get_children(id)[1]), Some((0.0, 0.0)));
+    }
+
+    /// Axes are decided independently: the bar case, where the content fills
+    /// the bar height yet still dictates the width of the visualizer behind
+    /// it.
+    #[test]
+    fn axes_are_decided_independently() {
+        let root = container()
+            .layout(ZStack::new())
+            // Background follows both axes
+            .child(container().width(fill()).height(fill()))
+            // Content fills the bar height but leads the width
+            .child(container().width(60).height(fill()));
+
+        // Tight height (a bar row), loose width
+        let (tree, id) = layout_root(root, Constraints::new(0.0, 34.0, 400.0, 34.0));
+
+        assert_eq!(tree.cached_size(id), Some(Size::new(60.0, 34.0)));
+        assert_eq!(child_size(&tree, id, 0), Size::new(60.0, 34.0));
+        assert_eq!(child_size(&tree, id, 1), Size::new(60.0, 34.0));
+    }
+
+    /// With no leader on an axis there is no sibling size to follow, so the
+    /// stack keeps the pre-follow behaviour: it takes what it was offered.
+    #[test]
+    fn all_followers_fall_back_to_the_available_space() {
+        let root = container()
+            .layout(ZStack::new())
+            .child(container().width(fill()).height(fill()))
+            .child(container().width(fill()).height(fill()));
+
+        let (tree, id) = layout_root(root, Constraints::new(0.0, 0.0, 400.0, 200.0));
+
+        assert_eq!(tree.cached_size(id), Some(Size::new(400.0, 200.0)));
+        assert_eq!(child_size(&tree, id, 0), Size::new(400.0, 200.0));
+        assert_eq!(child_size(&tree, id, 1), Size::new(400.0, 200.0));
+    }
+
+    /// A follower that fills both axes can position content inside the stack
+    /// with its own layout — a badge pinned to the leader's right edge.
+    #[test]
+    fn follower_can_align_inside_the_stack() {
+        let root = container()
+            .layout(ZStack::new())
+            .child(container().width(50).height(50))
+            .child(
+                container()
+                    .width(fill())
+                    .height(fill())
+                    .layout(Flex::row().main_alignment(crate::layout::MainAlignment::End))
+                    .child(container().width(4).height(4)),
+            );
+
+        let (tree, id) = layout_root(root, Constraints::new(0.0, 0.0, 400.0, 400.0));
+
+        assert_eq!(tree.cached_size(id), Some(Size::new(50.0, 50.0)));
+        let follower = tree.get_children(id)[1];
+        let badge = tree.get_children(follower)[0];
+        assert_eq!(
+            tree.get_origin(badge),
+            Some((46.0, 0.0)),
+            "the badge should sit at the right edge of the 50px leader"
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,7 @@ pub fn quit_app() {
 pub mod prelude {
     pub use crate::animation::{SpringConfig, TimingFunction, Transition, TransitionConfig};
     pub use crate::layout::{
-        Axis, Constraints, CrossAlignment, Flex, IntoF32, Length, MainAlignment, Overlay, Size,
+        Axis, Constraints, CrossAlignment, Flex, IntoF32, Length, MainAlignment, Size, ZStack,
         at_least, at_most, fill, fraction,
     };
     pub use crate::outputs::{OutputId, OutputInfo, outputs, surface_output};


### PR DESCRIPTION
Closes the audit item where the port sized decorations by measuring a sibling through a `WidgetRef` — a rect that is written *after* layout, so it lags a frame and reads zero on the first one.

## 1. `Overlay` → `ZStack` (rename only)

"Overlay" is the portal mechanism in most toolkits (Flutter's `Overlay`/`OverlayEntry`, iced's `Widget::overlay`, Qt Quick's `Overlay`), not a layout — and guido already spends the word twice on that meaning: `Layer::Overlay` in the prelude for the Wayland layer, `RenderLayer::Overlay` for ripples. Apps ended up with `.layer(Layer::Overlay)` and `.layout(Overlay::new())` side by side meaning unrelated things.

`ZStack` names the third axis next to `Flex::row/column`, and avoids the other collision: `Stack` means flex-with-spacing on the web (MUI, Chakra) and in WPF (`StackPanel`). Precedents: SwiftUI, Masonry/Xilem.

## 2. Followers are sized to their siblings

A child that declares `fill()` inside a `ZStack` now resolves against the size the **other** children established, per axis, instead of expanding to all the available space:

```rust
container()
    .layout(ZStack::new())
    // Follower: exactly as wide and tall as the card
    .child(container().width(fill()).height(fill()).child(visualizer()))
    // Leader: the stack is as big as this
    .child(card_content())
```

Mechanism: the two-pass shape `Flex` already uses for fill children, keyed on the `LayoutHints` the `Widget` trait already exposes. Pass 1 lays out the children that lead an axis and takes the max; pass 2 lays out the followers tight to it.

- **Axes are decided independently** — a child with only `.height(fill())` fills the bar height and still leads the width, which is what makes the status-bar case work.
- **No leader on an axis** → previous behaviour: the stack takes what it was offered.
- **A child that leads one axis and follows the other** is only re-laid out when the axis it follows actually changed; on the axis it leads, the max only ever shrinks down to the size it already reported.

Peers land on the same rule from different directions: iced's `Stack` has a `base_layer` that dictates the size while every other layer gets `0..size` limits, Flutter measures non-positioned children then lays out `Positioned.fill` against the result, Compose splits the two meanings outright (`fillMaxSize` vs `matchParentSize`).

## Docs

New book section (leaders/followers, per-axis rule, positioning inside the stack), a "when not to use it" section on the WidgetRef chapter pointing at `fraction()` and `ZStack`, and a fix to the layout chapter which claimed containers without an explicit `.layout()` stack their children — they use `Flex::column()`.

## Tests

4 layout tests (follower takes the leader's size; per-axis leading; all-followers fallback; a follower aligning content inside the stack) — the first, second and fourth fail on the old implementation. Plus 2 doctests.