### PR TITLE
Backdrop blur, and the draw ordering it needed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -396,7 +396,11 @@ This is a work-in-progress GUI library. Current implemented features:
 - Dynamic surface property modification (layer, keyboard interactivity, anchor, size, margins)
 - Multi-output support: reactive `outputs()` enumeration, per-output surface pinning, `surface_output()` tracking
 - Input regions: per-surface clickable rectangles / click-through surfaces (`input_region`, `click_through`, `set_input_region`)
-- Compositor background blur (`ext-background-effect-v1`) via `container().background_blur()`, shaped by bounds + corner radius
+- Backdrop blur via `container().backdrop_blur(radius)`: filters both the
+  surface's own drawn content (offscreen target, downsample + separable
+  gaussian, masked to the container's rounded shape) and the compositor's
+  backdrop (`ext-background-effect-v1`, shaped by bounds + corner radius).
+  Restrict with `BackdropSources`; check availability with `compositor_effects()`
 - Session lock (`ext-session-lock-v1`): `lock_session(factory)` / `unlock_session()` / reactive `lock_state()`, one lock surface per output with hotplug handling
 - Touch input (`wl_touch`): first finger drives the pointer pipeline — tap = click, works with hover/pressed state layers
 - Clipboard: async prefetch (paste never blocks the UI thread) + primary selection (select-to-copy, middle-click paste)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,9 @@ cargo test
 - Supports circles, gradients, and clipping
 - Text rendering via glyphon library
 - HiDPI-aware with automatic scaling
-- Layered rendering: shapes → text → overlay shapes (for effects like ripples)
+- Layered rendering: shapes → images → text → overlay, per draw group; a group is
+  split whenever the tree paints a lower layer over a higher one, so batching
+  never reorders drawing
 
 **`platform/`** - Wayland layer shell integration
 - Uses smithay-client-toolkit for Wayland protocol handling
@@ -182,7 +184,7 @@ animating surface renders once per callback, an idle surface renders nothing.
 8. `widget.paint(tree, ctx)` - Build render tree (clean children reuse Rc-shared cached `RenderNode`s — reuse is a refcount bump, not a clone)
 9. `flatten_root_into()` - Flatten render tree to draw commands (incremental: clean subtrees reuse cached commands)
 10. Re-arm the frame callback and report per-surface damage via `wl_surface.damage_buffer()` — both BEFORE presenting so they ride the commit performed inside `present()`
-11. GPU rendering with instanced SDF shapes, HiDPI scaling, layer ordering (shapes → images → text → overlay); on a lost/outdated swapchain the dirty state is kept and a retry frame is requested
+11. GPU rendering with instanced SDF shapes, HiDPI scaling, and per-group layer ordering (shapes → images → text → overlay, one group per draw-order regression); on a lost/outdated swapchain the dirty state is kept and a retry frame is requested
 12. `cache_paint_results()` - Rc-share paint output per widget, clear `needs_paint` flags (partial paints poison their ancestors and are never cached)
 
 ### Event System

--- a/book/src/advanced/wayland.md
+++ b/book/src/advanced/wayland.md
@@ -497,34 +497,79 @@ create_effect(move || {
 Note: keyboard focus is unaffected — use `keyboard_interactivity` for
 that. Rectangles are rounded outward to whole pixels.
 
-## Background Blur
+## Backdrop Blur
 
-Containers can ask the compositor to blur whatever is behind the
-surface (`ext-background-effect-v1`), shaped by their bounds and corner
-radius. Pair it with a translucent background so the blurred content
-shows through:
+`backdrop_blur` blurs whatever is behind a container. There are two
+things behind it, on opposite sides of the Wayland surface, and both
+are filtered:
+
+- what **this surface** already drew — a wallpaper, a photo, the panel
+  under a card;
+- what the **compositor** composites below the surface, through
+  `ext-background-effect-v1`, wherever the surface is translucent.
 
 ```rust
 container()
     .background(Color::rgba(0.12, 0.12, 0.18, 0.55))
     .corner_radius(16.0)
-    .background_blur()
+    .backdrop_blur(32.0)
     .child(text("Frosted glass"))
 ```
 
-The blur region follows the container automatically: layout moves,
-resizes, and (animated) corner radius changes are picked up each frame.
-Rounded corners are tessellated into small rectangles because
-`wl_region` has no notion of curves.
+Filtering both is not a compromise between mechanisms. Blur is a linear
+operator, so over a region of uniform alpha `a`:
 
-On compositors without the protocol or its blur capability this
-renders a plain translucent container — no error, no fallback blur.
-Surfaces that never use `background_blur()` are left untouched, so
-compositor-side blur rules (e.g. blur by namespace) keep working; once
-a surface has used blur, an empty region ("blur nothing") is reported
-instead of withdrawing, to keep the region authoritative.
+```text
+blur(a·ours + (1−a)·theirs) = a·blur(ours) + (1−a)·blur(theirs)
+```
 
-See `examples/blur_example.rs`.
+Blurring each layer separately and compositing gives exactly the same
+result — which is why neither is chosen over the other. A translucent
+panel is neither "ours" nor "theirs" at any pixel, so a per-box choice
+could only be right for some of them.
+
+Restrict it when only one side should soften:
+
+```rust
+// Desktop behind the panel softens; the panel's own islands stay crisp.
+container().backdrop_blur(
+    BackdropBlur::new(24.0).sources(BackdropSources::COMPOSITOR),
+)
+```
+
+### What each side costs
+
+The **compositor** side is a region handed over once per change: the
+region follows the container automatically as layout moves, resizes and
+(animated) corner radii change. Rounded corners are tessellated into
+small rectangles because `wl_region` has no notion of curves, and the
+protocol carries no radius — the compositor picks its own, so `radius`
+does not apply there. Check availability with `compositor_effects()`.
+
+The **surface** side is guido's own: the frame is drawn into an
+offscreen target, each region is downsampled, blurred with a separable
+gaussian and composited back masked to the container's rounded shape.
+Frames with no backdrop blur skip all of it and draw straight to the
+swapchain.
+
+Two skips keep that honest, and both are unobservable — they drop work
+that could not have changed a pixel, so they may switch on and off
+between frames without anything showing:
+
+- a region with nothing drawn beneath it is not filtered at all;
+- surfaces that never asked for a compositor region are left untouched,
+  so compositor-side rules (e.g. blur by namespace) keep working.
+
+### The seam
+
+Where alpha *varies* within the blur radius — at the edges of opaque
+content inside the box — the two blurs do not bleed into each other:
+the desktop does not smear into the surface's own content or the other
+way round. That cannot be fixed from guido. `set_blur_region` is
+fire-and-forget: it takes a region and returns nothing, so the
+compositor's pixels are never ours to filter across.
+
+See `examples/blur_example.rs` and `examples/draw_order_example.rs`.
 
 ## Popups (Menus, Dropdowns)
 

--- a/book/src/concepts/container.md
+++ b/book/src/concepts/container.md
@@ -65,20 +65,21 @@ container()
 
 See [Building UI](../building-ui/README.md) for complete styling reference.
 
-### Background Blur
+### Backdrop Blur
 
-On Wayland compositors that support `ext-background-effect-v1`, a
-container can blur whatever is behind the surface, shaped by its bounds
-and corner radius:
+Blur whatever is behind the container — both what this surface already
+drew and, where the surface is translucent, what the compositor has
+below it. Pair it with a translucent background so the result shows
+through:
 
 ```rust
 container()
     .background(Color::rgba(0.12, 0.12, 0.18, 0.55)) // translucent
     .corner_radius(16.0)
-    .background_blur()
+    .backdrop_blur(32.0)
 ```
 
-See [Wayland Layer Shell — Background Blur](../advanced/wayland.md#background-blur).
+See [Wayland Layer Shell — Backdrop Blur](../advanced/wayland.md#backdrop-blur).
 
 ## Layout
 

--- a/docs/RENDERER.md
+++ b/docs/RENDERER.md
@@ -213,6 +213,24 @@ glyphon draws everything a `TextRenderer` prepared in one call, so a group with
 directly-rendered text gets a renderer of its own from a pool that grows on
 demand. `examples/draw_order_example.rs` exercises the regressions.
 
+### Backdrop effects
+
+`RenderLayer::Backdrop` sits below `Shapes` so a backdrop command always opens
+a group: everything it reads must already have been drawn, which means it must
+land after the groups holding that content.
+
+A backdrop effect samples the render target, which a pass cannot do to its own
+attachment. When a frame contains one, it is drawn into an offscreen colour
+target instead of the swapchain; at each backdrop group the pass ends, the
+effect runs, and the pass resumes with `LoadOp::Load`. The target is blitted to
+the swapchain once at the end and released after enough idle frames.
+
+Per region: downsample into a quarter-size working texture (rendering into a
+smaller target with a linear sampler is already a box filter), two separable
+gaussian passes ping-ponging between two working textures, then a composite
+back over the scene masked by the container's rounded-rect SDF. See
+`src/renderer/backdrop_pass.rs`.
+
 ### FlattenedCommand
 
 The output of tree flattening:

--- a/docs/RENDERER.md
+++ b/docs/RENDERER.md
@@ -217,6 +217,13 @@ and `examples/showcase.rs` alone went to 16 groups, every one of them carrying
 its own glyphon renderer. Siblings do not overlap, so those splits bought
 nothing. With the test, `status_bar` is one group and `showcase` is four.
 
+Each layer of a group tracks its commands' rects individually, not just their
+union: labels scattered across a panel union into a box spanning the gaps
+between them, and the next sibling's background lands in a gap and splits for
+nothing. Past `MAX_TRACKED_RECTS` the union decides alone, which can only
+over-split. With the exact test, `status_bar` and `showcase` are one group each
+— the same draw calls as before groups existed.
+
 Bounds are conservative: shapes grow by their shadow and border, text by half a
 font size for glyph overshoot, and anything under a rotation or scale counts as
 covering everything. Over-splitting costs a draw call; under-splitting would

--- a/docs/RENDERER.md
+++ b/docs/RENDERER.md
@@ -209,6 +209,19 @@ lower layer over a higher one produces exactly one group — the same single set
 of draw calls as before. The split is minimal by construction, so no merge pass
 is needed afterwards.
 
+A layer going backwards is only split on when the incoming command's world
+bounds actually intersect something already drawn above it in that group.
+Without that test the rule fires between every pair of sibling widgets — each
+paints a background then a label, so the next sibling's background regresses —
+and `examples/showcase.rs` alone went to 16 groups, every one of them carrying
+its own glyphon renderer. Siblings do not overlap, so those splits bought
+nothing. With the test, `status_bar` is one group and `showcase` is four.
+
+Bounds are conservative: shapes grow by their shadow and border, text by half a
+font size for glyph overshoot, and anything under a rotation or scale counts as
+covering everything. Over-splitting costs a draw call; under-splitting would
+draw in the wrong order.
+
 glyphon draws everything a `TextRenderer` prepared in one call, so a group with
 directly-rendered text gets a renderer of its own from a pool that grows on
 demand. `examples/draw_order_example.rs` exercises the regressions.

--- a/docs/RENDERER.md
+++ b/docs/RENDERER.md
@@ -173,7 +173,7 @@ The transform origin is resolved from the node's bounds and used to center the t
 
 ### RenderLayer Ordering
 
-Commands are sorted by layer for correct render order:
+Commands are bucketed by kind so that commands of a kind share a draw call:
 
 ```rust
 pub enum RenderLayer {
@@ -183,6 +183,35 @@ pub enum RenderLayer {
     Overlay = 3,  // Overlay effects (ripples, highlights)
 }
 ```
+
+### Draw groups
+
+Bucketing on its own reorders drawing: with one set of buckets for the whole
+frame, *every* shape is drawn before *every* image, so a container background
+painted over an image ends up underneath it however the tree is arranged.
+
+The flattener therefore emits a sequence of **draw groups**. Each group has its
+own four buckets, and a new group is opened whenever a command's layer would go
+backwards:
+
+```rust
+pub struct CommandLayer {
+    pub shapes: Range<usize>,
+    pub images: Range<usize>,
+    pub text: Range<usize>,
+    pub overlay: Range<usize>,
+}
+```
+
+The renderer walks the groups in order and draws each one bucket by bucket.
+Batching survives, ordering survives with it, and a tree that never paints a
+lower layer over a higher one produces exactly one group — the same single set
+of draw calls as before. The split is minimal by construction, so no merge pass
+is needed afterwards.
+
+glyphon draws everything a `TextRenderer` prepared in one call, so a group with
+directly-rendered text gets a renderer of its own from a pool that grows on
+demand. `examples/draw_order_example.rs` exercises the regressions.
 
 ### FlattenedCommand
 

--- a/examples/blur_example.rs
+++ b/examples/blur_example.rs
@@ -32,9 +32,15 @@ fn main() {
                             .cross_alignment(CrossAlignment::Center),
                     )
                     .child(
-                        // Blurred card: translucent background + blur behind
+                        // Blurred card: translucent background + blur behind.
+                        // Restricted to the compositor's backdrop, since this
+                        // example is about the desktop showing through a
+                        // translucent surface, not about blurring the surface's
+                        // own content.
                         container()
-                            .background_blur()
+                            .backdrop_blur(
+                                BackdropBlur::new(0.0).sources(BackdropSources::COMPOSITOR),
+                            )
                             .background(Color::rgba(0.12, 0.12, 0.18, 0.55))
                             .corner_radius(radius)
                             .padding(24.0)

--- a/examples/draw_order_example.rs
+++ b/examples/draw_order_example.rs
@@ -77,6 +77,47 @@ fn main() {
                     ),
             ))
             .child(panel(
+                "backdrop blur",
+                container()
+                    .width(220.0)
+                    .height(140.0)
+                    .corner_radius(8.0)
+                    .overflow(Overflow::Hidden)
+                    .layout(ZStack::new())
+                    .child(photo())
+                    .child(
+                        container()
+                            .width(fill())
+                            .height(fill())
+                            .layout(
+                                Flex::column()
+                                    .main_alignment(MainAlignment::Center)
+                                    .cross_alignment(CrossAlignment::Center),
+                            )
+                            .child(
+                                container()
+                                    .width(150.0)
+                                    .height(70.0)
+                                    .corner_radius(16.0)
+                                    .squircle()
+                                    // Blurs the photo beneath it, then paints
+                                    // its own translucent tint over the result.
+                                    .backdrop_blur(18.0)
+                                    .background(Color::rgba(0.1, 0.1, 0.15, 0.45))
+                                    .layout(
+                                        Flex::column()
+                                            .main_alignment(MainAlignment::Center)
+                                            .cross_alignment(CrossAlignment::Center),
+                                    )
+                                    .child(
+                                        text("frosted")
+                                            .font_size(18.0)
+                                            .color(Color::rgb(0.95, 0.95, 1.0)),
+                                    ),
+                            ),
+                    ),
+            ))
+            .child(panel(
                 "image over text",
                 container()
                     .width(220.0)
@@ -110,7 +151,7 @@ fn main() {
 
         app.add_surface(
             SurfaceConfig::new()
-                .width(800)
+                .width(1040)
                 .height(230)
                 .anchor(Anchor::TOP | Anchor::LEFT)
                 .layer(Layer::Top)

--- a/examples/draw_order_example.rs
+++ b/examples/draw_order_example.rs
@@ -1,0 +1,122 @@
+//! Draw order across primitive kinds.
+//!
+//! Run with: cargo run --example draw_order_example
+//!
+//! Commands are batched by kind — all shapes together, then all images, then
+//! all text — because that is what lets them share a draw call. Batching alone
+//! would reorder them: a container background painted *over* an image would be
+//! drawn first and vanish underneath it. The renderer therefore opens a new
+//! draw group whenever a command's kind would go backwards.
+//!
+//! Every panel below paints something over an image. If the ordering ever
+//! regresses, the overlays disappear rather than degrade — the failure is
+//! obvious on sight.
+
+use guido::prelude::*;
+
+fn photo() -> Image {
+    image(ImageSource::Path("examples/assets/photo.webp".into()))
+        .width(220.0)
+        .height(140.0)
+        .content_fit(ContentFit::Cover)
+}
+
+fn panel(label: &'static str, content: Container) -> Container {
+    container()
+        .layout(Flex::column().spacing(8.0))
+        .child(content)
+        .child(
+            text(label)
+                .font_size(12.0)
+                .color(Color::rgb(0.7, 0.7, 0.75)),
+        )
+}
+
+fn main() {
+    env_logger::init();
+
+    App::new().run(|app| {
+        let view = container()
+            .padding(24.0)
+            .layout(Flex::row().spacing(24.0))
+            .child(panel(
+                "shape over image",
+                container()
+                    .width(220.0)
+                    .height(140.0)
+                    .corner_radius(8.0)
+                    .overflow(Overflow::Hidden)
+                    .layout(ZStack::new())
+                    .child(photo())
+                    // Translucent tint: batched with the frame's other shapes
+                    // it would be painted before the photo and never seen.
+                    .child(
+                        container()
+                            .width(fill())
+                            .height(fill())
+                            .background(Color::rgba(0.1, 0.05, 0.4, 0.55)),
+                    ),
+            ))
+            .child(panel(
+                "shape over image over shape",
+                container()
+                    .width(220.0)
+                    .height(140.0)
+                    .corner_radius(8.0)
+                    .overflow(Overflow::Hidden)
+                    // Two regressions in one subtree, so two extra groups.
+                    .background(Color::rgb(0.8, 0.2, 0.2))
+                    .layout(ZStack::new())
+                    .child(photo())
+                    .child(
+                        container()
+                            .width(80.0)
+                            .height(80.0)
+                            .corner_radius(40.0)
+                            .background(Color::rgba(1.0, 1.0, 1.0, 0.85)),
+                    ),
+            ))
+            .child(panel(
+                "image over text",
+                container()
+                    .width(220.0)
+                    .height(140.0)
+                    .corner_radius(8.0)
+                    .overflow(Overflow::Hidden)
+                    .background(Color::rgb(0.15, 0.15, 0.2))
+                    .layout(ZStack::new())
+                    .child(
+                        text("BEHIND")
+                            .font_size(40.0)
+                            .color(Color::rgb(0.9, 0.3, 0.3))
+                            .nowrap(),
+                    )
+                    // Text sits above images in the batch order, so this photo
+                    // needs a group of its own to land on top of the label.
+                    // Narrower than the panel and pushed right, so the label
+                    // is covered where they overlap and legible where they do
+                    // not. A photo that filled the panel would look identical
+                    // whether the order held or not. The row wrapper is what
+                    // keeps the photo at its own width — a stack child sized
+                    // directly would be stretched to the panel's tight bounds.
+                    .child(
+                        container()
+                            .width(fill())
+                            .height(fill())
+                            .layout(Flex::row().main_alignment(MainAlignment::End))
+                            .child(photo().width(120.0)),
+                    ),
+            ));
+
+        app.add_surface(
+            SurfaceConfig::new()
+                .width(800)
+                .height(230)
+                .anchor(Anchor::TOP | Anchor::LEFT)
+                .layer(Layer::Top)
+                .namespace("draw-order-example")
+                .background_color(Color::rgb(0.1, 0.1, 0.15)),
+            || view,
+        );
+    });
+}

--- a/src/backdrop.rs
+++ b/src/backdrop.rs
@@ -1,0 +1,89 @@
+//! Backdrop effects: filtering what is already behind a container.
+//!
+//! There are two things behind a container, and they live on opposite sides
+//! of the Wayland surface:
+//!
+//! - what *this surface* has already drawn — a wallpaper, a photo, the panel
+//!   underneath a card;
+//! - what the *compositor* composites below the surface — the desktop showing
+//!   through wherever the surface is translucent.
+//!
+//! [`backdrop_blur`](crate::widgets::Container::backdrop_blur) blurs both, and
+//! that is not a compromise between two mechanisms: blur is a linear
+//! operator, so where the surface has a uniform alpha `a` over a region,
+//!
+//! ```text
+//! blur(a·ours + (1−a)·theirs) = a·blur(ours) + (1−a)·blur(theirs)
+//! ```
+//!
+//! and blurring each layer separately, then compositing, is *exactly* the
+//! same result. Which is why the two are never chosen between — a translucent
+//! panel is neither "ours" nor "theirs" at any pixel, so a per-box choice
+//! could only be wrong for half of them.
+//!
+//! The one place the decomposition is approximate is where alpha *varies*
+//! within the blur radius, at the edges of opaque content inside the box:
+//! neither blur bleeds into the other's layer. That cannot be fixed from
+//! here, or from any design — `ext-background-effect-v1` is fire-and-forget
+//! (`set_blur_region` takes a region and nothing comes back), so the
+//! compositor's pixels are never ours to filter across.
+
+use bitflags::bitflags;
+
+bitflags! {
+    /// Which backdrop a blur reaches.
+    ///
+    /// Both by default. Restricting is an aesthetic choice, not a way to pick
+    /// a mechanism: `COMPOSITOR` alone leaves the surface's own content crisp
+    /// under a translucent panel while the desktop behind it softens.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct BackdropSources: u8 {
+        /// What this surface has already drawn.
+        const SURFACE = 1;
+        /// What the compositor composites behind this surface, via
+        /// `ext-background-effect-v1`. The protocol carries no radius — the
+        /// compositor picks its own — so `radius` does not apply here.
+        const COMPOSITOR = 2;
+    }
+}
+
+impl Default for BackdropSources {
+    fn default() -> Self {
+        Self::all()
+    }
+}
+
+/// A backdrop blur request.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct BackdropBlur {
+    /// Blur radius in logical pixels, for the surface's own content.
+    pub radius: f32,
+    pub sources: BackdropSources,
+}
+
+impl BackdropBlur {
+    pub fn new(radius: f32) -> Self {
+        Self {
+            radius,
+            sources: BackdropSources::default(),
+        }
+    }
+
+    /// Restrict which backdrops this blur reaches.
+    pub fn sources(mut self, sources: BackdropSources) -> Self {
+        self.sources = sources;
+        self
+    }
+}
+
+impl From<f32> for BackdropBlur {
+    fn from(radius: f32) -> Self {
+        Self::new(radius)
+    }
+}
+
+impl From<i32> for BackdropBlur {
+    fn from(radius: i32) -> Self {
+        Self::new(radius as f32)
+    }
+}

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -1,0 +1,54 @@
+//! What the compositor can do for us, exposed reactively.
+//!
+//! Effects like blur are negotiated at runtime: the compositor advertises
+//! them, may withdraw them, and may not implement the protocol at all. A
+//! widget that wants to adapt — falling back to a plain translucent panel
+//! where a blurred one is not on offer — needs to read that as a signal
+//! rather than ask once at startup.
+
+use std::cell::RefCell;
+
+use crate::reactive::{RwSignal, Signal, create_signal};
+
+/// Compositor-side effects currently on offer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct CompositorEffects {
+    /// The compositor can blur what it composites behind a surface
+    /// (`ext-background-effect-v1`).
+    ///
+    /// False when the protocol is missing, when the compositor advertises no
+    /// blur capability, or before it has answered.
+    pub blur: bool,
+}
+
+thread_local! {
+    /// Lazily created so it works both before and after platform init;
+    /// wiped by `reset_compositor_effects()`.
+    static EFFECTS: RefCell<Option<RwSignal<CompositorEffects>>> = const { RefCell::new(None) };
+}
+
+fn effects_signal() -> RwSignal<CompositorEffects> {
+    EFFECTS.with(|cell| {
+        *cell
+            .borrow_mut()
+            .get_or_insert_with(|| create_signal(CompositorEffects::default()))
+    })
+}
+
+/// Reactive view of the compositor's effect capabilities.
+///
+/// Reading this inside a tracked closure subscribes to capability changes —
+/// a compositor may gain or lose blur while the app is running.
+pub fn compositor_effects() -> Signal<CompositorEffects> {
+    effects_signal().read_only()
+}
+
+/// Record the compositor's blur capability. Called by the platform layer.
+pub(crate) fn set_blur_capability(blur: bool) {
+    effects_signal().update(|effects| effects.blur = blur);
+}
+
+/// Reset capabilities. Called during `App::drop()`.
+pub(crate) fn reset_compositor_effects() {
+    EFFECTS.with(|cell| *cell.borrow_mut() = None);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod animation;
 mod blur;
+pub mod compositor;
 pub mod image_metadata;
 mod ingress;
 mod jobs;
@@ -145,6 +146,7 @@ pub fn quit_app() {
 
 pub mod prelude {
     pub use crate::animation::{SpringConfig, TimingFunction, Transition, TransitionConfig};
+    pub use crate::compositor::{CompositorEffects, compositor_effects};
     pub use crate::layout::{
         Axis, Constraints, CrossAlignment, Flex, IntoF32, Length, MainAlignment, Size, ZStack,
         at_least, at_most, fill, fraction,
@@ -1216,6 +1218,7 @@ impl Drop for App {
         surface::reset_popups();
         widget_ref::reset_widget_refs();
         outputs::reset_outputs();
+        compositor::reset_compositor_effects();
         blur::reset_blur();
         session_lock::reset_session_lock();
         FONTS_CONSUMED.with(|f| f.set(false));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -722,11 +722,13 @@ fn render_surface(
             });
         });
 
-        // Flatten tree into reused buffer
-        let layer_boundaries;
+        // Flatten tree into reused buffers
         time_phase!(render_stats::Phase::Flatten, {
-            layer_boundaries =
-                flatten_root_into(&surface.root_node, &mut surface.flattened_commands);
+            flatten_root_into(
+                &surface.root_node,
+                &mut surface.flattened_commands,
+                &mut surface.command_layers,
+            );
         });
 
         // Re-arm the frame callback BEFORE presenting so the request rides
@@ -767,7 +769,7 @@ fn render_surface(
             presented = renderer.render(
                 wgpu_surface,
                 &surface.flattened_commands,
-                layer_boundaries,
+                &surface.command_layers,
                 surface.config.background_color,
             );
         });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod animation;
+pub mod backdrop;
 mod blur;
 pub mod compositor;
 pub mod image_metadata;
@@ -146,6 +147,7 @@ pub fn quit_app() {
 
 pub mod prelude {
     pub use crate::animation::{SpringConfig, TimingFunction, Transition, TransitionConfig};
+    pub use crate::backdrop::{BackdropBlur, BackdropSources};
     pub use crate::compositor::{CompositorEffects, compositor_effects};
     pub use crate::layout::{
         Axis, Constraints, CrossAlignment, Flex, IntoF32, Length, MainAlignment, Size, ZStack,

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -2396,6 +2396,7 @@ impl Dispatch<ExtBackgroundEffectManagerV1, ()> for WaylandState {
                 if blur { "available" } else { "lost" }
             );
             state.bg_effect_supports_blur = blur;
+            crate::compositor::set_blur_capability(blur);
 
             // The compositor drops its regions when the capability goes away:
             // forget ours and wake the loop to push them again if it's back.

--- a/src/renderer/backdrop_pass.rs
+++ b/src/renderer/backdrop_pass.rs
@@ -1,0 +1,513 @@
+//! Backdrop blur: filtering the render target in place.
+//!
+//! The effect reads pixels that have already been drawn, which a render pass
+//! cannot do to its own attachment. So the frame is drawn into an offscreen
+//! colour target, each blur ends the pass, filters its region, and the pass
+//! resumes with `LoadOp::Load`; the target is blitted to the swapchain once at
+//! the end. Frames with no backdrop blur skip all of it and draw straight to
+//! the swapchain, so the machinery costs nothing when unused.
+//!
+//! Per region: downsample into a working texture (rendering into a smaller
+//! target with a linear sampler is already a box filter), two separable
+//! gaussian passes, then composite back masked by the container's rounded
+//! shape. Working at a quarter resolution is what keeps a wide radius cheap —
+//! the same reason compositors downsample before blurring.
+
+use wgpu::util::DeviceExt;
+
+use crate::widgets::Rect;
+
+use super::commands::CornerRadii;
+
+/// How much the working texture is shrunk before blurring.
+///
+/// The downsample is a filter in its own right, so the gaussian afterwards
+/// only smooths what the shrink left behind — at a sixteenth of the fragments.
+const WORKING_SCALE: u32 = 4;
+
+/// Frames without any backdrop effect before the offscreen target is freed.
+const IDLE_FRAMES_BEFORE_RELEASE: u32 = 120;
+
+/// Cap on gaussian taps per axis. Beyond this the shrink is doing the work
+/// anyway, and an unbounded loop would let one huge radius stall a frame.
+const MAX_TAPS: f32 = 24.0;
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
+struct Params {
+    src_rect: [f32; 4],
+    direction: [f32; 2],
+    sigma: f32,
+    taps: f32,
+    dst_size: [f32; 2],
+    curvature: f32,
+    _pad: f32,
+    radii: [f32; 4],
+}
+
+/// A blur to apply, resolved to physical pixels.
+#[derive(Debug, Clone, Copy)]
+pub struct BackdropRegion {
+    /// Region on the target, in physical pixels.
+    pub rect: Rect,
+    /// Blur radius in physical pixels.
+    pub radius: f32,
+    pub radii: CornerRadii,
+    pub curvature: f32,
+}
+
+impl BackdropRegion {
+    /// Clamp to the target so a card running off-screen cannot ask for a
+    /// viewport wgpu will reject.
+    fn clamped(&self, width: u32, height: u32) -> Option<(u32, u32, u32, u32)> {
+        let x = self.rect.x.floor().max(0.0) as u32;
+        let y = self.rect.y.floor().max(0.0) as u32;
+        let right = (self.rect.x + self.rect.width).ceil().max(0.0) as u32;
+        let bottom = (self.rect.y + self.rect.height).ceil().max(0.0) as u32;
+        let right = right.min(width);
+        let bottom = bottom.min(height);
+        if x >= right || y >= bottom {
+            return None;
+        }
+        Some((x, y, right - x, bottom - y))
+    }
+}
+
+/// Offscreen target plus the working textures the blur ping-pongs between.
+struct Targets {
+    width: u32,
+    height: u32,
+    /// Size of the working textures, `WORKING_SCALE` smaller than the scene.
+    work_width: u32,
+    work_height: u32,
+    // The textures are held only to keep their views alive; everything is
+    // addressed through the views.
+    #[allow(dead_code)]
+    scene: wgpu::Texture,
+    /// Where the frame is drawn when any backdrop blur is present.
+    scene_view: wgpu::TextureView,
+    #[allow(dead_code)]
+    working: [wgpu::Texture; 2],
+    working_views: [wgpu::TextureView; 2],
+}
+
+pub struct BackdropRenderer {
+    format: wgpu::TextureFormat,
+    sampler: wgpu::Sampler,
+    bind_group_layout: wgpu::BindGroupLayout,
+    downsample: wgpu::RenderPipeline,
+    blur: wgpu::RenderPipeline,
+    composite: wgpu::RenderPipeline,
+    blit: wgpu::RenderPipeline,
+    targets: Option<Targets>,
+    idle_frames: u32,
+}
+
+impl BackdropRenderer {
+    pub fn new(device: &wgpu::Device, format: wgpu::TextureFormat) -> Self {
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("Backdrop Shader"),
+            source: wgpu::ShaderSource::Wgsl(include_str!("backdrop_shader.wgsl").into()),
+        });
+
+        let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+            label: Some("Backdrop Sampler"),
+            // Clamped so a tap near the edge smears the border rather than
+            // pulling in whatever sits outside the region.
+            address_mode_u: wgpu::AddressMode::ClampToEdge,
+            address_mode_v: wgpu::AddressMode::ClampToEdge,
+            address_mode_w: wgpu::AddressMode::ClampToEdge,
+            mag_filter: wgpu::FilterMode::Linear,
+            min_filter: wgpu::FilterMode::Linear,
+            ..Default::default()
+        });
+
+        let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("Backdrop Bind Group Layout"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        multisampled: false,
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 2,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+            ],
+        });
+
+        let layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("Backdrop Pipeline Layout"),
+            bind_group_layouts: &[&bind_group_layout],
+            immediate_size: 0,
+        });
+
+        let pipeline = |label: &str, entry: &str, blend: Option<wgpu::BlendState>| {
+            device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                label: Some(label),
+                layout: Some(&layout),
+                vertex: wgpu::VertexState {
+                    module: &shader,
+                    entry_point: Some("vs_main"),
+                    buffers: &[],
+                    compilation_options: Default::default(),
+                },
+                fragment: Some(wgpu::FragmentState {
+                    module: &shader,
+                    entry_point: Some(entry),
+                    targets: &[Some(wgpu::ColorTargetState {
+                        format,
+                        blend,
+                        write_mask: wgpu::ColorWrites::ALL,
+                    })],
+                    compilation_options: Default::default(),
+                }),
+                primitive: wgpu::PrimitiveState::default(),
+                depth_stencil: None,
+                multisample: wgpu::MultisampleState::default(),
+                multiview_mask: None,
+                cache: None,
+            })
+        };
+
+        // The composite is the only step that blends: it lays the blurred
+        // patch over the target, faded out by the shape mask at the edges.
+        // Everything else writes a fresh working texture.
+        let composite_blend = wgpu::BlendState {
+            color: wgpu::BlendComponent {
+                src_factor: wgpu::BlendFactor::SrcAlpha,
+                dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
+                operation: wgpu::BlendOperation::Add,
+            },
+            alpha: wgpu::BlendComponent {
+                src_factor: wgpu::BlendFactor::One,
+                dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
+                operation: wgpu::BlendOperation::Add,
+            },
+        };
+
+        Self {
+            format,
+            sampler,
+            downsample: pipeline("Backdrop Downsample", "fs_downsample", None),
+            blur: pipeline("Backdrop Blur", "fs_blur", None),
+            composite: pipeline("Backdrop Composite", "fs_composite", Some(composite_blend)),
+            blit: pipeline("Backdrop Blit", "fs_downsample", None),
+            bind_group_layout,
+            targets: None,
+            idle_frames: 0,
+        }
+    }
+
+    /// Allocate the offscreen target, or reallocate it after a resize.
+    pub fn ensure_targets(&mut self, device: &wgpu::Device, width: u32, height: u32) {
+        let stale = match &self.targets {
+            Some(targets) => targets.width != width || targets.height != height,
+            None => true,
+        };
+        if stale {
+            self.targets = Some(Targets::new(device, self.format, width, height));
+        }
+        self.idle_frames = 0;
+    }
+
+    /// The view the frame should be drawn into. `None` until
+    /// [`ensure_targets`](Self::ensure_targets) has run.
+    pub fn scene_view(&self) -> Option<&wgpu::TextureView> {
+        self.targets.as_ref().map(|targets| &targets.scene_view)
+    }
+
+    /// Note a frame that needed no backdrop effect, releasing the offscreen
+    /// target once enough of them go by.
+    ///
+    /// Not released on the first such frame: a menu that blurs while open
+    /// would otherwise reallocate a surface-sized target every time it opens,
+    /// which costs far more than holding it across a few idle frames.
+    pub fn note_unused(&mut self) {
+        if self.targets.is_none() {
+            return;
+        }
+        self.idle_frames += 1;
+        if self.idle_frames > IDLE_FRAMES_BEFORE_RELEASE {
+            self.targets = None;
+            self.idle_frames = 0;
+        }
+    }
+
+    fn bind(
+        &self,
+        device: &wgpu::Device,
+        view: &wgpu::TextureView,
+        params: Params,
+    ) -> wgpu::BindGroup {
+        let buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("Backdrop Params"),
+            contents: bytemuck::cast_slice(&[params]),
+            usage: wgpu::BufferUsages::UNIFORM,
+        });
+        device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("Backdrop Bind Group"),
+            layout: &self.bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::TextureView(view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::Sampler(&self.sampler),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: buffer.as_entire_binding(),
+                },
+            ],
+        })
+    }
+
+    /// Run one full-screen-triangle pass into `target` over `viewport`.
+    #[allow(clippy::too_many_arguments)]
+    fn pass(
+        &self,
+        encoder: &mut wgpu::CommandEncoder,
+        pipeline: &wgpu::RenderPipeline,
+        target: &wgpu::TextureView,
+        load: wgpu::LoadOp<wgpu::Color>,
+        bind_group: &wgpu::BindGroup,
+        viewport: (u32, u32, u32, u32),
+        label: &str,
+    ) {
+        let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some(label),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view: target,
+                resolve_target: None,
+                ops: wgpu::Operations {
+                    load,
+                    store: wgpu::StoreOp::Store,
+                },
+                depth_slice: None,
+            })],
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+            multiview_mask: None,
+        });
+        let (x, y, w, h) = viewport;
+        pass.set_viewport(x as f32, y as f32, w as f32, h as f32, 0.0, 1.0);
+        pass.set_pipeline(pipeline);
+        pass.set_bind_group(0, bind_group, &[]);
+        pass.draw(0..3, 0..1);
+    }
+
+    /// Blur one region of the scene target, in place.
+    pub fn apply(
+        &self,
+        device: &wgpu::Device,
+        encoder: &mut wgpu::CommandEncoder,
+        region: &BackdropRegion,
+    ) {
+        let Some(targets) = &self.targets else {
+            return;
+        };
+        let Some((x, y, width, height)) = region.clamped(targets.width, targets.height) else {
+            return;
+        };
+
+        let work_width = (width / WORKING_SCALE).max(1);
+        let work_height = (height / WORKING_SCALE).max(1);
+
+        // Radius shrinks with the working texture; the downsample already
+        // spent the rest of it.
+        let sigma = (region.radius / WORKING_SCALE as f32 / 2.0).max(0.5);
+        let taps = (sigma * 2.5).ceil().min(MAX_TAPS);
+
+        let scene_rect = [
+            x as f32 / targets.width as f32,
+            y as f32 / targets.height as f32,
+            width as f32 / targets.width as f32,
+            height as f32 / targets.height as f32,
+        ];
+        // Only the working textures' top-left corner holds this region, so
+        // reads have to stay inside it — normalised against the working size,
+        // not the scene's.
+        let work_rect = [
+            0.0,
+            0.0,
+            work_width as f32 / targets.work_width as f32,
+            work_height as f32 / targets.work_height as f32,
+        ];
+
+        let base = Params {
+            src_rect: scene_rect,
+            direction: [0.0, 0.0],
+            sigma,
+            taps,
+            dst_size: [width as f32, height as f32],
+            curvature: region.curvature,
+            _pad: 0.0,
+            radii: region.radii.to_array(),
+        };
+
+        // 1. Scene region → working[0], shrunk.
+        let bind = self.bind(device, &targets.scene_view, base);
+        self.pass(
+            encoder,
+            &self.downsample,
+            &targets.working_views[0],
+            wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+            &bind,
+            (0, 0, work_width, work_height),
+            "Backdrop Downsample",
+        );
+
+        // 2. Two separable gaussian passes, ping-ponging. The step is a texel
+        // of the *working* texture, which is what the blur samples — stepping
+        // by a scene texel would blur `WORKING_SCALE` times too narrowly.
+        let texel_x = 1.0 / targets.work_width as f32;
+        let texel_y = 1.0 / targets.work_height as f32;
+        for (index, direction) in [[texel_x, 0.0], [0.0, texel_y]].into_iter().enumerate() {
+            let bind = self.bind(
+                device,
+                &targets.working_views[index],
+                Params {
+                    src_rect: work_rect,
+                    direction,
+                    ..base
+                },
+            );
+            self.pass(
+                encoder,
+                &self.blur,
+                &targets.working_views[1 - index],
+                wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                &bind,
+                (0, 0, work_width, work_height),
+                "Backdrop Blur",
+            );
+        }
+
+        // 3. Back over the scene, masked to the container's shape.
+        let bind = self.bind(
+            device,
+            &targets.working_views[0],
+            Params {
+                src_rect: work_rect,
+                ..base
+            },
+        );
+        self.pass(
+            encoder,
+            &self.composite,
+            &targets.scene_view,
+            wgpu::LoadOp::Load,
+            &bind,
+            (x, y, width, height),
+            "Backdrop Composite",
+        );
+    }
+
+    /// Copy the offscreen scene onto the swapchain.
+    pub fn present(
+        &self,
+        device: &wgpu::Device,
+        encoder: &mut wgpu::CommandEncoder,
+        target: &wgpu::TextureView,
+    ) {
+        let Some(targets) = &self.targets else {
+            return;
+        };
+        let bind = self.bind(
+            device,
+            &targets.scene_view,
+            Params {
+                src_rect: [0.0, 0.0, 1.0, 1.0],
+                direction: [0.0, 0.0],
+                sigma: 0.0,
+                taps: 0.0,
+                dst_size: [targets.width as f32, targets.height as f32],
+                curvature: 1.0,
+                _pad: 0.0,
+                radii: [0.0; 4],
+            },
+        );
+        self.pass(
+            encoder,
+            &self.blit,
+            target,
+            wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+            &bind,
+            (0, 0, targets.width, targets.height),
+            "Backdrop Blit",
+        );
+    }
+}
+
+impl Targets {
+    fn new(device: &wgpu::Device, format: wgpu::TextureFormat, width: u32, height: u32) -> Self {
+        let width = width.max(1);
+        let height = height.max(1);
+        let make = |label: &str, width: u32, height: u32| {
+            device.create_texture(&wgpu::TextureDescriptor {
+                label: Some(label),
+                size: wgpu::Extent3d {
+                    width,
+                    height,
+                    depth_or_array_layers: 1,
+                },
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                format,
+                usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+                    | wgpu::TextureUsages::TEXTURE_BINDING,
+                view_formats: &[],
+            })
+        };
+
+        let scene = make("Backdrop Scene", width, height);
+        let scene_view = scene.create_view(&Default::default());
+        // One allocation serves every card on screen — each writes only the
+        // corner it needs — and at `WORKING_SCALE` down it costs a sixteenth
+        // of a full-size target.
+        let work_width = (width / WORKING_SCALE).max(1);
+        let work_height = (height / WORKING_SCALE).max(1);
+        let working = [
+            make("Backdrop Working 0", work_width, work_height),
+            make("Backdrop Working 1", work_width, work_height),
+        ];
+        let working_views = [
+            working[0].create_view(&Default::default()),
+            working[1].create_view(&Default::default()),
+        ];
+
+        Self {
+            width,
+            height,
+            work_width,
+            work_height,
+            scene,
+            scene_view,
+            working,
+            working_views,
+        }
+    }
+}

--- a/src/renderer/backdrop_shader.wgsl
+++ b/src/renderer/backdrop_shader.wgsl
@@ -1,0 +1,114 @@
+// Guido Backdrop Shader
+//
+// Filters what is already on the render target. Three entry points share one
+// fullscreen-triangle vertex stage; the render pass viewport decides where the
+// output lands, so no entry point needs to know about NDC.
+
+struct Params {
+    // Sub-rectangle of the source texture to read, in normalised UV.
+    src_rect: vec4<f32>,
+    // Texel step for the blur, in source UV. Zero on the downsample step.
+    direction: vec2<f32>,
+    // Gaussian sigma in source texels, and the tap count derived from it.
+    sigma: f32,
+    taps: f32,
+    // Destination rect size in physical pixels, for the mask SDF.
+    dst_size: vec2<f32>,
+    curvature: f32,
+    _pad: f32,
+    // Corner radii in physical pixels: top-left, top-right, bottom-right,
+    // bottom-left.
+    radii: vec4<f32>,
+}
+
+@group(0) @binding(0) var t_source: texture_2d<f32>;
+@group(0) @binding(1) var s_source: sampler;
+@group(0) @binding(2) var<uniform> params: Params;
+
+struct VertexOutput {
+    @builtin(position) clip_position: vec4<f32>,
+    // 0..1 across the destination viewport.
+    @location(0) uv: vec2<f32>,
+}
+
+// A single oversized triangle covering the viewport: cheaper than a quad and
+// avoids the diagonal seam two triangles can show under some drivers.
+@vertex
+fn vs_main(@builtin(vertex_index) index: u32) -> VertexOutput {
+    var out: VertexOutput;
+    let uv = vec2<f32>(f32((index << 1u) & 2u), f32(index & 2u));
+    out.uv = uv;
+    out.clip_position = vec4<f32>(uv * 2.0 - 1.0, 0.0, 1.0);
+    // Framebuffer Y grows downwards, clip space upwards.
+    out.clip_position.y = -out.clip_position.y;
+    return out;
+}
+
+fn source_uv(uv: vec2<f32>) -> vec2<f32> {
+    return params.src_rect.xy + uv * params.src_rect.zw;
+}
+
+// Copy the region into the working texture. Rendering into a smaller target
+// with a linear sampler is itself a box filter, which is most of the blur for
+// free — the gaussian afterwards only has to smooth what is left.
+@fragment
+fn fs_downsample(in: VertexOutput) -> @location(0) vec4<f32> {
+    return textureSample(t_source, s_source, source_uv(in.uv));
+}
+
+// One axis of a separable gaussian. Two of these compose into a 2D blur at a
+// fraction of the cost of sampling the full kernel.
+@fragment
+fn fs_blur(in: VertexOutput) -> @location(0) vec4<f32> {
+    let sigma = max(params.sigma, 0.0001);
+    let taps = i32(params.taps);
+
+    var accum = textureSample(t_source, s_source, source_uv(in.uv));
+    var weight_sum = 1.0;
+
+    for (var i = 1; i <= taps; i = i + 1) {
+        let offset = f32(i);
+        let weight = exp(-(offset * offset) / (2.0 * sigma * sigma));
+        let step = params.direction * offset;
+        // Clamped inside the region by the sampler's clamp-to-edge address
+        // mode, so the border smears rather than pulling in neighbours.
+        accum = accum + textureSample(t_source, s_source, source_uv(in.uv) + step) * weight;
+        accum = accum + textureSample(t_source, s_source, source_uv(in.uv) - step) * weight;
+        weight_sum = weight_sum + 2.0 * weight;
+    }
+
+    return accum / weight_sum;
+}
+
+// Signed distance to a superellipse-cornered rectangle centred on the origin.
+fn rounded_box_sdf(p: vec2<f32>, half_size: vec2<f32>, radii: vec4<f32>, k: f32) -> f32 {
+    // Pick the radius of the corner this fragment is nearest.
+    var r = select(radii.w, radii.x, p.x < 0.0 && p.y < 0.0);
+    r = select(r, radii.y, p.x >= 0.0 && p.y < 0.0);
+    r = select(r, radii.z, p.x >= 0.0 && p.y >= 0.0);
+    r = min(r, min(half_size.x, half_size.y));
+
+    let q = abs(p) - half_size + vec2<f32>(r, r);
+    if (q.x <= 0.0 || q.y <= 0.0 || r <= 0.0) {
+        return min(max(q.x, q.y), 0.0) + length(max(q, vec2<f32>(0.0))) - r;
+    }
+    // Superellipse corner: |x|^k + |y|^k = r^k, k = 1 is a circle.
+    let n = max(k, 0.05) * 2.0;
+    let d = pow(pow(q.x, n) + pow(q.y, n), 1.0 / n);
+    return d - r;
+}
+
+// Write the blurred region back over the target, shaped by the container's
+// own corners so the effect stops where the container does.
+@fragment
+fn fs_composite(in: VertexOutput) -> @location(0) vec4<f32> {
+    let blurred = textureSample(t_source, s_source, source_uv(in.uv));
+
+    let half_size = params.dst_size * 0.5;
+    let p = in.uv * params.dst_size - half_size;
+    let distance = rounded_box_sdf(p, half_size, params.radii, params.curvature);
+    // One pixel of feathering: the mask is the only anti-aliasing the edge gets.
+    let mask = 1.0 - smoothstep(-0.5, 0.5, distance);
+
+    return vec4<f32>(blurred.rgb, blurred.a * mask);
+}

--- a/src/renderer/commands.rs
+++ b/src/renderer/commands.rs
@@ -175,6 +175,22 @@ pub enum DrawCommand {
         font_weight: FontWeight,
     },
 
+    /// Filter what has already been drawn beneath `rect`, in place.
+    ///
+    /// Ordered before the container's own background so the container paints
+    /// over its own blurred backdrop. See [`crate::backdrop`].
+    BackdropBlur {
+        /// Region to filter, in local coordinates.
+        rect: Rect,
+        /// Blur radius in logical pixels.
+        radius: f32,
+        /// Corner radii of the region, so the result is masked to the
+        /// container's shape rather than its bounding box.
+        corner_radii: CornerRadii,
+        /// Superellipse curvature of those corners.
+        curvature: f32,
+    },
+
     /// Draw an image.
     Image {
         /// Image source (path or bytes)

--- a/src/renderer/flatten.rs
+++ b/src/renderer/flatten.rs
@@ -74,11 +74,16 @@ pub struct FlattenedCommand {
 /// Bucketing alone would reorder: with a single set of buckets for the whole
 /// frame, *every* shape is drawn before *every* image, so a container
 /// background painted over an image ends up underneath it however the tree is
-/// arranged. A new group is therefore opened whenever a command's layer would
-/// go backwards, and the groups are drawn in order. Batching survives, the
-/// order survives with it, and a tree that never paints a lower layer over a
-/// higher one produces exactly one group — the same single set of draw calls
-/// as before.
+/// arranged. A new group is therefore opened when a command's layer goes
+/// backwards, and the groups are drawn in order.
+///
+/// Only when it goes backwards *over something it would cover*, though.
+/// Sibling widgets each draw a background and then a label, so a plain
+/// "layer went backwards" rule fires between every pair of them — and splits
+/// there buy nothing, because siblings do not overlap. Reordering is only
+/// observable where the pixels meet, so the group is kept unless the incoming
+/// command's bounds actually intersect something already drawn above it. A
+/// column of buttons stays one group; a tint over a photo gets two.
 struct LayeredCommands {
     groups: Vec<LayerBuckets>,
 }
@@ -90,12 +95,42 @@ struct LayerBuckets {
     images: Vec<FlattenedCommand>,
     text: Vec<FlattenedCommand>,
     overlay: Vec<FlattenedCommand>,
-    /// Highest layer already in this group. A command below it has to start a
-    /// new group or it would be drawn too early.
+    /// Highest layer already in this group. Only a command below this can
+    /// possibly be drawn too early.
     high_water: RenderLayer,
+    /// World-space bounds of everything in this group, per layer, so a
+    /// regression can be tested for actual overlap. `None` means the layer is
+    /// empty; an unbounded command widens it to everything.
+    bounds: [Option<Rect>; LAYER_COUNT],
 }
 
+/// Number of [`RenderLayer`] variants.
+const LAYER_COUNT: usize = 5;
+
 impl LayerBuckets {
+    /// Does `rect` meet anything already drawn above `layer` in this group?
+    ///
+    /// Conservative: layer bounds are a union, so two commands straddling a
+    /// gap read as covering it. Over-splitting only costs a draw call, while
+    /// under-splitting would draw in the wrong order.
+    fn covered_above(&self, layer: RenderLayer, rect: Option<Rect>) -> bool {
+        let Some(rect) = rect else {
+            // Nothing to test against: assume the worst and split.
+            return true;
+        };
+        (layer as usize + 1..LAYER_COUNT)
+            .any(|above| self.bounds[above].is_some_and(|bounds| bounds.intersects(&rect)))
+    }
+
+    fn record(&mut self, layer: RenderLayer, rect: Option<Rect>) {
+        let slot = &mut self.bounds[layer as usize];
+        match (*slot, rect) {
+            (_, None) => *slot = Some(EVERYTHING),
+            (None, Some(rect)) => *slot = Some(rect),
+            (Some(current), Some(rect)) => *slot = Some(union(current, rect)),
+        }
+    }
+
     fn bucket_mut(&mut self, layer: RenderLayer) -> &mut Vec<FlattenedCommand> {
         match layer {
             RenderLayer::Backdrop => &mut self.backdrop,
@@ -124,9 +159,10 @@ impl LayeredCommands {
 
     fn push(&mut self, cmd: FlattenedCommand) {
         let layer = cmd.layer;
+        let rect = world_bounds(&cmd);
         // `expect`: `new` seeds one group and nothing ever removes one.
         let current = self.groups.last().expect("at least one group");
-        if layer < current.high_water {
+        if layer < current.high_water && current.covered_above(layer, rect) {
             self.groups.push(LayerBuckets {
                 high_water: layer,
                 ..Default::default()
@@ -134,6 +170,7 @@ impl LayeredCommands {
         }
         let current = self.groups.last_mut().expect("at least one group");
         current.high_water = current.high_water.max(layer);
+        current.record(layer, rect);
         current.bucket_mut(layer).push(cmd);
     }
 
@@ -397,6 +434,89 @@ fn flatten_node(
     crate::render_stats::record_flatten_full();
 }
 
+/// Stand-in for "this could be anywhere", used when a command's extent is not
+/// known: it intersects everything, so the group splits.
+const EVERYTHING: Rect = Rect {
+    x: f32::NEG_INFINITY,
+    y: f32::NEG_INFINITY,
+    width: f32::INFINITY,
+    height: f32::INFINITY,
+};
+
+fn union(a: Rect, b: Rect) -> Rect {
+    let x = a.x.min(b.x);
+    let y = a.y.min(b.y);
+    let right = (a.x + a.width).max(b.x + b.width);
+    let bottom = (a.y + a.height).max(b.y + b.height);
+    Rect::new(x, y, right - x, bottom - y)
+}
+
+/// What a command covers, in world space, or `None` when that cannot be
+/// bounded cheaply.
+///
+/// Only used to decide whether two commands can safely swap places, so it has
+/// to be generous: a box that is too small could let something be drawn
+/// underneath what it should cover.
+fn world_bounds(cmd: &FlattenedCommand) -> Option<Rect> {
+    let local = match &*cmd.command {
+        DrawCommand::RoundedRect {
+            rect,
+            border,
+            shadow,
+            ..
+        } => {
+            // A shadow spills well outside the rect, and a border straddles
+            // its edge.
+            let mut grow: f32 = border.map_or(0.0, |b| b.width);
+            let mut offset: (f32, f32) = (0.0, 0.0);
+            if let Some(shadow) = shadow {
+                grow = grow.max(shadow.blur + shadow.spread);
+                offset = shadow.offset;
+            }
+            Rect::new(
+                rect.x - grow + offset.0.min(0.0),
+                rect.y - grow + offset.1.min(0.0),
+                rect.width + grow * 2.0 + offset.0.abs(),
+                rect.height + grow * 2.0 + offset.1.abs(),
+            )
+        }
+        DrawCommand::Circle { center, radius, .. } => Rect::new(
+            center.0 - radius,
+            center.1 - radius,
+            radius * 2.0,
+            radius * 2.0,
+        ),
+        DrawCommand::Image { rect, .. } => *rect,
+        DrawCommand::BackdropBlur { rect, .. } => *rect,
+        DrawCommand::Text {
+            rect, font_size, ..
+        } => {
+            // Glyphs overshoot their layout box — descenders, italics, marks.
+            // A font-size of slack costs an occasional extra group, where too
+            // tight a box would let a background cover a letter.
+            let slack = font_size * 0.5;
+            Rect::new(
+                rect.x - slack,
+                rect.y - slack,
+                rect.width + slack * 2.0,
+                rect.height + slack * 2.0,
+            )
+        }
+    };
+
+    if !cmd.world_transform.is_translation_only() {
+        // Rotation and scale would need the transformed corners; rather than
+        // pay for that on every command, treat it as unbounded and split.
+        return None;
+    }
+    Some(Rect::new(
+        local.x + cmd.world_transform.tx(),
+        local.y + cmd.world_transform.ty(),
+        local.width,
+        local.height,
+    ))
+}
+
 /// Compute axis-aligned bounding box from an array of points.
 fn aabb_from_points(points: &[(f32, f32)]) -> Rect {
     let (min_x, max_x, min_y, max_y) = points.iter().fold(
@@ -477,12 +597,14 @@ mod tests {
     use crate::widgets::Color;
 
     fn command(layer: RenderLayer) -> FlattenedCommand {
+        command_at(layer, Rect::new(0.0, 0.0, 100.0, 100.0))
+    }
+
+    /// Commands are only reordered where they overlap, so tests that care
+    /// about splitting have to place them.
+    fn command_at(layer: RenderLayer, rect: Rect) -> FlattenedCommand {
         FlattenedCommand {
-            command: Rc::new(DrawCommand::rounded_rect(
-                Rect::new(0.0, 0.0, 1.0, 1.0),
-                Color::WHITE,
-                0.0,
-            )),
+            command: Rc::new(DrawCommand::rounded_rect(rect, Color::WHITE, 0.0)),
             world_transform: Transform::IDENTITY,
             world_transform_origin: None,
             layer,
@@ -608,6 +730,55 @@ mod tests {
                 .collect()
         };
         assert_eq!(order(&a_cmds, &a_layers), order(&b_cmds, &b_layers));
+    }
+
+    #[test]
+    fn a_regression_that_covers_nothing_stays_in_the_group() {
+        // Sibling widgets each paint a background then a label: the next
+        // sibling's background is a regression, but it lands somewhere the
+        // previous label is not, so splitting there would buy nothing. This
+        // is the shape of nearly every real tree, which is why the overlap
+        // test is what keeps the group count near one.
+        let mut layered = LayeredCommands::new();
+        for column in 0..4 {
+            let x = column as f32 * 200.0;
+            layered.push(command_at(Shapes, Rect::new(x, 0.0, 100.0, 40.0)));
+            layered.push(command_at(Text, Rect::new(x, 0.0, 100.0, 40.0)));
+        }
+
+        let mut commands = Vec::new();
+        let mut layers = Vec::new();
+        layered.drain_into(&mut commands, &mut layers);
+        assert_eq!(layers.len(), 1, "non-overlapping siblings must not split");
+    }
+
+    #[test]
+    fn a_regression_that_covers_something_still_splits() {
+        let mut layered = LayeredCommands::new();
+        layered.push(command_at(Text, Rect::new(0.0, 0.0, 100.0, 40.0)));
+        // Lands on top of the label, so it has to be drawn after it.
+        layered.push(command_at(Shapes, Rect::new(20.0, 10.0, 40.0, 10.0)));
+
+        let mut commands = Vec::new();
+        let mut layers = Vec::new();
+        layered.drain_into(&mut commands, &mut layers);
+        assert_eq!(layers.len(), 2);
+    }
+
+    #[test]
+    fn an_unbounded_command_forces_a_split() {
+        // A rotated or scaled command is not bounded cheaply, so it is
+        // assumed to cover anything: correctness over a spare draw call.
+        let mut layered = LayeredCommands::new();
+        layered.push(command_at(Text, Rect::new(0.0, 0.0, 10.0, 10.0)));
+        let mut rotated = command_at(Shapes, Rect::new(900.0, 900.0, 10.0, 10.0));
+        rotated.world_transform = Transform::rotate(45.0);
+        layered.push(rotated);
+
+        let mut commands = Vec::new();
+        let mut layers = Vec::new();
+        layered.drain_into(&mut commands, &mut layers);
+        assert_eq!(layers.len(), 2);
     }
 
     #[test]

--- a/src/renderer/flatten.rs
+++ b/src/renderer/flatten.rs
@@ -3,6 +3,8 @@
 use std::ops::Range;
 use std::rc::Rc;
 
+use smallvec::SmallVec;
+
 use crate::transform::Transform;
 use crate::widgets::Rect;
 
@@ -98,10 +100,63 @@ struct LayerBuckets {
     /// Highest layer already in this group. Only a command below this can
     /// possibly be drawn too early.
     high_water: RenderLayer,
-    /// World-space bounds of everything in this group, per layer, so a
-    /// regression can be tested for actual overlap. `None` means the layer is
-    /// empty; an unbounded command widens it to everything.
-    bounds: [Option<Rect>; LAYER_COUNT],
+    /// What each layer of this group covers, so a regression can be tested
+    /// for actual overlap.
+    bounds: [LayerBounds; LAYER_COUNT],
+}
+
+/// What one layer of a group covers.
+///
+/// A union alone is too coarse. Labels scattered across a panel union into a
+/// box that spans the gaps between them, and the next sibling's background
+/// lands in one of those gaps and splits for nothing — `examples/showcase.rs`
+/// split three times over exactly that, every split a false positive. Keeping
+/// the individual rects makes the test exact, up to a cap that stops a huge
+/// group turning the scan quadratic; past it the union decides alone, which
+/// can only ever over-split.
+#[derive(Default)]
+struct LayerBounds {
+    /// Cheap reject: nothing outside this can intersect anything inside.
+    union: Option<Rect>,
+    rects: SmallVec<[Rect; 16]>,
+    /// Set once `rects` stopped being the whole story.
+    overflowed: bool,
+}
+
+/// How many rects a layer tracks individually before falling back to the
+/// union. Past this the scan costs more than the draw call it saves.
+const MAX_TRACKED_RECTS: usize = 64;
+
+impl LayerBounds {
+    fn intersects(&self, rect: Rect) -> bool {
+        let Some(union) = self.union else {
+            return false;
+        };
+        if !union.intersects(&rect) {
+            return false;
+        }
+        // The union says "maybe"; the rects say for certain, unless there are
+        // more of them than we kept.
+        self.overflowed || self.rects.iter().any(|held| held.intersects(&rect))
+    }
+
+    fn record(&mut self, rect: Option<Rect>) {
+        let Some(rect) = rect else {
+            // Unbounded: covers anything from here on.
+            self.union = Some(EVERYTHING);
+            self.overflowed = true;
+            return;
+        };
+        self.union = Some(match self.union {
+            Some(union) => union_of(union, rect),
+            None => rect,
+        });
+        if self.rects.len() < MAX_TRACKED_RECTS {
+            self.rects.push(rect);
+        } else {
+            self.overflowed = true;
+        }
+    }
 }
 
 /// Number of [`RenderLayer`] variants.
@@ -109,26 +164,16 @@ const LAYER_COUNT: usize = 5;
 
 impl LayerBuckets {
     /// Does `rect` meet anything already drawn above `layer` in this group?
-    ///
-    /// Conservative: layer bounds are a union, so two commands straddling a
-    /// gap read as covering it. Over-splitting only costs a draw call, while
-    /// under-splitting would draw in the wrong order.
     fn covered_above(&self, layer: RenderLayer, rect: Option<Rect>) -> bool {
         let Some(rect) = rect else {
             // Nothing to test against: assume the worst and split.
             return true;
         };
-        (layer as usize + 1..LAYER_COUNT)
-            .any(|above| self.bounds[above].is_some_and(|bounds| bounds.intersects(&rect)))
+        (layer as usize + 1..LAYER_COUNT).any(|above| self.bounds[above].intersects(rect))
     }
 
     fn record(&mut self, layer: RenderLayer, rect: Option<Rect>) {
-        let slot = &mut self.bounds[layer as usize];
-        match (*slot, rect) {
-            (_, None) => *slot = Some(EVERYTHING),
-            (None, Some(rect)) => *slot = Some(rect),
-            (Some(current), Some(rect)) => *slot = Some(union(current, rect)),
-        }
+        self.bounds[layer as usize].record(rect);
     }
 
     fn bucket_mut(&mut self, layer: RenderLayer) -> &mut Vec<FlattenedCommand> {
@@ -466,7 +511,7 @@ const EVERYTHING: Rect = Rect {
     height: f32::INFINITY,
 };
 
-fn union(a: Rect, b: Rect) -> Rect {
+fn union_of(a: Rect, b: Rect) -> Rect {
     let x = a.x.min(b.x);
     let y = a.y.min(b.y);
     let right = (a.x + a.width).max(b.x + b.width);
@@ -832,6 +877,41 @@ mod tests {
         );
         assert_eq!(captured[0].layer, Shapes);
         assert_eq!(captured[1].layer, Text);
+    }
+
+    #[test]
+    fn a_gap_between_two_labels_is_not_covered() {
+        // The union of two labels spans the gap between them. Testing against
+        // the union alone would split on a background landing in that gap,
+        // which is what showcase did three times over.
+        let mut layered = LayeredCommands::new();
+        layered.push(command_at(Text, Rect::new(0.0, 0.0, 40.0, 20.0)));
+        layered.push(command_at(Text, Rect::new(400.0, 0.0, 40.0, 20.0)));
+        // Squarely between them, touching neither.
+        layered.push(command_at(Shapes, Rect::new(200.0, 0.0, 40.0, 20.0)));
+
+        let mut commands = Vec::new();
+        let mut layers = Vec::new();
+        layered.drain_into(&mut commands, &mut layers);
+        assert_eq!(layers.len(), 1);
+    }
+
+    #[test]
+    fn past_the_rect_cap_the_union_decides() {
+        // Beyond MAX_TRACKED_RECTS the scan would cost more than the draw
+        // call it saves, so the union takes over — which can only over-split.
+        let mut layered = LayeredCommands::new();
+        for i in 0..(MAX_TRACKED_RECTS + 1) {
+            let x = i as f32 * 100.0;
+            layered.push(command_at(Text, Rect::new(x, 0.0, 10.0, 10.0)));
+        }
+        // In a gap, so an exact test would keep one group.
+        layered.push(command_at(Shapes, Rect::new(50.0, 0.0, 10.0, 10.0)));
+
+        let mut commands = Vec::new();
+        let mut layers = Vec::new();
+        layered.drain_into(&mut commands, &mut layers);
+        assert_eq!(layers.len(), 2, "the union must stay conservative");
     }
 
     #[test]

--- a/src/renderer/flatten.rs
+++ b/src/renderer/flatten.rs
@@ -140,14 +140,6 @@ impl LayerBuckets {
             RenderLayer::Overlay => &mut self.overlay,
         }
     }
-
-    fn len(&self) -> usize {
-        self.backdrop.len()
-            + self.shapes.len()
-            + self.images.len()
-            + self.text.len()
-            + self.overlay.len()
-    }
 }
 
 impl LayeredCommands {
@@ -174,35 +166,56 @@ impl LayeredCommands {
         current.bucket_mut(layer).push(cmd);
     }
 
-    /// Number of commands pushed so far, used to capture a subtree's output.
-    fn len(&self) -> usize {
-        self.groups.iter().map(LayerBuckets::len).sum()
+    /// Where the buffers stand, so a subtree's own output can be picked out
+    /// again afterwards.
+    ///
+    /// A plain count would not do it. Commands land in the bucket for their
+    /// layer, so a shape pushed into a group that already holds text is
+    /// inserted *before* that text in draw order — the total is not a
+    /// position. Only the last group is ever appended to, so recording its
+    /// bucket lengths (and how many groups there were) pins the boundary
+    /// exactly.
+    fn mark(&self) -> Mark {
+        // `expect`: `new` seeds one group and nothing ever removes one.
+        let last = self.groups.last().expect("at least one group");
+        Mark {
+            groups: self.groups.len(),
+            buckets: [
+                last.backdrop.len(),
+                last.shapes.len(),
+                last.images.len(),
+                last.text.len(),
+                last.overlay.len(),
+            ],
+        }
     }
 
-    /// Every command added since `start`, in draw order.
+    /// Every command added since `mark`, in draw order.
     ///
     /// Draw order matters: `CachedFlatten` replays these through [`push`], so
     /// feeding them back in the order they will be drawn reproduces the same
     /// group boundaries next frame.
     ///
     /// [`push`]: Self::push
-    fn commands_since(&self, start: usize) -> Vec<FlattenedCommand> {
-        let mut result = Vec::with_capacity(self.len().saturating_sub(start));
-        let mut seen = 0;
-        for group in &self.groups {
-            for bucket in [
+    fn commands_since(&self, mark: Mark) -> Vec<FlattenedCommand> {
+        let mut result = Vec::new();
+        for (index, group) in self.groups.iter().enumerate().skip(mark.groups - 1) {
+            let buckets = [
                 &group.backdrop,
                 &group.shapes,
                 &group.images,
                 &group.text,
                 &group.overlay,
-            ] {
-                for cmd in bucket {
-                    if seen >= start {
-                        result.push(cmd.clone());
-                    }
-                    seen += 1;
-                }
+            ];
+            for (bucket_index, bucket) in buckets.into_iter().enumerate() {
+                // Groups opened after the mark are new all through; the group
+                // that was current keeps whatever it already held.
+                let from = if index == mark.groups - 1 {
+                    mark.buckets[bucket_index]
+                } else {
+                    0
+                };
+                result.extend_from_slice(&bucket[from..]);
             }
         }
         result
@@ -231,6 +244,16 @@ impl LayeredCommands {
             }
         }
     }
+}
+
+/// A position in [`LayeredCommands`], for capturing one subtree's output.
+#[derive(Debug, Clone, Copy)]
+struct Mark {
+    /// How many groups existed.
+    groups: usize,
+    /// Bucket lengths of the group that was current — the only one that can
+    /// still grow.
+    buckets: [usize; LAYER_COUNT],
 }
 
 /// Where one group's commands landed in the flat command buffer.
@@ -340,7 +363,7 @@ fn flatten_node(
     // (including children) can be collected for caching.
     let should_cache =
         node.clip.is_none() && parent_clip.is_none() && world_transform.is_translation_only();
-    let mark = if should_cache { Some(out.len()) } else { None };
+    let mark = if should_cache { Some(out.mark()) } else { None };
 
     // Compute world transform origin (for shapes that need it)
     let world_origin = if !node.local_transform.is_identity() {
@@ -705,7 +728,10 @@ mod tests {
         for layer in sequence {
             original.push(command(layer));
         }
-        let cached = original.commands_since(0);
+        let cached = original.commands_since(Mark {
+            groups: 1,
+            buckets: [0; LAYER_COUNT],
+        });
 
         let mut replayed = LayeredCommands::new();
         for cmd in cached {
@@ -779,6 +805,33 @@ mod tests {
         let mut layers = Vec::new();
         layered.drain_into(&mut commands, &mut layers);
         assert_eq!(layers.len(), 2);
+    }
+
+    #[test]
+    fn a_mark_survives_a_later_command_landing_in_an_earlier_bucket() {
+        // The reason a mark is not a count. Once a group can take a shape
+        // while already holding text — which is exactly what the overlap test
+        // allows — a later command is inserted *before* that text in draw
+        // order. A count would then hand a cached subtree its neighbour's
+        // commands, and the neighbour would be drawn twice.
+        let mut layered = LayeredCommands::new();
+        layered.push(command_at(Text, Rect::new(0.0, 0.0, 50.0, 20.0)));
+
+        // Everything from here belongs to the "subtree" being captured.
+        let mark = layered.mark();
+        // Does not overlap the text, so it joins the same group and slots
+        // into the shapes bucket, ahead of the text already there.
+        layered.push(command_at(Shapes, Rect::new(500.0, 0.0, 50.0, 20.0)));
+        layered.push(command_at(Text, Rect::new(500.0, 0.0, 50.0, 20.0)));
+
+        let captured = layered.commands_since(mark);
+        assert_eq!(
+            captured.len(),
+            2,
+            "the mark must not sweep up the earlier text"
+        );
+        assert_eq!(captured[0].layer, Shapes);
+        assert_eq!(captured[1].layer, Text);
     }
 
     #[test]

--- a/src/renderer/flatten.rs
+++ b/src/renderer/flatten.rs
@@ -12,15 +12,21 @@ use super::tree::{CachedFlatten, ClipRegion, RenderNode};
 /// Render layer for draw command ordering.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
 pub enum RenderLayer {
-    /// Background shapes (filled rectangles, borders, etc.)
+    /// Backdrop effects, which filter what is already on the target.
+    ///
+    /// Lowest so that one always opens a draw group: everything it reads must
+    /// already have been drawn, which means it must land in a group of its
+    /// own, after the groups holding that content.
     #[default]
-    Shapes = 0,
+    Backdrop = 0,
+    /// Background shapes (filled rectangles, borders, etc.)
+    Shapes = 1,
     /// Image content (after shapes, before text)
-    Images = 1,
+    Images = 2,
     /// Text content
-    Text = 2,
+    Text = 3,
     /// Overlay effects (ripples, highlights)
-    Overlay = 3,
+    Overlay = 4,
 }
 
 /// Clip region transformed to world space (axis-aligned bounding box).
@@ -79,6 +85,7 @@ struct LayeredCommands {
 
 #[derive(Default)]
 struct LayerBuckets {
+    backdrop: Vec<FlattenedCommand>,
     shapes: Vec<FlattenedCommand>,
     images: Vec<FlattenedCommand>,
     text: Vec<FlattenedCommand>,
@@ -91,6 +98,7 @@ struct LayerBuckets {
 impl LayerBuckets {
     fn bucket_mut(&mut self, layer: RenderLayer) -> &mut Vec<FlattenedCommand> {
         match layer {
+            RenderLayer::Backdrop => &mut self.backdrop,
             RenderLayer::Shapes => &mut self.shapes,
             RenderLayer::Images => &mut self.images,
             RenderLayer::Text => &mut self.text,
@@ -99,7 +107,11 @@ impl LayerBuckets {
     }
 
     fn len(&self) -> usize {
-        self.shapes.len() + self.images.len() + self.text.len() + self.overlay.len()
+        self.backdrop.len()
+            + self.shapes.len()
+            + self.images.len()
+            + self.text.len()
+            + self.overlay.len()
     }
 }
 
@@ -141,7 +153,13 @@ impl LayeredCommands {
         let mut result = Vec::with_capacity(self.len().saturating_sub(start));
         let mut seen = 0;
         for group in &self.groups {
-            for bucket in [&group.shapes, &group.images, &group.text, &group.overlay] {
+            for bucket in [
+                &group.backdrop,
+                &group.shapes,
+                &group.images,
+                &group.text,
+                &group.overlay,
+            ] {
                 for cmd in bucket {
                     if seen >= start {
                         result.push(cmd.clone());
@@ -159,6 +177,7 @@ impl LayeredCommands {
         for group in self.groups {
             let mut layer = CommandLayer::default();
             for (bucket, range) in [
+                (group.backdrop, &mut layer.backdrop),
                 (group.shapes, &mut layer.shapes),
                 (group.images, &mut layer.images),
                 (group.text, &mut layer.text),
@@ -182,6 +201,8 @@ impl LayeredCommands {
 /// Drawn in field order: shapes, images, text, overlay.
 #[derive(Debug, Clone, Default)]
 pub struct CommandLayer {
+    /// Backdrop effects applied to the target before this group draws.
+    pub backdrop: Range<usize>,
     pub shapes: Range<usize>,
     pub images: Range<usize>,
     pub text: Range<usize>,
@@ -190,7 +211,8 @@ pub struct CommandLayer {
 
 impl CommandLayer {
     pub fn is_empty(&self) -> bool {
-        self.shapes.is_empty()
+        self.backdrop.is_empty()
+            && self.shapes.is_empty()
             && self.images.is_empty()
             && self.text.is_empty()
             && self.overlay.is_empty()
@@ -310,6 +332,7 @@ fn flatten_node(
         let layer = match &**cmd {
             DrawCommand::Text { .. } => RenderLayer::Text,
             DrawCommand::Image { .. } => RenderLayer::Images,
+            DrawCommand::BackdropBlur { .. } => RenderLayer::Backdrop,
             _ => RenderLayer::Shapes,
         };
         out.push(FlattenedCommand {

--- a/src/renderer/flatten.rs
+++ b/src/renderer/flatten.rs
@@ -1,5 +1,6 @@
 //! Tree flattening with world transform computation.
 
+use std::ops::Range;
 use std::rc::Rc;
 
 use crate::transform::Transform;
@@ -9,9 +10,10 @@ use super::commands::DrawCommand;
 use super::tree::{CachedFlatten, ClipRegion, RenderNode};
 
 /// Render layer for draw command ordering.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
 pub enum RenderLayer {
     /// Background shapes (filled rectangles, borders, etc.)
+    #[default]
     Shapes = 0,
     /// Image content (after shapes, before text)
     Images = 1,
@@ -57,111 +59,162 @@ pub struct FlattenedCommand {
     pub clip_is_local: bool,
 }
 
-/// Layered command buffers that avoid post-flatten sorting.
+/// Draw commands grouped so that batching never reorders drawing.
 ///
-/// Commands are emitted directly into per-layer buckets during flattening,
-/// then concatenated in layer order. This replaces the O(n log n) sort with O(n) append.
+/// Each group buckets its commands by [`RenderLayer`], and the GPU draws a
+/// group one bucket at a time — shapes, then images, then text, then overlay.
+/// That is what lets commands of a kind share a draw call.
+///
+/// Bucketing alone would reorder: with a single set of buckets for the whole
+/// frame, *every* shape is drawn before *every* image, so a container
+/// background painted over an image ends up underneath it however the tree is
+/// arranged. A new group is therefore opened whenever a command's layer would
+/// go backwards, and the groups are drawn in order. Batching survives, the
+/// order survives with it, and a tree that never paints a lower layer over a
+/// higher one produces exactly one group — the same single set of draw calls
+/// as before.
 struct LayeredCommands {
+    groups: Vec<LayerBuckets>,
+}
+
+#[derive(Default)]
+struct LayerBuckets {
     shapes: Vec<FlattenedCommand>,
     images: Vec<FlattenedCommand>,
     text: Vec<FlattenedCommand>,
     overlay: Vec<FlattenedCommand>,
+    /// Highest layer already in this group. A command below it has to start a
+    /// new group or it would be drawn too early.
+    high_water: RenderLayer,
+}
+
+impl LayerBuckets {
+    fn bucket_mut(&mut self, layer: RenderLayer) -> &mut Vec<FlattenedCommand> {
+        match layer {
+            RenderLayer::Shapes => &mut self.shapes,
+            RenderLayer::Images => &mut self.images,
+            RenderLayer::Text => &mut self.text,
+            RenderLayer::Overlay => &mut self.overlay,
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.shapes.len() + self.images.len() + self.text.len() + self.overlay.len()
+    }
 }
 
 impl LayeredCommands {
     fn new() -> Self {
         Self {
-            shapes: Vec::new(),
-            images: Vec::new(),
-            text: Vec::new(),
-            overlay: Vec::new(),
+            groups: vec![LayerBuckets::default()],
         }
     }
 
     fn push(&mut self, cmd: FlattenedCommand) {
-        match cmd.layer {
-            RenderLayer::Shapes => self.shapes.push(cmd),
-            RenderLayer::Images => self.images.push(cmd),
-            RenderLayer::Text => self.text.push(cmd),
-            RenderLayer::Overlay => self.overlay.push(cmd),
+        let layer = cmd.layer;
+        // `expect`: `new` seeds one group and nothing ever removes one.
+        let current = self.groups.last().expect("at least one group");
+        if layer < current.high_water {
+            self.groups.push(LayerBuckets {
+                high_water: layer,
+                ..Default::default()
+            });
         }
+        let current = self.groups.last_mut().expect("at least one group");
+        current.high_water = current.high_water.max(layer);
+        current.bucket_mut(layer).push(cmd);
     }
 
-    /// Take a snapshot of current lengths across all layer buckets.
-    /// Used with `commands_since()` to capture everything added by a subtree.
-    fn snapshot(&self) -> LayerSnapshot {
-        LayerSnapshot {
-            shapes: self.shapes.len(),
-            images: self.images.len(),
-            text: self.text.len(),
-            overlay: self.overlay.len(),
-        }
+    /// Number of commands pushed so far, used to capture a subtree's output.
+    fn len(&self) -> usize {
+        self.groups.iter().map(LayerBuckets::len).sum()
     }
 
-    /// Collect all commands added since a snapshot (across all layers).
-    /// Used to populate `CachedFlatten` which stores a flat mixed-layer Vec.
-    fn commands_since(&self, snap: &LayerSnapshot) -> Vec<FlattenedCommand> {
-        let mut result = Vec::new();
-        result.extend_from_slice(&self.shapes[snap.shapes..]);
-        result.extend_from_slice(&self.images[snap.images..]);
-        result.extend_from_slice(&self.text[snap.text..]);
-        result.extend_from_slice(&self.overlay[snap.overlay..]);
+    /// Every command added since `start`, in draw order.
+    ///
+    /// Draw order matters: `CachedFlatten` replays these through [`push`], so
+    /// feeding them back in the order they will be drawn reproduces the same
+    /// group boundaries next frame.
+    ///
+    /// [`push`]: Self::push
+    fn commands_since(&self, start: usize) -> Vec<FlattenedCommand> {
+        let mut result = Vec::with_capacity(self.len().saturating_sub(start));
+        let mut seen = 0;
+        for group in &self.groups {
+            for bucket in [&group.shapes, &group.images, &group.text, &group.overlay] {
+                for cmd in bucket {
+                    if seen >= start {
+                        result.push(cmd.clone());
+                    }
+                    seen += 1;
+                }
+            }
+        }
         result
     }
 
-    /// Drain all layers into the output buffer in correct render order.
-    /// Returns the boundary offsets: (images_start, text_start, overlay_start).
-    fn drain_into(self, out: &mut Vec<FlattenedCommand>) -> LayerBoundaries {
-        let images_start = self.shapes.len();
-        let text_start = images_start + self.images.len();
-        let overlay_start = text_start + self.text.len();
-
-        out.extend(self.shapes);
-        out.extend(self.images);
-        out.extend(self.text);
-        out.extend(self.overlay);
-
-        LayerBoundaries {
-            images_start,
-            text_start,
-            overlay_start,
+    /// Flatten the groups into one buffer in draw order, recording where each
+    /// group's buckets landed.
+    fn drain_into(self, out: &mut Vec<FlattenedCommand>, layers: &mut Vec<CommandLayer>) {
+        for group in self.groups {
+            let mut layer = CommandLayer::default();
+            for (bucket, range) in [
+                (group.shapes, &mut layer.shapes),
+                (group.images, &mut layer.images),
+                (group.text, &mut layer.text),
+                (group.overlay, &mut layer.overlay),
+            ] {
+                let start = out.len();
+                out.extend(bucket);
+                *range = start..out.len();
+            }
+            // A group left empty by a subtree that drew nothing would cost a
+            // pointless set of pipeline switches.
+            if !layer.is_empty() {
+                layers.push(layer);
+            }
         }
     }
 }
 
-/// Snapshot of `LayeredCommands` lengths for capturing subtree output.
-struct LayerSnapshot {
-    shapes: usize,
-    images: usize,
-    text: usize,
-    overlay: usize,
+/// Where one group's commands landed in the flat command buffer.
+///
+/// Drawn in field order: shapes, images, text, overlay.
+#[derive(Debug, Clone, Default)]
+pub struct CommandLayer {
+    pub shapes: Range<usize>,
+    pub images: Range<usize>,
+    pub text: Range<usize>,
+    pub overlay: Range<usize>,
 }
 
-/// Pre-computed layer boundary offsets, eliminating the need for `partition_point` calls.
-#[derive(Debug, Clone, Copy, Default)]
-pub struct LayerBoundaries {
-    pub images_start: usize,
-    pub text_start: usize,
-    pub overlay_start: usize,
+impl CommandLayer {
+    pub fn is_empty(&self) -> bool {
+        self.shapes.is_empty()
+            && self.images.is_empty()
+            && self.text.is_empty()
+            && self.overlay.is_empty()
+    }
 }
 
-/// Flatten a render tree into an existing buffer (clears and reuses capacity).
+/// Flatten a render tree into existing buffers (cleared and reused).
 ///
 /// Flatten results are cached on nodes (via interior mutability) for
 /// incremental reuse in subsequent frames.
 ///
-/// Returns `LayerBoundaries` with pre-computed offsets for each render layer,
-/// replacing the previous `partition_point` lookups in the renderer.
+/// `layers` receives the groups to draw, in order; see [`LayeredCommands`].
 pub fn flatten_root_into(
     root: &RenderNode,
     commands: &mut Vec<FlattenedCommand>,
-) -> LayerBoundaries {
+    layers: &mut Vec<CommandLayer>,
+) {
     commands.clear();
+    layers.clear();
 
     let mut layered = LayeredCommands::new();
     flatten_node(root, Transform::IDENTITY, None, None, &mut layered);
 
-    layered.drain_into(commands)
+    layered.drain_into(commands, layers);
 }
 
 /// Recursively flatten a node and its children.
@@ -223,16 +276,12 @@ fn flatten_node(
     }
 
     // Full flatten — existing logic
-    // Track if we should cache this node's flatten output.
-    // Snapshot captures lengths across all layer buckets so we can collect
-    // everything added by this subtree (including children) for caching.
+    // Track if we should cache this node's flatten output. The mark captures
+    // how much has been pushed so far, so everything this subtree adds
+    // (including children) can be collected for caching.
     let should_cache =
         node.clip.is_none() && parent_clip.is_none() && world_transform.is_translation_only();
-    let snap = if should_cache {
-        Some(out.snapshot())
-    } else {
-        None
-    };
+    let mark = if should_cache { Some(out.len()) } else { None };
 
     // Compute world transform origin (for shapes that need it)
     let world_origin = if !node.local_transform.is_identity() {
@@ -314,11 +363,11 @@ fn flatten_node(
     }
 
     // Cache flatten results for next frame, but only when reuse is possible.
-    // The snapshot captures everything added since the start of this node
-    // (including all children), matching the original `out[start_idx..]` behavior.
-    *node.cached_flatten.borrow_mut() = snap.map(|snap| {
+    // The mark captures everything added since the start of this node
+    // (including all children).
+    *node.cached_flatten.borrow_mut() = mark.map(|mark| {
         Rc::new(CachedFlatten {
-            commands: out.commands_since(&snap),
+            commands: out.commands_since(mark),
             world_transform,
         })
     });
@@ -396,5 +445,158 @@ fn intersect_clips(a: &WorldClip, b: &WorldClip) -> WorldClip {
         rect: Rect::new(min_x, min_y, width, height),
         corner_radius,
         curvature,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::widgets::Color;
+
+    fn command(layer: RenderLayer) -> FlattenedCommand {
+        FlattenedCommand {
+            command: Rc::new(DrawCommand::rounded_rect(
+                Rect::new(0.0, 0.0, 1.0, 1.0),
+                Color::WHITE,
+                0.0,
+            )),
+            world_transform: Transform::IDENTITY,
+            world_transform_origin: None,
+            layer,
+            clip: None,
+            clip_is_local: false,
+        }
+    }
+
+    /// Drive `push` with a sequence of layers and report the resulting groups
+    /// as the layers each one holds, in draw order.
+    fn groups(sequence: &[RenderLayer]) -> Vec<Vec<RenderLayer>> {
+        let mut layered = LayeredCommands::new();
+        for layer in sequence {
+            layered.push(command(*layer));
+        }
+
+        let mut commands = Vec::new();
+        let mut layers = Vec::new();
+        layered.drain_into(&mut commands, &mut layers);
+
+        layers
+            .iter()
+            .map(|layer| {
+                [&layer.shapes, &layer.images, &layer.text, &layer.overlay]
+                    .iter()
+                    .flat_map(|range| commands[(*range).clone()].iter().map(|c| c.layer))
+                    .collect()
+            })
+            .collect()
+    }
+
+    use RenderLayer::{Images, Overlay, Shapes, Text};
+
+    #[test]
+    fn ascending_layers_stay_in_one_group() {
+        // The common case: nothing is painted over a higher layer, so the
+        // whole frame batches exactly as it did before groups existed.
+        assert_eq!(
+            groups(&[Shapes, Shapes, Images, Text, Overlay]),
+            vec![vec![Shapes, Shapes, Images, Text, Overlay]]
+        );
+    }
+
+    #[test]
+    fn a_shape_after_an_image_opens_a_group() {
+        // The bug groups exist to fix: a container background painted over an
+        // image must not be batched back underneath it.
+        assert_eq!(
+            groups(&[Shapes, Images, Shapes]),
+            vec![vec![Shapes, Images], vec![Shapes]]
+        );
+    }
+
+    #[test]
+    fn an_image_after_text_opens_a_group() {
+        assert_eq!(
+            groups(&[Images, Text, Images]),
+            vec![vec![Images, Text], vec![Images]]
+        );
+    }
+
+    #[test]
+    fn repeats_of_the_current_layer_do_not_split() {
+        assert_eq!(
+            groups(&[Images, Images, Images]),
+            vec![vec![Images, Images, Images]]
+        );
+    }
+
+    #[test]
+    fn each_regression_opens_exactly_one_group() {
+        assert_eq!(
+            groups(&[Shapes, Images, Shapes, Images, Shapes]),
+            vec![vec![Shapes, Images], vec![Shapes, Images], vec![Shapes]]
+        );
+    }
+
+    #[test]
+    fn a_group_is_reopened_only_below_its_high_water_mark() {
+        // Text lifts the group's mark to 2, so the following image regresses
+        // even though it is above the shapes already in the group.
+        assert_eq!(
+            groups(&[Shapes, Text, Images]),
+            vec![vec![Shapes, Text], vec![Images]]
+        );
+    }
+
+    #[test]
+    fn replaying_a_cached_subtree_reproduces_its_grouping() {
+        // `commands_since` feeds cached commands back through `push` on later
+        // frames. If it did not hand them back in draw order, a cached subtree
+        // would re-group differently from the one that produced it — the same
+        // widget would draw correctly on the frame it was painted and wrongly
+        // on every frame it was reused.
+        let sequence = [Shapes, Images, Shapes, Text, Images];
+
+        let mut original = LayeredCommands::new();
+        for layer in sequence {
+            original.push(command(layer));
+        }
+        let cached = original.commands_since(0);
+
+        let mut replayed = LayeredCommands::new();
+        for cmd in cached {
+            replayed.push(cmd);
+        }
+
+        let (mut a_cmds, mut a_layers) = (Vec::new(), Vec::new());
+        original.drain_into(&mut a_cmds, &mut a_layers);
+        let (mut b_cmds, mut b_layers) = (Vec::new(), Vec::new());
+        replayed.drain_into(&mut b_cmds, &mut b_layers);
+
+        assert_eq!(a_layers.len(), b_layers.len());
+        let order = |cmds: &[FlattenedCommand], layers: &[CommandLayer]| -> Vec<RenderLayer> {
+            layers
+                .iter()
+                .flat_map(|l| {
+                    [&l.shapes, &l.images, &l.text, &l.overlay]
+                        .iter()
+                        .flat_map(|r| cmds[(*r).clone()].iter().map(|c| c.layer))
+                        .collect::<Vec<_>>()
+                })
+                .collect()
+        };
+        assert_eq!(order(&a_cmds, &a_layers), order(&b_cmds, &b_layers));
+    }
+
+    #[test]
+    fn empty_groups_are_dropped() {
+        // A group that ends up with nothing in it would cost pipeline
+        // switches for no draws.
+        let mut layered = LayeredCommands::new();
+        layered.push(command(Images));
+        layered.push(command(Shapes));
+        let mut commands = Vec::new();
+        let mut layers = Vec::new();
+        layered.drain_into(&mut commands, &mut layers);
+        assert!(layers.iter().all(|layer| !layer.is_empty()));
     }
 }

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -26,7 +26,7 @@ mod tree;
 mod types;
 
 pub use commands::{Border, CornerRadii, DrawCommand};
-pub use flatten::{FlattenedCommand, LayerBoundaries, flatten_root_into};
+pub use flatten::{CommandLayer, FlattenedCommand, flatten_root_into};
 pub use gpu_context::{GpuContext, SurfaceState};
 pub use paint_context::PaintContext;
 pub use render::Renderer;

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -10,6 +10,7 @@
 //! - World transforms are computed automatically by walking the tree during flatten
 //! - Overlays (like ripples) naturally render after children
 
+mod backdrop_pass;
 mod commands;
 mod constants;
 mod flatten;

--- a/src/renderer/paint_context.rs
+++ b/src/renderer/paint_context.rs
@@ -321,6 +321,24 @@ impl<'a> PaintContext<'a> {
     }
 
     /// Draw a circle in local coordinates.
+    /// Blur whatever is already drawn beneath `rect`, masked to its rounded
+    /// shape. Emitted before the container's own background so it paints over
+    /// its blurred backdrop.
+    pub fn draw_backdrop_blur(
+        &mut self,
+        rect: Rect,
+        radius: f32,
+        corner_radii: impl Into<CornerRadii>,
+        curvature: f32,
+    ) {
+        self.node.commands.push(Rc::new(DrawCommand::BackdropBlur {
+            rect,
+            radius,
+            corner_radii: corner_radii.into(),
+            curvature,
+        }));
+    }
+
     pub fn draw_circle(&mut self, cx: f32, cy: f32, radius: f32, color: Color) {
         self.node.commands.push(Rc::new(DrawCommand::Circle {
             center: (cx, cy),

--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -11,7 +11,7 @@ use wgpu::{
 };
 
 use super::commands::DrawCommand;
-use super::flatten::FlattenedCommand;
+use super::flatten::{CommandLayer, FlattenedCommand};
 use super::gpu::{QUAD_INDICES, QUAD_VERTICES, QuadVertex, ShaderUniforms, ShapeInstance};
 use super::gpu_context::SurfaceState;
 use super::image_quad::{ImageQuadRenderer, PreparedImageQuad};
@@ -53,9 +53,11 @@ pub struct Renderer {
     image_quad_renderer: ImageQuadRenderer,
 
     // Reusable per-frame buffers (cleared and reused each frame to avoid allocations)
+    /// Every group's shape and overlay instances, addressed by range.
     shape_instance_buf: Vec<ShapeInstance>,
-    overlay_instance_buf: Vec<ShapeInstance>,
     text_entry_buf: Vec<TextEntry>,
+    image_quads: Vec<PreparedImageQuad>,
+    text_quads: Vec<PreparedTextQuad>,
 
     // Screen dimensions
     screen_width: f32,
@@ -155,8 +157,9 @@ impl Renderer {
             text_quad_renderer,
             image_quad_renderer,
             shape_instance_buf: Vec::new(),
-            overlay_instance_buf: Vec::new(),
             text_entry_buf: Vec::new(),
+            image_quads: Vec::new(),
+            text_quads: Vec::new(),
             screen_width: 800.0,
             screen_height: 600.0,
             scale_factor: 1.0,
@@ -258,7 +261,7 @@ impl Renderer {
         &mut self,
         surface: &mut SurfaceState,
         commands: &[FlattenedCommand],
-        boundaries: super::flatten::LayerBoundaries,
+        layers: &[CommandLayer],
         clear_color: Color,
     ) -> bool {
         let output = match surface.surface.get_current_texture() {
@@ -287,89 +290,18 @@ impl Renderer {
         self.queue
             .write_buffer(&self.uniform_buffer, 0, bytemuck::cast_slice(&[uniforms]));
 
-        // Commands are pre-sorted by layer via LayeredCommands bucketing.
-        // Use pre-computed boundaries instead of partition_point scans.
-        let images_start = boundaries.images_start;
-        let text_start = boundaries.text_start;
-        let overlay_start = boundaries.overlay_start;
+        let prepared = self.prepare_layers(commands, layers);
 
-        let shape_commands = &commands[..images_start];
-        let image_commands = &commands[images_start..text_start];
-        let text_commands = &commands[text_start..overlay_start];
-        let overlay_commands = &commands[overlay_start..];
-
-        // Convert shape commands to instances (reuse buffers)
-        let scale = self.scale_factor;
-        self.shape_instance_buf.clear();
-        self.shape_instance_buf.extend(
-            shape_commands
-                .iter()
-                .filter_map(|c| command_to_instance(c, scale)),
-        );
-        self.overlay_instance_buf.clear();
-        self.overlay_instance_buf.extend(
-            overlay_commands
-                .iter()
-                .filter_map(|c| command_to_instance(c, scale)),
-        );
-
-        // Convert text commands to TextEntry for text rendering (reuse buffer)
-        self.text_entry_buf.clear();
-        self.text_entry_buf
-            .extend(text_commands.iter().filter_map(command_to_text_entry));
-
-        // Prepare regular text and get indices of texts that need texture-based rendering
-        let transformed_indices = if !self.text_entry_buf.is_empty() {
-            self.text_state.prepare_text(
-                &self.device,
-                &self.queue,
-                &self.text_entry_buf,
-                self.screen_width as u32,
-                self.screen_height as u32,
-                self.scale_factor,
-            )
-        } else {
-            Vec::new()
-        };
-
-        // Prepare transformed text as textured quads
-        let text_quads: Vec<PreparedTextQuad> = if !transformed_indices.is_empty() {
-            log::debug!(
-                "Renderer: {} transformed texts to render as quads",
-                transformed_indices.len()
+        // Instances for every group live in one buffer; the groups address it
+        // by range, which is what keeps their draws in order.
+        self.ensure_instance_capacity(self.shape_instance_buf.len());
+        if !self.shape_instance_buf.is_empty() {
+            self.queue.write_buffer(
+                &self.instance_buffer,
+                0,
+                bytemuck::cast_slice(&self.shape_instance_buf),
             );
-            // Update text quad renderer screen size
-            self.text_quad_renderer
-                .set_screen_size(self.screen_width, self.screen_height);
-            self.text_quad_renderer.prepare(
-                &self.device,
-                &self.queue,
-                &self.text_entry_buf,
-                &transformed_indices,
-                self.scale_factor,
-            )
-        } else {
-            Vec::new()
-        };
-
-        // Prepare image quads
-        self.image_quad_renderer.begin_frame();
-        let image_quads: Vec<PreparedImageQuad> = if !image_commands.is_empty() {
-            self.image_quad_renderer
-                .set_screen_size(self.screen_width, self.screen_height);
-            self.image_quad_renderer.prepare(
-                &self.device,
-                &self.queue,
-                image_commands,
-                self.scale_factor,
-            )
-        } else {
-            Vec::new()
-        };
-
-        // Ensure we have enough capacity
-        let total_instances = self.shape_instance_buf.len() + self.overlay_instance_buf.len();
-        self.ensure_instance_capacity(total_instances);
+        }
 
         let mut encoder = self
             .device
@@ -400,71 +332,33 @@ impl Renderer {
                 multiview_mask: None,
             });
 
-            render_pass.set_pipeline(&self.pipeline);
-            render_pass.set_bind_group(0, &self.uniform_bind_group, &[]);
-            render_pass.set_vertex_buffer(0, self.vertex_buffer.slice(..));
-            render_pass.set_index_buffer(self.index_buffer.slice(..), wgpu::IndexFormat::Uint16);
+            // Groups are drawn in order; within a group, bucket order. The
+            // shape pipeline is re-bound per draw because the image and text
+            // renderers replace it.
+            for layer in &prepared {
+                if !layer.shapes.is_empty() {
+                    self.bind_shape_pipeline(&mut render_pass);
+                    render_pass.draw_indexed(0..6, 0, layer.shapes.clone());
+                }
 
-            // Draw shapes (background layer)
-            if !self.shape_instance_buf.is_empty() {
-                self.queue.write_buffer(
-                    &self.instance_buffer,
-                    0,
-                    bytemuck::cast_slice(&self.shape_instance_buf),
-                );
-                render_pass.set_vertex_buffer(1, self.instance_buffer.slice(..));
-                render_pass.draw_indexed(0..6, 0, 0..self.shape_instance_buf.len() as u32);
-            }
+                if !layer.images.is_empty() {
+                    self.image_quad_renderer
+                        .render(&mut render_pass, &self.image_quads[layer.images.clone()]);
+                }
 
-            // Draw images (after shapes, before text)
-            if !image_quads.is_empty() {
-                self.image_quad_renderer
-                    .render(&mut render_pass, &image_quads);
-            }
+                if let Some(slot) = layer.text_slot {
+                    self.text_state.render_slot(slot, &mut render_pass);
+                }
 
-            // Draw text layer (between images and overlay)
-            // Only render non-transformed text via glyphon
-            let has_non_transformed_text = !self.text_entry_buf.is_empty()
-                && transformed_indices.len() < self.text_entry_buf.len();
-            if has_non_transformed_text {
-                self.text_state.render(&mut render_pass, &self.device);
-            }
+                if !layer.text_quads.is_empty() {
+                    self.text_quad_renderer
+                        .render(&mut render_pass, &self.text_quads[layer.text_quads.clone()]);
+                }
 
-            // Draw transformed text as textured quads
-            if !text_quads.is_empty() {
-                log::debug!("Renderer: Rendering {} text quads", text_quads.len());
-                self.text_quad_renderer
-                    .render(&mut render_pass, &text_quads);
-            }
-
-            // Draw overlay shapes (after text, for effects like ripples)
-            if !self.overlay_instance_buf.is_empty() {
-                // Re-set the shape pipeline (text/image renderers may have changed it)
-                render_pass.set_pipeline(&self.pipeline);
-                render_pass.set_bind_group(0, &self.uniform_bind_group, &[]);
-                render_pass.set_vertex_buffer(0, self.vertex_buffer.slice(..));
-                render_pass
-                    .set_index_buffer(self.index_buffer.slice(..), wgpu::IndexFormat::Uint16);
-
-                // Write overlay instances after shape instances
-                let offset =
-                    (self.shape_instance_buf.len() * std::mem::size_of::<ShapeInstance>()) as u64;
-                self.queue.write_buffer(
-                    &self.instance_buffer,
-                    offset,
-                    bytemuck::cast_slice(&self.overlay_instance_buf),
-                );
-                render_pass.set_vertex_buffer(
-                    1,
-                    self.instance_buffer.slice(
-                        offset
-                            ..offset
-                                + (self.overlay_instance_buf.len()
-                                    * std::mem::size_of::<ShapeInstance>())
-                                    as u64,
-                    ),
-                );
-                render_pass.draw_indexed(0..6, 0, 0..self.overlay_instance_buf.len() as u32);
+                if !layer.overlay.is_empty() {
+                    self.bind_shape_pipeline(&mut render_pass);
+                    render_pass.draw_indexed(0..6, 0, layer.overlay.clone());
+                }
             }
         }
 
@@ -472,6 +366,130 @@ impl Renderer {
         output.present();
         true
     }
+
+    fn bind_shape_pipeline(&self, pass: &mut wgpu::RenderPass<'_>) {
+        pass.set_pipeline(&self.pipeline);
+        pass.set_bind_group(0, &self.uniform_bind_group, &[]);
+        pass.set_vertex_buffer(0, self.vertex_buffer.slice(..));
+        pass.set_vertex_buffer(1, self.instance_buffer.slice(..));
+        pass.set_index_buffer(self.index_buffer.slice(..), wgpu::IndexFormat::Uint16);
+    }
+
+    /// Resolve every group's GPU work before the pass opens.
+    ///
+    /// Uploads cannot happen inside a render pass, so all shaping, atlas
+    /// packing and buffer writes are done here and the pass only issues draws.
+    fn prepare_layers(
+        &mut self,
+        commands: &[FlattenedCommand],
+        layers: &[CommandLayer],
+    ) -> Vec<PreparedLayer> {
+        let scale = self.scale_factor;
+
+        self.shape_instance_buf.clear();
+        self.image_quads.clear();
+        self.text_quads.clear();
+        self.image_quad_renderer.begin_frame();
+        self.text_state.begin_frame();
+
+        let mut prepared = Vec::with_capacity(layers.len());
+        // Each group with directly-rendered text needs its own glyphon
+        // renderer, so slots are handed out only to groups that have some.
+        let mut next_text_slot = 0;
+
+        for layer in layers {
+            let shapes_start = self.shape_instance_buf.len() as u32;
+            self.shape_instance_buf.extend(
+                commands[layer.shapes.clone()]
+                    .iter()
+                    .filter_map(|c| command_to_instance(c, scale)),
+            );
+            let shapes = shapes_start..self.shape_instance_buf.len() as u32;
+
+            let images_start = self.image_quads.len();
+            if !layer.images.is_empty() {
+                self.image_quad_renderer
+                    .set_screen_size(self.screen_width, self.screen_height);
+                let quads = self.image_quad_renderer.prepare(
+                    &self.device,
+                    &self.queue,
+                    &commands[layer.images.clone()],
+                    scale,
+                );
+                self.image_quads.extend(quads);
+            }
+            let images = images_start..self.image_quads.len();
+
+            self.text_entry_buf.clear();
+            self.text_entry_buf.extend(
+                commands[layer.text.clone()]
+                    .iter()
+                    .filter_map(command_to_text_entry),
+            );
+            let text_quads_start = self.text_quads.len();
+            let mut text_slot = None;
+            if !self.text_entry_buf.is_empty() {
+                let slot = next_text_slot;
+                next_text_slot += 1;
+                let transformed = self.text_state.prepare_layer(
+                    slot,
+                    &self.device,
+                    &self.queue,
+                    &self.text_entry_buf,
+                    (self.screen_width as u32, self.screen_height as u32),
+                    scale,
+                );
+                // Rotated and scaled text goes through the textured-quad path
+                // instead, to keep the glyphon atlas stable.
+                if transformed.len() < self.text_entry_buf.len() {
+                    text_slot = Some(slot);
+                }
+                if !transformed.is_empty() {
+                    self.text_quad_renderer
+                        .set_screen_size(self.screen_width, self.screen_height);
+                    let quads = self.text_quad_renderer.prepare(
+                        &self.device,
+                        &self.queue,
+                        &self.text_entry_buf,
+                        &transformed,
+                        scale,
+                    );
+                    self.text_quads.extend(quads);
+                }
+            }
+            let text_quads = text_quads_start..self.text_quads.len();
+
+            let overlay_start = self.shape_instance_buf.len() as u32;
+            self.shape_instance_buf.extend(
+                commands[layer.overlay.clone()]
+                    .iter()
+                    .filter_map(|c| command_to_instance(c, scale)),
+            );
+            let overlay = overlay_start..self.shape_instance_buf.len() as u32;
+
+            prepared.push(PreparedLayer {
+                shapes,
+                images,
+                text_slot,
+                text_quads,
+                overlay,
+            });
+        }
+
+        self.text_state.end_frame();
+        prepared
+    }
+}
+
+/// One draw group's GPU work, addressed by range into the renderer's
+/// per-frame buffers.
+struct PreparedLayer {
+    shapes: std::ops::Range<u32>,
+    images: std::ops::Range<usize>,
+    /// Glyphon renderer holding this group's directly-rendered text.
+    text_slot: Option<usize>,
+    text_quads: std::ops::Range<usize>,
+    overlay: std::ops::Range<u32>,
 }
 
 /// Convert a single flattened command to a shape instance.

--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -10,6 +10,7 @@ use wgpu::{
     BindGroup, BindGroupLayout, Buffer, BufferUsages, Device, Queue, RenderPipeline, ShaderModule,
 };
 
+use super::backdrop_pass::{BackdropRegion, BackdropRenderer};
 use super::commands::DrawCommand;
 use super::flatten::{CommandLayer, FlattenedCommand};
 use super::gpu::{QUAD_INDICES, QUAD_VERTICES, QuadVertex, ShaderUniforms, ShapeInstance};
@@ -18,7 +19,7 @@ use super::image_quad::{ImageQuadRenderer, PreparedImageQuad};
 use super::text::TextRenderState;
 use super::text_quad::{PreparedTextQuad, TextQuadRenderer};
 use super::types::TextEntry;
-use crate::widgets::Color;
+use crate::widgets::{Color, Rect};
 
 /// The renderer using instanced rendering.
 ///
@@ -58,6 +59,7 @@ pub struct Renderer {
     text_entry_buf: Vec<TextEntry>,
     image_quads: Vec<PreparedImageQuad>,
     text_quads: Vec<PreparedTextQuad>,
+    backdrop: BackdropRenderer,
 
     // Screen dimensions
     screen_width: f32,
@@ -142,6 +144,8 @@ impl Renderer {
         // Initialize image renderer
         let image_quad_renderer = ImageQuadRenderer::new(&device, format);
 
+        let backdrop = BackdropRenderer::new(&device, format);
+
         Self {
             device,
             queue,
@@ -160,6 +164,7 @@ impl Renderer {
             text_entry_buf: Vec::new(),
             image_quads: Vec::new(),
             text_quads: Vec::new(),
+            backdrop,
             screen_width: 800.0,
             screen_height: 600.0,
             scale_factor: 1.0,
@@ -292,6 +297,21 @@ impl Renderer {
 
         let prepared = self.prepare_layers(commands, layers);
 
+        // A backdrop effect reads pixels already drawn, which a pass cannot do
+        // to its own attachment: the frame goes to an offscreen target and is
+        // blitted over at the end. Frames without one draw straight to the
+        // swapchain and never allocate it.
+        let uses_backdrop = layers.iter().any(|layer| !layer.backdrop.is_empty());
+        if uses_backdrop {
+            self.backdrop.ensure_targets(
+                &self.device,
+                surface.width().max(1),
+                surface.height().max(1),
+            );
+        } else {
+            self.backdrop.note_unused();
+        }
+
         // Instances for every group live in one buffer; the groups address it
         // by range, which is what keeps their draws in order.
         self.ensure_instance_capacity(self.shape_instance_buf.len());
@@ -309,33 +329,37 @@ impl Renderer {
                 label: Some("Renderer Encoder"),
             });
 
+        let scene_view = uses_backdrop.then(|| self.backdrop.scene_view()).flatten();
+        let target = scene_view.unwrap_or(&view);
+
+        let scale = self.scale_factor;
         {
-            let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                label: Some("Renderer Render Pass"),
-                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                    view: &view,
-                    resolve_target: None,
-                    ops: wgpu::Operations {
-                        load: wgpu::LoadOp::Clear(wgpu::Color {
-                            r: clear_color.r as f64,
-                            g: clear_color.g as f64,
-                            b: clear_color.b as f64,
-                            a: clear_color.a as f64,
-                        }),
-                        store: wgpu::StoreOp::Store,
-                    },
-                    depth_slice: None,
-                })],
-                depth_stencil_attachment: None,
-                timestamp_writes: None,
-                occlusion_query_set: None,
-                multiview_mask: None,
+            let clear = wgpu::LoadOp::Clear(wgpu::Color {
+                r: clear_color.r as f64,
+                g: clear_color.g as f64,
+                b: clear_color.b as f64,
+                a: clear_color.a as f64,
             });
+            let mut load = clear;
+            let mut render_pass = begin_pass(&mut encoder, target, load);
+            load = wgpu::LoadOp::Load;
 
             // Groups are drawn in order; within a group, bucket order. The
             // shape pipeline is re-bound per draw because the image and text
             // renderers replace it.
-            for layer in &prepared {
+            for (index, layer) in prepared.iter().enumerate() {
+                if !layers[index].backdrop.is_empty() {
+                    // The effect samples the target, so the pass has to end
+                    // and its contents be stored before it can run.
+                    drop(render_pass);
+                    for command in &commands[layers[index].backdrop.clone()] {
+                        if let Some(region) = command_to_backdrop_region(command, scale) {
+                            self.backdrop.apply(&self.device, &mut encoder, &region);
+                        }
+                    }
+                    render_pass = begin_pass(&mut encoder, target, load);
+                }
+
                 if !layer.shapes.is_empty() {
                     self.bind_shape_pipeline(&mut render_pass);
                     render_pass.draw_indexed(0..6, 0, layer.shapes.clone());
@@ -360,6 +384,10 @@ impl Renderer {
                     render_pass.draw_indexed(0..6, 0, layer.overlay.clone());
                 }
             }
+        }
+
+        if uses_backdrop {
+            self.backdrop.present(&self.device, &mut encoder, &view);
         }
 
         self.queue.submit(std::iter::once(encoder.finish()));
@@ -492,6 +520,78 @@ struct PreparedLayer {
     overlay: std::ops::Range<u32>,
 }
 
+/// Open a colour-only render pass over `target`.
+fn begin_pass<'a>(
+    encoder: &'a mut wgpu::CommandEncoder,
+    target: &'a wgpu::TextureView,
+    load: wgpu::LoadOp<wgpu::Color>,
+) -> wgpu::RenderPass<'a> {
+    encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+        label: Some("Renderer Render Pass"),
+        color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+            view: target,
+            resolve_target: None,
+            ops: wgpu::Operations {
+                load,
+                store: wgpu::StoreOp::Store,
+            },
+            depth_slice: None,
+        })],
+        depth_stencil_attachment: None,
+        timestamp_writes: None,
+        occlusion_query_set: None,
+        multiview_mask: None,
+    })
+}
+
+/// Resolve a backdrop command to the physical-pixel region it filters.
+fn command_to_backdrop_region(cmd: &FlattenedCommand, scale: f32) -> Option<BackdropRegion> {
+    let DrawCommand::BackdropBlur {
+        rect,
+        radius,
+        corner_radii,
+        curvature,
+    } = &*cmd.command
+    else {
+        return None;
+    };
+
+    // The effect works on axis-aligned pixels, so a rotated container gets the
+    // bounding box of its rotated rect — the mask still cuts the right shape
+    // out of it for the common translation-only case.
+    let corners = [
+        cmd.world_transform.transform_point(rect.x, rect.y),
+        cmd.world_transform
+            .transform_point(rect.x + rect.width, rect.y),
+        cmd.world_transform
+            .transform_point(rect.x, rect.y + rect.height),
+        cmd.world_transform
+            .transform_point(rect.x + rect.width, rect.y + rect.height),
+    ];
+    let min_x = corners.iter().map(|c| c.0).fold(f32::INFINITY, f32::min);
+    let max_x = corners
+        .iter()
+        .map(|c| c.0)
+        .fold(f32::NEG_INFINITY, f32::max);
+    let min_y = corners.iter().map(|c| c.1).fold(f32::INFINITY, f32::min);
+    let max_y = corners
+        .iter()
+        .map(|c| c.1)
+        .fold(f32::NEG_INFINITY, f32::max);
+
+    Some(BackdropRegion {
+        rect: Rect::new(
+            min_x * scale,
+            min_y * scale,
+            (max_x - min_x) * scale,
+            (max_y - min_y) * scale,
+        ),
+        radius: radius * scale,
+        radii: corner_radii.scaled(scale),
+        curvature: *curvature,
+    })
+}
+
 /// Convert a single flattened command to a shape instance.
 fn command_to_instance(cmd: &FlattenedCommand, scale: f32) -> Option<ShapeInstance> {
     match &*cmd.command {
@@ -558,6 +658,9 @@ fn command_to_instance(cmd: &FlattenedCommand, scale: f32) -> Option<ShapeInstan
         }
         // Text commands are handled separately via command_to_text_entry
         DrawCommand::Text { .. } => None,
+        // Filters the target rather than adding geometry; handled between
+        // draw groups, not as an instance.
+        DrawCommand::BackdropBlur { .. } => None,
         // Image commands are handled separately via ImageQuadRenderer
         DrawCommand::Image { .. } => None,
     }

--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -418,7 +418,10 @@ impl Renderer {
         self.image_quads.clear();
         self.text_quads.clear();
         self.image_quad_renderer.begin_frame();
-        self.text_state.begin_frame();
+        self.text_state.begin_frame(
+            &self.queue,
+            (self.screen_width as u32, self.screen_height as u32),
+        );
 
         let mut prepared = Vec::with_capacity(layers.len());
         // Each group with directly-rendered text needs its own glyphon

--- a/src/renderer/text.rs
+++ b/src/renderer/text.rs
@@ -34,7 +34,13 @@ pub struct TextRenderState {
     #[allow(dead_code)] // Used for viewport and atlas construction
     cache: Cache,
     atlas: TextAtlas,
-    text_renderer: TextRenderer,
+    /// One renderer per draw group that contains text.
+    ///
+    /// glyphon draws everything a `TextRenderer` prepared in a single call,
+    /// so text that must appear between two other groups needs a renderer of
+    /// its own. Grown on demand and reused across frames; a UI with one group
+    /// keeps exactly one, as before.
+    text_renderers: Vec<TextRenderer>,
     buffers: Vec<Buffer>,
     viewport: Viewport,
     /// Cache of shaped text buffers from the previous frame, keyed by
@@ -69,7 +75,7 @@ impl TextRenderState {
             swash_cache,
             cache,
             atlas,
-            text_renderer,
+            text_renderers: vec![text_renderer],
             buffers: Vec::new(),
             viewport,
             buffer_cache: HashMap::new(),
@@ -77,21 +83,48 @@ impl TextRenderState {
         }
     }
 
-    /// Prepare non-transformed text for rendering directly to screen.
-    /// Returns a list of indices of texts that have transforms and need special handling.
-    pub fn prepare_text(
-        &mut self,
-        device: &Device,
-        queue: &Queue,
-        texts: &[TextEntry],
-        screen_width: u32,
-        screen_height: u32,
-        scale_factor: f32,
-    ) -> Vec<usize> {
-        // Move last frame's buffers into cache for reuse
+    /// Start a frame: recycle last frame's shaped buffers into the cache.
+    ///
+    /// Split out of [`prepare_layer`](Self::prepare_layer) because a frame may
+    /// prepare several groups and the recycling has to happen once for all.
+    pub fn begin_frame(&mut self) {
         for (key, buffer) in self.frame_keys.drain(..).zip(self.buffers.drain(..)) {
             self.buffer_cache.entry(key).or_default().push(buffer);
         }
+    }
+
+    /// Drop shaped buffers no group asked for. Call once every group has been
+    /// prepared — whatever is still cached went unused this frame.
+    pub fn end_frame(&mut self) {
+        self.buffer_cache.clear();
+    }
+
+    /// Prepare one draw group's non-transformed text.
+    ///
+    /// `slot` selects the renderer, and with it when this text lands relative
+    /// to the other groups; see [`render_slot`](Self::render_slot).
+    /// Returns the indices, within `texts`, that need the textured-quad path.
+    pub fn prepare_layer(
+        &mut self,
+        slot: usize,
+        device: &Device,
+        queue: &Queue,
+        texts: &[TextEntry],
+        screen: (u32, u32),
+        scale_factor: f32,
+    ) -> Vec<usize> {
+        let (screen_width, screen_height) = screen;
+        while self.text_renderers.len() <= slot {
+            self.text_renderers.push(TextRenderer::new(
+                &mut self.atlas,
+                device,
+                MultisampleState::default(),
+                None,
+            ));
+        }
+        // Buffers accumulate across the frame's groups; this is where this
+        // group's own shaped buffers begin.
+        let buffers_start = self.buffers.len();
 
         // Collect indices of texts that have non-trivial transforms (for texture-based rendering)
         let mut transformed_indices = Vec::new();
@@ -188,9 +221,6 @@ impl TextRenderState {
             self.buffers.push(buffer);
         }
 
-        // Evict unused cache entries (anything still in buffer_cache was not used this frame)
-        self.buffer_cache.clear();
-
         // Filter to only non-transformed, non-culled texts for TextArea creation
         // Use HashSet for O(1) lookup instead of Vec::contains which is O(n)
         let transformed_set: HashSet<_> = transformed_indices.iter().copied().collect();
@@ -201,9 +231,21 @@ impl TextRenderState {
             .map(|(_, entry)| entry)
             .collect();
 
+        // Destructured so the text areas can borrow the buffers immutably
+        // while `prepare` takes the font system and atlas mutably.
+        let Self {
+            font_system,
+            swash_cache,
+            atlas,
+            viewport,
+            buffers,
+            text_renderers,
+            ..
+        } = self;
+
         let text_areas: Vec<TextArea> = non_transformed_texts
             .iter()
-            .zip(self.buffers.iter())
+            .zip(buffers[buffers_start..].iter())
             .map(|(entry, buffer)| {
                 // Position text in world space using the full transform.
                 // This is consistent with the clip rect (also in world space via
@@ -252,7 +294,7 @@ impl TextRenderState {
             .collect();
 
         // Update viewport with current screen dimensions
-        self.viewport.update(
+        viewport.update(
             queue,
             Resolution {
                 width: screen_width,
@@ -260,14 +302,14 @@ impl TextRenderState {
             },
         );
 
-        let result = self.text_renderer.prepare(
+        let result = text_renderers[slot].prepare(
             device,
             queue,
-            &mut self.font_system,
-            &mut self.atlas,
-            &self.viewport,
+            font_system,
+            atlas,
+            viewport,
             text_areas,
-            &mut self.swash_cache,
+            swash_cache,
         );
 
         if let Err(e) = result {
@@ -277,9 +319,12 @@ impl TextRenderState {
         transformed_indices
     }
 
-    pub fn render<'a>(&'a self, pass: &mut wgpu::RenderPass<'a>, _device: &Device) {
-        self.text_renderer
-            .render(&self.atlas, &self.viewport, pass)
-            .expect("Failed to render text");
+    /// Draw the text prepared into `slot`.
+    pub fn render_slot<'a>(&'a self, slot: usize, pass: &mut wgpu::RenderPass<'a>) {
+        if let Some(renderer) = self.text_renderers.get(slot) {
+            renderer
+                .render(&self.atlas, &self.viewport, pass)
+                .expect("Failed to render text");
+        }
     }
 }

--- a/src/renderer/text.rs
+++ b/src/renderer/text.rs
@@ -87,10 +87,19 @@ impl TextRenderState {
     ///
     /// Split out of [`prepare_layer`](Self::prepare_layer) because a frame may
     /// prepare several groups and the recycling has to happen once for all.
-    pub fn begin_frame(&mut self) {
+    pub fn begin_frame(&mut self, queue: &Queue, screen: (u32, u32)) {
         for (key, buffer) in self.frame_keys.drain(..).zip(self.buffers.drain(..)) {
             self.buffer_cache.entry(key).or_default().push(buffer);
         }
+        // Once per frame, not once per group: every group renders into the
+        // same viewport.
+        self.viewport.update(
+            queue,
+            Resolution {
+                width: screen.0,
+                height: screen.1,
+            },
+        );
     }
 
     /// Drop shaped buffers no group asked for. Call once every group has been
@@ -292,15 +301,6 @@ impl TextRenderState {
                 }
             })
             .collect();
-
-        // Update viewport with current screen dimensions
-        viewport.update(
-            queue,
-            Resolution {
-                width: screen_width,
-                height: screen_height,
-            },
-        );
 
         let result = text_renderers[slot].prepare(
             device,

--- a/src/surface_manager.rs
+++ b/src/surface_manager.rs
@@ -10,7 +10,7 @@ use smithay_client_toolkit::reexports::client::Connection;
 use crate::layout::Constraints;
 use crate::platform::{WaylandState, WaylandWindowWrapper};
 use crate::reactive::owner::{OwnerId, dispose_owner_now};
-use crate::renderer::{FlattenedCommand, GpuContext, RenderNode, SurfaceState};
+use crate::renderer::{CommandLayer, FlattenedCommand, GpuContext, RenderNode, SurfaceState};
 use crate::surface::{SurfaceConfig, SurfaceId};
 use crate::tree::{Tree, WidgetId};
 use crate::widgets::Widget;
@@ -36,6 +36,8 @@ pub struct ManagedSurface {
     pub root_node: RenderNode,
     /// Flattened commands buffer (reused across frames to avoid allocation)
     pub flattened_commands: Vec<FlattenedCommand>,
+    /// Draw groups over `flattened_commands`, in draw order.
+    pub command_layers: Vec<CommandLayer>,
 }
 
 impl ManagedSurface {
@@ -65,6 +67,7 @@ impl ManagedSurface {
             previous_scale_factor: 1.0,
             root_node: RenderNode::new(widget_id.as_u64()),
             flattened_commands: Vec::new(),
+            command_layers: Vec::new(),
         }
     }
 

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -22,6 +22,7 @@ use std::rc::Rc;
 
 use crate::advance_anim;
 use crate::animation::TransitionConfig;
+use crate::backdrop::{BackdropBlur, BackdropSources};
 use crate::jobs::{JobRequest, JobType, RequiredJob, request_job};
 use crate::layout::{Constraints, Flex, Layout, Length, Size};
 use crate::reactive::{
@@ -253,8 +254,8 @@ pub struct Container {
     // Widget ref for reactive bounds tracking
     pub(super) widget_ref: Option<WidgetRef>,
 
-    // Compositor-side background blur (ext-background-effect-v1)
-    pub(super) background_blur: bool,
+    // Backdrop blur: this surface's own content, the compositor's, or both.
+    pub(super) backdrop_blur: Option<BackdropBlur>,
 
     // Animation state (boxed to save ~400 bytes per non-animated container)
     pub(super) anims: Option<Box<ContainerAnims>>,
@@ -287,7 +288,7 @@ impl Container {
             transform_origin: None,
             interaction: None,
             widget_ref: None,
-            background_blur: false,
+            backdrop_blur: None,
             anims: None,
             scroll_axis: ScrollAxis::None,
             scroll_data: None,
@@ -426,23 +427,29 @@ impl Container {
         self
     }
 
-    /// Blur the compositor background behind this container
-    /// (`ext-background-effect-v1`), shaped by its bounds and corner radius.
+    /// Blur what is already behind this container.
     ///
-    /// Pair it with a translucent [`background()`](Self::background) so the
-    /// blurred content shows through. No-ops when the compositor doesn't
-    /// support the protocol.
-    ///
-    /// # Example
+    /// Both backdrops are filtered: what this surface has already drawn, and
+    /// what the compositor composites below it where the surface is
+    /// translucent. Pair it with a translucent
+    /// [`background()`](Self::background) so the result shows through.
     ///
     /// ```ignore
     /// container()
-    ///     .background(Color::rgba(0.1, 0.1, 0.15, 0.6))
     ///     .corner_radius(16.0)
-    ///     .background_blur()
+    ///     .backdrop_blur(32.0)
+    ///     .background(Color::rgba(0.1, 0.1, 0.15, 0.6))
     /// ```
-    pub fn background_blur(mut self) -> Self {
-        self.background_blur = true;
+    ///
+    /// Restrict it with [`BackdropSources`] when only one side should soften.
+    /// The compositor side needs `ext-background-effect-v1` — check
+    /// [`compositor_effects()`](crate::compositor::compositor_effects) — and
+    /// carries no radius of its own; the compositor picks one.
+    ///
+    /// See [`crate::backdrop`] for why both are filtered rather than one
+    /// being chosen.
+    pub fn backdrop_blur(mut self, blur: impl Into<BackdropBlur>) -> Self {
+        self.backdrop_blur = Some(blur.into());
         self
     }
 
@@ -1169,9 +1176,12 @@ impl Widget for Container {
         });
         let corner_radius = corner_radius.max(corner_radii.max());
 
-        // Publish the blur region: bounds are read fresh from the tree at
-        // frame sync, so only the (possibly animated) radius is recorded.
-        if self.background_blur {
+        // Publish the compositor blur region: bounds are read fresh from the
+        // tree at frame sync, so only the (possibly animated) radius is
+        // recorded here.
+        if let Some(blur) = self.backdrop_blur
+            && blur.sources.contains(BackdropSources::COMPOSITOR)
+        {
             crate::blur::register_blur(id, corner_radius);
         }
 
@@ -1183,6 +1193,16 @@ impl Widget for Container {
         // Compose our own transform on top of the position the parent set.
         if !user_transform.is_identity() {
             ctx.apply_transform_with_origin(user_transform, transform_origin);
+        }
+
+        // Before the decoration: the container paints over its own blurred
+        // backdrop, and the effect must read a target that does not yet
+        // include this container.
+        if let Some(blur) = self.backdrop_blur
+            && blur.sources.contains(BackdropSources::SURFACE)
+            && blur.radius > 0.0
+        {
+            ctx.draw_backdrop_blur(local_bounds, blur.radius, corner_radii, corner_curvature);
         }
 
         self.paint_decoration(

--- a/tests/render_snapshots.rs
+++ b/tests/render_snapshots.rs
@@ -132,6 +132,23 @@ fn dump_node(node: &RenderNode, depth: usize, out: &mut String) {
 fn dump_command(cmd: &DrawCommand, depth: usize, kind: &str, out: &mut String) {
     let pad = "  ".repeat(depth);
     match cmd {
+        DrawCommand::BackdropBlur {
+            rect: r,
+            radius,
+            corner_radii,
+            curvature,
+        } => {
+            out.push_str(&format!(
+                "{pad}{kind} backdrop-blur {} radius={} corners={}/{}/{}/{} k={}\n",
+                rect(r),
+                n(*radius),
+                n(corner_radii.top_left),
+                n(corner_radii.top_right),
+                n(corner_radii.bottom_right),
+                n(corner_radii.bottom_left),
+                n(*curvature),
+            ));
+        }
         DrawCommand::RoundedRect {
             rect: r,
             color: c,


### PR DESCRIPTION
Three things, in the order they had to happen.

## Draw order

Commands were bucketed by kind for the whole frame, so every shape was
submitted before every image and every image before every text. The bucketing
is what lets commands of a kind share a draw call, but it also discarded the
tree's order across kinds: a container background painted over an image was
drawn underneath it, whatever the tree said. There was no way to express "tint
this photo" or "put a card over a wallpaper" — the decoration simply vanished.

Flattening now emits a sequence of draw groups, each keeping its own four
buckets, and the renderer walks them in order. glyphon draws everything a
`TextRenderer` prepared in a single call, so text needs one renderer per
group; they come from a pool that grows on demand.

A group only splits where a lower layer actually **covers** something above
it. That took two passes to get right, and the intermediate states are worth
seeing in the history:

- splitting on any backwards layer step fired between every pair of sibling
  widgets (each paints a background then a label), taking `showcase` to 16
  groups and 16 glyphon renderers a frame;
- testing against a per-layer union AABB was still too coarse — labels
  scattered across a panel union into a box spanning the gaps between them.

With the exact test, `showcase` and `status_bar` are one group each: the same
draw calls, the same single glyphon renderer, as before draw groups existed.
`examples/draw_order_example.rs` covers the regressions, and its panels are
built so that a wrong order makes the overlays disappear rather than degrade.

One bug fixed on the way, in `2fb3964`: once a group can take a shape while
already holding text, a later command is inserted *before* that text in draw
order, so the command count `commands_since` used as a boundary stopped being
a position. A cached subtree came back with its neighbour's commands attached
and drew it twice.

## Compositor effects

`compositor_effects()` reports the `ext-background-effect-v1` capability as a
signal. It was tracked in the platform layer and never surfaced, so an app
could not tell a compositor that blurs from one that ignores the request.

## Backdrop blur

`background_blur()` only ever asked the compositor to blur what it composites
*below* the surface. That is nothing at all for a session lock surface — the
protocol requires everything underneath to be blanked — and nothing useful for
a wallpaper the app drew itself.

`backdrop_blur(radius)` filters both backdrops. Not as a compromise: blur is
linear, so over a region of uniform alpha

```
blur(a·ours + (1−a)·theirs) = a·blur(ours) + (1−a)·blur(theirs)
```

and blurring each layer separately then compositing is exactly the same
result. Which is why neither is chosen over the other — a translucent panel is
neither "ours" nor "theirs" at any pixel, so a per-box choice could only be
right for some of them. `BackdropSources` restricts it when that is an
aesthetic decision rather than a guess.

The surface side needs to read pixels already drawn, which a pass cannot do to
its own attachment: with a backdrop present the frame goes to an offscreen
target, each region ends the pass, and the pass resumes with `LoadOp::Load`.
Regions are downsampled to a quarter, blurred with a separable gaussian and
composited back through the container's rounded-rect SDF. Frames without one
draw straight to the swapchain and allocate nothing.

Known limit, and not fixable here: where alpha varies within the radius the
two blurs do not bleed into one another. `set_blur_region` is fire-and-forget,
so the compositor's pixels are never ours to filter across.

## Checks

`cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`,
`cargo test --all-features` (334 passing, snapshots included) and
`cargo build --all-features` all pass locally. Book and `docs/RENDERER.md`
updated.

Verified on screen rather than only in tests: every panel of
`draw_order_example`, and a lock screen built against this branch.

## Prior art

iced solves the ordering half differently — its layers are cut by clip pushes
as well as by kind, so it needs a merge pass afterwards; here the split is
minimal by construction and no merge is needed. Neither vello nor floem offers
a backdrop filter (vello has an analytic blurred rounded rect, for shadows).
GTK4's GSK grew `COPY`/`PASTE`/`ISOLATION` nodes for the same reason the
offscreen target exists here: the backdrop has to be captured explicitly.
