### PR TITLE
Interaction state joins the reactive graph

### DIFF
--- a/book/src/interactivity/states.md
+++ b/book/src/interactivity/states.md
@@ -80,6 +80,37 @@ container()
     .pressed_state(|s| s.ripple().darker(0.05))
 ```
 
+## Text Colour
+
+A state layer can change the colour of the text below the container, not just
+the box around it:
+
+```rust
+container()
+    .text_color(theme.text_weak)
+    .hover_state(|s| s.text_color(theme.text))
+    .child(text("Label"))
+```
+
+This works the same way the ordinary declaration does — the container publishes
+its text colour to descendants, and here what it publishes folds in the hover.
+A text that declares its own colour nearer down is unaffected, and a container
+with no state layer mentioning text creates nothing extra.
+
+The base it returns to when the state ends is the colour that would have been
+inherited anyway, so a container can override on hover without restating what
+its ancestors already said:
+
+```rust
+container()
+    .text_color(theme.text_weak)              // set once, further up
+    .child(
+        container()
+            .hover_state(|s| s.text_color(theme.text))
+            .child(text("Label")),            // weak, then strong, then weak
+    )
+```
+
 ## Combining Multiple Overrides
 
 Each state can override multiple properties:

--- a/docs/STATE_LAYER.md
+++ b/docs/STATE_LAYER.md
@@ -149,6 +149,8 @@ fn create_button(label: &str) -> Container {
         .corner_radius(8.0)
         .border(1.0, Color::rgb(0.4, 0.6, 0.9))
         .text_color(Color::WHITE)
+        // The label follows the state too, not just the box
+        .hover_state(|s| s.text_color(Color::rgb(0.95, 0.98, 1.0)))
         // Animations
         .animate_background(Transition::new(200.0, TimingFunction::EaseOut))
         .animate_border_width(Transition::new(150.0, TimingFunction::EaseOut))

--- a/examples/state_layer_example.rs
+++ b/examples/state_layer_example.rs
@@ -57,9 +57,11 @@ fn create_lighter_button() -> Container {
         .padding(16.0)
         .background(Color::rgb(0.2, 0.2, 0.3))
         .corner_radius(8.0)
-        .hover_state(|s| s.lighter(0.1))
-        .text_color(Color::rgb(0.9, 0.9, 0.95))
-        .child(text("Hover me (lighter)"))
+        .hover_state(|s| s.lighter(0.1).text_color(Color::WHITE))
+        // The state layer reaches the glyphs, not just the box: the label
+        // brightens with the background.
+        .text_color(Color::rgb(0.6, 0.6, 0.66))
+        .child(text("Hover me (lighter + text)"))
 }
 
 /// Button with explicit hover and pressed colors

--- a/guido-macros/src/lib.rs
+++ b/guido-macros/src/lib.rs
@@ -431,10 +431,6 @@ pub fn component(_attr: TokenStream, input: TokenStream) -> TokenStream {
                 self.__inner.borrow_mut().as_mut().unwrap().event(tree, id, event)
             }
 
-            fn has_focus_descendant(&self, tree: &::guido::tree::Tree, focused_id: ::guido::tree::WidgetId) -> bool {
-                self.ensure_built();
-                self.__inner.borrow().as_ref().unwrap().has_focus_descendant(tree, focused_id)
-            }
         }
 
         #vis fn #fn_name() -> #struct_name {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -914,6 +914,8 @@ impl App {
     pub fn run(mut self, setup: impl FnOnce(&mut Self)) -> ExitReason {
         // Create root owner scope — all signals/effects created in setup are owned
         self.root_owner_id = Some(reactive::create_root_owner());
+        // Under the root owner, so it outlives every component scope.
+        reactive::init_focus();
         setup(&mut self);
 
         if self.surface_definitions.is_empty() {

--- a/src/reactive/focus.rs
+++ b/src/reactive/focus.rs
@@ -22,6 +22,8 @@
 //! focus change, not just the two on the path — but it is bounded by a rare
 //! declaration, and it is what lets a focus change reach a descendant's text.
 
+use std::cell::RefCell;
+
 use smallvec::SmallVec;
 
 use crate::jobs::{JobRequest, request_job};
@@ -63,11 +65,28 @@ impl FocusPath {
 thread_local! {
     /// The focused widget and its ancestors. A signal, so that resolving a
     /// `focused_state` subscribes to it.
-    static FOCUS: RwSignal<FocusPath> = create_signal(FocusPath::default());
+    ///
+    /// Held as an `Option` rather than eagerly, because the handle has to be
+    /// *droppable*: `reset_reactive` wipes the signal storage at `App::drop`,
+    /// and a thread-local holding an id into the old arena would leave a
+    /// second `App` on the same thread with a focus that silently never
+    /// updates. As a plain `RefCell<Option<WidgetId>>` this was immune by
+    /// construction; as a signal it has to be released explicitly.
+    static FOCUS: RefCell<Option<RwSignal<FocusPath>>> = const { RefCell::new(None) };
 }
 
 fn focus() -> RwSignal<FocusPath> {
-    FOCUS.with(|f| *f)
+    FOCUS.with(|cell| {
+        *cell
+            .borrow_mut()
+            .get_or_insert_with(|| create_signal(FocusPath::default()))
+    })
+}
+
+/// Create the focus signal under the root owner, before anything can create it
+/// under a narrower one that might be disposed mid-run.
+pub(crate) fn init_focus() {
+    let _ = focus();
 }
 
 /// The current focus path. Reading this subscribes, like any other signal.
@@ -127,11 +146,12 @@ pub fn focused_widget() -> Option<WidgetId> {
     focus().get_untracked().widget()
 }
 
-/// Reset focus state (without paint jobs — used during App teardown).
+/// Release the focus signal (without paint jobs — used during App teardown).
 ///
-/// Called during `App::drop()` to clear focus state.
+/// Drops the handle rather than writing through it: the storage it points into
+/// is about to be replaced, and the next `App` has to get a fresh one.
 pub(crate) fn reset_focus() {
-    focus().set(FocusPath::default());
+    FOCUS.with(|cell| *cell.borrow_mut() = None);
 }
 
 /// Clear all focus (no widget will have focus).

--- a/src/reactive/focus.rs
+++ b/src/reactive/focus.rs
@@ -1,71 +1,145 @@
 //! Focus management system for keyboard input routing.
 //!
-//! This module provides a centralized way to track which widget has keyboard focus.
-//! Only one widget can have focus at a time.
+//! This module provides a centralized way to track which widget has keyboard
+//! focus. Only one widget can have focus at a time.
+//!
+//! # Why the path and not just the id
+//!
+//! A container's `focused_state` applies when *it or anything below it* has
+//! focus, so answering "is the focus inside me" used to mean walking the
+//! container's descendants with the tree in hand. That is fine at paint time
+//! and impossible anywhere else — in particular inside a `create_derived`
+//! closure, which is where a container has to resolve the text colour it
+//! publishes to its descendants.
+//!
+//! So the focused widget's ancestors are computed *once*, when focus moves and
+//! the tree is right there, and stored alongside it. Asking becomes
+//! `path.contains(id)`: no tree, and cheap enough to call from a closure.
+//!
+//! Being a signal, it also means a container that declares `focused_state`
+//! subscribes by asking. That is a wider fan-out than the two `request_job`
+//! calls it replaces — every container declaring `focused_state` wakes on any
+//! focus change, not just the two on the path — but it is bounded by a rare
+//! declaration, and it is what lets a focus change reach a descendant's text.
 
-use std::cell::RefCell;
+use smallvec::SmallVec;
 
 use crate::jobs::{JobRequest, request_job};
-use crate::tree::WidgetId;
+use crate::reactive::signal::{RwSignal, create_signal};
+use crate::tree::{Tree, WidgetId};
+
+/// The focused widget and every ancestor of it, innermost first.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct FocusPath {
+    chain: SmallVec<[WidgetId; 8]>,
+}
+
+impl FocusPath {
+    fn of(tree: &Tree, id: WidgetId) -> Self {
+        let mut chain = SmallVec::new();
+        let mut current = Some(id);
+        while let Some(node) = current {
+            chain.push(node);
+            current = tree.get_parent(node);
+        }
+        Self { chain }
+    }
+
+    /// The focused widget itself, if any.
+    pub fn widget(&self) -> Option<WidgetId> {
+        self.chain.first().copied()
+    }
+
+    /// Whether `id` is the focused widget or one of its ancestors.
+    pub fn contains(&self, id: WidgetId) -> bool {
+        self.chain.contains(&id)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.chain.is_empty()
+    }
+}
 
 thread_local! {
-    /// The currently focused widget ID, if any
-    static FOCUSED_WIDGET: RefCell<Option<WidgetId>> = const { RefCell::new(None) };
+    /// The focused widget and its ancestors. A signal, so that resolving a
+    /// `focused_state` subscribes to it.
+    static FOCUS: RwSignal<FocusPath> = create_signal(FocusPath::default());
+}
+
+fn focus() -> RwSignal<FocusPath> {
+    FOCUS.with(|f| *f)
+}
+
+/// The current focus path. Reading this subscribes, like any other signal.
+pub fn focus_path() -> FocusPath {
+    focus().get()
 }
 
 /// Request keyboard focus for a widget.
-/// Both the old and new widget are repainted so focus-dependent styling updates.
-pub fn request_focus(id: WidgetId) {
-    FOCUSED_WIDGET.with(|cell| {
-        let mut focused = cell.borrow_mut();
-        // Repaint the previously focused widget so it drops focused styling
-        if let Some(old_id) = *focused
-            && old_id != id
-        {
-            request_job(old_id, JobRequest::Paint);
-        }
-        *focused = Some(id);
-        // Repaint the newly focused widget so it picks up focused styling
-        request_job(id, JobRequest::Paint);
-    });
+///
+/// Takes the tree because the ancestor path is resolved here, once, rather
+/// than by every reader later — see the module docs.
+pub fn request_focus(tree: &Tree, id: WidgetId) {
+    let old = focus().get_untracked();
+    if old.widget() == Some(id) {
+        return;
+    }
+    // Repaint the previously focused widget so it drops focused styling. The
+    // signal write covers everything that *resolves* focus, but a widget that
+    // merely draws a caret (a text input) reads `has_focus` directly.
+    if let Some(old_id) = old.widget() {
+        request_job(old_id, JobRequest::Paint);
+    }
+    focus().set(FocusPath::of(tree, id));
+    request_job(id, JobRequest::Paint);
 }
 
 /// Release keyboard focus from a widget.
 /// Only releases if the given widget currently has focus, and repaints it.
 pub fn release_focus(id: WidgetId) {
-    FOCUSED_WIDGET.with(|cell| {
-        let mut focused = cell.borrow_mut();
-        if *focused == Some(id) {
-            request_job(id, JobRequest::Paint);
-            *focused = None;
-        }
-    });
+    if focus().get_untracked().widget() == Some(id) {
+        request_job(id, JobRequest::Paint);
+        focus().set(FocusPath::default());
+    }
+}
+
+/// Drop the focus if `id` is anywhere on the path.
+///
+/// Called when a widget leaves the tree. Before the path existed this was not
+/// needed: focus was a generational id, so a dead widget simply stopped
+/// matching any live one and `focused_state` resolved to false on its own.
+/// A stored path has no such self-correction — the ancestors would keep
+/// answering "the focus is inside me" for a widget that no longer exists.
+pub(crate) fn release_focus_if_within(id: WidgetId) {
+    let path = focus().get_untracked();
+    if path.contains(id) {
+        focus().set(FocusPath::default());
+    }
 }
 
 /// Check if a specific widget has keyboard focus.
 pub fn has_focus(id: WidgetId) -> bool {
-    FOCUSED_WIDGET.with(|cell| *cell.borrow() == Some(id))
+    focus().get_untracked().widget() == Some(id)
 }
 
 /// Get the ID of the currently focused widget, if any.
 pub fn focused_widget() -> Option<WidgetId> {
-    FOCUSED_WIDGET.with(|cell| *cell.borrow())
+    focus().get_untracked().widget()
 }
 
 /// Reset focus state (without paint jobs — used during App teardown).
 ///
 /// Called during `App::drop()` to clear focus state.
 pub(crate) fn reset_focus() {
-    FOCUSED_WIDGET.with(|f| *f.borrow_mut() = None);
+    focus().set(FocusPath::default());
 }
 
 /// Clear all focus (no widget will have focus).
 /// Repaints the previously focused widget if any.
 pub fn clear_focus() {
-    FOCUSED_WIDGET.with(|cell| {
-        let mut focused = cell.borrow_mut();
-        if let Some(old_id) = focused.take() {
-            request_job(old_id, JobRequest::Paint);
-        }
-    });
+    let old = focus().get_untracked();
+    if let Some(old_id) = old.widget() {
+        request_job(old_id, JobRequest::Paint);
+        focus().set(FocusPath::default());
+    }
 }

--- a/src/reactive/mod.rs
+++ b/src/reactive/mod.rs
@@ -29,7 +29,9 @@ pub use context::{
 pub(crate) use cursor::take_cursor_change;
 pub use cursor::{CursorIcon, set_cursor};
 pub use effect::{Effect, create_effect};
-pub(crate) use focus::{focused_widget, has_focus, release_focus, request_focus};
+pub(crate) use focus::{
+    focus_path, has_focus, release_focus, release_focus_if_within, request_focus,
+};
 #[doc(hidden)]
 pub use into_signal::{
     ClosureMarker, LossyMarker, MemoMarker, RwSignalMarker, SignalMarker, ValueMarker,

--- a/src/reactive/mod.rs
+++ b/src/reactive/mod.rs
@@ -30,7 +30,7 @@ pub(crate) use cursor::take_cursor_change;
 pub use cursor::{CursorIcon, set_cursor};
 pub use effect::{Effect, create_effect};
 pub(crate) use focus::{
-    focus_path, has_focus, release_focus, release_focus_if_within, request_focus,
+    focus_path, has_focus, init_focus, release_focus, release_focus_if_within, request_focus,
 };
 #[doc(hidden)]
 pub use into_signal::{
@@ -67,11 +67,15 @@ pub use signal::{
 pub(crate) fn reset_reactive() {
     owner::reset_owners();
     runtime::reset_runtime();
+    // Before `reset_storage`: the focus path lives in a signal now, held by a
+    // thread-local that outlives the storage. It releases the handle rather
+    // than writing through it, so the next `App` on this thread gets a fresh
+    // one instead of a silently dead signal.
+    focus::reset_focus();
     storage::reset_storage();
     invalidation::reset_invalidation();
     clipboard::reset_clipboard();
     cursor::reset_cursor();
-    focus::reset_focus();
     context::reset_contexts();
     diagnostics::reset();
 }

--- a/src/reactive/storage.rs
+++ b/src/reactive/storage.rs
@@ -355,6 +355,21 @@ pub(crate) fn reset_storage() {
 /// Check if a signal exists in the current thread's storage.
 /// Used by `WriteSignal` to determine if we can write directly (same thread)
 /// or must queue the write for the main thread.
+/// How many signal slots currently hold a value.
+///
+/// For leak tests: build something, tear it down, and the count has to come
+/// back to where it started.
+pub fn live_signal_count() -> usize {
+    STORAGE.with(|storage| {
+        storage
+            .borrow()
+            .slots
+            .iter()
+            .filter(|slot| slot.value.is_some())
+            .count()
+    })
+}
+
 pub fn has_signal(id: SignalId) -> bool {
     STORAGE.with(|storage| {
         let storage = storage.borrow();

--- a/src/reactive/storage.rs
+++ b/src/reactive/storage.rs
@@ -352,9 +352,6 @@ pub(crate) fn reset_storage() {
     STORAGE.with(|s| *s.borrow_mut() = SignalStorage::new());
 }
 
-/// Check if a signal exists in the current thread's storage.
-/// Used by `WriteSignal` to determine if we can write directly (same thread)
-/// or must queue the write for the main thread.
 /// How many signal slots currently hold a value.
 ///
 /// For leak tests: build something, tear it down, and the count has to come
@@ -370,6 +367,9 @@ pub fn live_signal_count() -> usize {
     })
 }
 
+/// Check if a signal exists in the current thread's storage.
+/// Used by `WriteSignal` to determine if we can write directly (same thread)
+/// or must queue the write for the main thread.
 pub fn has_signal(id: SignalId) -> bool {
     STORAGE.with(|storage| {
         let storage = storage.borrow();

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -221,6 +221,12 @@ impl Tree {
             None => return, // Invalid or stale ID
         };
 
+        // A widget leaving the tree takes the focus with it. The focus path is
+        // stored state, so unlike the bare generational id it used to be, it
+        // does not stop matching on its own: its ancestors would go on
+        // answering "the focus is inside me" for a widget that is gone.
+        crate::reactive::release_focus_if_within(id);
+
         // First, remove from parent's children list (before modifying dense array)
         if let Some(parent_id) = self.dense[dense_index].parent
             && let Some(parent_dense) = self.get_dense_index(parent_id)

--- a/src/widgets/children.rs
+++ b/src/widgets/children.rs
@@ -519,8 +519,4 @@ impl Widget for OwnedWidget {
     fn event(&mut self, tree: &mut Tree, id: WidgetId, event: &Event) -> EventResponse {
         self.inner.event(tree, id, event)
     }
-
-    fn has_focus_descendant(&self, tree: &Tree, focused_id: WidgetId) -> bool {
-        self.inner.has_focus_descendant(tree, focused_id)
-    }
 }

--- a/src/widgets/container/anim_bridge.rs
+++ b/src/widgets/container/anim_bridge.rs
@@ -109,7 +109,7 @@ impl Container {
     /// value its signal actually holds, not the one captured at construction.
     ///
     /// See the module docs for why this cannot wait for the first paint.
-    pub(super) fn seed_animations(&mut self, tree: &Tree, id: WidgetId) {
+    pub(super) fn seed_animations(&mut self, id: WidgetId) {
         // Written out one by one: each property animates a different type, so
         // there is no single accessor to loop over.
         let anims = self.anims.as_ref();
@@ -136,13 +136,13 @@ impl Container {
                     let _ = self.padding.get_or(Padding::default());
                 }
                 if bw_init {
-                    let _ = self.effective_border_width_target(tree);
+                    let _ = self.effective_border_width_target(id);
                 }
                 (
-                    bg_init.then(|| self.effective_background_target(tree)),
-                    cr_init.then(|| self.effective_corner_radius_target(tree)),
-                    bc_init.then(|| self.effective_border_color_target(tree)),
-                    tf_init.then(|| self.effective_transform_target(tree)),
+                    bg_init.then(|| self.effective_background_target(id)),
+                    cr_init.then(|| self.effective_corner_radius_target(id)),
+                    bc_init.then(|| self.effective_border_color_target(id)),
+                    tf_init.then(|| self.effective_transform_target(id)),
                 )
             });
 
@@ -176,7 +176,7 @@ impl Container {
     /// This is the pull half of the invariant. It keeps the subscriptions
     /// current through conditional closure branches and state-layer overrides,
     /// and it converges any write that landed before the subscription existed.
-    pub(super) fn resync_animation_targets(&self, tree: &Tree, id: WidgetId) {
+    pub(super) fn resync_animation_targets(&self, id: WidgetId) {
         if !self.has_signal_animated_props() {
             return;
         }
@@ -197,31 +197,31 @@ impl Container {
             if let Some(a) = &anims.border_width {
                 drift |= moved(
                     a.is_initial(),
-                    *a.target() == self.effective_border_width_target(tree),
+                    *a.target() == self.effective_border_width_target(id),
                 );
             }
             if let Some(a) = &anims.background {
                 drift |= moved(
                     a.is_initial(),
-                    *a.target() == self.effective_background_target(tree),
+                    *a.target() == self.effective_background_target(id),
                 );
             }
             if let Some(a) = &anims.corner_radius {
                 drift |= moved(
                     a.is_initial(),
-                    *a.target() == self.effective_corner_radius_target(tree),
+                    *a.target() == self.effective_corner_radius_target(id),
                 );
             }
             if let Some(a) = &anims.border_color {
                 drift |= moved(
                     a.is_initial(),
-                    *a.target() == self.effective_border_color_target(tree),
+                    *a.target() == self.effective_border_color_target(id),
                 );
             }
             if let Some(a) = &anims.transform {
                 drift |= moved(
                     a.is_initial(),
-                    *a.target() == self.effective_transform_target(tree),
+                    *a.target() == self.effective_transform_target(id),
                 );
             }
             drift

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -61,9 +61,16 @@ impl H {
 
     fn send(&mut self, event: Event) -> EventResponse {
         let root = self.root;
-        self.tree
-            .with_widget_mut(root, |w, id, t| w.event(t, id, &event))
-            .expect("root is registered")
+        // Event dispatch runs inside a snapshot zone in the real loop
+        // (`render_surface`, lib.rs): hit testing reads animated values for
+        // *this* event and must not subscribe to them. Outside the zone those
+        // reads trip the non-reactive-read diagnostic, which would be the
+        // harness reporting on itself.
+        crate::reactive::diagnostics::snapshot_zone(|| {
+            self.tree
+                .with_widget_mut(root, |w, id, t| w.event(t, id, &event))
+                .expect("root is registered")
+        })
     }
 
     fn children(&self) -> Vec<WidgetId> {
@@ -794,3 +801,255 @@ fn visibility_invalidates_layout() {
 // invalidate its container too — is covered by
 // `tests::a_layout_property_invalidates_its_container` in `mod.rs`, where it
 // carries the history of the bug it regressed on.
+
+// ---------------------------------------------------------------------------
+// A state layer reaching the text
+// ---------------------------------------------------------------------------
+
+/// Lay out, run the queued jobs, paint, and report the first text colour.
+///
+/// The job drain is what turns the flag write into `needs_paint` on the text
+/// that subscribed to it; without it this would be measuring the paint cache.
+fn painted_text_color(h: &mut H) -> Color {
+    h.drain_jobs();
+    h.fit(400.0, 400.0);
+    let node = h.paint();
+
+    fn find(node: &RenderNode) -> Option<Color> {
+        for cmd in &node.commands {
+            if let DrawCommand::Text { color, .. } = &**cmd {
+                return Some(*color);
+            }
+        }
+        node.children.iter().find_map(|child| find(child))
+    }
+    find(&node).expect("a text command")
+}
+
+fn set_hover(h: &mut H, inside: bool) {
+    let (x, y) = if inside { (5.0, 5.0) } else { (-50.0, -50.0) };
+    h.send(Event::MouseMove { x, y });
+}
+
+/// The failure this guards against is cache-shaped and silent: the container
+/// repaints with its new background while the text's cached render node is
+/// reused with the old colour still inside its draw commands.
+#[test]
+fn a_hover_state_reaches_the_text() {
+    let mut h = H::new(
+        container()
+            .width(100.0)
+            .height(40.0)
+            .text_color(Color::rgb(0.5, 0.5, 0.5))
+            .hover_state(|s| s.text_color(Color::WHITE))
+            .child(crate::widgets::text("Label")),
+    );
+
+    assert_eq!(painted_text_color(&mut h), Color::rgb(0.5, 0.5, 0.5));
+    set_hover(&mut h, true);
+    assert_eq!(painted_text_color(&mut h), Color::WHITE);
+    set_hover(&mut h, false);
+    assert_eq!(painted_text_color(&mut h), Color::rgb(0.5, 0.5, 0.5));
+}
+
+#[test]
+fn a_hover_state_reaches_text_below_a_plain_container() {
+    let mut h = H::new(
+        container()
+            .width(100.0)
+            .height(40.0)
+            .text_color(Color::rgb(0.5, 0.5, 0.5))
+            .hover_state(|s| s.text_color(Color::WHITE))
+            .child(
+                container()
+                    .layout(Flex::row())
+                    .child(crate::widgets::text("Label")),
+            ),
+    );
+
+    assert_eq!(painted_text_color(&mut h), Color::rgb(0.5, 0.5, 0.5));
+    set_hover(&mut h, true);
+    assert_eq!(painted_text_color(&mut h), Color::WHITE);
+}
+
+/// The hovered container declares no colour of its own, so releasing the hover
+/// has to land on what an ancestor said. That base is resolved by a walk done
+/// once at registration — a derived closure has no tree to walk.
+#[test]
+fn a_state_colour_falls_back_to_the_inherited_base() {
+    let mut h = H::new(
+        container().text_color(Color::RED).child(
+            container()
+                .width(100.0)
+                .height(40.0)
+                .hover_state(|s| s.text_color(Color::WHITE))
+                .child(crate::widgets::text("Label")),
+        ),
+    );
+
+    assert_eq!(painted_text_color(&mut h), Color::RED);
+    set_hover(&mut h, true);
+    assert_eq!(painted_text_color(&mut h), Color::WHITE);
+    set_hover(&mut h, false);
+    assert_eq!(painted_text_color(&mut h), Color::RED);
+}
+
+#[test]
+fn a_nearer_declaration_wins_over_an_outer_hover() {
+    let mut h = H::new(
+        container()
+            .width(100.0)
+            .height(40.0)
+            .text_color(Color::rgb(0.5, 0.5, 0.5))
+            .hover_state(|s| s.text_color(Color::WHITE))
+            .child(
+                container()
+                    .text_color(Color::BLUE)
+                    .child(crate::widgets::text("Label")),
+            ),
+    );
+
+    painted_text_color(&mut h);
+    set_hover(&mut h, true);
+    assert_eq!(
+        painted_text_color(&mut h),
+        Color::BLUE,
+        "a text told its own colour must not follow someone else's hover"
+    );
+}
+
+/// Nothing is created when no state layer mentions text, so a hover cannot
+/// disturb the published colour at all.
+#[test]
+fn a_container_with_no_state_text_colour_publishes_the_base_signal() {
+    let mut h = H::new(
+        container()
+            .width(100.0)
+            .height(40.0)
+            .text_color(Color::RED)
+            .hover_state(|s| s.lighter(0.1))
+            .child(crate::widgets::text("Label")),
+    );
+
+    painted_text_color(&mut h);
+    set_hover(&mut h, true);
+    assert_eq!(painted_text_color(&mut h), Color::RED);
+}
+
+// ---------------------------------------------------------------------------
+// The published derived must not outlive its container
+// ---------------------------------------------------------------------------
+
+/// The one reactive resource a container creates outside any user scope.
+///
+/// Everything else is built in the builder chain and freed with the caller's
+/// scope. The published derived is created at *registration*, where the
+/// ambient owner is the surface's and outlives any single container — so
+/// without the explicit teardown in `Drop`, a dynamic-children update that
+/// replaces this container leaks one derived per rebuild.
+///
+/// The shape below is what makes this test able to fail: the builder runs in
+/// a short-lived scope that is disposed each round, while registration happens
+/// under a long-lived one that is not. Building and dropping inside a single
+/// scope would free the derived as a side effect of freeing its parent, and
+/// the test would pass with the teardown removed.
+#[test]
+fn the_published_text_derived_is_freed_with_its_container() {
+    use crate::reactive::owner::{dispose_owner_now, with_owner};
+    use crate::reactive::storage::live_signal_count;
+
+    fn round() {
+        // Builder signals belong to this scope, as a component's would.
+        let (widget, item) = with_owner(|| {
+            container()
+                .text_color(Color::RED)
+                .hover_state(|s| s.text_color(Color::WHITE))
+                .child(crate::widgets::text("x"))
+        });
+        // Registration happens under the surrounding (surface) owner.
+        let mut h = H::new(widget);
+        h.fit(100.0, 100.0);
+        drop(h);
+        dispose_owner_now(item);
+    }
+
+    let (counts, surface) = with_owner(|| {
+        round(); // warm whatever is allocated lazily
+        let before = live_signal_count();
+        for _ in 0..50 {
+            round();
+        }
+        (before, live_signal_count())
+    });
+    dispose_owner_now(surface);
+
+    let (before, after) = counts;
+    assert_eq!(
+        after,
+        before,
+        "50 build-and-drop rounds leaked {} signals",
+        after as i64 - before as i64
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Focus, now that it is stored state
+// ---------------------------------------------------------------------------
+
+/// Focus used to be a bare generational id, which made this self-correcting:
+/// a dead widget stopped matching any live one and `focused_state` resolved to
+/// false on its own. The focus *path* is stored state and has no such
+/// property — its ancestors would go on answering "the focus is inside me" for
+/// a widget that no longer exists.
+#[test]
+fn unregistering_a_focused_widget_releases_the_focus() {
+    use crate::reactive::{focus_path, request_focus};
+
+    let mut h = H::new(
+        container()
+            .width(50.0)
+            .height(50.0)
+            .child(box_of(10.0, 10.0)),
+    );
+    h.fit(100.0, 100.0);
+    let child = h.children()[0];
+
+    request_focus(&h.tree, child);
+    assert!(focus_path().contains(child));
+    assert!(
+        focus_path().contains(h.root),
+        "the ancestor is on the path, which is what focused_state asks about"
+    );
+
+    h.tree.unregister(child);
+    assert!(
+        !focus_path().contains(h.root),
+        "an ancestor must stop claiming focus once the focused widget is gone"
+    );
+}
+
+/// A container resolves `focused_state` by asking the path, not by walking its
+/// descendants — that is what lets the same question be answered from inside a
+/// derived closure, which has no tree.
+#[test]
+fn a_focused_state_applies_while_a_descendant_holds_focus() {
+    use crate::reactive::focus::clear_focus;
+    use crate::reactive::request_focus;
+
+    let mut h = H::new(
+        container()
+            .width(50.0)
+            .height(50.0)
+            .background(Color::RED)
+            .focused_state(|s| s.background(Color::BLUE))
+            .child(box_of(10.0, 10.0)),
+    );
+    h.fit(100.0, 100.0);
+    let child = h.children()[0];
+
+    assert_eq!(rects(&h.paint())[0].1, Color::RED);
+    request_focus(&h.tree, child);
+    assert_eq!(rects(&h.paint())[0].1, Color::BLUE);
+    clear_focus();
+    assert_eq!(rects(&h.paint())[0].1, Color::RED);
+}

--- a/src/widgets/container/interaction.rs
+++ b/src/widgets/container/interaction.rs
@@ -80,13 +80,18 @@ pub(super) fn local_point(
 }
 
 impl Container {
-    /// Repaint after a hover/press change, as an Animation job when a state
-    /// layer animation has to pick the new target up.
+    /// Let a state-layer animation pick up its new target after a hover or
+    /// press change.
+    ///
+    /// The *repaint* needs no request: the flag write is a signal write, and
+    /// whatever resolved a state layer — this container, and any descendant
+    /// text whose colour resolves through it — subscribed to that signal and
+    /// is marked by it. What a signal write cannot do is drive the clock, so a
+    /// container with animated state properties still asks for its Animation
+    /// job here.
     pub(super) fn request_state_change_repaint(&self, id: WidgetId) {
         if self.has_animated_state_properties() {
             request_job(id, JobRequest::Animation(RequiredJob::Paint));
-        } else {
-            request_job(id, JobRequest::Paint);
         }
     }
 
@@ -98,17 +103,17 @@ impl Container {
         let Some(ref mut ix) = self.interaction else {
             return;
         };
+        // See `request_state_change_repaint`: the flag write invalidates, this
+        // only advances an animation.
         let request_repaint = |id: WidgetId| {
             if has_animated {
                 request_job(id, JobRequest::Animation(RequiredJob::Paint));
-            } else {
-                request_job(id, JobRequest::Paint);
             }
         };
 
         match event {
-            Event::MouseEnter { x, y } if hit.contains(*x, *y) && !ix.is_hovered => {
-                ix.is_hovered = true;
+            Event::MouseEnter { x, y } if hit.contains(*x, *y) && !ix.is_hovered() => {
+                ix.set_flag(InteractionFlags::HOVERED, true);
                 if ix.hover_state.is_some() {
                     request_repaint(id);
                 }
@@ -120,21 +125,21 @@ impl Container {
                 // A pressed container keeps receiving moves that leave it —
                 // that implicit capture is what makes dragging work.
                 if let Some(ref callback) = ix.on_pointer_move
-                    && (hit.contains(*x, *y) || ix.is_pressed)
+                    && (hit.contains(*x, *y) || ix.is_pressed())
                 {
                     let (lx, ly) = hit.rebase(*x, *y);
                     callback(lx, ly);
                 }
 
-                let was_hovered = ix.is_hovered;
-                ix.is_hovered = hit.contains(*x, *y);
+                let was_hovered = ix.is_hovered();
+                ix.set_flag(InteractionFlags::HOVERED, hit.contains(*x, *y));
 
-                if was_hovered != ix.is_hovered {
+                if was_hovered != ix.is_hovered() {
                     if ix.hover_state.is_some() {
                         request_repaint(id);
                     }
                     if let Some(ref callback) = ix.on_hover {
-                        callback(ix.is_hovered);
+                        callback(ix.is_hovered());
                     }
                 }
             }
@@ -182,8 +187,8 @@ impl Container {
                     && *button == MouseButton::Left
                     && let Some(ref mut ix) = self.interaction
                 {
-                    let was_pressed = ix.is_pressed;
-                    ix.is_pressed = true;
+                    let was_pressed = ix.is_pressed();
+                    ix.set_flag(InteractionFlags::PRESSED, true);
 
                     let has_ripple = ix
                         .pressed_state
@@ -218,11 +223,11 @@ impl Container {
 
             Event::MouseUp { x, y, button } => {
                 if let Some(ref mut ix) = self.interaction
-                    && ix.is_pressed
+                    && ix.is_pressed()
                     && *button == MouseButton::Left
                 {
-                    let was_pressed = ix.is_pressed;
-                    ix.is_pressed = false;
+                    let was_pressed = ix.is_pressed();
+                    ix.set_flag(InteractionFlags::PRESSED, false);
 
                     if ix.ripple.is_active() {
                         let (screen_x, screen_y) = event.coords().unwrap_or((*x, *y));
@@ -260,15 +265,15 @@ impl Container {
 
             Event::MouseLeave => {
                 if let Some(ref mut ix) = self.interaction {
-                    let was_hovered = ix.is_hovered;
-                    let was_pressed = ix.is_pressed;
-                    if ix.is_hovered {
-                        ix.is_hovered = false;
+                    let was_hovered = ix.is_hovered();
+                    let was_pressed = ix.is_pressed();
+                    if ix.is_hovered() {
+                        ix.set_flag(InteractionFlags::HOVERED, false);
                         if let Some(ref callback) = ix.on_hover {
                             callback(false);
                         }
                     }
-                    ix.is_pressed = false;
+                    ix.set_flag(InteractionFlags::PRESSED, false);
 
                     // The pointer left without a release, so the ripple has no
                     // exit point to fade toward — it collapses to the centre.

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -26,8 +26,8 @@ use crate::backdrop::{BackdropBlur, BackdropSources};
 use crate::jobs::{JobRequest, JobType, RequiredJob, request_job};
 use crate::layout::{Constraints, Flex, Layout, Length, Size};
 use crate::reactive::{
-    IntoSignal, OptionSignalExt, Signal, create_derived, create_stored, focused_widget,
-    with_signal_tracking,
+    IntoSignal, OptionSignalExt, OwnerId, RwSignal, Signal, create_derived, create_signal,
+    create_stored, dispose_owner_now, focus_path, with_owner, with_signal_tracking,
 };
 use crate::renderer::{GradientDir, PaintContext, Shadow};
 use crate::transform::Transform;
@@ -155,6 +155,15 @@ pub(super) struct ContainerAnims {
     pub(super) transform: Option<AnimationState<Transform>>,
 }
 
+bitflags::bitflags! {
+    /// What the pointer is doing to this container.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+    pub(super) struct InteractionFlags: u8 {
+        const HOVERED = 1;
+        const PRESSED = 2;
+    }
+}
+
 /// Interaction state (callbacks, hover/press tracking, state styles, ripple).
 /// Only allocated when `.on_click()`, `.hover_state()`, `.pressed_state()`, etc. are called.
 pub(super) struct InteractionState {
@@ -167,8 +176,19 @@ pub(super) struct InteractionState {
     pub(super) on_pointer_move: Option<PointerMoveCallback>,
     pub(super) on_mouse_down: Option<MouseDownCallback>,
     pub(super) on_mouse_up: Option<MouseUpCallback>,
-    pub(super) is_hovered: bool,
-    pub(super) is_pressed: bool,
+    /// Hover and press, behind a signal so that *resolving a state layer
+    /// subscribes to them*.
+    ///
+    /// This is the whole point. The container's own paint subscribes, as
+    /// before — but so does any descendant text whose colour resolves through
+    /// this container, and that is what a plain `bool` plus a hand-written
+    /// `request_job(id, Paint)` could never do: it marked one widget, and the
+    /// text's cached paint node was reused with the old colour still in it.
+    ///
+    /// Read with `get_untracked` from event handling, where the value drives
+    /// *behaviour* (drag capture, ripple) and a subscription would be noise;
+    /// with `get` from style resolution, where the subscription is the point.
+    pub(super) flags: RwSignal<InteractionFlags>,
     pub(super) hover_state: Option<StateStyle>,
     pub(super) pressed_state: Option<StateStyle>,
     pub(super) focused_state: Option<StateStyle>,
@@ -187,13 +207,45 @@ impl Default for InteractionState {
             on_pointer_move: None,
             on_mouse_down: None,
             on_mouse_up: None,
-            is_hovered: false,
-            is_pressed: false,
+            flags: create_signal(InteractionFlags::empty()),
             hover_state: None,
             pressed_state: None,
             focused_state: None,
             ripple: RippleState::new(),
         }
+    }
+}
+
+impl InteractionState {
+    pub(super) fn is_hovered(&self) -> bool {
+        self.flags
+            .get_untracked()
+            .contains(InteractionFlags::HOVERED)
+    }
+
+    pub(super) fn is_pressed(&self) -> bool {
+        self.flags
+            .get_untracked()
+            .contains(InteractionFlags::PRESSED)
+    }
+
+    /// Set a flag, writing only on a real change so an unchanged pointer move
+    /// does not wake every subscriber.
+    pub(super) fn set_flag(&self, flag: InteractionFlags, on: bool) {
+        let current = self.flags.get_untracked();
+        let next = if on { current | flag } else { current - flag };
+        if next != current {
+            self.flags.set(next);
+        }
+    }
+
+    /// Whether any state layer is declared at all.
+    ///
+    /// Gates the subscription in style resolution: a container with only an
+    /// `on_click` has nothing to resolve, and must not start repainting on
+    /// every hover just because the flags became reactive.
+    pub(super) fn has_any_state(&self) -> bool {
+        self.hover_state.is_some() || self.pressed_state.is_some() || self.focused_state.is_some()
     }
 }
 
@@ -263,6 +315,11 @@ pub struct Container {
     // text and pay one pointer for the whole feature.
     pub(super) text: Option<Box<TextStyle>>,
 
+    // Owns the derived published in place of the text colour when a state
+    // layer declares one. Created at registration, so it belongs to no user
+    // scope and has to be torn down by hand when the container goes.
+    pub(super) text_owner: Option<OwnerId>,
+
     // Animation state (boxed to save ~400 bytes per non-animated container)
     pub(super) anims: Option<Box<ContainerAnims>>,
 
@@ -296,6 +353,7 @@ impl Container {
             widget_ref: None,
             backdrop_blur: None,
             text: None,
+            text_owner: None,
             anims: None,
             scroll_axis: ScrollAxis::None,
             scroll_data: None,
@@ -926,6 +984,21 @@ impl Default for Container {
     }
 }
 
+impl Drop for Container {
+    /// Tear down the owner holding the published text derived.
+    ///
+    /// That derived is the one reactive resource a container creates outside
+    /// any user scope — at registration, where the ambient owner is the
+    /// surface's and would hold it until the app exits. A container removed by
+    /// a dynamic-children update would leak one derived per rebuild.
+    ///
+    /// Every other signal a container holds was created in the builder chain,
+    /// inside the caller's own scope, and is freed with it.
+    fn drop(&mut self) {
+        self.dispose_text_owner();
+    }
+}
+
 impl Widget for Container {
     fn advance_animations(&mut self, tree: &mut Tree, id: WidgetId) -> bool {
         // Use advance_animations_self for this widget's animations
@@ -956,11 +1029,11 @@ impl Widget for Container {
             ) = crate::reactive::diagnostics::snapshot_zone(|| {
                 (
                     self.padding.get_or(Padding::default()),
-                    self.effective_border_width_target(tree),
-                    self.effective_background_target(tree),
-                    self.effective_corner_radius_target(tree),
-                    self.effective_border_color_target(tree),
-                    self.effective_transform_target(tree),
+                    self.effective_border_width_target(id),
+                    self.effective_background_target(id),
+                    self.effective_corner_radius_target(id),
+                    self.effective_border_color_target(id),
+                    self.effective_transform_target(id),
                 )
             });
             let anims = self.anims.as_mut().unwrap();
@@ -1058,7 +1131,8 @@ impl Widget for Container {
         // by walking up. The signals themselves are stable ids, so a value
         // change needs no rewrite — only a rebuilt container does, and that
         // re-registers anyway.
-        tree.set_text_style(id, self.text.as_deref().copied());
+        let published = self.published_text_style(tree, id);
+        tree.set_text_style(id, published);
 
         // Register pending children
         self.children_source.register_pending(tree, id);
@@ -1145,7 +1219,7 @@ impl Widget for Container {
         }
 
         self.update_size_targets(tree, id, &lengths, content_size);
-        self.seed_animations(tree, id);
+        self.seed_animations(id);
 
         let size = self.resolve_size(&lengths, constraints, content_size);
 
@@ -1178,8 +1252,8 @@ impl Widget for Container {
 
         let hit = HitContext {
             bounds: tree.get_bounds(id).unwrap_or_default(),
-            corner_radius: self.animated_corner_radius(tree),
-            transform: self.animated_transform(tree),
+            corner_radius: self.animated_corner_radius(id),
+            transform: self.animated_transform(id),
             transform_origin: self.transform_origin.get_or(TransformOrigin::CENTER),
         };
 
@@ -1238,13 +1312,6 @@ impl Widget for Container {
         self.handle_own_event(id, &hit, event, &local_event)
     }
 
-    fn has_focus_descendant(&self, tree: &Tree, focused_id: WidgetId) -> bool {
-        if !self.visible.get_or(true) {
-            return false;
-        }
-        self.widget_has_focus(tree, focused_id)
-    }
-
     fn paint(&self, tree: &Tree, id: WidgetId, ctx: &mut PaintContext) {
         let is_visible = with_signal_tracking(id, JobType::Paint, || self.visible.get_or(true));
         if !is_visible {
@@ -1268,18 +1335,18 @@ impl Widget for Container {
             border_color,
         ) = with_signal_tracking(id, JobType::Paint, || {
             (
-                self.animated_background(tree),
-                self.animated_corner_radius(tree),
+                self.animated_background(id),
+                self.animated_corner_radius(id),
                 self.corner_curvature.get_or(1.0),
-                self.effective_elevation(tree),
-                self.animated_transform(tree),
+                self.effective_elevation(id),
+                self.animated_transform(id),
                 self.transform_origin.get_or(TransformOrigin::CENTER),
-                self.animated_border_width(tree),
-                self.animated_border_color(tree),
+                self.animated_border_width(id),
+                self.animated_border_color(id),
             )
         });
 
-        self.resync_animation_targets(tree, id);
+        self.resync_animation_targets(id);
 
         // Per-corner radii override the uniform (animated) radius for
         // drawing. Clip, blur region and rounded hit testing stay uniform,

--- a/src/widgets/container/style.rs
+++ b/src/widgets/container/style.rs
@@ -26,26 +26,12 @@ impl Container {
     // -----------------------------------------------------------------------
 
     /// Whether the focused widget is this container or one of its descendants.
-    pub(super) fn has_child_focus(&self, tree: &Tree) -> bool {
-        match focused_widget() {
-            Some(focused_id) => self.widget_has_focus(tree, focused_id),
-            None => false,
-        }
-    }
-
-    pub(super) fn widget_has_focus(&self, tree: &Tree, focused_id: WidgetId) -> bool {
-        for &child_id in self.children_source.get() {
-            if child_id == focused_id {
-                return true;
-            }
-            if tree.with_widget(child_id, |child| {
-                child.has_focus_descendant(tree, focused_id)
-            }) == Some(true)
-            {
-                return true;
-            }
-        }
-        false
+    ///
+    /// Asks the focus path rather than walking the tree, so it can be called
+    /// from a `create_derived` closure — which has no tree, and is where a
+    /// container resolves the text colour it publishes to its descendants.
+    pub(super) fn has_child_focus(id: WidgetId) -> bool {
+        focus_path().contains(id)
     }
 
     // -----------------------------------------------------------------------
@@ -56,27 +42,36 @@ impl Container {
     /// Priority is pressed > focused > hovered.
     fn resolve_state_value<T: Clone>(
         &self,
-        tree: &Tree,
+        id: WidgetId,
         base: T,
         extractor: impl Fn(&StateStyle) -> Option<T>,
     ) -> T {
         let Some(ref ix) = self.interaction else {
             return base;
         };
-        if ix.is_pressed
+        // Ask "does anything declare a state?" before touching the signals.
+        // Reading them first would make every interactive container — a bare
+        // `on_click`, say — subscribe to its own hover and start repainting on
+        // every pointer move, for a state layer it does not have.
+        if !ix.has_any_state() {
+            return base;
+        }
+
+        let flags = ix.flags.get();
+        if flags.contains(InteractionFlags::PRESSED)
             && let Some(ref state) = ix.pressed_state
             && let Some(value) = extractor(state)
         {
             return value;
         }
         if ix.focused_state.is_some()
-            && self.has_child_focus(tree)
+            && Self::has_child_focus(id)
             && let Some(ref state) = ix.focused_state
             && let Some(value) = extractor(state)
         {
             return value;
         }
-        if ix.is_hovered
+        if flags.contains(InteractionFlags::HOVERED)
             && let Some(ref state) = ix.hover_state
             && let Some(value) = extractor(state)
         {
@@ -87,9 +82,9 @@ impl Container {
 
     /// The background a state layer resolves to: its own colour if it declares
     /// one, its own alpha if it declares one, otherwise the base.
-    pub(super) fn effective_background_target(&self, tree: &Tree) -> Color {
+    pub(super) fn effective_background_target(&self, id: WidgetId) -> Color {
         let base = self.background.get_or(Color::TRANSPARENT);
-        self.resolve_state_value(tree, base, |state| {
+        self.resolve_state_value(id, base, |state| {
             let bg_color = state
                 .background
                 .as_ref()
@@ -110,30 +105,119 @@ impl Container {
         })
     }
 
-    pub(super) fn effective_border_width_target(&self, tree: &Tree) -> f32 {
+    pub(super) fn effective_border_width_target(&self, id: WidgetId) -> f32 {
         let base = self.border_width.get_or(0.0);
-        self.resolve_state_value(tree, base, |state| state.border_width)
+        self.resolve_state_value(id, base, |state| state.border_width)
     }
 
-    pub(super) fn effective_border_color_target(&self, tree: &Tree) -> Color {
+    pub(super) fn effective_border_color_target(&self, id: WidgetId) -> Color {
         let base = self.border_color.get_or(Color::TRANSPARENT);
-        self.resolve_state_value(tree, base, |state| state.border_color)
+        self.resolve_state_value(id, base, |state| state.border_color)
     }
 
-    pub(super) fn effective_corner_radius_target(&self, tree: &Tree) -> f32 {
+    pub(super) fn effective_corner_radius_target(&self, id: WidgetId) -> f32 {
         let base = self.corner_radius.get_or(0.0);
-        self.resolve_state_value(tree, base, |state| state.corner_radius)
+        self.resolve_state_value(id, base, |state| state.corner_radius)
     }
 
-    pub(super) fn effective_transform_target(&self, tree: &Tree) -> Transform {
+    pub(super) fn effective_transform_target(&self, id: WidgetId) -> Transform {
         let base = self.transform.get_or(Transform::IDENTITY);
-        self.resolve_state_value(tree, base, |state| state.transform)
+        self.resolve_state_value(id, base, |state| state.transform)
     }
 
     /// Elevation is never animated, so the target *is* the drawn value.
-    pub(super) fn effective_elevation(&self, tree: &Tree) -> f32 {
+    pub(super) fn effective_elevation(&self, id: WidgetId) -> f32 {
         let base = self.elevation.get_or(0.0);
-        self.resolve_state_value(tree, base, |state| state.elevation)
+        self.resolve_state_value(id, base, |state| state.elevation)
+    }
+
+    // -----------------------------------------------------------------------
+    // What descendants are told about text
+    // -----------------------------------------------------------------------
+
+    /// Whether any state layer declares a text colour.
+    fn has_state_text_color(&self) -> bool {
+        self.interaction.as_ref().is_some_and(|ix| {
+            [&ix.hover_state, &ix.pressed_state, &ix.focused_state]
+                .into_iter()
+                .flatten()
+                .any(|s| s.text_color.is_some())
+        })
+    }
+
+    /// The text style this container publishes to its descendants.
+    ///
+    /// Usually exactly what the builder was handed. When a state layer
+    /// declares a text colour, the *colour* published is instead a derived
+    /// folding the base and the interaction flags together — so a descendant
+    /// that reads it subscribes to this container's hover, and a flip reaches
+    /// the glyphs instead of stopping at the box.
+    ///
+    /// Nothing is created when no state layer mentions text, which is almost
+    /// always: the cost of the feature is paid only where it is used.
+    pub(super) fn published_text_style(&mut self, tree: &Tree, id: WidgetId) -> Option<TextStyle> {
+        let declared = self.text.as_deref().copied();
+        if !self.has_state_text_color() {
+            return declared;
+        }
+
+        let ix = self
+            .interaction
+            .as_ref()
+            .expect("has_state_text_color implies interaction");
+        let flags = ix.flags;
+        let pressed = ix.pressed_state.as_ref().and_then(|s| s.text_color);
+        let focused = ix.focused_state.as_ref().and_then(|s| s.text_color);
+        let hovered = ix.hover_state.as_ref().and_then(|s| s.text_color);
+
+        // What a descendant would have inherited without us — this container's
+        // own declaration, or the nearest ancestor's. Walked once, here: a
+        // derived closure has no tree, and which ancestor declares what cannot
+        // change without the subtree being rebuilt, which re-registers and
+        // re-walks.
+        let base = declared
+            .and_then(|s| s.color)
+            .or_else(|| tree.inherited_text_style(id).color);
+
+        let (color, owner) = with_owner(|| {
+            create_derived(move || {
+                let flags = flags.get();
+                if flags.contains(InteractionFlags::PRESSED)
+                    && let Some(color) = pressed
+                {
+                    return color;
+                }
+                // `focused` first: with no focused state there is nothing to
+                // resolve, and no reason to subscribe to the focus path.
+                if let Some(color) = focused
+                    && Self::has_child_focus(id)
+                {
+                    return color;
+                }
+                if flags.contains(InteractionFlags::HOVERED)
+                    && let Some(color) = hovered
+                {
+                    return color;
+                }
+                base.map(|base| base.get()).unwrap_or(Color::WHITE)
+            })
+        });
+
+        // Re-registration replaces the previous derived; without this the old
+        // one would outlive its container.
+        self.dispose_text_owner();
+        self.text_owner = Some(owner);
+
+        let mut style = declared.unwrap_or_default();
+        style.color = Some(color);
+        Some(style)
+    }
+
+    /// Tear down the owner holding the published derived, if there is one.
+    pub(super) fn dispose_text_owner(&mut self) {
+        if let Some(owner) = self.text_owner.take() {
+            dispose_owner_now(owner);
+        }
     }
 
     // -----------------------------------------------------------------------
@@ -146,38 +230,38 @@ impl Container {
         })
     }
 
-    pub(super) fn animated_background(&self, tree: &Tree) -> Color {
+    pub(super) fn animated_background(&self, id: WidgetId) -> Color {
         get_animated_value(
             self.anims.as_ref().and_then(|a| a.background.as_ref()),
-            || self.effective_background_target(tree),
+            || self.effective_background_target(id),
         )
     }
 
-    pub(super) fn animated_corner_radius(&self, tree: &Tree) -> f32 {
+    pub(super) fn animated_corner_radius(&self, id: WidgetId) -> f32 {
         get_animated_value(
             self.anims.as_ref().and_then(|a| a.corner_radius.as_ref()),
-            || self.effective_corner_radius_target(tree),
+            || self.effective_corner_radius_target(id),
         )
     }
 
-    pub(super) fn animated_border_width(&self, tree: &Tree) -> f32 {
+    pub(super) fn animated_border_width(&self, id: WidgetId) -> f32 {
         get_animated_value(
             self.anims.as_ref().and_then(|a| a.border_width.as_ref()),
-            || self.effective_border_width_target(tree),
+            || self.effective_border_width_target(id),
         )
     }
 
-    pub(super) fn animated_border_color(&self, tree: &Tree) -> Color {
+    pub(super) fn animated_border_color(&self, id: WidgetId) -> Color {
         get_animated_value(
             self.anims.as_ref().and_then(|a| a.border_color.as_ref()),
-            || self.effective_border_color_target(tree),
+            || self.effective_border_color_target(id),
         )
     }
 
-    pub(super) fn animated_transform(&self, tree: &Tree) -> Transform {
+    pub(super) fn animated_transform(&self, id: WidgetId) -> Transform {
         get_animated_value(
             self.anims.as_ref().and_then(|a| a.transform.as_ref()),
-            || self.effective_transform_target(tree),
+            || self.effective_transform_target(id),
         )
     }
 

--- a/src/widgets/diagnostic_audit.rs
+++ b/src/widgets/diagnostic_audit.rs
@@ -58,11 +58,6 @@ fn diagnostics_from_full_lifecycle(widget: impl Widget + 'static) -> u64 {
         w.reconcile_children(t, id);
     });
 
-    // `has_focus_descendant` is deliberately not called on its own: nothing
-    // does that. It is only ever reached from `resolve_state_value`, which the
-    // passes above already exercise, and calling it bare would measure a path
-    // that does not exist.
-
     // Event dispatch runs inside a snapshot zone in the real loop
     // (`render_surface`, lib.rs), so it is wrapped here too. The audit answers
     // "what will a user see in their console", and that question is only
@@ -230,6 +225,29 @@ fn a_text_inheriting_through_a_plain_container_is_quiet() {
 
     assert_quiet(
         "a text inheriting across a container that declares nothing",
+        diagnostics_from_full_lifecycle(widget),
+    );
+}
+
+/// The state layer now feeds the text through a derived created at
+/// registration, outside any tracking scope of its own. If that closure read
+/// something it should have snapshotted — or read it where nobody could
+/// subscribe — this is where it shows up.
+#[test]
+fn a_hover_driven_text_colour_is_quiet() {
+    let n = create_signal(0.0f32);
+
+    let widget = container()
+        .width(50.0)
+        .height(50.0)
+        .text_color(move || Color::WHITE.with_alpha(n.get().max(0.5)))
+        .hover_state(|s| s.text_color(Color::RED))
+        .pressed_state(|s| s.text_color(Color::BLUE))
+        .focused_state(|s| s.text_color(Color::GREEN))
+        .child(container().child(text("ciao")));
+
+    assert_quiet(
+        "a text whose colour comes from a state layer",
         diagnostics_from_full_lifecycle(widget),
     );
 }

--- a/src/widgets/state_layer.rs
+++ b/src/widgets/state_layer.rs
@@ -80,6 +80,12 @@ pub struct StateStyle {
     pub transform: Option<Transform>,
     /// Elevation (shadow) override
     pub elevation: Option<f32>,
+    /// Colour of the text below this container while the state is active.
+    ///
+    /// Reaches the glyphs, not just the box: the container publishes its text
+    /// colour to descendants as a derived over the interaction flags, so a
+    /// text that inherited it is subscribed to the flip.
+    pub text_color: Option<Color>,
     /// Override the background alpha channel (applied after background override)
     pub alpha: Option<f32>,
     /// Ripple effect configuration (typically used in pressed_state)
@@ -95,6 +101,19 @@ impl StateStyle {
     /// Set an explicit background color for this state.
     pub fn background(mut self, color: impl Into<Color>) -> Self {
         self.background = Some(BackgroundOverride::Exact(color.into()));
+        self
+    }
+
+    /// Set the colour of the text below this container for this state.
+    ///
+    /// ```ignore
+    /// container()
+    ///     .text_color(theme.text_weak)
+    ///     .hover_state(|s| s.text_color(theme.text))
+    ///     .child(text("Label"))
+    /// ```
+    pub fn text_color(mut self, color: impl Into<Color>) -> Self {
+        self.text_color = Some(color.into());
         self
     }
 

--- a/src/widgets/text_input.rs
+++ b/src/widgets/text_input.rs
@@ -1057,7 +1057,7 @@ impl Widget for TextInput {
                 if bounds.contains(*x, *y) && *button == MouseButton::Left =>
             {
                 // Request focus and start cursor blink animation
-                request_focus(id);
+                request_focus(tree, id);
                 request_job(id, JobRequest::Animation(RequiredJob::Paint));
 
                 // Set cursor position
@@ -1103,7 +1103,7 @@ impl Widget for TextInput {
                 if bounds.contains(*x, *y) && *button == MouseButton::Middle =>
             {
                 // Middle-click paste from the primary selection
-                request_focus(id);
+                request_focus(tree, id);
                 let char_index = self.char_index_at_x(*x, bounds);
                 self.selection = Selection::new(char_index);
                 if let Some(text) = primary_paste() {

--- a/src/widgets/widget.rs
+++ b/src/widgets/widget.rs
@@ -627,13 +627,6 @@ pub trait Widget {
         EventResponse::Ignored
     }
 
-    /// Check if this widget has a descendant with the given ID.
-    /// Used by containers to check if a child has focus.
-    /// Default implementation returns false (leaf widgets have no children).
-    fn has_focus_descendant(&self, _tree: &Tree, _id: WidgetId) -> bool {
-        false
-    }
-
     /// Register this widget's pending children with the arena.
     ///
     /// Called during widget tree registration to recursively register all
@@ -682,9 +675,6 @@ impl Widget for Box<dyn Widget> {
     }
     fn event(&mut self, tree: &mut Tree, id: WidgetId, event: &Event) -> EventResponse {
         (**self).event(tree, id, event)
-    }
-    fn has_focus_descendant(&self, tree: &Tree, id: WidgetId) -> bool {
-        (**self).has_focus_descendant(tree, id)
     }
     fn register_children(&mut self, tree: &mut Tree, id: WidgetId) {
         (**self).register_children(tree, id)


### PR DESCRIPTION
`StateStyle::text_color` could not have worked before this, and the reason is worth stating because it is the whole design.

Hover and press were plain `bool`s flipped during event handling, and the repaint that followed was hand-written — `request_job(id, Paint)` — which marks **one** widget. The text below it is a different widget, is not dirty, and `paint_children` reuses its cached render node with the old colour still inside the draw commands. The box would change and the glyphs would not.

So the two things producing values outside the reactive graph now live in it.

## Hover and press

An `InteractionFlags` bitfield behind an `RwSignal`. Resolving a state layer reads it and therefore subscribes — the container's own paint as before, and now also any descendant text whose colour resolves through this container. The flip is a signal write, so **the invalidation is the write**; the hand-written plain repaints are deleted.

What stays is `Animation(RequiredJob::Paint)`: that is not invalidation, it is the clock that advances ripples and transitions, and removing it would stop them.

Convention, stated once in the field's doc: `get_untracked` from event handling, where the value drives *behaviour* (drag capture, ripple) and a subscription would be noise; `get` from style resolution, where the subscription is the point.

**The guard matters.** `resolve_state_value` asks "does any state layer declare anything?" *before* touching the signal. Reading first would make every interactive container — a bare `on_click` — subscribe to its own hover and repaint on every pointer move, for a state layer it does not have. One check, and the difference between "pay if you use it" and a diffuse regression.

## Focus needed a different answer

`has_child_focus` walked the container's descendants with the tree in hand. That is fine at paint time and impossible inside a `create_derived` closure — and that closure is exactly where a container resolves the colour it publishes.

So the focused widget's ancestors are computed **once**, when focus moves and the tree is right there, and stored with it. Asking becomes `path.contains(id)`. `Widget::has_focus_descendant` and the whole descendant walk are deleted.

Two consequences, both real:

- **Wider fan-out.** Every container declaring `focused_state` now wakes on any focus change, not just the two on the path. Bounded by a rare declaration, and it is the price of letting a focus change reach a descendant's text.
- **A new invariant.** Focus used to be a bare generational id, so unregistering a focused widget self-corrected — the dead id stopped matching any live one. A stored path has no such property: its ancestors would go on claiming the focus for a widget that is gone. `Tree::unregister` now releases it, with a test.

## The colour

When a state layer declares one, the container publishes a `create_derived` folding base and flags instead of the raw signal. Nothing is created otherwise, so the feature costs nothing unused.

The base it falls back to is resolved by walking the ancestors **once at registration** — a derived has no tree, and which ancestor declares what cannot change without the subtree being rebuilt, which re-registers and re-walks. So `hover_state(|s| s.text_color(x))` on a container with no colour of its own returns to whatever an ancestor said.

## The leak test is built to fail

That derived is the one reactive resource a container creates outside any user scope — at registration, where the ambient owner is the surface's. Without teardown, a dynamic-children update leaks one per rebuild. It gets an owner of its own, disposed in `Drop`.

The first version of the test was vacuous: building and dropping inside one scope frees the derived as a side effect of freeing its parent, so it passed with the teardown removed. The version here has the builder in a short-lived scope and registration under a long-lived one, which is the real shape — with `Drop` removed it reports `50 build-and-drop rounds leaked 50 signals`. I checked that before keeping it.

## Tests

Leak test and focus-release-at-unregister first, then: hover reaching the text; reaching it through a container that declares nothing; falling back to the inherited base and returning to it; a nearer declaration winning over an outer hover; a container with no state text colour publishing the plain signal untouched; `focused_state` applying while a descendant holds focus.

Plus a reactive-diagnostics audit case for the hover-driven colour — that audit is the net for the one way this design can go wrong silently, so it is the test I would keep if I could keep only one.

The characterization harness now wraps event dispatch in `snapshot_zone`, as `render_surface` does in the real loop. Without it the hit-test reads trip the diagnostic and the harness reports on itself.