### PR TITLE
Debug builds name the signal reads that cannot be reactive

### DIFF
--- a/book/src/advanced/components.md
+++ b/book/src/advanced/components.md
@@ -115,6 +115,41 @@ pub fn button(
 }
 ```
 
+## The Body Runs Once
+
+A component's body executes **one time**, when the widget is first built, inside
+its own ownership scope — that is what lets the signals and effects it creates
+die with the component. Reactivity comes from the closures it leaves behind,
+not from re-running the body:
+
+```rust
+#[component]
+pub fn status_chip(label: String, active: bool) -> impl Widget {
+    container()
+        // Reactive: the closure re-runs when `active` changes
+        .background(move || if active.get() { Color::GREEN } else { Color::GRAY })
+        // Reactive: the signal is passed through untouched
+        .child(text(label))
+}
+```
+
+Reading a prop **outside** a closure takes a snapshot of it, and the component
+will never update:
+
+```rust
+// Wrong: the branch is decided once, for good
+if active.get() { selected_row() } else { plain_row() }
+
+// Right: the choice itself lives in a closure
+container().child(move || {
+    if active.get() { selected_row().into_any() } else { plain_row().into_any() }
+})
+```
+
+Debug builds warn at the exact line when a prop is read this way — unless the
+caller passed a plain value, which cannot change anyway. If the snapshot is
+deliberate, `get_untracked()` says so and silences the warning.
+
 ## Components with Children
 
 ```rust

--- a/book/src/concepts/reactive-model.md
+++ b/book/src/concepts/reactive-model.md
@@ -312,6 +312,30 @@ container().child(move || {
 })
 ```
 
+## Snapshots vs. Reactive Reads
+
+Reading a signal subscribes whoever is *currently* running. Inside a closure
+that guido re-runs — a widget property, a child closure, an effect — that means
+the UI follows the value. Outside one, there is nobody to subscribe, so the
+read is a snapshot:
+
+```rust
+text(format!("{}", count.get()))          // snapshot: never updates again
+text(move || format!("{}", count.get()))  // reactive
+text(count_as_string)                     // reactive: pass the signal itself
+```
+
+Rust cannot tell those apart at compile time, so **debug builds print a warning
+at the offending line**:
+
+```
+guido: src/main.rs:42:31: signal read with no reactive scope — this value is a
+snapshot and will not update. Pass a closure instead …
+```
+
+If the snapshot is what you meant, say so with `get_untracked()` and the
+warning goes away. Release builds contain none of this.
+
 ## API Reference
 
 ### Signal Creation

--- a/docs/REACTIVE.md
+++ b/docs/REACTIVE.md
@@ -70,6 +70,37 @@ container().child(move || {
 Only the value read *through* the memo (`active.get()` above) creates a
 dependency, and it only fires when the memoized value actually changes.
 
+### Snapshot Reads (and the debug warning)
+
+A tracked read (`get`/`with`) registers the *currently active* reactive scope
+as a subscriber. With no scope active there is nobody to register, so the value
+is a snapshot — frozen into whatever it was used for:
+
+```rust
+text(format!("{}", count.get()))          // snapshot: never updates again
+text(move || format!("{}", count.get()))  // reactive: the closure re-runs
+```
+
+The two lines differ only in *where* the read happens, which Rust cannot check
+at compile time. So debug builds warn at the read site instead, naming the
+exact line:
+
+```
+guido: src/main.rs:42:31: signal read with no reactive scope — this value is a
+snapshot and will not update. Pass a closure instead …
+```
+
+One warning per call site, nothing in release builds. Two ways to say a
+snapshot is intended:
+
+- `get_untracked()` / `with_untracked()` for a single read
+- `reactive::diagnostics::snapshot_zone(|| …)` for a whole callback region
+
+Reads that are already correct stay silent: inside a widget's layout/paint
+scope, inside effects and memos, inside event handlers and animation
+completions (guido marks those regions itself), and reads of `create_stored`
+values, which cannot change in the first place.
+
 ### Per-Field Signals (`SignalFields`)
 
 When a `Signal<AppState>` changes, **all** subscribers re-render — even if only one field changed. The `#[derive(SignalFields)]` macro solves this by generating per-field signal decomposition with zero-clone updates.

--- a/examples/children_example.rs
+++ b/examples/children_example.rs
@@ -112,7 +112,9 @@ fn main() {
                             container()
                                 .layout(Flex::row().spacing(4.0))
                                 .child(text("Fixed").color(Color::WHITE))
-                                // This is evaluated ONCE at creation - won't update!
+                                // Evaluated ONCE at creation — it will never
+                                // update. Debug builds warn about exactly this
+                                // read; the closure below is the fix.
                                 .maybe_child(
                                     if show_optional.get() {
                                         Some(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -469,10 +469,14 @@ fn render_surface(
         return;
     }
 
-    // Dispatch events to widget
+    // Dispatch events to widget. Handlers read signals for their current
+    // value, not to subscribe — a click wants the value at click time — so
+    // the whole dispatch is a snapshot zone.
     for event in &events {
-        tree.with_widget_mut(surface.widget_id, |widget, id, tree| {
-            widget.event(tree, id, event);
+        reactive::diagnostics::snapshot_zone(|| {
+            tree.with_widget_mut(surface.widget_id, |widget, id, tree| {
+                widget.event(tree, id, event);
+            });
         });
     }
 

--- a/src/reactive/diagnostics.rs
+++ b/src/reactive/diagnostics.rs
@@ -1,0 +1,227 @@
+//! Debug-build diagnostic for signal reads that cannot be reactive.
+//!
+//! A tracked read (`get`/`with`) registers the *current* reactive scope as a
+//! subscriber. With no scope active there is nobody to register, so the value
+//! is a snapshot: whatever it produced is frozen into whatever it was used
+//! for. That is the single most common way to write a UI that silently stops
+//! updating —
+//!
+//! ```ignore
+//! text(format!("{}", count.get()))          // snapshot: never updates
+//! text(move || format!("{}", count.get()))  // reactive: the closure re-runs
+//! ```
+//!
+//! Rust cannot express this at compile time: the two lines differ only in
+//! where the read happens, and a type that carried that information would
+//! have to poison every signature it touches (Leptos shipped `cx: Scope`
+//! everywhere and removed it again). So the check is a debug-build warning at
+//! the read site, with `#[track_caller]` giving the exact file and line, one
+//! warning per call site, and nothing at all in release builds.
+//!
+//! Snapshots are legitimate in plenty of places — an event handler wants the
+//! value at click time, not a subscription — so guido marks those regions as
+//! [`snapshot_zone`]s and the check stays quiet inside them.
+
+/// Run `f` in a region where snapshot reads are the intended semantics.
+///
+/// Suppresses the debug-build "read without a reactive scope" warning for
+/// everything `f` does. guido wraps its own callback regions (event dispatch,
+/// service tasks, animation completions) in one of these; apps need it only
+/// for their own callback machinery — for a single read, `get_untracked()`
+/// says the same thing more locally.
+///
+/// In release builds this is just a call to `f`.
+pub fn snapshot_zone<R>(f: impl FnOnce() -> R) -> R {
+    #[cfg(debug_assertions)]
+    {
+        imp::DEPTH.with(|d| d.set(d.get() + 1));
+        let _guard = crate::reactive::guard::defer(|| {
+            imp::DEPTH.with(|d| d.set(d.get().saturating_sub(1)));
+        });
+        f()
+    }
+    #[cfg(not(debug_assertions))]
+    {
+        f()
+    }
+}
+
+/// Report a tracked read that had no reactive scope to register with.
+///
+/// Called from the read itself, so `#[track_caller]` resolves to the user's
+/// line. No-op in release builds and inside a [`snapshot_zone`].
+#[cfg_attr(debug_assertions, track_caller)]
+#[inline]
+pub(crate) fn check_reactive_scope() {
+    #[cfg(debug_assertions)]
+    imp::check();
+}
+
+#[cfg(debug_assertions)]
+mod imp {
+    use std::cell::{Cell, RefCell};
+
+    use rustc_hash::FxHashSet;
+
+    thread_local! {
+        /// Nesting depth of `snapshot_zone`.
+        pub(super) static DEPTH: Cell<u32> = const { Cell::new(0) };
+        /// Call sites already reported, so a read in a hot path warns once.
+        static REPORTED: RefCell<FxHashSet<(&'static str, u32, u32)>> =
+            RefCell::new(FxHashSet::default());
+        /// Number of reports emitted — the hook the diagnostic's own tests use.
+        pub(super) static REPORTS: Cell<u64> = const { Cell::new(0) };
+    }
+
+    #[track_caller]
+    pub(super) fn check() {
+        if DEPTH.with(|d| d.get()) > 0 {
+            return;
+        }
+        if crate::reactive::invalidation::widget_tracking_active()
+            || crate::reactive::runtime::effect_tracking_active()
+        {
+            return;
+        }
+
+        let loc = std::panic::Location::caller();
+        let key = (loc.file(), loc.line(), loc.column());
+        let first_time = REPORTED.with(|r| r.borrow_mut().insert(key));
+        if !first_time {
+            return;
+        }
+
+        REPORTS.with(|c| c.set(c.get() + 1));
+
+        let message = format!(
+            "{}:{}:{}: signal read with no reactive scope — this value is a \
+             snapshot and will not update. Pass a closure instead (e.g. \
+             `move || …` rather than the value it computes), or use \
+             `get_untracked()`/`with_untracked()` if a snapshot is what you \
+             meant. (debug builds only)",
+            loc.file(),
+            loc.line(),
+            loc.column(),
+        );
+        // The audience for this warning is whoever just wrote their first
+        // guido app, who quite likely has no logger installed yet — with the
+        // log crate uninitialised `max_level` is Off and a `warn!` would go
+        // nowhere, so say it on stderr instead.
+        if log::max_level() == log::LevelFilter::Off {
+            eprintln!("guido: {message}");
+        } else {
+            log::warn!("{message}");
+        }
+    }
+
+    /// Forget every reported call site (used by `reset_reactive`).
+    pub(crate) fn reset() {
+        REPORTED.with(|r| r.borrow_mut().clear());
+        DEPTH.with(|d| d.set(0));
+        REPORTS.with(|c| c.set(0));
+    }
+}
+
+#[cfg(debug_assertions)]
+pub(crate) fn reset() {
+    imp::reset();
+}
+
+#[cfg(not(debug_assertions))]
+pub(crate) fn reset() {}
+
+/// Number of snapshot reads reported so far on this thread (debug builds).
+#[cfg(all(debug_assertions, test))]
+pub(crate) fn report_count() -> u64 {
+    imp::REPORTS.with(|c| c.get())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::jobs::JobType;
+    use crate::reactive::invalidation::with_signal_tracking;
+    use crate::reactive::{create_signal, create_stored};
+    use crate::tree::WidgetId;
+
+    fn reports_of(f: impl FnOnce()) -> u64 {
+        let before = report_count();
+        f();
+        report_count() - before
+    }
+
+    /// The mistake this exists for: reading a signal while building a widget
+    /// tree, with nothing to subscribe to.
+    #[test]
+    fn a_read_with_no_scope_is_reported() {
+        let count = create_signal(0);
+        assert_eq!(
+            reports_of(|| {
+                let _ = count.get();
+            }),
+            1
+        );
+    }
+
+    /// Every legitimate shape must stay silent, or the warning becomes noise
+    /// and nobody reads it.
+    #[test]
+    fn legitimate_reads_are_not_reported() {
+        let count = create_signal(0);
+        let stored = create_stored(7);
+        let wid = WidgetId::from_u64(9001);
+
+        // Inside a widget scope: layout/paint/reconcile register a subscriber
+        assert_eq!(
+            reports_of(|| with_signal_tracking(wid, JobType::Paint, || {
+                let _ = count.get();
+            })),
+            0
+        );
+        // Explicit snapshot
+        assert_eq!(
+            reports_of(|| {
+                let _ = count.get_untracked();
+            }),
+            0
+        );
+        assert_eq!(reports_of(|| count.with_untracked(|_| ())), 0);
+        // Inside a region guido marks as callback-like
+        assert_eq!(
+            reports_of(|| snapshot_zone(|| {
+                let _ = count.get();
+            })),
+            0
+        );
+        // A stored value cannot change, so reading it is never a missed
+        // subscription — component props default to these
+        assert_eq!(
+            reports_of(|| {
+                let _ = stored.get();
+            }),
+            0
+        );
+        // Effects establish their own tracking
+        assert_eq!(
+            reports_of(|| crate::reactive::create_effect(move || {
+                let _ = count.get();
+            })
+            .detach()),
+            0
+        );
+    }
+
+    /// One report per call site, however hot the path.
+    #[test]
+    fn a_call_site_is_reported_once() {
+        let count = create_signal(0);
+        assert_eq!(
+            reports_of(|| {
+                for _ in 0..50 {
+                    let _ = count.get();
+                }
+            }),
+            1
+        );
+    }
+}

--- a/src/reactive/invalidation.rs
+++ b/src/reactive/invalidation.rs
@@ -109,6 +109,11 @@ where
     f()
 }
 
+/// Whether a widget tracking scope is currently active (layout/paint/reconcile).
+pub(crate) fn widget_tracking_active() -> bool {
+    TRACKING_CONTEXT.with(|ctx| !ctx.borrow().is_empty())
+}
+
 /// Record that a signal was read. Called from Signal::get().
 /// If tracking is active, registers the current widget as a subscriber.
 pub fn record_signal_read(signal_id: SignalId) {

--- a/src/reactive/memo.rs
+++ b/src/reactive/memo.rs
@@ -1,3 +1,4 @@
+use super::diagnostics::snapshot_zone;
 use super::effect::create_effect;
 use super::into_signal::{IntoSignal, MemoMarker};
 use super::invalidation::suspend_widget_tracking;
@@ -60,7 +61,7 @@ where
     // every dependency the memo exists to absorb: a hot signal read only
     // inside the memo would rebuild the enclosing subtree on every write.
     // The memo's own effect below establishes the real dependencies.
-    let initial = suspend_widget_tracking(|| suspend_effect_tracking(&f));
+    let initial = snapshot_zone(|| suspend_widget_tracking(|| suspend_effect_tracking(&f)));
     let signal = create_signal(initial);
     // The effect runs immediately (establishing dependencies) and re-runs
     // whenever any dependency changes. Signal::set() uses PartialEq to

--- a/src/reactive/mod.rs
+++ b/src/reactive/mod.rs
@@ -1,6 +1,7 @@
 pub mod clipboard;
 pub mod context;
 pub mod cursor;
+pub mod diagnostics;
 pub mod effect;
 pub mod focus;
 pub(crate) mod guard;
@@ -68,4 +69,5 @@ pub(crate) fn reset_reactive() {
     cursor::reset_cursor();
     focus::reset_focus();
     context::reset_contexts();
+    diagnostics::reset();
 }

--- a/src/reactive/owner.rs
+++ b/src/reactive/owner.rs
@@ -279,7 +279,8 @@ pub fn dispose_owner_now(id: OwnerId) {
 
     // Run cleanup callbacks in reverse order (LIFO)
     for cleanup in owner.cleanups.into_iter().rev() {
-        cleanup();
+        // Teardown code reads for the current value; the scope is going away
+        crate::reactive::diagnostics::snapshot_zone(cleanup);
     }
 
     // Dispose effects and remove from reverse mapping

--- a/src/reactive/runtime.rs
+++ b/src/reactive/runtime.rs
@@ -128,6 +128,11 @@ fn vec_remove<T: PartialEq>(vec: &mut Vec<T>, value: &T) {
     }
 }
 
+/// Whether an effect (or memo) is currently executing and collecting reads.
+pub(crate) fn effect_tracking_active() -> bool {
+    EFFECT_TRACKING.with(|stack| stack.try_borrow().map(|s| !s.is_empty()).unwrap_or(true))
+}
+
 /// Buffer a signal read for the currently executing effect.
 /// Called from tracked_get/tracked_with. During effect execution, the Runtime
 /// RefCell is already borrowed, so reads are buffered here and applied after.

--- a/src/reactive/signal.rs
+++ b/src/reactive/signal.rs
@@ -1,5 +1,6 @@
 use std::marker::PhantomData;
 
+use super::diagnostics::{check_reactive_scope, snapshot_zone};
 use super::invalidation::{notify_signal_change, record_signal_read};
 use super::owner::register_signal;
 use super::runtime::{
@@ -47,11 +48,19 @@ pub(crate) enum SignalKind {
 /// - Mutable: full effect + widget tracking, reads `Rc<RefCell<T>>`
 /// - Derived: calls the closure (which tracks its own reads internally)
 #[inline]
+#[cfg_attr(debug_assertions, track_caller)]
 fn tracked_get<T: Clone + 'static>(id: SignalId, kind: SignalKind) -> T {
     match kind {
+        // A stored value never changes: reading it outside a scope is not a
+        // missed subscription, there is nothing to subscribe to.
         SignalKind::Stored => get_stored_value(id),
-        SignalKind::Derived => try_call_derived::<T>(id).expect("derived closure missing"),
+        SignalKind::Derived => {
+            check_reactive_scope();
+            // The closure's own reads would otherwise report a second time
+            snapshot_zone(|| try_call_derived::<T>(id).expect("derived closure missing"))
+        }
         SignalKind::Mutable => {
+            check_reactive_scope();
             record_effect_read(id);
             record_signal_read(id);
             get_signal_value(id)
@@ -64,6 +73,7 @@ fn tracked_get<T: Clone + 'static>(id: SignalId, kind: SignalKind) -> T {
 /// - Mutable: full tracking, borrows through `Rc<RefCell<T>>`
 /// - Derived: calls the closure and passes the result to `f`
 #[inline]
+#[cfg_attr(debug_assertions, track_caller)]
 fn tracked_with<T: Clone + 'static, R>(
     id: SignalId,
     kind: SignalKind,
@@ -72,10 +82,12 @@ fn tracked_with<T: Clone + 'static, R>(
     match kind {
         SignalKind::Stored => with_stored_value(id, f),
         SignalKind::Derived => {
-            let val = try_call_derived::<T>(id).unwrap();
+            check_reactive_scope();
+            let val = snapshot_zone(|| try_call_derived::<T>(id).unwrap());
             f(&val)
         }
         SignalKind::Mutable => {
+            check_reactive_scope();
             record_effect_read(id);
             record_signal_read(id);
             with_signal_value(id, f)
@@ -140,6 +152,7 @@ impl_signal_id_traits!(Signal);
 
 impl<T: Clone + 'static> Signal<T> {
     /// Get the current value (tracks as dependency for effects)
+    #[cfg_attr(debug_assertions, track_caller)]
     pub fn get(&self) -> T {
         tracked_get(self.id, self.kind)
     }
@@ -148,12 +161,15 @@ impl<T: Clone + 'static> Signal<T> {
     pub fn get_untracked(&self) -> T {
         match self.kind {
             SignalKind::Stored => get_stored_value(self.id),
-            SignalKind::Derived => try_call_derived::<T>(self.id).unwrap(),
+            // The caller asked for a snapshot; the closure's own reads are
+            // part of that snapshot and must not be reported either
+            SignalKind::Derived => snapshot_zone(|| try_call_derived::<T>(self.id).unwrap()),
             SignalKind::Mutable => get_signal_value(self.id),
         }
     }
 
     /// Borrow the value for reading
+    #[cfg_attr(debug_assertions, track_caller)]
     pub fn with<R>(&self, f: impl FnOnce(&T) -> R) -> R {
         tracked_with(self.id, self.kind, f)
     }
@@ -163,7 +179,7 @@ impl<T: Clone + 'static> Signal<T> {
         match self.kind {
             SignalKind::Stored => with_stored_value(self.id, f),
             SignalKind::Derived => {
-                let val = try_call_derived::<T>(self.id).unwrap();
+                let val = snapshot_zone(|| try_call_derived::<T>(self.id).unwrap());
                 f(&val)
             }
             SignalKind::Mutable => with_signal_value(self.id, f),
@@ -194,7 +210,9 @@ impl_signal_id_traits!(RwSignal);
 impl<T: Clone + 'static> RwSignal<T> {
     /// Get the current value (tracks as dependency for effects)
     #[inline]
+    #[cfg_attr(debug_assertions, track_caller)]
     pub fn get(&self) -> T {
+        check_reactive_scope();
         record_effect_read(self.id);
         record_signal_read(self.id);
         get_signal_value(self.id)
@@ -208,7 +226,9 @@ impl<T: Clone + 'static> RwSignal<T> {
 
     /// Borrow the value for reading
     #[inline]
+    #[cfg_attr(debug_assertions, track_caller)]
     pub fn with<R>(&self, f: impl FnOnce(&T) -> R) -> R {
+        check_reactive_scope();
         record_effect_read(self.id);
         record_signal_read(self.id);
         with_signal_value(self.id, f)
@@ -512,12 +532,19 @@ pub trait OptionSignalExt<T: Clone + 'static> {
     /// Get the signal's value, or compute a default if no signal exists.
     fn get_or_else(&self, f: impl FnOnce() -> T) -> T;
 
+    /// Snapshot the signal's value without subscribing, or return `default`.
+    /// For reads that are consumed within the current pass.
+    fn get_or_untracked(&self, default: T) -> T;
+
     /// Return the existing signal, or create a stored signal from `default`
     /// and write it back into `self` for future use.
     fn signal_or(&mut self, default: T) -> Signal<T>;
 }
 
 impl<T: Clone + 'static> OptionSignalExt<T> for Option<Signal<T>> {
+    // track_caller so the snapshot diagnostic names the widget code that read
+    // the property, not this helper
+    #[cfg_attr(debug_assertions, track_caller)]
     fn get_or(&self, default: T) -> T {
         match self {
             Some(s) => s.get(),
@@ -525,10 +552,18 @@ impl<T: Clone + 'static> OptionSignalExt<T> for Option<Signal<T>> {
         }
     }
 
+    #[cfg_attr(debug_assertions, track_caller)]
     fn get_or_else(&self, f: impl FnOnce() -> T) -> T {
         match self {
             Some(s) => s.get(),
             None => f(),
+        }
+    }
+
+    fn get_or_untracked(&self, default: T) -> T {
+        match self {
+            Some(s) => s.get_untracked(),
+            None => default,
         }
     }
 

--- a/src/widgets/container/animations.rs
+++ b/src/widgets/container/animations.rs
@@ -191,7 +191,9 @@ impl<T: Animatable> AnimationState<T> {
             && !self.is_animating()
             && let Some(cb) = self.active_transition().on_complete.clone()
         {
-            cb();
+            // A completion callback reads for the current value, like an
+            // event handler — it is not a place to subscribe from.
+            crate::reactive::diagnostics::snapshot_zone(|| cb());
         }
 
         if changed {

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -642,7 +642,8 @@ impl Container {
             .width
             .as_ref()
             .map(|w| {
-                let len = w.get();
+                // Builder time, before the widget exists: a snapshot by nature
+                let len = w.get_untracked();
                 len.exact.or(len.min).unwrap_or(0.0)
             })
             .unwrap_or(0.0);
@@ -656,7 +657,7 @@ impl Container {
             .height
             .as_ref()
             .map(|h| {
-                let len = h.get();
+                let len = h.get_untracked();
                 len.exact.or(len.min).unwrap_or(0.0)
             })
             .unwrap_or(0.0);
@@ -666,42 +667,42 @@ impl Container {
 
     /// Enable animation for background color changes
     pub fn animate_background(mut self, transition: impl Into<TransitionConfig>) -> Self {
-        let initial = self.background.get_or(Color::TRANSPARENT);
+        let initial = self.background.get_or_untracked(Color::TRANSPARENT);
         self.anims_mut().background = Some(AnimationState::new(initial, transition));
         self
     }
 
     /// Enable animation for corner radius changes
     pub fn animate_corner_radius(mut self, transition: impl Into<TransitionConfig>) -> Self {
-        let initial = self.corner_radius.get_or(0.0);
+        let initial = self.corner_radius.get_or_untracked(0.0);
         self.anims_mut().corner_radius = Some(AnimationState::new(initial, transition));
         self
     }
 
     /// Enable animation for padding changes
     pub fn animate_padding(mut self, transition: impl Into<TransitionConfig>) -> Self {
-        let initial = self.padding.get_or(Padding::default());
+        let initial = self.padding.get_or_untracked(Padding::default());
         self.anims_mut().padding = Some(AnimationState::new(initial, transition));
         self
     }
 
     /// Enable animation for border width changes
     pub fn animate_border_width(mut self, transition: impl Into<TransitionConfig>) -> Self {
-        let initial = self.border_width.get_or(0.0);
+        let initial = self.border_width.get_or_untracked(0.0);
         self.anims_mut().border_width = Some(AnimationState::new(initial, transition));
         self
     }
 
     /// Enable animation for border color changes
     pub fn animate_border_color(mut self, transition: impl Into<TransitionConfig>) -> Self {
-        let initial = self.border_color.get_or(Color::TRANSPARENT);
+        let initial = self.border_color.get_or_untracked(Color::TRANSPARENT);
         self.anims_mut().border_color = Some(AnimationState::new(initial, transition));
         self
     }
 
     /// Enable animation for transform changes
     pub fn animate_transform(mut self, transition: impl Into<TransitionConfig>) -> Self {
-        let initial = self.transform.get_or(Transform::IDENTITY);
+        let initial = self.transform.get_or_untracked(Transform::IDENTITY);
         self.anims_mut().transform = Some(AnimationState::new(initial, transition));
         self
     }
@@ -721,7 +722,7 @@ impl Container {
         enter_from: Transform,
         transition: impl Into<TransitionConfig>,
     ) -> Self {
-        let initial = self.transform.get_or(Transform::IDENTITY);
+        let initial = self.transform.get_or_untracked(Transform::IDENTITY);
         self.anims_mut().transform =
             Some(AnimationState::new(initial, transition).with_enter_from(enter_from));
         self
@@ -807,11 +808,16 @@ impl Container {
         // This happens when:
         // 1. It has explicit fixed width AND height
         // 2. OR the parent passes tight constraints (min == max)
-        let has_fixed_width = self.width.as_ref().is_some_and(|w| w.get().exact.is_some());
+        // Snapshots: this runs inside the widget's own layout, which reads the
+        // same signals under tracking right after — the subscription exists
+        let has_fixed_width = self
+            .width
+            .as_ref()
+            .is_some_and(|w| w.get_untracked().exact.is_some());
         let has_fixed_height = self
             .height
             .as_ref()
-            .is_some_and(|h| h.get().exact.is_some());
+            .is_some_and(|h| h.get_untracked().exact.is_some());
         let tight_width = constraints.min_width == constraints.max_width;
         let tight_height = constraints.min_height == constraints.max_height;
         (has_fixed_width || tight_width) && (has_fixed_height || tight_height)
@@ -1134,12 +1140,23 @@ impl Widget for Container {
     }
 
     fn layout_hints(&self) -> LayoutHints {
-        if !self.visible.get_or(true) {
+        // The parent asks this while laying out; snapshots are right here,
+        // because the child's own layout subscribes to the same signals and a
+        // change re-runs it (and bubbles to the parent) anyway.
+        if !self.visible.get_or_untracked(true) {
             return LayoutHints::default();
         }
         LayoutHints {
-            fill_width: self.width.as_ref().map(|w| w.get().fill).unwrap_or(false),
-            fill_height: self.height.as_ref().map(|h| h.get().fill).unwrap_or(false),
+            fill_width: self
+                .width
+                .as_ref()
+                .map(|w| w.get_untracked().fill)
+                .unwrap_or(false),
+            fill_height: self
+                .height
+                .as_ref()
+                .map(|h| h.get_untracked().fill)
+                .unwrap_or(false),
         }
     }
 


### PR DESCRIPTION
## The problem, and why it is not a compile-time one

A tracked read registers the *currently active* scope as a subscriber. With no scope there is nobody to register, so the value is a snapshot — frozen into whatever it was used for:

```rust
text(format!("{}", count.get()))          // snapshot: never updates again
text(move || format!("{}", count.get()))  // reactive
```

The two lines differ only in **where** the read happens. Rust cannot express that:

- a scope token on every read (`count.get(cx)`) — Leptos shipped exactly this and **removed it in 0.5** because it poisoned every signature;
- a wrapper type instead of `T` — viral: breaks `format!`, arithmetic, comparisons;
- a Clippy lint — needs `dylint`, an external tool a library cannot assume.

A check inside `#[component]` was the other option considered, but it only covers code that goes through the macro — someone's first app, written in `main()`, would fall straight into the trap.

So the check runs where the information actually exists: **at the read, in debug builds**. `#[track_caller]` gives the exact line, one report per call site, nothing at all in release. Leptos ships the same diagnostic for the same reason.

```
guido: src/main.rs:42:31: signal read with no reactive scope — this value is a
snapshot and will not update. Pass a closure instead (e.g. `move || …` rather
than the value it computes), or use `get_untracked()`/`with_untracked()` if a
snapshot is what you meant. (debug builds only)
```

It goes through `log::warn!`, falling back to stderr when no logger is installed — the audience is whoever just wrote their first guido app.

## Staying quiet is the hard part

A warning that cries wolf is worse than none, so silence is by construction wherever the read is fine:

- under a widget's layout/paint/reconcile scope, and inside effects and memos, a subscriber already exists;
- a `create_stored` value **cannot change**, so reading it is never a missed subscription. This is what keeps component props quiet when the caller passed a plain value — the common case;
- callback regions are snapshot zones by nature, and guido marks its own: event dispatch, animation completion callbacks, cleanup callbacks, and a memo's seed computation. `reactive::diagnostics::snapshot_zone()` is public for app-side callback machinery; `get_untracked()` says the same thing for a single read.

## What it found immediately

Five snapshot reads inside guido itself: the `animate_*` builders seeding from a property, the relayout-boundary decision, and `layout_hints`. All deliberate — all now spelled with the untracked reads that say so, which is the point. Reading a derived signal untracked now also runs its closure inside a snapshot zone, so the closure's own reads belong to the snapshot the caller asked for.

Sixteen examples and the ashell port (bar, menus, audio submenu) run clean. The one remaining report is `children_example`, whose whole purpose is to demonstrate the frozen read — the warning there is the lesson, and the comment now says so.

## Tests

Three, on a debug-only report counter: a read with no scope is reported; every legitimate shape (widget scope, `get_untracked`, `with_untracked`, `snapshot_zone`, stored value, effect) reports nothing; a hot loop reports once.

Docs: `docs/REACTIVE.md`, the book's reactive chapter, and a new "The Body Runs Once" section in the components chapter with the structural recipe (`.child(move || if flag.get() { a } else { b })`).