### PR TITLE
A memo must not leak its dependencies to the scope that built it

### DIFF
--- a/book/src/concepts/reactive-model.md
+++ b/book/src/concepts/reactive-model.md
@@ -297,6 +297,21 @@ let count = create_signal(0);
 let doubled = create_memo(move || count.get() * 2);
 ```
 
+A memo is also a **tracking barrier**, which is what makes it the tool for
+narrowing a rebuild. Signals read inside it belong to it alone, even when the
+memo is created inside something that is itself tracked — a dynamic-children
+closure, a paint pass, an effect:
+
+```rust
+// `levels` is written 60 times a second by an audio service
+container().child(move || {
+    let active = create_memo(move || levels.with(|l| !l.is_empty()));
+    // This closure depends on the bool, not on `levels`: the subtree is
+    // rebuilt when the bool flips, not on every write
+    active.get().then(|| expensive_module())
+})
+```
+
 ## API Reference
 
 ### Signal Creation

--- a/docs/REACTIVE.md
+++ b/docs/REACTIVE.md
@@ -52,6 +52,24 @@ let label = create_memo(move || format!("Count: {}", count.get()));
 text(label)  // Only repaints when the formatted string changes
 ```
 
+A memo is a **tracking barrier**: what it reads is its own business. Creating
+one inside something that is itself tracked — a dynamic-children closure
+building a component, a paint or layout pass, another effect — registers no
+dependency on the surrounding scope. That is what makes the pattern work:
+
+```rust
+// Inside a dynamic-children closure. `levels` is written 60 times a second.
+container().child(move || {
+    let active = create_memo(move || levels.with(|l| !l.is_empty()));
+    // The closure depends on `active` (a bool that rarely flips), NOT on
+    // `levels` — the subtree is rebuilt when the bool changes, not per frame.
+    active.get().then(|| expensive_module())
+})
+```
+
+Only the value read *through* the memo (`active.get()` above) creates a
+dependency, and it only fires when the memoized value actually changes.
+
 ### Per-Field Signals (`SignalFields`)
 
 When a `Signal<AppState>` changes, **all** subscribers re-render — even if only one field changed. The `#[derive(SignalFields)]` macro solves this by generating per-field signal decomposition with zero-clone updates.

--- a/src/reactive/memo.rs
+++ b/src/reactive/memo.rs
@@ -1,5 +1,7 @@
 use super::effect::create_effect;
 use super::into_signal::{IntoSignal, MemoMarker};
+use super::invalidation::suspend_widget_tracking;
+use super::runtime::suspend_effect_tracking;
 use super::signal::{RwSignal, Signal, create_signal};
 
 /// Eager computed value that recomputes immediately when dependencies change.
@@ -51,7 +53,14 @@ where
     T: Clone + PartialEq + Send + 'static,
     F: Fn() -> T + 'static,
 {
-    let initial = f();
+    // The seed value is computed with tracking suspended. A memo is often
+    // created inside something that is itself being tracked — a dynamic
+    // children closure building a component, a paint/layout pass, another
+    // effect — and attributing this first read to that scope would hand it
+    // every dependency the memo exists to absorb: a hot signal read only
+    // inside the memo would rebuild the enclosing subtree on every write.
+    // The memo's own effect below establishes the real dependencies.
+    let initial = suspend_widget_tracking(|| suspend_effect_tracking(&f));
     let signal = create_signal(initial);
     // The effect runs immediately (establishing dependencies) and re-runs
     // whenever any dependency changes. Signal::set() uses PartialEq to
@@ -154,6 +163,70 @@ mod tests {
 
         count.set(5);
         assert_eq!(observed.get(), 10, "memo change must propagate to effects");
+    }
+
+    /// A memo built inside a widget's tracked scope must not hand that widget
+    /// its dependencies. This is the whole point of memoizing: a component
+    /// created inside a dynamic-children closure that memoizes a hot signal
+    /// (a per-frame audio level, a clock tick) must not make the closure —
+    /// and with it the entire subtree it builds — rebuild on every write.
+    #[test]
+    fn memo_created_in_a_tracked_scope_does_not_leak_its_dependencies() {
+        use crate::jobs::{self, JobType};
+        use crate::reactive::invalidation::with_signal_tracking;
+        use crate::tree::WidgetId;
+
+        let hot = create_signal(0);
+        let wid = WidgetId::from_u64(4242);
+
+        let memo = with_signal_tracking(wid, JobType::Reconcile, || {
+            create_memo(move || hot.get() * 2)
+        });
+        assert_eq!(memo.get(), 0);
+
+        // Discard anything queued while building
+        jobs::reset_jobs();
+
+        hot.set(21);
+
+        assert!(
+            !jobs::has_pending_jobs(),
+            "writing a signal only the memo reads must not invalidate the \
+             widget whose scope happened to build the memo"
+        );
+        assert_eq!(memo.get(), 42, "the memo itself must still track it");
+    }
+
+    /// Same isolation for the effect that happens to be running: creating a
+    /// memo inside an effect must not add the memo's dependencies to it.
+    #[test]
+    fn memo_created_inside_an_effect_does_not_leak_its_dependencies() {
+        use std::cell::Cell;
+        use std::rc::Rc;
+
+        let hot = create_signal(0);
+        let trigger = create_signal(0);
+        let runs = Rc::new(Cell::new(0));
+        let runs_c = runs.clone();
+
+        crate::reactive::create_effect(move || {
+            trigger.get();
+            runs_c.set(runs_c.get() + 1);
+            let _memo = create_memo(move || hot.get() * 2);
+        })
+        .detach();
+
+        assert_eq!(runs.get(), 1);
+
+        hot.set(1);
+        assert_eq!(
+            runs.get(),
+            1,
+            "the enclosing effect must not depend on what the memo reads"
+        );
+
+        trigger.set(1);
+        assert_eq!(runs.get(), 2, "its own dependencies must still fire");
     }
 
     /// Memo-of-memo chains must propagate through both levels.

--- a/src/reactive/runtime.rs
+++ b/src/reactive/runtime.rs
@@ -142,6 +142,25 @@ pub fn record_effect_read(signal_id: SignalId) {
     });
 }
 
+/// Suspend effect-level read tracking during the given closure.
+///
+/// Reads inside the closure are attributed to no effect. The counterpart of
+/// [`suspend_widget_tracking`](super::invalidation::suspend_widget_tracking):
+/// together they make a computation invisible to whatever is tracking around
+/// it, which is what a memo's seed computation needs.
+pub(crate) fn suspend_effect_tracking<F, R>(f: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    let saved: Vec<_> = EFFECT_TRACKING.with(|stack| stack.borrow_mut().drain(..).collect());
+    // Restore on unwind too: losing the saved stack would silently drop the
+    // dependencies of every effect currently on the stack.
+    let _guard = super::guard::defer(move || {
+        EFFECT_TRACKING.with(|stack| *stack.borrow_mut() = saved);
+    });
+    f()
+}
+
 /// Return the current write epoch. Captured by `WriteSignal` at creation
 /// time so that writes queued after a restart carry the old epoch.
 pub(crate) fn current_write_epoch() -> u64 {


### PR DESCRIPTION
`create_memo` computed its seed value in whatever tracking context happened to be active:

```rust
let initial = f();                 // ← runs in the CALLER's tracking scope
let signal = create_signal(initial);
let effect = create_effect(move || signal.set(f()));   // this part was already isolated
```

Building a memo inside a widget's tracked closure therefore registered **that widget** as a subscriber of every signal the memo reads — the exact opposite of what a memo is for. Effects run under `suspend_widget_tracking`, so the memo's own effect was fine; only the seed call was bare.

## Why it hurts exactly where memos are used

The cost lands on whoever memoizes a hot signal precisely to avoid rebuilding a subtree — the textbook use:

```rust
container().child(move || {
    let active = create_memo(move || levels.with(|l| !l.is_empty()));  // levels: 60 writes/s
    active.get().then(|| expensive_module())
})
```

Intent: rebuild when the bool flips. Actual: the closure subscribed to `levels` and rebuilt every frame.

Measured on the ashell port, whose media player module does exactly this to keep per-frame visualizer data from rebuilding it:

| | before | after |
|---|---|---|
| module rebuilds while moving the mouse onto it | **1583** | **7** |
| CPU, bar with the visualizer running (release) | **37-40%** of a core | **3%** |
| painted frames for 60 content updates/s | 121/s | 59/s |
| paint cache hit rate | 0.0% | 10.7% |

The user-visible symptoms were a module that never showed its hover highlight (each rebuild resets the interaction state, and a stationary pointer sends no new motion event) and clicks that were silently dropped when a rebuild landed between press and release.

## The fix

The seed value is computed with both tracking layers suspended:

```rust
let initial = suspend_widget_tracking(|| suspend_effect_tracking(&f));
```

`suspend_effect_tracking` is new — the runtime-side counterpart of the existing `suspend_widget_tracking`, drains the effect-tracking stack for the duration and restores it on unwind. So a memo created inside an effect no longer adds its dependencies to that effect either.

## Tests

Two, both failing on the previous behaviour:
- `memo_created_in_a_tracked_scope_does_not_leak_its_dependencies` — a write to a signal only the memo reads must queue no job for the widget whose scope built it
- `memo_created_inside_an_effect_does_not_leak_its_dependencies` — the enclosing effect must not re-run, while its own dependencies still fire

Docs: the "memo as tracking barrier" property is now stated in `docs/REACTIVE.md` and the book's reactive chapter, with the rebuild-narrowing example.