### PR TITLE
Text stroke and shadow

### DIFF
--- a/book/src/building-ui/text.md
+++ b/book/src/building-ui/text.md
@@ -35,6 +35,38 @@ Containers that say nothing about text are transparent to this, so layout
 wrappers do not interrupt it. Properties nothing declares fall back to white,
 14 logical pixels, the registered default family and normal weight.
 
+## Legibility over an image
+
+Over a photograph no single text colour works, because the picture is light in
+some places and dark in others. Two declarations separate the glyphs from
+whatever is behind them:
+
+```rust
+container()
+    .text_color(Color::WHITE)
+    // A contour around the glyphs. CSS spells this `-webkit-text-stroke`;
+    // CSS `outline` is the contour of a box, which is why the name differs.
+    .text_stroke(TextStroke::new(1.5, Color::BLACK))
+    // As CSS `text-shadow`: offset x, offset y, blur, colour.
+    .text_shadow(TextShadow::new(0.0, 2.0, 10.0, Color::rgba(0.0, 0.0, 0.0, 0.75)))
+    .child(text("09:41"))
+```
+
+The shadow is usually the more effective of the two: it darkens the whole
+neighbourhood the glyph sits in rather than only its edge. Both are drawn
+*under* the fill, so a stroke outlines the text instead of eating into it.
+
+Both are approximated by re-drawing the glyphs at offsets, which costs fill
+rate but no extra rasterization — the glyph atlas is keyed on glyph, size and
+weight, and takes colour per draw. The approximation shows first in a thick
+stroke, whose corners begin to scallop past a few pixels; a shadow hides it
+completely, being soft and low-contrast to begin with.
+
+Neither changes how much room the text takes, so adding a shadow never moves
+its neighbours.
+
+`cargo run --example text_decoration_example` shows both against a control.
+
 ## Styling
 
 ### Font Size

--- a/docs/STYLING.md
+++ b/docs/STYLING.md
@@ -246,6 +246,22 @@ container()
 Properties nothing declares fall back to white, 14 logical pixels, the
 registered default family and normal weight.
 
+### Stroke and shadow
+
+For text over an image, where no single colour works against the whole
+picture:
+
+```rust
+container()
+    .text_color(Color::WHITE)
+    .text_stroke(TextStroke::new(1.5, Color::BLACK))
+    .text_shadow(TextShadow::new(0.0, 2.0, 10.0, Color::rgba(0.0, 0.0, 0.0, 0.75)))
+    .child(text("09:41"))
+```
+
+Both are drawn under the fill — a stroke painted over it would eat half the
+weight of every stem. Neither affects layout.
+
 ## Layout Styling
 
 ### Flex Layout

--- a/examples/text_decoration_example.rs
+++ b/examples/text_decoration_example.rs
@@ -1,0 +1,99 @@
+//! Stroke and shadow on text over a photograph.
+//!
+//! Run with: cargo run --example text_decoration_example
+//!
+//! The problem both solve: over a picture there is no single text colour that
+//! works, because the picture is light in some places and dark in others. The
+//! left column is the control — plain white, illegible wherever the photo is
+//! bright. The others separate the glyphs from whatever is behind them.
+
+use guido::prelude::*;
+
+const LABEL: &str = "09:41";
+
+fn photo() -> Container {
+    container().width(fill()).height(fill()).child(
+        image(ImageSource::Path("examples/assets/photo.webp".into()))
+            .content_fit(ContentFit::Cover),
+    )
+}
+
+/// One sample: the same text over the same photo, styled differently.
+fn panel(caption: &'static str, styled: Container) -> Container {
+    container()
+        .layout(Flex::column().spacing(8.0))
+        .child(
+            container()
+                .width(240.0)
+                .height(120.0)
+                .corner_radius(8.0)
+                .overflow(Overflow::Hidden)
+                .layout(ZStack::new())
+                .child(photo())
+                .child(
+                    styled
+                        .width(fill())
+                        .height(fill())
+                        .font_size(52.0)
+                        .text_color(Color::WHITE)
+                        .layout(
+                            Flex::column()
+                                .main_alignment(MainAlignment::Center)
+                                .cross_alignment(CrossAlignment::Center),
+                        )
+                        .child(text(LABEL).nowrap()),
+                ),
+        )
+        .child(
+            container()
+                .font_size(12.0)
+                .text_color(Color::rgb(0.7, 0.7, 0.75))
+                .child(text(caption)),
+        )
+}
+
+fn main() {
+    env_logger::init();
+
+    App::new().run(|app| {
+        let view = container()
+            .padding(24.0)
+            .layout(Flex::row().spacing(20.0))
+            .child(panel("nothing", container()))
+            .child(panel(
+                "stroke 1.5",
+                container().text_stroke(TextStroke::new(1.5, Color::BLACK)),
+            ))
+            .child(panel(
+                "shadow 0,2 blur 10",
+                container().text_shadow(TextShadow::new(
+                    0.0,
+                    2.0,
+                    10.0,
+                    Color::rgba(0.0, 0.0, 0.0, 0.75),
+                )),
+            ))
+            .child(panel(
+                "both",
+                container()
+                    .text_stroke(TextStroke::new(1.0, Color::rgba(0.0, 0.0, 0.0, 0.6)))
+                    .text_shadow(TextShadow::new(
+                        0.0,
+                        2.0,
+                        8.0,
+                        Color::rgba(0.0, 0.0, 0.0, 0.6),
+                    )),
+            ));
+
+        app.add_surface(
+            SurfaceConfig::new()
+                .width(1080)
+                .height(210)
+                .anchor(Anchor::TOP | Anchor::LEFT)
+                .layer(Layer::Top)
+                .namespace("text-decoration-example")
+                .background_color(Color::rgb(0.1, 0.1, 0.15)),
+            || view,
+        );
+    });
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,8 +177,8 @@ pub mod prelude {
         AnyWidget, Border, Color, Container, ContentFit, CornerRadii, Event, EventResponse,
         FontFamily, FontWeight, GradientDirection, Image, ImageSource, IntoChildren, Key,
         LinearGradient, Modifiers, MouseButton, Overflow, Padding, Rect, ScrollAxis, ScrollSource,
-        ScrollbarBuilder, ScrollbarVisibility, Selection, StateStyle, Text, TextInput, TextStyle,
-        Widget, container, image, keyed, text, text_input,
+        ScrollbarBuilder, ScrollbarVisibility, Selection, StateStyle, Text, TextInput, TextShadow,
+        TextStroke, TextStyle, Widget, container, image, keyed, text, text_input,
     };
     pub use crate::{
         App, ExitReason, SignalFields, component, default_font_family, load_font, quit_app,

--- a/src/renderer/paint_context.rs
+++ b/src/renderer/paint_context.rs
@@ -9,6 +9,7 @@ use crate::transform::Transform;
 use crate::transform_origin::TransformOrigin;
 use crate::widgets::font::{FontFamily, FontWeight};
 use crate::widgets::image::{ContentFit, ImageSource};
+use crate::widgets::text_style::{TextShadow, TextStroke};
 use crate::widgets::{Color, Rect};
 
 /// Painting context for the renderer.
@@ -385,6 +386,57 @@ impl<'a> PaintContext<'a> {
             font_family,
             font_weight,
         }));
+    }
+
+    /// Draw text with its decorations, back to front: shadow, stroke, fill.
+    ///
+    /// The order is the whole point of having this in one place. A stroke
+    /// painted *over* the fill eats half the weight of every stem, so the text
+    /// reads as thinner rather than outlined — the same reason SVG spells it
+    /// `paint-order: stroke fill`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn draw_text_decorated(
+        &mut self,
+        text: &str,
+        rect: Rect,
+        color: Color,
+        font_size: f32,
+        font_family: FontFamily,
+        font_weight: FontWeight,
+        stroke: Option<TextStroke>,
+        shadow: Option<TextShadow>,
+    ) {
+        if text.is_empty() {
+            return;
+        }
+
+        if let Some(shadow) = shadow {
+            for (dx, dy, sample_color) in shadow.samples() {
+                self.draw_text_styled(
+                    text,
+                    rect.offset(dx, dy),
+                    sample_color,
+                    font_size,
+                    font_family.clone(),
+                    font_weight,
+                );
+            }
+        }
+
+        if let Some(stroke) = stroke.filter(|s| s.width > 0.0) {
+            for (dx, dy) in stroke.samples() {
+                self.draw_text_styled(
+                    text,
+                    rect.offset(dx, dy),
+                    stroke.color,
+                    font_size,
+                    font_family.clone(),
+                    font_weight,
+                );
+            }
+        }
+
+        self.draw_text_styled(text, rect, color, font_size, font_family, font_weight);
     }
 
     // -------------------------------------------------------------------------

--- a/src/renderer/types.rs
+++ b/src/renderer/types.rs
@@ -46,6 +46,17 @@ impl Shadow {
         }
     }
 
+    /// How far this shadow reaches past the box that casts it.
+    ///
+    /// The amount the damage rect has to grow by, so repainting the box also
+    /// re-composites the shadow instead of leaving the old one behind.
+    pub fn extent(&self) -> f32 {
+        if self.color.a <= 0.0 {
+            return 0.0;
+        }
+        self.blur + self.spread + self.offset.0.abs().max(self.offset.1.abs())
+    }
+
     /// Create a shadow with no spread
     pub fn simple(offset: (f32, f32), blur: f32, color: Color) -> Self {
         Self {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -120,6 +120,13 @@ struct Node {
     /// Boxed because most nodes declare nothing: the miss costs a null check
     /// instead of the ~96 bytes the struct would add to every node.
     text_style: Option<Box<crate::widgets::TextStyle>>,
+    /// How far this widget paints outside its own bounds, in logical pixels.
+    ///
+    /// A shadow — a box's or a glyph's — lands outside the box that cast it,
+    /// and damage is computed from the bounds. Without this, repainting such a
+    /// widget tells the compositor to re-composite a rect that stops short of
+    /// the shadow, leaving the old one on screen as a fringe.
+    paint_overflow: f32,
 }
 
 /// Central tree for widget storage using arena-based sparse-set architecture.
@@ -191,6 +198,7 @@ impl Tree {
             sparse_index,
             cached_paint: None,
             text_style: None,
+            paint_overflow: 0.0,
         });
 
         // Update sparse map
@@ -365,6 +373,16 @@ impl Tree {
         }
 
         resolved
+    }
+
+    /// Declare how far this widget paints outside its own bounds.
+    ///
+    /// Widgets that cast a shadow or stroke set this during layout; it widens
+    /// the damage they report without touching the size they occupy.
+    pub fn set_paint_overflow(&mut self, id: WidgetId, overflow: f32) {
+        if let Some(idx) = self.get_dense_index(id) {
+            self.dense[idx].paint_overflow = overflow.max(0.0);
+        }
     }
 
     /// Get the children of a widget (returns a slice to avoid heap allocation).
@@ -568,7 +586,18 @@ impl Tree {
                 None => break,
             }
         }
-        Some((current, Rect::new(x, y, size.width, size.height)))
+        // Widen by whatever this widget paints outside itself, so a shadow is
+        // re-composited along with the thing that cast it.
+        let overflow = self.dense[idx].paint_overflow;
+        Some((
+            current,
+            Rect::new(
+                x - overflow,
+                y - overflow,
+                size.width + overflow * 2.0,
+                size.height + overflow * 2.0,
+            ),
+        ))
     }
 
     /// Find the surface root (topmost ancestor) of a widget.
@@ -1192,6 +1221,47 @@ mod tests {
         );
     }
 
+    /// Whatever a widget paints outside its own bounds — an elevation shadow,
+    /// a glyph shadow — has to be inside the damage it reports, or repainting
+    /// it re-composites a rect that stops short and the old one stays on
+    /// screen as a fringe.
+    #[test]
+    fn damage_covers_what_a_widget_paints_outside_its_bounds() {
+        let (mut tree, root, a, _b) = two_children_tree();
+        tree.set_paint_overflow(a, 8.0);
+
+        tree.mark_needs_paint(a);
+
+        match tree.take_damage(root) {
+            DamageRegion::Partial(rect) => {
+                assert!(
+                    rect.x <= -8.0 && rect.y <= -8.0,
+                    "damage must reach above and left of the widget, got {rect:?}"
+                );
+                assert!(
+                    rect.width >= 40.0 + 16.0 && rect.height >= 20.0 + 16.0,
+                    "and past its far edges, got {rect:?}"
+                );
+            }
+            other => panic!("expected partial damage, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_widget_with_no_overflow_damages_exactly_its_bounds() {
+        let (mut tree, root, a, _b) = two_children_tree();
+
+        tree.mark_needs_paint(a);
+
+        match tree.take_damage(root) {
+            DamageRegion::Partial(rect) => {
+                assert_eq!((rect.x, rect.y), (0.0, 0.0));
+                assert_eq!((rect.width, rect.height), (40.0, 20.0));
+            }
+            other => panic!("expected partial damage, got {other:?}"),
+        }
+    }
+
     // -----------------------------------------------------------------------
     // Inherited text style
     // -----------------------------------------------------------------------
@@ -1326,6 +1396,16 @@ mod tests {
                 font_size: Some(create_stored(12.0)),
                 font_family: Some(create_stored(Default::default())),
                 font_weight: Some(create_stored(FontWeight::BOLD)),
+                stroke: Some(create_stored(crate::widgets::TextStroke::new(
+                    1.0,
+                    Color::BLACK,
+                ))),
+                shadow: Some(create_stored(crate::widgets::TextShadow::new(
+                    0.0,
+                    1.0,
+                    2.0,
+                    Color::BLACK,
+                ))),
                 cursor_color: Some(create_stored(Color::WHITE)),
                 selection_color: Some(create_stored(Color::BLACK)),
             }),

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -43,7 +43,7 @@ use super::scroll::{
     ScrollAxis, ScrollState, ScrollbarBuilder, ScrollbarConfig, ScrollbarVisibility,
 };
 use super::state_layer::{StateStyle, resolve_background};
-use super::text_style::TextStyle;
+use super::text_style::{TextShadow, TextStroke, TextStyle};
 use super::widget::{
     Color, Event, EventResponse, Key, LayoutHints, Modifiers, MouseButton, Padding, Rect,
     ScrollSource, Widget,
@@ -448,6 +448,29 @@ impl Container {
     /// Shorthand for [`font_family(FontFamily::Monospace)`](Self::font_family).
     pub fn mono(self) -> Self {
         self.font_family(FontFamily::Monospace)
+    }
+
+    /// Draw a contour around the glyphs, under the fill.
+    ///
+    /// Named `text_stroke` and not `text_outline` because CSS `outline` is the
+    /// contour of a *box* — this is the one CSS spells `-webkit-text-stroke`.
+    ///
+    /// ```ignore
+    /// container().text_color(Color::WHITE).text_stroke(1.5, Color::BLACK)
+    /// ```
+    pub fn text_stroke<M>(mut self, stroke: impl IntoSignal<TextStroke, M>) -> Self {
+        self.text_mut().stroke = Some(stroke.into_signal());
+        self
+    }
+
+    /// Cast a soft shadow from the glyphs, as CSS `text-shadow`.
+    ///
+    /// ```ignore
+    /// container().text_shadow(TextShadow::new(0.0, 2.0, 8.0, shadow_color))
+    /// ```
+    pub fn text_shadow<M>(mut self, shadow: impl IntoSignal<TextShadow, M>) -> Self {
+        self.text_mut().shadow = Some(shadow.into_signal());
+        self
     }
 
     /// Set the caret colour of any [`TextInput`](crate::widgets::TextInput)
@@ -1132,6 +1155,13 @@ impl Widget for Container {
 
         // Cache constraints and size for partial layout
         tree.cache_layout(id, constraints, size);
+
+        // An elevation shadow falls outside the box that casts it, so the
+        // damage this container reports has to reach past its own bounds.
+        // Snapshotted: a hover that only changes the elevation goes through
+        // paint, and this is here to size the damage, not to subscribe to it.
+        let elevation = self.elevation.get_or_untracked(0.0);
+        tree.set_paint_overflow(id, style::elevation_to_shadow(elevation).extent());
 
         // Register widget ref so update_widget_refs() can refresh bounds
         if let Some(ref wr) = self.widget_ref {

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -26,7 +26,7 @@ pub use scroll::{ScrollAxis, ScrollbarBuilder, ScrollbarConfig, ScrollbarVisibil
 pub use state_layer::{BackgroundOverride, RippleConfig, StateStyle};
 pub use text::{Text, text};
 pub use text_input::{Selection, TextInput, text_input};
-pub use text_style::TextStyle;
+pub use text_style::{TextShadow, TextStroke, TextStyle};
 pub use widget::{
     AnyWidget, Color, Event, EventResponse, Key, LayoutHints, Modifiers, MouseButton, Padding,
     Rect, ScrollSource, Widget,

--- a/src/widgets/text.rs
+++ b/src/widgets/text.rs
@@ -6,7 +6,20 @@ use crate::renderer::{PaintContext, measure_text_styled};
 use crate::tree::{Tree, WidgetId};
 
 use super::font::{FontFamily, FontWeight};
+use super::text_style::{TextShadow, TextStroke};
 use super::widget::{Color, EventResponse, Rect, Widget};
+
+/// How far a stroke and a shadow reach past the glyphs they decorate.
+///
+/// Used for the damage slop, not for layout: decoration must not change how
+/// much room the text takes, or a shadow would push its neighbours around.
+pub(crate) fn decoration_overflow(stroke: Option<TextStroke>, shadow: Option<TextShadow>) -> f32 {
+    let from_stroke = stroke.map(|s| s.width.max(0.0)).unwrap_or(0.0);
+    let from_shadow = shadow
+        .map(|s| s.blur.max(0.0) + s.offset.0.abs().max(s.offset.1.abs()))
+        .unwrap_or(0.0);
+    from_stroke.max(from_shadow)
+}
 
 /// A run of text.
 ///
@@ -58,14 +71,18 @@ impl Text {
     /// The signals are read here, inside this widget's tracking scope, so the
     /// text is re-laid-out when whichever ancestor supplied a metric changes
     /// it — and is left alone when an ancestor it does not depend on changes.
-    fn refresh(&mut self, tree: &Tree, id: WidgetId) {
+    ///
+    /// Returns how far the decoration reaches past the glyphs, which the
+    /// caller records as damage slop.
+    fn refresh(&mut self, tree: &Tree, id: WidgetId) -> f32 {
         with_signal_tracking(id, JobType::Layout, || {
             let style = tree.inherited_text_style(id);
             self.cached_text = self.content.get();
             self.cached_font_size = style.font_size.get_or(14.0);
             self.cached_font_family = style.font_family.get_or_else(default_font_family);
             self.cached_font_weight = style.font_weight.get_or(FontWeight::NORMAL);
-        });
+            decoration_overflow(style.stroke.map(|s| s.get()), style.shadow.map(|s| s.get()))
+        })
     }
 }
 
@@ -93,7 +110,8 @@ impl Widget for Text {
 
         // Refresh cached values from content and inherited style.
         // This reads signals and registers layout dependencies.
-        self.refresh(tree, id);
+        let overflow = self.refresh(tree, id);
+        tree.set_paint_overflow(id, overflow);
 
         // Determine the effective max_width for measurement
         // If nowrap is true, don't pass max_width so text won't wrap
@@ -139,18 +157,25 @@ impl Widget for Text {
         // Parent Container sets position transform
         let size = tree.cached_size(id).unwrap_or_default();
         let local_bounds = Rect::new(0.0, 0.0, size.width, size.height);
-        // Read colour with tracking so a change on whichever ancestor supplied
-        // it triggers a repaint of this text and nothing else.
-        let color = with_signal_tracking(id, JobType::Paint, || {
-            tree.inherited_text_style(id).color.get_or(Color::WHITE)
+        // Read the painted properties with tracking so a change on whichever
+        // ancestor supplied them repaints this text and nothing else.
+        let (color, stroke, shadow) = with_signal_tracking(id, JobType::Paint, || {
+            let style = tree.inherited_text_style(id);
+            (
+                style.color.get_or(Color::WHITE),
+                style.stroke.map(|s| s.get()),
+                style.shadow.map(|s| s.get()),
+            )
         });
-        ctx.draw_text_styled(
+        ctx.draw_text_decorated(
             &self.cached_text,
             local_bounds,
             color,
             self.cached_font_size,
             self.cached_font_family.clone(),
             self.cached_font_weight,
+            stroke,
+            shadow,
         );
     }
 

--- a/src/widgets/text_input.rs
+++ b/src/widgets/text_input.rs
@@ -387,8 +387,8 @@ impl TextInput {
     ///
     /// The reads happen in this widget's tracking scope, so whichever ancestor
     /// supplied a metric is the one whose change re-lays-out this input.
-    fn refresh(&mut self, tree: &Tree, id: WidgetId) {
-        let (new_value, new_font_size, new_font_family, new_font_weight) =
+    fn refresh(&mut self, tree: &Tree, id: WidgetId) -> f32 {
+        let (new_value, new_font_size, new_font_family, new_font_weight, overflow) =
             with_signal_tracking(id, JobType::Layout, || {
                 let style = tree.inherited_text_style(id);
                 (
@@ -396,6 +396,10 @@ impl TextInput {
                     style.font_size.get_or(14.0),
                     style.font_family.get_or_else(default_font_family),
                     style.font_weight.get_or(FontWeight::NORMAL),
+                    crate::widgets::text::decoration_overflow(
+                        style.stroke.map(|s| s.get()),
+                        style.shadow.map(|s| s.get()),
+                    ),
                 )
             });
 
@@ -423,6 +427,8 @@ impl TextInput {
             self.cached_font_weight = new_font_weight;
             self.measurements_dirty = true;
         }
+
+        overflow
     }
 
     /// Update cursor blink state.
@@ -935,7 +941,8 @@ impl Widget for TextInput {
 
         // Refresh cached values from reactive properties
         // This reads signals and registers layout dependencies
-        self.refresh(tree, id);
+        let overflow = self.refresh(tree, id);
+        tree.set_paint_overflow(id, overflow);
 
         // Handle key repeat for held keys
         self.handle_key_repeat(tree, id);
@@ -981,7 +988,7 @@ impl Widget for TextInput {
 
         // Read the inherited colours with tracking so a change on whichever
         // ancestor supplied them repaints this input and nothing else.
-        let (text_color, selection_color, cursor_color) =
+        let (text_color, selection_color, cursor_color, stroke, shadow) =
             with_signal_tracking(id, JobType::Paint, || {
                 let style = tree.inherited_text_style(id);
                 let text_color = style.color.get_or(Color::WHITE);
@@ -993,6 +1000,8 @@ impl Widget for TextInput {
                     // The caret defaults to the text colour: an input that
                     // only sets `text_color` should not sprout a blue cursor.
                     style.cursor_color.get_or(text_color),
+                    style.stroke.map(|s| s.get()),
+                    style.shadow.map(|s| s.get()),
                 )
             });
 
@@ -1015,13 +1024,15 @@ impl Widget for TextInput {
             self.cached_text_width.max(bounds.width),
             bounds.height,
         );
-        ctx.draw_text_styled(
+        ctx.draw_text_decorated(
             display,
             text_bounds,
             text_color,
             self.cached_font_size,
             self.cached_font_family.clone(),
             self.cached_font_weight,
+            stroke,
+            shadow,
         );
 
         // Draw cursor if focused and visible (LOCAL coords)

--- a/src/widgets/text_style.rs
+++ b/src/widgets/text_style.rs
@@ -54,10 +54,113 @@
 //! shape of the walk cannot change under a text without the container being
 //! rebuilt, and a rebuild re-registers the subtree anyway.
 
+use smallvec::SmallVec;
+
 use crate::reactive::Signal;
 
 use super::font::{FontFamily, FontWeight};
 use super::widget::Color;
+
+/// A contour drawn around the glyphs.
+///
+/// The legibility fix for text over an image, where no single colour works
+/// against both the light and dark parts of the picture.
+///
+/// It is drawn *under* the fill, like SVG's `paint-order: stroke fill` and
+/// unlike a naive implementation: painted over, a stroke eats half the weight
+/// of every stem and the text reads as thinner rather than outlined.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct TextStroke {
+    /// Half-width of the contour, in logical pixels — how far the stroke
+    /// reaches outwards from the glyph edge.
+    pub width: f32,
+    pub color: Color,
+}
+
+impl TextStroke {
+    pub fn new(width: f32, color: Color) -> Self {
+        Self { width, color }
+    }
+
+    /// The offsets to draw the glyphs at, in logical pixels.
+    ///
+    /// A ring of copies around the original. This is the classic approximation
+    /// and it costs nothing new: glyphon keys its atlas on glyph, size and
+    /// weight, and takes colour per draw, so the extra copies re-use the
+    /// rasterization already there and cost fill rate only.
+    ///
+    /// Its ceiling is the corners, which scallop once the gaps between samples
+    /// exceed a pixel — so the tap count grows with the width instead of being
+    /// fixed at the usual eight. Past a few pixels the honest fix is a dilate
+    /// on an offscreen mask, not more taps.
+    pub(crate) fn samples(&self) -> SmallVec<[(f32, f32); 24]> {
+        let taps = (self.width * 6.0).clamp(8.0, 24.0) as usize;
+        (0..taps)
+            .map(|i| {
+                let angle = std::f32::consts::TAU * i as f32 / taps as f32;
+                (self.width * angle.cos(), self.width * angle.sin())
+            })
+            .collect()
+    }
+}
+
+/// A soft shadow cast by the glyphs, as CSS `text-shadow`.
+///
+/// Usually the better of the two for legibility over a photograph: it darkens
+/// the neighbourhood the glyph sits in rather than only its edge, which is
+/// what actually separates the text from a busy background.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct TextShadow {
+    /// Offset in logical pixels, positive being right and down.
+    pub offset: (f32, f32),
+    /// How far the shadow spreads past the glyphs.
+    pub blur: f32,
+    pub color: Color,
+}
+
+impl TextShadow {
+    pub fn new(offset_x: f32, offset_y: f32, blur: f32, color: Color) -> Self {
+        Self {
+            offset: (offset_x, offset_y),
+            blur,
+            color,
+        }
+    }
+
+    /// The offsets and colours to draw the glyphs at, back to front.
+    ///
+    /// Same trick as the stroke, and the approximation lands far better here:
+    /// a shadow is already soft and low-contrast, so the banding a ring of
+    /// samples produces is invisible where a scalloped stroke would not be.
+    /// The rings composite with ordinary source-over blending, so they do not
+    /// sum to a gaussian — they saturate towards the centre, which is the
+    /// shape a shadow wants anyway.
+    pub(crate) fn samples(&self) -> SmallVec<[(f32, f32, Color); 25]> {
+        let (ox, oy) = self.offset;
+        let mut out = SmallVec::new();
+
+        if self.blur <= 0.0 {
+            out.push((ox, oy, self.color));
+            return out;
+        }
+
+        // Outermost first: the faint wide ring, then the tighter one, then the
+        // solid core on top.
+        let taps = (self.blur * 1.5).clamp(8.0, 12.0) as usize;
+        for (radius, alpha) in [(self.blur, 0.35), (self.blur * 0.5, 0.6)] {
+            for i in 0..taps {
+                let angle = std::f32::consts::TAU * i as f32 / taps as f32;
+                out.push((
+                    ox + radius * angle.cos(),
+                    oy + radius * angle.sin(),
+                    self.color.with_alpha(self.color.a * alpha),
+                ));
+            }
+        }
+        out.push((ox, oy, self.color));
+        out
+    }
+}
 
 /// The text style a container declares for its descendants.
 ///
@@ -76,6 +179,10 @@ pub struct TextStyle {
     pub font_family: Option<Signal<FontFamily>>,
     /// Font weight on the CSS 100-900 scale.
     pub font_weight: Option<Signal<FontWeight>>,
+    /// Contour drawn around the glyphs, under the fill.
+    pub stroke: Option<Signal<TextStroke>>,
+    /// Soft shadow cast by the glyphs.
+    pub shadow: Option<Signal<TextShadow>>,
     /// Caret colour. Only [`TextInput`](crate::widgets::TextInput) reads it.
     pub cursor_color: Option<Signal<Color>>,
     /// Selection highlight colour. Only
@@ -101,6 +208,8 @@ impl TextStyle {
         self.font_size = self.font_size.or(outer.font_size);
         self.font_family = self.font_family.or(outer.font_family);
         self.font_weight = self.font_weight.or(outer.font_weight);
+        self.stroke = self.stroke.or(outer.stroke);
+        self.shadow = self.shadow.or(outer.shadow);
         self.cursor_color = self.cursor_color.or(outer.cursor_color);
         self.selection_color = self.selection_color.or(outer.selection_color);
     }
@@ -111,6 +220,8 @@ impl TextStyle {
             && self.font_size.is_some()
             && self.font_family.is_some()
             && self.font_weight.is_some()
+            && self.stroke.is_some()
+            && self.shadow.is_some()
             && self.cursor_color.is_some()
             && self.selection_color.is_some()
     }

--- a/tests/text_decoration.rs
+++ b/tests/text_decoration.rs
@@ -1,0 +1,232 @@
+//! Stroke and shadow: the draws they emit, and in what order.
+//!
+//! Both are approximated by re-drawing the glyphs at offsets, so what there is
+//! to test is exactly that: how many copies, where, in what colour, and — the
+//! part that is easy to get backwards — that the stroke lands *under* the fill.
+
+use guido::layout::Constraints;
+use guido::prelude::*;
+use guido::renderer::{DrawCommand, PaintContext, RenderNode};
+use guido::tree::Tree;
+use guido::widgets::Widget;
+
+/// Every text command a widget emits, in draw order, as (x, y, colour).
+fn draws(widget: impl Widget + 'static) -> Vec<(f32, f32, Color)> {
+    let mut tree = Tree::new();
+    let root = tree.register(Box::new(widget));
+    tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
+    tree.with_widget_mut(root, |w, id, t| {
+        w.layout(t, id, Constraints::new(0.0, 0.0, 800.0, 600.0))
+    });
+
+    let mut node = RenderNode::new(root.as_u64());
+    tree.with_widget_mut(root, |w, id, t| {
+        let mut ctx = PaintContext::new(&mut node);
+        w.paint(t, id, &mut ctx);
+    });
+
+    let mut out = Vec::new();
+    collect(&node, &mut out);
+    out
+}
+
+fn collect(node: &RenderNode, out: &mut Vec<(f32, f32, Color)>) {
+    for cmd in &node.commands {
+        if let DrawCommand::Text { rect, color, .. } = &**cmd {
+            out.push((rect.x, rect.y, *color));
+        }
+    }
+    for child in &node.children {
+        collect(child, out);
+    }
+}
+
+#[test]
+fn plain_text_is_a_single_draw() {
+    assert_eq!(
+        draws(container().text_color(Color::WHITE).child(text("hi"))).len(),
+        1
+    );
+}
+
+#[test]
+fn the_fill_is_drawn_last() {
+    // The one ordering that matters: painted over the fill, a stroke eats half
+    // the weight of every stem and the text reads as thinner, not outlined.
+    let cmds = draws(
+        container()
+            .text_color(Color::WHITE)
+            .text_stroke(TextStroke::new(2.0, Color::BLACK))
+            .text_shadow(TextShadow::new(0.0, 2.0, 4.0, Color::RED))
+            .child(text("hi")),
+    );
+
+    let (x, y, color) = *cmds.last().unwrap();
+    assert_eq!(color, Color::WHITE, "the fill is the last thing drawn");
+    assert_eq!((x, y), (0.0, 0.0), "and it is the undisplaced one");
+    assert!(
+        cmds[..cmds.len() - 1]
+            .iter()
+            .all(|(_, _, c)| *c != Color::WHITE),
+        "nothing else should be drawn in the fill colour"
+    );
+}
+
+#[test]
+fn the_shadow_is_drawn_before_the_stroke() {
+    let cmds = draws(
+        container()
+            .text_color(Color::WHITE)
+            .text_stroke(TextStroke::new(1.0, Color::BLACK))
+            .text_shadow(TextShadow::new(0.0, 0.0, 0.0, Color::RED))
+            .child(text("hi")),
+    );
+
+    let last_shadow = cmds.iter().rposition(|(_, _, c)| *c == Color::RED).unwrap();
+    let first_stroke = cmds
+        .iter()
+        .position(|(_, _, c)| *c == Color::BLACK)
+        .unwrap();
+    assert!(last_shadow < first_stroke);
+}
+
+#[test]
+fn a_stroke_surrounds_the_glyphs() {
+    let cmds = draws(
+        container()
+            .text_color(Color::WHITE)
+            .text_stroke(TextStroke::new(2.0, Color::BLACK))
+            .child(text("hi")),
+    );
+
+    let ring: Vec<_> = cmds.iter().filter(|(_, _, c)| *c == Color::BLACK).collect();
+    assert!(ring.len() >= 8, "got {} samples", ring.len());
+
+    // Every copy sits on a circle of the stroke's width around the original.
+    for (x, y, _) in &ring {
+        let distance = (x * x + y * y).sqrt();
+        assert!(
+            (distance - 2.0).abs() < 1e-3,
+            "sample at ({x}, {y}) is {distance} from the glyph, expected 2"
+        );
+    }
+
+    // And they surround it rather than bunching on one side.
+    assert!(ring.iter().any(|(x, _, _)| *x > 1.0));
+    assert!(ring.iter().any(|(x, _, _)| *x < -1.0));
+    assert!(ring.iter().any(|(_, y, _)| *y > 1.0));
+    assert!(ring.iter().any(|(_, y, _)| *y < -1.0));
+}
+
+#[test]
+fn a_wider_stroke_uses_more_samples() {
+    let count = |width: f32| {
+        draws(
+            container()
+                .text_stroke(TextStroke::new(width, Color::BLACK))
+                .child(text("hi")),
+        )
+        .iter()
+        .filter(|(_, _, c)| *c == Color::BLACK)
+        .count()
+    };
+    assert!(
+        count(4.0) > count(1.0),
+        "the gaps between samples grow with the radius, so the tap count has \
+         to grow with it too or the corners scallop"
+    );
+}
+
+#[test]
+fn an_unblurred_shadow_is_one_offset_copy() {
+    let cmds = draws(
+        container()
+            .text_color(Color::WHITE)
+            .text_shadow(TextShadow::new(3.0, 4.0, 0.0, Color::RED))
+            .child(text("hi")),
+    );
+
+    let shadow: Vec<_> = cmds.iter().filter(|(_, _, c)| *c == Color::RED).collect();
+    assert_eq!(shadow.len(), 1);
+    assert_eq!((shadow[0].0, shadow[0].1), (3.0, 4.0));
+}
+
+#[test]
+fn a_blurred_shadow_spreads_around_the_offset() {
+    let cmds = draws(
+        container()
+            .text_color(Color::WHITE)
+            .text_shadow(TextShadow::new(
+                0.0,
+                4.0,
+                6.0,
+                Color::rgba(0.0, 0.0, 0.0, 0.8),
+            ))
+            .child(text("hi")),
+    );
+
+    let shadow: Vec<_> = cmds
+        .iter()
+        .filter(|(_, _, c)| c.a > 0.0 && c.r == 0.0)
+        .collect();
+    assert!(shadow.len() > 8, "got {} samples", shadow.len());
+
+    // Centred on the offset, not on the glyph.
+    let mean_y = shadow.iter().map(|(_, y, _)| y).sum::<f32>() / shadow.len() as f32;
+    assert!(
+        (mean_y - 4.0).abs() < 0.5,
+        "mean y was {mean_y}, expected ~4"
+    );
+
+    // The outer ring is fainter than the core, so the edge falls off.
+    let core = shadow
+        .iter()
+        .find(|(x, y, _)| *x == 0.0 && *y == 4.0)
+        .unwrap();
+    assert!(shadow.iter().any(|(_, _, c)| c.a < core.2.a));
+}
+
+#[test]
+fn a_zero_width_stroke_draws_nothing_extra() {
+    assert_eq!(
+        draws(
+            container()
+                .text_stroke(TextStroke::new(0.0, Color::BLACK))
+                .child(text("hi"))
+        )
+        .len(),
+        1
+    );
+}
+
+#[test]
+fn decoration_is_inherited_like_everything_else() {
+    let cmds = draws(
+        container()
+            .text_stroke(TextStroke::new(1.0, Color::BLACK))
+            .child(container().layout(Flex::row()).child(text("hi"))),
+    );
+    assert!(cmds.iter().any(|(_, _, c)| *c == Color::BLACK));
+}
+
+#[test]
+fn decoration_does_not_change_how_much_room_the_text_takes() {
+    // A shadow must not push the text's neighbours around.
+    let measure = |decorated: bool| {
+        let mut tree = Tree::new();
+        let c = container().text_color(Color::WHITE);
+        let c = if decorated {
+            c.text_stroke(TextStroke::new(3.0, Color::BLACK))
+                .text_shadow(TextShadow::new(2.0, 2.0, 8.0, Color::RED))
+        } else {
+            c
+        };
+        let root = tree.register(Box::new(c.child(text("hi"))));
+        tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
+        tree.with_widget_mut(root, |w, id, t| {
+            w.layout(t, id, Constraints::new(0.0, 0.0, 800.0, 600.0))
+        })
+        .unwrap()
+    };
+    assert_eq!(measure(true), measure(false));
+}


### PR DESCRIPTION
Stacked on #164, which is stacked on #163.

This is the thing the whole stack was for. Over a photograph no single text colour works — the picture is light in some places and dark in others — so a lock screen's clock is illegible against half of it.

```rust
container()
    .text_color(Color::WHITE)
    .text_stroke(TextStroke::new(1.5, Color::BLACK))
    .text_shadow(TextShadow::new(0.0, 2.0, 10.0, shadow))
    .child(text("09:41"))
```

Named `text_stroke` and not `text_outline` because CSS `outline` is the contour of a *box*; this is the one CSS spells `-webkit-text-stroke`. Both are inherited like every other text property, and `text_input` reads them too, since it reads the same style.

`cargo run --example text_decoration_example` puts both against a control over the same photo.

## How they are drawn

By re-drawing the glyphs at offsets — a ring for the stroke, two rings and a core for the shadow. That costs fill rate and nothing else: glyphon keys its atlas on glyph, size and weight and takes colour per draw, so the copies reuse rasterization that is already there, and the shaped buffers are cached across frames as they already were.

No new render pass, no new shader, no new draw-ordering constraint. The alternative — an offscreen mask, dilated and blurred, reusing `backdrop_pass` — is several hundred lines of renderer and buys quality this does not need yet. It remains a drop-in replacement behind the same two types.

**Where the approximation shows.** A stroke scallops at the corners once the gaps between samples exceed a pixel, so the tap count grows with the width rather than being fixed at the usual eight; past a few pixels the honest fix is the dilate. A shadow hides the same artefact completely, being soft and low-contrast to begin with — which is also why it is the more effective of the two for legibility. The rings composite with ordinary source-over blending, so they saturate towards the centre rather than summing to a gaussian, which is the shape a shadow wants anyway.

## Ordering

`draw_text_decorated` exists so the order lives in exactly one place: shadow, stroke, fill. A stroke painted *over* the fill eats half the weight of every stem and the text reads as thinner rather than outlined — what SVG's `paint-order: stroke fill` is for. There is a test asserting the fill is last and that nothing else is drawn in its colour.

## A damage bug this would have introduced, and one it fixes

Decoration deliberately does not affect layout: a shadow must not push a text's neighbours around. But it lands *outside* the widget's bounds, and `surface_relative_bounds_and_root` computes damage from exactly those bounds. Repainting a shadowed text would therefore tell the compositor to re-composite a rect that stops short of the shadow, leaving the old one on screen as a fringe — very visible on a clock, where the glyphs change under a static shadow every minute.

Hence `Tree::set_paint_overflow`: slop on the damage rect, nothing else — it does not touch layout, hit testing or draw groups.

Containers now declare it for their elevation shadow too. That one had the same hole already, with nothing to catch it: a moving or resizing elevated container leaves a stale fringe of its old shadow. Two tests cover the inflated and the plain case.

## Tests

10 on the emitted draws (`tests/text_decoration.rs`): counts, positions on the ring, colours, both orderings, that a zero-width stroke draws nothing extra, that decoration is inherited, and that it does not change the measured size. 2 on the damage slop in `tree.rs`.