### PR TITLE
The container decides an image's box

### DIFF
--- a/book/src/building-ui/images.md
+++ b/book/src/building-ui/images.md
@@ -10,14 +10,16 @@ The `image()` function creates an image widget from a file path:
 use guido::prelude::*;
 
 // Load a PNG image
-image("./icon.png")
+container()
     .width(32.0)
     .height(32.0)
+    .child(image("./icon.png"))
 
 // Load an SVG (auto-detected by extension)
-image("./logo.svg")
+container()
     .width(100.0)
     .height(100.0)
+    .child(image("./logo.svg"))
 ```
 
 ## Image Sources
@@ -47,43 +49,49 @@ When using a string path with `image()`, the file extension determines the type 
 
 ## Sizing
 
-You can specify explicit dimensions or let the image use its intrinsic size:
+The box comes from the enclosing container, like every other size in guido; the
+image decides only how its pixels land inside it.
 
 ```rust
-// Explicit width and height
-image("./icon.png")
-    .width(32.0)
-    .height(32.0)
+// A 32x32 box
+container().width(32.0).height(32.0).child(image("./icon.png"))
 
-// Only width - height calculated from aspect ratio
-image("./banner.png")
-    .width(200.0)
+// Width fixed, height from the aspect ratio (the default fit is Contain)
+container().width(200.0).child(image("./banner.png"))
 
-// Only height - width calculated from aspect ratio
-image("./logo.svg")
-    .height(48.0)
-
-// No size - uses intrinsic dimensions
+// No box at all - the image reports its intrinsic size
 image("./icon.png")
 ```
 
 ## Content Fit Modes
 
-The `content_fit()` method controls how images fit within their bounds:
+The `content_fit()` method controls how the image maps into the box it is
+given:
 
 | Mode | Description |
 |------|-------------|
-| `ContentFit::Contain` | Fit within bounds, preserving aspect ratio (default) |
-| `ContentFit::Cover` | Cover the bounds, may crop, preserving aspect ratio |
+| `ContentFit::Contain` | Fit within the box, preserving aspect ratio (default) |
+| `ContentFit::Cover` | Fill the box, cropping, preserving aspect ratio |
 | `ContentFit::Fill` | Stretch to fill exactly, ignoring aspect ratio |
-| `ContentFit::None` | Use intrinsic size, ignoring widget bounds |
+| `ContentFit::None` | Intrinsic size, ignoring the box |
+
+`Cover` and `Fill` take all the room the container offers; they differ in how
+the pixels land. `Contain` takes only the largest rect of the image's own
+aspect ratio that fits, so the empty strip is left to the parent's alignment
+rather than painted.
 
 ```rust
-// Cover mode - fills the space, may crop
-image("./photo.jpg")
+// Cover a 200x150 box, cropping what does not fit
+container()
     .width(200.0)
     .height(150.0)
-    .content_fit(ContentFit::Cover)
+    .child(image("./photo.jpg").content_fit(ContentFit::Cover))
+
+// A wallpaper: cover the whole surface
+container()
+    .width(fill())
+    .height(fill())
+    .child(image(wallpaper).content_fit(ContentFit::Cover))
 ```
 
 ## Transform Composition
@@ -95,18 +103,20 @@ Images inherit transforms from parent containers, just like text:
 container()
     .rotate(15.0)
     .child(
-        image("./badge.svg")
+        container()
             .width(32.0)
             .height(32.0)
+            .child(image("./badge.svg"))
     )
 
 // Scaled image
 container()
     .scale(1.5)
     .child(
-        image("./icon.png")
+        container()
             .width(24.0)
             .height(24.0)
+            .child(image("./icon.png"))
     )
 
 // Combined transforms
@@ -150,9 +160,10 @@ Image sources can be reactive, allowing dynamic image changes:
 let icon_source = create_signal(ImageSource::Path("./play.png".into()));
 
 // The image updates when the signal changes
-image(icon_source)
+container()
     .width(32.0)
     .height(32.0)
+    .child(image(icon_source))
 
 // Change the image on click
 container()
@@ -193,9 +204,10 @@ fn main() {
             .layout(Flex::row().spacing(16.0))
             .child(
                 // PNG image
-                image("./logo.png")
+                container()
                     .width(48.0)
                     .height(48.0)
+                    .child(image("./logo.png"))
             )
             .child(
                 // SVG from memory
@@ -208,9 +220,10 @@ fn main() {
                 container()
                     .rotate(15.0)
                     .child(
-                        image("./icon.svg")
+                        container()
                             .width(24.0)
                             .height(24.0)
+                            .child(image("./icon.svg"))
                     )
             );
 

--- a/docs/IMAGES.md
+++ b/docs/IMAGES.md
@@ -8,14 +8,16 @@ The Image widget displays raster images (PNG, JPEG, GIF, WebP) and SVG vector gr
 use guido::prelude::*;
 
 // Load from file path (auto-detects SVG)
-image("./icon.png")
+container()
     .width(32.0)
     .height(32.0)
+    .child(image("./icon.png"))
 
 // SVG from path
-image("./logo.svg")
+container()
     .width(100.0)
     .height(100.0)
+    .child(image("./logo.svg"))
 
 // SVG from memory
 image(ImageSource::SvgBytes(svg_data.into()))
@@ -55,28 +57,58 @@ Control how images fit within their bounds:
 | `ContentFit::None` | Use intrinsic size, ignore widget bounds |
 
 ```rust
-image("./photo.jpg")
+container()
     .width(200.0)
     .height(150.0)
+    .child(image("./photo.jpg"))
     .content_fit(ContentFit::Cover)
 ```
 
 ## Sizing
 
-Images can specify explicit dimensions or derive size from intrinsic dimensions:
+The box comes from the enclosing container, like every other size in guido; the
+image decides only how its pixels land inside it.
 
 ```rust
-// Explicit size
-image("./icon.png").width(32.0).height(32.0)
+// A 32x32 box
+container().width(32.0).height(32.0).child(image("./icon.png"))
 
-// Width only - height from aspect ratio
-image("./banner.png").width(200.0)
+// Width fixed, height from the aspect ratio (the default fit is Contain)
+container().width(200.0).child(image("./banner.png"))
 
-// Height only - width from aspect ratio
-image("./logo.svg").height(48.0)
-
-// No size - uses intrinsic dimensions (or 100x100 default)
+// No box at all - the image reports its intrinsic size
 image("./icon.png")
+```
+
+## Content Fit Modes
+
+The `content_fit()` method controls how the image maps into the box it is
+given:
+
+| Mode | Description |
+|------|-------------|
+| `ContentFit::Contain` | Fit within the box, preserving aspect ratio (default) |
+| `ContentFit::Cover` | Fill the box, cropping, preserving aspect ratio |
+| `ContentFit::Fill` | Stretch to fill exactly, ignoring aspect ratio |
+| `ContentFit::None` | Intrinsic size, ignoring the box |
+
+`Cover` and `Fill` take all the room the container offers; they differ in how
+the pixels land. `Contain` takes only the largest rect of the image's own
+aspect ratio that fits, so the empty strip is left to the parent's alignment
+rather than painted.
+
+```rust
+// Cover a 200x150 box, cropping what does not fit
+container()
+    .width(200.0)
+    .height(150.0)
+    .child(image("./photo.jpg").content_fit(ContentFit::Cover))
+
+// A wallpaper: cover the whole surface
+container()
+    .width(fill())
+    .height(fill())
+    .child(image(wallpaper).content_fit(ContentFit::Cover))
 ```
 
 ## Transform Composition
@@ -87,12 +119,12 @@ Images inherit transforms from parent containers, following the same pattern as 
 // Rotated image
 container()
     .rotate(15.0)
-    .child(image("./badge.svg").width(32.0).height(32.0))
+    .child(container().width(32.0).height(32.0).child(image("./badge.svg")))
 
 // Scaled image
 container()
     .scale(1.5)
-    .child(image("./icon.png").width(24.0).height(24.0))
+    .child(container().width(24.0).height(24.0).child(image("./icon.png")))
 
 // Combined transforms
 container()

--- a/examples/draw_order_example.rs
+++ b/examples/draw_order_example.rs
@@ -14,11 +14,17 @@
 
 use guido::prelude::*;
 
-fn photo() -> Image {
-    image(ImageSource::Path("examples/assets/photo.webp".into()))
-        .width(220.0)
-        .height(140.0)
-        .content_fit(ContentFit::Cover)
+/// The photo, in a box of its own. The panels are all 220x140, so `photo()`
+/// carries that size and `photo_of(w, h)` covers the one case that differs.
+fn photo() -> Container {
+    photo_of(220.0, 140.0)
+}
+
+fn photo_of(w: f32, h: f32) -> Container {
+    container().width(w).height(h).child(
+        image(ImageSource::Path("examples/assets/photo.webp".into()))
+            .content_fit(ContentFit::Cover),
+    )
 }
 
 fn panel(label: &'static str, content: Container) -> Container {
@@ -144,7 +150,7 @@ fn main() {
                             .width(fill())
                             .height(fill())
                             .layout(Flex::row().main_alignment(MainAlignment::End))
-                            .child(photo().width(120.0)),
+                            .child(photo_of(120.0, 140.0)),
                     ),
             ));
 

--- a/examples/image_example.rs
+++ b/examples/image_example.rs
@@ -5,12 +5,17 @@
 use guido::prelude::*;
 
 fn main() {
-    // Helper to create a labeled image card
-    fn image_card(label: &'static str, img: Image) -> Container {
+    // Helper to create a labeled image card.
+    //
+    // The card decides the box; the image only decides how its pixels land in
+    // it. That is why the sizes moved here from the image calls below.
+    fn image_card(label: &'static str, (w, h): (f32, f32), img: Image) -> Container {
         container()
             .layout(Flex::column().spacing(8.0))
             .child(
                 container()
+                    .width(w)
+                    .height(h)
                     .background(Color::rgb(0.2, 0.2, 0.25))
                     .corner_radius(4.0)
                     .child(img),
@@ -24,11 +29,18 @@ fn main() {
     }
 
     // Helper to create a transformed image card
-    fn transformed_card(label: &'static str, img: Image, transform: Container) -> Container {
+    fn transformed_card(
+        label: &'static str,
+        (w, h): (f32, f32),
+        img: Image,
+        transform: Container,
+    ) -> Container {
         container()
             .layout(Flex::column().spacing(8.0))
             .child(
                 transform
+                    .width(w)
+                    .height(h)
                     .background(Color::rgb(0.2, 0.2, 0.25))
                     .corner_radius(4.0)
                     .child(img),
@@ -60,24 +72,18 @@ fn main() {
                         .layout(Flex::row().spacing(32.0))
                         .child(image_card(
                             "Contain",
-                            image("examples/assets/photo.webp")
-                                .width(90.0)
-                                .height(90.0)
-                                .content_fit(ContentFit::Contain),
+                            (90.0, 90.0),
+                            image("examples/assets/photo.webp").content_fit(ContentFit::Contain),
                         ))
                         .child(image_card(
                             "Cover",
-                            image("examples/assets/photo.webp")
-                                .width(90.0)
-                                .height(90.0)
-                                .content_fit(ContentFit::Cover),
+                            (90.0, 90.0),
+                            image("examples/assets/photo.webp").content_fit(ContentFit::Cover),
                         ))
                         .child(image_card(
                             "Fill",
-                            image("examples/assets/photo.webp")
-                                .width(90.0)
-                                .height(90.0)
-                                .content_fit(ContentFit::Fill),
+                            (90.0, 90.0),
+                            image("examples/assets/photo.webp").content_fit(ContentFit::Fill),
                         )),
                 )
                 .child(
@@ -85,18 +91,14 @@ fn main() {
                         .layout(Flex::row().spacing(48.0))
                         .child(transformed_card(
                             "Rotated 10°",
-                            image("examples/assets/photo.webp")
-                                .width(90.0)
-                                .height(90.0)
-                                .content_fit(ContentFit::Cover),
+                            (90.0, 90.0),
+                            image("examples/assets/photo.webp").content_fit(ContentFit::Cover),
                             container().rotate(10.0),
                         ))
                         .child(transformed_card(
                             "Scaled 1.5x",
-                            image("examples/assets/photo.webp")
-                                .width(90.0)
-                                .height(90.0)
-                                .content_fit(ContentFit::Cover),
+                            (90.0, 90.0),
+                            image("examples/assets/photo.webp").content_fit(ContentFit::Cover),
                             container().scale(1.5),
                         )),
                 ),
@@ -116,16 +118,19 @@ fn main() {
                         .layout(Flex::row().spacing(32.0))
                         .child(image_card(
                             "Normal",
-                            image("examples/assets/logo.svg").width(80.0).height(60.0),
+                            (80.0, 60.0),
+                            image("examples/assets/logo.svg"),
                         ))
                         .child(transformed_card(
                             "Rotated 15°",
-                            image("examples/assets/logo.svg").width(80.0).height(60.0),
+                            (80.0, 60.0),
+                            image("examples/assets/logo.svg"),
                             container().rotate(15.0),
                         ))
                         .child(transformed_card(
                             "Scaled 1.5x",
-                            image("examples/assets/logo.svg").width(80.0).height(60.0),
+                            (80.0, 60.0),
+                            image("examples/assets/logo.svg"),
                             container().scale(1.5),
                         )),
                 ),

--- a/examples/scroll_mixed_content.rs
+++ b/examples/scroll_mixed_content.rs
@@ -48,13 +48,10 @@ fn main() {
                     container()
                         .background(Color::rgb(0.2, 0.2, 0.25))
                         .corner_radius(8.0)
+                        .width(120.0)
+                        .height(90.0)
                         .hover_state(|s| s.lighter(0.05))
-                        .child(
-                            image(path)
-                                .width(120.0)
-                                .height(90.0)
-                                .content_fit(ContentFit::Cover),
-                        ),
+                        .child(image(path).content_fit(ContentFit::Cover)),
                 )
                 .child(
                     container()
@@ -107,11 +104,11 @@ fn main() {
                                             .child(
                                                 container()
                                                     .corner_radius(40.0)
+                                                    .width(80.0)
+                                                    .height(80.0)
                                                     .background(Color::rgb(0.25, 0.25, 0.3))
                                                     .child(
                                                         image("examples/assets/photo.webp")
-                                                            .width(80.0)
-                                                            .height(80.0)
                                                             .content_fit(ContentFit::Cover),
                                                     ),
                                             )
@@ -321,9 +318,12 @@ fn main() {
                                                                     ),
                                                             )
                                                             .child(
-                                                                image("examples/assets/logo.svg")
+                                                                container()
                                                                     .width(32.0)
-                                                                    .height(24.0),
+                                                                    .height(24.0)
+                                                                    .child(image(
+                                                                        "examples/assets/logo.svg",
+                                                                    )),
                                                             ),
                                                     )
                                                     .child(

--- a/src/widgets/diagnostic_audit.rs
+++ b/src/widgets/diagnostic_audit.rs
@@ -260,13 +260,14 @@ fn a_fully_reactive_text_input_is_quiet() {
 #[test]
 fn an_image_is_quiet() {
     // Raw pixels: no file to find, no decoder to reach for.
-    let widget = image(ImageSource::Rgba {
-        width: 2,
-        height: 2,
-        pixels: std::sync::Arc::from(vec![255u8; 2 * 2 * 4].into_boxed_slice()),
-    })
-    .width(20.0)
-    .height(20.0);
+    let widget = container()
+        .width(20.0)
+        .height(20.0)
+        .child(image(ImageSource::Rgba {
+            width: 2,
+            height: 2,
+            pixels: std::sync::Arc::from(vec![255u8; 2 * 2 * 4].into_boxed_slice()),
+        }));
 
     assert_quiet("an image", diagnostics_from_full_lifecycle(widget));
 }

--- a/src/widgets/image.rs
+++ b/src/widgets/image.rs
@@ -93,10 +93,19 @@ pub enum ContentFit {
 }
 
 /// Image widget for displaying raster and SVG images.
+///
+/// The image carries the pixels and how they map into the box it is given;
+/// the box itself comes from the enclosing container, like every other size in
+/// guido:
+///
+/// ```ignore
+/// container()
+///     .width(fill())
+///     .height(fill())
+///     .child(image(source).content_fit(ContentFit::Cover))
+/// ```
 pub struct Image {
     source: Signal<ImageSource>,
-    width: Option<Signal<f32>>,
-    height: Option<Signal<f32>>,
     content_fit: ContentFit,
     /// Cached intrinsic size from the image source
     intrinsic_size: Option<(u32, u32)>,
@@ -109,24 +118,10 @@ impl Image {
     pub fn new<M>(source: impl IntoSignal<ImageSource, M>) -> Self {
         Self {
             source: source.into_signal(),
-            width: None,
-            height: None,
             content_fit: ContentFit::default(),
             intrinsic_size: None,
             cached_source: None,
         }
-    }
-
-    /// Set a fixed width for the image.
-    pub fn width<M>(mut self, width: impl IntoSignal<f32, M>) -> Self {
-        self.width = Some(width.into_signal());
-        self
-    }
-
-    /// Set a fixed height for the image.
-    pub fn height<M>(mut self, height: impl IntoSignal<f32, M>) -> Self {
-        self.height = Some(height.into_signal());
-        self
     }
 
     /// Set the content fit mode.
@@ -140,77 +135,65 @@ impl Image {
         self.intrinsic_size
     }
 
-    /// Calculate the display size based on intrinsic size, explicit dimensions, and fit mode.
-    fn calculate_size(
-        &self,
-        constraints: &Constraints,
-        explicit_width: Option<f32>,
-        explicit_height: Option<f32>,
-    ) -> Size {
-        // If we have both explicit dimensions, use them
-        if let (Some(w), Some(h)) = (explicit_width, explicit_height) {
-            return Size::new(
-                w.max(constraints.min_width).min(constraints.max_width),
-                h.max(constraints.min_height).min(constraints.max_height),
-            );
-        }
-
-        // Get intrinsic size or use a default
+    /// The box this image occupies, from the constraints and the fit mode.
+    ///
+    /// The fit modes disagree only about what to do with room that is offered
+    /// but not demanded:
+    ///
+    /// - `Fill` and `Cover` take all of it. They differ in how the pixels land
+    ///   inside — stretched or cropped — which is the renderer's job, not this
+    ///   one's. `Cover` sizing itself to the aspect ratio was the old bug: an
+    ///   image asked to cover its box would letterbox instead, because it had
+    ///   shrunk the box to the shape it was trying to cover.
+    /// - `Contain` promises the whole image is visible, so with room to spare
+    ///   it takes only the largest aspect-preserving rect that fits, leaving
+    ///   the letterboxing to the parent's alignment rather than painting it.
+    /// - `None` is the intrinsic pixels, clamped into whatever room there is.
+    ///
+    /// An axis whose constraint is unbounded has no room to take, so every
+    /// mode falls back to the intrinsic size there.
+    fn calculate_size(&self, constraints: &Constraints) -> Size {
         let (intrinsic_w, intrinsic_h) = self.intrinsic_size.unwrap_or((100, 100));
         let intrinsic_w = intrinsic_w as f32;
         let intrinsic_h = intrinsic_h as f32;
         let aspect = intrinsic_w / intrinsic_h;
 
-        match self.content_fit {
-            ContentFit::None => {
-                // Use intrinsic size directly
-                Size::new(
-                    intrinsic_w.max(constraints.min_width),
-                    intrinsic_h.max(constraints.min_height),
-                )
-            }
-            ContentFit::Fill => {
-                // Use explicit dimensions or fill available space
-                let width = explicit_width
-                    .unwrap_or(constraints.max_width)
-                    .max(constraints.min_width)
-                    .min(constraints.max_width);
-                let height = explicit_height
-                    .unwrap_or(constraints.max_height)
-                    .max(constraints.min_height)
-                    .min(constraints.max_height);
-                Size::new(width, height)
-            }
-            ContentFit::Contain | ContentFit::Cover => {
-                // If one dimension is explicit, calculate the other from aspect ratio
-                let (target_w, target_h) = match (explicit_width, explicit_height) {
-                    (Some(w), None) => (w, w / aspect),
-                    (None, Some(h)) => (h * aspect, h),
-                    (None, None) => {
-                        // Fit within constraints
-                        let max_w = constraints.max_width;
-                        let max_h = constraints.max_height;
-                        if max_w / max_h > aspect {
-                            // Height is the limiting factor
-                            (max_h * aspect, max_h)
+        let offered_w = if constraints.max_width.is_finite() {
+            constraints.max_width
+        } else {
+            intrinsic_w
+        };
+        let offered_h = if constraints.max_height.is_finite() {
+            constraints.max_height
+        } else {
+            intrinsic_h
+        };
+
+        let size = match self.content_fit {
+            ContentFit::None => Size::new(intrinsic_w, intrinsic_h),
+            ContentFit::Fill | ContentFit::Cover => Size::new(offered_w, offered_h),
+            ContentFit::Contain => {
+                // A tight axis is not room on offer, it is a decision already
+                // made; the other axis follows from the aspect ratio.
+                let tight_w = constraints.min_width == constraints.max_width;
+                let tight_h = constraints.min_height == constraints.max_height;
+                match (tight_w, tight_h) {
+                    (true, true) => Size::new(offered_w, offered_h),
+                    (true, false) => Size::new(offered_w, offered_w / aspect),
+                    (false, true) => Size::new(offered_h * aspect, offered_h),
+                    // Largest rect of this aspect that fits in what is offered.
+                    (false, false) => {
+                        if offered_w / offered_h > aspect {
+                            Size::new(offered_h * aspect, offered_h)
                         } else {
-                            // Width is the limiting factor
-                            (max_w, max_w / aspect)
+                            Size::new(offered_w, offered_w / aspect)
                         }
                     }
-                    (Some(w), Some(h)) => (w, h),
-                };
-
-                Size::new(
-                    target_w
-                        .max(constraints.min_width)
-                        .min(constraints.max_width),
-                    target_h
-                        .max(constraints.min_height)
-                        .min(constraints.max_height),
-                )
+                }
             }
-        }
+        };
+
+        constraints.constrain(size)
     }
 }
 
@@ -219,15 +202,8 @@ impl Widget for Image {
         // Images are never relayout boundaries
         tree.set_relayout_boundary(id, false);
 
-        // Read reactive properties with signal tracking so changes trigger re-layout
-        let (current_source, explicit_width, explicit_height) =
-            with_signal_tracking(id, JobType::Layout, || {
-                (
-                    self.source.get(),
-                    self.width.map(|w| w.get()),
-                    self.height.map(|h| h.get()),
-                )
-            });
+        // Read the source with signal tracking so a change triggers re-layout
+        let current_source = with_signal_tracking(id, JobType::Layout, || self.source.get());
 
         // Load intrinsic size if not cached or source changed
         let source_changed = self
@@ -243,7 +219,7 @@ impl Widget for Image {
         // Update cached source
         self.cached_source = Some(current_source);
 
-        let size = self.calculate_size(&constraints, explicit_width, explicit_height);
+        let size = self.calculate_size(&constraints);
 
         // Cache constraints and size for partial layout
         tree.cache_layout(id, constraints, size);

--- a/tests/image_sizing.rs
+++ b/tests/image_sizing.rs
@@ -1,0 +1,225 @@
+//! How an image sizes itself inside the box a container gives it.
+//!
+//! These are layout-only: they assert the widget's size, never its pixels, so
+//! they need no GPU and no fonts. The source is raw RGBA, so the intrinsic
+//! size is known without touching the filesystem or a decoder.
+
+use guido::layout::{Constraints, Size};
+use guido::prelude::*;
+use guido::tree::Tree;
+use guido::widgets::Widget;
+
+/// A 200x100 image — 2:1, so an aspect mistake is never a rounding artefact.
+fn source() -> ImageSource {
+    ImageSource::Rgba {
+        pixels: vec![0u8; 200 * 100 * 4].into(),
+        width: 200,
+        height: 100,
+    }
+}
+
+fn size_of(widget: impl Widget + 'static, constraints: Constraints) -> Size {
+    let mut tree = Tree::new();
+    let root = tree.register(Box::new(widget));
+    tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
+    tree.with_widget_mut(root, |w, id, t| w.layout(t, id, constraints))
+        .expect("root is registered")
+}
+
+/// The size the image itself takes inside a box of exactly `w` x `h`.
+fn in_box(fit: ContentFit, w: f32, h: f32) -> Size {
+    let mut tree = Tree::new();
+    let root = tree.register(Box::new(
+        container()
+            .width(w)
+            .height(h)
+            .child(image(source()).content_fit(fit)),
+    ));
+    tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
+    tree.with_widget_mut(root, |w, id, t| {
+        w.layout(t, id, Constraints::new(0.0, 0.0, 1000.0, 1000.0))
+    });
+    let child = tree.get_children(root)[0];
+    tree.cached_size(child).expect("the image was laid out")
+}
+
+// ---------------------------------------------------------------------------
+// Cover
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cover_fills_a_box_that_is_the_wrong_shape() {
+    // The regression this PR exists for: a 2:1 image asked to cover a 16:10
+    // box used to shrink itself to 2:1 and letterbox. Covering means taking
+    // the whole box; the cropping happens in the pixels, not in the layout.
+    assert_eq!(
+        in_box(ContentFit::Cover, 1600.0, 1000.0),
+        Size::new(1600.0, 1000.0)
+    );
+}
+
+#[test]
+fn cover_fills_a_taller_box_too() {
+    assert_eq!(
+        in_box(ContentFit::Cover, 400.0, 800.0),
+        Size::new(400.0, 800.0)
+    );
+}
+
+#[test]
+fn cover_takes_the_room_it_is_offered_even_when_loose() {
+    // A stack child gets loose constraints; "cover" still means "all of it".
+    assert_eq!(
+        size_of(
+            image(source()).content_fit(ContentFit::Cover),
+            Constraints::new(0.0, 0.0, 1600.0, 1000.0)
+        ),
+        Size::new(1600.0, 1000.0)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Contain
+// ---------------------------------------------------------------------------
+
+#[test]
+fn contain_fits_inside_the_offered_room() {
+    // 2:1 inside 1600x1000: width is the limit.
+    assert_eq!(
+        size_of(
+            image(source()).content_fit(ContentFit::Contain),
+            Constraints::new(0.0, 0.0, 1600.0, 1000.0)
+        ),
+        Size::new(1600.0, 800.0)
+    );
+}
+
+#[test]
+fn contain_fits_inside_when_height_is_the_limit() {
+    assert_eq!(
+        size_of(
+            image(source()).content_fit(ContentFit::Contain),
+            Constraints::new(0.0, 0.0, 1000.0, 100.0)
+        ),
+        Size::new(200.0, 100.0)
+    );
+}
+
+#[test]
+fn contain_shrinks_rather_than_painting_letterbox_bars() {
+    // A fixed-size container still offers its child loose constraints, so
+    // "contain" reports the 2:1 rect that fits and lets the parent's alignment
+    // place it. Nothing is drawn in the empty strip, which is the difference
+    // between letterboxing and just being smaller.
+    assert_eq!(
+        in_box(ContentFit::Contain, 300.0, 300.0),
+        Size::new(300.0, 150.0)
+    );
+}
+
+#[test]
+fn contain_takes_a_tight_box_whole() {
+    // Told exactly how big to be — a stack child that fills, say — it does not
+    // argue, and the letterboxing is drawn inside those bounds instead.
+    assert_eq!(
+        size_of(
+            image(source()).content_fit(ContentFit::Contain),
+            Constraints::tight(Size::new(300.0, 300.0))
+        ),
+        Size::new(300.0, 300.0)
+    );
+}
+
+#[test]
+fn contain_derives_the_loose_axis_from_the_tight_one() {
+    assert_eq!(
+        size_of(
+            image(source()).content_fit(ContentFit::Contain),
+            Constraints::new(300.0, 0.0, 300.0, 1000.0)
+        ),
+        Size::new(300.0, 150.0)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Fill and None
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fill_takes_the_whole_box() {
+    assert_eq!(
+        in_box(ContentFit::Fill, 640.0, 480.0),
+        Size::new(640.0, 480.0)
+    );
+}
+
+#[test]
+fn none_uses_the_intrinsic_pixels() {
+    assert_eq!(
+        size_of(
+            image(source()).content_fit(ContentFit::None),
+            Constraints::new(0.0, 0.0, 1600.0, 1000.0)
+        ),
+        Size::new(200.0, 100.0)
+    );
+}
+
+#[test]
+fn none_is_still_clamped_by_a_box_too_small_for_it() {
+    assert_eq!(
+        in_box(ContentFit::None, 50.0, 50.0),
+        Size::new(50.0, 50.0),
+        "a widget may not report a size larger than its constraints allow"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Unbounded
+// ---------------------------------------------------------------------------
+
+#[test]
+fn unbounded_constraints_fall_back_to_the_intrinsic_size() {
+    // Nothing is on offer, so there is nothing to fill or cover. Without this
+    // the size would be infinite.
+    for fit in [
+        ContentFit::Cover,
+        ContentFit::Fill,
+        ContentFit::Contain,
+        ContentFit::None,
+    ] {
+        assert_eq!(
+            size_of(image(source()).content_fit(fit), Constraints::unbounded()),
+            Size::new(200.0, 100.0),
+            "{fit:?} under unbounded constraints"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The container decides the box
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_filling_container_hands_the_image_the_whole_surface() {
+    // What a wallpaper does. Before, this needed the output size threaded into
+    // the image by hand because it could not be taken from the parent.
+    let mut tree = Tree::new();
+    let root = tree.register(Box::new(
+        container()
+            .width(fill())
+            .height(fill())
+            .layout(ZStack::new())
+            .child(image(source()).content_fit(ContentFit::Cover)),
+    ));
+    tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
+    tree.with_widget_mut(root, |w, id, t| {
+        w.layout(t, id, Constraints::new(0.0, 0.0, 2560.0, 1440.0))
+    });
+
+    let child = tree.get_children(root)[0];
+    assert_eq!(
+        tree.cached_size(child),
+        Some(Size::new(2560.0, 1440.0)),
+        "the image should cover the whole output"
+    );
+}


### PR DESCRIPTION
Reopened from #164, which GitHub auto-closed when its base branch was deleted on merging #163. Same commit, retargeted to `main`.

---

`Image` had `width` and `height`, duplicating the container's — and doing it worse: they took `f32`, so an image could not express `fill()` at all. They existed because the layout ignored the constraints it was handed, which is the thing that was actually wrong.

## What changes

They are gone. Sizing comes from the enclosing container; `content_fit` keeps its real job — deciding how the pixels land in the box, not how big the box is.

```rust
container()
    .width(fill())
    .height(fill())
    .child(image(source).content_fit(ContentFit::Cover))
```

## The `Cover` bug

`ContentFit::Cover` could not cover. With no explicit size it took the `(None, None)` branch of `calculate_size` and fitted *inside* the constraints, so a 2:1 image asked to cover a 16:10 box shrank itself to 2:1 and letterboxed — it had reduced the box to the shape it was supposed to be covering.

`Cover` and `Fill` now both take all the room offered and differ only in how the pixels map into it. The renderer already implemented that correctly, cropping via UVs against the widget rect (`image_quad.rs`); only the layout was refusing to hand it a full rect.

allock's wallpaper is where this came from. It had to read the output's logical size and thread it into the image by hand, with a `log::warn!` fallback for outputs that report no size, purely because the image could not take its box from its parent.

## The other modes

- `Contain` still reports the largest rect of its own aspect ratio that fits, so the empty strip is left to the parent's alignment rather than painted. A *tight* constraint is a decision already made, though, so it takes that whole.
- `None` is the intrinsic pixels, clamped into whatever room there is.
- An unbounded axis has no room on offer, so every mode falls back to the intrinsic size there rather than to infinity — a hazard `Fill` previously had.

## Tests

13 layout tests (`tests/image_sizing.rs`) over `ImageSource::Rgba`, so they need no GPU, no fonts and no filesystem. They cover each fit mode under tight, loose and unbounded constraints, plus the wallpaper case end to end.

One of them caught my own wrong assumption rather than a bug: a fixed-size container passes its child *loose* constraints, so `Contain` inside `container().width(300).height(300)` correctly reports 300x150 rather than taking the square. That is now asserted explicitly, with the tight case tested separately via `Constraints::tight`.