### PR TITLE
fix: at_most is ignored while a size animation is attached

### DIFF
--- a/examples/at_most_animation.rs
+++ b/examples/at_most_animation.rs
@@ -1,0 +1,123 @@
+//! Does attaching a size animation change how a capped container lays out?
+//!
+//! Each row below is the SAME container twice: on the left as written, on the
+//! right with `.animate_width(...)` added and nothing else. The animation never
+//! runs — there is no signal to move it — so the two ought to be identical.
+//!
+//! Run it on a build with the fix and the pairs match. Run it on one without
+//! and the right-hand box of each pair is wrong: `at_most` bounded the
+//! container but not what it told its children, so they were laid out against
+//! the surface's full width and then the box was cut back to the cap.
+//!
+//! The dashed-looking outline is the cap. Anything drawn past it is content
+//! that was measured against a width that never existed.
+//!
+//!     cargo run --example at_most_animation
+
+use guido::prelude::*;
+
+const CAP: f32 = 160.0;
+const SENTENCE: &str = "una frase lunga che deve andare a capo dentro il box";
+
+fn label(s: &str) -> Text {
+    text(s).color(Color::rgb(0.75, 0.78, 0.85)).font_size(12.0)
+}
+
+fn heading(s: &str) -> Text {
+    text(s).color(Color::WHITE).font_size(15.0)
+}
+
+/// The cap, drawn as an outline so overflowing content is visible against it.
+fn capped(animated: bool, body: impl Widget + 'static) -> Container {
+    let c = container()
+        .width(at_most(CAP))
+        .border(1.0, Color::rgb(0.45, 0.5, 0.65))
+        .corner_radius(4.0)
+        .padding(6.0)
+        // Visible, not Hidden: clipping would conceal exactly what we are here
+        // to look at.
+        .overflow(Overflow::Visible)
+        .child(body);
+    if animated {
+        c.animate_width(Transition::new(200, TimingFunction::EaseOut))
+    } else {
+        c
+    }
+}
+
+/// One case, shown twice, with its measured size printed underneath.
+fn pair(title: &str, build: impl Fn(bool) -> Container + 'static) -> Container {
+    let plain_ref = create_widget_ref();
+    let anim_ref = create_widget_ref();
+
+    let side = |caption: &str, w: Container, r: WidgetRef| {
+        container()
+            .width(240.0)
+            .layout(Flex::column().spacing(6.0))
+            .child(label(caption))
+            .child(w.widget_ref(r))
+            .child(
+                text(move || {
+                    let b = r.rect().get();
+                    format!("{:.1} x {:.1}", b.width, b.height)
+                })
+                .color(Color::rgb(0.55, 0.85, 0.6))
+                .font_size(12.0),
+            )
+    };
+
+    container()
+        .layout(Flex::column().spacing(10.0))
+        .child(heading(title))
+        .child(
+            container()
+                .layout(Flex::row().spacing(24.0))
+                .child(side("come scritto", build(false), plain_ref))
+                .child(side("+ .animate_width()", build(true), anim_ref)),
+        )
+}
+
+fn main() {
+    App::new().run(|app| {
+        app.add_surface(
+            SurfaceConfig::new()
+                .width(content())
+                .height(content())
+                .anchor(Anchor::TOP | Anchor::LEFT)
+                .margin(40, 0, 0, 40)
+                .layer(Layer::Overlay)
+                .keyboard_interactivity(KeyboardInteractivity::OnDemand)
+                .namespace("guido-at-most")
+                .background_color(Color::rgb(0.09, 0.09, 0.13)),
+            move || {
+                container()
+                    .padding(20.0)
+                    .layout(Flex::column().spacing(28.0))
+                    .child(
+                        text("at_most + animazione: le coppie devono essere identiche")
+                            .color(Color::WHITE)
+                            .font_size(17.0),
+                    )
+                    .child(pair("testo che va a capo", |animated| {
+                        capped(animated, text(SENTENCE).color(Color::WHITE).font_size(13.0))
+                    }))
+                    .child(pair("figlio con fill()", |animated| {
+                        capped(
+                            animated,
+                            container()
+                                .width(fill())
+                                .height(22.0)
+                                .background(Color::rgb(0.85, 0.35, 0.35))
+                                .corner_radius(3.0),
+                        )
+                    }))
+                    .child(label("Esc per chiudere").color(Color::rgb(0.5, 0.53, 0.6)))
+                    .on_key_down(|key, _| {
+                        if key == Key::Escape {
+                            quit_app();
+                        }
+                    })
+            },
+        );
+    });
+}

--- a/src/widgets/container/anim_bridge.rs
+++ b/src/widgets/container/anim_bridge.rs
@@ -54,11 +54,13 @@ impl Container {
             (
                 lengths.width.exact,
                 lengths.width.min,
+                lengths.width.max,
                 content.width + lengths.padding.horizontal(),
             ),
             (
                 lengths.height.exact,
                 lengths.height.min,
+                lengths.height.max,
                 content.height + lengths.padding.vertical(),
             ),
         ];
@@ -67,12 +69,22 @@ impl Container {
         };
         let mut retargeted = false;
 
-        for (anim, (exact, min, content_extent)) in [anims.width.as_mut(), anims.height.as_mut()]
-            .into_iter()
-            .zip(targets)
+        for (anim, (exact, min, max, content_extent)) in
+            [anims.width.as_mut(), anims.height.as_mut()]
+                .into_iter()
+                .zip(targets)
         {
             let Some(anim) = anim else { continue };
-            let target = exact.unwrap_or_else(|| content_extent.max(min.unwrap_or(0.0)));
+            // The target is where the size is heading, so it obeys the same
+            // bounds the size does. An unclamped one animates toward a value
+            // `resolve_size` will cap anyway: frames spent going nowhere.
+            let target = exact.unwrap_or_else(|| {
+                let grown = content_extent.max(min.unwrap_or(0.0));
+                match max {
+                    Some(max) => grown.min(max),
+                    None => grown,
+                }
+            });
 
             if anim.is_initial() {
                 // Mark initialized at the first layout whatever the value, so

--- a/src/widgets/container/box_model.rs
+++ b/src/widgets/container/box_model.rs
@@ -118,22 +118,20 @@ impl Container {
     /// back in would make the content define the target that defines the
     /// content.
     ///
-    /// Note the asymmetry in the animated branch: it does **not** clamp to
-    /// `length.max`, while the static branch does. Pinned by
-    /// `characterization::an_animated_width_does_not_clamp_children_to_at_most`
-    /// because it is what the code has always done; it reads like an
-    /// oversight, and correcting it belongs in its own change.
+    /// Everything outside the running-animation case falls through to the same
+    /// answer, cap included: what children are offered must not depend on
+    /// whether an animation happens to be attached.
     fn animated_extent(
         &self,
         anim: Option<&AnimationState<f32>>,
         length: &Length,
         available: f32,
     ) -> f32 {
-        if let Some(anim) = anim {
-            if !anim.is_initial() && length.exact.is_some() {
-                return anim.displayed();
-            }
-            return length.exact.unwrap_or(available);
+        if let Some(anim) = anim
+            && !anim.is_initial()
+            && length.exact.is_some()
+        {
+            return anim.displayed();
         }
         match length.exact {
             Some(exact) => exact,

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -227,42 +227,62 @@ fn overflowing_content_grows_a_visible_container() {
     assert_eq!(hidden.fit(100.0, 500.0).width, 100.0);
 }
 
-/// Pins an asymmetry rather than endorsing it: with a width animation
-/// attached, the extent children are laid out inside ignores `at_most`, while
-/// without one it is clamped. It reads like an oversight — the container's own
-/// final size honours the cap either way, so only the children's constraints
-/// differ — but it is what the code has always done, and changing it is a
-/// behaviour change that belongs in its own commit with its own test.
+/// Attaching an animation must not change what children are offered. It used
+/// to: the animated path skipped the `at_most` clamp, so children were laid out
+/// against the parent's full width and then the container was cut back to the
+/// cap — content overflowing a box that had told it there was room.
 #[test]
-fn an_animated_width_does_not_clamp_children_to_at_most() {
+fn at_most_bounds_children_with_or_without_a_size_animation() {
     use crate::animation::{TimingFunction, Transition};
 
-    let mut clamped = H::new(
-        container()
-            .width(at_most(60.0))
-            .child(container().width(fill()).height(5.0)),
-    );
-    clamped.fit(500.0, 500.0);
-    let child = clamped.children()[0];
-    assert_eq!(clamped.tree.get_bounds(child).unwrap().width, 60.0);
+    for animated in [false, true] {
+        let inner = container().width(fill()).height(5.0);
+        let outer = container().width(at_most(60.0));
+        let outer = if animated {
+            outer.animate_width(Transition::new(200, TimingFunction::EaseOut))
+        } else {
+            outer
+        };
+
+        let mut h = H::new(outer.child(inner));
+        h.fit(500.0, 500.0);
+        let child = h.children()[0];
+        assert_eq!(
+            h.tree.get_bounds(child).unwrap().width,
+            60.0,
+            "child must be bounded by the cap (animated: {animated})"
+        );
+        assert_eq!(h.tree.cached_size(h.root).unwrap().width, 60.0);
+    }
+}
+
+/// The worst of the same bug: a wrapping child measured against the wrong width
+/// gets the wrong *height* too, and no clamp downstream can recover it. Text
+/// laid out as one 366px line inside a 100px box came out 16.8 tall instead of
+/// 84 — the container was the right width and the wrong shape.
+///
+/// Font-independent by construction: it asserts the two agree, never a metric.
+#[test]
+fn a_size_animation_does_not_change_how_content_wraps() {
+    use crate::animation::{TimingFunction, Transition};
+    use crate::widgets::text::text;
+
+    let sentence = "una frase abbastanza lunga da dover andare a capo piu volte";
+
+    let mut plain = H::new(container().width(at_most(100.0)).child(text(sentence)));
+    let plain_size = plain.fit(500.0, 500.0);
 
     let mut animated = H::new(
         container()
-            .width(at_most(60.0))
+            .width(at_most(100.0))
             .animate_width(Transition::new(200, TimingFunction::EaseOut))
-            .child(container().width(fill()).height(5.0)),
+            .child(text(sentence)),
     );
-    animated.fit(500.0, 500.0);
-    let child = animated.children()[0];
+    let animated_size = animated.fit(500.0, 500.0);
+
     assert_eq!(
-        animated.tree.get_bounds(child).unwrap().width,
-        500.0,
-        "the animated branch offers the full width, cap ignored"
-    );
-    assert_eq!(
-        animated.tree.cached_size(animated.root).unwrap().width,
-        60.0,
-        "the container itself still honours the cap"
+        plain_size, animated_size,
+        "an attached animation must not change how the content wraps"
     );
 }
 


### PR DESCRIPTION
`.width(at_most(N))` bounds the container but not what the container tells its children: with `.animate_width()` attached, the animated path skipped the cap and offered them the parent's full width. The container was then cut back to `N`, so the content had been laid out against a width that never existed.

For a `fill()` child that is an overflow. For anything that **wraps** it is worse, because the wrong width produces the wrong *height*, and no clamp downstream can recover it:

```
at_most(100) + text            ->   93.5 x 84     wraps over 5 lines
at_most(100) + text + animate  ->  100   x 16.8   one 366px line, clipped
```

Same bug in the animation target (`update_size_targets`): it applied `min` but not `max`, so a container whose content exceeded the cap animated toward a value `resolve_size` clamps anyway — frames spent going nowhere.

Both now go through the same bounds the size itself obeys. Nothing about what children are offered should depend on whether an animation happens to be attached.

### Tests

Two, both seen failing before the fix:

- `at_most_bounds_children_with_or_without_a_size_animation` — the same assertion with and without the animation
- `a_size_animation_does_not_change_how_content_wraps` — asserts the two layouts **agree**, not a measurement, so it says nothing about which fonts are installed

This replaces `an_animated_width_does_not_clamp_children_to_at_most`, added in #155 to pin the behaviour while noting it looked like an oversight and that correcting it belonged in its own change. This is that change.