### PR TITLE
watch() — the read half of the background-task bridge

### DIFF
--- a/book/src/advanced/background-threads.md
+++ b/book/src/advanced/background-threads.md
@@ -199,6 +199,44 @@ let view = container()
     .child(text(move || time.get()).font_size(48.0).color(Color::WHITE));
 ```
 
+## Reading UI State From a Task: `watch()`
+
+`writer()` carries values from a task to the UI. The other direction —
+a task that needs to follow something the UI decides — is `watch()`, which
+returns a `tokio::sync::watch::Receiver<T>`: `Send`, always holding the current
+value, and awaitable.
+
+```rust
+let menu_open = create_memo(move || active_menu.get() == Some(Menu::SystemInfo));
+let mut open_rx = menu_open.watch();
+
+let _ = create_service::<(), _, _>(move |_rx, ctx| async move {
+    while ctx.is_running() {
+        // Current value, no polling
+        let scope = if *open_rx.borrow_and_update() { Scope::All } else { Scope::Bar };
+        sample(scope);
+
+        // Sleep, but wake early if the UI changes its mind
+        tokio::select! {
+            _ = tokio::time::sleep(interval) => {}
+            changed = open_rx.changed() => {
+                if changed.is_err() {
+                    return;   // the scope that owns the watcher is gone
+                }
+            }
+        }
+    }
+});
+```
+
+Watching a `Memo` is usually what you want: it only notifies when the derived
+value actually changes, so the task wakes on real transitions rather than on
+every keystroke behind them.
+
+This replaces the `Arc<AtomicBool>` mirrored by an effect that apps otherwise
+write by hand — and unlike the atomic, the task can *wait* on the change
+instead of polling for it.
+
 ## Best Practices
 
 ### Use `tokio::select!` for Responsive Shutdown
@@ -247,24 +285,26 @@ let _ = create_service::<(), _, _>(move |_rx, ctx| async move {
 });
 ```
 
-### Clone Service Handle for Multiple Callbacks
+### The Service Handle Is `Copy`
+
+`Service<Cmd>` is a handle into the reactive arena, so it goes into as many
+callbacks as you like without a clone:
 
 ```rust
 let service = create_service(...);
 
-// Clone for each callback that needs it
-let svc1 = service.clone();
-let svc2 = service.clone();
-
 container()
     .child(
         container()
-            .on_click(move || svc1.send(Cmd::Action1))
+            .on_click(move || service.send(Cmd::Action1))
             .child(text("Action 1"))
     )
     .child(
         container()
-            .on_click(move || svc2.send(Cmd::Action2))
+            .on_click(move || service.send(Cmd::Action2))
             .child(text("Action 2"))
     )
 ```
+
+To send commands from *inside* another background task, take the `Send` half
+with `service.sender()` — the handle itself is main-thread only, like signals.

--- a/src/reactive/memo.rs
+++ b/src/reactive/memo.rs
@@ -94,6 +94,18 @@ impl<T: Clone + PartialEq + Send + 'static> Memo<T> {
         self.signal.with(f)
     }
 
+    /// Watch this memo from a background task.
+    ///
+    /// See [`RwSignal::watch`](super::RwSignal::watch). A memo is usually what
+    /// you want to watch: it only notifies when the derived value actually
+    /// changes, so the task wakes on real transitions.
+    pub fn watch(&self) -> tokio::sync::watch::Receiver<T>
+    where
+        T: Send + Sync,
+    {
+        self.signal.watch()
+    }
+
     /// Extract as a read-only signal.
     pub fn into_signal(self) -> Signal<T> {
         self.signal.read_only()

--- a/src/reactive/signal.rs
+++ b/src/reactive/signal.rs
@@ -187,6 +187,16 @@ impl<T: Clone + 'static> Signal<T> {
     }
 }
 
+impl<T: Clone + Send + Sync + 'static> Signal<T> {
+    /// Watch this signal from a background task.
+    ///
+    /// See [`RwSignal::watch`].
+    pub fn watch(&self) -> tokio::sync::watch::Receiver<T> {
+        let this = *self;
+        watch_value(this.get_untracked(), move || this.get())
+    }
+}
+
 /// A read-write reactive signal.
 ///
 /// Created by [`create_signal`]. Provides both read and write access.
@@ -288,6 +298,39 @@ impl<T: Clone + 'static> RwSignal<T> {
     /// Update the value using a closure, notifying unconditionally.
     pub fn update_always<F: FnOnce(&mut T)>(&self, f: F) {
         update_and_notify_always(self.id, f);
+    }
+}
+
+impl<T: Clone + Send + Sync + 'static> RwSignal<T> {
+    /// Watch this signal from a background task.
+    ///
+    /// The mirror of [`writer()`](RwSignal::writer): that one carries writes
+    /// from a task to the main thread, this one carries the value the other
+    /// way. The returned `watch::Receiver` is `Send`, always holds the current
+    /// value (`borrow()`), and can be awaited (`changed()`) instead of polled
+    /// — which is what an `Arc<AtomicBool>` mirrored by hand cannot do.
+    ///
+    /// When the scope that created it is disposed the sender drops, so
+    /// `changed()` returns `Err`: the task's cue that the UI is gone.
+    ///
+    /// ```ignore
+    /// let wide = create_memo(move || menu.get() == Some(Menu::SystemInfo));
+    /// let mut wide_rx = wide.watch();
+    ///
+    /// create_service::<(), _, _>(move |_rx, ctx| async move {
+    ///     while ctx.is_running() {
+    ///         let scope = if *wide_rx.borrow() { Scope::All } else { Scope::Bar };
+    ///         sample(scope);
+    ///         tokio::select! {
+    ///             _ = wide_rx.changed() => {}                       // react at once
+    ///             _ = tokio::time::sleep(interval) => {}
+    ///         }
+    ///     }
+    /// });
+    /// ```
+    pub fn watch(&self) -> tokio::sync::watch::Receiver<T> {
+        let this = *self;
+        watch_value(this.get_untracked(), move || this.get())
     }
 }
 
@@ -520,6 +563,29 @@ pub fn create_derived<T: Clone + 'static>(f: impl Fn() -> T + 'static) -> Signal
     }
 }
 
+/// Feed a `tokio::watch` channel from a reactive read.
+///
+/// Shared by the `watch()` of every signal kind. The effect that pumps the
+/// channel belongs to the current scope, so it dies with whatever created it
+/// — exactly like the task on the other end of the channel.
+fn watch_value<T: Clone + Send + Sync + 'static>(
+    initial: T,
+    read: impl Fn() -> T + 'static,
+) -> tokio::sync::watch::Receiver<T> {
+    let (tx, rx) = tokio::sync::watch::channel(initial);
+    let effect = super::effect::create_effect(move || {
+        let _ = tx.send(read());
+    });
+    if super::owner::current_owner().is_some() {
+        // Owned: the scope disposes it, and dropping the sender is how the
+        // task learns the UI is gone (`changed()` returns Err)
+        drop(effect);
+    } else {
+        effect.detach();
+    }
+    rx
+}
+
 /// Extension trait for `Option<Signal<T>>` to support lazy-default widget properties.
 ///
 /// Widget properties stored as `Option<Signal<T>>` start as `None` (zero allocation).
@@ -576,6 +642,63 @@ impl<T: Clone + 'static> OptionSignalExt<T> for Option<Signal<T>> {
                 s
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod watch_tests {
+    use super::*;
+
+    /// The bridge apps were hand-rolling with `Arc<AtomicBool>`: a value a
+    /// background task can read, kept current by the reactive graph.
+    #[test]
+    fn a_watcher_sees_the_current_value_and_every_change() {
+        let flag = create_signal(false);
+        let rx = flag.watch();
+        assert!(!*rx.borrow());
+
+        flag.set(true);
+        assert!(*rx.borrow(), "the watcher follows the signal");
+        assert!(rx.has_changed().unwrap(), "and is notified, not polled");
+    }
+
+    /// A memo is the natural thing to watch: only real transitions wake the
+    /// task.
+    #[test]
+    fn watching_a_memo_reports_only_real_changes() {
+        let count = create_signal(0);
+        let is_high = crate::reactive::create_memo(move || count.get() > 10);
+        let mut rx = is_high.watch();
+        assert!(!*rx.borrow_and_update());
+
+        count.set(5);
+        assert!(
+            !rx.has_changed().unwrap(),
+            "still false: nothing to wake for"
+        );
+
+        count.set(50);
+        assert!(rx.has_changed().unwrap());
+        assert!(*rx.borrow_and_update());
+    }
+
+    /// Disposing the scope drops the sender, which is how the task learns the
+    /// UI is gone.
+    #[test]
+    fn disposing_the_scope_closes_the_channel() {
+        let (rx, owner) = crate::reactive::owner::with_owner(|| {
+            let flag = create_signal(false);
+            flag.watch()
+        });
+
+        assert!(!rx.borrow().to_owned());
+        crate::reactive::__internal::dispose_owner(owner);
+
+        // The sender is gone: the channel reports closed without awaiting
+        assert!(
+            rx.has_changed().is_err(),
+            "a disposed scope must close the channel"
+        );
     }
 }
 


### PR DESCRIPTION
## The missing direction

guido had one half of the bridge between the main thread and async tasks:

| | | |
|---|---|---|
| main → task | `rw.writer()` → `WriteSignal<T>` (Send) | ✅ |
| task ← main | *nothing* | ❌ every app improvises |

So apps mirror UI state into an atomic by hand. In the ashell port, twice. The system-info one spans three files:

```rust
// main.rs — created before the state it mirrors even exists
let sysinfo_menu_open = Arc::new(AtomicBool::new(false));
let system_info = …then(|| modules::system_info::create(sysinfo_menu_open.clone()));
    // → start_system_info_service(writers, config, menu_open: Arc<AtomicBool>)

// main.rs, 100 lines below — the effect that keeps them in sync
create_effect(move || flag.store(matches!(menu.active_menu.get(), Some(MenuType::SystemInfo)), Relaxed));
```

with a comment admitting the awkwardness: *"Synced by an effect further down once the menu state exists."*

## `watch()`

The mirror of `writer()`: a `tokio::sync::watch::Receiver<T>` — `Send`, always holding the current value, fed by an effect owned by the scope that created it. Available on `Signal`, `RwSignal` and `Memo`.

```rust
let wide = create_memo(move || menu.get() == Some(Menu::SystemInfo));
let mut wide_rx = wide.watch();

create_service::<(), _, _>(move |_rx, ctx| async move {
    while ctx.is_running() {
        let scope = if *wide_rx.borrow_and_update() { Scope::All } else { Scope::Bar };
        sample(scope);
        tokio::select! {
            _ = tokio::time::sleep(interval) => {}
            changed = wide_rx.changed() => { if changed.is_err() { return } }  // UI gone
        }
    }
});
```

Returning tokio's receiver rather than wrapping it is deliberate: tokio is already in the public surface (`create_service` takes tokio futures, `Service::sender()` returns an `UnboundedSender`), and the caller gets `borrow()`, `changed()` and `wait_for()` for free.

## Why it is not cosmetic

An atomic can only be polled. A watcher can be **awaited**, and both port sites were paying for that:

- the sysinfo sampler chopped its 5s interval into **ten 500ms slices** for the sole purpose of noticing the flag flip. It now sleeps once and wakes on the change — 10 wake-ups per interval become 1.
- the clock picks its cadence from the active format (1s when seconds are shown, otherwise the minute boundary). Switching format used to take effect **at the next wake-up, up to a minute later**. Now it is immediate.

Watching a `Memo` is the intended shape: it only notifies on real transitions, so the task wakes on those rather than on everything behind them.

## Verification

Three tests: a watcher sees the current value and is notified of changes; watching a memo reports only real transitions; disposing the scope closes the channel. 259 tests green, clippy clean.

Docs: a `watch()` section in the book's Background Tasks chapter, next to `writer()` — which also stops telling readers to clone the (now `Copy`) service handle.

In the port this removes both `Arc<Atomic*>`, both mirroring effects, and the parameter threaded through three files; `MenuCtx` moved up so the memo can be built where it belongs.