### PR TITLE
Service and Callback are Copy handles

### DIFF
--- a/book/src/advanced/components.md
+++ b/book/src/advanced/components.md
@@ -17,7 +17,7 @@ pub fn button(label: String) -> impl Widget {
         .corner_radius(6.0)
         .hover_state(|s| s.lighter(0.1))
         .pressed_state(|s| s.ripple())
-        .child(text(label.clone()).color(Color::WHITE))
+        .child(text(label).color(Color::WHITE))
 }
 ```
 
@@ -40,7 +40,7 @@ Parameters without attributes become standard props with `Default::default()`:
 ```rust
 #[component]
 pub fn button(label: String) -> impl Widget {
-    container().child(text(label.clone()))
+    container().child(text(label))
 }
 ```
 
@@ -62,7 +62,7 @@ pub fn button(
     container()
         .padding(padding)
         .background(background)
-        .child(text(label.clone()).color(Color::WHITE))
+        .child(text(label).color(Color::WHITE))
 }
 ```
 
@@ -82,8 +82,8 @@ pub fn button(
     #[prop(callback)] on_click: (),
 ) -> impl Widget {
     container()
-        .on_click_option(on_click.clone())
-        .child(text(label.clone()))
+        .on_click_option(on_click)
+        .child(text(label))
 }
 ```
 
@@ -93,6 +93,26 @@ Provide closures for events:
 button()
     .label("Click me")
     .on_click(|| println!("Clicked!"))
+```
+
+Inside the body a callback prop is an `Option<Callback<..>>`. A
+[`Callback`](../concepts/reactive-model.md) is a `Copy` handle to the closure,
+so it goes into as many closures as needed without being cloned, and is called
+with `run`:
+
+```rust
+#[component]
+pub fn stepper(#[prop(callback)] on_change: fn(i32)) -> impl Widget {
+    container()
+        .layout(Flex::row().spacing(4))
+        // The same handle used twice — no clone in sight
+        .child(container().on_click(move || {
+            if let Some(cb) = on_change { cb.run(-1) }
+        }))
+        .child(container().on_click(move || {
+            if let Some(cb) = on_change { cb.run(1) }
+        }))
+}
 ```
 
 ## Accessing Props
@@ -110,8 +130,8 @@ pub fn button(
     container()
         .padding(padding)                  // Pass Signal<Padding> directly (Copy, keeps reactivity)
         .background(background)            // Pass Signal<Color> directly (Copy, keeps reactivity)
-        .on_click_option(on_click.clone()) // Clone optional callback
-        .child(text(label.clone()))
+        .on_click_option(on_click)         // Copy handle, no clone
+        .child(text(label))
 }
 ```
 
@@ -163,7 +183,7 @@ pub fn card(
         .background(Color::rgb(0.18, 0.18, 0.22))
         .corner_radius(8.0)
         .layout(Flex::column().spacing(8.0))
-        .child(text(title.clone()).font_size(18.0).color(Color::WHITE))
+        .child(text(title).font_size(18.0).color(Color::WHITE))
         .children_source(children)
 }
 ```
@@ -247,8 +267,8 @@ pub fn button(
         .corner_radius(6.0)
         .hover_state(|s| s.lighter(0.1))
         .pressed_state(|s| s.ripple())
-        .on_click_option(on_click.clone())
-        .child(text(label.clone()).color(Color::WHITE))
+        .on_click_option(on_click)
+        .child(text(label).color(Color::WHITE))
 }
 
 #[component]
@@ -262,7 +282,7 @@ pub fn card(
         .background(background)
         .corner_radius(8.0)
         .layout(Flex::column().spacing(8.0))
-        .child(text(title.clone()).font_size(18.0).color(Color::WHITE))
+        .child(text(title).font_size(18.0).color(Color::WHITE))
         .children_source(children)
 }
 

--- a/docs/REACTIVE.md
+++ b/docs/REACTIVE.md
@@ -350,6 +350,31 @@ For comparison: Solid deduplicates by default with per-signal opt-out
 on `Memo` for cutoff. Guido keeps dedup as the default (idle cost
 matters here) and opts out per-write.
 
+## Copy Handles
+
+Signals, [`Service`](#background-task-updates) and `Callback` are all `Copy`:
+each is an id into the reactive arena, not the thing itself. That is what lets
+them be dropped into as many closures as a view needs without a clone, and what
+keeps a struct that groups them `Copy` too:
+
+```rust
+#[derive(Clone, Copy)]
+struct AudioHandles {
+    data: RwSignal<Option<AudioService>>,   // Copy
+    svc: Service<AudioCommand>,             // Copy
+    on_toggle: Callback,                    // Copy
+}
+```
+
+The `Send` halves are separate by design, since the arena is main-thread only:
+`RwSignal::writer()` for a background write, `Service::sender()` for a command
+from a background task.
+
+```rust
+let cb = Callback::new(move |v: i32| println!("{v}"));
+cb.run(7);          // arity stays flat: run(), run(a), run(a, b)
+```
+
 ## Signal Internals
 
 Signals are lightweight handles that index into thread-local storage:

--- a/examples/component_example.rs
+++ b/examples/component_example.rs
@@ -14,7 +14,7 @@ pub fn button(
         .corner_radius(6.0)
         .hover_state(|s| s.lighter(0.1))
         .pressed_state(|s| s.ripple())
-        .on_click_option(on_click.clone())
+        .on_click_option(on_click)
         .child(text(label).color(Color::WHITE))
 }
 

--- a/examples/service_example.rs
+++ b/examples/service_example.rs
@@ -67,7 +67,7 @@ async fn main() {
                 .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
                 .background_color(Color::rgb(0.1, 0.1, 0.15)),
             move || {
-                let svc = service.clone();
+                let svc = service;
 
                 container()
                     .layout(
@@ -79,7 +79,6 @@ async fn main() {
                     // Workspace buttons
                     .child(container().layout(Flex::row().spacing(4.0)).children(
                         workspaces.clone().into_iter().map(move |id| {
-                            let svc = svc.clone();
                             container()
                                 .width(32.0)
                                 .height(32.0)

--- a/guido-macros/src/lib.rs
+++ b/guido-macros/src/lib.rs
@@ -34,6 +34,18 @@ use syn::{DeriveInput, Expr, Fields, ItemFn, Meta, Type, TypeBareFn, parse_macro
 ///         .child(text(label).color(Color::WHITE))
 /// }
 /// ```
+/// The argument tuple for a callback prop: `()`, `(A,)`, `(A, B)`, …
+fn callback_args_tuple(params: &[Type]) -> proc_macro2::TokenStream {
+    match params.len() {
+        0 => quote! { () },
+        1 => {
+            let only = &params[0];
+            quote! { (#only,) }
+        }
+        _ => quote! { (#(#params),*) },
+    }
+}
+
 #[proc_macro_attribute]
 pub fn component(_attr: TokenStream, input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as ItemFn);
@@ -188,9 +200,9 @@ pub fn component(_attr: TokenStream, input: TokenStream) -> TokenStream {
         let ty = &field.ty;
 
         if field.is_callback {
-            let params = &field.callback_params;
+            let args = callback_args_tuple(&field.callback_params);
             quote! {
-                #name: Option<std::rc::Rc<dyn Fn(#(#params),*)>>
+                #name: Option<::guido::reactive::Callback<#args>>
             }
         } else if field.is_children {
             quote! {
@@ -243,7 +255,7 @@ pub fn component(_attr: TokenStream, input: TokenStream) -> TokenStream {
             let params = &field.callback_params;
             quote! {
                 #vis fn #name<F: Fn(#(#params),*) + 'static>(mut self, f: F) -> Self {
-                    self.#name = Some(std::rc::Rc::new(f));
+                    self.#name = Some(::guido::reactive::Callback::new(f));
                     self
                 }
             }
@@ -320,9 +332,9 @@ pub fn component(_attr: TokenStream, input: TokenStream) -> TokenStream {
                 let #name = self.#take_name();
             }
         } else if field.is_callback {
-            // Callbacks are Option<Rc<...>> — not Copy, need reference
+            // Option<Callback<..>> is Copy: bind by value, no clone ceremony
             quote! {
-                let #name = &self.#name;
+                let #name = self.#name;
             }
         } else {
             // Signal<T> is Copy — just copy it

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,9 +141,9 @@ pub mod prelude {
     pub use crate::outputs::{OutputId, OutputInfo, outputs, surface_output};
     pub use crate::platform::{Anchor, KeyboardInteractivity, Layer};
     pub use crate::reactive::{
-        CursorIcon, Memo, OptionSignalExt, RwSignal, Service, Signal, Trigger, WriteSignal,
-        create_derived, create_effect, create_memo, create_service, create_signal, create_stored,
-        create_trigger, expect_context, has_context, on_cleanup, provide_context,
+        Callback, CursorIcon, Memo, OptionSignalExt, RwSignal, Service, Signal, Trigger,
+        WriteSignal, create_derived, create_effect, create_memo, create_service, create_signal,
+        create_stored, create_trigger, expect_context, has_context, on_cleanup, provide_context,
         provide_signal_context, set_cursor, use_context, with_context,
     };
     pub use crate::renderer::{PaintContext, Shadow, measure_text};

--- a/src/reactive/callback.rs
+++ b/src/reactive/callback.rs
@@ -1,0 +1,167 @@
+//! `Callback` — a `Copy` handle to a closure.
+//!
+//! An `Rc<dyn Fn(..)>` has to be cloned for every closure that wants to call
+//! it, which is how component bodies end up opening with a row of
+//! `let on_click = on_click.clone();` and cloning again inside each nested
+//! closure. A `Callback` stores the closure in the reactive arena and hands
+//! back its id, so the handle is `Copy` and goes wherever it is needed.
+//!
+//! It is also what keeps a struct that groups handles `Copy` — the same
+//! reason [`Signal`](super::Signal) and [`Service`](super::Service) are.
+//!
+//! The argument list is a tuple, and each arity gets its own `new`/`run` so
+//! both ends stay flat:
+//!
+//! ```ignore
+//! let greet = Callback::new(|name: String| println!("hi {name}"));
+//! greet.run("world".into());
+//! ```
+
+use std::marker::PhantomData;
+use std::rc::Rc;
+
+use super::signal::{Signal, create_stored};
+
+/// A `Copy` handle to a closure, parameterised by its argument tuple.
+///
+/// `Callback<()>` takes no arguments, `Callback<(i32,)>` takes one,
+/// `Callback<(f32, f32)>` takes two. `#[component]` callback props are these.
+pub struct Callback<Args = ()> {
+    inner: Signal<Rc<dyn Fn(Args)>>,
+    _args: PhantomData<Args>,
+}
+
+// Manual impls: the derives would demand bounds on `Args`, but the handle is
+// an arena id whatever the arguments are.
+impl<Args> Clone for Callback<Args> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<Args> Copy for Callback<Args> {}
+
+impl<Args: 'static> Callback<Args> {
+    fn from_rc(f: Rc<dyn Fn(Args)>) -> Self {
+        Self {
+            inner: create_stored(f),
+            _args: PhantomData,
+        }
+    }
+
+    /// Call with the arguments already packed into their tuple.
+    ///
+    /// Prefer the flat `run` of the matching arity; this is the escape hatch
+    /// for generic code that only knows `Args`.
+    pub fn run_packed(&self, args: Args) {
+        self.inner.with_untracked(|f| f(args));
+    }
+}
+
+impl<Args: 'static> Callback<Args> {
+    /// Wrap a closure. The arity is inferred from the closure itself:
+    /// `Callback::new(|| …)`, `Callback::new(|v: i32| …)`,
+    /// `Callback::new(|x: f32, y: f32| …)`.
+    pub fn new<F: IntoCallback<Args>>(f: F) -> Self {
+        f.into_callback()
+    }
+}
+
+/// Closures that can become a [`Callback`], one impl per arity.
+///
+/// Same shape as [`IntoSignal`](super::IntoSignal): the trait parameter is
+/// what lets one constructor accept closures of different arities.
+pub trait IntoCallback<Args> {
+    fn into_callback(self) -> Callback<Args>;
+}
+
+impl<F: Fn() + 'static> IntoCallback<()> for F {
+    fn into_callback(self) -> Callback<()> {
+        Callback::from_rc(Rc::new(move |()| self()))
+    }
+}
+
+impl<A: 'static, F: Fn(A) + 'static> IntoCallback<(A,)> for F {
+    fn into_callback(self) -> Callback<(A,)> {
+        Callback::from_rc(Rc::new(move |(a,)| self(a)))
+    }
+}
+
+impl<A: 'static, B: 'static, F: Fn(A, B) + 'static> IntoCallback<(A, B)> for F {
+    fn into_callback(self) -> Callback<(A, B)> {
+        Callback::from_rc(Rc::new(move |(a, b)| self(a, b)))
+    }
+}
+
+impl<A: 'static, B: 'static, C: 'static, F: Fn(A, B, C) + 'static> IntoCallback<(A, B, C)> for F {
+    fn into_callback(self) -> Callback<(A, B, C)> {
+        Callback::from_rc(Rc::new(move |(a, b, c)| self(a, b, c)))
+    }
+}
+
+impl Callback<()> {
+    /// Call the closure.
+    pub fn run(&self) {
+        self.run_packed(());
+    }
+}
+
+impl<A: 'static> Callback<(A,)> {
+    /// Call the closure.
+    pub fn run(&self, a: A) {
+        self.run_packed((a,));
+    }
+}
+
+impl<A: 'static, B: 'static> Callback<(A, B)> {
+    /// Call the closure.
+    pub fn run(&self, a: A, b: B) {
+        self.run_packed((a, b));
+    }
+}
+
+impl<A: 'static, B: 'static, C: 'static> Callback<(A, B, C)> {
+    /// Call the closure.
+    pub fn run(&self, a: A, b: B, c: C) {
+        self.run_packed((a, b, c));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    use super::*;
+
+    /// The whole point: a handle that can be dropped into several closures
+    /// without a clone in sight.
+    #[test]
+    fn a_callback_is_copy_and_callable_from_many_closures() {
+        let hits = Rc::new(Cell::new(0));
+        let hits_cb = hits.clone();
+        let cb = Callback::new(move || hits_cb.set(hits_cb.get() + 1));
+
+        let first = move || cb.run();
+        let second = move || cb.run();
+        first();
+        second();
+        cb.run();
+
+        assert_eq!(hits.get(), 3);
+    }
+
+    #[test]
+    fn arguments_stay_flat() {
+        let seen = Rc::new(Cell::new(0));
+        let seen_one = seen.clone();
+        let one = Callback::new(move |v: i32| seen_one.set(v));
+        one.run(7);
+        assert_eq!(seen.get(), 7);
+
+        let seen_two = seen.clone();
+        let two = Callback::new(move |a: i32, b: i32| seen_two.set(a * b));
+        two.run(6, 7);
+        assert_eq!(seen.get(), 42);
+    }
+}

--- a/src/reactive/mod.rs
+++ b/src/reactive/mod.rs
@@ -1,3 +1,4 @@
+pub mod callback;
 pub mod clipboard;
 pub mod context;
 pub mod cursor;
@@ -50,6 +51,7 @@ pub mod __internal {
     pub use super::owner::{OwnerId, dispose_owner_now as dispose_owner, with_owner};
     pub use super::runtime::batch;
 }
+pub use callback::Callback;
 pub(crate) use runtime::flush_bg_writes;
 pub use service::{Service, ServiceContext, create_service};
 pub use signal::{

--- a/src/reactive/service.rs
+++ b/src/reactive/service.rs
@@ -25,6 +25,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::sync::mpsc;
 
 use super::on_cleanup;
+use super::signal::{Signal, create_stored};
 
 /// Context passed to the service function.
 ///
@@ -46,27 +47,44 @@ impl ServiceContext {
 
 /// Handle to a background service for sending commands.
 ///
-/// Clone this handle to send commands from multiple places.
+/// `Copy`, like [`Signal`](super::Signal): the channel lives in the reactive
+/// arena and the handle is just its id, so it can be dropped into as many
+/// closures as needed without a clone. Handles of services, signals and
+/// callbacks being `Copy` is what keeps a struct that groups them `Copy` too.
+///
+/// Main-thread only (`!Send`). To send commands from a background task, take
+/// the [`sender()`](Service::sender) — the same split as
+/// [`RwSignal::writer`](super::RwSignal::writer).
 pub struct Service<Cmd> {
-    sender: mpsc::UnboundedSender<Cmd>,
+    sender: Signal<mpsc::UnboundedSender<Cmd>>,
 }
 
-// Manual impl: the derive would add a spurious `Cmd: Clone` bound, but only
-// the sender is cloned.
+// Manual impls: the derives would demand `Cmd: Clone`/`Cmd: Copy`, but the
+// handle is an arena id whatever the command type is.
 impl<Cmd> Clone for Service<Cmd> {
     fn clone(&self) -> Self {
-        Self {
-            sender: self.sender.clone(),
-        }
+        *self
     }
 }
 
-impl<Cmd> Service<Cmd> {
+impl<Cmd> Copy for Service<Cmd> {}
+
+impl<Cmd: 'static> Service<Cmd> {
     /// Send a command to the service.
     ///
-    /// Returns silently if the service has stopped.
+    /// Returns silently if the service has stopped. Sending after the owning
+    /// scope was disposed logs a warning and does nothing — the task it would
+    /// reach was aborted with that scope.
     pub fn send(&self, cmd: Cmd) {
-        let _ = self.sender.send(cmd);
+        self.sender.with_untracked(|tx| {
+            let _ = tx.send(cmd);
+        });
+    }
+
+    /// The `Send` half of this handle, for driving the service from a
+    /// background task. The counterpart of `RwSignal::writer()`.
+    pub fn sender(&self) -> mpsc::UnboundedSender<Cmd> {
+        self.sender.with_untracked(|tx| tx.clone())
     }
 }
 
@@ -135,6 +153,8 @@ where
 
     let ctx = ServiceContext { running };
     let handle = service_runtime().spawn(f(rx, ctx));
+    // The channel lives in the arena so the handle can be Copy
+    let sender = create_stored(tx);
 
     // Register cleanup to stop the task when component unmounts.
     // Setting is_running to false allows graceful shutdown, while abort()
@@ -145,7 +165,7 @@ where
         handle.abort();
     });
 
-    Service { sender: tx }
+    Service { sender }
 }
 
 /// Get a runtime handle for spawning service tasks.
@@ -307,7 +327,7 @@ mod tests {
         });
 
         // Clone and send from different handles
-        let service2 = service.clone();
+        let service2 = service;
         service.send(5);
         service2.send(7);
 

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -530,10 +530,12 @@ impl Container {
         self
     }
 
-    /// Accept an optional click callback (useful for components)
-    pub fn on_click_option(mut self, callback: Option<ClickCallback>) -> Self {
+    /// Accept an optional click callback — the shape a `#[component]`
+    /// callback prop has, so it can be forwarded straight through.
+    pub fn on_click_option(mut self, callback: Option<crate::reactive::Callback>) -> Self {
         if callback.is_some() || self.interaction.is_some() {
-            self.interact_mut().on_click = callback;
+            self.interact_mut().on_click =
+                callback.map(|cb| std::rc::Rc::new(move || cb.run()) as ClickCallback);
         }
         self
     }


### PR DESCRIPTION
## The ceremony, measured

On the ashell port, before this change:

- **496** `.clone()` calls
- **93** of the form `let x = x.clone();`, written for no reason except to feed the next closure
- **110** of the total on service handles, callbacks, or the structs holding them

The cause was structural, not stylistic. `Service<Cmd>` held an `UnboundedSender`, so it could not be `Copy`; so a struct grouping a dozen signals and four services could not be `Copy` either:

```rust
pub struct SettingsSignals {
    pub audio_data: ServiceSignal<AudioService>,   // Copy
    pub audio_svc:  Service<AudioCommand>,         // ← not Copy
    pub submenu:    RwSignal<Option<SubMenu>>,     // Copy
    …                                              // everything else Copy
}
```

which produced, verbatim:

```rust
let settings2 = settings.clone();
let settings3 = settings.clone();
```

And guido's own `service_example` taught the same dance, twice in six lines.

## The change

Both types now live in the arena the signals already use, so the handle is just an id:

- **`Service<Cmd>` is `Copy`.** Being an arena handle makes it `!Send` like signals, and it gains the same escape signals have: **`sender()`** is the `Send` half, the counterpart of `RwSignal::writer()`. Sending after the owning scope was disposed warns and does nothing, matching disposed-signal writes — the task it would have reached was aborted with that scope.
- **`Callback<Args>` is new**: a `Copy` handle to a closure. `IntoCallback` impls for arities 0–3 keep both ends flat — `Callback::new(|a, b| …)` and `cb.run(a, b)`, no tuple at the call site. `#[component]` callback props are now `Option<Callback<..>>` bound **by value** instead of `Option<Rc<dyn Fn>>` bound by reference, which is what forced `let on_click = on_click.clone();` at the top of every component body and a second clone inside each nested closure.

Leptos landed in the same place (`StoredValue` for Copy handles, `Callback` Copy since 0.6), as did Dioxus 0.5.

## Effect on the port

| | before | after |
|---|---|---|
| `.clone()` calls | 496 | **379** |
| `let x = x.clone();` ceremony | 93 | **69** |
| clones on services / callbacks / their structs | 110 | **11** |

The 11 that remain are `String`s (the MPRIS service *name*), config structs, and two app-side closures — nothing the library can help with. `SettingsSignals` is now `#[derive(Clone, Copy)]` and `settings2`/`settings3` are gone. The slider stopped cloning its `on_change` three times for its three closures.

The real win is that `clippy::clone_on_copy` now finds the rest by itself: the ceremony became a lint instead of a habit. It flagged 78 sites on the first run.

## Verification

256 tests green, clippy clean, and two new tests on `Callback` (a handle used from several closures without a clone; flat arguments at arity 1 and 2). Live: the port's menus open and close, which exercises the rewired path — `close_menu` went from `impl Fn() + Clone` to `Callback`, so tray, updates, power actions and the toggle all run through the new type.

Docs: a "Copy Handles" section in `docs/REACTIVE.md`, and the book's components chapter now documents callback props as `Copy` handles (and stops cloning `Signal` props, which were already `Copy`).