### PR TITLE
refactor: give Container internal seams, one per concern

### DIFF
--- a/src/widgets/container/box_model.rs
+++ b/src/widgets/container/box_model.rs
@@ -1,0 +1,338 @@
+//! The container's box model: what it offers its children, and how big it
+//! ends up.
+//!
+//! A layout pass asks three questions in order, and this module answers all
+//! three:
+//!
+//! 1. **What did the author declare?** — [`read_box_lengths`] reads padding,
+//!    width and height under the container's Layout tracking scope and
+//!    resolves fractional lengths against the incoming constraints. From that
+//!    point on a fraction is an ordinary exact length that happened to become
+//!    known at layout time, so nothing downstream has to know about it.
+//! 2. **What do the children get?** — [`child_layout`] subtracts the padding
+//!    and any scrollbar gutter, opens the scrolled axis to infinity so content
+//!    can exceed the viewport, and reports the finite viewport separately —
+//!    that second value is what scrolling measures its content against.
+//! 3. **How big are we?** — [`resolve_size`] combines the declared length, the
+//!    measured content and the shrink policy, then clamps to what the parent
+//!    allows.
+//!
+//! Sizes read through the animation state wherever one exists, which is why
+//! several methods here consult `self.anims`: an animating width has to drive
+//! both what children are offered and what the parent is told, or the content
+//! would jump while the box glides.
+//!
+//! [`read_box_lengths`]: Container::read_box_lengths
+//! [`child_layout`]: Container::child_layout
+//! [`resolve_size`]: Container::resolve_size
+
+use super::*;
+use crate::layout::Axis;
+
+/// The container's own size declarations, resolved for one layout pass.
+pub(super) struct BoxLengths {
+    pub padding: Padding,
+    pub width: Length,
+    pub height: Length,
+}
+
+/// What the children of one layout pass are laid out into.
+pub(super) struct ChildLayout {
+    /// What children are offered. A scrolled axis is unbounded here.
+    pub constraints: Constraints,
+    /// Where the first child starts, inside the padding.
+    pub origin: (f32, f32),
+    /// The extent children are actually *visible* within — finite on every
+    /// axis, including a scrolled one. Scrolling compares its content against
+    /// this, so it must never be the unbounded value from `constraints`: an
+    /// infinite viewport is never exceeded, and a scrollbar that never has
+    /// anything to scroll is a scrollbar that never appears.
+    pub viewport: Size,
+}
+
+impl Container {
+    /// Whether this container's size is independent of its children, so a
+    /// dirty descendant can stop bubbling here instead of reaching the root.
+    pub(super) fn is_relayout_boundary_for(&self, constraints: Constraints) -> bool {
+        // A layout-affecting animation re-sizes the container every frame, so
+        // the parent has to keep repositioning its siblings: not a boundary.
+        let has_active_layout_anim = self.anims.as_ref().is_some_and(|a| {
+            a.width.as_ref().is_some_and(|x| x.is_animating())
+                || a.height.as_ref().is_some_and(|x| x.is_animating())
+                || a.padding.as_ref().is_some_and(|x| x.is_animating())
+        });
+        if has_active_layout_anim {
+            return false;
+        }
+
+        // Snapshots: this runs inside the container's own layout, which reads
+        // the same signals under tracking right after, so the subscription
+        // exists either way.
+        let has_fixed_width = self
+            .width
+            .as_ref()
+            .is_some_and(|w| w.get_untracked().exact.is_some());
+        let has_fixed_height = self
+            .height
+            .as_ref()
+            .is_some_and(|h| h.get_untracked().exact.is_some());
+        let tight_width = constraints.min_width == constraints.max_width;
+        let tight_height = constraints.min_height == constraints.max_height;
+        (has_fixed_width || tight_width) && (has_fixed_height || tight_height)
+    }
+
+    /// Read the declared padding and lengths, tracked so a later write
+    /// re-runs this layout, with fractions resolved against `constraints`.
+    pub(super) fn read_box_lengths(&self, id: WidgetId, constraints: Constraints) -> BoxLengths {
+        let (padding, mut width, mut height) = with_signal_tracking(id, JobType::Layout, || {
+            (
+                self.animated_padding(),
+                self.width.as_ref().map(|w| w.get()).unwrap_or_default(),
+                self.height.as_ref().map(|h| h.get()).unwrap_or_default(),
+            )
+        });
+
+        if let Some(f) = width.fraction
+            && constraints.max_width.is_finite()
+        {
+            width.exact = Some((constraints.max_width * f).max(0.0));
+        }
+        if let Some(f) = height.fraction
+            && constraints.max_height.is_finite()
+        {
+            height.exact = Some((constraints.max_height * f).max(0.0));
+        }
+
+        BoxLengths {
+            padding,
+            width,
+            height,
+        }
+    }
+
+    /// The extent this container lays its children out inside, on one axis.
+    ///
+    /// While a size animation runs on an *exact* length, children follow the
+    /// in-flight value so alignment tracks the box as it glides. A shrink-to-fit
+    /// length keeps using the declared value instead: feeding the animated size
+    /// back in would make the content define the target that defines the
+    /// content.
+    ///
+    /// Note the asymmetry in the animated branch: it does **not** clamp to
+    /// `length.max`, while the static branch does. Pinned by
+    /// `characterization::an_animated_width_does_not_clamp_children_to_at_most`
+    /// because it is what the code has always done; it reads like an
+    /// oversight, and correcting it belongs in its own change.
+    fn animated_extent(
+        &self,
+        anim: Option<&AnimationState<f32>>,
+        length: &Length,
+        available: f32,
+    ) -> f32 {
+        if let Some(anim) = anim {
+            if !anim.is_initial() && length.exact.is_some() {
+                return if animations::measuring_final() {
+                    *anim.target()
+                } else {
+                    *anim.current()
+                };
+            }
+            return length.exact.unwrap_or(available);
+        }
+        match length.exact {
+            Some(exact) => exact,
+            None => match length.max {
+                Some(max) => available.min(max),
+                None => available,
+            },
+        }
+    }
+
+    /// What the children are offered, where the first one starts, and the
+    /// viewport they are seen through.
+    pub(super) fn child_layout(
+        &self,
+        lengths: &BoxLengths,
+        constraints: Constraints,
+    ) -> ChildLayout {
+        let padding = lengths.padding;
+        let layout_width = self.animated_extent(
+            self.anims.as_ref().and_then(|a| a.width.as_ref()),
+            &lengths.width,
+            constraints.max_width,
+        );
+        let layout_height = self.animated_extent(
+            self.anims.as_ref().and_then(|a| a.height.as_ref()),
+            &lengths.height,
+            constraints.max_height,
+        );
+
+        let mut max_width = (layout_width - padding.horizontal()).max(0.0);
+        let mut max_height = (layout_height - padding.vertical()).max(0.0);
+
+        // A reserved gutter is space the content never gets, scrollbar shown
+        // or not — that is the point of reserving it.
+        if let Some(ref sd) = self.scroll_data
+            && sd.scrollbar_config.reserve_gutter
+            && sd.scrollbar_visibility != ScrollbarVisibility::Hidden
+        {
+            let gutter = sd.scrollbar_config.width + sd.scrollbar_config.margin * 2.0;
+            if self.scroll_axis.allows_vertical() {
+                max_width = (max_width - gutter).max(0.0);
+            }
+            if self.scroll_axis.allows_horizontal() {
+                max_height = (max_height - gutter).max(0.0);
+            }
+        }
+
+        // Pass the effective minimum down so alignments like Center and End
+        // know how much room they actually have to place children in.
+        let min_width = if lengths.width.exact.is_some() || lengths.width.fill {
+            max_width
+        } else {
+            let effective = lengths.width.min.unwrap_or(0.0).max(constraints.min_width);
+            (effective - padding.horizontal()).max(0.0).min(max_width)
+        };
+        let min_height = if lengths.height.exact.is_some() || lengths.height.fill {
+            max_height
+        } else {
+            let effective = lengths
+                .height
+                .min
+                .unwrap_or(0.0)
+                .max(constraints.min_height);
+            (effective - padding.vertical()).max(0.0).min(max_height)
+        };
+
+        // The visible extent, captured before the scrolled axis is opened up.
+        let viewport = Size::new(max_width, max_height);
+
+        // A scrolled axis is unbounded: the content is free to exceed the
+        // viewport, which is what there is to scroll through.
+        let child = match self.scroll_axis {
+            ScrollAxis::Vertical => Constraints {
+                min_width: 0.0,
+                min_height: 0.0,
+                max_width,
+                max_height: f32::INFINITY,
+            },
+            ScrollAxis::Horizontal => Constraints {
+                min_width: 0.0,
+                min_height: 0.0,
+                max_width: f32::INFINITY,
+                max_height,
+            },
+            ScrollAxis::Both => Constraints {
+                min_width: 0.0,
+                min_height: 0.0,
+                max_width: f32::INFINITY,
+                max_height: f32::INFINITY,
+            },
+            ScrollAxis::None => Constraints {
+                min_width,
+                min_height,
+                max_width,
+                max_height,
+            },
+        };
+
+        ChildLayout {
+            constraints: child,
+            // Children sit in local coordinates; the parent places the container.
+            origin: (padding.left, padding.top),
+            viewport,
+        }
+    }
+
+    /// The container's final size, given what its content measured.
+    pub(super) fn resolve_size(
+        &self,
+        lengths: &BoxLengths,
+        constraints: Constraints,
+        content: Size,
+    ) -> Size {
+        Size::new(
+            self.resolve_axis(
+                Axis::Horizontal,
+                &lengths.width,
+                content.width + lengths.padding.horizontal(),
+                constraints.min_width,
+                constraints.max_width,
+            ),
+            self.resolve_axis(
+                Axis::Vertical,
+                &lengths.height,
+                content.height + lengths.padding.vertical(),
+                constraints.min_height,
+                constraints.max_height,
+            ),
+        )
+    }
+
+    fn resolve_axis(
+        &self,
+        axis: Axis,
+        length: &Length,
+        content: f32,
+        parent_min: f32,
+        parent_max: f32,
+    ) -> f32 {
+        let anim = self.anims.as_ref().and_then(|a| match axis {
+            Axis::Horizontal => a.width.as_ref(),
+            Axis::Vertical => a.height.as_ref(),
+        });
+        let animating = anim.is_some_and(|a| a.is_animating());
+        let has_exact = length.exact.is_some();
+
+        // Growing back to fit the content is the default; these are the cases
+        // where the author asked for a smaller box on purpose.
+        let allow_shrink = self.overflow == Overflow::Hidden
+            || animating
+            || has_exact
+            || match axis {
+                Axis::Horizontal => self.scroll_axis.allows_horizontal(),
+                Axis::Vertical => self.scroll_axis.allows_vertical(),
+            };
+
+        // Measure-final reports the animation's destination, so a
+        // content-sized surface sizes itself once instead of every frame.
+        let mut size = if let Some(anim) = anim {
+            let animated = if animations::measuring_final() {
+                *anim.target()
+            } else {
+                *anim.current()
+            };
+            if allow_shrink {
+                animated
+            } else {
+                content.max(animated)
+            }
+        } else if let Some(exact) = length.exact {
+            exact
+        } else if length.fill {
+            parent_max
+        } else {
+            content
+        };
+
+        // min/max apply on top of everything above, fill included.
+        if let Some(min) = length.min {
+            size = size.max(min);
+        }
+        if let Some(max) = length.max {
+            size = size.min(max);
+        }
+        if !allow_shrink && anim.is_none() && !has_exact {
+            size = size.max(content);
+        }
+
+        // An explicit length answers to the parent's maximum but not to its
+        // minimum: that is what keeps `.width(60)` at 60 inside a stretching
+        // parent.
+        if has_exact {
+            size.min(parent_max)
+        } else {
+            size.max(parent_min).min(parent_max)
+        }
+    }
+}

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -227,6 +227,45 @@ fn overflowing_content_grows_a_visible_container() {
     assert_eq!(hidden.fit(100.0, 500.0).width, 100.0);
 }
 
+/// Pins an asymmetry rather than endorsing it: with a width animation
+/// attached, the extent children are laid out inside ignores `at_most`, while
+/// without one it is clamped. It reads like an oversight — the container's own
+/// final size honours the cap either way, so only the children's constraints
+/// differ — but it is what the code has always done, and changing it is a
+/// behaviour change that belongs in its own commit with its own test.
+#[test]
+fn an_animated_width_does_not_clamp_children_to_at_most() {
+    use crate::animation::{TimingFunction, Transition};
+
+    let mut clamped = H::new(
+        container()
+            .width(at_most(60.0))
+            .child(container().width(fill()).height(5.0)),
+    );
+    clamped.fit(500.0, 500.0);
+    let child = clamped.children()[0];
+    assert_eq!(clamped.tree.get_bounds(child).unwrap().width, 60.0);
+
+    let mut animated = H::new(
+        container()
+            .width(at_most(60.0))
+            .animate_width(Transition::new(200, TimingFunction::EaseOut))
+            .child(container().width(fill()).height(5.0)),
+    );
+    animated.fit(500.0, 500.0);
+    let child = animated.children()[0];
+    assert_eq!(
+        animated.tree.get_bounds(child).unwrap().width,
+        500.0,
+        "the animated branch offers the full width, cap ignored"
+    );
+    assert_eq!(
+        animated.tree.cached_size(animated.root).unwrap().width,
+        60.0,
+        "the container itself still honours the cap"
+    );
+}
+
 #[test]
 fn an_invisible_container_measures_zero() {
     let mut h = H::new(container().visible(false).child(box_of(40.0, 20.0)));

--- a/src/widgets/container/interaction.rs
+++ b/src/widgets/container/interaction.rs
@@ -1,0 +1,336 @@
+//! Turning pointer and key events into container state and callbacks.
+//!
+//! A container resolves every event against its [`HitContext`] — the geometry
+//! it was laid out and transformed into. Hit testing therefore happens in two
+//! steps: undo the container's own transform, then test the point against the
+//! laid-out bounds *and* their corner radius, so a rounded container does not
+//! answer for the pixels outside its shape.
+//!
+//! Hover is tracked **before** children see the event ([`track_pointer`]),
+//! because a child handling a `MouseMove` must not stop its ancestors from
+//! noticing the pointer passed over them. Everything else is handled after the
+//! children have had their turn ([`handle_own_event`]), so the innermost
+//! interested widget wins.
+//!
+//! [`track_pointer`]: Container::track_pointer
+//! [`handle_own_event`]: Container::handle_own_event
+
+use super::*;
+
+/// The geometry an event is resolved against: where the container ended up,
+/// what shape it is, and the transform standing between the two.
+pub(super) struct HitContext {
+    pub bounds: Rect,
+    pub corner_radius: f32,
+    pub transform: Transform,
+    pub transform_origin: TransformOrigin,
+}
+
+impl HitContext {
+    /// Whether a point falls inside the container's *shape* — its bounds
+    /// narrowed by the corner radius, not the bounding box.
+    pub(super) fn contains(&self, x: f32, y: f32) -> bool {
+        self.bounds.contains_rounded(x, y, self.corner_radius)
+    }
+
+    /// A surface-space point expressed relative to the container's own origin.
+    pub(super) fn local(&self, x: f32, y: f32) -> (f32, f32) {
+        local_point(&self.transform, self.transform_origin, self.bounds, x, y)
+    }
+
+    /// The same, for a point that has already had the transform undone.
+    fn rebase(&self, x: f32, y: f32) -> (f32, f32) {
+        (x - self.bounds.x, y - self.bounds.y)
+    }
+}
+
+/// Map a point from surface space into the container's untransformed space.
+///
+/// A container's own transform is applied around its origin at paint time, so
+/// hit testing has to undo it before comparing against the laid-out bounds.
+/// An identity transform returns the point unchanged.
+pub(super) fn untransform_point(
+    transform: &Transform,
+    origin: TransformOrigin,
+    bounds: Rect,
+    x: f32,
+    y: f32,
+) -> (f32, f32) {
+    if transform.is_identity() {
+        return (x, y);
+    }
+    let (origin_x, origin_y) = origin.resolve(bounds);
+    transform
+        .center_at(origin_x, origin_y)
+        .inverse()
+        .transform_point(x, y)
+}
+
+/// [`untransform_point`] expressed relative to the container's own origin —
+/// the space ripples and pointer callbacks work in.
+pub(super) fn local_point(
+    transform: &Transform,
+    origin: TransformOrigin,
+    bounds: Rect,
+    x: f32,
+    y: f32,
+) -> (f32, f32) {
+    let (ux, uy) = untransform_point(transform, origin, bounds, x, y);
+    (ux - bounds.x, uy - bounds.y)
+}
+
+impl Container {
+    /// Repaint after a hover/press change, as an Animation job when a state
+    /// layer animation has to pick the new target up.
+    pub(super) fn request_state_change_repaint(&self, id: WidgetId) {
+        if self.has_animated_state_properties() {
+            request_job(id, JobRequest::Animation(RequiredJob::Paint));
+        } else {
+            request_job(id, JobRequest::Paint);
+        }
+    }
+
+    /// Update hover state and fire the pointer-move callback, before children
+    /// get the event: a child that handles a `MouseMove` must not stop its
+    /// ancestors from tracking their own hover.
+    pub(super) fn track_pointer(&mut self, id: WidgetId, hit: &HitContext, event: &Event) {
+        let has_animated = self.has_animated_state_properties();
+        let Some(ref mut ix) = self.interaction else {
+            return;
+        };
+        let request_repaint = |id: WidgetId| {
+            if has_animated {
+                request_job(id, JobRequest::Animation(RequiredJob::Paint));
+            } else {
+                request_job(id, JobRequest::Paint);
+            }
+        };
+
+        match event {
+            Event::MouseEnter { x, y } if hit.contains(*x, *y) && !ix.is_hovered => {
+                ix.is_hovered = true;
+                if ix.hover_state.is_some() {
+                    request_repaint(id);
+                }
+                if let Some(ref callback) = ix.on_hover {
+                    callback(true);
+                }
+            }
+            Event::MouseMove { x, y } => {
+                // A pressed container keeps receiving moves that leave it —
+                // that implicit capture is what makes dragging work.
+                if let Some(ref callback) = ix.on_pointer_move
+                    && (hit.contains(*x, *y) || ix.is_pressed)
+                {
+                    let (lx, ly) = hit.rebase(*x, *y);
+                    callback(lx, ly);
+                }
+
+                let was_hovered = ix.is_hovered;
+                ix.is_hovered = hit.contains(*x, *y);
+
+                if was_hovered != ix.is_hovered {
+                    if ix.hover_state.is_some() {
+                        request_repaint(id);
+                    }
+                    if let Some(ref callback) = ix.on_hover {
+                        callback(ix.is_hovered);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Handle an event the children did not take.
+    ///
+    /// `event` is the original, still in surface space: the ripple needs it to
+    /// place its origin under the actual cursor. `local` is the same event with
+    /// this container's transform undone, which is what everything else tests
+    /// against.
+    pub(super) fn handle_own_event(
+        &mut self,
+        id: WidgetId,
+        hit: &HitContext,
+        event: &Event,
+        local: &Event,
+    ) -> EventResponse {
+        match local {
+            // Hover was tracked before the children ran. Returning Ignored
+            // here is deliberate: a hover change must not stop sibling
+            // containers from tracking their own.
+            Event::MouseEnter { .. } | Event::MouseMove { .. } => {}
+
+            Event::MouseDown { x, y, button } if *button != MouseButton::Left => {
+                if hit.contains(*x, *y)
+                    && let Some(ref ix) = self.interaction
+                {
+                    let callback = match button {
+                        MouseButton::Right => ix.on_right_click.as_ref(),
+                        MouseButton::Middle => ix.on_middle_click.as_ref(),
+                        MouseButton::Left => None,
+                    };
+                    if let Some(callback) = callback {
+                        callback();
+                        return EventResponse::Handled;
+                    }
+                }
+            }
+
+            Event::MouseDown { x, y, button } => {
+                if hit.contains(*x, *y)
+                    && *button == MouseButton::Left
+                    && let Some(ref mut ix) = self.interaction
+                {
+                    let was_pressed = ix.is_pressed;
+                    ix.is_pressed = true;
+
+                    let has_ripple = ix
+                        .pressed_state
+                        .as_ref()
+                        .is_some_and(|s| s.ripple.is_some());
+                    if has_ripple {
+                        let (screen_x, screen_y) = event.coords().unwrap_or((*x, *y));
+                        let (local_x, local_y) = hit.local(screen_x, screen_y);
+                        ix.ripple.start(local_x, local_y);
+                        request_job(id, JobRequest::Animation(RequiredJob::Paint));
+                    }
+
+                    if !was_pressed && ix.pressed_state.is_some() {
+                        self.request_state_change_repaint(id);
+                    }
+                    if let Some(ref ix) = self.interaction
+                        && let Some(ref callback) = ix.on_mouse_down
+                    {
+                        let (lx, ly) = hit.rebase(*x, *y);
+                        callback(lx, ly);
+                        return EventResponse::Handled;
+                    }
+                    // A press is claimed even without a down handler, so the
+                    // matching release reaches the click handler.
+                    if let Some(ref ix) = self.interaction
+                        && (ix.on_click.is_some() || ix.on_mouse_up.is_some())
+                    {
+                        return EventResponse::Handled;
+                    }
+                }
+            }
+
+            Event::MouseUp { x, y, button } => {
+                if let Some(ref mut ix) = self.interaction
+                    && ix.is_pressed
+                    && *button == MouseButton::Left
+                {
+                    let was_pressed = ix.is_pressed;
+                    ix.is_pressed = false;
+
+                    if ix.ripple.is_active() {
+                        let (screen_x, screen_y) = event.coords().unwrap_or((*x, *y));
+                        let (local_x, local_y) = hit.local(screen_x, screen_y);
+                        ix.ripple.start_fade(local_x, local_y);
+                        request_job(id, JobRequest::Animation(RequiredJob::Paint));
+                    }
+
+                    if was_pressed && ix.pressed_state.is_some() {
+                        self.request_state_change_repaint(id);
+                    }
+
+                    let mut handled = false;
+                    if let Some(ref ix) = self.interaction
+                        && let Some(ref callback) = ix.on_mouse_up
+                    {
+                        let (lx, ly) = hit.rebase(*x, *y);
+                        callback(lx, ly);
+                        handled = true;
+                    }
+                    // A click is a release *inside* the shape; a release that
+                    // wandered off only ends the press.
+                    if let Some(ref ix) = self.interaction
+                        && hit.contains(*x, *y)
+                        && let Some(ref callback) = ix.on_click
+                    {
+                        callback();
+                        return EventResponse::Handled;
+                    }
+                    if handled {
+                        return EventResponse::Handled;
+                    }
+                }
+            }
+
+            Event::MouseLeave => {
+                if let Some(ref mut ix) = self.interaction {
+                    let was_hovered = ix.is_hovered;
+                    let was_pressed = ix.is_pressed;
+                    if ix.is_hovered {
+                        ix.is_hovered = false;
+                        if let Some(ref callback) = ix.on_hover {
+                            callback(false);
+                        }
+                    }
+                    ix.is_pressed = false;
+
+                    // The pointer left without a release, so the ripple has no
+                    // exit point to fade toward — it collapses to the centre.
+                    if ix.ripple.is_active() {
+                        ix.ripple
+                            .start_fade_to_center(hit.bounds.width, hit.bounds.height);
+                        request_job(id, JobRequest::Animation(RequiredJob::Paint));
+                    }
+
+                    if (was_hovered && ix.hover_state.is_some())
+                        || (was_pressed && ix.pressed_state.is_some())
+                    {
+                        self.request_state_change_repaint(id);
+                    }
+                }
+            }
+
+            Event::Scroll {
+                x,
+                y,
+                delta_x,
+                delta_y,
+                source,
+            } => {
+                if hit.contains(*x, *y) {
+                    // Our own scrolling consumes the event first; the callback
+                    // only sees what scrolling did not take.
+                    if self.scroll_axis != ScrollAxis::None
+                        && self.apply_scroll(*delta_x, *delta_y, *source)
+                    {
+                        let sd = self.scroll();
+                        let has_velocity = sd.scroll_state.velocity_x.abs() > 0.5
+                            || sd.scroll_state.velocity_y.abs() > 0.5;
+                        if has_velocity {
+                            request_job(id, JobRequest::Animation(RequiredJob::Paint));
+                        } else {
+                            request_job(id, JobRequest::Paint);
+                        }
+                        return EventResponse::Handled;
+                    }
+
+                    if let Some(ref ix) = self.interaction
+                        && let Some(ref callback) = ix.on_scroll
+                    {
+                        callback(*delta_x, *delta_y, *source);
+                        return EventResponse::Handled;
+                    }
+                }
+            }
+
+            Event::KeyDown { key, modifiers } => {
+                if let Some(ref ix) = self.interaction
+                    && let Some(ref callback) = ix.on_key_down
+                {
+                    callback(*key, *modifiers);
+                    return EventResponse::Handled;
+                }
+            }
+
+            Event::KeyUp { .. } | Event::FocusIn | Event::FocusOut => {}
+        }
+
+        EventResponse::Ignored
+    }
+}

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -1,15 +1,20 @@
 //! Container widget and related functionality.
 
 mod animations;
+mod box_model;
+mod interaction;
 mod ripple;
 mod scrollable;
+mod style;
 
 #[cfg(test)]
 mod characterization;
 
 pub(crate) use animations::with_measure_final;
 pub use animations::{AdvanceResult, AnimationState, get_animated_value};
+use interaction::{HitContext, untransform_point};
 pub use ripple::RippleState;
+use style::Decoration;
 
 use std::borrow::Cow;
 use std::rc::Rc;
@@ -802,296 +807,6 @@ impl Container {
         self.interact_mut().focused_state = Some(f(StateStyle::new()));
         self
     }
-
-    /// Check if any child widget has focus
-    fn has_child_focus(&self, tree: &Tree) -> bool {
-        if let Some(focused_id) = focused_widget() {
-            return self.widget_has_focus(tree, focused_id);
-        }
-        false
-    }
-
-    /// Recursively check if this widget or any child matches the focused widget ID
-    fn widget_has_focus(&self, tree: &Tree, focused_id: WidgetId) -> bool {
-        for &child_id in self.children_source.get() {
-            if child_id == focused_id {
-                return true;
-            }
-            // Recursively check nested containers/widgets
-            if tree.with_widget(child_id, |child| {
-                child.has_focus_descendant(tree, focused_id)
-            }) == Some(true)
-            {
-                return true;
-            }
-        }
-        false
-    }
-
-    /// Check if this widget is a relayout boundary given constraints.
-    /// A widget is a boundary if its size doesn't depend on children.
-    fn is_relayout_boundary_for(&self, constraints: Constraints) -> bool {
-        // A widget with an active layout-affecting animation is NOT a boundary,
-        // because its size changes each frame and the parent must reposition siblings.
-        let has_active_layout_anim = self.anims.as_ref().is_some_and(|a| {
-            a.width.as_ref().is_some_and(|x| x.is_animating())
-                || a.height.as_ref().is_some_and(|x| x.is_animating())
-                || a.padding.as_ref().is_some_and(|x| x.is_animating())
-        });
-        if has_active_layout_anim {
-            return false;
-        }
-
-        // Widget is a boundary if its size doesn't depend on children.
-        // This happens when:
-        // 1. It has explicit fixed width AND height
-        // 2. OR the parent passes tight constraints (min == max)
-        // Snapshots: this runs inside the widget's own layout, which reads the
-        // same signals under tracking right after — the subscription exists
-        let has_fixed_width = self
-            .width
-            .as_ref()
-            .is_some_and(|w| w.get_untracked().exact.is_some());
-        let has_fixed_height = self
-            .height
-            .as_ref()
-            .is_some_and(|h| h.get_untracked().exact.is_some());
-        let tight_width = constraints.min_width == constraints.max_width;
-        let tight_height = constraints.min_height == constraints.max_height;
-        (has_fixed_width || tight_width) && (has_fixed_height || tight_height)
-    }
-
-    // State layer resolution helper
-    // Priority: pressed > focused > hovered
-    fn resolve_state_value<T: Clone>(
-        &self,
-        tree: &Tree,
-        base: T,
-        extractor: impl Fn(&StateStyle) -> Option<T>,
-    ) -> T {
-        let Some(ref ix) = self.interaction else {
-            return base;
-        };
-        if ix.is_pressed
-            && let Some(ref state) = ix.pressed_state
-            && let Some(value) = extractor(state)
-        {
-            return value;
-        }
-        // Check focused state
-        if ix.focused_state.is_some()
-            && self.has_child_focus(tree)
-            && let Some(ref state) = ix.focused_state
-            && let Some(value) = extractor(state)
-        {
-            return value;
-        }
-        if ix.is_hovered
-            && let Some(ref state) = ix.hover_state
-            && let Some(value) = extractor(state)
-        {
-            return value;
-        }
-        base
-    }
-
-    /// Get the effective background color target considering state layers.
-    fn effective_background_target(&self, tree: &Tree) -> Color {
-        let base = self.background.get_or(Color::TRANSPARENT);
-        self.resolve_state_value(tree, base, |state| {
-            let bg_color = state
-                .background
-                .as_ref()
-                .map(|bg| resolve_background(base, bg));
-            match (bg_color, state.alpha) {
-                (Some(mut c), Some(a)) => {
-                    c.a = a;
-                    Some(c)
-                }
-                (Some(c), None) => Some(c),
-                (None, Some(a)) => {
-                    let mut c = base;
-                    c.a = a;
-                    Some(c)
-                }
-                (None, None) => None,
-            }
-        })
-    }
-
-    /// Get the effective border width target considering state layers.
-    fn effective_border_width_target(&self, tree: &Tree) -> f32 {
-        let base = self.border_width.get_or(0.0);
-        self.resolve_state_value(tree, base, |state| state.border_width)
-    }
-
-    /// Get the effective border color target considering state layers.
-    fn effective_border_color_target(&self, tree: &Tree) -> Color {
-        let base = self.border_color.get_or(Color::TRANSPARENT);
-        self.resolve_state_value(tree, base, |state| state.border_color)
-    }
-
-    /// Get the effective corner radius target considering state layers.
-    fn effective_corner_radius_target(&self, tree: &Tree) -> f32 {
-        let base = self.corner_radius.get_or(0.0);
-        self.resolve_state_value(tree, base, |state| state.corner_radius)
-    }
-
-    /// Get the effective transform target considering state layers.
-    fn effective_transform_target(&self, tree: &Tree) -> Transform {
-        let base = self.transform.get_or(Transform::IDENTITY);
-        self.resolve_state_value(tree, base, |state| state.transform)
-    }
-
-    /// Get the effective elevation considering state layers (not animated).
-    fn effective_elevation(&self, tree: &Tree) -> f32 {
-        let base = self.elevation.get_or(0.0);
-        self.resolve_state_value(tree, base, |state| state.elevation)
-    }
-
-    /// Get current padding (animated or static)
-    fn animated_padding(&self) -> Padding {
-        get_animated_value(self.anims.as_ref().and_then(|a| a.padding.as_ref()), || {
-            self.padding.get_or(Padding::default())
-        })
-    }
-
-    /// Get current background color (animated or effective target)
-    fn animated_background(&self, tree: &Tree) -> Color {
-        get_animated_value(
-            self.anims.as_ref().and_then(|a| a.background.as_ref()),
-            || self.effective_background_target(tree),
-        )
-    }
-
-    /// Get current corner radius (animated or effective target)
-    fn animated_corner_radius(&self, tree: &Tree) -> f32 {
-        get_animated_value(
-            self.anims.as_ref().and_then(|a| a.corner_radius.as_ref()),
-            || self.effective_corner_radius_target(tree),
-        )
-    }
-
-    /// Get current border width (animated or effective target)
-    fn animated_border_width(&self, tree: &Tree) -> f32 {
-        get_animated_value(
-            self.anims.as_ref().and_then(|a| a.border_width.as_ref()),
-            || self.effective_border_width_target(tree),
-        )
-    }
-
-    /// Get current border color (animated or effective target)
-    fn animated_border_color(&self, tree: &Tree) -> Color {
-        get_animated_value(
-            self.anims.as_ref().and_then(|a| a.border_color.as_ref()),
-            || self.effective_border_color_target(tree),
-        )
-    }
-
-    /// Get current transform (animated or effective target)
-    fn animated_transform(&self, tree: &Tree) -> Transform {
-        get_animated_value(
-            self.anims.as_ref().and_then(|a| a.transform.as_ref()),
-            || self.effective_transform_target(tree),
-        )
-    }
-
-    /// Check if any state layer properties have animations enabled
-    fn has_animated_state_properties(&self) -> bool {
-        self.anims.as_ref().is_some_and(|a| {
-            a.background.is_some()
-                || a.corner_radius.is_some()
-                || a.border_color.is_some()
-                || a.transform.is_some()
-        })
-    }
-
-    /// Whether any animation follows a signal-backed target (as opposed to
-    /// width/height, whose targets are content-driven and recomputed every
-    /// layout). These are the animations that keep a copy of signal state
-    /// and therefore need the paint-time target re-sync.
-    fn has_signal_animated_props(&self) -> bool {
-        self.anims.as_ref().is_some_and(|a| {
-            a.padding.is_some()
-                || a.border_width.is_some()
-                || a.background.is_some()
-                || a.corner_radius.is_some()
-                || a.border_color.is_some()
-                || a.transform.is_some()
-        })
-    }
-
-    /// Request repaint for state changes (hover/press), with Animation job if needed
-    fn request_state_change_repaint(&self, id: WidgetId) {
-        if self.has_animated_state_properties() {
-            request_job(id, JobRequest::Animation(RequiredJob::Paint));
-        } else {
-            request_job(id, JobRequest::Paint);
-        }
-    }
-}
-
-/// Convert elevation level to shadow parameters
-/// Map a point from surface space into the container's untransformed space.
-///
-/// A container's own transform is applied around its origin at paint time, so
-/// hit testing has to undo it before comparing against the laid-out bounds.
-/// An identity transform returns the point unchanged.
-fn untransform_point(
-    transform: &Transform,
-    origin: TransformOrigin,
-    bounds: Rect,
-    x: f32,
-    y: f32,
-) -> (f32, f32) {
-    if transform.is_identity() {
-        return (x, y);
-    }
-    let (origin_x, origin_y) = origin.resolve(bounds);
-    transform
-        .center_at(origin_x, origin_y)
-        .inverse()
-        .transform_point(x, y)
-}
-
-/// Same as [`untransform_point`], expressed relative to the container's own
-/// origin — the space ripples and pointer callbacks work in.
-fn local_point(
-    transform: &Transform,
-    origin: TransformOrigin,
-    bounds: Rect,
-    x: f32,
-    y: f32,
-) -> (f32, f32) {
-    let (ux, uy) = untransform_point(transform, origin, bounds, x, y);
-    (ux - bounds.x, uy - bounds.y)
-}
-
-fn elevation_to_shadow(level: f32) -> Shadow {
-    if level <= 0.0 {
-        return Shadow::none();
-    }
-
-    let (offset_y, blur, alpha) = match level as i32 {
-        1 => (1.0, 3.0, 0.12),
-        2 => (2.0, 4.0, 0.16),
-        3 => (3.0, 6.0, 0.19),
-        4 => (4.0, 8.0, 0.20),
-        5 => (6.0, 10.0, 0.22),
-        _ => {
-            let offset = (level * 1.2).min(12.0);
-            let blur = (level * 2.0).min(24.0);
-            let alpha = (0.12 + level * 0.02).min(0.25);
-            (offset, blur, alpha)
-        }
-    };
-
-    Shadow::new(
-        (0.0, offset_y),
-        blur,
-        0.0,
-        Color::rgba(0.0, 0.0, 0.0, alpha),
-    )
 }
 
 impl Default for Container {
@@ -1234,7 +949,6 @@ impl Widget for Container {
     }
 
     fn layout(&mut self, tree: &mut Tree, id: WidgetId, constraints: Constraints) -> Size {
-        // Check visibility with signal tracking so changes trigger re-layout
         let is_visible = with_signal_tracking(id, JobType::Layout, || self.visible.get_or(true));
         if !is_visible {
             tree.set_relayout_boundary(id, true);
@@ -1244,188 +958,29 @@ impl Widget for Container {
             return size;
         }
 
-        // Register this widget's relayout boundary status with the tree
         tree.set_relayout_boundary(id, self.is_relayout_boundary_for(constraints));
-
-        // Ensure scrollbar containers exist if scrolling is enabled
         self.ensure_scrollbar_containers(tree, id);
 
-        // Check if constraints changed compared to cached value in Tree
+        // Nothing to redo when the constraints are the same and no tracked
+        // signal (or animation) marked us dirty.
         let constraints_changed = tree.cached_constraints(id) != Some(constraints);
-
-        // Check if this widget was marked dirty by signal changes or animations
-        // (animations call mark_needs_layout directly when their value changes)
         let reactive_changed = tree.needs_layout(id);
-
-        let needs_layout = constraints_changed || reactive_changed;
-
-        if !needs_layout {
+        if !constraints_changed && !reactive_changed {
             crate::render_stats::record_layout_skipped();
-            // Return cached size from Tree
             return tree.cached_size(id).unwrap_or_default();
         }
-
         crate::render_stats::record_layout_executed_with_reasons(
             crate::render_stats::LayoutReasons {
                 constraints_changed,
                 reactive_changed,
             },
         );
-
-        // Clear dirty flag since we're doing layout now
         tree.clear_needs_layout(id);
 
-        // Auto-track signal reads for layout properties.
-        // Any signals read here (including closures) will register this widget
-        // as a Layout subscriber so future changes trigger re-layout.
-        let (padding, mut width_length, mut height_length) =
-            with_signal_tracking(id, JobType::Layout, || {
-                (
-                    self.animated_padding(),
-                    self.width.as_ref().map(|w| w.get()).unwrap_or_default(),
-                    self.height.as_ref().map(|h| h.get()).unwrap_or_default(),
-                )
-            });
+        let lengths = self.read_box_lengths(id, constraints);
+        let child = self.child_layout(&lengths, constraints);
+        let padding = lengths.padding;
 
-        // Resolve fractional lengths against the incoming constraints: from
-        // here on a fraction is an exact length whose value became known at
-        // layout time, so everything downstream (flex sizing, animation
-        // targets, min/max clamping) works unchanged.
-        if let Some(f) = width_length.fraction
-            && constraints.max_width.is_finite()
-        {
-            width_length.exact = Some((constraints.max_width * f).max(0.0));
-        }
-        if let Some(f) = height_length.fraction
-            && constraints.max_height.is_finite()
-        {
-            height_length.exact = Some((constraints.max_height * f).max(0.0));
-        }
-
-        // Calculate dimensions for child layout constraints.
-        // When a layout animation is active and the width/height is exact, use
-        // the animated current value so children are positioned within the actual
-        // visible bounds (e.g., Center alignment tracks the animating size).
-        // For non-exact (shrink-to-fit) widths, use the signal value to avoid a
-        // circular dependency: animated width → constrains children → target = clamped.
-        let child_layout_width =
-            if let Some(anim) = self.anims.as_ref().and_then(|a| a.width.as_ref()) {
-                if !anim.is_initial() && width_length.exact.is_some() {
-                    if animations::measuring_final() {
-                        *anim.target()
-                    } else {
-                        *anim.current()
-                    }
-                } else {
-                    width_length.exact.unwrap_or(constraints.max_width)
-                }
-            } else if let Some(exact) = width_length.exact {
-                exact
-            } else {
-                let w = constraints.max_width;
-                if let Some(max) = width_length.max {
-                    w.min(max)
-                } else {
-                    w
-                }
-            };
-
-        let child_layout_height =
-            if let Some(anim) = self.anims.as_ref().and_then(|a| a.height.as_ref()) {
-                if !anim.is_initial() && height_length.exact.is_some() {
-                    if animations::measuring_final() {
-                        *anim.target()
-                    } else {
-                        *anim.current()
-                    }
-                } else {
-                    height_length.exact.unwrap_or(constraints.max_height)
-                }
-            } else if let Some(exact) = height_length.exact {
-                exact
-            } else {
-                let h = constraints.max_height;
-                if let Some(max) = height_length.max {
-                    h.min(max)
-                } else {
-                    h
-                }
-            };
-
-        // Child constraints with padding
-        let mut child_max_width = (child_layout_width - padding.horizontal()).max(0.0);
-        let mut child_max_height = (child_layout_height - padding.vertical()).max(0.0);
-
-        // Reserve gutter space for scrollbars
-        if let Some(ref sd) = self.scroll_data
-            && sd.scrollbar_config.reserve_gutter
-            && sd.scrollbar_visibility != ScrollbarVisibility::Hidden
-        {
-            let gutter = sd.scrollbar_config.width + sd.scrollbar_config.margin * 2.0;
-            if self.scroll_axis.allows_vertical() {
-                child_max_width = (child_max_width - gutter).max(0.0);
-            }
-            if self.scroll_axis.allows_horizontal() {
-                child_max_height = (child_max_height - gutter).max(0.0);
-            }
-        }
-
-        let child_min_width = if width_length.exact.is_some() || width_length.fill {
-            child_max_width
-        } else {
-            // Propagate the effective minimum so layouts like Center/End know
-            // how much space they actually have to position children within.
-            // Sources of minimum: explicit at_least(min) or parent constraints.
-            let effective_min = width_length.min.unwrap_or(0.0).max(constraints.min_width);
-            (effective_min - padding.horizontal())
-                .max(0.0)
-                .min(child_max_width)
-        };
-        let child_min_height = if height_length.exact.is_some() || height_length.fill {
-            child_max_height
-        } else {
-            let effective_min = height_length.min.unwrap_or(0.0).max(constraints.min_height);
-            (effective_min - padding.vertical())
-                .max(0.0)
-                .min(child_max_height)
-        };
-
-        // For scrollable containers, use unbounded constraints in scroll direction
-        let scroll_axis = self.scroll_axis;
-
-        let child_constraints = match scroll_axis {
-            ScrollAxis::Vertical => Constraints {
-                min_width: 0.0,
-                min_height: 0.0,
-                max_width: child_max_width,
-                max_height: f32::INFINITY,
-            },
-            ScrollAxis::Horizontal => Constraints {
-                min_width: 0.0,
-                min_height: 0.0,
-                max_width: f32::INFINITY,
-                max_height: child_max_height,
-            },
-            ScrollAxis::Both => Constraints {
-                min_width: 0.0,
-                min_height: 0.0,
-                max_width: f32::INFINITY,
-                max_height: f32::INFINITY,
-            },
-            ScrollAxis::None => Constraints {
-                min_width: child_min_width,
-                min_height: child_min_height,
-                max_width: child_max_width,
-                max_height: child_max_height,
-            },
-        };
-
-        // Children are positioned in LOCAL coordinates (relative to container's 0,0).
-        // The container's absolute position is handled by the parent via transforms.
-        // Scroll offset is applied as a transform in paint().
-        let (child_origin_x, child_origin_y) = (padding.left, padding.top);
-
-        // Reconcile and get children IDs
         let children = self.children_source.reconcile_and_get(tree);
 
         // A layout reads its own reactive properties (Flex's spacing and
@@ -1437,29 +992,25 @@ impl Widget for Container {
         let layout_impl = &mut self.layout;
         let content_size = if !children.is_empty() {
             with_signal_tracking(id, JobType::Layout, || {
-                layout_impl.layout(
-                    tree,
-                    children,
-                    child_constraints,
-                    (child_origin_x, child_origin_y),
-                )
+                layout_impl.layout(tree, children, child.constraints, child.origin)
             })
         } else {
             Size::zero()
         };
 
-        // Update scroll state with the viewport dimensions available for children.
-        if scroll_axis != ScrollAxis::None {
+        if self.scroll_axis != ScrollAxis::None {
             let sd = self.scroll_mut();
             sd.scroll_state.content_width = content_size.width + padding.horizontal();
             sd.scroll_state.content_height = content_size.height + padding.vertical();
-            sd.scroll_state.viewport_width = child_max_width;
-            sd.scroll_state.viewport_height = child_max_height;
+            sd.scroll_state.viewport_width = child.viewport.width;
+            sd.scroll_state.viewport_height = child.viewport.height;
             sd.scroll_state.clamp_offsets();
         }
 
         let content_width = content_size.width + padding.horizontal();
         let content_height = content_size.height + padding.vertical();
+        let width_length = lengths.width;
+        let height_length = lengths.height;
 
         // Update animation targets
         if let Some(ref mut anims) = self.anims {
@@ -1588,110 +1139,7 @@ impl Widget for Container {
             }
         }
 
-        // Determine shrink behavior
-        let width_animating = self
-            .anims
-            .as_ref()
-            .and_then(|a| a.width.as_ref())
-            .is_some_and(|a| a.is_animating());
-        let height_animating = self
-            .anims
-            .as_ref()
-            .and_then(|a| a.height.as_ref())
-            .is_some_and(|a| a.is_animating());
-        let has_exact_width = width_length.exact.is_some();
-        let has_exact_height = height_length.exact.is_some();
-        let allow_shrink_width = self.overflow == Overflow::Hidden
-            || width_animating
-            || has_exact_width
-            || self.scroll_axis.allows_horizontal();
-        let allow_shrink_height = self.overflow == Overflow::Hidden
-            || height_animating
-            || has_exact_height
-            || self.scroll_axis.allows_vertical();
-
-        // Calculate final dimensions (measure-final: report animation
-        // targets so content-sized surfaces size once, not per frame)
-        let mut width = if let Some(anim) = self.anims.as_ref().and_then(|a| a.width.as_ref()) {
-            let animated = if animations::measuring_final() {
-                *anim.target()
-            } else {
-                *anim.current()
-            };
-            if allow_shrink_width {
-                animated
-            } else {
-                content_width.max(animated)
-            }
-        } else if let Some(exact) = width_length.exact {
-            exact
-        } else if width_length.fill {
-            constraints.max_width
-        } else {
-            content_width
-        };
-
-        // Apply Length min/max as post-adjustments (works with all cases including fill)
-        if let Some(min) = width_length.min {
-            width = width.max(min);
-        }
-        if let Some(max) = width_length.max {
-            width = width.min(max);
-        }
-
-        let mut height = if let Some(anim) = self.anims.as_ref().and_then(|a| a.height.as_ref()) {
-            let animated = if animations::measuring_final() {
-                *anim.target()
-            } else {
-                *anim.current()
-            };
-            if allow_shrink_height {
-                animated
-            } else {
-                content_height.max(animated)
-            }
-        } else if let Some(exact) = height_length.exact {
-            exact
-        } else if height_length.fill {
-            constraints.max_height
-        } else {
-            content_height
-        };
-
-        // Apply Length min/max as post-adjustments (works with all cases including fill)
-        if let Some(min) = height_length.min {
-            height = height.max(min);
-        }
-        if let Some(max) = height_length.max {
-            height = height.min(max);
-        }
-
-        let has_width_anim = self.anims.as_ref().is_some_and(|a| a.width.is_some());
-        let has_height_anim = self.anims.as_ref().is_some_and(|a| a.height.is_some());
-        if !allow_shrink_width && !has_width_anim && !has_exact_width {
-            width = width.max(content_width);
-        }
-        if !allow_shrink_height && !has_height_anim && !has_exact_height {
-            height = height.max(content_height);
-        }
-
-        // When explicit dimensions are set, respect them over min constraints
-        // This allows children with .width(60) to stay 60px even when parent uses Stretch
-        let final_width = if width_length.exact.is_some() {
-            // Explicit width: only apply max constraint, not min
-            width.min(constraints.max_width)
-        } else {
-            width.max(constraints.min_width).min(constraints.max_width)
-        };
-        let final_height = if height_length.exact.is_some() {
-            // Explicit height: only apply max constraint, not min
-            height.min(constraints.max_height)
-        } else {
-            height
-                .max(constraints.min_height)
-                .min(constraints.max_height)
-        };
-        let size = Size::new(final_width, final_height);
+        let size = self.resolve_size(&lengths, constraints, content_size);
 
         // Layout scrollbar containers after size is determined
         // Note: cache_layout is called at the end which stores size in Tree
@@ -1713,108 +1161,54 @@ impl Widget for Container {
             return EventResponse::Ignored;
         }
 
-        // Get bounds from Tree (single source of truth)
-        let bounds = tree.get_bounds(id).unwrap_or_default();
-
-        let transform = self.animated_transform(tree);
-        let transform_origin = self.transform_origin.get_or(TransformOrigin::CENTER);
-        let corner_radius = self.animated_corner_radius(tree);
+        let hit = HitContext {
+            bounds: tree.get_bounds(id).unwrap_or_default(),
+            corner_radius: self.animated_corner_radius(tree),
+            transform: self.animated_transform(tree),
+            transform_origin: self.transform_origin.get_or(TransformOrigin::CENTER),
+        };
 
         // Undo our own transform before hit testing against the laid-out bounds
         let local_event: Cow<'_, Event> = match event.coords() {
-            Some((x, y)) if !transform.is_identity() => {
+            Some((x, y)) if !hit.transform.is_identity() => {
                 let (local_x, local_y) =
-                    untransform_point(&transform, transform_origin, bounds, x, y);
+                    untransform_point(&hit.transform, hit.transform_origin, hit.bounds, x, y);
                 Cow::Owned(event.with_coords(local_x, local_y))
             }
             _ => Cow::Borrowed(event),
         };
 
-        // Handle scrollbar events first
-        if let Some(response) = self.handle_scrollbar_event(tree, id, bounds, &local_event) {
+        if let Some(response) = self.handle_scrollbar_event(tree, id, hit.bounds, &local_event) {
             return response;
         }
 
-        // Pre-dispatch: update hover state and fire pointer move callback
-        // before children get the event. This ensures parent hover tracking
-        // works even when a child container handles the MouseMove/MouseEnter.
-        let has_animated = self.has_animated_state_properties();
-        if let Some(ref mut ix) = self.interaction {
-            let request_repaint = |id: WidgetId| {
-                if has_animated {
-                    request_job(id, JobRequest::Animation(RequiredJob::Paint));
-                } else {
-                    request_job(id, JobRequest::Paint);
-                }
-            };
-            match local_event.as_ref() {
-                Event::MouseEnter { x, y }
-                    if bounds.contains_rounded(*x, *y, corner_radius) && !ix.is_hovered =>
-                {
-                    ix.is_hovered = true;
-                    if ix.hover_state.is_some() {
-                        request_repaint(id);
-                    }
-                    if let Some(ref callback) = ix.on_hover {
-                        callback(true);
-                    }
-                }
-                Event::MouseMove { x, y } => {
-                    if let Some(ref callback) = ix.on_pointer_move
-                        && (bounds.contains_rounded(*x, *y, corner_radius) || ix.is_pressed)
-                    {
-                        callback(*x - bounds.x, *y - bounds.y);
-                    }
+        self.track_pointer(id, &hit, &local_event);
 
-                    let was_hovered = ix.is_hovered;
-                    ix.is_hovered = bounds.contains_rounded(*x, *y, corner_radius);
-
-                    if was_hovered != ix.is_hovered {
-                        if ix.hover_state.is_some() {
-                            request_repaint(id);
-                        }
-                        if let Some(ref callback) = ix.on_hover {
-                            callback(ix.is_hovered);
-                        }
-                    }
+        // Children are positioned relative to our origin (and to the scroll
+        // offset, when we scroll), so their events have to be too.
+        let child_event: Cow<'_, Event> = match local_event.coords() {
+            Some((x, y)) => {
+                let (mut cx, mut cy) = (x - hit.bounds.x, y - hit.bounds.y);
+                if self.scroll_axis != ScrollAxis::None {
+                    let sd = self.scroll();
+                    cx += sd.scroll_state.offset_x;
+                    cy += sd.scroll_state.offset_y;
                 }
-                _ => {}
+                Cow::Owned(local_event.with_coords(cx, cy))
             }
-        }
-
-        // Transform event coordinates to local space (relative to container origin)
-        // Children are positioned in local coordinates, so events must be too
-        let child_event: Cow<'_, Event> = if let Some((x, y)) = local_event.coords() {
-            // Convert from global/window coordinates to local (relative to container)
-            let local_x = x - bounds.x;
-            let local_y = y - bounds.y;
-
-            // For scrollable containers, also add scroll offset
-            let (child_x, child_y) = if self.scroll_axis != ScrollAxis::None {
-                let sd = self.scroll();
-                (
-                    local_x + sd.scroll_state.offset_x,
-                    local_y + sd.scroll_state.offset_y,
-                )
-            } else {
-                (local_x, local_y)
-            };
-            Cow::Owned(local_event.with_coords(child_x, child_y))
-        } else {
-            local_event.clone()
+            None => local_event.clone(),
         };
 
-        // When overflow is hidden, children outside the container's bounds are
-        // clipped and invisible. Skip dispatching pointer events to them so that
-        // invisible children (e.g. inside a 0-height collapsed submenu) cannot
-        // steal clicks from siblings positioned below.
-        let skip_child_dispatch = (self.overflow == Overflow::Hidden
-            || self.scroll_axis != ScrollAxis::None)
+        // Children clipped away by hidden overflow or scrolling are invisible,
+        // and an invisible child must not steal a click from a sibling drawn
+        // below it (a collapsed submenu used to do exactly that).
+        let clips_children =
+            self.overflow == Overflow::Hidden || self.scroll_axis != ScrollAxis::None;
+        let skip_child_dispatch = clips_children
             && local_event
                 .coords()
-                .is_some_and(|(x, y)| !bounds.contains(x, y));
+                .is_some_and(|(x, y)| !hit.bounds.contains(x, y));
 
-        // Let children handle first (layout already reconciled)
         if !skip_child_dispatch {
             for &child_id in self.children_source.get() {
                 if let Some(response) = tree.with_widget_mut(child_id, |child, child_id, tree| {
@@ -1826,175 +1220,7 @@ impl Widget for Container {
             }
         }
 
-        // Handle our own events
-        match local_event.as_ref() {
-            // Hover tracking already handled in pre-dispatch above.
-            // Don't return Handled — hover changes should not prevent
-            // sibling containers from tracking their own hover state.
-            Event::MouseEnter { .. } | Event::MouseMove { .. } => {}
-            Event::MouseDown { x, y, button } if *button != MouseButton::Left => {
-                if bounds.contains_rounded(*x, *y, corner_radius)
-                    && let Some(ref ix) = self.interaction
-                {
-                    let callback = match button {
-                        MouseButton::Right => ix.on_right_click.as_ref(),
-                        MouseButton::Middle => ix.on_middle_click.as_ref(),
-                        MouseButton::Left => None,
-                    };
-                    if let Some(callback) = callback {
-                        callback();
-                        return EventResponse::Handled;
-                    }
-                }
-            }
-            Event::MouseDown { x, y, button } => {
-                if bounds.contains_rounded(*x, *y, corner_radius)
-                    && *button == MouseButton::Left
-                    && let Some(ref mut ix) = self.interaction
-                {
-                    let was_pressed = ix.is_pressed;
-                    ix.is_pressed = true;
-
-                    // Start ripple animation if configured
-                    let has_ripple = ix
-                        .pressed_state
-                        .as_ref()
-                        .is_some_and(|s| s.ripple.is_some());
-                    if has_ripple {
-                        let (screen_x, screen_y) = event.coords().unwrap_or((*x, *y));
-                        let (local_x, local_y) =
-                            local_point(&transform, transform_origin, bounds, screen_x, screen_y);
-                        ix.ripple.start(local_x, local_y);
-                        // Ripple animation needs Animation + Paint
-                        request_job(id, JobRequest::Animation(RequiredJob::Paint));
-                    }
-
-                    if !was_pressed && ix.pressed_state.is_some() {
-                        self.request_state_change_repaint(id);
-                    }
-                    if let Some(ref ix) = self.interaction
-                        && let Some(ref callback) = ix.on_mouse_down
-                    {
-                        callback(*x - bounds.x, *y - bounds.y);
-                        return EventResponse::Handled;
-                    }
-                    if let Some(ref ix) = self.interaction
-                        && (ix.on_click.is_some() || ix.on_mouse_up.is_some())
-                    {
-                        return EventResponse::Handled;
-                    }
-                }
-            }
-            Event::MouseUp { x, y, button } => {
-                if let Some(ref mut ix) = self.interaction
-                    && ix.is_pressed
-                    && *button == MouseButton::Left
-                {
-                    let was_pressed = ix.is_pressed;
-                    ix.is_pressed = false;
-
-                    // Start ripple fade animation
-                    if ix.ripple.is_active() {
-                        let (screen_x, screen_y) = event.coords().unwrap_or((*x, *y));
-                        let (local_x, local_y) =
-                            local_point(&transform, transform_origin, bounds, screen_x, screen_y);
-                        ix.ripple.start_fade(local_x, local_y);
-                        // Ripple fade animation needs Animation + Paint
-                        request_job(id, JobRequest::Animation(RequiredJob::Paint));
-                    }
-
-                    if was_pressed && ix.pressed_state.is_some() {
-                        self.request_state_change_repaint(id);
-                    }
-                    let mut handled = false;
-                    if let Some(ref ix) = self.interaction
-                        && let Some(ref callback) = ix.on_mouse_up
-                    {
-                        callback(*x - bounds.x, *y - bounds.y);
-                        handled = true;
-                    }
-                    if let Some(ref ix) = self.interaction
-                        && bounds.contains_rounded(*x, *y, corner_radius)
-                        && let Some(ref callback) = ix.on_click
-                    {
-                        callback();
-                        return EventResponse::Handled;
-                    }
-                    if handled {
-                        return EventResponse::Handled;
-                    }
-                }
-            }
-            Event::MouseLeave => {
-                if let Some(ref mut ix) = self.interaction {
-                    let was_hovered = ix.is_hovered;
-                    let was_pressed = ix.is_pressed;
-                    if ix.is_hovered {
-                        ix.is_hovered = false;
-                        if let Some(ref callback) = ix.on_hover {
-                            callback(false);
-                        }
-                    }
-                    ix.is_pressed = false;
-
-                    // Start ripple fade to center
-                    if ix.ripple.is_active() {
-                        ix.ripple.start_fade_to_center(bounds.width, bounds.height);
-                        // Ripple fade animation needs Animation + Paint
-                        request_job(id, JobRequest::Animation(RequiredJob::Paint));
-                    }
-
-                    if (was_hovered && ix.hover_state.is_some())
-                        || (was_pressed && ix.pressed_state.is_some())
-                    {
-                        self.request_state_change_repaint(id);
-                    }
-                }
-            }
-            Event::Scroll {
-                x,
-                y,
-                delta_x,
-                delta_y,
-                source,
-            } => {
-                if bounds.contains_rounded(*x, *y, corner_radius) {
-                    if self.scroll_axis != ScrollAxis::None {
-                        let consumed = self.apply_scroll(*delta_x, *delta_y, *source);
-                        if consumed {
-                            // Kinetic scrolling needs Animation + Paint if has velocity
-                            let sd = self.scroll();
-                            let has_velocity = sd.scroll_state.velocity_x.abs() > 0.5
-                                || sd.scroll_state.velocity_y.abs() > 0.5;
-                            if has_velocity {
-                                request_job(id, JobRequest::Animation(RequiredJob::Paint));
-                            } else {
-                                request_job(id, JobRequest::Paint);
-                            }
-                            return EventResponse::Handled;
-                        }
-                    }
-
-                    if let Some(ref ix) = self.interaction
-                        && let Some(ref callback) = ix.on_scroll
-                    {
-                        callback(*delta_x, *delta_y, *source);
-                        return EventResponse::Handled;
-                    }
-                }
-            }
-            Event::KeyDown { key, modifiers } => {
-                if let Some(ref ix) = self.interaction
-                    && let Some(ref callback) = ix.on_key_down
-                {
-                    callback(*key, *modifiers);
-                    return EventResponse::Handled;
-                }
-            }
-            Event::KeyUp { .. } | Event::FocusIn | Event::FocusOut => {}
-        }
-
-        EventResponse::Ignored
+        self.handle_own_event(id, &hit, event, &local_event)
     }
 
     fn has_focus_descendant(&self, tree: &Tree, focused_id: WidgetId) -> bool {
@@ -2104,60 +1330,28 @@ impl Widget for Container {
             crate::blur::register_blur(id, corner_radius);
         }
 
-        let shadow = elevation_to_shadow(elevation_level);
-
-        // LOCAL bounds (0,0 is widget origin) - all drawing uses these
+        // LOCAL bounds: the origin is this container, the parent already
+        // positioned the node.
         let local_bounds = Rect::new(0.0, 0.0, bounds.width, bounds.height);
         ctx.set_bounds(local_bounds);
 
-        // Apply user transform (rotation, scale, user-specified translate)
-        // Position is handled by the parent via set_transform before calling paint
-        // We COMPOSE our user transform with the existing position transform
+        // Compose our own transform on top of the position the parent set.
         if !user_transform.is_identity() {
             ctx.apply_transform_with_origin(user_transform, transform_origin);
         }
 
-        // Draw background using LOCAL coordinates
-        if let Some(ref gradient) = self.gradient {
-            ctx.draw_gradient_rect(
-                local_bounds,
-                crate::renderer::Gradient {
-                    start_color: gradient.start_color,
-                    end_color: gradient.end_color,
-                    direction: gradient.direction.into(),
-                },
+        self.paint_decoration(
+            ctx,
+            local_bounds,
+            &Decoration {
+                background,
                 corner_radii,
                 corner_curvature,
-            );
-        } else if background.a > 0.0 {
-            if elevation_level > 0.0 {
-                ctx.draw_rounded_rect_with_shadow(
-                    local_bounds,
-                    background,
-                    corner_radii,
-                    corner_curvature,
-                    shadow,
-                );
-            } else {
-                ctx.draw_rounded_rect_with_curvature(
-                    local_bounds,
-                    background,
-                    corner_radii,
-                    corner_curvature,
-                );
-            }
-        }
-
-        // Draw border using LOCAL coordinates (values captured above in with_signal_tracking)
-        if border_width > 0.0 {
-            ctx.draw_border_frame_with_curvature(
-                local_bounds,
-                border_color,
-                corner_radii,
+                elevation: elevation_level,
                 border_width,
-                corner_curvature,
-            );
-        }
+                border_color,
+            },
+        );
 
         // Determine if we need to clip children
         let is_scrollable = self.scroll_axis != ScrollAxis::None;

--- a/src/widgets/container/style.rs
+++ b/src/widgets/container/style.rs
@@ -1,0 +1,302 @@
+//! Resolving a container's styled values.
+//!
+//! Every visual property of a container exists at three levels, and this
+//! module is the only place that knows how they combine:
+//!
+//! 1. the **base** value the builder was given (a signal, possibly a closure);
+//! 2. the **state layer** override that applies while the container is
+//!    pressed, focused or hovered — pressed wins, then focused, then hovered;
+//! 3. the **animation** currently interpolating toward that value.
+//!
+//! The two families below correspond to the last two steps. `effective_*`
+//! answers "what should this property be right now" — the *target*, base plus
+//! state layer, which is what an animation is asked to animate toward.
+//! `animated_*` answers "what should be drawn right now" — the in-flight value
+//! when an animation exists, the target otherwise.
+//!
+//! Layout and paint both read through these, which is why they live apart from
+//! either: a state-layer change has to move the same value whether it lands in
+//! a size or in a colour.
+
+use super::*;
+
+impl Container {
+    // -----------------------------------------------------------------------
+    // Focus, as seen by the focused state layer
+    // -----------------------------------------------------------------------
+
+    /// Whether the focused widget is this container or one of its descendants.
+    pub(super) fn has_child_focus(&self, tree: &Tree) -> bool {
+        match focused_widget() {
+            Some(focused_id) => self.widget_has_focus(tree, focused_id),
+            None => false,
+        }
+    }
+
+    pub(super) fn widget_has_focus(&self, tree: &Tree, focused_id: WidgetId) -> bool {
+        for &child_id in self.children_source.get() {
+            if child_id == focused_id {
+                return true;
+            }
+            if tree.with_widget(child_id, |child| {
+                child.has_focus_descendant(tree, focused_id)
+            }) == Some(true)
+            {
+                return true;
+            }
+        }
+        false
+    }
+
+    // -----------------------------------------------------------------------
+    // State layer: base value plus the override of the active state
+    // -----------------------------------------------------------------------
+
+    /// Apply the active state layer's override to `base`, if it declares one.
+    /// Priority is pressed > focused > hovered.
+    fn resolve_state_value<T: Clone>(
+        &self,
+        tree: &Tree,
+        base: T,
+        extractor: impl Fn(&StateStyle) -> Option<T>,
+    ) -> T {
+        let Some(ref ix) = self.interaction else {
+            return base;
+        };
+        if ix.is_pressed
+            && let Some(ref state) = ix.pressed_state
+            && let Some(value) = extractor(state)
+        {
+            return value;
+        }
+        if ix.focused_state.is_some()
+            && self.has_child_focus(tree)
+            && let Some(ref state) = ix.focused_state
+            && let Some(value) = extractor(state)
+        {
+            return value;
+        }
+        if ix.is_hovered
+            && let Some(ref state) = ix.hover_state
+            && let Some(value) = extractor(state)
+        {
+            return value;
+        }
+        base
+    }
+
+    /// The background a state layer resolves to: its own colour if it declares
+    /// one, its own alpha if it declares one, otherwise the base.
+    pub(super) fn effective_background_target(&self, tree: &Tree) -> Color {
+        let base = self.background.get_or(Color::TRANSPARENT);
+        self.resolve_state_value(tree, base, |state| {
+            let bg_color = state
+                .background
+                .as_ref()
+                .map(|bg| resolve_background(base, bg));
+            match (bg_color, state.alpha) {
+                (Some(mut c), Some(a)) => {
+                    c.a = a;
+                    Some(c)
+                }
+                (Some(c), None) => Some(c),
+                (None, Some(a)) => {
+                    let mut c = base;
+                    c.a = a;
+                    Some(c)
+                }
+                (None, None) => None,
+            }
+        })
+    }
+
+    pub(super) fn effective_border_width_target(&self, tree: &Tree) -> f32 {
+        let base = self.border_width.get_or(0.0);
+        self.resolve_state_value(tree, base, |state| state.border_width)
+    }
+
+    pub(super) fn effective_border_color_target(&self, tree: &Tree) -> Color {
+        let base = self.border_color.get_or(Color::TRANSPARENT);
+        self.resolve_state_value(tree, base, |state| state.border_color)
+    }
+
+    pub(super) fn effective_corner_radius_target(&self, tree: &Tree) -> f32 {
+        let base = self.corner_radius.get_or(0.0);
+        self.resolve_state_value(tree, base, |state| state.corner_radius)
+    }
+
+    pub(super) fn effective_transform_target(&self, tree: &Tree) -> Transform {
+        let base = self.transform.get_or(Transform::IDENTITY);
+        self.resolve_state_value(tree, base, |state| state.transform)
+    }
+
+    /// Elevation is never animated, so the target *is* the drawn value.
+    pub(super) fn effective_elevation(&self, tree: &Tree) -> f32 {
+        let base = self.elevation.get_or(0.0);
+        self.resolve_state_value(tree, base, |state| state.elevation)
+    }
+
+    // -----------------------------------------------------------------------
+    // Animation: the in-flight value when one is running
+    // -----------------------------------------------------------------------
+
+    pub(super) fn animated_padding(&self) -> Padding {
+        get_animated_value(self.anims.as_ref().and_then(|a| a.padding.as_ref()), || {
+            self.padding.get_or(Padding::default())
+        })
+    }
+
+    pub(super) fn animated_background(&self, tree: &Tree) -> Color {
+        get_animated_value(
+            self.anims.as_ref().and_then(|a| a.background.as_ref()),
+            || self.effective_background_target(tree),
+        )
+    }
+
+    pub(super) fn animated_corner_radius(&self, tree: &Tree) -> f32 {
+        get_animated_value(
+            self.anims.as_ref().and_then(|a| a.corner_radius.as_ref()),
+            || self.effective_corner_radius_target(tree),
+        )
+    }
+
+    pub(super) fn animated_border_width(&self, tree: &Tree) -> f32 {
+        get_animated_value(
+            self.anims.as_ref().and_then(|a| a.border_width.as_ref()),
+            || self.effective_border_width_target(tree),
+        )
+    }
+
+    pub(super) fn animated_border_color(&self, tree: &Tree) -> Color {
+        get_animated_value(
+            self.anims.as_ref().and_then(|a| a.border_color.as_ref()),
+            || self.effective_border_color_target(tree),
+        )
+    }
+
+    pub(super) fn animated_transform(&self, tree: &Tree) -> Transform {
+        get_animated_value(
+            self.anims.as_ref().and_then(|a| a.transform.as_ref()),
+            || self.effective_transform_target(tree),
+        )
+    }
+
+    /// Whether a state-layer change can move an animated property — i.e.
+    /// whether hovering or pressing needs an Animation job rather than a plain
+    /// repaint.
+    pub(super) fn has_animated_state_properties(&self) -> bool {
+        self.anims.as_ref().is_some_and(|a| {
+            a.background.is_some()
+                || a.corner_radius.is_some()
+                || a.border_color.is_some()
+                || a.transform.is_some()
+        })
+    }
+
+    /// Whether any animation follows a signal-backed target, as opposed to
+    /// width/height whose targets are content-driven and recomputed at every
+    /// layout. These are the ones holding a copy of signal state, so they are
+    /// the ones needing the paint-time target re-sync.
+    pub(super) fn has_signal_animated_props(&self) -> bool {
+        self.anims.as_ref().is_some_and(|a| {
+            a.padding.is_some()
+                || a.border_width.is_some()
+                || a.background.is_some()
+                || a.corner_radius.is_some()
+                || a.border_color.is_some()
+                || a.transform.is_some()
+        })
+    }
+}
+
+/// The container's own surface, resolved for one frame.
+pub(super) struct Decoration {
+    pub background: Color,
+    pub corner_radii: crate::renderer::CornerRadii,
+    pub corner_curvature: f32,
+    pub elevation: f32,
+    pub border_width: f32,
+    pub border_color: Color,
+}
+
+impl Container {
+    /// Draw the container's own surface: background or gradient, its shadow,
+    /// and the border frame. Children are painted separately, after this.
+    ///
+    /// `bounds` is local — the origin is the container itself, and the parent
+    /// has already positioned the node.
+    pub(super) fn paint_decoration(&self, ctx: &mut PaintContext, bounds: Rect, d: &Decoration) {
+        // A gradient replaces the solid fill rather than layering over it.
+        if let Some(ref gradient) = self.gradient {
+            ctx.draw_gradient_rect(
+                bounds,
+                crate::renderer::Gradient {
+                    start_color: gradient.start_color,
+                    end_color: gradient.end_color,
+                    direction: gradient.direction.into(),
+                },
+                d.corner_radii,
+                d.corner_curvature,
+            );
+        } else if d.background.a > 0.0 {
+            if d.elevation > 0.0 {
+                ctx.draw_rounded_rect_with_shadow(
+                    bounds,
+                    d.background,
+                    d.corner_radii,
+                    d.corner_curvature,
+                    elevation_to_shadow(d.elevation),
+                );
+            } else {
+                ctx.draw_rounded_rect_with_curvature(
+                    bounds,
+                    d.background,
+                    d.corner_radii,
+                    d.corner_curvature,
+                );
+            }
+        }
+
+        if d.border_width > 0.0 {
+            ctx.draw_border_frame_with_curvature(
+                bounds,
+                d.border_color,
+                d.corner_radii,
+                d.border_width,
+                d.corner_curvature,
+            );
+        }
+    }
+}
+
+/// Convert an elevation level to the shadow that expresses it.
+///
+/// Material-style: the higher the surface sits, the further the shadow falls
+/// and the softer it gets. Levels 1–5 are tabulated; above that the numbers
+/// keep growing on the same curve, up to a ceiling.
+pub(super) fn elevation_to_shadow(level: f32) -> Shadow {
+    if level <= 0.0 {
+        return Shadow::none();
+    }
+
+    let (offset_y, blur, alpha) = match level as i32 {
+        1 => (1.0, 3.0, 0.12),
+        2 => (2.0, 4.0, 0.16),
+        3 => (3.0, 6.0, 0.19),
+        4 => (4.0, 8.0, 0.20),
+        5 => (6.0, 10.0, 0.22),
+        _ => {
+            let offset = (level * 1.2).min(12.0);
+            let blur = (level * 2.0).min(24.0);
+            let alpha = (0.12 + level * 0.02).min(0.25);
+            (offset, blur, alpha)
+        }
+    };
+
+    Shadow::new(
+        (0.0, offset_y),
+        blur,
+        0.0,
+        Color::rgba(0.0, 0.0, 0.0, alpha),
+    )
+}


### PR DESCRIPTION
The container is meant to be the one layout-and-looks widget — an HTML `div`, not one of two thousand widgets — and **that stays**. This PR changes no public API.

What it lacked was any seam *inside*: `layout`, `event` and `paint` were 465, 311 and 386 lines with the box model, scrolling, state layers, animations and interaction interleaved in the same function bodies. A browser has the same breadth of API on a `div` and still decomposes the implementation into box model, paint and compositing.

Split by concern using the pattern `scrollable.rs` already established — an inherent impl spread over several files, **no traits with a single implementor**:

- **`box_model.rs`** — the declared lengths (fractions resolved), what children are offered (padding, scrollbar gutter, unbounded scrolled axis), and the final size. Width and height now run through one `resolve_axis` instead of two near-identical blocks.
- **`style.rs`** — the three levels every visual property has (base signal, state-layer override, animation) and the one place that combines them, plus the drawing of the resolved surface.
- **`interaction.rs`** — hit testing against the container's *shape*, hover tracked before children so an ancestor still sees the pointer, everything else after them. The repeated `bounds.contains_rounded(x, y, corner_radius)` is now `hit.contains(x, y)` on a `HitContext` carrying the geometry.

`Container::layout` 465 → 208, `event` 311 → 67, `mod.rs` 2568 → 1729.

### One asymmetry preserved, not endorsed

Unifying the two axes surfaced this: with a width animation attached, the extent children are laid out inside **ignores `at_most`**, while without one it is clamped. The container itself honours the cap either way, so only the children's constraints differ.

It is preserved exactly and pinned by `an_animated_width_does_not_clamp_children_to_at_most`, whose comment says it looks like an oversight. A refactor is the wrong place to decide that.

---

**PR 4 of 6**, based on #154.