### PR TITLE
Paint invalidation follows what layout touched, not the layout root

### DIFF
--- a/examples/incremental_layout_test.rs
+++ b/examples/incremental_layout_test.rs
@@ -1,0 +1,79 @@
+//! Benchmark: a small piece of a big UI changes, ten times a second.
+//!
+//! A header label updates while 100 static rows sit untouched. This is the
+//! canonical incremental-invalidation case: layout must only re-run along the
+//! dirty path, and paint must only redraw what layout actually touched — the
+//! untouched rows should come out of the paint/flatten caches, and the damage
+//! reported to the compositor should be the header's rectangle, not the whole
+//! surface.
+//!
+//! ```bash
+//! cargo run --release --example incremental_layout_test --features render-stats
+//! ```
+//!
+//! Read `paint: cache_rate` (higher is better) and `damage:` (partial, not
+//! full) in the per-second stats.
+
+use guido::prelude::*;
+
+#[tokio::main]
+async fn main() {
+    App::new().run(|app| {
+        // A label that changes text — and therefore size — 10 times a second
+        let ticks = create_signal(0u32);
+        let ticks_w = ticks.writer();
+        let _ = create_service::<(), _, _>(move |_rx, ctx| async move {
+            while ctx.is_running() {
+                ticks_w.update(|t| *t += 1);
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            }
+        });
+
+        app.add_surface(
+            SurfaceConfig::new()
+                .width(600)
+                .height(800)
+                .anchor(Anchor::TOP | Anchor::LEFT)
+                .layer(Layer::Top)
+                .namespace("guido-incremental-layout")
+                .background_color(Color::rgb(0.10, 0.10, 0.14)),
+            move || {
+                container()
+                    .width(fill())
+                    .height(fill())
+                    .layout(Flex::column().spacing(8.0))
+                    .padding(12.0)
+                    .child(
+                        container()
+                            .width(fill())
+                            .padding(12.0)
+                            .corner_radius(12.0)
+                            .background(Color::rgb(0.18, 0.18, 0.24))
+                            .child(
+                                text(move || format!("elapsed: {} ticks", ticks.get()))
+                                    .font_size(18.0),
+                            ),
+                    )
+                    .children((0..100).map(static_row).collect::<Vec<_>>())
+            },
+        );
+    });
+}
+
+/// A row that never changes: everything below it should stay cached.
+fn static_row(i: usize) -> Container {
+    container()
+        .width(fill())
+        .padding(8.0)
+        .corner_radius(8.0)
+        .background(Color::rgb(0.14, 0.14, 0.19))
+        .layout(Flex::row().spacing(8.0))
+        .child(
+            container()
+                .width(16.0)
+                .height(16.0)
+                .corner_radius(8.0)
+                .background(Color::rgb(0.3, 0.5, 0.9)),
+        )
+        .child(text(format!("row {i}")).font_size(14.0))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -606,10 +606,13 @@ fn render_surface(
                     widget.layout(tree, id, cached);
                 });
             }
-            // Layout may reposition children — conservatively mark subtrees as needing paint
-            for root_id in &roots {
-                tree.mark_subtree_needs_paint(*root_id);
-            }
+            // Paint invalidation is per widget, not per subtree: every widget
+            // that actually ran its layout marked itself (and its ancestors)
+            // inside Tree::cache_layout, and Tree::set_origin damaged what
+            // moved. Marking the whole subtree here instead would repaint
+            // every descendant of the layout root — which in a
+            // content-sized tree is the whole surface — and throw away the
+            // paint and flatten caches the layout pass just earned.
         } else if needs_resize {
             // Full layout from root only when explicitly needed (first frame, resize, etc.)
             tree.with_widget_mut(surface.widget_id, |widget, id, tree| {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -575,12 +575,39 @@ impl Tree {
             .unwrap_or(false)
     }
 
-    /// Cache the constraints and size for a widget.
+    /// Cache the constraints and size for a widget, and invalidate its paint.
+    ///
+    /// This is only reached by a widget that actually ran its layout — the
+    /// ones that hit the early-out (clean, same constraints) return before
+    /// getting here — so it is the point where the layout pass tells paint
+    /// what it touched. Same rule as Flutter, whose `RenderObject.layout()`
+    /// ends in `markNeedsPaint()` for the objects that laid out; everything
+    /// the pass skipped keeps its cached paint.
+    ///
+    /// Running layout is the invalidation signal, not a size change: a
+    /// widget's painted output can depend on state it refreshes during
+    /// layout (a `Text` re-reads its content there and paints from the
+    /// cached copy), so a clock going from `15:23` to `15:24` at the very
+    /// same width still has to be redrawn.
+    ///
+    /// When the size changes, the damage covers both the rectangle the
+    /// widget used to occupy and the one it occupies now.
     pub fn cache_layout(&mut self, id: WidgetId, constraints: Constraints, size: Size) {
-        if let Some(idx) = self.get_dense_index(id) {
-            self.dense[idx].cached_constraints = Some(constraints);
-            self.dense[idx].cached_size = Some(size);
+        let Some(idx) = self.get_dense_index(id) else {
+            return;
+        };
+        let previous_size = self.dense[idx].cached_size;
+        if previous_size.is_some_and(|prev| prev != size)
+            && let Some((root, vacated)) = self.surface_relative_bounds_and_root(id)
+        {
+            self.expand_damage_rect(root, vacated);
         }
+        let idx = self.get_dense_index(id).expect("checked above");
+        self.dense[idx].cached_constraints = Some(constraints);
+        self.dense[idx].cached_size = Some(size);
+        // Damages the new rect and marks the ancestors, which have to redraw
+        // to re-emit this widget at its new geometry.
+        self.mark_needs_paint(id);
     }
 
     /// Get cached constraints for a widget.
@@ -596,9 +623,26 @@ impl Tree {
     }
 
     /// Set the origin (position) for a widget.
+    ///
+    /// A widget that moves damages the pixels it leaves behind as well as the
+    /// ones it now covers. It does not need repainting for that: its painted
+    /// content is position-independent and the parent re-emits it at the new
+    /// offset (paint-cache reuse re-parents the cached node). The parent is
+    /// already marked, since moving a child means it ran its own layout.
     pub fn set_origin(&mut self, id: WidgetId, x: f32, y: f32) {
-        if let Some(idx) = self.get_dense_index(id) {
-            self.dense[idx].origin = (x, y);
+        let Some(idx) = self.get_dense_index(id) else {
+            return;
+        };
+        if self.dense[idx].origin == (x, y) {
+            return;
+        }
+        if let Some((root, vacated)) = self.surface_relative_bounds_and_root(id) {
+            self.expand_damage_rect(root, vacated);
+        }
+        let idx = self.get_dense_index(id).expect("checked above");
+        self.dense[idx].origin = (x, y);
+        if let Some((root, occupied)) = self.surface_relative_bounds_and_root(id) {
+            self.expand_damage_rect(root, occupied);
         }
     }
 
@@ -985,6 +1029,117 @@ mod tests {
         assert!(
             tree.needs_paint(root_id),
             "surface root must see the dirty descendant or the frame is skipped"
+        );
+    }
+
+    /// Build `root -> [a, b]`, both laid out and clean.
+    fn two_children_tree() -> (Tree, WidgetId, WidgetId, WidgetId) {
+        let mut tree = Tree::new();
+        let root = tree.register(Box::new(MockWidget::new()));
+        let a = tree.register(Box::new(MockWidget::new()));
+        let b = tree.register(Box::new(MockWidget::new()));
+        tree.set_parent(a, root);
+        tree.set_parent(b, root);
+
+        let c = Constraints::new(0.0, 0.0, 100.0, 100.0);
+        tree.cache_layout(root, c, Size::new(100.0, 100.0));
+        tree.cache_layout(a, c, Size::new(40.0, 20.0));
+        tree.set_origin(a, 0.0, 0.0);
+        tree.cache_layout(b, c, Size::new(40.0, 20.0));
+        tree.set_origin(b, 0.0, 20.0);
+        for id in [root, a, b] {
+            tree.clear_needs_paint(id);
+        }
+        let _ = tree.take_damage(root);
+        (tree, root, a, b)
+    }
+
+    /// The point of incremental invalidation: re-laying out one subtree must
+    /// leave its siblings' paint caches alone. Marking the layout root's whole
+    /// subtree instead (the old behaviour) repainted every widget under it,
+    /// which in a content-sized tree is the entire surface.
+    #[test]
+    fn relayout_of_one_child_leaves_its_sibling_paintable_from_cache() {
+        let (mut tree, root, a, b) = two_children_tree();
+
+        // `a` re-runs its layout; `b` is untouched
+        tree.cache_layout(
+            a,
+            Constraints::new(0.0, 0.0, 100.0, 100.0),
+            Size::new(60.0, 20.0),
+        );
+
+        assert!(tree.needs_paint(a), "the widget that laid out repaints");
+        assert!(
+            tree.needs_paint(root),
+            "its ancestors repaint to re-emit it at the new geometry"
+        );
+        assert!(
+            !tree.needs_paint(b),
+            "an untouched sibling must keep its cached paint"
+        );
+    }
+
+    /// A widget can run layout and come out the same size while painting
+    /// something else — a clock going from `15:23` to `15:24` refreshes its
+    /// glyphs during layout. Running layout is the invalidation signal.
+    #[test]
+    fn running_layout_repaints_even_when_the_size_is_unchanged() {
+        let (mut tree, _root, a, _b) = two_children_tree();
+        let same = tree.cached_size(a).unwrap();
+
+        tree.cache_layout(a, Constraints::new(0.0, 0.0, 100.0, 100.0), same);
+
+        assert!(tree.needs_paint(a));
+    }
+
+    /// Shrinking must damage the rectangle the widget stops covering, or the
+    /// compositor keeps showing the pixels it left behind.
+    #[test]
+    fn shrinking_damages_the_vacated_rectangle() {
+        let (mut tree, root, a, _b) = two_children_tree();
+
+        tree.cache_layout(
+            a,
+            Constraints::new(0.0, 0.0, 100.0, 100.0),
+            Size::new(10.0, 20.0),
+        );
+
+        match tree.take_damage(root) {
+            DamageRegion::Partial(rect) => {
+                assert!(
+                    rect.width >= 40.0,
+                    "damage must cover the old 40px-wide box, got {rect:?}"
+                );
+            }
+            other => panic!("expected partial damage, got {other:?}"),
+        }
+    }
+
+    /// Moving a widget damages both where it was and where it lands. Its own
+    /// paint stays valid — the parent re-emits it at the new offset.
+    #[test]
+    fn moving_a_widget_damages_both_positions() {
+        let (mut tree, root, a, _b) = two_children_tree();
+
+        tree.set_origin(a, 0.0, 60.0);
+
+        match tree.take_damage(root) {
+            DamageRegion::Partial(rect) => {
+                assert!(
+                    rect.y <= 0.0,
+                    "damage must reach the old position, got {rect:?}"
+                );
+                assert!(
+                    rect.y + rect.height >= 80.0,
+                    "damage must reach the new position, got {rect:?}"
+                );
+            }
+            other => panic!("expected partial damage, got {other:?}"),
+        }
+        assert!(
+            !tree.needs_paint(a),
+            "a widget that only moved keeps its cached paint"
         );
     }
 }

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -2206,27 +2206,38 @@ impl Widget for Container {
                 && !tree.needs_paint(child_id)
                 && let Some(cached) = tree.cached_paint(child_id)
             {
-                if cached.parent_position == child_position && cached.bounds == child_local {
-                    // Position unchanged: reuse the cached node wholesale.
-                    // Zero copies — the render tree and the cache share it.
-                    ctx.add_child_rc(std::rc::Rc::clone(cached));
-                } else {
-                    // Position changed: shallow header clone (children and
-                    // commands are Rc-shared, so this copies no subtree).
-                    // Decompose: extract user transform, recompose with new position.
-                    let mut reused = (**cached).clone();
-                    let user_part = cached
-                        .parent_position
-                        .inverse()
-                        .then(&cached.local_transform);
-                    reused.local_transform = child_position.then(&user_part);
-                    reused.parent_position = child_position;
-                    reused.bounds = child_local;
-                    reused.repainted.set(false);
-                    ctx.add_child_rc(std::rc::Rc::new(reused));
+                // A cached node may only be re-parented, never re-sized: its
+                // commands were built for the size it was painted at. A size
+                // change means the child ran layout and marked itself, so it
+                // should not reach here — falling through to a full paint if
+                // it ever does keeps a missed invalidation from turning into
+                // stale content stretched to the wrong box.
+                let same_size = cached.bounds.width == child_local.width
+                    && cached.bounds.height == child_local.height;
+                if same_size {
+                    if cached.parent_position == child_position {
+                        // Position unchanged: reuse the cached node wholesale.
+                        // Zero copies — the render tree and the cache share it.
+                        ctx.add_child_rc(std::rc::Rc::clone(cached));
+                    } else {
+                        // Position changed: shallow header clone (children and
+                        // commands are Rc-shared, so this copies no subtree).
+                        // Decompose: extract user transform, recompose with new position.
+                        let mut reused = (**cached).clone();
+                        let user_part = cached
+                            .parent_position
+                            .inverse()
+                            .then(&cached.local_transform);
+                        reused.local_transform = child_position.then(&user_part);
+                        reused.parent_position = child_position;
+                        reused.bounds = child_local;
+                        reused.repainted.set(false);
+                        ctx.add_child_rc(std::rc::Rc::new(reused));
+                    }
+                    crate::render_stats::record_paint_child_cached();
+                    continue;
                 }
-                crate::render_stats::record_paint_child_cached();
-                continue;
+                // Different size: fall through to a full paint below.
             }
 
             // Full paint (child is dirty, no cache, or partially visible scrollable child)

--- a/src/widgets/text.rs
+++ b/src/widgets/text.rs
@@ -127,6 +127,23 @@ impl Widget for Text {
         // Text widgets are never relayout boundaries
         tree.set_relayout_boundary(id, false);
 
+        // Same early-out as Container: an unchanged text under unchanged
+        // constraints neither re-measures nor gets repainted, even when an
+        // ancestor re-runs its layout. Content and style changes come through
+        // signals tracked below, which mark this widget for layout.
+        let constraints_changed = tree.cached_constraints(id) != Some(constraints);
+        let reactive_changed = tree.needs_layout(id);
+        if !(constraints_changed || reactive_changed) {
+            crate::render_stats::record_layout_skipped();
+            return tree.cached_size(id).unwrap_or_default();
+        }
+        crate::render_stats::record_layout_executed_with_reasons(
+            crate::render_stats::LayoutReasons {
+                constraints_changed,
+                reactive_changed,
+            },
+        );
+
         // Refresh cached values from reactive properties
         // This reads signals and registers layout dependencies
         self.refresh(id);


### PR DESCRIPTION
## The problem

Layout is already incremental. `Container::layout` has the same early-out as Flutter's `RenderObject.layout()` — clean widget + unchanged constraints returns the cached size without walking the subtree — and it works: **98% of layout calls skipped** in a 300-widget tree, ~16 nodes touched per pass in a 90-widget status bar.

Paint then threw the result away (`lib.rs:609`):

```rust
// Layout may reposition children — conservatively mark subtrees as needing paint
for root_id in &roots {
    tree.mark_subtree_needs_paint(*root_id);   // whole subtree + DamageRegion::Full
}
```

And the layout root is rarely deep. A relayout boundary requires a size that cannot depend on children (fixed on both axes, or tight constraints) — so any content-sized subtree bubbles all the way up. Measured with a temporary probe on a real app, 12 idle seconds:

```
133 partial layouts — 133 rooted at the SURFACE ROOT (subtree of 88-92 widgets)
```

Every clock tick repainted ~90 widgets and reported the entire surface as damaged. Paint and flatten cache hit rate: **0.0%, always**.

## What the peers do

| | |
|---|---|
| **Flutter** | `RenderObject.layout()` ends in `markNeedsPaint()` — only for objects that actually laid out. Subtrees that hit the early-out keep their layers |
| **Blink** | `PaintInvalidator` walks only what is marked, invalidates **old ∪ new** visual rect; `PaintController` reuses cached subsequences, and a moved subtree gets a paint-offset translation instead of a repaint |
| **UIKit/AppKit** | `setNeedsDisplay(rect)` per view, dirty rects unioned |

Nobody invalidates "the subtree of the layout root".

## The change

- **`Tree::cache_layout`** is only reached by a widget that actually ran its layout (the early-out returns before it), so it marks that widget and its ancestors — the ancestors have to redraw to re-emit it at its new geometry. **Running layout is the signal, not a size change**: `Text` refreshes its content during layout and paints from the cached copy (`text.rs:115`), so a clock going from `15:23` to `15:24` at identical width still has to be redrawn. When the size does change, the damage covers the rectangle vacated as well as the new one.
- **`Tree::set_origin`** damages old ∪ new when a widget moves. Its own paint stays valid: the parent re-emits it at the new offset and the cached node is re-parented (that path already existed).
- **Paint-cache reuse** now requires the cached bounds to have the same *size*; position-only differences keep the re-parenting path. A missed invalidation degrades into a repaint instead of stale content stretched to the wrong box.
- **`Text` gained `Container`'s early-out**, so an unchanged label neither re-measures nor repaints when an ancestor re-lays out.

`mark_subtree_needs_paint` + full damage stay where they are correct: init, resize, scale change.

## Numbers

New harness, `examples/incremental_layout_test` — 100 static rows and one label ticking 10×/s, the canonical incremental case:

| | before | after |
|---|---|---|
| widgets painted /s | 3020 (cache **0.0%**) | 20 (cache **98.0%**) |
| flatten nodes /s | 3030 (cache 0.0%) | 30 (cache **97.1%**) |
| damage | full ×10 | **partial ×10** |
| paint / flatten / cache per frame | 266µs / 110µs / 186µs | **13µs / 34µs / 4µs** |

Real status bar at idle: **89 → 15** widget paints per frame, paint cache 54%, damage partial instead of full-surface — which is work saved in the compositor too, not just here.

## Verification

Four new `tree` tests, all failing on the previous behaviour: a re-laid-out child leaves its sibling cache-paintable; running layout repaints even at an unchanged size; shrinking damages the vacated rectangle; moving damages both positions while keeping the moved widget's paint.

Ran on screen: the new example (label updates correctly at constant width — the case a size-based rule would have broken), showcase, scrolling in `bench_list`, a spring width animation expanding and settling, and a real app — bar, menus, and a calendar month change, which is the reconcile-only update that #138 fixed and which still reaches the screen.

**Known limit, unchanged by this PR**: damage uses widget bounds, so paint that exceeds them (shadows, scale > 1) is under-reported — that was already true of the existing `mark_needs_paint` path. Worth a follow-up.