### PR TITLE
fix: stop reporting the animation advance as a non-reactive read

### DIFF
--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -654,6 +654,57 @@ fn scroll_reaches_the_callback_inside_the_bounds() {
 // Reactivity: which job type each property invalidates
 // ---------------------------------------------------------------------------
 
+/// Advancing animations reads each animated property's target. That read is a
+/// snapshot — the subscription is established by `seed_animations` at the first
+/// layout and refreshed by `resync_animation_targets` at every paint — so the
+/// debug diagnostic must stay quiet about it.
+///
+/// It did not, and reported every animated container's border width and corner
+/// radius as a value that "will not update", which is the opposite of true. A
+/// warning that cries wolf on correct code is worse than no warning: it teaches
+/// people to scroll past the ones that are right.
+///
+/// Both halves are asserted together on purpose — silence is only correct if
+/// the property really is subscribed.
+#[cfg(debug_assertions)]
+#[test]
+fn advancing_animations_does_not_report_a_missing_scope() {
+    use crate::animation::{TimingFunction, Transition};
+    use crate::reactive::diagnostics::report_count;
+
+    let t = || Transition::new(200, TimingFunction::EaseOut);
+    let wide = create_signal(false);
+    let mut h = H::new(
+        container()
+            .width(50.0)
+            .height(50.0)
+            .background(Color::RED)
+            .border(move || if wide.get() { 6.0 } else { 2.0 }, Color::BLUE)
+            .corner_radius(move || if wide.get() { 20.0 } else { 4.0 })
+            .animate_border_width(t())
+            .animate_corner_radius(t()),
+    );
+    h.fit(200.0, 200.0);
+    h.paint();
+
+    let before = report_count();
+    let root = h.root;
+    h.tree.with_widget_mut(root, |w, id, tree| {
+        w.advance_animations(tree, id);
+    });
+    assert_eq!(
+        report_count() - before,
+        0,
+        "advancing animations must not be reported as a non-reactive read"
+    );
+
+    let queued = h.jobs_from(|| wide.set(true));
+    assert!(
+        queued.contains(&JobType::Animation),
+        "and the properties must genuinely be subscribed, got {queued:?}"
+    );
+}
+
 /// Layout-affecting properties queue a Layout job when their signal changes.
 #[test]
 fn padding_invalidates_layout() {

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -827,12 +827,32 @@ impl Widget for Container {
             // Compute targets before borrowing anims mutably (&self methods conflict
             // with &mut self.anims). Skipped entirely for the majority of non-animated
             // containers since self.anims is None.
-            let padding_target = self.padding.get_or(Padding::default());
-            let border_width_target = self.effective_border_width_target(tree);
-            let bg_target = self.effective_background_target(tree);
-            let corner_radius_target = self.effective_corner_radius_target(tree);
-            let border_color_target = self.effective_border_color_target(tree);
-            let transform_target = self.effective_transform_target(tree);
+            //
+            // A snapshot on purpose: this pass consumes the target, it does not
+            // subscribe to it. The subscriptions for these very properties are
+            // established by `seed_animations` at the first layout and refreshed
+            // by `resync_animation_targets` at every paint, both under an
+            // Animation tracking scope — see anim_bridge.rs. Without saying so,
+            // the debug diagnostic reports each of these reads as a value that
+            // "will not update", which is the opposite of true and trains the
+            // reader to ignore a warning that is usually right.
+            let (
+                padding_target,
+                border_width_target,
+                bg_target,
+                corner_radius_target,
+                border_color_target,
+                transform_target,
+            ) = crate::reactive::diagnostics::snapshot_zone(|| {
+                (
+                    self.padding.get_or(Padding::default()),
+                    self.effective_border_width_target(tree),
+                    self.effective_background_target(tree),
+                    self.effective_corner_radius_target(tree),
+                    self.effective_border_color_target(tree),
+                    self.effective_transform_target(tree),
+                )
+            });
             let anims = self.anims.as_mut().unwrap();
             // Layout-affecting animations: width, height, padding
             advance_anim!(anims, width, id, any_animating, layout);


### PR DESCRIPTION
Running any example with an animated border or corner radius prints this on startup, twice:

```
style.rs:114:38: signal read with no reactive scope — this value is a
snapshot and will not update. Pass a closure instead...
```

It is the opposite of true.

`advance_animations` reads each animated property's target in order to **consume** it, not to subscribe to it. The subscriptions for those very properties are established by `seed_animations` at the first layout and refreshed by `resync_animation_targets` at every paint, both under an Animation tracking scope. Writing the signal does queue an Animation job — verified in the test below.

### Why this is worth a PR rather than a shrug

That diagnostic exists to catch the single most common way to write a UI that silently stops updating, and it only works if people believe it. Firing on the library's own correct paths is how a warning stops being read.

The fix marks the block as the snapshot it is, which is what `snapshot_zone` is for and what guido already does for event dispatch, service tasks and animation completions.

### Not a refactor regression

The reads are unchanged since before #158 — byte for byte, verified against `acf6339`. The container split only moved them from `mod.rs` to `style.rs`, which is why the line numbers in the message changed. Reproduced headlessly on both commits.

### Test

`advancing_animations_does_not_report_a_missing_scope` asserts **both halves together**, because silence is only correct if the property really is reactive:

- advancing animations reports zero diagnostics
- writing the signal still queues an `Animation` job

Seen failing before the fix.