### PR TITLE
Text style belongs on the container

### DIFF
--- a/book/src/advanced/background-threads.md
+++ b/book/src/advanced/background-threads.md
@@ -102,9 +102,9 @@ fn main() {
             .layout(Flex::column().spacing(8.0))
             .padding(16.0)
             .children([
-                text(move || format!("CPU: {:.1}%", cpu_usage.get())).color(Color::WHITE),
-                text(move || format!("Memory: {:.1}%", memory_usage.get())).color(Color::WHITE),
-                text(move || format!("Time: {}", time.get())).color(Color::WHITE),
+                container().text_color(Color::WHITE).child(text(move || format!("CPU: {:.1}%", cpu_usage.get()))),
+                container().text_color(Color::WHITE).child(text(move || format!("Memory: {:.1}%", memory_usage.get()))),
+                container().text_color(Color::WHITE).child(text(move || format!("Time: {}", time.get()))),
             ]);
 
         app.add_surface(
@@ -196,7 +196,7 @@ let _ = create_service::<(), _, _>(move |_rx, ctx| async move {
 
 let view = container()
     .padding(20.0)
-    .child(text(move || time.get()).font_size(48.0).color(Color::WHITE));
+    .child(container().font_size(48.0).text_color(Color::WHITE).child(text(move || time.get())));
 ```
 
 ## Reading UI State From a Task: `watch()`

--- a/book/src/advanced/components.md
+++ b/book/src/advanced/components.md
@@ -17,7 +17,7 @@ pub fn button(label: String) -> impl Widget {
         .corner_radius(6.0)
         .hover_state(|s| s.lighter(0.1))
         .pressed_state(|s| s.ripple())
-        .child(text(label).color(Color::WHITE))
+        .child(container().text_color(Color::WHITE).child(text(label)))
 }
 ```
 
@@ -62,7 +62,7 @@ pub fn button(
     container()
         .padding(padding)
         .background(background)
-        .child(text(label).color(Color::WHITE))
+        .child(container().text_color(Color::WHITE).child(text(label)))
 }
 ```
 
@@ -183,7 +183,7 @@ pub fn card(
         .background(Color::rgb(0.18, 0.18, 0.22))
         .corner_radius(8.0)
         .layout(Flex::column().spacing(8.0))
-        .child(text(title).font_size(18.0).color(Color::WHITE))
+        .child(container().font_size(18.0).text_color(Color::WHITE).child(text(title)))
         .children_source(children)
 }
 ```
@@ -268,7 +268,7 @@ pub fn button(
         .hover_state(|s| s.lighter(0.1))
         .pressed_state(|s| s.ripple())
         .on_click_option(on_click)
-        .child(text(label).color(Color::WHITE))
+        .child(container().text_color(Color::WHITE).child(text(label)))
 }
 
 #[component]
@@ -282,7 +282,7 @@ pub fn card(
         .background(background)
         .corner_radius(8.0)
         .layout(Flex::column().spacing(8.0))
-        .child(text(title).font_size(18.0).color(Color::WHITE))
+        .child(container().font_size(18.0).text_color(Color::WHITE).child(text(title)))
         .children_source(children)
 }
 
@@ -296,7 +296,7 @@ fn main() {
             .child(
                 card()
                     .title("Counter")
-                    .child(text(move || format!("Count: {}", count.get())).color(Color::WHITE))
+                    .child(container().text_color(Color::WHITE).child(text(move || format!("Count: {}", count.get()))))
                     .child(
                         container()
                             .layout(Flex::row().spacing(8.0))

--- a/book/src/advanced/dynamic-children.md
+++ b/book/src/advanced/dynamic-children.md
@@ -190,7 +190,7 @@ fn button(label: &str, on_click: impl Fn() + 'static) -> Container {
         .hover_state(|s| s.lighter(0.1))
         .pressed_state(|s| s.ripple())
         .on_click(on_click)
-        .child(text(label).color(Color::WHITE))
+        .child(container().text_color(Color::WHITE).child(text(label)))
 }
 ```
 
@@ -202,13 +202,13 @@ Combine static and dynamic children freely, in any order:
 container()
     .layout(Flex::column().spacing(8.0))
     // Static header
-    .child(text("Items:").font_size(18.0).color(Color::WHITE))
+    .child(container().font_size(18.0).text_color(Color::WHITE).child(text("Items:")))
     // Reactive middle
     .child(move || warning.get().then(|| warning_banner()))
     // Reactive keyed list
     .children(keyed(move || items.get(), |i| i.id, item_view))
     // Static footer
-    .child(text("End of list").color(Color::rgb(0.6, 0.6, 0.7)))
+    .child(container().text_color(Color::rgb(0.6, 0.6, 0.7)).child(text("End of list")))
 ```
 
 ## API Reference

--- a/book/src/advanced/wayland.md
+++ b/book/src/advanced/wayland.md
@@ -227,7 +227,7 @@ fn main() {
                             .corner_radius(8.0)
                             .hover_state(|s| s.lighter(0.1))
                             .on_click(move || count.update(|c| *c += 1))
-                            .child(text("+").color(Color::WHITE))
+                            .child(container().text_color(Color::WHITE).child(text("+")))
                     )
             },
         );
@@ -747,7 +747,7 @@ fn main() {
                     .padding(20.0)
                     .background(Color::rgb(0.15, 0.15, 0.2))
                     .corner_radius(12.0)
-                    .child(text("Notification").color(Color::WHITE))
+                    .child(container().text_color(Color::WHITE).child(text("Notification")))
             },
         );
     });

--- a/book/src/animations/springs.md
+++ b/book/src/animations/springs.md
@@ -153,7 +153,7 @@ fn spring_button() -> Container {
             // In real app: trigger action and reset
         })
 
-        .child(text("Spring!").color(Color::WHITE).font_size(18.0))
+        .child(container().text_color(Color::WHITE).font_size(18.0).child(text("Spring!")))
 }
 ```
 

--- a/book/src/animations/transitions.md
+++ b/book/src/animations/transitions.md
@@ -95,7 +95,7 @@ fn animated_card() -> Container {
             .elevation(2.0)
         )
 
-        .child(text("Hover me!").color(Color::WHITE))
+        .child(container().text_color(Color::WHITE).child(text("Hover me!")))
 }
 ```
 

--- a/book/src/building-ui/borders.md
+++ b/book/src/building-ui/borders.md
@@ -140,6 +140,6 @@ fn card_with_border() -> Container {
             .border(2.0, Color::rgb(0.4, 0.6, 0.9))
             .lighter(0.03)
         )
-        .child(text("Hover to see border change").color(Color::WHITE))
+        .child(container().text_color(Color::WHITE).child(text("Hover to see border change")))
 }
 ```

--- a/book/src/building-ui/elevation.md
+++ b/book/src/building-ui/elevation.md
@@ -72,8 +72,8 @@ fn elevated_card() -> Container {
         .pressed_state(|s| s.elevation(2.0).darker(0.05))
         .layout(Flex::column().spacing(8.0))
         .children([
-            text("Card Title").font_size(18.0).bold().color(Color::WHITE),
-            text("Card content goes here").color(Color::rgb(0.7, 0.7, 0.75)),
+            container().font_size(18.0).bold().text_color(Color::WHITE).child(text("Card Title")),
+            container().text_color(Color::rgb(0.7, 0.7, 0.75)).child(text("Card content goes here")),
         ])
 }
 ```

--- a/book/src/building-ui/styling.md
+++ b/book/src/building-ui/styling.md
@@ -155,13 +155,8 @@ fn styled_card(title: &str, content: &str) -> Container {
 
         // Children
         .children([
-            text(title)
-                .font_size(18.0)
-                .bold()
-                .color(Color::WHITE),
-            text(content)
-                .font_size(14.0)
-                .color(Color::rgb(0.7, 0.7, 0.75)),
+            container().font_size(18.0).bold().text_color(Color::WHITE).child(text(title)),
+            container().font_size(14.0).text_color(Color::rgb(0.7, 0.7, 0.75)).child(text(content)),
         ])
 }
 ```

--- a/book/src/building-ui/text-input.md
+++ b/book/src/building-ui/text-input.md
@@ -21,57 +21,48 @@ No manual synchronization is needed - just pass a `Signal<String>` and the bindi
 ### Text Color
 
 ```rust
-text_input(value)
-    .text_color(Color::WHITE)
+container().text_color(Color::WHITE).child(text_input(value))
 ```
 
 ### Cursor Color
 
 ```rust
-text_input(value)
-    .cursor_color(Color::rgb(0.4, 0.8, 1.0))
+container().cursor_color(Color::rgb(0.4, 0.8, 1.0)).child(text_input(value))
 ```
 
 ### Selection Color
 
 ```rust
-text_input(value)
-    .selection_color(Color::rgba(0.4, 0.6, 1.0, 0.4))
+container().selection_color(Color::rgba(0.4, 0.6, 1.0, 0.4)).child(text_input(value))
 ```
 
 ### Font Size
 
 ```rust
-text_input(value)
-    .font_size(16.0)
+container().font_size(16.0).child(text_input(value))
 ```
 
 ### Font Family
 
 ```rust
 // Predefined families
-text_input(value)
-    .font_family(FontFamily::Monospace)
+container().font_family(FontFamily::Monospace).child(text_input(value))
 
 // Shorthand for monospace
-text_input(value)
-    .mono()
+container().mono().child(text_input(value))
 
 // Custom font
-text_input(value)
-    .font_family(FontFamily::Name("JetBrains Mono".into()))
+container().font_family(FontFamily::Name("JetBrains Mono".into())).child(text_input(value))
 ```
 
 ### Font Weight
 
 ```rust
 // Using constants
-text_input(value)
-    .font_weight(FontWeight::BOLD)
+container().font_weight(FontWeight::BOLD).child(text_input(value))
 
 // Shorthand for bold
-text_input(value)
-    .bold()
+container().bold().child(text_input(value))
 ```
 
 ## Password Mode
@@ -145,9 +136,7 @@ container()
     .border(1.0, Color::rgb(0.3, 0.3, 0.4))
     .corner_radius(4.0)
     .child(
-        text_input(value)
-            .text_color(Color::WHITE)
-            .font_size(14.0)
+        container().text_color(Color::WHITE).font_size(14.0).child(text_input(value))
     )
 ```
 
@@ -163,8 +152,7 @@ container()
     .corner_radius(4.0)
     .focused_state(|s| s.border_color(Color::rgb(0.4, 0.6, 1.0)))
     .child(
-        text_input(value)
-            .text_color(Color::WHITE)
+        container().text_color(Color::WHITE).child(text_input(value))
     )
 ```
 
@@ -187,9 +175,7 @@ fn login_form() -> Container {
             container()
                 .layout(Flex::column().spacing(4.0))
                 .children([
-                    text("Username")
-                        .font_size(12.0)
-                        .color(Color::rgb(0.6, 0.6, 0.7)),
+                    container().font_size(12.0).text_color(Color::rgb(0.6, 0.6, 0.7)).child(text("Username")),
                     container()
                         .padding(Padding::horizontal(12.0).vertical(8.0))
                         .background(Color::rgb(0.15, 0.15, 0.2))
@@ -197,18 +183,14 @@ fn login_form() -> Container {
                         .corner_radius(4.0)
                         .focused_state(|s| s.border_color(Color::rgb(0.4, 0.6, 1.0)))
                         .child(
-                            text_input(username)
-                                .text_color(Color::WHITE)
-                                .font_size(14.0)
+                            container().text_color(Color::WHITE).font_size(14.0).child(text_input(username))
                         ),
                 ]),
             // Password field
             container()
                 .layout(Flex::column().spacing(4.0))
                 .children([
-                    text("Password")
-                        .font_size(12.0)
-                        .color(Color::rgb(0.6, 0.6, 0.7)),
+                    container().font_size(12.0).text_color(Color::rgb(0.6, 0.6, 0.7)).child(text("Password")),
                     container()
                         .padding(Padding::horizontal(12.0).vertical(8.0))
                         .background(Color::rgb(0.15, 0.15, 0.2))
@@ -216,10 +198,7 @@ fn login_form() -> Container {
                         .corner_radius(4.0)
                         .focused_state(|s| s.border_color(Color::rgb(0.4, 0.6, 1.0)))
                         .child(
-                            text_input(password)
-                                .password(true)
-                                .text_color(Color::WHITE)
-                                .font_size(14.0)
+                            container().text_color(Color::WHITE).font_size(14.0).child(text_input(password).password(true))
                         ),
                 ]),
             // Submit button
@@ -233,10 +212,7 @@ fn login_form() -> Container {
                     println!("Login: {} / {}", username.get(), password.get());
                 })
                 .child(
-                    text("Sign In")
-                        .color(Color::WHITE)
-                        .font_size(14.0)
-                        .bold()
+                    container().text_color(Color::WHITE).font_size(14.0).bold().child(text("Sign In"))
                 ),
         ])
 }

--- a/book/src/building-ui/text.md
+++ b/book/src/building-ui/text.md
@@ -1,6 +1,6 @@
 # Text
 
-The Text widget renders styled text content with support for reactive updates.
+The Text widget renders text content with support for reactive updates.
 
 ## Basic Text
 
@@ -8,20 +8,47 @@ The Text widget renders styled text content with support for reactive updates.
 text("Hello, World!")
 ```
 
+## Where styling lives
+
+Guido has one styling widget. A `text` carries the string and nothing else —
+how it looks is declared on an enclosing container, next to that container's
+background, border and animations:
+
+```rust
+container().font_size(24.0).text_color(theme.text).child(text("Hello"))
+```
+
+Each property is inherited by everything below, until a nearer container
+overrides it. Resolution is per property, so overriding the size leaves a
+colour set further up alone:
+
+```rust
+container()
+    .text_color(theme.text)
+    .font_size(14.0)
+    .layout(Flex::column().spacing(8.0))
+    .child(text("inherits both"))
+    .child(container().font_size(21.0).child(text("bigger, same colour")))
+```
+
+Containers that say nothing about text are transparent to this, so layout
+wrappers do not interrupt it. Properties nothing declares fall back to white,
+14 logical pixels, the registered default family and normal weight.
+
 ## Styling
 
 ### Font Size
 
 ```rust
-text("Large text").font_size(24.0)
-text("Small text").font_size(12.0)
+container().font_size(24.0).child(text("Large text"))
+container().font_size(12.0).child(text("Small text"))
 ```
 
 ### Color
 
 ```rust
-text("Colored text").color(Color::rgb(0.9, 0.3, 0.3))
-text("White text").color(Color::WHITE)
+container().text_color(Color::rgb(0.9, 0.3, 0.3)).child(text("Colored text"))
+container().text_color(Color::WHITE).child(text("White text"))
 ```
 
 ### Font Family
@@ -30,15 +57,15 @@ Set the font family using predefined families or custom font names:
 
 ```rust
 // Predefined font families
-text("Sans-serif text").font_family(FontFamily::SansSerif)
-text("Serif text").font_family(FontFamily::Serif)
-text("Monospace text").font_family(FontFamily::Monospace)
+container().font_family(FontFamily::SansSerif).child(text("Sans-serif text"))
+container().font_family(FontFamily::Serif).child(text("Serif text"))
+container().font_family(FontFamily::Monospace).child(text("Monospace text"))
 
 // Shorthand for monospace
-text("Code example").mono()
+container().mono().child(text("Code example"))
 
 // Custom font by name (if available on system)
-text("Custom font").font_family(FontFamily::Name("Inter".into()))
+container().font_family(FontFamily::Name("Inter".into())).child(text("Custom font"))
 ```
 
 Available font families:
@@ -55,19 +82,19 @@ Set the font weight using predefined constants or numeric values (100-900):
 
 ```rust
 // Using constants
-text("Thin text").font_weight(FontWeight::THIN)
-text("Light text").font_weight(FontWeight::LIGHT)
-text("Normal text").font_weight(FontWeight::NORMAL)
-text("Medium text").font_weight(FontWeight::MEDIUM)
-text("Semi-bold text").font_weight(FontWeight::SEMI_BOLD)
-text("Bold text").font_weight(FontWeight::BOLD)
-text("Black text").font_weight(FontWeight::BLACK)
+container().font_weight(FontWeight::THIN).child(text("Thin text"))
+container().font_weight(FontWeight::LIGHT).child(text("Light text"))
+container().font_weight(FontWeight::NORMAL).child(text("Normal text"))
+container().font_weight(FontWeight::MEDIUM).child(text("Medium text"))
+container().font_weight(FontWeight::SEMI_BOLD).child(text("Semi-bold text"))
+container().font_weight(FontWeight::BOLD).child(text("Bold text"))
+container().font_weight(FontWeight::BLACK).child(text("Black text"))
 
 // Shorthand for bold
-text("Bold text").bold()
+container().bold().child(text("Bold text"))
 
 // Custom numeric weight
-text("Custom weight").font_weight(FontWeight(550))
+container().font_weight(FontWeight(550)).child(text("Custom weight"))
 ```
 
 Available weight constants:
@@ -112,12 +139,7 @@ text(move || format!("Count: {}", count.get()))
 Chain style methods:
 
 ```rust
-text("Styled Text")
-    .font_size(18.0)
-    .color(Color::WHITE)
-    .font_family(FontFamily::Serif)
-    .bold()
-    .nowrap()
+container().font_size(18.0).text_color(Color::WHITE).font_family(FontFamily::Serif).bold().child(text("Styled Text").nowrap())
 ```
 
 ## Text in Containers
@@ -130,9 +152,7 @@ container()
     .background(Color::rgb(0.2, 0.2, 0.3))
     .corner_radius(4.0)
     .child(
-        text("Button Label")
-            .color(Color::WHITE)
-            .font_size(14.0)
+        container().text_color(Color::WHITE).font_size(14.0).child(text("Button Label"))
     )
 ```
 
@@ -141,44 +161,31 @@ container()
 ### Headings
 
 ```rust
-text("Page Title")
-    .font_size(24.0)
-    .bold()
-    .color(Color::WHITE)
+container().font_size(24.0).bold().text_color(Color::WHITE).child(text("Page Title"))
 ```
 
 ### Body Text
 
 ```rust
-text("Regular content text")
-    .font_size(14.0)
-    .color(Color::rgb(0.8, 0.8, 0.85))
+container().font_size(14.0).text_color(Color::rgb(0.8, 0.8, 0.85)).child(text("Regular content text"))
 ```
 
 ### Secondary Text
 
 ```rust
-text("Subtitle or caption")
-    .font_size(12.0)
-    .color(Color::rgb(0.6, 0.6, 0.65))
+container().font_size(12.0).text_color(Color::rgb(0.6, 0.6, 0.65)).child(text("Subtitle or caption"))
 ```
 
 ### Code/Monospace Text
 
 ```rust
-text("let x = 42;")
-    .mono()
-    .font_size(13.0)
-    .color(Color::rgb(0.6, 0.9, 0.6))
+container().mono().font_size(13.0).text_color(Color::rgb(0.6, 0.9, 0.6)).child(text("let x = 42;"))
 ```
 
 ### Labels
 
 ```rust
-text("LABEL")
-    .font_size(11.0)
-    .bold()
-    .color(Color::rgb(0.5, 0.5, 0.55))
+container().font_size(11.0).bold().text_color(Color::rgb(0.5, 0.5, 0.55)).child(text("LABEL"))
 ```
 
 ## App-Level Default Font
@@ -206,24 +213,15 @@ fn article_card(title: &str, author: &str, preview: &str) -> Container {
         .layout(Flex::column().spacing(8.0))
         .child(
             // Title - bold serif
-            text(title)
-                .font_size(18.0)
-                .font_family(FontFamily::Serif)
-                .bold()
-                .color(Color::WHITE)
+            container().font_size(18.0).font_family(FontFamily::Serif).bold().text_color(Color::WHITE).child(text(title))
         )
         .child(
             // Author - light weight
-            text(format!("By {}", author))
-                .font_size(12.0)
-                .font_weight(FontWeight::LIGHT)
-                .color(Color::rgb(0.5, 0.5, 0.6))
+            container().font_size(12.0).font_weight(FontWeight::LIGHT).text_color(Color::rgb(0.5, 0.5, 0.6)).child(text(format!("By {}", author)))
         )
         .child(
             // Preview text
-            text(preview)
-                .font_size(14.0)
-                .color(Color::rgb(0.7, 0.7, 0.75))
+            container().font_size(14.0).text_color(Color::rgb(0.7, 0.7, 0.75)).child(text(preview))
         )
 }
 ```

--- a/book/src/concepts/container.md
+++ b/book/src/concepts/container.md
@@ -235,7 +235,7 @@ fn create_button(label: &str, on_click: impl Fn() + 'static) -> Container {
         .on_click(on_click)
 
         // Content
-        .child(text(label).color(Color::WHITE))
+        .child(container().text_color(Color::WHITE).child(text(label)))
 }
 ```
 

--- a/book/src/concepts/layout.md
+++ b/book/src/concepts/layout.md
@@ -125,14 +125,14 @@ container()
     )
     .padding(20.0)
     .children([
-        text("Left").font_size(24.0),
+        container().font_size(24.0).child(text("Left")),
         container()
             .layout(Flex::column().spacing(4.0))
             .children([
                 text("Center"),
                 text("Items"),
             ]),
-        text("Right").font_size(24.0),
+        container().font_size(24.0).child(text("Right")),
     ])
 ```
 

--- a/book/src/concepts/widgets.md
+++ b/book/src/concepts/widgets.md
@@ -47,10 +47,7 @@ See [Container](container.md) for details.
 Renders text content:
 
 ```rust
-text("Hello, World!")
-    .font_size(16.0)
-    .color(Color::WHITE)
-    .bold()
+container().font_size(16.0).text_color(Color::WHITE).bold().child(text("Hello, World!"))
 ```
 
 See [Text](../building-ui/text.md) for styling options.
@@ -62,9 +59,7 @@ Single-line text editing with selection, clipboard, and undo/redo:
 ```rust
 let username = create_signal(String::new());
 
-text_input(username)
-    .text_color(Color::WHITE)
-    .on_submit(|text| println!("Submitted: {}", text))
+container().text_color(Color::WHITE).child(text_input(username).on_submit(|text| println!("Submitted: {}", text)))
 ```
 
 See [Text Input](../building-ui/text-input.md) for details.
@@ -77,7 +72,7 @@ Guido UIs are built through composition - nesting widgets inside containers:
 container()
     .layout(Flex::column().spacing(8.0))
     .children([
-        text("Title").font_size(24.0),
+        container().font_size(24.0).child(text("Title")),
         container()
             .layout(Flex::row().spacing(4.0))
             .children([
@@ -128,7 +123,7 @@ fn my_button(label: &str) -> impl Widget {
         .padding(12.0)
         .background(Color::rgb(0.3, 0.5, 0.8))
         .corner_radius(8.0)
-        .child(text(label).color(Color::WHITE))
+        .child(container().text_color(Color::WHITE).child(text(label)))
 }
 ```
 

--- a/book/src/getting-started/hello-world.md
+++ b/book/src/getting-started/hello-world.md
@@ -140,7 +140,15 @@ The container has:
 text("Hello World!")
 ```
 
-The `text()` function creates a text widget. Text inherits styling from its container by default, with white text color.
+The `text()` function creates a text widget. It carries the content and nothing
+else: colour, size, family and weight are declared on an enclosing container and
+inherited from the nearest one that sets them.
+
+```rust
+container().font_size(24.0).text_color(Color::WHITE).child(text("Hello World!"))
+```
+
+With nothing declared above it, text is white at 14 logical pixels.
 
 ## Adding Interactivity
 

--- a/book/src/getting-started/installation.md
+++ b/book/src/getting-started/installation.md
@@ -80,7 +80,7 @@ fn main() {
                 container()
                     .padding(20.0)
                     .background(Color::rgb(0.2, 0.3, 0.4))
-                    .child(text("Hello, Guido!").color(Color::WHITE))
+                    .child(container().text_color(Color::WHITE).child(text("Hello, Guido!")))
             },
         );
     });

--- a/book/src/interactivity/events.md
+++ b/book/src/interactivity/events.md
@@ -163,8 +163,7 @@ fn interactive_counter() -> impl Widget {
                 .pressed_state(|s| s.ripple())
                 .on_click(move || count.update(|c| *c += 1))
                 .child(
-                    text(move || format!("Clicked {} times", count.get()))
-                        .color(Color::WHITE)
+                    container().text_color(Color::WHITE).child(text(move || format!("Clicked {} times", count.get())))
                 ),
 
             // Scroll display
@@ -177,8 +176,7 @@ fn interactive_counter() -> impl Widget {
                     scroll_offset.update(|o| *o += dy);
                 })
                 .child(
-                    text(move || format!("Scroll offset: {:.0}", scroll_offset.get()))
-                        .color(Color::WHITE)
+                    container().text_color(Color::WHITE).child(text(move || format!("Scroll offset: {:.0}", scroll_offset.get())))
                 ),
         ])
 }

--- a/book/src/interactivity/ripples.md
+++ b/book/src/interactivity/ripples.md
@@ -108,7 +108,7 @@ fn ripple_button(label: &str, color: Color) -> Container {
         .pressed_state(|s| s.ripple().transform(Transform::scale(0.98)))
 
         .on_click(|| println!("Clicked!"))
-        .child(text(label).color(Color::WHITE))
+        .child(container().text_color(Color::WHITE).child(text(label)))
 }
 
 // Usage

--- a/book/src/interactivity/state-layer.md
+++ b/book/src/interactivity/state-layer.md
@@ -126,7 +126,7 @@ fn interactive_button(label: &str) -> Container {
             .transform(Transform::scale(0.98))
         )
 
-        .child(text(label).color(Color::WHITE))
+        .child(container().text_color(Color::WHITE).child(text(label)))
 }
 ```
 

--- a/book/src/interactivity/states.md
+++ b/book/src/interactivity/states.md
@@ -125,7 +125,7 @@ container()
     .hover_state(|s| s.lighter(0.1))
     .pressed_state(|s| s.ripple())
     .on_click(|| println!("Clicked!"))
-    .child(text("Click me").color(Color::WHITE))
+    .child(container().text_color(Color::WHITE).child(text("Click me")))
 ```
 
 ### Outlined Button
@@ -138,7 +138,7 @@ container()
     .border(1.0, Color::rgb(0.5, 0.5, 0.6))
     .hover_state(|s| s.background(Color::rgba(1.0, 1.0, 1.0, 0.1)))
     .pressed_state(|s| s.ripple())
-    .child(text("Outlined").color(Color::WHITE))
+    .child(container().text_color(Color::WHITE).child(text("Outlined")))
 ```
 
 ### Card with Lift

--- a/book/src/transforms/animated.md
+++ b/book/src/transforms/animated.md
@@ -131,7 +131,7 @@ fn animated_transforms_demo() -> impl Widget {
                 .pressed_state(|s| s.ripple())
                 .on_click(move || rotation.update(|r| *r += 45.0))
                 .layout(Flex::column().main_alignment(MainAlignment::Center).cross_alignment(CrossAlignment::Center))
-                .child(text("Rotate").color(Color::WHITE).font_size(12.0)),
+                .child(container().text_color(Color::WHITE).font_size(12.0).child(text("Rotate"))),
 
             // Spring-based scale
             container()
@@ -148,7 +148,7 @@ fn animated_transforms_demo() -> impl Widget {
                     scale.set(if is_scaled.get() { 1.3 } else { 1.0 });
                 })
                 .layout(Flex::column().main_alignment(MainAlignment::Center).cross_alignment(CrossAlignment::Center))
-                .child(text("Scale").color(Color::WHITE).font_size(12.0)),
+                .child(container().text_color(Color::WHITE).font_size(12.0).child(text("Scale"))),
         ])
 }
 ```

--- a/book/src/transforms/basics.md
+++ b/book/src/transforms/basics.md
@@ -123,7 +123,7 @@ fn transform_demo() -> impl Widget {
                 .background(Color::rgb(0.8, 0.3, 0.3))
                 .corner_radius(8.0)
                 .rotate(45.0)
-                .child(text("45°").color(Color::WHITE)),
+                .child(container().text_color(Color::WHITE).child(text("45°"))),
 
             // Click to rotate
             container()
@@ -134,7 +134,7 @@ fn transform_demo() -> impl Widget {
                 .rotate(rotation)
                 .hover_state(|s| s.lighter(0.1))
                 .on_click(move || rotation.update(|r| *r += 45.0))
-                .child(text("Click").color(Color::WHITE)),
+                .child(container().text_color(Color::WHITE).child(text("Click"))),
 
             // Click to scale
             container()
@@ -148,7 +148,7 @@ fn transform_demo() -> impl Widget {
                     let new = if scale_factor.get() > 1.0 { 1.0 } else { 1.3 };
                     scale_factor.set(new);
                 })
-                .child(text("Scale").color(Color::WHITE)),
+                .child(container().text_color(Color::WHITE).child(text("Scale"))),
         ])
 }
 ```

--- a/book/src/transforms/nested.md
+++ b/book/src/transforms/nested.md
@@ -112,7 +112,7 @@ fn nested_transforms_demo() -> impl Widget {
                 .rotate(10.0)
                 .layout(Flex::column().spacing(16.0).main_alignment(MainAlignment::Center).cross_alignment(CrossAlignment::Center))
                 .children([
-                    text("Parent (rotated 10°)").color(Color::WHITE).font_size(12.0),
+                    container().text_color(Color::WHITE).font_size(12.0).child(text("Parent (rotated 10°)")),
 
                     // Inner container with scale
                     container()
@@ -125,9 +125,7 @@ fn nested_transforms_demo() -> impl Widget {
                         .pressed_state(|s| s.ripple())
                         .layout(Flex::column().main_alignment(MainAlignment::Center).cross_alignment(CrossAlignment::Center))
                         .child(
-                            text("Child (scaled 0.9)")
-                                .color(Color::WHITE)
-                                .font_size(10.0)
+                            container().text_color(Color::WHITE).font_size(10.0).child(text("Child (scaled 0.9)"))
                         ),
                 ])
         )

--- a/book/src/transforms/origins.md
+++ b/book/src/transforms/origins.md
@@ -140,7 +140,7 @@ fn create_rotating_box(origin: TransformOrigin, label: &'static str) -> Containe
                 .animate_transform(Transition::new(300.0, TimingFunction::EaseOut))
                 .hover_state(|s| s.lighter(0.1))
                 .on_click(move || rotation.update(|r| *r += 45.0)),
-            text(label).font_size(12.0).color(Color::WHITE),
+            container().font_size(12.0).text_color(Color::WHITE).child(text(label)),
         ])
 }
 ```

--- a/docs/STATE_LAYER.md
+++ b/docs/STATE_LAYER.md
@@ -148,13 +148,14 @@ fn create_button(label: &str) -> Container {
         .background(Color::rgb(0.3, 0.5, 0.8))
         .corner_radius(8.0)
         .border(1.0, Color::rgb(0.4, 0.6, 0.9))
+        .text_color(Color::WHITE)
         // Animations
         .animate_background(Transition::new(200.0, TimingFunction::EaseOut))
         .animate_border_width(Transition::new(150.0, TimingFunction::EaseOut))
         // State overrides
         .hover_state(|s| s.lighter(0.1).border(2.0, Color::rgb(0.5, 0.7, 1.0)))
         .pressed_state(|s| s.ripple().darker(0.05).transform(Transform::scale(0.98)))
-        .child(text(label).color(Color::WHITE))
+        .child(text(label))
 }
 ```
 

--- a/docs/STYLING.md
+++ b/docs/STYLING.md
@@ -206,14 +206,45 @@ container()
 
 ## Text Styling
 
+Text carries content; how it looks is declared on the container, alongside
+every other visual property:
+
 ```rust
-text("Hello")
+container()
     .font_size(16.0)
-    .color(Color::WHITE)
-    .bold()              // Font weight
-    .italic()            // Font style
-    .nowrap()            // Prevent wrapping
+    .text_color(Color::WHITE)
+    .bold()                          // font weight
+    .child(text("Hello").nowrap())   // nowrap is about wrapping, not looks
 ```
+
+Each property is inherited by everything below the container, until a nearer
+one overrides that property — and only that one:
+
+```rust
+container()
+    .text_color(theme.text)
+    .font_size(14.0)
+    .layout(Flex::column().spacing(8.0))
+    .child(text("inherits both"))
+    .child(
+        // Overrides the size; the colour still comes from above.
+        container().font_size(21.0).child(text("bigger, same colour")),
+    )
+```
+
+The same declarations style a `text_input`, which additionally reads
+`cursor_color` and `selection_color`:
+
+```rust
+container()
+    .mono()
+    .text_color(Color::WHITE)
+    .cursor_color(Color::rgb(0.4, 0.8, 1.0))
+    .child(text_input(value))
+```
+
+Properties nothing declares fall back to white, 14 logical pixels, the
+registered default family and normal weight.
 
 ## Layout Styling
 
@@ -268,13 +299,8 @@ fn styled_card(title: &str, content: &str) -> Container {
         .hover_state(|s| s.lighter(0.05).elevation(6.0))
         // Children
         .children([
-            text(title)
-                .font_size(18.0)
-                .bold()
-                .color(Color::WHITE),
-            text(content)
-                .font_size(14.0)
-                .color(Color::rgb(0.7, 0.7, 0.75)),
+            container().font_size(18.0).bold().text_color(Color::WHITE).child(text(title)),
+            container().font_size(14.0).text_color(Color::rgb(0.7, 0.7, 0.75)).child(text(content)),
         ])
 }
 ```

--- a/examples/animation_example.rs
+++ b/examples/animation_example.rs
@@ -48,18 +48,20 @@ fn create_width_animation_card(expanded: RwSignal<bool>) -> Container {
         .on_click(move || expanded.update(|e| *e = !*e))
         .child(
             container().layout(Flex::column().spacing(8.0)).children([
-                text("Width Animation with Spring")
+                container()
                     .font_size(18.0)
-                    .color(Color::rgb(0.9, 0.9, 0.95)),
-                text(move || {
-                    if expanded.get() {
-                        "Click to collapse (watch the spring bounce!)".to_string()
-                    } else {
-                        "Click to expand (watch the spring bounce!)".to_string()
-                    }
-                })
-                .font_size(14.0)
-                .color(Color::rgb(0.6, 0.6, 0.7)),
+                    .text_color(Color::rgb(0.9, 0.9, 0.95))
+                    .child(text("Width Animation with Spring")),
+                container()
+                    .font_size(14.0)
+                    .text_color(Color::rgb(0.6, 0.6, 0.7))
+                    .child(text(move || {
+                        if expanded.get() {
+                            "Click to collapse (watch the spring bounce!)".to_string()
+                        } else {
+                            "Click to expand (watch the spring bounce!)".to_string()
+                        }
+                    })),
             ]),
         )
 }
@@ -77,12 +79,14 @@ fn create_color_animation_card() -> Container {
         .pressed_state(|s| s.ripple())
         .child(
             container().layout(Flex::column().spacing(8.0)).children([
-                text("Background Color Animation")
+                container()
                     .font_size(18.0)
-                    .color(Color::rgb(0.9, 0.9, 0.95)),
-                text("Hover to see smooth color transition")
+                    .text_color(Color::rgb(0.9, 0.9, 0.95))
+                    .child(text("Background Color Animation")),
+                container()
                     .font_size(14.0)
-                    .color(Color::rgb(0.6, 0.6, 0.7)),
+                    .text_color(Color::rgb(0.6, 0.6, 0.7))
+                    .child(text("Hover to see smooth color transition")),
             ]),
         )
 }
@@ -105,18 +109,20 @@ fn create_combined_animation_card() -> Container {
         .on_click(move || clicked.update(|c| *c = !*c))
         .child(
             container().layout(Flex::column().spacing(8.0)).children([
-                text("Combined Animations")
+                container()
                     .font_size(18.0)
-                    .color(Color::rgb(0.9, 0.9, 0.95)),
-                text(move || {
-                    if clicked.get() {
-                        "Width, color, and corner radius all animating!".to_string()
-                    } else {
-                        "Click to see multiple properties animate together".to_string()
-                    }
-                })
-                .font_size(14.0)
-                .color(Color::rgb(0.6, 0.6, 0.7)),
+                    .text_color(Color::rgb(0.9, 0.9, 0.95))
+                    .child(text("Combined Animations")),
+                container()
+                    .font_size(14.0)
+                    .text_color(Color::rgb(0.6, 0.6, 0.7))
+                    .child(text(move || {
+                        if clicked.get() {
+                            "Width, color, and corner radius all animating!".to_string()
+                        } else {
+                            "Click to see multiple properties animate together".to_string()
+                        }
+                    })),
             ]),
         )
 }
@@ -143,18 +149,20 @@ fn create_border_animation_card() -> Container {
         .on_click(move || clicked.update(|c| *c = !*c))
         .child(
             container().layout(Flex::column().spacing(8.0)).children([
-                text("Border Animation")
+                container()
                     .font_size(18.0)
-                    .color(Color::rgb(0.9, 0.9, 0.95)),
-                text(move || {
-                    if clicked.get() {
-                        "Border width and color animating! Click to reset.".to_string()
-                    } else {
-                        "Hover for color change, click for width + color".to_string()
-                    }
-                })
-                .font_size(14.0)
-                .color(Color::rgb(0.6, 0.6, 0.7)),
+                    .text_color(Color::rgb(0.9, 0.9, 0.95))
+                    .child(text("Border Animation")),
+                container()
+                    .font_size(14.0)
+                    .text_color(Color::rgb(0.6, 0.6, 0.7))
+                    .child(text(move || {
+                        if clicked.get() {
+                            "Border width and color animating! Click to reset.".to_string()
+                        } else {
+                            "Hover for color change, click for width + color".to_string()
+                        }
+                    })),
             ]),
         )
 }

--- a/examples/at_most_animation.rs
+++ b/examples/at_most_animation.rs
@@ -19,12 +19,18 @@ use guido::prelude::*;
 const CAP: f32 = 160.0;
 const SENTENCE: &str = "una frase lunga che deve andare a capo dentro il box";
 
-fn label(s: &str) -> Text {
-    text(s).color(Color::rgb(0.75, 0.78, 0.85)).font_size(12.0)
+fn label(s: &str) -> Container {
+    container()
+        .text_color(Color::rgb(0.75, 0.78, 0.85))
+        .font_size(12.0)
+        .child(text(s))
 }
 
-fn heading(s: &str) -> Text {
-    text(s).color(Color::WHITE).font_size(15.0)
+fn heading(s: &str) -> Container {
+    container()
+        .text_color(Color::WHITE)
+        .font_size(15.0)
+        .child(text(s))
 }
 
 /// The cap, drawn as an outline so overflowing content is visible against it.
@@ -57,12 +63,13 @@ fn pair(title: &str, build: impl Fn(bool) -> Container + 'static) -> Container {
             .child(label(caption))
             .child(w.widget_ref(r))
             .child(
-                text(move || {
-                    let b = r.rect().get();
-                    format!("{:.1} x {:.1}", b.width, b.height)
-                })
-                .color(Color::rgb(0.55, 0.85, 0.6))
-                .font_size(12.0),
+                container()
+                    .text_color(Color::rgb(0.55, 0.85, 0.6))
+                    .font_size(12.0)
+                    .child(text(move || {
+                        let b = r.rect().get();
+                        format!("{:.1} x {:.1}", b.width, b.height)
+                    })),
             )
     };
 
@@ -94,12 +101,21 @@ fn main() {
                     .padding(20.0)
                     .layout(Flex::column().spacing(28.0))
                     .child(
-                        text("at_most + animazione: le coppie devono essere identiche")
-                            .color(Color::WHITE)
-                            .font_size(17.0),
+                        container()
+                            .text_color(Color::WHITE)
+                            .font_size(17.0)
+                            .child(text(
+                                "at_most + animazione: le coppie devono essere identiche",
+                            )),
                     )
                     .child(pair("testo che va a capo", |animated| {
-                        capped(animated, text(SENTENCE).color(Color::WHITE).font_size(13.0))
+                        capped(
+                            animated,
+                            container()
+                                .text_color(Color::WHITE)
+                                .font_size(13.0)
+                                .child(text(SENTENCE)),
+                        )
                     }))
                     .child(pair("figlio con fill()", |animated| {
                         capped(
@@ -111,7 +127,7 @@ fn main() {
                                 .corner_radius(3.0),
                         )
                     }))
-                    .child(label("Esc per chiudere").color(Color::rgb(0.5, 0.53, 0.6)))
+                    .child(label("Esc per chiudere").text_color(Color::rgb(0.5, 0.53, 0.6)))
                     .on_key_down(|key, _| {
                         if key == Key::Escape {
                             quit_app();

--- a/examples/bench_list.rs
+++ b/examples/bench_list.rs
@@ -69,11 +69,11 @@ fn bench_row(i: usize) -> Container {
                 })
                 .hover_state(|s| s.lighter(0.08))
                 .on_click(move || checked.update(|c| *c = !*c))
-                .child(
-                    text(move || (if checked.get() { "x" } else { "" }).to_string())
-                        .color(Color::WHITE)
-                        .font_size(12.0),
-                ),
+                .text_color(Color::WHITE)
+                .font_size(12.0)
+                .child(text(move || {
+                    (if checked.get() { "x" } else { "" }).to_string()
+                })),
         )
         .child(
             container()
@@ -82,6 +82,8 @@ fn bench_row(i: usize) -> Container {
                 .background(Color::rgb(0.18, 0.18, 0.24))
                 .corner_radius(4.0)
                 .focused_state(|s| s.border(1.5, Color::rgb(0.4, 0.8, 1.0)))
-                .child(text_input(value).text_color(Color::WHITE).font_size(13.0)),
+                .text_color(Color::WHITE)
+                .font_size(13.0)
+                .child(text_input(value)),
         )
 }

--- a/examples/children_example.rs
+++ b/examples/children_example.rs
@@ -58,8 +58,8 @@ fn main() {
                 .child(
                     container()
                         .layout(Flex::column().spacing(8.0))
-                        .child(text("1. Static Children (.child)").color(Color::rgb(0.9, 0.9, 1.0)))
-                        .child(text("These children are fixed at creation time:").color(Color::WHITE))
+                        .child(container().text_color(Color::rgb(0.9, 0.9, 1.0)).child(text("1. Static Children (.child)")))
+                        .child(container().text_color(Color::WHITE).child(text("These children are fixed at creation time:")))
                         .child(
                             container()
                                 .layout(Flex::row().spacing(4.0))
@@ -68,21 +68,21 @@ fn main() {
                                         .padding(8.0)
                                         .background(Color::rgb(0.3, 0.2, 0.4))
                                         .corner_radius(4.0)
-                                        .child(text("Child A").color(Color::WHITE))
+                                        .text_color(Color::WHITE).child(text("Child A"))
                                 )
                                 .child(
                                     container()
                                         .padding(8.0)
                                         .background(Color::rgb(0.2, 0.3, 0.4))
                                         .corner_radius(4.0)
-                                        .child(text("Child B").color(Color::WHITE))
+                                        .text_color(Color::WHITE).child(text("Child B"))
                                 )
                                 .child(
                                     container()
                                         .padding(8.0)
                                         .background(Color::rgb(0.4, 0.3, 0.2))
                                         .corner_radius(4.0)
-                                        .child(text("Child C").color(Color::WHITE))
+                                        .text_color(Color::WHITE).child(text("Child C"))
                                 )
                         )
                 )
@@ -97,21 +97,18 @@ fn main() {
                     container()
                         .layout(Flex::column().spacing(8.0))
                         .child(
-                            text("2. .maybe_child() - NOT REACTIVE!")
-                                .color(Color::rgb(1.0, 0.9, 0.9))
+                            container().text_color(Color::rgb(1.0, 0.9, 0.9)).child(text("2. .maybe_child() - NOT REACTIVE!"))
                         )
                         .child(
-                            text("LIMITATION: Evaluated ONCE at creation")
-                                .color(Color::rgb(1.0, 0.7, 0.7))
+                            container().text_color(Color::rgb(1.0, 0.7, 0.7)).child(text("LIMITATION: Evaluated ONCE at creation"))
                         )
                         .child(
-                            text(move || format!("Signal: {} (but .maybe_child won't react!)", show_optional.get()))
-                                .color(Color::WHITE)
+                            container().text_color(Color::WHITE).child(text(move || format!("Signal: {} (but .maybe_child won't react!)", show_optional.get())))
                         )
                         .child(
                             container()
                                 .layout(Flex::row().spacing(4.0))
-                                .child(text("Fixed").color(Color::WHITE))
+                                .child(container().text_color(Color::WHITE).child(text("Fixed")))
                                 // Evaluated ONCE at creation — it will never
                                 // update. Debug builds warn about exactly this
                                 // read; the closure below is the fix.
@@ -122,7 +119,7 @@ fn main() {
                                                 .padding(6.0)
                                                 .background(Color::rgb(0.4, 0.2, 0.2))
                                                 .corner_radius(4.0)
-                                                .child(text("Frozen").color(Color::WHITE))
+                                                .text_color(Color::WHITE).child(text("Frozen"))
                                         )
                                     } else {
                                         None
@@ -146,12 +143,10 @@ fn main() {
                     container()
                         .layout(Flex::column().spacing(8.0))
                         .child(
-                            text("3. Dynamic Children (.children) - REACTIVE!")
-                                .color(Color::rgb(0.9, 1.0, 0.9))
+                            container().text_color(Color::rgb(0.9, 1.0, 0.9)).child(text("3. Dynamic Children (.children) - REACTIVE!"))
                         )
                         .child(
-                            text("These react to signal changes with state preservation")
-                                .color(Color::WHITE)
+                            container().text_color(Color::WHITE).child(text("These react to signal changes with state preservation"))
                         )
                         .child(
                             // Control buttons
@@ -178,7 +173,7 @@ fn main() {
                                                 });
                                             });
                                         })
-                                        .child(text("Add").color(Color::WHITE))
+                                        .text_color(Color::WHITE).child(text("Add"))
                                 )
                                 .child(
                                     container()
@@ -194,7 +189,7 @@ fn main() {
                                                 }
                                             });
                                         })
-                                        .child(text("Remove").color(Color::WHITE))
+                                        .text_color(Color::WHITE).child(text("Remove"))
                                 )
                                 .child(
                                     container()
@@ -208,12 +203,11 @@ fn main() {
                                                 list.reverse();
                                             });
                                         })
-                                        .child(text("Reverse").color(Color::WHITE))
+                                        .text_color(Color::WHITE).child(text("Reverse"))
                                 )
                         )
                         .child(
-                            text("Notice: Reversing preserves widget state (animations, etc.)")
-                                .color(Color::rgb(0.8, 0.8, 0.8))
+                            container().text_color(Color::rgb(0.8, 0.8, 0.8)).child(text("Notice: Reversing preserves widget state (animations, etc.)"))
                         )
                         .child(
                             // Dynamic list: key by ID preserves widget state on
@@ -227,7 +221,7 @@ fn main() {
                                         .padding(8.0)
                                         .background(item.color)
                                         .corner_radius(4.0)
-                                        .child(text(item.name).color(Color::WHITE)),
+                                        .text_color(Color::WHITE).child(text(item.name)),
                                 ))
                         )
                 )
@@ -242,12 +236,10 @@ fn main() {
                     container()
                         .layout(Flex::column().spacing(8.0))
                         .child(
-                            text("4. NEW! Mixing Static and Dynamic - ANY ORDER!")
-                                .color(Color::rgb(0.9, 1.0, 0.9))
+                            container().text_color(Color::rgb(0.9, 1.0, 0.9)).child(text("4. NEW! Mixing Static and Dynamic - ANY ORDER!"))
                         )
                         .child(
-                            text("You can now freely mix static and dynamic children!")
-                                .color(Color::WHITE)
+                            container().text_color(Color::WHITE).child(text("You can now freely mix static and dynamic children!"))
                         )
                         .child(
                             container()
@@ -259,16 +251,13 @@ fn main() {
                                 .on_click(move || {
                                     show_optional.update(|v| *v = !*v);
                                 })
-                                .child(
-                                    text(move || {
+                                .text_color(Color::WHITE).child(text(move || {
                                         if show_optional.get() {
                                             "Click to Hide Middle".to_string()
                                         } else {
                                             "Click to Show Middle".to_string()
                                         }
-                                    })
-                                    .color(Color::WHITE)
-                                )
+                                    }))
                         )
                         .child(
                             // Demonstrate mixing: static -> dynamic -> static
@@ -279,7 +268,7 @@ fn main() {
                                         .padding(8.0)
                                         .background(Color::rgb(0.3, 0.4, 0.3))
                                         .corner_radius(4.0)
-                                        .child(text("Static Header").color(Color::WHITE))
+                                        .text_color(Color::WHITE).child(text("Static Header"))
                                 )
                                 .child(
                                     // Dynamic child in the middle!
@@ -288,7 +277,7 @@ fn main() {
                                             .padding(8.0)
                                             .background(Color::rgb(0.5, 0.3, 0.5))
                                             .corner_radius(4.0)
-                                            .child(text("Dynamic Middle!").color(Color::WHITE)))
+                                            .text_color(Color::WHITE).child(text("Dynamic Middle!")))
                                     }
                                 )
                                 .child(
@@ -296,12 +285,11 @@ fn main() {
                                         .padding(8.0)
                                         .background(Color::rgb(0.3, 0.4, 0.3))
                                         .corner_radius(4.0)
-                                        .child(text("Static Footer").color(Color::WHITE))
+                                        .text_color(Color::WHITE).child(text("Static Footer"))
                                 )
                         )
                         .child(
-                            text("This was IMPOSSIBLE before - would panic!")
-                                .color(Color::rgb(0.8, 1.0, 0.8))
+                            container().text_color(Color::rgb(0.8, 1.0, 0.8)).child(text("This was IMPOSSIBLE before - would panic!"))
                         )
                 )
                 )
@@ -320,12 +308,10 @@ fn main() {
                     container()
                         .layout(Flex::column().spacing(8.0))
                         .child(
-                            text("5. Complex Mixing Example")
-                                .color(Color::rgb(1.0, 0.9, 1.0))
+                            container().text_color(Color::rgb(1.0, 0.9, 1.0)).child(text("5. Complex Mixing Example"))
                         )
                         .child(
-                            text("Multiple static and dynamic children in any order:")
-                                .color(Color::WHITE)
+                            container().text_color(Color::WHITE).child(text("Multiple static and dynamic children in any order:"))
                         )
                         .child(
                             container()
@@ -337,38 +323,35 @@ fn main() {
                                 .on_click(move || {
                                     show_optional2.update(|v| *v = !*v);
                                 })
-                                .child(
-                                    text(move || {
+                                .text_color(Color::WHITE).child(text(move || {
                                         if show_optional2.get() {
                                             "Click to Hide Dynamics".to_string()
                                         } else {
                                             "Click to Show Dynamics".to_string()
                                         }
-                                    })
-                                    .color(Color::WHITE)
-                                )
+                                    }))
                         )
                         .child(
                             // Complex pattern: S D S D S
                             container()
                                 .layout(Flex::column().spacing(4.0))
-                                .child(text("Static 1").color(Color::WHITE))
+                                .child(container().text_color(Color::WHITE).child(text("Static 1")))
                                 .child(move || {
                                     show_optional2.get().then(|| container()
                                         .padding(6.0)
                                         .background(Color::rgb(0.5, 0.2, 0.3))
                                         .corner_radius(4.0)
-                                        .child(text("Dynamic 1").color(Color::WHITE)))
+                                        .text_color(Color::WHITE).child(text("Dynamic 1")))
                                 })
-                                .child(text("Static 2").color(Color::WHITE))
+                                .child(container().text_color(Color::WHITE).child(text("Static 2")))
                                 .child(move || {
                                     show_optional.get().then(|| container()
                                         .padding(6.0)
                                         .background(Color::rgb(0.3, 0.2, 0.5))
                                         .corner_radius(4.0)
-                                        .child(text("Dynamic 2").color(Color::WHITE)))
+                                        .text_color(Color::WHITE).child(text("Dynamic 2")))
                                 })
-                                .child(text("Static 3").color(Color::WHITE))
+                                .child(container().text_color(Color::WHITE).child(text("Static 3")))
                         )
                 )
                 )
@@ -382,18 +365,16 @@ fn main() {
                     container()
                         .layout(Flex::column().spacing(8.0))
                         .child(
-                            text("6. .children() - For keyed lists")
-                                .color(Color::rgb(0.9, 0.9, 1.0))
+                            container().text_color(Color::rgb(0.9, 0.9, 1.0)).child(text("6. .children() - For keyed lists"))
                         )
                         .child(
-                            text("Use this for lists that need state preservation:")
-                                .color(Color::WHITE)
+                            container().text_color(Color::WHITE).child(text("Use this for lists that need state preservation:"))
                         )
                         .child(
                             // Can even mix static before keyed list!
                             container()
                                 .layout(Flex::column().spacing(4.0))
-                                .child(text("Static header before list").color(Color::rgb(0.8, 0.8, 0.8)))
+                                .child(container().text_color(Color::rgb(0.8, 0.8, 0.8)).child(text("Static header before list")))
                                 .children(keyed(
                                     || vec!["Keyed Item 1", "Keyed Item 2"],
                                     |content| {
@@ -405,9 +386,9 @@ fn main() {
                                         .padding(8.0)
                                         .background(Color::rgb(0.5, 0.3, 0.5))
                                         .corner_radius(4.0)
-                                        .child(text(content).color(Color::WHITE)),
+                                        .text_color(Color::WHITE).child(text(content)),
                                 ))
-                                .child(text("Static footer after list").color(Color::rgb(0.8, 0.8, 0.8)))
+                                .child(container().text_color(Color::rgb(0.8, 0.8, 0.8)).child(text("Static footer after list")))
                         )
                 )
         )

--- a/examples/component_example.rs
+++ b/examples/component_example.rs
@@ -15,7 +15,8 @@ pub fn button(
         .hover_state(|s| s.lighter(0.1))
         .pressed_state(|s| s.ripple())
         .on_click_option(on_click)
-        .child(text(label).color(Color::WHITE))
+        .text_color(Color::WHITE)
+        .child(text(label))
 }
 
 /// A reusable Card component with children
@@ -30,7 +31,9 @@ pub fn card(
         .background(background)
         .corner_radius(8.0)
         .layout(Flex::column().spacing(8.0))
-        .child(text(title).font_size(18.0).color(Color::WHITE))
+        .font_size(18.0)
+        .text_color(Color::WHITE)
+        .child(text(title))
         .children_source(children)
 }
 
@@ -56,18 +59,14 @@ fn main() {
                     .background(Color::rgb(0.1, 0.1, 0.15))
                     .layout(Flex::column().spacing(12.0))
                     .child(
-                        text("Component Example")
-                            .font_size(24.0)
-                            .color(Color::WHITE),
+                        container().font_size(24.0).text_color(Color::WHITE).child(text("Component Example")),
                     )
                     .child(
                         card()
                             .title("Counter")
                             .background(Color::rgb(0.15, 0.2, 0.25))
                             .child(
-                                text(move || format!("Count: {}", count.get()))
-                                    .font_size(16.0)
-                                    .color(Color::WHITE),
+                                container().font_size(16.0).text_color(Color::WHITE).child(text(move || format!("Count: {}", count.get()))),
                             )
                             .child(
                                 container()
@@ -96,12 +95,10 @@ fn main() {
                         card()
                             .title("Static Content")
                             .child(
-                                text("This is a card with static content.")
-                                    .color(Color::rgb(0.8, 0.8, 0.8)),
+                                container().text_color(Color::rgb(0.8, 0.8, 0.8)).child(text("This is a card with static content.")),
                             )
                             .child(
-                                text("Cards can have multiple children.")
-                                    .color(Color::rgb(0.8, 0.8, 0.8)),
+                                container().text_color(Color::rgb(0.8, 0.8, 0.8)).child(text("Cards can have multiple children.")),
                             ),
                     )
                     .child(
@@ -145,8 +142,7 @@ fn main() {
                                 }
                             })
                             .child(
-                                text("The card background changes color based on the count value.")
-                                    .color(Color::rgb(0.8, 0.8, 0.8)),
+                                container().text_color(Color::rgb(0.8, 0.8, 0.8)).child(text("The card background changes color based on the count value.")),
                             )
                             .child(
                                 container().layout(Flex::row().spacing(8.0)).child(

--- a/examples/draw_order_example.rs
+++ b/examples/draw_order_example.rs
@@ -26,9 +26,10 @@ fn panel(label: &'static str, content: Container) -> Container {
         .layout(Flex::column().spacing(8.0))
         .child(content)
         .child(
-            text(label)
+            container()
                 .font_size(12.0)
-                .color(Color::rgb(0.7, 0.7, 0.75)),
+                .text_color(Color::rgb(0.7, 0.7, 0.75))
+                .child(text(label)),
         )
 }
 
@@ -109,11 +110,9 @@ fn main() {
                                             .main_alignment(MainAlignment::Center)
                                             .cross_alignment(CrossAlignment::Center),
                                     )
-                                    .child(
-                                        text("frosted")
-                                            .font_size(18.0)
-                                            .color(Color::rgb(0.95, 0.95, 1.0)),
-                                    ),
+                                    .font_size(18.0)
+                                    .text_color(Color::rgb(0.95, 0.95, 1.0))
+                                    .child(text("frosted")),
                             ),
                     ),
             ))
@@ -127,10 +126,10 @@ fn main() {
                     .background(Color::rgb(0.15, 0.15, 0.2))
                     .layout(ZStack::new())
                     .child(
-                        text("BEHIND")
+                        container()
                             .font_size(40.0)
-                            .color(Color::rgb(0.9, 0.3, 0.3))
-                            .nowrap(),
+                            .text_color(Color::rgb(0.9, 0.3, 0.3))
+                            .child(text("BEHIND").nowrap()),
                     )
                     // Text sits above images in the batch order, so this photo
                     // needs a group of its own to land on top of the label.

--- a/examples/effect_cleanup_test.rs
+++ b/examples/effect_cleanup_test.rs
@@ -99,9 +99,15 @@ fn create_child_widget(id: u64) -> impl Widget {
         .padding(12.0)
         .background(Color::rgb(0.2, 0.2, 0.3))
         .corner_radius(8.0)
-        .child(text(format!("Child {}", id)).color(Color::WHITE))
         .child(
-            text(move || format!("Ticks: {}", tick_signal.get())).color(Color::rgb(0.6, 0.8, 1.0)),
+            container()
+                .text_color(Color::WHITE)
+                .child(text(format!("Child {}", id))),
+        )
+        .child(
+            container()
+                .text_color(Color::rgb(0.6, 0.8, 1.0))
+                .child(text(move || format!("Ticks: {}", tick_signal.get()))),
         )
 }
 
@@ -126,15 +132,13 @@ fn main() {
                 container()
                     .layout(Flex::column().spacing(4.0))
                     .child(
-                        text("Effect Cleanup Test (Automatic Ownership)").color(Color::WHITE),
+                        container().text_color(Color::WHITE).child(text("Effect Cleanup Test (Automatic Ownership)")),
                     )
                     .child(
-                        text("Watch the console: each child logs every 2 seconds.")
-                            .color(Color::rgb(0.7, 0.7, 0.7)),
+                        container().text_color(Color::rgb(0.7, 0.7, 0.7)).child(text("Watch the console: each child logs every 2 seconds.")),
                     )
                     .child(
-                        text("When removed, on_cleanup runs and effect logs STOP.")
-                            .color(Color::rgb(0.7, 0.7, 0.7)),
+                        container().text_color(Color::rgb(0.7, 0.7, 0.7)).child(text("When removed, on_cleanup runs and effect logs STOP.")),
                     ),
             )
             .child(
@@ -153,7 +157,7 @@ fn main() {
                                 log::info!("[Child {}] Adding to list", id);
                                 children_ids.update(|list| list.push(id));
                             })
-                            .child(text("Add Child").color(Color::WHITE)),
+                            .text_color(Color::WHITE).child(text("Add Child")),
                     )
                     .child(
                         container()
@@ -172,7 +176,7 @@ fn main() {
                                     }
                                 });
                             })
-                            .child(text("Remove Last").color(Color::WHITE)),
+                            .text_color(Color::WHITE).child(text("Remove Last")),
                     )
                     .child(
                         container()
@@ -190,16 +194,15 @@ fn main() {
                                     list.clear();
                                 });
                             })
-                            .child(text("Remove All").color(Color::WHITE)),
+                            .text_color(Color::WHITE).child(text("Remove All")),
                     ),
             )
             .child(
                 // Status display
-                text(move || {
+                container().text_color(Color::WHITE).child(text(move || {
                     let count = children_ids.get().len();
                     format!("Active children: {}", count)
-                })
-                .color(Color::WHITE),
+                })),
             )
             .child(
                 // Children container with dynamic children — the builder runs

--- a/examples/elevation_example.rs
+++ b/examples/elevation_example.rs
@@ -20,6 +20,9 @@ fn main() {
             || {
                 container()
                     .layout(Flex::column().spacing(16.0))
+                    // Declared once: the cards below inherit it through the
+                    // rows, and row 3 overrides it per card.
+                    .text_color(Color::rgb(0.2, 0.2, 0.2))
                     .child(
                         // Row 1: Basic elevation levels
                         container()
@@ -30,10 +33,7 @@ fn main() {
                                     .background(Color::WHITE)
                                     .corner_radius(8.0)
                                     .elevation(0.0)
-                                    .child(
-                                        text("Level 0\n(No shadow)")
-                                            .color(Color::rgb(0.2, 0.2, 0.2)),
-                                    ),
+                                    .child(text("Level 0\n(No shadow)")),
                             )
                             .child(
                                 container()
@@ -41,7 +41,7 @@ fn main() {
                                     .background(Color::WHITE)
                                     .corner_radius(8.0)
                                     .elevation(1.0)
-                                    .child(text("Level 1").color(Color::rgb(0.2, 0.2, 0.2))),
+                                    .child(text("Level 1")),
                             )
                             .child(
                                 container()
@@ -49,7 +49,7 @@ fn main() {
                                     .background(Color::WHITE)
                                     .corner_radius(8.0)
                                     .elevation(2.0)
-                                    .child(text("Level 2").color(Color::rgb(0.2, 0.2, 0.2))),
+                                    .child(text("Level 2")),
                             )
                             .child(
                                 container()
@@ -57,7 +57,7 @@ fn main() {
                                     .background(Color::WHITE)
                                     .corner_radius(8.0)
                                     .elevation(3.0)
-                                    .child(text("Level 3").color(Color::rgb(0.2, 0.2, 0.2))),
+                                    .child(text("Level 3")),
                             ),
                     )
                     .child(
@@ -70,7 +70,7 @@ fn main() {
                                     .background(Color::WHITE)
                                     .corner_radius(8.0)
                                     .elevation(4.0)
-                                    .child(text("Level 4").color(Color::rgb(0.2, 0.2, 0.2))),
+                                    .child(text("Level 4")),
                             )
                             .child(
                                 container()
@@ -78,7 +78,7 @@ fn main() {
                                     .background(Color::WHITE)
                                     .corner_radius(8.0)
                                     .elevation(5.0)
-                                    .child(text("Level 5").color(Color::rgb(0.2, 0.2, 0.2))),
+                                    .child(text("Level 5")),
                             )
                             .child(
                                 container()
@@ -86,7 +86,7 @@ fn main() {
                                     .background(Color::WHITE)
                                     .corner_radius(8.0)
                                     .elevation(7.0)
-                                    .child(text("Level 7").color(Color::rgb(0.2, 0.2, 0.2))),
+                                    .child(text("Level 7")),
                             )
                             .child(
                                 container()
@@ -94,7 +94,7 @@ fn main() {
                                     .background(Color::WHITE)
                                     .corner_radius(8.0)
                                     .elevation(10.0)
-                                    .child(text("Level 10").color(Color::rgb(0.2, 0.2, 0.2))),
+                                    .child(text("Level 10")),
                             ),
                     )
                     .child(
@@ -107,7 +107,8 @@ fn main() {
                                     .background(Color::rgb(0.9, 0.7, 0.7))
                                     .corner_radius(12.0)
                                     .elevation(2.0)
-                                    .child(text("Card 1").color(Color::rgb(0.3, 0.1, 0.1))),
+                                    .text_color(Color::rgb(0.3, 0.1, 0.1))
+                                    .child(text("Card 1")),
                             )
                             .child(
                                 container()
@@ -115,7 +116,8 @@ fn main() {
                                     .background(Color::rgb(0.7, 0.9, 0.7))
                                     .corner_radius(12.0)
                                     .elevation(3.0)
-                                    .child(text("Card 2").color(Color::rgb(0.1, 0.3, 0.1))),
+                                    .text_color(Color::rgb(0.1, 0.3, 0.1))
+                                    .child(text("Card 2")),
                             )
                             .child(
                                 container()
@@ -123,7 +125,8 @@ fn main() {
                                     .background(Color::rgb(0.7, 0.7, 0.9))
                                     .corner_radius(12.0)
                                     .elevation(4.0)
-                                    .child(text("Card 3").color(Color::rgb(0.1, 0.1, 0.3))),
+                                    .text_color(Color::rgb(0.1, 0.1, 0.3))
+                                    .child(text("Card 3")),
                             ),
                     )
                     .child(
@@ -137,10 +140,7 @@ fn main() {
                                     .corner_radius(16.0)
                                     .squircle()
                                     .elevation(2.0)
-                                    .child(
-                                        text("Squircle\nElevation 2")
-                                            .color(Color::rgb(0.2, 0.2, 0.2)),
-                                    ),
+                                    .child(text("Squircle\nElevation 2")),
                             )
                             .child(
                                 container()
@@ -149,10 +149,7 @@ fn main() {
                                     .corner_radius(16.0)
                                     .squircle()
                                     .elevation(4.0)
-                                    .child(
-                                        text("Squircle\nElevation 4")
-                                            .color(Color::rgb(0.2, 0.2, 0.2)),
-                                    ),
+                                    .child(text("Squircle\nElevation 4")),
                             )
                             .child(
                                 container()
@@ -161,10 +158,7 @@ fn main() {
                                     .corner_radius(16.0)
                                     .squircle()
                                     .elevation(6.0)
-                                    .child(
-                                        text("Squircle\nElevation 6")
-                                            .color(Color::rgb(0.2, 0.2, 0.2)),
-                                    ),
+                                    .child(text("Squircle\nElevation 6")),
                             ),
                     )
             },

--- a/examples/flex_layout_test.rs
+++ b/examples/flex_layout_test.rs
@@ -66,11 +66,17 @@ fn main() {
 }
 
 fn section_title(title: &'static str) -> impl Widget {
-    text(title).color(Color::rgb(0.7, 0.7, 0.8)).font_size(11.0)
+    container()
+        .text_color(Color::rgb(0.7, 0.7, 0.8))
+        .font_size(11.0)
+        .child(text(title))
 }
 
 fn label(s: &'static str) -> impl Widget {
-    text(s).color(Color::rgb(0.6, 0.6, 0.7)).font_size(9.0)
+    container()
+        .text_color(Color::rgb(0.6, 0.6, 0.7))
+        .font_size(9.0)
+        .child(text(s))
 }
 
 fn test_box(color: Color) -> Container {

--- a/examples/image_example.rs
+++ b/examples/image_example.rs
@@ -15,7 +15,12 @@ fn main() {
                     .corner_radius(4.0)
                     .child(img),
             )
-            .child(text(label).font_size(12.0).color(Color::rgb(0.7, 0.7, 0.7)))
+            .child(
+                container()
+                    .font_size(12.0)
+                    .text_color(Color::rgb(0.7, 0.7, 0.7))
+                    .child(text(label)),
+            )
     }
 
     // Helper to create a transformed image card
@@ -28,7 +33,12 @@ fn main() {
                     .corner_radius(4.0)
                     .child(img),
             )
-            .child(text(label).font_size(12.0).color(Color::rgb(0.7, 0.7, 0.7)))
+            .child(
+                container()
+                    .font_size(12.0)
+                    .text_color(Color::rgb(0.7, 0.7, 0.7))
+                    .child(text(label)),
+            )
     }
 
     // Panel with two columns: raster images and SVG images
@@ -39,7 +49,12 @@ fn main() {
             // Left column: Raster images
             container()
                 .layout(Flex::column().spacing(32.0))
-                .child(text("Raster Image").font_size(16.0).color(Color::WHITE))
+                .child(
+                    container()
+                        .font_size(16.0)
+                        .text_color(Color::WHITE)
+                        .child(text("Raster Image")),
+                )
                 .child(
                     container()
                         .layout(Flex::row().spacing(32.0))
@@ -90,7 +105,12 @@ fn main() {
             // Right column: SVG images
             container()
                 .layout(Flex::column().spacing(32.0))
-                .child(text("SVG Image").font_size(16.0).color(Color::WHITE))
+                .child(
+                    container()
+                        .font_size(16.0)
+                        .text_color(Color::WHITE)
+                        .child(text("SVG Image")),
+                )
                 .child(
                     container()
                         .layout(Flex::row().spacing(32.0))

--- a/examples/image_fit_none_test.rs
+++ b/examples/image_fit_none_test.rs
@@ -16,7 +16,12 @@ fn main() {
         container()
             .layout(Flex::column().spacing(8.0))
             .child(widget)
-            .child(text(label).font_size(11.0).color(Color::rgb(0.7, 0.7, 0.7)))
+            .child(
+                container()
+                    .font_size(11.0)
+                    .text_color(Color::rgb(0.7, 0.7, 0.7))
+                    .child(text(label)),
+            )
     }
 
     // Helper to create a clipped container with visible border
@@ -47,18 +52,22 @@ fn main() {
         .padding(24.0)
         .layout(Flex::column().spacing(24.0))
         .child(
-            text("Image Clipping Test")
+            container()
                 .font_size(20.0)
-                .color(Color::WHITE),
+                .text_color(Color::WHITE)
+                .child(text("Image Clipping Test")),
         )
         // Row 1: Clipping comparison
         .child(
             container()
                 .layout(Flex::column().spacing(12.0))
                 .child(
-                    text("Clipping: 120x120 container with 257x248 image (ContentFit::None)")
+                    container()
                         .font_size(13.0)
-                        .color(Color::rgb(0.7, 0.7, 0.7)),
+                        .text_color(Color::rgb(0.7, 0.7, 0.7))
+                        .child(text(
+                            "Clipping: 120x120 container with 257x248 image (ContentFit::None)",
+                        )),
                 )
                 .child(
                     container()
@@ -86,9 +95,10 @@ fn main() {
             container()
                 .layout(Flex::column().spacing(12.0))
                 .child(
-                    text("Clipped containers at different sizes")
+                    container()
                         .font_size(13.0)
-                        .color(Color::rgb(0.7, 0.7, 0.7)),
+                        .text_color(Color::rgb(0.7, 0.7, 0.7))
+                        .child(text("Clipped containers at different sizes")),
                 )
                 .child(
                     container()
@@ -136,9 +146,10 @@ fn main() {
             container()
                 .layout(Flex::column().spacing(12.0))
                 .child(
-                    text("Intrinsic size layout (no explicit dimensions)")
+                    container()
                         .font_size(13.0)
-                        .color(Color::rgb(0.7, 0.7, 0.7)),
+                        .text_color(Color::rgb(0.7, 0.7, 0.7))
+                        .child(text("Intrinsic size layout (no explicit dimensions)")),
                 )
                 .child(labeled(
                     "ContentFit::None at intrinsic size (~257x248)",

--- a/examples/incremental_layout_test.rs
+++ b/examples/incremental_layout_test.rs
@@ -49,10 +49,8 @@ async fn main() {
                             .padding(12.0)
                             .corner_radius(12.0)
                             .background(Color::rgb(0.18, 0.18, 0.24))
-                            .child(
-                                text(move || format!("elapsed: {} ticks", ticks.get()))
-                                    .font_size(18.0),
-                            ),
+                            .font_size(18.0)
+                            .child(text(move || format!("elapsed: {} ticks", ticks.get()))),
                     )
                     .children((0..100).map(static_row).collect::<Vec<_>>())
             },
@@ -75,5 +73,5 @@ fn static_row(i: usize) -> Container {
                 .corner_radius(8.0)
                 .background(Color::rgb(0.3, 0.5, 0.9)),
         )
-        .child(text(format!("row {i}")).font_size(14.0))
+        .child(container().font_size(14.0).child(text(format!("row {i}"))))
 }

--- a/examples/multi_surface.rs
+++ b/examples/multi_surface.rs
@@ -32,14 +32,16 @@ fn main() {
                     )
                     .padding([0.0, 16.0])
                     .child(
-                        text("Multi-Surface Demo")
-                            .color(Color::WHITE)
-                            .font_size(14.0),
+                        container()
+                            .text_color(Color::WHITE)
+                            .font_size(14.0)
+                            .child(text("Multi-Surface Demo")),
                     )
                     .child(
-                        text(move || format!("Count: {}", count.get()))
-                            .color(Color::WHITE)
-                            .font_size(14.0),
+                        container()
+                            .text_color(Color::WHITE)
+                            .font_size(14.0)
+                            .child(text(move || format!("Count: {}", count.get()))),
                     )
             },
         );
@@ -68,7 +70,9 @@ fn main() {
                             .hover_state(|s| s.lighter(0.1))
                             .pressed_state(|s| s.ripple())
                             .on_click(move || count.update(|c| *c += 1))
-                            .child(text("+").color(Color::WHITE).font_size(16.0)),
+                            .text_color(Color::WHITE)
+                            .font_size(16.0)
+                            .child(text("+")),
                         container()
                             .background(Color::rgb(0.3, 0.3, 0.4))
                             .padding([8.0, 16.0])
@@ -76,7 +80,9 @@ fn main() {
                             .hover_state(|s| s.lighter(0.1))
                             .pressed_state(|s| s.ripple())
                             .on_click(move || count.update(|c| *c -= 1))
-                            .child(text("-").color(Color::WHITE).font_size(16.0)),
+                            .text_color(Color::WHITE)
+                            .font_size(16.0)
+                            .child(text("-")),
                         container()
                             .background(Color::rgb(0.4, 0.2, 0.2))
                             .padding([8.0, 16.0])
@@ -84,7 +90,9 @@ fn main() {
                             .hover_state(|s| s.lighter(0.1))
                             .pressed_state(|s| s.ripple())
                             .on_click(move || count.set(0))
-                            .child(text("Reset").color(Color::WHITE).font_size(16.0)),
+                            .text_color(Color::WHITE)
+                            .font_size(16.0)
+                            .child(text("Reset")),
                     ])
             },
         );

--- a/examples/perf_stress_test.rs
+++ b/examples/perf_stress_test.rs
@@ -63,9 +63,10 @@ fn main() {
             .padding(20.0)
             .layout(Flex::column().spacing(20.0))
             .child(
-                text("Performance Stress Test")
-                    .color(Color::WHITE)
-                    .font_size(28.0),
+                container()
+                    .text_color(Color::WHITE)
+                    .font_size(28.0)
+                    .child(text("Performance Stress Test")),
             )
             .child(create_add_button(item_ids, store_for_button))
             .child(
@@ -114,7 +115,9 @@ fn create_add_button(
             });
             item_ids.update(|ids| ids.push(id));
         })
-        .child(text("Add Item").color(Color::WHITE).font_size(14.0))
+        .text_color(Color::WHITE)
+        .font_size(14.0)
+        .child(text("Add Item"))
 }
 
 fn create_item_row(
@@ -158,17 +161,15 @@ fn create_toggle_button(enabled: RwSignal<bool>) -> Container {
         .on_click(move || {
             enabled.update(|e| *e = !*e);
         })
-        .child(
-            text(move || {
-                if enabled.get() {
-                    "Enabled".to_string()
-                } else {
-                    "Disabled".to_string()
-                }
-            })
-            .color(Color::WHITE)
-            .font_size(12.0),
-        )
+        .text_color(Color::WHITE)
+        .font_size(12.0)
+        .child(text(move || {
+            if enabled.get() {
+                "Enabled".to_string()
+            } else {
+                "Disabled".to_string()
+            }
+        }))
 }
 
 fn create_info_section(
@@ -179,16 +180,23 @@ fn create_info_section(
     container()
         .width(at_least(200.0))
         .layout(Flex::column().spacing(4.0))
-        .child(text(name).color(Color::WHITE).font_size(18.0))
         .child(
-            text(description)
-                .color(Color::rgb(0.7, 0.7, 0.8))
-                .font_size(14.0),
+            container()
+                .text_color(Color::WHITE)
+                .font_size(18.0)
+                .child(text(name)),
         )
         .child(
-            text(move || format!("Input: {}", input_value.get()))
-                .color(Color::rgb(0.6, 0.6, 0.7))
-                .font_size(12.0),
+            container()
+                .text_color(Color::rgb(0.7, 0.7, 0.8))
+                .font_size(14.0)
+                .child(text(description)),
+        )
+        .child(
+            container()
+                .text_color(Color::rgb(0.6, 0.6, 0.7))
+                .font_size(12.0)
+                .child(text(move || format!("Input: {}", input_value.get()))),
         )
 }
 
@@ -200,11 +208,9 @@ fn create_text_input_field(input_value: RwSignal<String>) -> Container {
         .border(1.0, Color::rgb(0.3, 0.3, 0.4))
         .corner_radius(6.0)
         .focused_state(|s| s.border(2.0, Color::rgb(0.4, 0.8, 1.0)))
-        .child(
-            text_input(input_value)
-                .text_color(Color::WHITE)
-                .cursor_color(Color::rgb(0.4, 0.8, 1.0))
-                .selection_color(Color::rgba(0.4, 0.6, 1.0, 0.4))
-                .font_size(14.0),
-        )
+        .text_color(Color::WHITE)
+        .cursor_color(Color::rgb(0.4, 0.8, 1.0))
+        .selection_color(Color::rgba(0.4, 0.6, 1.0, 0.4))
+        .font_size(14.0)
+        .child(text_input(input_value))
 }

--- a/examples/popup_example.rs
+++ b/examples/popup_example.rs
@@ -14,7 +14,8 @@ fn menu_entry(label: &str) -> Container {
         .padding([8.0, 12.0])
         .corner_radius(6.0)
         .hover_state(|s| s.lighter(0.12))
-        .child(text(label).font_size(13))
+        .font_size(13)
+        .child(text(label))
 }
 
 fn main() {

--- a/examples/reactive_example.rs
+++ b/examples/reactive_example.rs
@@ -52,10 +52,8 @@ fn main() {
                             .on_click(move || {
                                 count.update(|c| *c += 10);
                             })
-                            .child(
-                                text(move || format!("Count: {} (click me!)", count.get()))
-                                    .color(Color::WHITE),
-                            ),
+                            .text_color(Color::WHITE)
+                            .child(text(move || format!("Count: {} (click me!)", count.get()))),
                     )
                     .child(
                         // Scrollable container with hover state
@@ -69,10 +67,10 @@ fn main() {
                                     *offset += dy;
                                 });
                             })
-                            .child(
-                                text(move || format!("Scroll: {:.0}px", scroll_offset.get()))
-                                    .color(Color::WHITE),
-                            ),
+                            .text_color(Color::WHITE)
+                            .child(text(move || {
+                                format!("Scroll: {:.0}px", scroll_offset.get())
+                            })),
                     )
                     .child(
                         // Container with border and hover state
@@ -81,7 +79,8 @@ fn main() {
                             .background(Color::rgb(0.15, 0.15, 0.2))
                             .border(2.0, Color::rgb(0.4, 0.6, 0.8))
                             .hover_state(|s| s.lighter(0.1))
-                            .child(text("With border").color(Color::WHITE)),
+                            .text_color(Color::WHITE)
+                            .child(text("With border")),
                     )
                     .child(
                         // Container with gradient and hover state
@@ -93,7 +92,8 @@ fn main() {
                             )
                             .corner_radius(4.0)
                             .hover_state(|s| s.lighter(0.1))
-                            .child(text("Gradient!").color(Color::WHITE)),
+                            .text_color(Color::WHITE)
+                            .child(text("Gradient!")),
                     )
             },
         );

--- a/examples/render_stats_test.rs
+++ b/examples/render_stats_test.rs
@@ -38,20 +38,23 @@ async fn main() {
                     .padding(8.0)
                     .background(Color::rgb(0.2, 0.2, 0.3))
                     .rotate(rotation)
-                    .child(text("Rotating").color(Color::WHITE)),
+                    .text_color(Color::WHITE)
+                    .child(text("Rotating")),
             )
             // Static containers (should have layout skipped after first frame)
             .child(
                 container()
                     .padding(8.0)
                     .background(Color::rgb(0.2, 0.3, 0.2))
-                    .child(text("Static text 1").color(Color::WHITE)),
+                    .text_color(Color::WHITE)
+                    .child(text("Static text 1")),
             )
             .child(
                 container()
                     .padding(8.0)
                     .background(Color::rgb(0.3, 0.2, 0.2))
-                    .child(text("Static text 2").color(Color::WHITE)),
+                    .text_color(Color::WHITE)
+                    .child(text("Static text 2")),
             );
 
         app.add_surface(

--- a/examples/rounded_hitbox_test.rs
+++ b/examples/rounded_hitbox_test.rs
@@ -43,17 +43,9 @@ fn main() {
                             make_box("r=50", 50.0, Color::rgb(0.8, 0.3, 0.8), click_count),
                         ]),
                     // Instructions
-                    container().child(
-                        text("Hover over corners - should NOT highlight outside the rounded area")
-                            .font_size(14.0)
-                            .color(Color::rgb(0.7, 0.7, 0.7)),
-                    ),
+                    container().font_size(14.0).text_color(Color::rgb(0.7, 0.7, 0.7)).child(text("Hover over corners - should NOT highlight outside the rounded area")),
                     // Click counter display
-                    container().child(
-                        text(move || format!("Clicks: {}", click_count.get()))
-                            .font_size(20.0)
-                            .color(Color::WHITE),
-                    ),
+                    container().font_size(20.0).text_color(Color::WHITE).child(text(move || format!("Clicks: {}", click_count.get()))),
                 ])
             },
         );
@@ -79,5 +71,7 @@ fn make_box(
                 .main_alignment(MainAlignment::Center)
                 .cross_alignment(CrossAlignment::Center),
         )
-        .child(text(label).font_size(14.0).color(Color::WHITE))
+        .font_size(14.0)
+        .text_color(Color::WHITE)
+        .child(text(label))
 }

--- a/examples/rounded_transform_test.rs
+++ b/examples/rounded_transform_test.rs
@@ -53,17 +53,17 @@ fn main() {
                                     .scale(1.2),
                             ]),
                         // Instructions
-                        container().child(
-                            text("Rectangular boxes with transforms. Hover and click to test.")
-                                .font_size(14.0)
-                                .color(Color::rgb(0.7, 0.7, 0.7)),
-                        ),
+                        container()
+                            .font_size(14.0)
+                            .text_color(Color::rgb(0.7, 0.7, 0.7))
+                            .child(text(
+                                "Rectangular boxes with transforms. Hover and click to test.",
+                            )),
                         // Click counter display
-                        container().child(
-                            text(move || format!("Clicks: {}", click_count.get()))
-                                .font_size(20.0)
-                                .color(Color::WHITE),
-                        ),
+                        container()
+                            .font_size(20.0)
+                            .text_color(Color::WHITE)
+                            .child(text(move || format!("Clicks: {}", click_count.get()))),
                     ])
             },
         );
@@ -83,5 +83,7 @@ fn make_box(label: &'static str, base_color: Color, click_count: RwSignal<i32>) 
                 .main_alignment(MainAlignment::Center)
                 .cross_alignment(CrossAlignment::Center),
         )
-        .child(text(label).font_size(12.0).color(Color::WHITE))
+        .font_size(12.0)
+        .text_color(Color::WHITE)
+        .child(text(label))
 }

--- a/examples/scroll_example.rs
+++ b/examples/scroll_example.rs
@@ -17,7 +17,11 @@ fn main() {
         .child(
             container()
                 .layout(Flex::column().spacing(4.0))
-                .child(text("Vertical Scroll").color(Color::WHITE))
+                .child(
+                    container()
+                        .text_color(Color::WHITE)
+                        .child(text("Vertical Scroll")),
+                )
                 .child(
                     container()
                         .width(200.0)
@@ -37,10 +41,8 @@ fn main() {
                                                 .background(Color::rgb(0.25, 0.25, 0.35))
                                                 .corner_radius(4.0)
                                                 .hover_state(|s| s.lighter(0.05))
-                                                .child(
-                                                    text(format!("Item {}", i + 1))
-                                                        .color(Color::WHITE),
-                                                )
+                                                .text_color(Color::WHITE)
+                                                .child(text(format!("Item {}", i + 1)))
                                         })
                                         .collect::<Vec<_>>(),
                                 ),
@@ -51,7 +53,11 @@ fn main() {
         .child(
             container()
                 .layout(Flex::column().spacing(4.0))
-                .child(text("Horizontal Scroll").color(Color::WHITE))
+                .child(
+                    container()
+                        .text_color(Color::WHITE)
+                        .child(text("Horizontal Scroll")),
+                )
                 .child(
                     container()
                         .width(200.0)
@@ -81,9 +87,8 @@ fn main() {
                                                         .main_alignment(MainAlignment::Center)
                                                         .cross_alignment(CrossAlignment::Center),
                                                 )
-                                                .child(
-                                                    text(format!("{}", i + 1)).color(Color::WHITE),
-                                                )
+                                                .text_color(Color::WHITE)
+                                                .child(text(format!("{}", i + 1)))
                                         })
                                         .collect::<Vec<_>>(),
                                 ),
@@ -94,7 +99,11 @@ fn main() {
         .child(
             container()
                 .layout(Flex::column().spacing(4.0))
-                .child(text("Custom Scrollbar").color(Color::WHITE))
+                .child(
+                    container()
+                        .text_color(Color::WHITE)
+                        .child(text("Custom Scrollbar")),
+                )
                 .child(
                     container()
                         .width(200.0)
@@ -122,10 +131,8 @@ fn main() {
                                                 .background(Color::rgb(0.2, 0.3, 0.45))
                                                 .corner_radius(4.0)
                                                 .hover_state(|s| s.lighter(0.05))
-                                                .child(
-                                                    text(format!("Blue Item {}", i + 1))
-                                                        .color(Color::WHITE),
-                                                )
+                                                .text_color(Color::WHITE)
+                                                .child(text(format!("Blue Item {}", i + 1)))
                                         })
                                         .collect::<Vec<_>>(),
                                 ),
@@ -136,7 +143,11 @@ fn main() {
         .child(
             container()
                 .layout(Flex::column().spacing(4.0))
-                .child(text("Hidden Scrollbar").color(Color::WHITE))
+                .child(
+                    container()
+                        .text_color(Color::WHITE)
+                        .child(text("Hidden Scrollbar")),
+                )
                 .child(
                     container()
                         .width(200.0)
@@ -157,10 +168,8 @@ fn main() {
                                                 .background(Color::rgb(0.3, 0.25, 0.2))
                                                 .corner_radius(4.0)
                                                 .hover_state(|s| s.lighter(0.05))
-                                                .child(
-                                                    text(format!("Hidden {}", i + 1))
-                                                        .color(Color::WHITE),
-                                                )
+                                                .text_color(Color::WHITE)
+                                                .child(text(format!("Hidden {}", i + 1)))
                                         })
                                         .collect::<Vec<_>>(),
                                 ),

--- a/examples/scroll_mixed_content.rs
+++ b/examples/scroll_mixed_content.rs
@@ -19,7 +19,12 @@ fn main() {
         fn form_field(label: &'static str, input_signal: RwSignal<String>) -> Container {
             container()
                 .layout(Flex::column().spacing(4.0))
-                .child(text(label).color(Color::rgb(0.7, 0.7, 0.8)).font_size(12.0))
+                .child(
+                    container()
+                        .text_color(Color::rgb(0.7, 0.7, 0.8))
+                        .font_size(12.0)
+                        .child(text(label)),
+                )
                 .child(
                     container()
                         .padding(8.0)
@@ -27,13 +32,11 @@ fn main() {
                         .border(1.0, Color::rgb(0.3, 0.3, 0.4))
                         .corner_radius(6.0)
                         .focused_state(|s| s.border(2.0, Color::rgb(0.4, 0.8, 1.0)))
-                        .child(
-                            text_input(input_signal)
-                                .text_color(Color::WHITE)
-                                .cursor_color(Color::rgb(0.4, 0.8, 1.0))
-                                .selection_color(Color::rgba(0.4, 0.6, 1.0, 0.4))
-                                .font_size(14.0),
-                        ),
+                        .text_color(Color::WHITE)
+                        .cursor_color(Color::rgb(0.4, 0.8, 1.0))
+                        .selection_color(Color::rgba(0.4, 0.6, 1.0, 0.4))
+                        .font_size(14.0)
+                        .child(text_input(input_signal)),
                 )
         }
 
@@ -53,7 +56,12 @@ fn main() {
                                 .content_fit(ContentFit::Cover),
                         ),
                 )
-                .child(text(label).font_size(11.0).color(Color::rgb(0.6, 0.6, 0.7)))
+                .child(
+                    container()
+                        .font_size(11.0)
+                        .text_color(Color::rgb(0.6, 0.6, 0.7))
+                        .child(text(label)),
+                )
         }
 
         // Main scrollable content
@@ -65,10 +73,11 @@ fn main() {
                 container()
                     .layout(Flex::column().spacing(8.0))
                     .child(
-                        text("User Profile")
-                            .color(Color::WHITE)
+                        container()
+                            .text_color(Color::WHITE)
                             .font_size(16.0)
-                            .font_weight(FontWeight::BOLD),
+                            .font_weight(FontWeight::BOLD)
+                            .child(text("User Profile")),
                     )
                     .child(
                         container()
@@ -110,14 +119,16 @@ fn main() {
                                                 container()
                                                     .layout(Flex::column().spacing(4.0))
                                                     .child(
-                                                        text("Edit Profile")
-                                                            .color(Color::WHITE)
-                                                            .font_size(18.0),
+                                                        container()
+                                                            .text_color(Color::WHITE)
+                                                            .font_size(18.0)
+                                                            .child(text("Edit Profile")),
                                                     )
                                                     .child(
-                                                        text("Update your information")
-                                                            .color(Color::rgb(0.5, 0.5, 0.6))
-                                                            .font_size(12.0),
+                                                        container()
+                                                            .text_color(Color::rgb(0.5, 0.5, 0.6))
+                                                            .font_size(12.0)
+                                                            .child(text("Update your information")),
                                                     ),
                                             ),
                                     )
@@ -130,9 +141,10 @@ fn main() {
                                         container()
                                             .layout(Flex::column().spacing(8.0))
                                             .child(
-                                                text("Account Settings")
-                                                    .color(Color::WHITE)
-                                                    .font_size(14.0),
+                                                container()
+                                                    .text_color(Color::WHITE)
+                                                    .font_size(14.0)
+                                                    .child(text("Account Settings")),
                                             )
                                             .children(
                                                 [
@@ -150,10 +162,8 @@ fn main() {
                                                         .corner_radius(6.0)
                                                         .hover_state(|s| s.lighter(0.05))
                                                         .pressed_state(|s| s.ripple())
-                                                        .child(
-                                                            text(item)
-                                                                .color(Color::rgb(0.8, 0.8, 0.9)),
-                                                        )
+                                                        .text_color(Color::rgb(0.8, 0.8, 0.9))
+                                                        .child(text(item))
                                                 })
                                                 .collect::<Vec<_>>(),
                                             ),
@@ -163,9 +173,10 @@ fn main() {
                                         container()
                                             .layout(Flex::column().spacing(8.0))
                                             .child(
-                                                text("Recent Activity")
-                                                    .color(Color::WHITE)
-                                                    .font_size(14.0),
+                                                container()
+                                                    .text_color(Color::WHITE)
+                                                    .font_size(14.0)
+                                                    .child(text("Recent Activity")),
                                             )
                                             .children(
                                                 (1..=8)
@@ -192,24 +203,26 @@ fn main() {
                                                                         Flex::column().spacing(2.0),
                                                                     )
                                                                     .child(
-                                                                        text(format!(
-                                                                            "Activity {}",
-                                                                            i
-                                                                        ))
-                                                                        .color(Color::rgb(
-                                                                            0.8, 0.8, 0.9,
-                                                                        ))
-                                                                        .font_size(13.0),
+                                                                        container()
+                                                                            .text_color(Color::rgb(
+                                                                                0.8, 0.8, 0.9,
+                                                                            ))
+                                                                            .font_size(13.0)
+                                                                            .child(text(format!(
+                                                                                "Activity {}",
+                                                                                i
+                                                                            ))),
                                                                     )
                                                                     .child(
-                                                                        text(format!(
-                                                                            "{} hours ago",
-                                                                            i * 2
-                                                                        ))
-                                                                        .color(Color::rgb(
-                                                                            0.5, 0.5, 0.6,
-                                                                        ))
-                                                                        .font_size(11.0),
+                                                                        container()
+                                                                            .text_color(Color::rgb(
+                                                                                0.5, 0.5, 0.6,
+                                                                            ))
+                                                                            .font_size(11.0)
+                                                                            .child(text(format!(
+                                                                                "{} hours ago",
+                                                                                i * 2
+                                                                            ))),
                                                                     ),
                                                             )
                                                     })
@@ -224,10 +237,11 @@ fn main() {
                 container()
                     .layout(Flex::column().spacing(8.0))
                     .child(
-                        text("Image Gallery")
-                            .color(Color::WHITE)
+                        container()
+                            .text_color(Color::WHITE)
                             .font_size(16.0)
-                            .font_weight(FontWeight::BOLD),
+                            .font_weight(FontWeight::BOLD)
+                            .child(text("Image Gallery")),
                     )
                     .child(
                         container()
@@ -256,10 +270,11 @@ fn main() {
                     )
                     // SVG icons row
                     .child(
-                        text("Icons")
-                            .color(Color::WHITE)
+                        container()
+                            .text_color(Color::WHITE)
                             .font_size(16.0)
-                            .font_weight(FontWeight::BOLD),
+                            .font_weight(FontWeight::BOLD)
+                            .child(text("Icons")),
                     )
                     .child(
                         container()
@@ -312,9 +327,10 @@ fn main() {
                                                             ),
                                                     )
                                                     .child(
-                                                        text(format!("Icon {}", i + 1))
+                                                        container()
                                                             .font_size(10.0)
-                                                            .color(Color::rgb(0.5, 0.5, 0.6)),
+                                                            .text_color(Color::rgb(0.5, 0.5, 0.6))
+                                                            .child(text(format!("Icon {}", i + 1))),
                                                     )
                                             })
                                             .collect::<Vec<_>>(),
@@ -329,24 +345,28 @@ fn main() {
                             .corner_radius(8.0)
                             .layout(Flex::column().spacing(4.0))
                             .child(
-                                text("Form Values:")
-                                    .color(Color::rgb(0.5, 0.5, 0.6))
-                                    .font_size(11.0),
+                                container()
+                                    .text_color(Color::rgb(0.5, 0.5, 0.6))
+                                    .font_size(11.0)
+                                    .child(text("Form Values:")),
                             )
                             .child(
-                                text(move || format!("Name: {}", name.get()))
-                                    .color(Color::rgb(0.7, 0.7, 0.8))
-                                    .font_size(12.0),
+                                container()
+                                    .text_color(Color::rgb(0.7, 0.7, 0.8))
+                                    .font_size(12.0)
+                                    .child(text(move || format!("Name: {}", name.get()))),
                             )
                             .child(
-                                text(move || format!("Email: {}", email.get()))
-                                    .color(Color::rgb(0.7, 0.7, 0.8))
-                                    .font_size(12.0),
+                                container()
+                                    .text_color(Color::rgb(0.7, 0.7, 0.8))
+                                    .font_size(12.0)
+                                    .child(text(move || format!("Email: {}", email.get()))),
                             )
                             .child(
-                                text(move || format!("Bio: {}", bio.get()))
-                                    .color(Color::rgb(0.7, 0.7, 0.8))
-                                    .font_size(12.0),
+                                container()
+                                    .text_color(Color::rgb(0.7, 0.7, 0.8))
+                                    .font_size(12.0)
+                                    .child(text(move || format!("Bio: {}", bio.get()))),
                             ),
                     ),
             );

--- a/examples/service_example.rs
+++ b/examples/service_example.rs
@@ -100,7 +100,8 @@ async fn main() {
                                                 .main_alignment(MainAlignment::Center)
                                                 .cross_alignment(CrossAlignment::Center),
                                         )
-                                        .child(text(format!("{}", id)).color(Color::WHITE)),
+                                        .text_color(Color::WHITE)
+                                        .child(text(format!("{}", id))),
                                 )
                         }),
                     ))
@@ -110,7 +111,8 @@ async fn main() {
                             .padding(8.0)
                             .background(Color::rgb(0.2, 0.2, 0.3))
                             .corner_radius(4.0)
-                            .child(text(move || time.get()).color(Color::WHITE)),
+                            .text_color(Color::WHITE)
+                            .child(text(move || time.get())),
                     )
             },
         );

--- a/examples/showcase.rs
+++ b/examples/showcase.rs
@@ -29,7 +29,8 @@ fn main() {
                                     .background(Color::rgb(0.3, 0.2, 0.4))
                                     .corner_radius(12.0)
                                     .squircle() // K=2 → n=4
-                                    .child(text("Squircle\n(K=2)").color(Color::WHITE)),
+                                    .text_color(Color::WHITE)
+                                    .child(text("Squircle\n(K=2)")),
                             )
                             .child(
                                 container()
@@ -37,7 +38,8 @@ fn main() {
                                     .background(Color::rgb(0.2, 0.3, 0.4))
                                     .corner_radius(12.0)
                                     // Default circular K=1 → n=2
-                                    .child(text("Circle\n(K=1)").color(Color::WHITE)),
+                                    .text_color(Color::WHITE)
+                                    .child(text("Circle\n(K=1)")),
                             )
                             .child(
                                 container()
@@ -45,7 +47,8 @@ fn main() {
                                     .background(Color::rgb(0.4, 0.3, 0.2))
                                     .corner_radius(12.0)
                                     .bevel() // K=0 → n=1
-                                    .child(text("Bevel\n(K=0)").color(Color::WHITE)),
+                                    .text_color(Color::WHITE)
+                                    .child(text("Bevel\n(K=0)")),
                             )
                             .child(
                                 container()
@@ -55,7 +58,8 @@ fn main() {
                                     .scoop() // K=-1 → n=0.5
                                     .hover_state(|s| s.lighter(0.1))
                                     .pressed_state(|s| s.ripple())
-                                    .child(text("Scoop\n(K=-1)").color(Color::WHITE)),
+                                    .text_color(Color::WHITE)
+                                    .child(text("Scoop\n(K=-1)")),
                             ),
                     )
                     .child(
@@ -69,7 +73,8 @@ fn main() {
                                     .corner_radius(12.0)
                                     .border(2.0, Color::rgb(0.5, 0.3, 0.7))
                                     .squircle()
-                                    .child(text("Squircle\nBorder").color(Color::WHITE)),
+                                    .text_color(Color::WHITE)
+                                    .child(text("Squircle\nBorder")),
                             )
                             .child(
                                 container()
@@ -77,7 +82,8 @@ fn main() {
                                     .background(Color::rgb(0.15, 0.15, 0.2))
                                     .corner_radius(12.0)
                                     .border(2.0, Color::rgb(0.3, 0.5, 0.7))
-                                    .child(text("Circle\nBorder").color(Color::WHITE)),
+                                    .text_color(Color::WHITE)
+                                    .child(text("Circle\nBorder")),
                             )
                             .child(
                                 container()
@@ -86,7 +92,8 @@ fn main() {
                                     .corner_radius(12.0)
                                     .border(2.0, Color::rgb(0.7, 0.5, 0.3))
                                     .bevel()
-                                    .child(text("Bevel\nBorder").color(Color::WHITE)),
+                                    .text_color(Color::WHITE)
+                                    .child(text("Bevel\nBorder")),
                             )
                             .child(
                                 container()
@@ -97,7 +104,8 @@ fn main() {
                                     .scoop()
                                     .hover_state(|s| s.lighter(0.1))
                                     .pressed_state(|s| s.ripple())
-                                    .child(text("Scoop\nBorder").color(Color::WHITE)),
+                                    .text_color(Color::WHITE)
+                                    .child(text("Scoop\nBorder")),
                             ),
                     )
                     .child(
@@ -113,7 +121,8 @@ fn main() {
                                     )
                                     .corner_radius(12.0)
                                     .squircle()
-                                    .child(text("Squircle\nGradient").color(Color::WHITE)),
+                                    .text_color(Color::WHITE)
+                                    .child(text("Squircle\nGradient")),
                             )
                             .child(
                                 container()
@@ -123,7 +132,8 @@ fn main() {
                                         Color::rgb(0.4, 0.2, 0.6),
                                     )
                                     .corner_radius(12.0)
-                                    .child(text("Circle\nGradient").color(Color::WHITE)),
+                                    .text_color(Color::WHITE)
+                                    .child(text("Circle\nGradient")),
                             )
                             .child(
                                 container()
@@ -134,7 +144,8 @@ fn main() {
                                     )
                                     .corner_radius(12.0)
                                     .bevel()
-                                    .child(text("Bevel\nGradient").color(Color::WHITE)),
+                                    .text_color(Color::WHITE)
+                                    .child(text("Bevel\nGradient")),
                             )
                             .child(
                                 container()
@@ -145,7 +156,8 @@ fn main() {
                                     )
                                     .corner_radius(12.0)
                                     .scoop()
-                                    .child(text("Scoop\nGradient").color(Color::WHITE)),
+                                    .text_color(Color::WHITE)
+                                    .child(text("Scoop\nGradient")),
                             ),
                     )
                     .child(
@@ -158,7 +170,8 @@ fn main() {
                                     .background(Color::rgb(0.3, 0.3, 0.4))
                                     .corner_radius(12.0)
                                     .corner_curvature(0.5) // K=0.5 → n=1.41
-                                    .child(text("K=0.5").color(Color::WHITE)),
+                                    .text_color(Color::WHITE)
+                                    .child(text("K=0.5")),
                             )
                             .child(
                                 container()
@@ -166,7 +179,8 @@ fn main() {
                                     .background(Color::rgb(0.3, 0.4, 0.3))
                                     .corner_radius(12.0)
                                     .corner_curvature(1.5) // K=1.5 → n=2.83
-                                    .child(text("K=1.5").color(Color::WHITE)),
+                                    .text_color(Color::WHITE)
+                                    .child(text("K=1.5")),
                             )
                             .child(
                                 container()
@@ -174,7 +188,8 @@ fn main() {
                                     .background(Color::rgb(0.4, 0.3, 0.3))
                                     .corner_radius(12.0)
                                     .corner_curvature(2.5) // K=2.5 → n=5.66
-                                    .child(text("K=2.5").color(Color::WHITE)),
+                                    .text_color(Color::WHITE)
+                                    .child(text("K=2.5")),
                             )
                             .child(
                                 container()
@@ -182,7 +197,8 @@ fn main() {
                                     .background(Color::rgb(0.35, 0.3, 0.4))
                                     .corner_radius(12.0)
                                     .corner_curvature(-0.5) // K=-0.5 → n=0.707
-                                    .child(text("K=-0.5").color(Color::WHITE)),
+                                    .text_color(Color::WHITE)
+                                    .child(text("K=-0.5")),
                             ),
                     )
             },

--- a/examples/simple_lock.rs
+++ b/examples/simple_lock.rs
@@ -44,17 +44,19 @@ fn lock_screen(output: OutputInfo) -> Container {
                 .cross_alignment(CrossAlignment::Center),
         )
         .child(
-            text(format!(
-                "Locked — {}",
-                output.name.unwrap_or_else(|| "output".into())
-            ))
-            .color(Color::WHITE)
-            .font_size(24.0),
+            container()
+                .text_color(Color::WHITE)
+                .font_size(24.0)
+                .child(text(format!(
+                    "Locked — {}",
+                    output.name.unwrap_or_else(|| "output".into())
+                ))),
         )
         .child(
-            text("password: guido (auto-unlocks after 30s)")
-                .color(Color::rgb(0.6, 0.6, 0.7))
-                .font_size(13.0),
+            container()
+                .text_color(Color::rgb(0.6, 0.6, 0.7))
+                .font_size(13.0)
+                .child(text("password: guido (auto-unlocks after 30s)")),
         )
         .child(
             container()
@@ -63,19 +65,15 @@ fn lock_screen(output: OutputInfo) -> Container {
                 .background(Color::rgb(0.15, 0.15, 0.2))
                 .corner_radius(8.0)
                 .focused_state(|s| s.border(2.0, Color::rgb(0.4, 0.8, 1.0)))
-                .child(
-                    text_input(attempt)
-                        .password(true)
-                        .text_color(Color::WHITE)
-                        .cursor_color(Color::rgb(0.4, 0.8, 1.0))
-                        .on_submit(move |s| {
-                            if s == PASSWORD {
-                                unlock_session();
-                            } else {
-                                error.set(true);
-                            }
-                        }),
-                ),
+                .text_color(Color::WHITE)
+                .cursor_color(Color::rgb(0.4, 0.8, 1.0))
+                .child(text_input(attempt).password(true).on_submit(move |s| {
+                    if s == PASSWORD {
+                        unlock_session();
+                    } else {
+                        error.set(true);
+                    }
+                })),
         )
         .child(text(move || {
             if error.get() {

--- a/examples/simple_text_transform.rs
+++ b/examples/simple_text_transform.rs
@@ -23,7 +23,9 @@ fn main() {
                         .main_alignment(MainAlignment::Center)
                         .cross_alignment(CrossAlignment::Center),
                 )
-                .child(text("No Transform").font_size(14.0).color(Color::WHITE)),
+                .font_size(14.0)
+                .text_color(Color::WHITE)
+                .child(text("No Transform")),
             // With rotation - should use texture
             container()
                 .width(120.0)
@@ -36,7 +38,9 @@ fn main() {
                         .cross_alignment(CrossAlignment::Center),
                 )
                 .rotate(15.0)
-                .child(text("Rotated 15").font_size(14.0).color(Color::WHITE)),
+                .font_size(14.0)
+                .text_color(Color::WHITE)
+                .child(text("Rotated 15")),
             // With scale - should use texture
             container()
                 .width(120.0)
@@ -49,7 +53,9 @@ fn main() {
                         .cross_alignment(CrossAlignment::Center),
                 )
                 .scale(1.2)
-                .child(text("Scale 1.2").font_size(14.0).color(Color::WHITE)),
+                .font_size(14.0)
+                .text_color(Color::WHITE)
+                .child(text("Scale 1.2")),
         ]);
 
     App::new().run(|app| {

--- a/examples/state_layer_example.rs
+++ b/examples/state_layer_example.rs
@@ -22,12 +22,8 @@ fn main() {
                 .child(
                     // Title section
                     container().layout(Flex::column().spacing(8.0)).children([
-                        text("State Layer Demo")
-                            .font_size(24.0)
-                            .color(Color::rgb(0.9, 0.9, 0.95)),
-                        text("Hover and click the buttons to see state changes and ripple effects")
-                            .font_size(14.0)
-                            .color(Color::rgb(0.6, 0.6, 0.7)),
+                        container().font_size(24.0).text_color(Color::rgb(0.9, 0.9, 0.95)).child(text("State Layer Demo")),
+                        container().font_size(14.0).text_color(Color::rgb(0.6, 0.6, 0.7)).child(text("Hover and click the buttons to see state changes and ripple effects")),
                     ]),
                 )
                 .child(
@@ -62,7 +58,8 @@ fn create_lighter_button() -> Container {
         .background(Color::rgb(0.2, 0.2, 0.3))
         .corner_radius(8.0)
         .hover_state(|s| s.lighter(0.1))
-        .child(text("Hover me (lighter)").color(Color::rgb(0.9, 0.9, 0.95)))
+        .text_color(Color::rgb(0.9, 0.9, 0.95))
+        .child(text("Hover me (lighter)"))
 }
 
 /// Button with explicit hover and pressed colors
@@ -73,7 +70,8 @@ fn create_explicit_colors_button() -> Container {
         .corner_radius(8.0)
         .hover_state(|s| s.background(Color::rgb(0.4, 0.6, 0.9)))
         .pressed_state(|s| s.background(Color::rgb(0.2, 0.4, 0.7)))
-        .child(text("Click me (explicit colors)").color(Color::WHITE))
+        .text_color(Color::WHITE)
+        .child(text("Click me (explicit colors)"))
 }
 
 /// Button with transform on press
@@ -84,7 +82,8 @@ fn create_transform_button() -> Container {
         .corner_radius(8.0)
         .hover_state(|s| s.lighter(0.05))
         .pressed_state(|s| s.darker(0.1).transform(Transform::scale(0.98)))
-        .child(text("Press me (scale down)").color(Color::WHITE))
+        .text_color(Color::WHITE)
+        .child(text("Press me (scale down)"))
 }
 
 /// Button with smooth animated transitions
@@ -96,7 +95,8 @@ fn create_animated_button() -> Container {
         .animate_background(Transition::new(200.0, TimingFunction::EaseOut))
         .hover_state(|s| s.lighter(0.15))
         .pressed_state(|s| s.darker(0.1))
-        .child(text("Animated transitions").color(Color::WHITE))
+        .text_color(Color::WHITE)
+        .child(text("Animated transitions"))
 }
 
 /// Button with border changes on hover/press
@@ -110,7 +110,8 @@ fn create_border_button() -> Container {
         .animate_border_color(Transition::new(150.0, TimingFunction::EaseOut))
         .hover_state(|s| s.border(2.0, Color::rgb(0.5, 0.5, 0.6)))
         .pressed_state(|s| s.border(3.0, Color::rgb(0.7, 0.7, 0.8)))
-        .child(text("Border changes").color(Color::rgb(0.8, 0.8, 0.85)))
+        .text_color(Color::rgb(0.8, 0.8, 0.85))
+        .child(text("Border changes"))
 }
 
 /// Button with default ripple effect
@@ -121,7 +122,8 @@ fn create_ripple_button() -> Container {
         .corner_radius(8.0)
         .hover_state(|s| s.lighter(0.1))
         .pressed_state(|s| s.ripple())
-        .child(text("Default ripple").color(Color::rgb(0.9, 0.9, 0.95)))
+        .text_color(Color::rgb(0.9, 0.9, 0.95))
+        .child(text("Default ripple"))
 }
 
 /// Button with colored ripple effect
@@ -132,7 +134,8 @@ fn create_colored_ripple_button() -> Container {
         .corner_radius(8.0)
         .hover_state(|s| s.lighter(0.1))
         .pressed_state(|s| s.ripple_with_color(Color::rgba(1.0, 0.8, 0.0, 0.4)))
-        .child(text("Yellow ripple").color(Color::WHITE))
+        .text_color(Color::WHITE)
+        .child(text("Yellow ripple"))
 }
 
 /// Button with ripple and scale transform
@@ -143,7 +146,8 @@ fn create_ripple_with_scale_button() -> Container {
         .corner_radius(8.0)
         .hover_state(|s| s.lighter(0.1))
         .pressed_state(|s| s.ripple().transform(Transform::scale(0.98)))
-        .child(text("Ripple + scale").color(Color::WHITE))
+        .text_color(Color::WHITE)
+        .child(text("Ripple + scale"))
 }
 
 /// Button with rotation and translation to test transformed ripple
@@ -155,5 +159,6 @@ fn create_rotated_ripple_button() -> Container {
         .transform(Transform::rotate_degrees(5.0).then(&Transform::translate(10.0, 15.0)))
         .hover_state(|s| s.lighter(0.1))
         .pressed_state(|s| s.ripple_with_color(Color::rgba(1.0, 1.0, 1.0, 0.5)))
-        .child(text("Rotated + translated").color(Color::WHITE))
+        .text_color(Color::WHITE)
+        .child(text("Rotated + translated"))
 }

--- a/examples/surface_properties_example.rs
+++ b/examples/surface_properties_example.rs
@@ -33,9 +33,10 @@ fn main() {
                     .padding(24.0)
                     .layout(Flex::column().spacing(16.0))
                     .child(
-                        text("Surface Properties Demo")
+                        container()
                             .font_size(20.0)
-                            .color(Color::WHITE),
+                            .text_color(Color::WHITE)
+                            .child(text("Surface Properties Demo")),
                     )
                     // Current state display
                     .child(
@@ -45,16 +46,23 @@ fn main() {
                             .corner_radius(8.0)
                             .layout(Flex::column().spacing(8.0))
                             .child(
-                                text(move || format!("Current Layer: {}", current_layer.get()))
-                                    .color(Color::rgb(0.7, 0.9, 0.7))
-                                    .font_size(14.0),
+                                container()
+                                    .text_color(Color::rgb(0.7, 0.9, 0.7))
+                                    .font_size(14.0)
+                                    .child(text(move || {
+                                        format!("Current Layer: {}", current_layer.get())
+                                    })),
                             )
                             .child(
-                                text(move || {
-                                    format!("Keyboard Interactivity: {}", current_keyboard.get())
-                                })
-                                .color(Color::rgb(0.7, 0.9, 0.7))
-                                .font_size(14.0),
+                                container()
+                                    .text_color(Color::rgb(0.7, 0.9, 0.7))
+                                    .font_size(14.0)
+                                    .child(text(move || {
+                                        format!(
+                                            "Keyboard Interactivity: {}",
+                                            current_keyboard.get()
+                                        )
+                                    })),
                             ),
                     )
                     // Layer controls
@@ -62,9 +70,10 @@ fn main() {
                         container()
                             .layout(Flex::column().spacing(8.0))
                             .child(
-                                text("Change Layer:")
-                                    .color(Color::rgb(0.6, 0.6, 0.7))
-                                    .font_size(12.0),
+                                container()
+                                    .text_color(Color::rgb(0.6, 0.6, 0.7))
+                                    .font_size(12.0)
+                                    .child(text("Change Layer:")),
                             )
                             .child(
                                 container()
@@ -100,9 +109,10 @@ fn main() {
                         container()
                             .layout(Flex::column().spacing(8.0))
                             .child(
-                                text("Change Keyboard Interactivity:")
-                                    .color(Color::rgb(0.6, 0.6, 0.7))
-                                    .font_size(12.0),
+                                container()
+                                    .text_color(Color::rgb(0.6, 0.6, 0.7))
+                                    .font_size(12.0)
+                                    .child(text("Change Keyboard Interactivity:")),
                             )
                             .child(
                                 container()
@@ -135,24 +145,30 @@ fn main() {
                             .corner_radius(6.0)
                             .layout(Flex::column().spacing(4.0))
                             .child(
-                                text("Tips:")
-                                    .color(Color::rgb(0.5, 0.5, 0.6))
-                                    .font_size(11.0),
+                                container()
+                                    .text_color(Color::rgb(0.5, 0.5, 0.6))
+                                    .font_size(11.0)
+                                    .child(text("Tips:")),
                             )
                             .child(
-                                text("- Overlay layer appears above other windows")
-                                    .color(Color::rgb(0.5, 0.5, 0.6))
-                                    .font_size(11.0),
+                                container()
+                                    .text_color(Color::rgb(0.5, 0.5, 0.6))
+                                    .font_size(11.0)
+                                    .child(text("- Overlay layer appears above other windows")),
                             )
                             .child(
-                                text("- Background layer appears below the desktop")
-                                    .color(Color::rgb(0.5, 0.5, 0.6))
-                                    .font_size(11.0),
+                                container()
+                                    .text_color(Color::rgb(0.5, 0.5, 0.6))
+                                    .font_size(11.0)
+                                    .child(text("- Background layer appears below the desktop")),
                             )
                             .child(
-                                text("- Exclusive keyboard grabs focus from other apps")
-                                    .color(Color::rgb(0.5, 0.5, 0.6))
-                                    .font_size(11.0),
+                                container()
+                                    .text_color(Color::rgb(0.5, 0.5, 0.6))
+                                    .font_size(11.0)
+                                    .child(text(
+                                        "- Exclusive keyboard grabs focus from other apps",
+                                    )),
                             ),
                     )
             },
@@ -182,7 +198,9 @@ fn layer_button(
                 current_layer.set(label);
             }
         })
-        .child(text(label).color(Color::WHITE).font_size(13.0))
+        .text_color(Color::WHITE)
+        .font_size(13.0)
+        .child(text(label))
 }
 
 fn keyboard_button(
@@ -204,5 +222,7 @@ fn keyboard_button(
                 current_keyboard.set(label);
             }
         })
-        .child(text(label).color(Color::WHITE).font_size(13.0))
+        .text_color(Color::WHITE)
+        .font_size(13.0)
+        .child(text(label))
 }

--- a/examples/test_dynamic.rs
+++ b/examples/test_dynamic.rs
@@ -28,9 +28,15 @@ async fn main() {
             .layout(Flex::column().spacing(8.0))
             .padding(20.0)
             .background(Color::rgb(0.1, 0.1, 0.15))
-            .child(text("Dynamic Children Test").color(Color::WHITE))
             .child(
-                text("An item will be added after 2 seconds...").color(Color::rgb(0.7, 0.7, 0.7)),
+                container()
+                    .text_color(Color::WHITE)
+                    .child(text("Dynamic Children Test")),
+            )
+            .child(
+                container()
+                    .text_color(Color::rgb(0.7, 0.7, 0.7))
+                    .child(text("An item will be added after 2 seconds...")),
             )
             .child(container().layout(Flex::row().spacing(4.0)).children(keyed(
                 move || items.get(),
@@ -40,7 +46,8 @@ async fn main() {
                         .padding(8.0)
                         .background(Color::rgb(0.3 + id as f32 * 0.1, 0.3, 0.4))
                         .corner_radius(4.0)
-                        .child(text(format!("Item {}", id)).color(Color::WHITE))
+                        .text_color(Color::WHITE)
+                        .child(text(format!("Item {}", id)))
                 },
             )));
 

--- a/examples/text_input_example.rs
+++ b/examples/text_input_example.rs
@@ -23,16 +23,20 @@ fn main() {
             .layout(Flex::column().spacing(16.0))
             .child(
                 // Title
-                text("Text Input Demo").color(Color::WHITE).font_size(20.0),
+                container()
+                    .text_color(Color::WHITE)
+                    .font_size(20.0)
+                    .child(text("Text Input Demo")),
             )
             .child(
                 // Username section
                 container()
                     .layout(Flex::column().spacing(4.0))
                     .child(
-                        text("Username")
-                            .color(Color::rgb(0.7, 0.7, 0.8))
-                            .font_size(12.0),
+                        container()
+                            .text_color(Color::rgb(0.7, 0.7, 0.8))
+                            .font_size(12.0)
+                            .child(text("Username")),
                     )
                     .child(
                         container()
@@ -43,13 +47,11 @@ fn main() {
                             .corner_radius(6.0)
                             // Highlight border when text input is focused
                             .focused_state(|s| s.border(2.0, Color::rgb(0.4, 0.8, 1.0)))
-                            .child(
-                                text_input(username)
-                                    .text_color(Color::WHITE)
-                                    .cursor_color(Color::rgb(0.4, 0.8, 1.0))
-                                    .selection_color(Color::rgba(0.4, 0.6, 1.0, 0.4))
-                                    .font_size(14.0),
-                            ),
+                            .text_color(Color::WHITE)
+                            .cursor_color(Color::rgb(0.4, 0.8, 1.0))
+                            .selection_color(Color::rgba(0.4, 0.6, 1.0, 0.4))
+                            .font_size(14.0)
+                            .child(text_input(username)),
                     ),
             )
             .child(
@@ -57,9 +59,10 @@ fn main() {
                 container()
                     .layout(Flex::column().spacing(4.0))
                     .child(
-                        text("Password")
-                            .color(Color::rgb(0.7, 0.7, 0.8))
-                            .font_size(12.0),
+                        container()
+                            .text_color(Color::rgb(0.7, 0.7, 0.8))
+                            .font_size(12.0)
+                            .child(text("Password")),
                     )
                     .child(
                         container()
@@ -70,18 +73,14 @@ fn main() {
                             .corner_radius(6.0)
                             // Highlight border when text input is focused
                             .focused_state(|s| s.border(2.0, Color::rgb(0.4, 0.8, 1.0)))
-                            .child(
-                                text_input(password)
-                                    .text_color(Color::WHITE)
-                                    .cursor_color(Color::rgb(0.4, 0.8, 1.0))
-                                    .selection_color(Color::rgba(0.4, 0.6, 1.0, 0.4))
-                                    .font_size(14.0)
-                                    .password(true)
-                                    .on_submit(move |_| {
-                                        let msg = format!("Login attempt: {}", username.get());
-                                        submitted.set(msg);
-                                    }),
-                            ),
+                            .text_color(Color::WHITE)
+                            .cursor_color(Color::rgb(0.4, 0.8, 1.0))
+                            .selection_color(Color::rgba(0.4, 0.6, 1.0, 0.4))
+                            .font_size(14.0)
+                            .child(text_input(password).password(true).on_submit(move |_| {
+                                let msg = format!("Login attempt: {}", username.get());
+                                submitted.set(msg);
+                            })),
                     ),
             )
             .child(
@@ -92,33 +91,39 @@ fn main() {
                     .corner_radius(6.0)
                     .layout(Flex::column().spacing(8.0))
                     .child(
-                        text("Current Values:")
-                            .color(Color::rgb(0.6, 0.6, 0.7))
-                            .font_size(12.0),
+                        container()
+                            .text_color(Color::rgb(0.6, 0.6, 0.7))
+                            .font_size(12.0)
+                            .child(text("Current Values:")),
                     )
                     .child(
-                        text(move || format!("Username: {}", username.get()))
-                            .color(Color::rgb(0.8, 0.8, 0.9))
-                            .font_size(13.0),
+                        container()
+                            .text_color(Color::rgb(0.8, 0.8, 0.9))
+                            .font_size(13.0)
+                            .child(text(move || format!("Username: {}", username.get()))),
                     )
                     .child(
-                        text(move || format!("Password: {} chars", password.get().len()))
-                            .color(Color::rgb(0.8, 0.8, 0.9))
-                            .font_size(13.0),
+                        container()
+                            .text_color(Color::rgb(0.8, 0.8, 0.9))
+                            .font_size(13.0)
+                            .child(text(move || {
+                                format!("Password: {} chars", password.get().len())
+                            })),
                     ),
             )
             .child(
                 // Submit status
-                text(move || {
-                    let msg = submitted.get();
-                    if msg.is_empty() {
-                        "Press Enter in password field to submit".to_string()
-                    } else {
-                        msg
-                    }
-                })
-                .color(Color::rgb(0.5, 0.8, 0.5))
-                .font_size(13.0),
+                container()
+                    .text_color(Color::rgb(0.5, 0.8, 0.5))
+                    .font_size(13.0)
+                    .child(text(move || {
+                        let msg = submitted.get();
+                        if msg.is_empty() {
+                            "Press Enter in password field to submit".to_string()
+                        } else {
+                            msg
+                        }
+                    })),
             )
             .child(
                 // Instructions
@@ -128,54 +133,64 @@ fn main() {
                     .corner_radius(6.0)
                     .layout(Flex::column().spacing(4.0))
                     .child(
-                        text("Keyboard shortcuts:")
-                            .color(Color::rgb(0.5, 0.5, 0.6))
-                            .font_size(11.0),
+                        container()
+                            .text_color(Color::rgb(0.5, 0.5, 0.6))
+                            .font_size(11.0)
+                            .child(text("Keyboard shortcuts:")),
                     )
                     .child(
-                        text("• Click to focus and position cursor")
-                            .color(Color::rgb(0.5, 0.5, 0.6))
-                            .font_size(11.0),
+                        container()
+                            .text_color(Color::rgb(0.5, 0.5, 0.6))
+                            .font_size(11.0)
+                            .child(text("• Click to focus and position cursor")),
                     )
                     .child(
-                        text("• Arrow keys to move cursor")
-                            .color(Color::rgb(0.5, 0.5, 0.6))
-                            .font_size(11.0),
+                        container()
+                            .text_color(Color::rgb(0.5, 0.5, 0.6))
+                            .font_size(11.0)
+                            .child(text("• Arrow keys to move cursor")),
                     )
                     .child(
-                        text("• Shift+Arrow to select text")
-                            .color(Color::rgb(0.5, 0.5, 0.6))
-                            .font_size(11.0),
+                        container()
+                            .text_color(Color::rgb(0.5, 0.5, 0.6))
+                            .font_size(11.0)
+                            .child(text("• Shift+Arrow to select text")),
                     )
                     .child(
-                        text("• Ctrl+A to select all")
-                            .color(Color::rgb(0.5, 0.5, 0.6))
-                            .font_size(11.0),
+                        container()
+                            .text_color(Color::rgb(0.5, 0.5, 0.6))
+                            .font_size(11.0)
+                            .child(text("• Ctrl+A to select all")),
                     )
                     .child(
-                        text("• Ctrl+Arrow for word jump")
-                            .color(Color::rgb(0.5, 0.5, 0.6))
-                            .font_size(11.0),
+                        container()
+                            .text_color(Color::rgb(0.5, 0.5, 0.6))
+                            .font_size(11.0)
+                            .child(text("• Ctrl+Arrow for word jump")),
                     )
                     .child(
-                        text("• Home/End to go to start/end")
-                            .color(Color::rgb(0.5, 0.5, 0.6))
-                            .font_size(11.0),
+                        container()
+                            .text_color(Color::rgb(0.5, 0.5, 0.6))
+                            .font_size(11.0)
+                            .child(text("• Home/End to go to start/end")),
                     )
                     .child(
-                        text("• Enter to submit (in password field)")
-                            .color(Color::rgb(0.5, 0.5, 0.6))
-                            .font_size(11.0),
+                        container()
+                            .text_color(Color::rgb(0.5, 0.5, 0.6))
+                            .font_size(11.0)
+                            .child(text("• Enter to submit (in password field)")),
                     )
                     .child(
-                        text("• Ctrl+C/X/V to copy/cut/paste")
-                            .color(Color::rgb(0.5, 0.5, 0.6))
-                            .font_size(11.0),
+                        container()
+                            .text_color(Color::rgb(0.5, 0.5, 0.6))
+                            .font_size(11.0)
+                            .child(text("• Ctrl+C/X/V to copy/cut/paste")),
                     )
                     .child(
-                        text("• Ctrl+Z to undo, Ctrl+Y to redo")
-                            .color(Color::rgb(0.5, 0.5, 0.6))
-                            .font_size(11.0),
+                        container()
+                            .text_color(Color::rgb(0.5, 0.5, 0.6))
+                            .font_size(11.0)
+                            .child(text("• Ctrl+Z to undo, Ctrl+Y to redo")),
                     ),
             );
 

--- a/examples/text_input_transform_test.rs
+++ b/examples/text_input_transform_test.rs
@@ -20,18 +20,20 @@ fn main() {
             .padding(32.0)
             .layout(Flex::column().spacing(32.0))
             .child(
-                text("TextInput Transform Test")
-                    .color(Color::WHITE)
-                    .font_size(18.0),
+                container()
+                    .text_color(Color::WHITE)
+                    .font_size(18.0)
+                    .child(text("TextInput Transform Test")),
             )
             // 1. Normal (no transform) - baseline
             .child(
                 container()
                     .layout(Flex::column().spacing(4.0))
                     .child(
-                        text("No transform (baseline)")
-                            .color(Color::rgb(0.6, 0.6, 0.7))
-                            .font_size(12.0),
+                        container()
+                            .text_color(Color::rgb(0.6, 0.6, 0.7))
+                            .font_size(12.0)
+                            .child(text("No transform (baseline)")),
                     )
                     .child(
                         container()
@@ -40,12 +42,10 @@ fn main() {
                             .background(Color::rgb(0.18, 0.18, 0.24))
                             .border(1.0, Color::rgb(0.3, 0.8, 0.3))
                             .corner_radius(6.0)
-                            .child(
-                                text_input(input1)
-                                    .text_color(Color::WHITE)
-                                    .cursor_color(Color::rgb(0.4, 0.8, 1.0))
-                                    .font_size(14.0),
-                            ),
+                            .text_color(Color::WHITE)
+                            .cursor_color(Color::rgb(0.4, 0.8, 1.0))
+                            .font_size(14.0)
+                            .child(text_input(input1)),
                     ),
             )
             // 2. Rotated container
@@ -53,9 +53,10 @@ fn main() {
                 container()
                     .layout(Flex::column().spacing(4.0))
                     .child(
-                        text("Rotated 15°")
-                            .color(Color::rgb(0.6, 0.6, 0.7))
-                            .font_size(12.0),
+                        container()
+                            .text_color(Color::rgb(0.6, 0.6, 0.7))
+                            .font_size(12.0)
+                            .child(text("Rotated 15°")),
                     )
                     .child(
                         container()
@@ -65,12 +66,10 @@ fn main() {
                             .border(1.0, Color::rgb(0.8, 0.5, 0.3))
                             .corner_radius(6.0)
                             .rotate(15.0)
-                            .child(
-                                text_input(input2)
-                                    .text_color(Color::WHITE)
-                                    .cursor_color(Color::rgb(0.4, 0.8, 1.0))
-                                    .font_size(14.0),
-                            ),
+                            .text_color(Color::WHITE)
+                            .cursor_color(Color::rgb(0.4, 0.8, 1.0))
+                            .font_size(14.0)
+                            .child(text_input(input2)),
                     ),
             )
             // 3. Scaled container
@@ -78,9 +77,10 @@ fn main() {
                 container()
                     .layout(Flex::column().spacing(4.0))
                     .child(
-                        text("Scaled 1.2x")
-                            .color(Color::rgb(0.6, 0.6, 0.7))
-                            .font_size(12.0),
+                        container()
+                            .text_color(Color::rgb(0.6, 0.6, 0.7))
+                            .font_size(12.0)
+                            .child(text("Scaled 1.2x")),
                     )
                     .child(
                         container()
@@ -90,12 +90,10 @@ fn main() {
                             .border(1.0, Color::rgb(0.3, 0.5, 0.8))
                             .corner_radius(6.0)
                             .scale(1.2)
-                            .child(
-                                text_input(input3)
-                                    .text_color(Color::WHITE)
-                                    .cursor_color(Color::rgb(0.4, 0.8, 1.0))
-                                    .font_size(14.0),
-                            ),
+                            .text_color(Color::WHITE)
+                            .cursor_color(Color::rgb(0.4, 0.8, 1.0))
+                            .font_size(14.0)
+                            .child(text_input(input3)),
                     ),
             )
             // 4. Translated container
@@ -103,9 +101,10 @@ fn main() {
                 container()
                     .layout(Flex::column().spacing(4.0))
                     .child(
-                        text("Translated (50, 10)")
-                            .color(Color::rgb(0.6, 0.6, 0.7))
-                            .font_size(12.0),
+                        container()
+                            .text_color(Color::rgb(0.6, 0.6, 0.7))
+                            .font_size(12.0)
+                            .child(text("Translated (50, 10)")),
                     )
                     .child(
                         container()
@@ -115,12 +114,10 @@ fn main() {
                             .border(1.0, Color::rgb(0.8, 0.8, 0.3))
                             .corner_radius(6.0)
                             .translate(50.0, 10.0)
-                            .child(
-                                text_input(input4)
-                                    .text_color(Color::WHITE)
-                                    .cursor_color(Color::rgb(0.4, 0.8, 1.0))
-                                    .font_size(14.0),
-                            ),
+                            .text_color(Color::WHITE)
+                            .cursor_color(Color::rgb(0.4, 0.8, 1.0))
+                            .font_size(14.0)
+                            .child(text_input(input4)),
                     ),
             )
             // 5. All transforms combined: translate + rotate + scale
@@ -128,9 +125,10 @@ fn main() {
                 container()
                     .layout(Flex::column().spacing(4.0))
                     .child(
-                        text("Translate(20,5) + Rotate(-10°) + Scale(0.9)")
-                            .color(Color::rgb(0.6, 0.6, 0.7))
-                            .font_size(12.0),
+                        container()
+                            .text_color(Color::rgb(0.6, 0.6, 0.7))
+                            .font_size(12.0)
+                            .child(text("Translate(20,5) + Rotate(-10°) + Scale(0.9)")),
                     )
                     .child(
                         container()
@@ -144,19 +142,18 @@ fn main() {
                                     .then(&Transform::rotate_degrees(-10.0))
                                     .then(&Transform::scale(0.9)),
                             )
-                            .child(
-                                text_input(input5)
-                                    .text_color(Color::WHITE)
-                                    .cursor_color(Color::rgb(0.4, 0.8, 1.0))
-                                    .font_size(14.0),
-                            ),
+                            .text_color(Color::WHITE)
+                            .cursor_color(Color::rgb(0.4, 0.8, 1.0))
+                            .font_size(14.0)
+                            .child(text_input(input5)),
                     ),
             )
             // Instructions
             .child(
-                text("Click in each input to test cursor positioning")
-                    .color(Color::rgb(0.5, 0.5, 0.6))
-                    .font_size(11.0),
+                container()
+                    .text_color(Color::rgb(0.5, 0.5, 0.6))
+                    .font_size(11.0)
+                    .child(text("Click in each input to test cursor positioning")),
             );
 
         app.add_surface(

--- a/examples/text_styling_example.rs
+++ b/examples/text_styling_example.rs
@@ -1,6 +1,9 @@
 //! Text Styling Example
 //!
-//! Demonstrates text styling with font family and font weight options.
+//! Text carries content; how it looks is declared on an enclosing container and
+//! inherited by everything below it, down to the nearest container that
+//! overrides that particular property.
+//!
 //! Run with: cargo run --example text_styling_example
 
 use guido::prelude::*;
@@ -22,12 +25,16 @@ fn main() {
                         .background(Color::rgb(0.08, 0.08, 0.12))
                         .padding(24.0)
                         .layout(Flex::column().spacing(20.0))
+                        // Declared once for the whole screen. Every sample
+                        // below inherits it through the sections and cards,
+                        // and overrides only what it is demonstrating.
+                        .text_color(Color::WHITE)
                         .child(
-                            // Title
-                            text("Text Styling Demo")
+                            container()
                                 .font_size(28.0)
                                 .bold()
-                                .color(Color::rgb(0.9, 0.9, 0.95)),
+                                .text_color(Color::rgb(0.9, 0.9, 0.95))
+                                .child(text("Text Styling Demo")),
                         )
                         .child(create_font_family_section())
                         .child(create_font_weight_section())
@@ -38,95 +45,72 @@ fn main() {
         });
 }
 
+/// A section heading — the one place its style is written.
+fn heading(label: &str) -> Container {
+    container()
+        .font_size(16.0)
+        .bold()
+        .text_color(Color::rgb(0.7, 0.7, 0.8))
+        .child(text(label))
+}
+
+/// The card each section's samples sit in. It declares nothing about text, so
+/// the colour set at the root passes straight through it.
+fn card() -> Container {
+    container()
+        .padding(12.0)
+        .background(Color::rgb(0.12, 0.12, 0.18))
+        .corner_radius(8.0)
+        .layout(Flex::column().spacing(8.0))
+}
+
 /// Section demonstrating different font families
 fn create_font_family_section() -> Container {
+    let sample = |label: &'static str, family: FontFamily| {
+        container().font_family(family).child(text(label))
+    };
+
     container()
         .layout(Flex::column().spacing(8.0))
+        .child(heading("Font Families:"))
         .child(
-            text("Font Families:")
-                .font_size(16.0)
-                .bold()
-                .color(Color::rgb(0.7, 0.7, 0.8)),
-        )
-        .child(
-            container()
-                .padding(12.0)
-                .background(Color::rgb(0.12, 0.12, 0.18))
-                .corner_radius(8.0)
-                .layout(Flex::column().spacing(8.0))
+            card()
+                .child(sample("Sans-Serif (default)", FontFamily::SansSerif))
+                .child(sample("Serif font family", FontFamily::Serif))
+                .child(sample("Monospace font family", FontFamily::Monospace))
                 .child(
-                    text("Sans-Serif (default)")
-                        .font_family(FontFamily::SansSerif)
-                        .color(Color::WHITE),
-                )
-                .child(
-                    text("Serif font family")
-                        .font_family(FontFamily::Serif)
-                        .color(Color::WHITE),
-                )
-                .child(
-                    text("Monospace font family")
-                        .font_family(FontFamily::Monospace)
-                        .color(Color::WHITE),
-                )
-                .child(
-                    text("Using .mono() shorthand")
+                    container()
                         .mono()
-                        .color(Color::rgb(0.6, 0.9, 0.6)),
+                        // Overrides only the colour: the family comes from
+                        // .mono() here and the size from the root.
+                        .text_color(Color::rgb(0.6, 0.9, 0.6))
+                        .child(text("Using .mono() shorthand")),
                 ),
         )
 }
 
 /// Section demonstrating different font weights
 fn create_font_weight_section() -> Container {
+    let sample = |label: &'static str, weight: FontWeight| {
+        container().font_weight(weight).child(text(label))
+    };
+
     container()
         .layout(Flex::column().spacing(8.0))
+        .child(heading("Font Weights:"))
         .child(
-            text("Font Weights:")
-                .font_size(16.0)
-                .bold()
-                .color(Color::rgb(0.7, 0.7, 0.8)),
-        )
-        .child(
-            container()
-                .padding(12.0)
-                .background(Color::rgb(0.12, 0.12, 0.18))
-                .corner_radius(8.0)
-                .layout(Flex::column().spacing(8.0))
+            card()
+                .child(sample("Thin (100)", FontWeight::THIN))
+                .child(sample("Light (300)", FontWeight::LIGHT))
+                .child(sample("Normal (400)", FontWeight::NORMAL))
+                .child(sample("Medium (500)", FontWeight::MEDIUM))
+                .child(sample("Semi-Bold (600)", FontWeight::SEMI_BOLD))
+                .child(sample("Bold (700)", FontWeight::BOLD))
                 .child(
-                    text("Thin (100)")
-                        .font_weight(FontWeight::THIN)
-                        .color(Color::WHITE),
-                )
-                .child(
-                    text("Light (300)")
-                        .font_weight(FontWeight::LIGHT)
-                        .color(Color::WHITE),
-                )
-                .child(
-                    text("Normal (400)")
-                        .font_weight(FontWeight::NORMAL)
-                        .color(Color::WHITE),
-                )
-                .child(
-                    text("Medium (500)")
-                        .font_weight(FontWeight::MEDIUM)
-                        .color(Color::WHITE),
-                )
-                .child(
-                    text("Semi-Bold (600)")
-                        .font_weight(FontWeight::SEMI_BOLD)
-                        .color(Color::WHITE),
-                )
-                .child(
-                    text("Bold (700)")
-                        .font_weight(FontWeight::BOLD)
-                        .color(Color::WHITE),
-                )
-                .child(
-                    text("Using .bold() shorthand")
+                    container()
                         .bold()
-                        .color(Color::rgb(0.9, 0.7, 0.4)),
+                        .text_color(Color::rgb(0.9, 0.7, 0.4))
+                        .child(text("Using .bold() shorthand")),
                 ),
         )
 }
@@ -135,61 +119,51 @@ fn create_font_weight_section() -> Container {
 fn create_combined_section() -> Container {
     container()
         .layout(Flex::column().spacing(8.0))
+        .child(heading("Combined Styling:"))
         .child(
-            text("Combined Styling:")
-                .font_size(16.0)
-                .bold()
-                .color(Color::rgb(0.7, 0.7, 0.8)),
-        )
-        .child(
-            container()
-                .padding(12.0)
-                .background(Color::rgb(0.12, 0.12, 0.18))
-                .corner_radius(8.0)
-                .layout(Flex::column().spacing(8.0))
+            card()
                 .child(
-                    text("Bold Monospace")
+                    container()
                         .mono()
                         .bold()
-                        .color(Color::rgb(0.4, 0.8, 1.0)),
+                        .text_color(Color::rgb(0.4, 0.8, 1.0))
+                        .child(text("Bold Monospace")),
                 )
                 .child(
-                    text("Light Serif")
+                    container()
                         .font_family(FontFamily::Serif)
                         .font_weight(FontWeight::LIGHT)
-                        .color(Color::rgb(0.9, 0.8, 0.7)),
+                        .text_color(Color::rgb(0.9, 0.8, 0.7))
+                        .child(text("Light Serif")),
                 )
                 .child(
-                    text("Bold Serif")
+                    container()
                         .font_family(FontFamily::Serif)
                         .bold()
-                        .color(Color::rgb(1.0, 0.9, 0.8)),
+                        .text_color(Color::rgb(1.0, 0.9, 0.8))
+                        .child(text("Bold Serif")),
                 ),
         )
 }
 
 /// Section demonstrating text input with styling
+///
+/// The input reads the same declarations a `text` would: there is no separate
+/// styling vocabulary for it, and `cursor_color` would be declared alongside.
 fn create_text_input_section() -> Container {
     let input_value = create_signal("Type here...".to_string());
 
     container()
         .layout(Flex::column().spacing(8.0))
-        .child(
-            text("Styled Text Input:")
-                .font_size(16.0)
-                .bold()
-                .color(Color::rgb(0.7, 0.7, 0.8)),
-        )
+        .child(heading("Styled Text Input:"))
         .child(
             container()
                 .padding(12.0)
                 .background(Color::rgb(0.15, 0.15, 0.2))
                 .corner_radius(8.0)
-                .child(
-                    text_input(input_value)
-                        .mono()
-                        .font_size(16.0)
-                        .text_color(Color::rgb(0.4, 1.0, 0.6)),
-                ),
+                .mono()
+                .font_size(16.0)
+                .text_color(Color::rgb(0.4, 1.0, 0.6))
+                .child(text_input(input_value)),
         )
 }

--- a/examples/text_transform_example.rs
+++ b/examples/text_transform_example.rs
@@ -41,11 +41,10 @@ async fn main() {
             .padding(30.0)
             .children([
                 // Title
-                container().child(
-                    text("Text Transform Demo")
-                        .font_size(24.0)
-                        .color(Color::WHITE),
-                ),
+                container()
+                    .font_size(24.0)
+                    .text_color(Color::WHITE)
+                    .child(text("Text Transform Demo")),
                 // Row 1: Basic transforms (rotation, scale, translation)
                 container()
                     .layout(
@@ -67,7 +66,9 @@ async fn main() {
                                     .cross_alignment(CrossAlignment::Center),
                             )
                             .rotate(15.0)
-                            .child(text("Rotate 15°").font_size(13.0).color(Color::WHITE)),
+                            .font_size(13.0)
+                            .text_color(Color::WHITE)
+                            .child(text("Rotate 15°")),
                         // Scale
                         container()
                             .width(110.0)
@@ -80,7 +81,9 @@ async fn main() {
                                     .cross_alignment(CrossAlignment::Center),
                             )
                             .scale(1.2)
-                            .child(text("Scale 1.2x").font_size(13.0).color(Color::WHITE)),
+                            .font_size(13.0)
+                            .text_color(Color::WHITE)
+                            .child(text("Scale 1.2x")),
                         // Translation
                         container()
                             .width(110.0)
@@ -93,7 +96,9 @@ async fn main() {
                                     .cross_alignment(CrossAlignment::Center),
                             )
                             .translate(10.0, -10.0)
-                            .child(text("Translate").font_size(13.0).color(Color::WHITE)),
+                            .font_size(13.0)
+                            .text_color(Color::WHITE)
+                            .child(text("Translate")),
                         // Rotation + Scale
                         container()
                             .width(110.0)
@@ -107,7 +112,9 @@ async fn main() {
                             )
                             .rotate(-20.0)
                             .scale(0.9)
-                            .child(text("Rot + Scale").font_size(13.0).color(Color::WHITE)),
+                            .font_size(13.0)
+                            .text_color(Color::WHITE)
+                            .child(text("Rot + Scale")),
                     ]),
                 // Row 2: Combined transforms and custom origin
                 container()
@@ -132,7 +139,9 @@ async fn main() {
                             .rotate(10.0)
                             .scale(1.1)
                             .translate(5.0, 5.0)
-                            .child(text("All Combined").font_size(13.0).color(Color::WHITE)),
+                            .font_size(13.0)
+                            .text_color(Color::WHITE)
+                            .child(text("All Combined")),
                         // Custom origin: top-left
                         container()
                             .width(130.0)
@@ -146,7 +155,9 @@ async fn main() {
                             )
                             .transform_origin(TransformOrigin::TOP_LEFT)
                             .rotate(15.0)
-                            .child(text("Origin: Top-Left").font_size(12.0).color(Color::WHITE)),
+                            .font_size(12.0)
+                            .text_color(Color::WHITE)
+                            .child(text("Origin: Top-Left")),
                         // Custom origin: bottom-right
                         container()
                             .width(130.0)
@@ -160,11 +171,9 @@ async fn main() {
                             )
                             .transform_origin(TransformOrigin::BOTTOM_RIGHT)
                             .rotate(15.0)
-                            .child(
-                                text("Origin: Bot-Right")
-                                    .font_size(12.0)
-                                    .color(Color::WHITE),
-                            ),
+                            .font_size(12.0)
+                            .text_color(Color::WHITE)
+                            .child(text("Origin: Bot-Right")),
                         // Custom origin with scale
                         container()
                             .width(130.0)
@@ -179,7 +188,9 @@ async fn main() {
                             .transform_origin(TransformOrigin::TOP_RIGHT)
                             .scale(1.15)
                             .rotate(-10.0)
-                            .child(text("Origin + Scale").font_size(12.0).color(Color::WHITE)),
+                            .font_size(12.0)
+                            .text_color(Color::WHITE)
+                            .child(text("Origin + Scale")),
                     ]),
                 // Row 3: Nested transforms
                 container()
@@ -213,7 +224,9 @@ async fn main() {
                                             .main_alignment(MainAlignment::Center)
                                             .cross_alignment(CrossAlignment::Center),
                                     )
-                                    .child(text("Nested").font_size(14.0).color(Color::WHITE)),
+                                    .font_size(14.0)
+                                    .text_color(Color::WHITE)
+                                    .child(text("Nested")),
                             ),
                         // Double nested with additional rotation
                         container()
@@ -239,11 +252,9 @@ async fn main() {
                                             .cross_alignment(CrossAlignment::Center),
                                     )
                                     .rotate(15.0)
-                                    .child(
-                                        text("30° Total")
-                                            .font_size(13.0)
-                                            .color(Color::rgb(0.1, 0.1, 0.1)),
-                                    ),
+                                    .font_size(13.0)
+                                    .text_color(Color::rgb(0.1, 0.1, 0.1))
+                                    .child(text("30° Total")),
                             ),
                         // Nested with scale + translation
                         container()
@@ -270,11 +281,9 @@ async fn main() {
                                             .cross_alignment(CrossAlignment::Center),
                                     )
                                     .rotate(-10.0)
-                                    .child(
-                                        text("Scale+Trans")
-                                            .font_size(12.0)
-                                            .color(Color::rgb(0.1, 0.1, 0.1)),
-                                    ),
+                                    .font_size(12.0)
+                                    .text_color(Color::rgb(0.1, 0.1, 0.1))
+                                    .child(text("Scale+Trans")),
                             ),
                         // Animated rotating text
                         container()
@@ -288,7 +297,9 @@ async fn main() {
                                     .cross_alignment(CrossAlignment::Center),
                             )
                             .rotate(move || angle.get())
-                            .child(text("Spinning!").font_size(14.0).color(Color::WHITE)),
+                            .font_size(14.0)
+                            .text_color(Color::WHITE)
+                            .child(text("Spinning!")),
                     ]),
             ]);
 

--- a/examples/transform_events_test.rs
+++ b/examples/transform_events_test.rs
@@ -98,11 +98,10 @@ fn main() {
                                     ),
                             ]),
                         // Click counter display
-                        container().child(
-                            text(move || format!("Clicks: {}", click_count.get()))
-                                .font_size(20.0)
-                                .color(Color::WHITE),
-                        ),
+                        container()
+                            .font_size(20.0)
+                            .text_color(Color::WHITE)
+                            .child(text(move || format!("Clicks: {}", click_count.get()))),
                     ])
             },
         );
@@ -123,5 +122,7 @@ fn make_box(label: &'static str, base_color: Color, click_count: RwSignal<i32>) 
                 .main_alignment(MainAlignment::Center)
                 .cross_alignment(CrossAlignment::Center),
         )
-        .child(text(label).font_size(10.0).color(Color::WHITE).nowrap())
+        .font_size(10.0)
+        .text_color(Color::WHITE)
+        .child(text(label).nowrap())
 }

--- a/examples/transform_example.rs
+++ b/examples/transform_example.rs
@@ -46,7 +46,9 @@ fn main() {
                                             .main_alignment(MainAlignment::Center)
                                             .cross_alignment(CrossAlignment::Center),
                                     )
-                                    .child(text("45").color(Color::WHITE).font_size(12.0)),
+                                    .text_color(Color::WHITE)
+                                    .font_size(12.0)
+                                    .child(text("45")),
                             ),
                         // 2. Click to rotate (increments by 45 degrees)
                         container()
@@ -68,9 +70,9 @@ fn main() {
                                             .main_alignment(MainAlignment::Center)
                                             .cross_alignment(CrossAlignment::Center),
                                     )
-                                    .child(
-                                        text("Click").color(Color::WHITE).font_size(10.0).nowrap(),
-                                    ),
+                                    .text_color(Color::WHITE)
+                                    .font_size(10.0)
+                                    .child(text("Click").nowrap()),
                             ),
                         // 3. Click to toggle scale with spring animation
                         container()
@@ -94,9 +96,9 @@ fn main() {
                                             .main_alignment(MainAlignment::Center)
                                             .cross_alignment(CrossAlignment::Center),
                                     )
-                                    .child(
-                                        text("Scale").color(Color::WHITE).font_size(10.0).nowrap(),
-                                    ),
+                                    .text_color(Color::WHITE)
+                                    .font_size(10.0)
+                                    .child(text("Scale").nowrap()),
                             ),
                         // 4. Static scale (smaller)
                         container()
@@ -112,7 +114,9 @@ fn main() {
                                             .main_alignment(MainAlignment::Center)
                                             .cross_alignment(CrossAlignment::Center),
                                     )
-                                    .child(text("0.7x").color(Color::WHITE).font_size(12.0)),
+                                    .text_color(Color::WHITE)
+                                    .font_size(12.0)
+                                    .child(text("0.7x")),
                             ),
                         // 5. Combined rotation + scale
                         container()
@@ -128,9 +132,9 @@ fn main() {
                                             .main_alignment(MainAlignment::Center)
                                             .cross_alignment(CrossAlignment::Center),
                                     )
-                                    .child(
-                                        text("Both").color(Color::WHITE).font_size(10.0).nowrap(),
-                                    ),
+                                    .text_color(Color::WHITE)
+                                    .font_size(10.0)
+                                    .child(text("Both").nowrap()),
                             ),
                         // 6. Rotation around top-left corner (transform origin)
                         container()
@@ -147,7 +151,9 @@ fn main() {
                                             .main_alignment(MainAlignment::Center)
                                             .cross_alignment(CrossAlignment::Center),
                                     )
-                                    .child(text("TL").color(Color::WHITE).font_size(12.0)),
+                                    .text_color(Color::WHITE)
+                                    .font_size(12.0)
+                                    .child(text("TL")),
                             ),
                         // 7. Scale from bottom-right corner (transform origin)
                         container()
@@ -164,7 +170,9 @@ fn main() {
                                             .main_alignment(MainAlignment::Center)
                                             .cross_alignment(CrossAlignment::Center),
                                     )
-                                    .child(text("BR").color(Color::WHITE).font_size(12.0)),
+                                    .text_color(Color::WHITE)
+                                    .font_size(12.0)
+                                    .child(text("BR")),
                             ),
                         // 8. Interactive: click to cycle through origins
                         {
@@ -192,12 +200,9 @@ fn main() {
                                                 .main_alignment(MainAlignment::Center)
                                                 .cross_alignment(CrossAlignment::Center),
                                         )
-                                        .child(
-                                            text("Cycle")
-                                                .color(Color::WHITE)
-                                                .font_size(10.0)
-                                                .nowrap(),
-                                        ),
+                                        .text_color(Color::WHITE)
+                                        .font_size(10.0)
+                                        .child(text("Cycle").nowrap()),
                                 )
                         },
                     ])

--- a/examples/widget_ref_example.rs
+++ b/examples/widget_ref_example.rs
@@ -33,7 +33,8 @@ fn main() {
                             .padding([8.0, 16.0])
                             .background(Color::rgb(0.25, 0.25, 0.35))
                             .corner_radius(6.0)
-                            .child(text("Measured Module").color(Color::WHITE)),
+                            .text_color(Color::WHITE)
+                            .child(text("Measured Module")),
                     )
                     .child(
                         // Display the bounds reactively
@@ -41,16 +42,14 @@ fn main() {
                             .padding([8.0, 16.0])
                             .background(Color::rgb(0.15, 0.2, 0.15))
                             .corner_radius(6.0)
-                            .child(
-                                text(move || {
-                                    let r = module_ref.rect().get();
-                                    format!(
-                                        "Bounds: x={:.0} y={:.0} w={:.0} h={:.0}",
-                                        r.x, r.y, r.width, r.height
-                                    )
-                                })
-                                .color(Color::WHITE),
-                            ),
+                            .text_color(Color::WHITE)
+                            .child(text(move || {
+                                let r = module_ref.rect().get();
+                                format!(
+                                    "Bounds: x={:.0} y={:.0} w={:.0} h={:.0}",
+                                    r.x, r.y, r.width, r.height
+                                )
+                            })),
                     )
             },
         );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,8 +177,8 @@ pub mod prelude {
         AnyWidget, Border, Color, Container, ContentFit, CornerRadii, Event, EventResponse,
         FontFamily, FontWeight, GradientDirection, Image, ImageSource, IntoChildren, Key,
         LinearGradient, Modifiers, MouseButton, Overflow, Padding, Rect, ScrollAxis, ScrollSource,
-        ScrollbarBuilder, ScrollbarVisibility, Selection, StateStyle, Text, TextInput, Widget,
-        container, image, keyed, text, text_input,
+        ScrollbarBuilder, ScrollbarVisibility, Selection, StateStyle, Text, TextInput, TextStyle,
+        Widget, container, image, keyed, text, text_input,
     };
     pub use crate::{
         App, ExitReason, SignalFields, component, default_font_family, load_font, quit_app,

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -115,6 +115,11 @@ struct Node {
     sparse_index: u32,
     /// Cached paint output from last frame
     cached_paint: Option<std::rc::Rc<crate::renderer::RenderNode>>,
+    /// Text style this node declares for its direct children, if any.
+    ///
+    /// Boxed because most nodes declare nothing: the miss costs a null check
+    /// instead of the ~96 bytes the struct would add to every node.
+    text_style: Option<Box<crate::widgets::TextStyle>>,
 }
 
 /// Central tree for widget storage using arena-based sparse-set architecture.
@@ -185,6 +190,7 @@ impl Tree {
             origin: (0.0, 0.0),
             sparse_index,
             cached_paint: None,
+            text_style: None,
         });
 
         // Update sparse map
@@ -316,6 +322,49 @@ impl Tree {
     pub fn get_parent(&self, id: WidgetId) -> Option<WidgetId> {
         self.get_dense_index(id)
             .and_then(|idx| self.dense[idx].parent)
+    }
+
+    /// Record the text style a node declares for its descendants.
+    ///
+    /// Containers call this as they enter the tree. An empty style clears the
+    /// slot rather than storing a box of nothing, which is what lets the walk
+    /// pass through layout-only containers at the cost of a null check.
+    pub fn set_text_style(&mut self, id: WidgetId, style: Option<crate::widgets::TextStyle>) {
+        if let Some(idx) = self.get_dense_index(id) {
+            self.dense[idx].text_style = style.filter(|s| !s.is_empty()).map(Box::new);
+        }
+    }
+
+    /// Resolve the text style that applies to a widget, per property.
+    ///
+    /// Walks the ancestors outwards and takes each property from the nearest
+    /// one that declares it, so a container overriding the size does not
+    /// disturb a colour set further up. Stops as soon as everything is
+    /// resolved.
+    ///
+    /// The result holds signals, not values: it is the caller that reads them,
+    /// which is what makes a text subscribe to the ancestors it actually
+    /// depended on. Callers must therefore `get()` inside their own
+    /// [`with_signal_tracking`](crate::reactive::with_signal_tracking) scope —
+    /// see [`TextStyle`](crate::widgets::TextStyle).
+    pub fn inherited_text_style(&self, id: WidgetId) -> crate::widgets::TextStyle {
+        let mut resolved = crate::widgets::TextStyle::default();
+        let mut cursor = self.get_parent(id);
+
+        while let Some(ancestor) = cursor {
+            let Some(idx) = self.get_dense_index(ancestor) else {
+                break;
+            };
+            if let Some(declared) = self.dense[idx].text_style.as_deref() {
+                resolved.inherit_from(declared);
+                if resolved.is_complete() {
+                    break;
+                }
+            }
+            cursor = self.dense[idx].parent;
+        }
+
+        resolved
     }
 
     /// Get the children of a widget (returns a slice to avoid heap allocation).
@@ -1141,5 +1190,149 @@ mod tests {
             !tree.needs_paint(a),
             "a widget that only moved keeps its cached paint"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Inherited text style
+    // -----------------------------------------------------------------------
+
+    use crate::reactive::create_stored;
+    use crate::widgets::{Color, FontWeight, TextStyle};
+
+    /// Build a chain root → … → leaf, returning every id in order.
+    fn chain(tree: &mut Tree, depth: usize) -> Vec<WidgetId> {
+        let mut ids = Vec::with_capacity(depth);
+        for i in 0..depth {
+            let id = tree.register(Box::new(MockWidget::new()));
+            if i > 0 {
+                tree.set_parent(id, ids[i - 1]);
+            }
+            ids.push(id);
+        }
+        ids
+    }
+
+    fn colored(color: Color) -> TextStyle {
+        TextStyle {
+            color: Some(create_stored(color)),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn inherited_style_is_empty_without_declarations() {
+        let mut tree = Tree::new();
+        let ids = chain(&mut tree, 3);
+        assert!(tree.inherited_text_style(ids[2]).is_empty());
+    }
+
+    #[test]
+    fn inherited_style_crosses_containers_that_declare_nothing() {
+        let mut tree = Tree::new();
+        let ids = chain(&mut tree, 4);
+        tree.set_text_style(ids[0], Some(colored(Color::RED)));
+
+        // Two undeclared ancestors in between must be transparent, which is the
+        // whole reason the lookup is a walk and not a parent read.
+        let resolved = tree.inherited_text_style(ids[3]);
+        assert_eq!(resolved.color.map(|c| c.get()), Some(Color::RED));
+    }
+
+    #[test]
+    fn nearest_declaration_wins() {
+        let mut tree = Tree::new();
+        let ids = chain(&mut tree, 3);
+        tree.set_text_style(ids[0], Some(colored(Color::RED)));
+        tree.set_text_style(ids[1], Some(colored(Color::BLUE)));
+
+        let resolved = tree.inherited_text_style(ids[2]);
+        assert_eq!(resolved.color.map(|c| c.get()), Some(Color::BLUE));
+    }
+
+    #[test]
+    fn resolution_is_per_property() {
+        let mut tree = Tree::new();
+        let ids = chain(&mut tree, 3);
+        tree.set_text_style(
+            ids[0],
+            Some(TextStyle {
+                color: Some(create_stored(Color::RED)),
+                font_size: Some(create_stored(30.0)),
+                ..Default::default()
+            }),
+        );
+        // The nearer container speaks only about size.
+        tree.set_text_style(
+            ids[1],
+            Some(TextStyle {
+                font_size: Some(create_stored(12.0)),
+                ..Default::default()
+            }),
+        );
+
+        let resolved = tree.inherited_text_style(ids[2]);
+        assert_eq!(resolved.font_size.map(|s| s.get()), Some(12.0));
+        assert_eq!(
+            resolved.color.map(|c| c.get()),
+            Some(Color::RED),
+            "overriding the size must not drop the colour set further up"
+        );
+    }
+
+    #[test]
+    fn a_node_does_not_inherit_its_own_declaration() {
+        // The container declares for what is inside it, not for itself; a
+        // container is not a text, so reading its own style would only ever
+        // confuse the widget that does the resolving.
+        let mut tree = Tree::new();
+        let ids = chain(&mut tree, 2);
+        tree.set_text_style(ids[1], Some(colored(Color::RED)));
+        assert!(tree.inherited_text_style(ids[1]).is_empty());
+    }
+
+    #[test]
+    fn empty_declarations_are_not_stored() {
+        let mut tree = Tree::new();
+        let ids = chain(&mut tree, 2);
+        tree.set_text_style(ids[0], Some(TextStyle::default()));
+        assert!(
+            tree.dense[tree.get_dense_index(ids[0]).unwrap()]
+                .text_style
+                .is_none(),
+            "a container declaring nothing must cost a null check, not a box"
+        );
+    }
+
+    #[test]
+    fn declarations_can_be_cleared() {
+        let mut tree = Tree::new();
+        let ids = chain(&mut tree, 2);
+        tree.set_text_style(ids[0], Some(colored(Color::RED)));
+        tree.set_text_style(ids[0], None);
+        assert!(tree.inherited_text_style(ids[1]).is_empty());
+    }
+
+    #[test]
+    fn walk_stops_once_everything_is_resolved() {
+        // A fully-declaring container shields whatever sits above it, so a deep
+        // tree does not pay for ancestors that can no longer contribute.
+        let mut tree = Tree::new();
+        let ids = chain(&mut tree, 3);
+        tree.set_text_style(ids[0], Some(colored(Color::RED)));
+        tree.set_text_style(
+            ids[1],
+            Some(TextStyle {
+                color: Some(create_stored(Color::BLUE)),
+                font_size: Some(create_stored(12.0)),
+                font_family: Some(create_stored(Default::default())),
+                font_weight: Some(create_stored(FontWeight::BOLD)),
+                cursor_color: Some(create_stored(Color::WHITE)),
+                selection_color: Some(create_stored(Color::BLACK)),
+            }),
+        );
+
+        let resolved = tree.inherited_text_style(ids[2]);
+        assert!(resolved.is_complete());
+        assert_eq!(resolved.color.map(|c| c.get()), Some(Color::BLUE));
     }
 }

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -36,12 +36,14 @@ use crate::tree::{Tree, WidgetId};
 use crate::widget_ref::{WidgetRef, register_widget_ref};
 
 use super::children::ChildrenSource;
+use super::font::{FontFamily, FontWeight};
 use super::into_child::{IntoChild, IntoChildren};
 use super::paint_children::{ChildPaintOptions, paint_children};
 use super::scroll::{
     ScrollAxis, ScrollState, ScrollbarBuilder, ScrollbarConfig, ScrollbarVisibility,
 };
 use super::state_layer::{StateStyle, resolve_background};
+use super::text_style::TextStyle;
 use super::widget::{
     Color, Event, EventResponse, Key, LayoutHints, Modifiers, MouseButton, Padding, Rect,
     ScrollSource, Widget,
@@ -257,6 +259,10 @@ pub struct Container {
     // Backdrop blur: this surface's own content, the compositor's, or both.
     pub(super) backdrop_blur: Option<BackdropBlur>,
 
+    // How text inside this container looks. Boxed: most containers hold no
+    // text and pay one pointer for the whole feature.
+    pub(super) text: Option<Box<TextStyle>>,
+
     // Animation state (boxed to save ~400 bytes per non-animated container)
     pub(super) anims: Option<Box<ContainerAnims>>,
 
@@ -289,6 +295,7 @@ impl Container {
             interaction: None,
             widget_ref: None,
             backdrop_blur: None,
+            text: None,
             anims: None,
             scroll_axis: ScrollAxis::None,
             scroll_data: None,
@@ -381,6 +388,79 @@ impl Container {
     /// ```
     pub fn background<M>(mut self, color: impl IntoSignal<Color, M>) -> Self {
         self.background = Some(color.into_signal());
+        self
+    }
+
+    // -----------------------------------------------------------------------
+    // Text
+    //
+    // Text widgets carry content, not style; how they look is declared here.
+    // Each property is inherited by descendants until a nearer container
+    // overrides it — see [`TextStyle`](crate::widgets::TextStyle).
+    // -----------------------------------------------------------------------
+
+    fn text_mut(&mut self) -> &mut TextStyle {
+        self.text.get_or_insert_with(Box::default)
+    }
+
+    /// Set the colour of text in this container and its descendants.
+    ///
+    /// Named `text_color` rather than `color` because `color` on a box reads
+    /// as its fill — that one is [`background`](Self::background).
+    ///
+    /// ```ignore
+    /// container().text_color(theme.text).child(text("Hello"))
+    /// ```
+    pub fn text_color<M>(mut self, color: impl IntoSignal<Color, M>) -> Self {
+        self.text_mut().color = Some(color.into_signal());
+        self
+    }
+
+    /// Set the font size of text in this container and its descendants, in
+    /// logical pixels.
+    pub fn font_size<M>(mut self, size: impl IntoSignal<f32, M>) -> Self {
+        self.text_mut().font_size = Some(size.into_signal());
+        self
+    }
+
+    /// Set the font family of text in this container and its descendants.
+    ///
+    /// ```ignore
+    /// container().font_family(FontFamily::Name("Inter".into()))
+    /// ```
+    pub fn font_family<M>(mut self, family: impl IntoSignal<FontFamily, M>) -> Self {
+        self.text_mut().font_family = Some(family.into_signal());
+        self
+    }
+
+    /// Set the font weight of text in this container and its descendants, on
+    /// the CSS 100-900 scale.
+    pub fn font_weight<M>(mut self, weight: impl IntoSignal<FontWeight, M>) -> Self {
+        self.text_mut().font_weight = Some(weight.into_signal());
+        self
+    }
+
+    /// Shorthand for [`font_weight(FontWeight::BOLD)`](Self::font_weight).
+    pub fn bold(self) -> Self {
+        self.font_weight(FontWeight::BOLD)
+    }
+
+    /// Shorthand for [`font_family(FontFamily::Monospace)`](Self::font_family).
+    pub fn mono(self) -> Self {
+        self.font_family(FontFamily::Monospace)
+    }
+
+    /// Set the caret colour of any [`TextInput`](crate::widgets::TextInput)
+    /// below this container. Defaults to the text colour.
+    pub fn cursor_color<M>(mut self, color: impl IntoSignal<Color, M>) -> Self {
+        self.text_mut().cursor_color = Some(color.into_signal());
+        self
+    }
+
+    /// Set the selection highlight colour of any
+    /// [`TextInput`](crate::widgets::TextInput) below this container.
+    pub fn selection_color<M>(mut self, color: impl IntoSignal<Color, M>) -> Self {
+        self.text_mut().selection_color = Some(color.into_signal());
         self
     }
 
@@ -950,6 +1030,12 @@ impl Widget for Container {
     fn register_children(&mut self, tree: &mut Tree, id: WidgetId) {
         // Set container_id for children source
         self.children_source.set_container_id(id);
+
+        // Publish the declared text style on the node so descendants find it
+        // by walking up. The signals themselves are stable ids, so a value
+        // change needs no rewrite — only a rebuilt container does, and that
+        // re-registers anyway.
+        tree.set_text_style(id, self.text.as_deref().copied());
 
         // Register pending children
         self.children_source.register_pending(tree, id);

--- a/src/widgets/diagnostic_audit.rs
+++ b/src/widgets/diagnostic_audit.rs
@@ -200,18 +200,36 @@ fn a_fully_reactive_text_is_quiet() {
     let n = create_signal(0.0f32);
     let label = create_signal(String::from("ciao"));
 
-    let widget = text(move || label.get())
-        .color(move || {
+    // The style is reactive on the container and read by the text as it walks
+    // up, so this also covers the inherited path being resolved inside the
+    // text's own tracking scope rather than someone else's.
+    let widget = container()
+        .text_color(move || {
             if n.get() > 0.0 {
                 Color::RED
             } else {
                 Color::WHITE
             }
         })
-        .font_size(move || n.get() + 12.0);
+        .font_size(move || n.get() + 12.0)
+        .child(text(move || label.get()));
 
     assert_quiet(
         "a fully reactive text",
+        diagnostics_from_full_lifecycle(widget),
+    );
+}
+
+#[test]
+fn a_text_inheriting_through_a_plain_container_is_quiet() {
+    let n = create_signal(0.0f32);
+
+    let widget = container()
+        .font_size(move || n.get() + 12.0)
+        .child(container().child(text("ciao")));
+
+    assert_quiet(
+        "a text inheriting across a container that declares nothing",
         diagnostics_from_full_lifecycle(widget),
     );
 }
@@ -221,7 +239,7 @@ fn a_fully_reactive_text_input_is_quiet() {
     let value = create_signal(String::from("ciao"));
     let n = create_signal(0.0f32);
 
-    let widget = text_input(value)
+    let widget = container()
         .text_color(move || {
             if n.get() > 0.0 {
                 Color::RED
@@ -230,7 +248,8 @@ fn a_fully_reactive_text_input_is_quiet() {
             }
         })
         .cursor_color(move || Color::WHITE.with_alpha(n.get().max(0.5)))
-        .font_size(move || n.get() + 12.0);
+        .font_size(move || n.get() + 12.0)
+        .child(text_input(value));
 
     assert_quiet(
         "a fully reactive text input",

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -11,6 +11,7 @@ pub mod scroll;
 pub mod state_layer;
 pub mod text;
 pub mod text_input;
+pub mod text_style;
 pub mod widget;
 
 pub use crate::renderer::CornerRadii;
@@ -25,6 +26,7 @@ pub use scroll::{ScrollAxis, ScrollbarBuilder, ScrollbarConfig, ScrollbarVisibil
 pub use state_layer::{BackgroundOverride, RippleConfig, StateStyle};
 pub use text::{Text, text};
 pub use text_input::{Selection, TextInput, text_input};
+pub use text_style::TextStyle;
 pub use widget::{
     AnyWidget, Color, Event, EventResponse, Key, LayoutHints, Modifiers, MouseButton, Padding,
     Rect, ScrollSource, Widget,

--- a/src/widgets/text.rs
+++ b/src/widgets/text.rs
@@ -8,12 +8,18 @@ use crate::tree::{Tree, WidgetId};
 use super::font::{FontFamily, FontWeight};
 use super::widget::{Color, EventResponse, Rect, Widget};
 
+/// A run of text.
+///
+/// Content only: colour, size, family and weight are declared on an enclosing
+/// container and inherited from the nearest one that sets them — see
+/// [`TextStyle`](super::TextStyle).
+///
+/// ```ignore
+/// container().font_size(21.0).text_color(theme.text)
+///     .child(text("Hello"))
+/// ```
 pub struct Text {
     content: Signal<String>,
-    color: Option<Signal<Color>>,
-    font_size: Option<Signal<f32>>,
-    font_family: Option<Signal<FontFamily>>,
-    font_weight: Option<Signal<FontWeight>>,
     /// If true, text won't wrap and will be clipped by parent container
     nowrap: bool,
     /// Cached values for painting (avoid re-reading signals)
@@ -32,74 +38,12 @@ impl Text {
         let default_family = default_font_family();
         Self {
             content,
-            color: None,
-            font_size: None,
-            font_family: None,
-            font_weight: None,
             nowrap: false,
             cached_text: String::new(), // Will be set during first layout
             cached_font_size: 14.0,
             cached_font_family: default_family,
             cached_font_weight: FontWeight::NORMAL,
         }
-    }
-
-    pub fn color<M>(mut self, color: impl IntoSignal<Color, M>) -> Self {
-        self.color = Some(color.into_signal());
-        self
-    }
-
-    pub fn font_size<M>(mut self, size: impl IntoSignal<f32, M>) -> Self {
-        self.font_size = Some(size.into_signal());
-        self
-    }
-
-    /// Set the font family.
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// text("Hello").font_family(FontFamily::Monospace)
-    /// text("Hello").font_family(FontFamily::Name("Inter".into()))
-    /// ```
-    pub fn font_family<M>(mut self, family: impl IntoSignal<FontFamily, M>) -> Self {
-        self.font_family = Some(family.into_signal());
-        self
-    }
-
-    /// Set the font weight.
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// text("Hello").font_weight(FontWeight::BOLD)
-    /// text("Hello").font_weight(FontWeight(600))
-    /// ```
-    pub fn font_weight<M>(mut self, weight: impl IntoSignal<FontWeight, M>) -> Self {
-        self.font_weight = Some(weight.into_signal());
-        self
-    }
-
-    /// Shorthand for bold text (FontWeight::BOLD).
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// text("Hello").bold()
-    /// ```
-    pub fn bold(self) -> Self {
-        self.font_weight(FontWeight::BOLD)
-    }
-
-    /// Shorthand for monospace font (FontFamily::Monospace).
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// text("Hello").mono()
-    /// ```
-    pub fn mono(self) -> Self {
-        self.font_family(FontFamily::Monospace)
     }
 
     /// Prevent text from wrapping. Text will be clipped by parent container.
@@ -109,15 +53,18 @@ impl Text {
         self
     }
 
-    /// Refresh cached values from reactive properties.
-    /// Uses signal tracking to register layout dependencies so the widget
-    /// is re-laid out when any of these signals change.
-    fn refresh(&mut self, id: WidgetId) {
+    /// Refresh cached values from the inherited style.
+    ///
+    /// The signals are read here, inside this widget's tracking scope, so the
+    /// text is re-laid-out when whichever ancestor supplied a metric changes
+    /// it — and is left alone when an ancestor it does not depend on changes.
+    fn refresh(&mut self, tree: &Tree, id: WidgetId) {
         with_signal_tracking(id, JobType::Layout, || {
+            let style = tree.inherited_text_style(id);
             self.cached_text = self.content.get();
-            self.cached_font_size = self.font_size.get_or(14.0);
-            self.cached_font_family = self.font_family.get_or_else(default_font_family);
-            self.cached_font_weight = self.font_weight.get_or(FontWeight::NORMAL);
+            self.cached_font_size = style.font_size.get_or(14.0);
+            self.cached_font_family = style.font_family.get_or_else(default_font_family);
+            self.cached_font_weight = style.font_weight.get_or(FontWeight::NORMAL);
         });
     }
 }
@@ -144,9 +91,9 @@ impl Widget for Text {
             },
         );
 
-        // Refresh cached values from reactive properties
-        // This reads signals and registers layout dependencies
-        self.refresh(id);
+        // Refresh cached values from content and inherited style.
+        // This reads signals and registers layout dependencies.
+        self.refresh(tree, id);
 
         // Determine the effective max_width for measurement
         // If nowrap is true, don't pass max_width so text won't wrap
@@ -192,8 +139,11 @@ impl Widget for Text {
         // Parent Container sets position transform
         let size = tree.cached_size(id).unwrap_or_default();
         let local_bounds = Rect::new(0.0, 0.0, size.width, size.height);
-        // Read color with tracking so signal changes trigger repaint
-        let color = with_signal_tracking(id, JobType::Paint, || self.color.get_or(Color::WHITE));
+        // Read colour with tracking so a change on whichever ancestor supplied
+        // it triggers a repaint of this text and nothing else.
+        let color = with_signal_tracking(id, JobType::Paint, || {
+            tree.inherited_text_style(id).color.get_or(Color::WHITE)
+        });
         ctx.draw_text_styled(
             &self.cached_text,
             local_bounds,
@@ -222,6 +172,92 @@ impl Widget for Text {
 /// text(move || format!("Count: {}", count.get()))  // reactive closure
 /// text(my_signal)  // reactive signal
 /// ```
+///
+/// Styling lives on an enclosing container:
+/// ```ignore
+/// container().font_size(18.0).bold().child(text("Hello"))
+/// ```
 pub fn text<M>(content: impl IntoSignal<String, M>) -> Text {
     Text::new(content)
+}
+
+#[cfg(test)]
+mod tests {
+    use rustc_hash::FxHashSet;
+
+    use super::*;
+    use crate::jobs;
+    use crate::layout::Constraints;
+    use crate::reactive::create_signal;
+    use crate::renderer::{DrawCommand, RenderNode};
+    use crate::widgets::container;
+
+    /// Lay out and paint, returning the first text command's colour and size.
+    ///
+    /// The queued jobs are processed first, which is what turns a signal write
+    /// into `needs_layout` on the widgets that read it — and, because
+    /// `mark_needs_layout` walks to the relayout boundary, on the ancestors
+    /// that have to descend to reach them. Skip it and every container takes
+    /// its unchanged-constraints early-out, so the text is never asked to lay
+    /// out again and the test measures the cache instead of the resolution.
+    fn frame(tree: &mut Tree, root: WidgetId) -> (Color, f32) {
+        let roots: FxHashSet<WidgetId> = [root].into_iter().collect();
+        jobs::distribute_jobs(tree, &roots);
+        let drained = jobs::drain_surface_jobs(root);
+        let mut layout_roots = Vec::new();
+        jobs::process_jobs(&drained, tree, &mut layout_roots);
+        jobs::recycle_job_buffer(drained);
+        jobs::recycle_job_buffer(jobs::drain_orphan_jobs());
+
+        tree.with_widget_mut(root, |w, id, t| {
+            w.layout(t, id, Constraints::new(0.0, 0.0, 800.0, 600.0))
+        });
+        let mut node = RenderNode::new(root.as_u64());
+        tree.with_widget_mut(root, |w, id, t| {
+            let mut ctx = PaintContext::new(&mut node);
+            w.paint(t, id, &mut ctx);
+        });
+
+        fn find(node: &RenderNode) -> Option<(Color, f32)> {
+            for cmd in &node.commands {
+                if let DrawCommand::Text {
+                    color, font_size, ..
+                } = &**cmd
+                {
+                    return Some((*color, *font_size));
+                }
+            }
+            node.children.iter().find_map(|c| find(c))
+        }
+        find(&node).expect("a text command")
+    }
+
+    #[test]
+    fn a_text_follows_the_ancestor_signal_it_resolved_from() {
+        let size = create_signal(10.0f32);
+        let color = create_signal(Color::RED);
+
+        let mut tree = Tree::new();
+        let root = tree.register(Box::new(
+            container()
+                .font_size(move || size.get())
+                .text_color(move || color.get())
+                // A plain container in between: the text must still end up
+                // subscribed to the signals two levels up.
+                .child(container().child(text("hi"))),
+        ));
+        tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
+
+        assert_eq!(frame(&mut tree, root), (Color::RED, 10.0));
+
+        size.set(40.0);
+        color.set(Color::BLUE);
+
+        assert_eq!(
+            frame(&mut tree, root),
+            (Color::BLUE, 40.0),
+            "a change to an inherited declaration must re-measure and repaint \
+             the text that read it"
+        );
+    }
 }

--- a/src/widgets/text_input.rs
+++ b/src/widgets/text_input.rs
@@ -15,9 +15,8 @@ use crate::default_font_family;
 use crate::jobs::{JobRequest, JobType, RequiredJob, request_job};
 use crate::layout::{Constraints, Size};
 use crate::reactive::{
-    CursorIcon, IntoSignal, OptionSignalExt, RwSignal, Signal, clipboard_copy, clipboard_paste,
-    has_focus, primary_copy, primary_paste, release_focus, request_focus, set_cursor,
-    with_signal_tracking,
+    CursorIcon, OptionSignalExt, RwSignal, clipboard_copy, clipboard_paste, has_focus,
+    primary_copy, primary_paste, release_focus, request_focus, set_cursor, with_signal_tracking,
 };
 use crate::renderer::{PaintContext, char_index_from_x_styled};
 use crate::tree::{Tree, WidgetId};
@@ -207,13 +206,8 @@ pub struct TextInput {
     /// Whether measurements need to be recalculated
     measurements_dirty: bool,
 
-    // Styling
-    text_color: Option<Signal<Color>>,
-    cursor_color: Option<Signal<Color>>,
-    selection_color: Option<Signal<Color>>,
-    font_size: Option<Signal<f32>>,
-    font_family: Option<Signal<FontFamily>>,
-    font_weight: Option<Signal<FontWeight>>,
+    // Metrics resolved from the enclosing container's style. Cached because a
+    // change to any of them invalidates the glyph measurements below.
     cached_font_size: f32,
     cached_font_family: FontFamily,
     cached_font_weight: FontWeight,
@@ -269,12 +263,6 @@ impl TextInput {
             cached_text_width: 0.0,
             cached_glyph_positions: Vec::new(),
             measurements_dirty: true,
-            text_color: None,
-            cursor_color: None,
-            selection_color: None,
-            font_size: None,
-            font_family: None,
-            font_weight: None,
             cached_font_size: 14.0,
             cached_font_family: default_family,
             cached_font_weight: FontWeight::NORMAL,
@@ -293,64 +281,6 @@ impl TextInput {
             on_change: None,
             on_submit: None,
         }
-    }
-
-    /// Set the text color
-    pub fn text_color<M>(mut self, color: impl IntoSignal<Color, M>) -> Self {
-        self.text_color = Some(color.into_signal());
-        self
-    }
-
-    /// Set the cursor color
-    pub fn cursor_color<M>(mut self, color: impl IntoSignal<Color, M>) -> Self {
-        self.cursor_color = Some(color.into_signal());
-        self
-    }
-
-    /// Set the selection highlight color
-    pub fn selection_color<M>(mut self, color: impl IntoSignal<Color, M>) -> Self {
-        self.selection_color = Some(color.into_signal());
-        self
-    }
-
-    /// Set the font size
-    pub fn font_size<M>(mut self, size: impl IntoSignal<f32, M>) -> Self {
-        self.font_size = Some(size.into_signal());
-        self
-    }
-
-    /// Set the font family.
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// text_input(signal).font_family(FontFamily::Monospace)
-    /// ```
-    pub fn font_family<M>(mut self, family: impl IntoSignal<FontFamily, M>) -> Self {
-        self.font_family = Some(family.into_signal());
-        self
-    }
-
-    /// Set the font weight.
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// text_input(signal).font_weight(FontWeight::BOLD)
-    /// ```
-    pub fn font_weight<M>(mut self, weight: impl IntoSignal<FontWeight, M>) -> Self {
-        self.font_weight = Some(weight.into_signal());
-        self
-    }
-
-    /// Shorthand for bold text (FontWeight::BOLD).
-    pub fn bold(self) -> Self {
-        self.font_weight(FontWeight::BOLD)
-    }
-
-    /// Shorthand for monospace font (FontFamily::Monospace).
-    pub fn mono(self) -> Self {
-        self.font_family(FontFamily::Monospace)
     }
 
     /// Enable password mode (masks text with bullet characters)
@@ -453,17 +383,19 @@ impl TextInput {
         (byte_start, byte_end)
     }
 
-    /// Refresh cached values from reactive properties.
-    /// Uses signal tracking to register layout dependencies so the widget
-    /// is re-laid out when any of these signals change.
-    fn refresh(&mut self, id: WidgetId) {
+    /// Refresh cached values from the bound signal and the inherited style.
+    ///
+    /// The reads happen in this widget's tracking scope, so whichever ancestor
+    /// supplied a metric is the one whose change re-lays-out this input.
+    fn refresh(&mut self, tree: &Tree, id: WidgetId) {
         let (new_value, new_font_size, new_font_family, new_font_weight) =
             with_signal_tracking(id, JobType::Layout, || {
+                let style = tree.inherited_text_style(id);
                 (
                     self.value.get(),
-                    self.font_size.get_or(14.0),
-                    self.font_family.get_or_else(default_font_family),
-                    self.font_weight.get_or(FontWeight::NORMAL),
+                    style.font_size.get_or(14.0),
+                    style.font_family.get_or_else(default_font_family),
+                    style.font_weight.get_or(FontWeight::NORMAL),
                 )
             });
 
@@ -1003,7 +935,7 @@ impl Widget for TextInput {
 
         // Refresh cached values from reactive properties
         // This reads signals and registers layout dependencies
-        self.refresh(id);
+        self.refresh(tree, id);
 
         // Handle key repeat for held keys
         self.handle_key_repeat(tree, id);
@@ -1047,13 +979,20 @@ impl Widget for TextInput {
         let display = self.display_text_cached();
         let is_focused = has_focus(id);
 
-        // Read color signals with tracking so changes trigger repaint
+        // Read the inherited colours with tracking so a change on whichever
+        // ancestor supplied them repaints this input and nothing else.
         let (text_color, selection_color, cursor_color) =
             with_signal_tracking(id, JobType::Paint, || {
+                let style = tree.inherited_text_style(id);
+                let text_color = style.color.get_or(Color::WHITE);
                 (
-                    self.text_color.get_or(Color::WHITE),
-                    self.selection_color.get_or(Color::rgba(0.4, 0.6, 1.0, 0.4)),
-                    self.cursor_color.get_or(Color::rgb(0.4, 0.8, 1.0)),
+                    text_color,
+                    style
+                        .selection_color
+                        .get_or(Color::rgba(0.4, 0.6, 1.0, 0.4)),
+                    // The caret defaults to the text colour: an input that
+                    // only sets `text_color` should not sprout a blue cursor.
+                    style.cursor_color.get_or(text_color),
                 )
             });
 

--- a/src/widgets/text_style.rs
+++ b/src/widgets/text_style.rs
@@ -1,0 +1,117 @@
+//! How text looks — declared on the container, not on the text.
+//!
+//! Guido keeps one styling widget. A container decides what its box looks
+//! like, and that includes the text inside it: colour, metrics, and the
+//! caret and selection of an input. [`Text`](crate::widgets::Text) and
+//! [`TextInput`](crate::widgets::TextInput) carry the content and nothing
+//! else.
+//!
+//! The payoff is that text stops being a second styling system with its own
+//! parallel setters, its own caches, and no access to anything else. Because
+//! the declaration lives on the container, text colour reaches the state
+//! layers ([`StateStyle::text_color`](crate::widgets::StateStyle::text_color))
+//! and the animation machinery
+//! ([`animate_text_color`](crate::widgets::Container::animate_text_color))
+//! that already exist there, instead of needing a second copy of both.
+//!
+//! # Inheritance
+//!
+//! A text resolves each property from the nearest ancestor that declares it.
+//! Containers in between that say nothing about text are transparent, so the
+//! declaration can sit on the card while the layout rows underneath stay
+//! plain:
+//!
+//! ```ignore
+//! container().text_color(theme.text).font_size(14.0)
+//!     .child(container().layout(Flex::row())
+//!         .child(text("inherits both"))
+//!         .child(container().font_size(21.0).child(text("own size, inherited colour"))))
+//! ```
+//!
+//! Resolution is **per property**, like CSS computed values: the inner
+//! container above overrides the size without disturbing the colour. Whole
+//! struct nearest-wins would have made every partial declaration reset
+//! everything it did not mention.
+//!
+//! # Why the walk starts at the text
+//!
+//! The obvious alternative is for each container to compute a resolved style
+//! and hand it down. It is wrong here, and quietly so: guido skips layout for
+//! subtrees whose constraints did not change, so a container could recompute
+//! its style, its children skip their layout, and the text would keep
+//! rendering at the old size.
+//!
+//! Walking up from the text instead makes the reactivity fall out. The walk
+//! happens inside the text's own
+//! [`with_signal_tracking`](crate::reactive::with_signal_tracking) scope, so
+//! the text subscribes to exactly the ancestor signals it actually read, and
+//! stops at the first ancestor that answers. A container changing its colour
+//! invalidates the descendants that inherited it and not the ones that
+//! declared their own — no invalidation plumbing, and no window in which a
+//! stale value can be drawn.
+//!
+//! Which ancestors *declare* what is fixed once the tree is built, so the
+//! shape of the walk cannot change under a text without the container being
+//! rebuilt, and a rebuild re-registers the subtree anyway.
+
+use crate::reactive::Signal;
+
+use super::font::{FontFamily, FontWeight};
+use super::widget::Color;
+
+/// The text style a container declares for its descendants.
+///
+/// Every field is optional and resolved independently: a container that sets
+/// only `color` leaves the metrics to whatever an ancestor said, rather than
+/// resetting them. Properties no ancestor declares fall back to
+/// [`Text`](crate::widgets::Text)'s defaults — white, 14 logical pixels, the
+/// registered default family, normal weight.
+#[derive(Clone, Copy, Default, PartialEq)]
+pub struct TextStyle {
+    /// Colour of the glyphs.
+    pub color: Option<Signal<Color>>,
+    /// Font size in logical pixels.
+    pub font_size: Option<Signal<f32>>,
+    /// Font family.
+    pub font_family: Option<Signal<FontFamily>>,
+    /// Font weight on the CSS 100-900 scale.
+    pub font_weight: Option<Signal<FontWeight>>,
+    /// Caret colour. Only [`TextInput`](crate::widgets::TextInput) reads it.
+    pub cursor_color: Option<Signal<Color>>,
+    /// Selection highlight colour. Only
+    /// [`TextInput`](crate::widgets::TextInput) reads it.
+    pub selection_color: Option<Signal<Color>>,
+}
+
+impl TextStyle {
+    /// Whether nothing at all is declared.
+    ///
+    /// A container in this state is not recorded on its node, so the walk
+    /// skips it with a null check instead of a dereference.
+    pub fn is_empty(&self) -> bool {
+        *self == Self::default()
+    }
+
+    /// Take from `outer` every property this style does not already declare.
+    ///
+    /// Called as the walk moves away from the text, so a nearer container
+    /// always wins: whatever is already set was found closer.
+    pub(crate) fn inherit_from(&mut self, outer: &Self) {
+        self.color = self.color.or(outer.color);
+        self.font_size = self.font_size.or(outer.font_size);
+        self.font_family = self.font_family.or(outer.font_family);
+        self.font_weight = self.font_weight.or(outer.font_weight);
+        self.cursor_color = self.cursor_color.or(outer.cursor_color);
+        self.selection_color = self.selection_color.or(outer.selection_color);
+    }
+
+    /// Whether every property has been resolved, so the walk can stop early.
+    pub(crate) fn is_complete(&self) -> bool {
+        self.color.is_some()
+            && self.font_size.is_some()
+            && self.font_family.is_some()
+            && self.font_weight.is_some()
+            && self.cursor_color.is_some()
+            && self.selection_color.is_some()
+    }
+}

--- a/tests/text_style_inheritance.rs
+++ b/tests/text_style_inheritance.rs
@@ -1,0 +1,145 @@
+//! What a container declares must reach the glyphs.
+//!
+//! The unit tests in `tree.rs` cover the walk in isolation, over styles poked
+//! straight onto nodes. These go through the real thing: a container built with
+//! the public builders, laid out and painted, with the assertions made on the
+//! `DrawCommand::Text` that comes out the far end. That is the only place where
+//! a mistake in *any* of the links — the builder, the node publication, the
+//! walk, or the widget reading the wrong signal — actually shows up.
+//!
+//! Only the style is asserted, never the measured geometry: text metrics depend
+//! on the fonts installed on the machine, and the declared colour and size do
+//! not.
+
+use guido::layout::Constraints;
+use guido::prelude::*;
+use guido::renderer::{DrawCommand, PaintContext, RenderNode};
+use guido::tree::Tree;
+use guido::widgets::Widget;
+
+/// Lay out and paint `widget`, then collect every text command it emitted.
+fn text_commands(widget: impl Widget + 'static) -> Vec<(String, Color, f32, FontWeight)> {
+    let mut tree = Tree::new();
+    let root = tree.register(Box::new(widget));
+    tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
+    tree.with_widget_mut(root, |w, id, t| {
+        w.layout(t, id, Constraints::new(0.0, 0.0, 800.0, 600.0))
+    });
+
+    let mut node = RenderNode::new(root.as_u64());
+    tree.with_widget_mut(root, |w, id, t| {
+        let mut ctx = PaintContext::new(&mut node);
+        w.paint(t, id, &mut ctx);
+    });
+
+    let mut found = Vec::new();
+    collect(&node, &mut found);
+    found
+}
+
+fn collect(node: &RenderNode, out: &mut Vec<(String, Color, f32, FontWeight)>) {
+    for cmd in &node.commands {
+        if let DrawCommand::Text {
+            text,
+            color,
+            font_size,
+            font_weight,
+            ..
+        } = &**cmd
+        {
+            out.push((text.clone(), *color, *font_size, *font_weight));
+        }
+    }
+    for child in &node.children {
+        collect(child, out);
+    }
+}
+
+fn only(widget: impl Widget + 'static) -> (String, Color, f32, FontWeight) {
+    let mut cmds = text_commands(widget);
+    assert_eq!(cmds.len(), 1, "expected exactly one text command");
+    cmds.pop().unwrap()
+}
+
+#[test]
+fn a_text_with_nothing_declared_gets_the_defaults() {
+    let (_, color, size, weight) = only(container().child(text("hi")));
+    assert_eq!(color, Color::WHITE);
+    assert_eq!(size, 14.0);
+    assert_eq!(weight, FontWeight::NORMAL);
+}
+
+#[test]
+fn the_enclosing_container_styles_the_text() {
+    let (content, color, size, weight) = only(
+        container()
+            .text_color(Color::RED)
+            .font_size(30.0)
+            .bold()
+            .child(text("hi")),
+    );
+    assert_eq!(content, "hi");
+    assert_eq!(color, Color::RED);
+    assert_eq!(size, 30.0);
+    assert_eq!(weight, FontWeight::BOLD);
+}
+
+#[test]
+fn style_reaches_through_containers_that_declare_nothing() {
+    // The layout wrappers in between are exactly the case a parent-only lookup
+    // would have failed on.
+    let (_, color, size, _) = only(
+        container().text_color(Color::RED).font_size(30.0).child(
+            container()
+                .padding(8.0)
+                .layout(Flex::row())
+                .child(container().child(text("hi"))),
+        ),
+    );
+    assert_eq!(color, Color::RED);
+    assert_eq!(size, 30.0);
+}
+
+#[test]
+fn a_nearer_container_wins() {
+    let (_, color, _, _) = only(
+        container()
+            .text_color(Color::RED)
+            .child(container().text_color(Color::BLUE).child(text("hi"))),
+    );
+    assert_eq!(color, Color::BLUE);
+}
+
+#[test]
+fn overriding_one_property_leaves_the_others_alone() {
+    let (_, color, size, weight) = only(
+        container()
+            .text_color(Color::RED)
+            .font_size(30.0)
+            .bold()
+            .child(container().font_size(12.0).child(text("hi"))),
+    );
+    assert_eq!(size, 12.0, "the nearer container sets the size");
+    assert_eq!(color, Color::RED, "and must not drop the colour above it");
+    assert_eq!(weight, FontWeight::BOLD, "nor the weight");
+}
+
+#[test]
+fn siblings_resolve_independently() {
+    let cmds = text_commands(
+        container()
+            .text_color(Color::RED)
+            .layout(Flex::column())
+            .child(text("inherits"))
+            .child(container().text_color(Color::BLUE).child(text("overrides"))),
+    );
+
+    assert_eq!(cmds.len(), 2);
+    let inherits = cmds.iter().find(|c| c.0 == "inherits").unwrap();
+    let overrides = cmds.iter().find(|c| c.0 == "overrides").unwrap();
+    assert_eq!(inherits.1, Color::RED);
+    assert_eq!(overrides.1, Color::BLUE);
+}
+
+// Following a *change* to an inherited signal needs the job queue pumped, and
+// `jobs` is crate-private — that test lives in `widgets::text`.


### PR DESCRIPTION
Guido has one styling widget. A container decides what its box looks like — background, border, elevation, transforms, animations, state layers — and that should include the text inside it.

It did not. `Text` had grown `color`/`font_size`/`font_family`/`font_weight`/`bold`/`mono`, and `TextInput` had grown the same six a second time, plus `cursor_color`, `selection_color`, and its own copy of the three `cached_font_*` fields. Two parallel styling systems, neither able to reach the machinery the container already has.

## What changes

Those setters are gone. `Text` keeps `nowrap()` (that is about wrapping, not looks); `TextInput` keeps `password`, `mask_char`, `on_change`, `on_submit`. How they look is declared on an enclosing container:

```rust
container().font_size(76.0).text_color(theme.text).child(text(clock))
```

New on `Container`: `text_color`, `font_size`, `font_family`, `font_weight`, `bold`, `mono`, `cursor_color`, `selection_color`. Stored as `Option<Box<TextStyle>>` — one pointer for the containers that hold no text — following the `interaction`/`anims` pattern.

Each property is inherited by descendants until a nearer container overrides **that property**, like CSS computed values: overriding the size does not drop a colour set further up. Containers that declare nothing are transparent, so layout wrappers do not interrupt it.

`TextInput`'s caret now defaults to the text colour instead of a hardcoded blue.

## Why the walk starts at the text

The obvious alternative — each container computes a resolved style and hands it down — is quietly wrong here. Guido skips layout for subtrees whose constraints did not change, so a container could recompute its style, its children skip theirs, and the text keep rendering at the old size.

Walking up from the text makes the reactivity fall out instead: the walk happens inside the text's own `with_signal_tracking` scope, so it subscribes to exactly the ancestor signals it read and stops at the first one that answers. A container changing its colour invalidates the descendants that inherited it and not the ones that declared their own — no invalidation plumbing, no stale-value window.

The declaration lives on the tree node rather than inside the widget, because paint only has `&Tree`. Empty declarations are not stored, so passing through a plain container costs a null check rather than a dereference.

## Tests

- 7 unit tests on the walk in isolation (`tree.rs`): crossing undeclared ancestors, nearest-wins, per-property resolution, a node not inheriting its own declaration, empty declarations not stored, early exit once complete.
- 6 end-to-end tests (`tests/text_style_inheritance.rs`) asserting on the `DrawCommand::Text` that comes out of a real layout + paint, so a mistake in any link — builder, node publication, walk, or widget — shows up. Style only, never geometry: text metrics depend on the installed fonts.
- 1 test that a change to an inherited signal re-measures and repaints the text that read it (in `widgets::text`, since it needs the crate-private job queue).
- The existing reactive-diagnostics audit now covers the inherited path, including inheriting across a container that declares nothing.

## Migration

~580 call sites across `src/`, 51 examples and the book. Mechanical but not a `sed` job — the shape of the expression changes, not just a method name. Done with a paren-matching script, then a second pass that hoists the style onto the container that was already there wherever the text was its only child, so the tree shape is unchanged from before in those cases.

`text_styling_example` and `elevation_example` were then rewritten by hand to demonstrate inheritance rather than merely survive it.

## Deliberately not included

`StateStyle::text_color` and `animate_text_color`. Both produce a value at paint time rather than a signal, and `paint_children` reuses a child's cached node whenever it is not dirty — so a container repainting on hover would not repaint its text. That needs either reactive interaction state or a container-owned signal republished into the style. Its own design question, and its own PR.

Also queued separately: `Image` has the same disease (`width`/`height` duplicating the container's, and second-class — `f32`, so an image cannot express `fill()`), and `ContentFit::Cover` currently fits *inside* the constraints rather than covering them when no explicit size is given. The scrollbar is the extreme case, with ~16 builders re-implementing the container's whole vocabulary twice, but it is painted by the container rather than being child widgets, so it is not a cheap refactor.