### PR TITLE
test: render-tree snapshots over trees taken from the examples

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -327,6 +327,16 @@ See [docs/STYLING.md](docs/STYLING.md) for full styling reference.
 - **CRITICAL: Check that all CI checks pass before merging the PR**
 - Merge to main only through PRs after CI is green
 
+**Render-tree snapshots.** `tests/render_snapshots.rs` lays out and paints widget
+trees taken from `examples/` (no compositor, no GPU) and diffs the render tree
+against golden files in `tests/snapshots/`. A change in geometry or in what gets
+drawn shows up there without anyone having had to predict the assertion. When a
+change is intended, re-bless and **read the diff** — it is the review:
+
+```bash
+UPDATE_SNAPSHOTS=1 cargo test --test render_snapshots
+```
+
 **CRITICAL: Always run `cargo clippy` and `cargo fmt` before committing code changes.**
 - Fix all clippy errors (compilation will fail)
 - Address clippy warnings when reasonable

--- a/tests/render_snapshots.rs
+++ b/tests/render_snapshots.rs
@@ -1,0 +1,509 @@
+//! Render-tree snapshots over widget trees lifted from `examples/`.
+//!
+//! The examples are the library's realistic widget trees, but they cannot be
+//! imported: each is its own crate root, with the tree built inline in `main`.
+//! So the trees are reproduced here — each scenario names the example it comes
+//! from — and run through the real layout and paint passes, neither of which
+//! needs a compositor or a GPU. The resulting render tree is dumped as text and
+//! compared against a committed golden file.
+//!
+//! What this catches that the unit tests do not: a change in *geometry* or in
+//! *what gets drawn*, anywhere in a realistic composition. A widget that moves
+//! by a pixel, a clip that stops being emitted, a scrollbar that quietly
+//! disappears — all of it shows up as a diff, without anyone having to think of
+//! the specific assertion in advance.
+//!
+//! **No text.** Text metrics depend on the fonts installed on the machine, so a
+//! snapshot containing them would pass locally and fail in CI for reasons that
+//! have nothing to do with the change under review. Text is covered by the
+//! container-level tests instead; the scenarios here stay on the geometry, which
+//! is where the layout logic lives anyway.
+//!
+//! To re-bless after an intended change:
+//!
+//! ```sh
+//! UPDATE_SNAPSHOTS=1 cargo test --test render_snapshots
+//! ```
+//!
+//! Read the resulting diff before committing it — that diff *is* the review.
+
+use std::fmt::Write as _;
+
+use guido::layout::Constraints;
+use guido::prelude::*;
+use guido::renderer::{DrawCommand, PaintContext, RenderNode};
+use guido::tree::Tree;
+use guido::widgets::Widget;
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+/// Lay out `widget` in a `width` x `height` viewport, paint it, and dump the
+/// resulting render tree.
+fn render(widget: impl Widget + 'static, width: f32, height: f32) -> String {
+    let mut tree = Tree::new();
+    let root = tree.register(Box::new(widget));
+    tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
+    tree.with_widget_mut(root, |w, id, t| {
+        w.layout(t, id, Constraints::new(0.0, 0.0, width, height))
+    });
+
+    let mut node = RenderNode::new(root.as_u64());
+    tree.with_widget_mut(root, |w, id, t| {
+        let mut ctx = PaintContext::new(&mut node);
+        w.paint(t, id, &mut ctx);
+    });
+
+    let mut out = String::new();
+    dump_node(&node, 0, &mut out);
+    out
+}
+
+/// Two decimals is finer than a physical pixel at any sane scale, and coarse
+/// enough that an arithmetic reassociation does not rewrite the golden file.
+fn n(v: f32) -> String {
+    let r = (v * 100.0).round() / 100.0;
+    if r == 0.0 { "0".into() } else { format!("{r}") }
+}
+
+fn rect(r: &Rect) -> String {
+    format!("{},{} {}x{}", n(r.x), n(r.y), n(r.width), n(r.height))
+}
+
+fn color(c: &Color) -> String {
+    let (r, g, b, a) = c.to_rgba8();
+    format!("#{r:02x}{g:02x}{b:02x}{a:02x}")
+}
+
+fn dump_node(node: &RenderNode, depth: usize, out: &mut String) {
+    let pad = "  ".repeat(depth);
+    let t = node.local_transform;
+    let transform = if t.is_identity() {
+        String::new()
+    } else if t.is_translation_only() {
+        format!(" at {},{}", n(t.tx()), n(t.ty()))
+    } else {
+        // Full matrix: a rotation or a scale is exactly the kind of thing a
+        // refactor can silently reassociate.
+        format!(
+            " matrix[{} {} {} {} {} {}]",
+            n(t.a()),
+            n(t.b()),
+            n(t.c()),
+            n(t.d()),
+            n(t.tx()),
+            n(t.ty())
+        )
+    };
+    // The origin is resolved during flatten, not baked into local_transform,
+    // so two nodes rotating about different pivots carry identical matrices.
+    // Without this a regression in origin handling would not show. Only
+    // reported where it can matter: a translation is the same about any pivot.
+    let origin = if t.is_identity() || t.is_translation_only() {
+        String::new()
+    } else {
+        let o = node.transform_origin;
+        format!(" origin={:?}/{:?}", o.horizontal, o.vertical)
+    };
+    let clip = match &node.clip {
+        Some(c) => format!(" clip({} r={})", rect(&c.rect), n(c.corner_radius)),
+        None => String::new(),
+    };
+    let partial = if node.partial { " partial" } else { "" };
+
+    let _ = writeln!(
+        out,
+        "{pad}node {}{transform}{origin}{clip}{partial}",
+        rect(&node.bounds)
+    );
+
+    for cmd in &node.commands {
+        dump_command(cmd, depth + 1, "draw", out);
+    }
+    for child in &node.children {
+        dump_node(child, depth + 1, out);
+    }
+    for cmd in &node.overlay_commands {
+        dump_command(cmd, depth + 1, "overlay", out);
+    }
+}
+
+fn dump_command(cmd: &DrawCommand, depth: usize, kind: &str, out: &mut String) {
+    let pad = "  ".repeat(depth);
+    match cmd {
+        DrawCommand::RoundedRect {
+            rect: r,
+            color: c,
+            radius,
+            curvature,
+            border,
+            shadow,
+            gradient,
+        } => {
+            let mut line = format!(
+                "{pad}{kind} rect {} fill={} radius={}/{}/{}/{}",
+                rect(r),
+                color(c),
+                n(radius.top_left),
+                n(radius.top_right),
+                n(radius.bottom_right),
+                n(radius.bottom_left)
+            );
+            if *curvature != 1.0 {
+                let _ = write!(line, " curvature={}", n(*curvature));
+            }
+            if let Some(b) = border {
+                let _ = write!(line, " border={}@{}", color(&b.color), n(b.width));
+            }
+            if let Some(s) = shadow {
+                let _ = write!(
+                    line,
+                    " shadow={}+{},{} blur={}",
+                    color(&s.color),
+                    n(s.offset.0),
+                    n(s.offset.1),
+                    n(s.blur)
+                );
+            }
+            if let Some(g) = gradient {
+                let _ = write!(
+                    line,
+                    " gradient={}->{} {:?}",
+                    color(&g.start_color),
+                    color(&g.end_color),
+                    g.direction
+                );
+            }
+            let _ = writeln!(out, "{line}");
+        }
+        DrawCommand::Circle {
+            center,
+            radius,
+            color: c,
+        } => {
+            let _ = writeln!(
+                out,
+                "{pad}{kind} circle at {},{} r={} fill={}",
+                n(center.0),
+                n(center.1),
+                n(*radius),
+                color(c)
+            );
+        }
+        // Deliberately metric-free: see the module docs.
+        DrawCommand::Text { .. } => {
+            let _ = writeln!(out, "{pad}{kind} text <not snapshotted>");
+        }
+        DrawCommand::Image { rect: r, .. } => {
+            let _ = writeln!(out, "{pad}{kind} image {}", rect(r));
+        }
+    }
+}
+
+/// Compare against the golden file, or rewrite it under `UPDATE_SNAPSHOTS=1`.
+#[track_caller]
+fn assert_snapshot(name: &str, actual: String) {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/snapshots")
+        .join(format!("{name}.snap"));
+
+    if std::env::var_os("UPDATE_SNAPSHOTS").is_some() {
+        std::fs::write(&path, &actual).expect("write snapshot");
+        return;
+    }
+
+    let expected = std::fs::read_to_string(&path).unwrap_or_else(|_| {
+        panic!("missing snapshot {name}. Create it with UPDATE_SNAPSHOTS=1 cargo test")
+    });
+
+    if expected != actual {
+        panic!(
+            "render tree changed for `{name}`.\n\
+             If the change is intended, re-bless with:\n  \
+             UPDATE_SNAPSHOTS=1 cargo test --test render_snapshots\n\n\
+             --- expected ---\n{expected}\n--- actual ---\n{actual}"
+        );
+    }
+}
+
+/// A leaf of an exactly known size, so no scenario depends on font metrics.
+fn box_of(w: f32, h: f32) -> Container {
+    container().width(w).height(h)
+}
+
+fn swatch(w: f32, h: f32, c: Color) -> Container {
+    box_of(w, h).background(c)
+}
+
+// ---------------------------------------------------------------------------
+// Scenarios
+// ---------------------------------------------------------------------------
+
+/// After `examples/scroll_example.rs`: a vertical scroller whose content
+/// overflows (so it carries a scrollbar) beside one whose content fits (so it
+/// does not), plus a horizontal scroller.
+#[test]
+fn scrolling() {
+    let column = |n: usize| {
+        container()
+            .layout(Flex::column().spacing(8.0))
+            .padding(8.0)
+            .children((0..n).map(|i| {
+                swatch(120.0, 24.0, Color::rgb(0.25, 0.25, 0.35))
+                    .corner_radius(4.0)
+                    .translate(0.0, i as f32)
+            }))
+    };
+
+    let view = container()
+        .layout(Flex::row().spacing(16.0))
+        .padding(8.0)
+        .child(
+            box_of(200.0, 200.0)
+                .background(Color::rgb(0.15, 0.15, 0.2))
+                .corner_radius(8.0)
+                .scrollable(ScrollAxis::Vertical)
+                .child(column(20)),
+        )
+        .child(
+            box_of(200.0, 200.0)
+                .background(Color::rgb(0.15, 0.15, 0.2))
+                .scrollable(ScrollAxis::Vertical)
+                .child(column(2)),
+        )
+        .child(
+            box_of(200.0, 80.0)
+                .background(Color::rgb(0.15, 0.15, 0.2))
+                .scrollable(ScrollAxis::Horizontal)
+                .child(
+                    container()
+                        .layout(Flex::row().spacing(8.0))
+                        .padding(8.0)
+                        .children((0..10).map(|_| swatch(80.0, 40.0, Color::BLUE))),
+                ),
+        );
+
+    assert_snapshot("scrolling", render(view, 800.0, 300.0));
+}
+
+/// After `examples/flex_layout_test.rs`: the alignment matrix, plus `fill()`
+/// sharing what the fixed children leave.
+#[test]
+fn flex_alignment_matrix() {
+    let row = |main: MainAlignment, cross: CrossAlignment| {
+        box_of(300.0, 60.0)
+            .background(Color::rgb(0.12, 0.12, 0.16))
+            .layout(
+                Flex::row()
+                    .spacing(6.0)
+                    .main_alignment(main)
+                    .cross_alignment(cross),
+            )
+            .child(swatch(40.0, 20.0, Color::RED))
+            .child(swatch(40.0, 32.0, Color::GREEN))
+            .child(swatch(40.0, 44.0, Color::BLUE))
+    };
+
+    let view = container()
+        .layout(Flex::column().spacing(4.0))
+        .child(row(MainAlignment::Start, CrossAlignment::Start))
+        .child(row(MainAlignment::Center, CrossAlignment::Center))
+        .child(row(MainAlignment::End, CrossAlignment::End))
+        .child(row(MainAlignment::SpaceBetween, CrossAlignment::Stretch))
+        .child(row(MainAlignment::SpaceAround, CrossAlignment::Center))
+        .child(row(MainAlignment::SpaceEvenly, CrossAlignment::Center))
+        .child(
+            box_of(300.0, 40.0)
+                .layout(Flex::row().spacing(6.0))
+                .child(swatch(50.0, 20.0, Color::RED))
+                .child(
+                    container()
+                        .width(fill())
+                        .height(20.0)
+                        .background(Color::GRAY),
+                )
+                .child(swatch(50.0, 20.0, Color::BLUE)),
+        );
+
+    assert_snapshot("flex_alignment_matrix", render(view, 400.0, 500.0));
+}
+
+/// After `examples/transform_example.rs` and `transform_origin_test.rs`:
+/// rotation and scale about several origins, and a transform nested inside
+/// another so the composition shows up.
+#[test]
+fn transforms_and_origins() {
+    let card = |c: Color| swatch(80.0, 40.0, c).corner_radius(6.0);
+
+    let view = container()
+        .layout(Flex::column().spacing(12.0))
+        .padding(20.0)
+        .child(card(Color::RED).rotate(30.0))
+        .child(
+            card(Color::GREEN)
+                .rotate(30.0)
+                .transform_origin(TransformOrigin::TOP_LEFT),
+        )
+        .child(card(Color::BLUE).scale(1.5))
+        .child(card(Color::YELLOW).scale_xy(2.0, 0.5))
+        .child(card(Color::CYAN).translate(15.0, -5.0))
+        .child(
+            box_of(200.0, 80.0)
+                .background(Color::rgb(0.2, 0.2, 0.25))
+                .rotate(10.0)
+                .child(card(Color::MAGENTA).rotate(20.0).scale(0.8)),
+        );
+
+    assert_snapshot("transforms_and_origins", render(view, 400.0, 600.0));
+}
+
+/// After `examples/showcase.rs` and `elevation_example.rs`: the corner
+/// curvature family and the elevation ladder, both of which land entirely in
+/// the emitted draw commands.
+#[test]
+fn corners_borders_and_elevation() {
+    let base = |c: Color| swatch(70.0, 70.0, c).corner_radius(16.0);
+
+    let view = container()
+        .layout(Flex::column().spacing(10.0))
+        .padding(10.0)
+        .child(
+            container()
+                .layout(Flex::row().spacing(10.0))
+                .child(base(Color::rgb(0.3, 0.5, 0.9)))
+                .child(base(Color::rgb(0.3, 0.5, 0.9)).squircle())
+                .child(base(Color::rgb(0.3, 0.5, 0.9)).bevel())
+                .child(base(Color::rgb(0.3, 0.5, 0.9)).scoop())
+                .child(base(Color::rgb(0.3, 0.5, 0.9)).corner_curvature(1.5)),
+        )
+        .child(
+            container()
+                .layout(Flex::row().spacing(10.0))
+                .children((0..6).map(|level| {
+                    swatch(60.0, 60.0, Color::rgb(0.9, 0.9, 0.95))
+                        .corner_radius(8.0)
+                        .elevation(level as f32)
+                })),
+        )
+        .child(
+            container()
+                .layout(Flex::row().spacing(10.0))
+                .child(base(Color::TRANSPARENT).border(2.0, Color::WHITE))
+                .child(
+                    box_of(70.0, 70.0)
+                        .corner_radii(CornerRadii {
+                            top_left: 16.0,
+                            top_right: 0.0,
+                            bottom_right: 16.0,
+                            bottom_left: 0.0,
+                        })
+                        .background(Color::RED),
+                )
+                .child(
+                    box_of(70.0, 70.0).gradient(LinearGradient::vertical(Color::RED, Color::BLUE)),
+                ),
+        );
+
+    assert_snapshot("corners_borders_and_elevation", render(view, 500.0, 400.0));
+}
+
+/// After `examples/clip_test.rs`: hidden overflow clips its children, and a
+/// clip nested inside another intersects.
+#[test]
+fn overflow_and_clipping() {
+    let view = container()
+        .layout(Flex::row().spacing(12.0))
+        .padding(8.0)
+        .child(
+            box_of(100.0, 60.0)
+                .overflow(Overflow::Hidden)
+                .corner_radius(12.0)
+                .background(Color::rgb(0.2, 0.2, 0.3))
+                .child(swatch(300.0, 40.0, Color::RED)),
+        )
+        .child(
+            box_of(120.0, 80.0)
+                .overflow(Overflow::Hidden)
+                .background(Color::rgb(0.2, 0.2, 0.3))
+                .child(
+                    box_of(200.0, 40.0)
+                        .overflow(Overflow::Hidden)
+                        .corner_radius(8.0)
+                        .child(swatch(400.0, 30.0, Color::GREEN)),
+                ),
+        )
+        .child(
+            box_of(100.0, 60.0)
+                .background(Color::rgb(0.2, 0.2, 0.3))
+                .child(swatch(300.0, 40.0, Color::BLUE)),
+        );
+
+    assert_snapshot("overflow_and_clipping", render(view, 500.0, 200.0));
+}
+
+/// After `examples/children_example.rs`: a keyed list and a reactive child,
+/// which is what the reconciler produces once it has settled.
+#[test]
+fn dynamic_children() {
+    let items = create_signal(vec![(1u64, 30.0f32), (2, 50.0), (3, 20.0)]);
+    let show_footer = create_signal(true);
+
+    let view = container()
+        .layout(Flex::column().spacing(6.0))
+        .padding(8.0)
+        .children(keyed(
+            move || items.get(),
+            |(id, _)| *id,
+            |(_, height)| swatch(120.0, height, Color::rgb(0.3, 0.3, 0.4)).corner_radius(4.0),
+        ))
+        .child(move || {
+            show_footer
+                .get()
+                .then(|| swatch(120.0, 16.0, Color::rgb(0.5, 0.2, 0.2)))
+        });
+
+    assert_snapshot("dynamic_children", render(view, 300.0, 400.0));
+}
+
+/// After `examples/nested_transform_example.rs`, and closest to a real bar: a
+/// row of modules, one of them scrolling, inside a rounded background.
+#[test]
+fn bar_like_composition() {
+    let module = |w: f32, c: Color| {
+        container()
+            .padding([4.0, 8.0])
+            .background(c)
+            .corner_radius(10.0)
+            .hover_state(|s| s.lighter(0.1))
+            .child(swatch(w, 14.0, Color::WHITE.with_alpha(0.8)))
+    };
+
+    let view = container()
+        .width(fill())
+        .height(36.0)
+        .background(Color::rgb(0.1, 0.1, 0.14))
+        .padding([0.0, 8.0])
+        .layout(
+            Flex::row()
+                .spacing(8.0)
+                .cross_alignment(CrossAlignment::Center),
+        )
+        .child(module(40.0, Color::rgb(0.2, 0.2, 0.3)))
+        .child(module(70.0, Color::rgb(0.2, 0.3, 0.2)))
+        .child(container().width(fill()).height(1.0))
+        .child(
+            box_of(90.0, 24.0)
+                .scrollable(ScrollAxis::Horizontal)
+                .background(Color::rgb(0.15, 0.15, 0.2))
+                .corner_radius(6.0)
+                .child(
+                    container()
+                        .layout(Flex::row().spacing(4.0))
+                        .children((0..6).map(|_| swatch(30.0, 20.0, Color::CYAN))),
+                ),
+        )
+        .child(module(50.0, Color::rgb(0.3, 0.2, 0.2)).elevation(2.0));
+
+    assert_snapshot("bar_like_composition", render(view, 600.0, 36.0));
+}

--- a/tests/snapshots/bar_like_composition.snap
+++ b/tests/snapshots/bar_like_composition.snap
@@ -1,0 +1,34 @@
+node 0,0 600x36
+  draw rect 0,0 600x36 fill=#1a1a24ff radius=0/0/0/0
+  node 0,0 56x22 at 8,7
+    draw rect 0,0 56x22 fill=#33334dff radius=10/10/10/10
+    node 0,0 40x14 at 8,4
+      draw rect 0,0 40x14 fill=#ffffffcc radius=0/0/0/0
+  node 0,0 86x22 at 72,7
+    draw rect 0,0 86x22 fill=#334d33ff radius=10/10/10/10
+    node 0,0 70x14 at 8,4
+      draw rect 0,0 70x14 fill=#ffffffcc radius=0/0/0/0
+  node 0,0 254x1 at 166,17.5
+  node 0,0 90x24 at 428,6 clip(0,0 90x24 r=6)
+    draw rect 0,0 90x24 fill=#262633ff radius=6/6/6/6
+    node 0,0 200x14
+      node 0,0 30x14
+        draw rect 0,0 30x14 fill=#00ffffff radius=0/0/0/0
+      node 0,0 30x14 at 34,0
+        draw rect 0,0 30x14 fill=#00ffffff radius=0/0/0/0
+      node 0,0 30x14 at 68,0
+        draw rect 0,0 30x14 fill=#00ffffff radius=0/0/0/0
+      node 0,0 30x14 at 102,0
+        draw rect 0,0 30x14 fill=#00ffffff radius=0/0/0/0
+      node 0,0 30x14 at 136,0
+        draw rect 0,0 30x14 fill=#00ffffff radius=0/0/0/0
+      node 0,0 30x14 at 170,0
+        draw rect 0,0 30x14 fill=#00ffffff radius=0/0/0/0
+    node 0,0 86x6 at 2,16
+      draw rect 0,0 86x6 fill=#ffffff0d radius=100/100/100/100
+    node 0,0 38.7x6 at 2,16
+      draw rect 0,0 38.7x6 fill=#ffffff4d radius=100/100/100/100
+  node 0,0 66x22 at 526,7
+    draw rect 0,0 66x22 fill=#4d3333ff radius=10/10/10/10 shadow=#00000029+0,2 blur=4
+    node 0,0 50x14 at 8,4
+      draw rect 0,0 50x14 fill=#ffffffcc radius=0/0/0/0

--- a/tests/snapshots/corners_borders_and_elevation.snap
+++ b/tests/snapshots/corners_borders_and_elevation.snap
@@ -1,0 +1,32 @@
+node 0,0 430x240
+  node 0,0 410x70 at 10,10
+    node 0,0 70x70
+      draw rect 0,0 70x70 fill=#4d80e6ff radius=16/16/16/16
+    node 0,0 70x70 at 80,0
+      draw rect 0,0 70x70 fill=#4d80e6ff radius=16/16/16/16 curvature=2
+    node 0,0 70x70 at 160,0
+      draw rect 0,0 70x70 fill=#4d80e6ff radius=16/16/16/16 curvature=0
+    node 0,0 70x70 at 240,0
+      draw rect 0,0 70x70 fill=#4d80e6ff radius=16/16/16/16 curvature=-1
+    node 0,0 70x70 at 320,0
+      draw rect 0,0 70x70 fill=#4d80e6ff radius=16/16/16/16 curvature=1.5
+  node 0,0 410x60 at 10,90
+    node 0,0 60x60
+      draw rect 0,0 60x60 fill=#e6e6f2ff radius=8/8/8/8
+    node 0,0 60x60 at 70,0
+      draw rect 0,0 60x60 fill=#e6e6f2ff radius=8/8/8/8 shadow=#0000001f+0,1 blur=3
+    node 0,0 60x60 at 140,0
+      draw rect 0,0 60x60 fill=#e6e6f2ff radius=8/8/8/8 shadow=#00000029+0,2 blur=4
+    node 0,0 60x60 at 210,0
+      draw rect 0,0 60x60 fill=#e6e6f2ff radius=8/8/8/8 shadow=#00000030+0,3 blur=6
+    node 0,0 60x60 at 280,0
+      draw rect 0,0 60x60 fill=#e6e6f2ff radius=8/8/8/8 shadow=#00000033+0,4 blur=8
+    node 0,0 60x60 at 350,0
+      draw rect 0,0 60x60 fill=#e6e6f2ff radius=8/8/8/8 shadow=#00000038+0,6 blur=10
+  node 0,0 410x70 at 10,160
+    node 0,0 70x70
+      draw rect 0,0 70x70 fill=#00000000 radius=16/16/16/16 border=#ffffffff@2
+    node 0,0 70x70 at 80,0
+      draw rect 0,0 70x70 fill=#ff0000ff radius=16/0/16/0
+    node 0,0 70x70 at 160,0
+      draw rect 0,0 70x70 fill=#ff0000ff radius=0/0/0/0 gradient=#ff0000ff->#0000ffff Vertical

--- a/tests/snapshots/dynamic_children.snap
+++ b/tests/snapshots/dynamic_children.snap
@@ -1,0 +1,9 @@
+node 0,0 136x150
+  node 0,0 120x30 at 8,8
+    draw rect 0,0 120x30 fill=#4d4d66ff radius=4/4/4/4
+  node 0,0 120x50 at 8,44
+    draw rect 0,0 120x50 fill=#4d4d66ff radius=4/4/4/4
+  node 0,0 120x20 at 8,100
+    draw rect 0,0 120x20 fill=#4d4d66ff radius=4/4/4/4
+  node 0,0 120x16 at 8,126
+    draw rect 0,0 120x16 fill=#803333ff radius=0/0/0/0

--- a/tests/snapshots/flex_alignment_matrix.snap
+++ b/tests/snapshots/flex_alignment_matrix.snap
@@ -1,0 +1,56 @@
+node 0,0 300x424
+  node 0,0 300x60
+    draw rect 0,0 300x60 fill=#1f1f29ff radius=0/0/0/0
+    node 0,0 40x20
+      draw rect 0,0 40x20 fill=#ff0000ff radius=0/0/0/0
+    node 0,0 40x32 at 46,0
+      draw rect 0,0 40x32 fill=#00ff00ff radius=0/0/0/0
+    node 0,0 40x44 at 92,0
+      draw rect 0,0 40x44 fill=#0000ffff radius=0/0/0/0
+  node 0,0 300x60 at 0,64
+    draw rect 0,0 300x60 fill=#1f1f29ff radius=0/0/0/0
+    node 0,0 40x20 at 84,20
+      draw rect 0,0 40x20 fill=#ff0000ff radius=0/0/0/0
+    node 0,0 40x32 at 130,14
+      draw rect 0,0 40x32 fill=#00ff00ff radius=0/0/0/0
+    node 0,0 40x44 at 176,8
+      draw rect 0,0 40x44 fill=#0000ffff radius=0/0/0/0
+  node 0,0 300x60 at 0,128
+    draw rect 0,0 300x60 fill=#1f1f29ff radius=0/0/0/0
+    node 0,0 40x20 at 168,40
+      draw rect 0,0 40x20 fill=#ff0000ff radius=0/0/0/0
+    node 0,0 40x32 at 214,28
+      draw rect 0,0 40x32 fill=#00ff00ff radius=0/0/0/0
+    node 0,0 40x44 at 260,16
+      draw rect 0,0 40x44 fill=#0000ffff radius=0/0/0/0
+  node 0,0 300x60 at 0,192
+    draw rect 0,0 300x60 fill=#1f1f29ff radius=0/0/0/0
+    node 0,0 40x20
+      draw rect 0,0 40x20 fill=#ff0000ff radius=0/0/0/0
+    node 0,0 40x32 at 130,0
+      draw rect 0,0 40x32 fill=#00ff00ff radius=0/0/0/0
+    node 0,0 40x44 at 260,0
+      draw rect 0,0 40x44 fill=#0000ffff radius=0/0/0/0
+  node 0,0 300x60 at 0,256
+    draw rect 0,0 300x60 fill=#1f1f29ff radius=0/0/0/0
+    node 0,0 40x20 at 28,20
+      draw rect 0,0 40x20 fill=#ff0000ff radius=0/0/0/0
+    node 0,0 40x32 at 130,14
+      draw rect 0,0 40x32 fill=#00ff00ff radius=0/0/0/0
+    node 0,0 40x44 at 232,8
+      draw rect 0,0 40x44 fill=#0000ffff radius=0/0/0/0
+  node 0,0 300x60 at 0,320
+    draw rect 0,0 300x60 fill=#1f1f29ff radius=0/0/0/0
+    node 0,0 40x20 at 42,20
+      draw rect 0,0 40x20 fill=#ff0000ff radius=0/0/0/0
+    node 0,0 40x32 at 130,14
+      draw rect 0,0 40x32 fill=#00ff00ff radius=0/0/0/0
+    node 0,0 40x44 at 218,8
+      draw rect 0,0 40x44 fill=#0000ffff radius=0/0/0/0
+  node 0,0 300x40 at 0,384
+    node 0,0 50x20
+      draw rect 0,0 50x20 fill=#ff0000ff radius=0/0/0/0
+    node 0,0 188x20 at 56,0
+      draw rect 0,0 188x20 fill=#808080ff radius=0/0/0/0
+    node 0,0 50x20 at 250,0
+      draw rect 0,0 50x20 fill=#0000ffff radius=0/0/0/0

--- a/tests/snapshots/overflow_and_clipping.snap
+++ b/tests/snapshots/overflow_and_clipping.snap
@@ -1,0 +1,14 @@
+node 0,0 360x96
+  node 0,0 100x60 at 8,8 clip(0,0 100x60 r=12)
+    draw rect 0,0 100x60 fill=#33334dff radius=12/12/12/12
+    node 0,0 100x40
+      draw rect 0,0 100x40 fill=#ff0000ff radius=0/0/0/0
+  node 0,0 120x80 at 120,8 clip(0,0 120x80 r=0)
+    draw rect 0,0 120x80 fill=#33334dff radius=0/0/0/0
+    node 0,0 120x40 clip(0,0 120x40 r=8)
+      node 0,0 200x30
+        draw rect 0,0 200x30 fill=#00ff00ff radius=0/0/0/0
+  node 0,0 100x60 at 252,8
+    draw rect 0,0 100x60 fill=#33334dff radius=0/0/0/0
+    node 0,0 100x40
+      draw rect 0,0 100x40 fill=#0000ffff radius=0/0/0/0

--- a/tests/snapshots/scrolling.snap
+++ b/tests/snapshots/scrolling.snap
@@ -1,0 +1,82 @@
+node 0,0 648x216
+  node 0,0 200x200 at 8,8 clip(0,0 200x200 r=8)
+    draw rect 0,0 200x200 fill=#262633ff radius=8/8/8/8
+    node 0,0 136x648
+      node 0,0 120x24 at 8,8
+        draw rect 0,0 120x24 fill=#404059ff radius=4/4/4/4
+      node 0,0 120x24 at 8,41
+        draw rect 0,0 120x24 fill=#404059ff radius=4/4/4/4
+      node 0,0 120x24 at 8,74
+        draw rect 0,0 120x24 fill=#404059ff radius=4/4/4/4
+      node 0,0 120x24 at 8,107
+        draw rect 0,0 120x24 fill=#404059ff radius=4/4/4/4
+      node 0,0 120x24 at 8,140
+        draw rect 0,0 120x24 fill=#404059ff radius=4/4/4/4
+      node 0,0 120x24 at 8,173
+        draw rect 0,0 120x24 fill=#404059ff radius=4/4/4/4
+      node 0,0 120x24 at 8,206
+        draw rect 0,0 120x24 fill=#404059ff radius=4/4/4/4
+      node 0,0 120x24 at 8,239
+        draw rect 0,0 120x24 fill=#404059ff radius=4/4/4/4
+      node 0,0 120x24 at 8,272
+        draw rect 0,0 120x24 fill=#404059ff radius=4/4/4/4
+      node 0,0 120x24 at 8,305
+        draw rect 0,0 120x24 fill=#404059ff radius=4/4/4/4
+      node 0,0 120x24 at 8,338
+        draw rect 0,0 120x24 fill=#404059ff radius=4/4/4/4
+      node 0,0 120x24 at 8,371
+        draw rect 0,0 120x24 fill=#404059ff radius=4/4/4/4
+      node 0,0 120x24 at 8,404
+        draw rect 0,0 120x24 fill=#404059ff radius=4/4/4/4
+      node 0,0 120x24 at 8,437
+        draw rect 0,0 120x24 fill=#404059ff radius=4/4/4/4
+      node 0,0 120x24 at 8,470
+        draw rect 0,0 120x24 fill=#404059ff radius=4/4/4/4
+      node 0,0 120x24 at 8,503
+        draw rect 0,0 120x24 fill=#404059ff radius=4/4/4/4
+      node 0,0 120x24 at 8,536
+        draw rect 0,0 120x24 fill=#404059ff radius=4/4/4/4
+      node 0,0 120x24 at 8,569
+        draw rect 0,0 120x24 fill=#404059ff radius=4/4/4/4
+      node 0,0 120x24 at 8,602
+        draw rect 0,0 120x24 fill=#404059ff radius=4/4/4/4
+      node 0,0 120x24 at 8,635
+        draw rect 0,0 120x24 fill=#404059ff radius=4/4/4/4
+    node 0,0 6x196 at 192,2
+      draw rect 0,0 6x196 fill=#ffffff0d radius=100/100/100/100
+    node 0,0 6x60.49 at 192,2
+      draw rect 0,0 6x60.49 fill=#ffffff4d radius=100/100/100/100
+  node 0,0 200x200 at 224,8 clip(0,0 200x200 r=0)
+    draw rect 0,0 200x200 fill=#262633ff radius=0/0/0/0
+    node 0,0 136x72
+      node 0,0 120x24 at 8,8
+        draw rect 0,0 120x24 fill=#404059ff radius=4/4/4/4
+      node 0,0 120x24 at 8,41
+        draw rect 0,0 120x24 fill=#404059ff radius=4/4/4/4
+  node 0,0 200x80 at 440,8 clip(0,0 200x80 r=0)
+    draw rect 0,0 200x80 fill=#262633ff radius=0/0/0/0
+    node 0,0 888x56
+      node 0,0 80x40 at 8,8
+        draw rect 0,0 80x40 fill=#0000ffff radius=0/0/0/0
+      node 0,0 80x40 at 96,8
+        draw rect 0,0 80x40 fill=#0000ffff radius=0/0/0/0
+      node 0,0 80x40 at 184,8
+        draw rect 0,0 80x40 fill=#0000ffff radius=0/0/0/0
+      node 0,0 80x40 at 272,8
+        draw rect 0,0 80x40 fill=#0000ffff radius=0/0/0/0
+      node 0,0 80x40 at 360,8
+        draw rect 0,0 80x40 fill=#0000ffff radius=0/0/0/0
+      node 0,0 80x40 at 448,8
+        draw rect 0,0 80x40 fill=#0000ffff radius=0/0/0/0
+      node 0,0 80x40 at 536,8
+        draw rect 0,0 80x40 fill=#0000ffff radius=0/0/0/0
+      node 0,0 80x40 at 624,8
+        draw rect 0,0 80x40 fill=#0000ffff radius=0/0/0/0
+      node 0,0 80x40 at 712,8
+        draw rect 0,0 80x40 fill=#0000ffff radius=0/0/0/0
+      node 0,0 80x40 at 800,8
+        draw rect 0,0 80x40 fill=#0000ffff radius=0/0/0/0
+    node 0,0 196x6 at 2,72
+      draw rect 0,0 196x6 fill=#ffffff0d radius=100/100/100/100
+    node 0,0 44.14x6 at 2,72
+      draw rect 0,0 44.14x6 fill=#ffffff4d radius=100/100/100/100

--- a/tests/snapshots/transforms_and_origins.snap
+++ b/tests/snapshots/transforms_and_origins.snap
@@ -1,0 +1,15 @@
+node 0,0 240x380
+  node 0,0 80x40 matrix[0.87 -0.5 0.5 0.87 20 20] origin=Center/Center
+    draw rect 0,0 80x40 fill=#ff0000ff radius=6/6/6/6
+  node 0,0 80x40 matrix[0.87 -0.5 0.5 0.87 20 72] origin=Left/Top
+    draw rect 0,0 80x40 fill=#00ff00ff radius=6/6/6/6
+  node 0,0 80x40 matrix[1.5 0 0 1.5 20 124] origin=Center/Center
+    draw rect 0,0 80x40 fill=#0000ffff radius=6/6/6/6
+  node 0,0 80x40 matrix[2 0 0 0.5 20 176] origin=Center/Center
+    draw rect 0,0 80x40 fill=#ffff00ff radius=6/6/6/6
+  node 0,0 80x40 at 35,223
+    draw rect 0,0 80x40 fill=#00ffffff radius=6/6/6/6
+  node 0,0 200x80 matrix[0.98 -0.17 0.17 0.98 20 280] origin=Center/Center
+    draw rect 0,0 200x80 fill=#333340ff radius=0/0/0/0
+    node 0,0 80x40 matrix[0.75 -0.27 0.27 0.75 0 0] origin=Center/Center
+      draw rect 0,0 80x40 fill=#ff00ffff radius=6/6/6/6


### PR DESCRIPTION
The examples are the library's realistic widget trees, and until now their only use was someone looking at them. They cannot be imported by a test — each is its own crate root with the tree built inline in `main` — so the trees are reproduced here, **each scenario naming the example it came from**, and run through the real layout and paint passes. Neither needs a compositor or a GPU, so this is an ordinary `cargo test`.

Seven scenarios: `scrolling`, `flex_alignment_matrix`, `transforms_and_origins`, `corners_borders_and_elevation`, `overflow_and_clipping`, `dynamic_children`, `bar_like_composition`.

The render tree is dumped as text and diffed against a committed golden file:

```
node 0,0 200x200 at 8,8 clip(0,0 200x200 r=8)
  draw rect 0,0 200x200 fill=#262633ff radius=8/8/8/8
  node 0,0 136x648
    ...
  node 0,0 6x196 at 192,2
    draw rect 0,0 6x196 fill=#ffffff0d radius=100/100/100/100
  node 0,0 6x60.49 at 192,2
    draw rect 0,0 6x60.49 fill=#ffffff4d radius=100/100/100/100
```

Those last two are a scrollbar's track and handle — and 196 × (200/648) ≈ 60.5, so the proportion is checkable by eye in the golden file.

The point is catching regressions **nobody thought to assert**, which is the class unit tests miss because you only write the assertion for the thing you already had in mind.

### Checked against the real thing

Reintroducing the scrollbar viewport bug turns `scrolling` and `bar_like_composition` red and leaves the five non-scrolling scenarios green.

### Two deliberate exclusions

- **No text metrics.** They depend on the fonts installed on the machine, so a snapshot containing them would pass locally and fail in CI for reasons unrelated to the change. Text stays covered by the container-level tests.
- **Transform origins only where a transform is more than a translation** — a translation is the same about any pivot. They are reported at all because the origin is resolved during flatten, so two nodes rotating about different pivots otherwise carry identical matrices.

Re-blessing after an intended change (`CLAUDE.md` updated to say so):

```sh
UPDATE_SNAPSHOTS=1 cargo test --test render_snapshots
```

Read the diff before committing it — that diff *is* the review.

---

**PR 6 of 6**, based on #156.

Known limitation: the scenarios are hand-written and can drift from the examples they cite. If this suite proves useful, the natural next step is inverting the dependency — extract `pub fn view()` from the ~8 examples the scenarios already cover and have the test import them, so the example becomes the source of truth and cannot drift.