### PR TITLE
refactor: one home for the animation/signal bridge

### DIFF
--- a/src/widgets/container/anim_bridge.rs
+++ b/src/widgets/container/anim_bridge.rs
@@ -1,0 +1,222 @@
+//! Keeping animation state in step with the signals it mirrors.
+//!
+//! An [`AnimationState`] is a **cache of signal-derived state**: it holds a
+//! target computed from a signal (plus whatever the active state layer
+//! overrides) and interpolates toward it. A cache like that is only correct if
+//! it is both
+//!
+//! 1. **subscribed from the moment it exists**, so no write can slip past
+//!    before anyone is listening, and
+//! 2. **reconciled against the live value at every use**, so a target reached
+//!    through a branch nobody tracked still converges.
+//!
+//! Neither half is sufficient on its own, and both failure modes have been
+//! shipped: a menu whose open-flip timer fired between its first layout and a
+//! heavy first paint stayed collapsed forever (no subscription yet), and a
+//! transform whose target moved through a conditional closure branch sat on
+//! the stale value (subscribed, but to the branch not taken).
+//!
+//! The three passes below are where that invariant lives.
+//!
+//! - [`seed_animations`] is (1): at the first layout, every animated property
+//!   is read under Animation tracking so its subscription starts *now*. Widget
+//!   creation and first layout run in one synchronous block — for popups, the
+//!   measure-before-spawn — so nothing can land in between.
+//! - [`resync_animation_targets`] is (2): every paint re-reads the targets
+//!   under tracking and asks for an Animation job when one has drifted, so
+//!   `advance_animations` adopts whatever the subscription missed.
+//! - [`update_size_targets`] is neither, and that is the point: width and
+//!   height do not mirror a signal, they follow the measured content, so their
+//!   targets are simply recomputed at every layout.
+//!
+//! [`seed_animations`]: Container::seed_animations
+//! [`resync_animation_targets`]: Container::resync_animation_targets
+//! [`update_size_targets`]: Container::update_size_targets
+
+use super::box_model::BoxLengths;
+use super::*;
+
+impl Container {
+    /// Point the size animations at the content just measured.
+    ///
+    /// A size target is content-driven, so unlike every other animated
+    /// property it is recomputed from scratch at each layout and needs no
+    /// subscription. Retargeting also invalidates the *parent*: a child whose
+    /// width is moving makes its siblings move too.
+    pub(super) fn update_size_targets(
+        &mut self,
+        tree: &Tree,
+        id: WidgetId,
+        lengths: &BoxLengths,
+        content: Size,
+    ) {
+        let targets = [
+            (
+                lengths.width.exact,
+                lengths.width.min,
+                content.width + lengths.padding.horizontal(),
+            ),
+            (
+                lengths.height.exact,
+                lengths.height.min,
+                content.height + lengths.padding.vertical(),
+            ),
+        ];
+        let Some(ref mut anims) = self.anims else {
+            return;
+        };
+        let mut retargeted = false;
+
+        for (anim, (exact, min, content_extent)) in [anims.width.as_mut(), anims.height.as_mut()]
+            .into_iter()
+            .zip(targets)
+        {
+            let Some(anim) = anim else { continue };
+            let target = exact.unwrap_or_else(|| content_extent.max(min.unwrap_or(0.0)));
+
+            if anim.is_initial() {
+                // Mark initialized at the first layout whatever the value, so
+                // later changes animate instead of snapping.
+                anim.set_immediate(target);
+            } else if (target - *anim.target()).abs() > 0.001 {
+                anim.animate_to(target);
+                retargeted = true;
+            }
+        }
+
+        if retargeted {
+            // A size animation moves layout, not just paint.
+            request_job(id, JobRequest::Animation(RequiredJob::Layout));
+            if let Some(parent_id) = tree.get_parent(id) {
+                request_job(parent_id, JobRequest::Layout);
+            }
+        }
+    }
+
+    /// First layout: subscribe every animated property and start it from the
+    /// value its signal actually holds, not the one captured at construction.
+    ///
+    /// See the module docs for why this cannot wait for the first paint.
+    pub(super) fn seed_animations(&mut self, tree: &Tree, id: WidgetId) {
+        // Written out one by one: each property animates a different type, so
+        // there is no single accessor to loop over.
+        let anims = self.anims.as_ref();
+        let pd_init = anims.is_some_and(|a| a.padding.as_ref().is_some_and(|a| a.is_initial()));
+        let bw_init =
+            anims.is_some_and(|a| a.border_width.as_ref().is_some_and(|a| a.is_initial()));
+        let bg_init = anims.is_some_and(|a| a.background.as_ref().is_some_and(|a| a.is_initial()));
+        let cr_init =
+            anims.is_some_and(|a| a.corner_radius.as_ref().is_some_and(|a| a.is_initial()));
+        let bc_init =
+            anims.is_some_and(|a| a.border_color.as_ref().is_some_and(|a| a.is_initial()));
+        let tf_init = anims.is_some_and(|a| a.transform.as_ref().is_some_and(|a| a.is_initial()));
+
+        if !(pd_init || bw_init || bg_init || cr_init || bc_init || tf_init) {
+            return;
+        }
+
+        // Targets are computed under `&self` first: the writes below need
+        // `&mut self.anims`, and the effective_* readers need `&self`.
+        let (bg_target, cr_target, bc_target, tf_target) =
+            with_signal_tracking(id, JobType::Animation, || {
+                // Read for the subscription even where the value is unused.
+                if pd_init {
+                    let _ = self.padding.get_or(Padding::default());
+                }
+                if bw_init {
+                    let _ = self.effective_border_width_target(tree);
+                }
+                (
+                    bg_init.then(|| self.effective_background_target(tree)),
+                    cr_init.then(|| self.effective_corner_radius_target(tree)),
+                    bc_init.then(|| self.effective_border_color_target(tree)),
+                    tf_init.then(|| self.effective_transform_target(tree)),
+                )
+            });
+
+        let Some(ref mut anims) = self.anims else {
+            return;
+        };
+        if let (Some(anim), Some(target)) = (&mut anims.background, bg_target) {
+            anim.set_immediate(target);
+        }
+        if let (Some(anim), Some(target)) = (&mut anims.corner_radius, cr_target) {
+            anim.set_immediate(target);
+        }
+        if let (Some(anim), Some(target)) = (&mut anims.border_color, bc_target) {
+            anim.set_immediate(target);
+        }
+        if let (Some(anim), Some(target)) = (&mut anims.transform, tf_target) {
+            // An enter transition animates in from the declared value instead
+            // of snapping to the target.
+            if let Some(enter) = anim.take_enter_from() {
+                anim.begin_from(enter, target);
+                request_job(id, JobRequest::Animation(RequiredJob::Paint));
+            } else {
+                anim.set_immediate(target);
+            }
+        }
+    }
+
+    /// Every paint: re-read the animated targets under tracking, and ask for an
+    /// Animation job if any has drifted from what its animation is aiming at.
+    ///
+    /// This is the pull half of the invariant. It keeps the subscriptions
+    /// current through conditional closure branches and state-layer overrides,
+    /// and it converges any write that landed before the subscription existed.
+    pub(super) fn resync_animation_targets(&self, tree: &Tree, id: WidgetId) {
+        if !self.has_signal_animated_props() {
+            return;
+        }
+
+        let drifted = with_signal_tracking(id, JobType::Animation, || {
+            let anims = self.anims.as_ref().expect("checked by has_signal_*");
+            // An animation still in its initial state has no target to drift
+            // from — seed_animations has not run for it yet.
+            let moved = |initial: bool, same: bool| !initial && !same;
+            let mut drift = false;
+
+            if let Some(a) = &anims.padding {
+                drift |= moved(
+                    a.is_initial(),
+                    *a.target() == self.padding.get_or(Padding::default()),
+                );
+            }
+            if let Some(a) = &anims.border_width {
+                drift |= moved(
+                    a.is_initial(),
+                    *a.target() == self.effective_border_width_target(tree),
+                );
+            }
+            if let Some(a) = &anims.background {
+                drift |= moved(
+                    a.is_initial(),
+                    *a.target() == self.effective_background_target(tree),
+                );
+            }
+            if let Some(a) = &anims.corner_radius {
+                drift |= moved(
+                    a.is_initial(),
+                    *a.target() == self.effective_corner_radius_target(tree),
+                );
+            }
+            if let Some(a) = &anims.border_color {
+                drift |= moved(
+                    a.is_initial(),
+                    *a.target() == self.effective_border_color_target(tree),
+                );
+            }
+            if let Some(a) = &anims.transform {
+                drift |= moved(
+                    a.is_initial(),
+                    *a.target() == self.effective_transform_target(tree),
+                );
+            }
+            drift
+        });
+
+        if drifted {
+            request_job(id, JobRequest::Animation(RequiredJob::None));
+        }
+    }
+}

--- a/src/widgets/container/animations.rs
+++ b/src/widgets/container/animations.rs
@@ -345,20 +345,35 @@ pub(crate) fn measuring_final() -> bool {
     MEASURE_FINAL.with(|m| m.get())
 }
 
-/// Helper to get an animated value or a fallback
+impl<T: Animatable + Copy> AnimationState<T> {
+    /// The value this animation contributes right now.
+    ///
+    /// Normally the in-flight value — that is the animation. While a natural
+    /// size is being measured it is the destination instead, so a
+    /// content-sized surface resizes once to where the animation is going and
+    /// the animation plays inside it, rather than asking the compositor for a
+    /// new size on every frame.
+    ///
+    /// Every read of an animated value goes through here, so that rule is
+    /// stated once.
+    #[inline]
+    pub fn displayed(&self) -> T {
+        if measuring_final() {
+            *self.target()
+        } else {
+            *self.current()
+        }
+    }
+}
+
+/// The animated value if an animation exists, the fallback otherwise.
 #[inline]
 pub fn get_animated_value<T: Animatable + Copy>(
     anim: Option<&AnimationState<T>>,
     fallback: impl FnOnce() -> T,
 ) -> T {
     match anim {
-        Some(a) => {
-            if measuring_final() {
-                *a.target()
-            } else {
-                *a.current()
-            }
-        }
+        Some(a) => a.displayed(),
         None => fallback(),
     }
 }

--- a/src/widgets/container/box_model.rs
+++ b/src/widgets/container/box_model.rs
@@ -131,11 +131,7 @@ impl Container {
     ) -> f32 {
         if let Some(anim) = anim {
             if !anim.is_initial() && length.exact.is_some() {
-                return if animations::measuring_final() {
-                    *anim.target()
-                } else {
-                    *anim.current()
-                };
+                return anim.displayed();
             }
             return length.exact.unwrap_or(available);
         }
@@ -294,14 +290,8 @@ impl Container {
                 Axis::Vertical => self.scroll_axis.allows_vertical(),
             };
 
-        // Measure-final reports the animation's destination, so a
-        // content-sized surface sizes itself once instead of every frame.
         let mut size = if let Some(anim) = anim {
-            let animated = if animations::measuring_final() {
-                *anim.target()
-            } else {
-                *anim.current()
-            };
+            let animated = anim.displayed();
             if allow_shrink {
                 animated
             } else {

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -1,5 +1,6 @@
 //! Container widget and related functionality.
 
+mod anim_bridge;
 mod animations;
 mod box_model;
 mod interaction;
@@ -1007,137 +1008,8 @@ impl Widget for Container {
             sd.scroll_state.clamp_offsets();
         }
 
-        let content_width = content_size.width + padding.horizontal();
-        let content_height = content_size.height + padding.vertical();
-        let width_length = lengths.width;
-        let height_length = lengths.height;
-
-        // Update animation targets
-        if let Some(ref mut anims) = self.anims {
-            if let Some(ref mut anim) = anims.width {
-                let effective_target = if let Some(exact) = width_length.exact {
-                    exact
-                } else {
-                    let min_w = width_length.min.unwrap_or(0.0);
-                    content_width.max(min_w)
-                };
-                if anim.is_initial() {
-                    // Always mark as initialized on first layout so subsequent
-                    // changes animate rather than snap.
-                    anim.set_immediate(effective_target);
-                } else if (effective_target - *anim.target()).abs() > 0.001 {
-                    anim.animate_to(effective_target);
-                    // Width affects layout, so use RequiredJob::Layout
-                    request_job(id, JobRequest::Animation(RequiredJob::Layout));
-                    // Parent must reposition siblings as this child's width changes
-                    if let Some(parent_id) = tree.get_parent(id) {
-                        request_job(parent_id, JobRequest::Layout);
-                    }
-                }
-            }
-
-            if let Some(ref mut anim) = anims.height {
-                let effective_target = if let Some(exact) = height_length.exact {
-                    exact
-                } else {
-                    let min_h = height_length.min.unwrap_or(0.0);
-                    content_height.max(min_h)
-                };
-                if anim.is_initial() {
-                    anim.set_immediate(effective_target);
-                } else if (effective_target - *anim.target()).abs() > 0.001 {
-                    anim.animate_to(effective_target);
-                    // Height affects layout, so use RequiredJob::Layout
-                    request_job(id, JobRequest::Animation(RequiredJob::Layout));
-                    // Parent must reposition siblings as this child's height changes
-                    if let Some(parent_id) = tree.get_parent(id) {
-                        request_job(parent_id, JobRequest::Layout);
-                    }
-                }
-            }
-        }
-
-        // Initialize paint animations on first layout (set_immediate so they start
-        // from the correct signal value rather than a stale construction-time value)
-        // Compute targets first to avoid borrow conflicts with &mut anim + &self
-        let pd_init = self
-            .anims
-            .as_ref()
-            .and_then(|a| a.padding.as_ref())
-            .is_some_and(|a| a.is_initial());
-        let bw_init = self
-            .anims
-            .as_ref()
-            .and_then(|a| a.border_width.as_ref())
-            .is_some_and(|a| a.is_initial());
-        let bg_init = self
-            .anims
-            .as_ref()
-            .and_then(|a| a.background.as_ref())
-            .is_some_and(|a| a.is_initial());
-        let cr_init = self
-            .anims
-            .as_ref()
-            .and_then(|a| a.corner_radius.as_ref())
-            .is_some_and(|a| a.is_initial());
-        let bc_init = self
-            .anims
-            .as_ref()
-            .and_then(|a| a.border_color.as_ref())
-            .is_some_and(|a| a.is_initial());
-        let tf_init = self
-            .anims
-            .as_ref()
-            .and_then(|a| a.transform.as_ref())
-            .is_some_and(|a| a.is_initial());
-        if pd_init || bw_init || bg_init || cr_init || bc_init || tf_init {
-            // First layout of a container with signal-animated props: read
-            // every animated prop's signal under Animation tracking so the
-            // subscriptions exist from THIS moment. Widget creation and
-            // first layout run in one synchronous block (for popups, the
-            // measure-before-spawn), so no write can land before them —
-            // without this, subscriptions would only appear at the first
-            // PAINT, and a write in between (a menu's open-flip timer
-            // racing a heavy first paint) would notify nobody. Paint's
-            // drift pass re-tracks every frame afterwards, so dependencies
-            // taken through conditional closure branches stay current.
-            let (bg_target, cr_target, bc_target, tf_target) =
-                with_signal_tracking(id, JobType::Animation, || {
-                    if pd_init {
-                        let _ = self.padding.get_or(Padding::default());
-                    }
-                    if bw_init {
-                        let _ = self.effective_border_width_target(tree);
-                    }
-                    (
-                        bg_init.then(|| self.effective_background_target(tree)),
-                        cr_init.then(|| self.effective_corner_radius_target(tree)),
-                        bc_init.then(|| self.effective_border_color_target(tree)),
-                        tf_init.then(|| self.effective_transform_target(tree)),
-                    )
-                });
-            if let Some(ref mut anims) = self.anims {
-                if let (Some(anim), Some(target)) = (&mut anims.background, bg_target) {
-                    anim.set_immediate(target);
-                }
-                if let (Some(anim), Some(target)) = (&mut anims.corner_radius, cr_target) {
-                    anim.set_immediate(target);
-                }
-                if let (Some(anim), Some(target)) = (&mut anims.border_color, bc_target) {
-                    anim.set_immediate(target);
-                }
-                if let (Some(anim), Some(target)) = (&mut anims.transform, tf_target) {
-                    // Enter transition: animate in from the declared value
-                    // instead of snapping to the target
-                    if let Some(enter) = anim.take_enter_from() {
-                        anim.begin_from(enter, target);
-                        request_job(id, JobRequest::Animation(RequiredJob::Paint));
-                    } else {
-                        anim.set_immediate(target);
-                    }
-                }
-            }
-        }
+        self.update_size_targets(tree, id, &lengths, content_size);
+        self.seed_animations(tree, id);
 
         let size = self.resolve_size(&lengths, constraints, content_size);
 
@@ -1264,54 +1136,7 @@ impl Widget for Container {
             )
         });
 
-        // When animations exist, also track raw signal reads for Animation jobs.
-        // This ensures signal changes trigger advance_animations() to update targets.
-        // (The animated_* methods above may read from the animation cache instead of the signal,
-        // so we do a second pass reading targets for Animation subscriber registration.)
-        //
-        // The same pass compares each animation's stored target against the
-        // current effective value and requests one Animation job on drift,
-        // letting advance_animations adopt whatever the subscription may
-        // have missed. Together with the first-layout registration in
-        // layout() this upholds the AnimationState invariant: a cache of
-        // signal-derived state must either be subscribed from creation or
-        // reconciled pull-style at every use — AnimationState gets both
-        // (registration closes the creation window, this pass converges
-        // conditional closure branches and state-layer overrides).
-        if self.has_signal_animated_props() {
-            let target_drift = with_signal_tracking(id, JobType::Animation, || {
-                let anims = self.anims.as_ref().unwrap();
-                let mut drift = false;
-                if let Some(a) = &anims.padding {
-                    let t = self.padding.get_or(Padding::default());
-                    drift |= !a.is_initial() && *a.target() != t;
-                }
-                if let Some(a) = &anims.border_width {
-                    let t = self.effective_border_width_target(tree);
-                    drift |= !a.is_initial() && *a.target() != t;
-                }
-                if let Some(a) = &anims.background {
-                    let t = self.effective_background_target(tree);
-                    drift |= !a.is_initial() && *a.target() != t;
-                }
-                if let Some(a) = &anims.corner_radius {
-                    let t = self.effective_corner_radius_target(tree);
-                    drift |= !a.is_initial() && *a.target() != t;
-                }
-                if let Some(a) = &anims.border_color {
-                    let t = self.effective_border_color_target(tree);
-                    drift |= !a.is_initial() && *a.target() != t;
-                }
-                if let Some(a) = &anims.transform {
-                    let t = self.effective_transform_target(tree);
-                    drift |= !a.is_initial() && *a.target() != t;
-                }
-                drift
-            });
-            if target_drift {
-                request_job(id, JobRequest::Animation(RequiredJob::None));
-            }
-        }
+        self.resync_animation_targets(tree, id);
 
         // Per-corner radii override the uniform (animated) radius for
         // drawing. Clip, blur region and rounded hit testing stay uniform,


### PR DESCRIPTION
An `AnimationState` is a **cache of signal-derived state**, and a cache like that is correct only if it is

1. **subscribed from the moment it exists**, and
2. **reconciled against the live value at every use**.

Both halves were implemented — and both have shipped as bugs (#131, #133) — but they sat in different functions, 800 lines apart, each explaining the invariant in its own words: the seeding inside `layout()`, the drift pass inside `paint()`.

`anim_bridge.rs` states it once and holds all three passes:

- **`seed_animations`** — first layout: subscribe and start from the value the signal actually holds
- **`resync_animation_targets`** — every paint: converge whatever the subscription missed
- **`update_size_targets`** — width/height, which mirror no signal at all: their targets follow the measured content, so they are simply recomputed

The third one living in the same file is the point: it is the property that *looks* like the others and is not, and putting it beside them says so.

Two further consolidations:

- "the target while measuring a final size, the in-flight value otherwise" was written out at three call sites and is now `AnimationState::displayed()`
- the width and height target updates were two copies of one loop body

`Container::layout` 208 → 79 lines, `paint` 312 → 233, `mod.rs` 1729 → 1554.

The four pre-existing animation regression tests pass untouched — they are the ones that would notice if either half of the invariant were dropped in the move.

---

**PR 5 of 6**, based on #155.