### PR TITLE
Right/middle click, key handlers, and an idempotent font registry

### DIFF
--- a/book/src/interactivity/events.md
+++ b/book/src/interactivity/events.md
@@ -54,6 +54,23 @@ container().on_hover(|hovered| {
 })
 ```
 
+## Other Buttons and Keys
+
+```rust
+container()
+    .on_click(|| println!("left"))
+    .on_right_click(|| println!("right"))
+    .on_middle_click(|| println!("middle"))
+    .on_key_down(|key, _mods| {
+        if key == Key::Escape {
+            close();
+        }
+    })
+```
+
+`on_key_down` fires while the surface has keyboard focus — a layer surface
+with `KeyboardInteractivity` set, or a popup holding a grab.
+
 ## Scroll Events
 
 ```rust

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,8 @@ use smithay_client_toolkit::reexports::calloop_wayland_source::WaylandSource;
 thread_local! {
     static DEFAULT_FONT_FAMILY: RefCell<FontFamily> = const { RefCell::new(FontFamily::SansSerif) };
     static CUSTOM_FONTS: RefCell<Vec<Arc<Vec<u8>>>> = const { RefCell::new(Vec::new()) };
+    static CUSTOM_FONT_HASHES: RefCell<rustc_hash::FxHashSet<u64>> =
+        RefCell::new(rustc_hash::FxHashSet::default());
     static FONTS_CONSUMED: Cell<bool> = const { Cell::new(false) };
 }
 
@@ -89,6 +91,15 @@ pub fn load_font(data: Vec<u8>) {
             "load_font() called after FontSystem initialization — \
              this font will not be available. Call load_font() before App::run()."
         );
+    }
+    // Idempotent: an app that reloads its config re-registers the same fonts
+    // on every run, and without this each run would keep another copy.
+    let mut hasher = std::hash::BuildHasher::build_hasher(&rustc_hash::FxBuildHasher);
+    std::hash::Hasher::write(&mut hasher, &data);
+    let hash = std::hash::Hasher::finish(&hasher);
+    let is_new = CUSTOM_FONT_HASHES.with(|seen| seen.borrow_mut().insert(hash));
+    if !is_new {
+        return;
     }
     CUSTOM_FONTS.with(|fonts| {
         fonts.borrow_mut().push(Arc::new(data));
@@ -1212,5 +1223,27 @@ impl Drop for App {
 impl Default for App {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod font_registry_tests {
+    /// An app that reloads its config calls load_font again on every run.
+    /// Without dedup each run kept another copy of the same bytes.
+    #[test]
+    fn loading_the_same_font_twice_registers_it_once() {
+        let font = vec![7u8; 64];
+        super::load_font(font.clone());
+        let after_first = super::CUSTOM_FONTS.with(|f| f.borrow().len());
+        super::load_font(font);
+        let after_second = super::CUSTOM_FONTS.with(|f| f.borrow().len());
+        assert_eq!(after_first, after_second);
+
+        super::load_font(vec![9u8; 64]);
+        assert_eq!(
+            super::CUSTOM_FONTS.with(|f| f.borrow().len()),
+            after_second + 1,
+            "a different font must still register"
+        );
     }
 }

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -32,11 +32,15 @@ use super::scroll::{
 };
 use super::state_layer::{StateStyle, resolve_background};
 use super::widget::{
-    Color, Event, EventResponse, LayoutHints, MouseButton, Padding, Rect, ScrollSource, Widget,
+    Color, Event, EventResponse, Key, LayoutHints, Modifiers, MouseButton, Padding, Rect,
+    ScrollSource, Widget,
 };
 
 /// Callback for click events
 pub type ClickCallback = Rc<dyn Fn()>;
+
+/// Callback for a key press: the key and the modifiers held with it.
+pub type KeyCallback = Rc<dyn Fn(Key, Modifiers)>;
 /// Callback for hover events (bool = is_hovered)
 pub type HoverCallback = Rc<dyn Fn(bool)>;
 /// Callback for scroll events (delta_x, delta_y, source)
@@ -142,6 +146,9 @@ pub(super) struct ContainerAnims {
 /// Only allocated when `.on_click()`, `.hover_state()`, `.pressed_state()`, etc. are called.
 pub(super) struct InteractionState {
     pub(super) on_click: Option<ClickCallback>,
+    pub(super) on_right_click: Option<ClickCallback>,
+    pub(super) on_middle_click: Option<ClickCallback>,
+    pub(super) on_key_down: Option<KeyCallback>,
     pub(super) on_hover: Option<HoverCallback>,
     pub(super) on_scroll: Option<ScrollCallback>,
     pub(super) on_pointer_move: Option<PointerMoveCallback>,
@@ -159,6 +166,9 @@ impl Default for InteractionState {
     fn default() -> Self {
         Self {
             on_click: None,
+            on_right_click: None,
+            on_middle_click: None,
+            on_key_down: None,
             on_hover: None,
             on_scroll: None,
             on_pointer_move: None,
@@ -527,6 +537,28 @@ impl Container {
 
     pub fn on_click<F: Fn() + 'static>(mut self, callback: F) -> Self {
         self.interact_mut().on_click = Some(Rc::new(callback));
+        self
+    }
+
+    /// Called on a right-button press inside the bounds.
+    pub fn on_right_click<F: Fn() + 'static>(mut self, callback: F) -> Self {
+        self.interact_mut().on_right_click = Some(Rc::new(callback));
+        self
+    }
+
+    /// Called on a middle-button press inside the bounds.
+    pub fn on_middle_click<F: Fn() + 'static>(mut self, callback: F) -> Self {
+        self.interact_mut().on_middle_click = Some(Rc::new(callback));
+        self
+    }
+
+    /// Called for every key press this container's surface receives.
+    ///
+    /// Delivered while the surface has keyboard focus — a layer surface with
+    /// [`KeyboardInteractivity`](crate::platform::KeyboardInteractivity) set,
+    /// or a popup holding a grab.
+    pub fn on_key_down<F: Fn(Key, Modifiers) + 'static>(mut self, callback: F) -> Self {
+        self.interact_mut().on_key_down = Some(Rc::new(callback));
         self
     }
 
@@ -1757,6 +1789,21 @@ impl Widget for Container {
             // Don't return Handled — hover changes should not prevent
             // sibling containers from tracking their own hover state.
             Event::MouseEnter { .. } | Event::MouseMove { .. } => {}
+            Event::MouseDown { x, y, button } if *button != MouseButton::Left => {
+                if bounds.contains_rounded(*x, *y, corner_radius)
+                    && let Some(ref ix) = self.interaction
+                {
+                    let callback = match button {
+                        MouseButton::Right => ix.on_right_click.as_ref(),
+                        MouseButton::Middle => ix.on_middle_click.as_ref(),
+                        MouseButton::Left => None,
+                    };
+                    if let Some(callback) = callback {
+                        callback();
+                        return EventResponse::Handled;
+                    }
+                }
+            }
             Event::MouseDown { x, y, button } => {
                 if bounds.contains_rounded(*x, *y, corner_radius)
                     && *button == MouseButton::Left
@@ -1911,8 +1958,15 @@ impl Widget for Container {
                     }
                 }
             }
-            // Keyboard and focus events are handled by focused widgets, not containers
-            Event::KeyDown { .. } | Event::KeyUp { .. } | Event::FocusIn | Event::FocusOut => {}
+            Event::KeyDown { key, modifiers } => {
+                if let Some(ref ix) = self.interaction
+                    && let Some(ref callback) = ix.on_key_down
+                {
+                    callback(*key, *modifiers);
+                    return EventResponse::Handled;
+                }
+            }
+            Event::KeyUp { .. } | Event::FocusIn | Event::FocusOut => {}
         }
 
         EventResponse::Ignored


### PR DESCRIPTION
Three small gaps the ashell port hit while cleaning up its config handling, all in the same area.

## `on_right_click` / `on_middle_click`

`Container` only ever called back on the left button, so a config with `on_right_click` / `on_middle_click` (upstream ashell supports both for custom modules) had nowhere to land — the port parsed the keys and dropped them. Both are now builders next to `on_click`, dispatched on press.

## `on_key_down`

`Container` ignored `Event::KeyDown` entirely — only `TextInput` consumed keys — so "close this menu on Escape" was not expressible. `on_key_down(|key, modifiers| …)` fires while the surface has keyboard focus: a layer surface with `KeyboardInteractivity` set, or a popup holding a grab.

## `load_font` is idempotent

`App::drop` resets `FONTS_CONSUMED` so a restart can register fonts again, but `CUSTOM_FONTS` was never cleared. An app that reloads its config therefore re-registered the same embedded fonts on every run and **each run added another copy** — for the ashell port that is three subset fonts plus, when the config uses custom glyphs, the whole system Symbols Nerd Font, on every config reload.

Clearing the registry on drop would have been the wrong fix: it breaks apps that load their fonts once before the first run, which is what the docs tell you to do. Instead the registry dedupes by content hash, so both call patterns work and neither accumulates.

A test covers it: loading the same bytes twice registers one font, different bytes still register.