### PR TITLE
Animate the text colour

### DIFF
--- a/book/src/interactivity/states.md
+++ b/book/src/interactivity/states.md
@@ -111,6 +111,22 @@ container()
     )
 ```
 
+It can be animated like any other container property:
+
+```rust
+container()
+    .text_color(theme.text_weak)
+    .hover_state(|s| s.text_color(theme.text))
+    .animate_text_color(Transition::new(200.0, TimingFunction::EaseOut))
+    .child(text("Label"))
+```
+
+A transition declared on two levels — an animated colour whose own base comes
+from an ancestor that is itself animating — currently retargets every frame,
+which gives a damped chase rather than a transition with its own curve. It
+converges either way; CSS instead starts the inner one once, towards the
+outer's final value.
+
 ## Combining Multiple Overrides
 
 Each state can override multiple properties:

--- a/examples/state_layer_example.rs
+++ b/examples/state_layer_example.rs
@@ -59,8 +59,10 @@ fn create_lighter_button() -> Container {
         .corner_radius(8.0)
         .hover_state(|s| s.lighter(0.1).text_color(Color::WHITE))
         // The state layer reaches the glyphs, not just the box: the label
-        // brightens with the background.
+        // brightens with the background, and eases there with it.
         .text_color(Color::rgb(0.6, 0.6, 0.66))
+        .animate_background(Transition::new(200.0, TimingFunction::EaseOut))
+        .animate_text_color(Transition::new(200.0, TimingFunction::EaseOut))
         .child(text("Hover me (lighter + text)"))
 }
 

--- a/src/widgets/container/anim_bridge.rs
+++ b/src/widgets/container/anim_bridge.rs
@@ -122,14 +122,15 @@ impl Container {
         let bc_init =
             anims.is_some_and(|a| a.border_color.as_ref().is_some_and(|a| a.is_initial()));
         let tf_init = anims.is_some_and(|a| a.transform.as_ref().is_some_and(|a| a.is_initial()));
+        let tc_init = anims.is_some_and(|a| a.text_color.as_ref().is_some_and(|a| a.is_initial()));
 
-        if !(pd_init || bw_init || bg_init || cr_init || bc_init || tf_init) {
+        if !(pd_init || bw_init || bg_init || cr_init || bc_init || tf_init || tc_init) {
             return;
         }
 
         // Targets are computed under `&self` first: the writes below need
         // `&mut self.anims`, and the effective_* readers need `&self`.
-        let (bg_target, cr_target, bc_target, tf_target) =
+        let (bg_target, cr_target, bc_target, tf_target, tc_target) =
             with_signal_tracking(id, JobType::Animation, || {
                 // Read for the subscription even where the value is unused.
                 if pd_init {
@@ -143,12 +144,22 @@ impl Container {
                     cr_init.then(|| self.effective_corner_radius_target(id)),
                     bc_init.then(|| self.effective_border_color_target(id)),
                     tf_init.then(|| self.effective_transform_target(id)),
+                    tc_init.then(|| self.effective_text_color_target(id)),
                 )
             });
 
+        let animated_text = self.animated_text;
         let Some(ref mut anims) = self.anims else {
             return;
         };
+        if let (Some(anim), Some(target)) = (&mut anims.text_color, tc_target) {
+            anim.set_immediate(target);
+            // Seeded, not animating: the published derived falls through to the
+            // ordinary fold, which resolves to this same value.
+            if let Some(signal) = animated_text {
+                signal.set(None);
+            }
+        }
         if let (Some(anim), Some(target)) = (&mut anims.background, bg_target) {
             anim.set_immediate(target);
         }
@@ -222,6 +233,12 @@ impl Container {
                 drift |= moved(
                     a.is_initial(),
                     *a.target() == self.effective_transform_target(id),
+                );
+            }
+            if let Some(a) = &anims.text_color {
+                drift |= moved(
+                    a.is_initial(),
+                    *a.target() == self.effective_text_color_target(id),
                 );
             }
             drift

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -14,6 +14,7 @@
 use rustc_hash::FxHashSet;
 
 use super::*;
+use crate::animation::{TimingFunction, Transition};
 use crate::jobs::{self, JobType};
 use crate::layout::{Constraints, Flex, at_least, at_most, fill, fraction};
 use crate::reactive::create_signal;
@@ -1052,4 +1053,90 @@ fn a_focused_state_applies_while_a_descendant_holds_focus() {
     assert_eq!(rects(&h.paint())[0].1, Color::BLUE);
     clear_focus();
     assert_eq!(rects(&h.paint())[0].1, Color::RED);
+}
+
+// ---------------------------------------------------------------------------
+// An animated text colour
+// ---------------------------------------------------------------------------
+
+/// Advance until nothing is animating, or `limit` frames pass.
+///
+/// Animations step against the wall clock, so a tight loop would advance them
+/// by microseconds and never arrive — the frames have to take real time.
+fn settle(h: &mut H, limit: usize) -> usize {
+    for frame in 0..limit {
+        std::thread::sleep(std::time::Duration::from_millis(4));
+        let root = h.root;
+        let animating = h
+            .tree
+            .with_widget_mut(root, |w, id, t| w.advance_animations(t, id))
+            .unwrap_or(false);
+        painted_text_color(h);
+        if !animating {
+            return frame;
+        }
+    }
+    limit
+}
+
+/// The in-flight value has to reach a widget that is not the one animating.
+/// Every other animated property is consumed by the paint of the container
+/// that owns it; this one is drawn by a descendant, so each step leaves
+/// through a signal — and if that write did not happen, the text would simply
+/// jump to the final colour on the first frame while the box eased.
+#[test]
+fn an_animated_text_colour_passes_through_intermediate_values() {
+    let mut h = H::new(
+        container()
+            .width(100.0)
+            .height(40.0)
+            .text_color(Color::BLACK)
+            .hover_state(|s| s.text_color(Color::WHITE))
+            .animate_text_color(Transition::new(80.0, TimingFunction::Linear))
+            .child(crate::widgets::text("Label")),
+    );
+
+    assert_eq!(painted_text_color(&mut h), Color::BLACK);
+
+    set_hover(&mut h, true);
+    std::thread::sleep(std::time::Duration::from_millis(20));
+    let root = h.root;
+    h.tree
+        .with_widget_mut(root, |w, id, t| w.advance_animations(t, id));
+    let mid = painted_text_color(&mut h);
+    assert!(
+        mid != Color::BLACK && mid != Color::WHITE,
+        "expected a value between the two, got {mid:?}"
+    );
+
+    settle(&mut h, 80);
+    assert_eq!(
+        painted_text_color(&mut h),
+        Color::WHITE,
+        "and it has to arrive"
+    );
+}
+
+/// Once settled the derived goes back to the ordinary fold, so the animation
+/// is not left pinning its last frame.
+#[test]
+fn a_settled_animation_releases_the_colour_back_to_the_fold() {
+    let mut h = H::new(
+        container()
+            .width(100.0)
+            .height(40.0)
+            .text_color(Color::BLACK)
+            .hover_state(|s| s.text_color(Color::WHITE))
+            .animate_text_color(Transition::new(80.0, TimingFunction::Linear))
+            .child(crate::widgets::text("Label")),
+    );
+
+    painted_text_color(&mut h);
+    set_hover(&mut h, true);
+    settle(&mut h, 80);
+    assert_eq!(painted_text_color(&mut h), Color::WHITE);
+
+    set_hover(&mut h, false);
+    settle(&mut h, 80);
+    assert_eq!(painted_text_color(&mut h), Color::BLACK);
 }

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -807,12 +807,28 @@ fn visibility_invalidates_layout() {
 // A state layer reaching the text
 // ---------------------------------------------------------------------------
 
-/// Lay out, run the queued jobs, paint, and report the first text colour.
+/// Run the queued jobs, returning whether any of them was an animation step.
 ///
-/// The job drain is what turns the flag write into `needs_paint` on the text
-/// that subscribed to it; without it this would be measuring the paint cache.
+/// Processing rather than discarding matters twice over: it is what turns a
+/// flag write into `needs_paint` on the text that subscribed to it, and it is
+/// what advances an animation on the widget that owns it. `advance_animations`
+/// does not recurse — in the real loop the job carries the widget id — so a
+/// test that calls it on the root never touches an animated child.
+fn pump(h: &mut H) -> bool {
+    let roots = h.roots();
+    jobs::distribute_jobs(&h.tree, &roots);
+    let drained = jobs::drain_surface_jobs(h.root);
+    let animating = drained.iter().any(|job| job.job_type == JobType::Animation);
+    let mut layout_roots = Vec::new();
+    jobs::process_jobs(&drained, &mut h.tree, &mut layout_roots);
+    jobs::recycle_job_buffer(drained);
+    jobs::recycle_job_buffer(jobs::drain_orphan_jobs());
+    animating
+}
+
+/// Lay out, run the queued jobs, paint, and report the first text colour.
 fn painted_text_color(h: &mut H) -> Color {
-    h.drain_jobs();
+    pump(h);
     h.fit(400.0, 400.0);
     let node = h.paint();
 
@@ -1059,24 +1075,27 @@ fn a_focused_state_applies_while_a_descendant_holds_focus() {
 // An animated text colour
 // ---------------------------------------------------------------------------
 
-/// Advance until nothing is animating, or `limit` frames pass.
+/// Run frames until nothing is animating, or `limit` frames pass.
 ///
 /// Animations step against the wall clock, so a tight loop would advance them
 /// by microseconds and never arrive — the frames have to take real time.
 fn settle(h: &mut H, limit: usize) -> usize {
     for frame in 0..limit {
         std::thread::sleep(std::time::Duration::from_millis(4));
-        let root = h.root;
-        let animating = h
-            .tree
-            .with_widget_mut(root, |w, id, t| w.advance_animations(t, id))
-            .unwrap_or(false);
-        painted_text_color(h);
+        let animating = pump(h);
+        h.fit(400.0, 400.0);
+        h.paint();
         if !animating {
             return frame;
         }
     }
     limit
+}
+
+/// One frame: let time pass, run the jobs, and report what the text ended up.
+fn frame(h: &mut H) -> Color {
+    std::thread::sleep(std::time::Duration::from_millis(8));
+    painted_text_color(h)
 }
 
 /// The in-flight value has to reach a widget that is not the one animating.
@@ -1099,11 +1118,7 @@ fn an_animated_text_colour_passes_through_intermediate_values() {
     assert_eq!(painted_text_color(&mut h), Color::BLACK);
 
     set_hover(&mut h, true);
-    std::thread::sleep(std::time::Duration::from_millis(20));
-    let root = h.root;
-    h.tree
-        .with_widget_mut(root, |w, id, t| w.advance_animations(t, id));
-    let mid = painted_text_color(&mut h);
+    let mid = frame(&mut h);
     assert!(
         mid != Color::BLACK && mid != Color::WHITE,
         "expected a value between the two, got {mid:?}"
@@ -1139,4 +1154,46 @@ fn a_settled_animation_releases_the_colour_back_to_the_fold() {
     set_hover(&mut h, false);
     settle(&mut h, 80);
     assert_eq!(painted_text_color(&mut h), Color::BLACK);
+}
+
+/// The animation has to start from the colour a descendant would actually have
+/// shown — which, for a container with no colour of its own, is the inherited
+/// one.
+///
+/// Two notions of "base" have to agree: the one the published derived folds
+/// (declared, else inherited) and the one the animation is seeded from and
+/// aims at. Where they diverge the transition departs from somewhere the text
+/// never was, so hovering flashes through a third colour on the way.
+#[test]
+fn an_animated_colour_starts_from_the_inherited_base() {
+    let mut h = H::new(
+        container().text_color(Color::RED).child(
+            container()
+                .width(100.0)
+                .height(40.0)
+                .hover_state(|s| s.text_color(Color::BLUE))
+                .animate_text_color(Transition::new(80.0, TimingFunction::Linear))
+                .child(crate::widgets::text("Label")),
+        ),
+    );
+
+    assert_eq!(painted_text_color(&mut h), Color::RED);
+
+    set_hover(&mut h, true);
+    let first = frame(&mut h);
+    assert!(
+        first.r > first.b,
+        "the transition must leave from the inherited red, got {first:?}"
+    );
+
+    settle(&mut h, 80);
+    assert_eq!(painted_text_color(&mut h), Color::BLUE);
+
+    set_hover(&mut h, false);
+    settle(&mut h, 80);
+    assert_eq!(
+        painted_text_color(&mut h),
+        Color::RED,
+        "and come back to it"
+    );
 }

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -328,6 +328,14 @@ pub struct Container {
     // what a per-frame repaint of the text costs under any design.
     pub(super) animated_text: Option<RwSignal<Option<Color>>>,
 
+    // The base the published derived falls back to: this container's own
+    // declaration, or the nearest ancestor's, resolved once at registration.
+    //
+    // The animation has to aim at the same value the derived would fold, or it
+    // departs from a colour the text was never showing — see
+    // `effective_text_color_target`.
+    pub(super) text_base: Option<Signal<Color>>,
+
     // Animation state (boxed to save ~400 bytes per non-animated container)
     pub(super) anims: Option<Box<ContainerAnims>>,
 
@@ -363,6 +371,7 @@ impl Container {
             text: None,
             text_owner: None,
             animated_text: None,
+            text_base: None,
             anims: None,
             scroll_axis: ScrollAxis::None,
             scroll_data: None,
@@ -1066,9 +1075,15 @@ impl Widget for Container {
                     self.effective_transform_target(id),
                 )
             });
-            let text_color_target = crate::reactive::diagnostics::snapshot_zone(|| {
-                self.effective_text_color_target(id)
-            });
+            let text_color_target = self
+                .anims
+                .as_ref()
+                .is_some_and(|a| a.text_color.is_some())
+                .then(|| {
+                    crate::reactive::diagnostics::snapshot_zone(|| {
+                        self.effective_text_color_target(id)
+                    })
+                });
             let animated_text = self.animated_text;
             let anims = self.anims.as_mut().unwrap();
 
@@ -1076,8 +1091,8 @@ impl Widget for Container {
             // other animated property is consumed by this container's own
             // paint, but this one is drawn by a descendant, so each step has
             // to leave through a signal. The write is what wakes the text.
-            if let Some(ref mut anim) = anims.text_color {
-                anim.animate_to(text_color_target);
+            if let (Some(anim), Some(target)) = (anims.text_color.as_mut(), text_color_target) {
+                anim.animate_to(target);
                 if anim.is_animating() {
                     any_animating = true;
                     let required = if anim.advance().is_changed() {

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -153,6 +153,7 @@ pub(super) struct ContainerAnims {
     pub(super) border_width: Option<AnimationState<f32>>,
     pub(super) border_color: Option<AnimationState<Color>>,
     pub(super) transform: Option<AnimationState<Transform>>,
+    pub(super) text_color: Option<AnimationState<Color>>,
 }
 
 bitflags::bitflags! {
@@ -320,6 +321,13 @@ pub struct Container {
     // scope and has to be torn down by hand when the container goes.
     pub(super) text_owner: Option<OwnerId>,
 
+    // The in-flight value of an animated text colour, `None` while nothing is
+    // animating. Every other animated property is consumed by the paint of the
+    // container that owns it; this one is drawn by a *different* widget, so
+    // the value has to leave through a signal — a write per frame, which is
+    // what a per-frame repaint of the text costs under any design.
+    pub(super) animated_text: Option<RwSignal<Option<Color>>>,
+
     // Animation state (boxed to save ~400 bytes per non-animated container)
     pub(super) anims: Option<Box<ContainerAnims>>,
 
@@ -354,6 +362,7 @@ impl Container {
             backdrop_blur: None,
             text: None,
             text_owner: None,
+            animated_text: None,
             anims: None,
             scroll_axis: ScrollAxis::None,
             scroll_data: None,
@@ -906,6 +915,27 @@ impl Container {
     }
 
     /// Enable animation for border color changes
+    /// Animate the text colour of this container and its descendants.
+    ///
+    /// ```ignore
+    /// container()
+    ///     .text_color(theme.text_weak)
+    ///     .hover_state(|s| s.text_color(theme.text))
+    ///     .animate_text_color(Transition::new(200.0, TimingFunction::EaseOut))
+    /// ```
+    ///
+    /// A transition declared on two levels — an animated colour whose own base
+    /// is inherited from an ancestor that is itself animating — currently
+    /// retargets every frame, giving a damped chase rather than a transition
+    /// with its own curve. CSS starts the inner one once, towards the outer's
+    /// *final* value; that is the rule to adopt if it ever comes up. The chase
+    /// converges either way.
+    pub fn animate_text_color(mut self, transition: impl Into<TransitionConfig>) -> Self {
+        self.anims_mut().text_color = Some(AnimationState::new(Color::WHITE, transition.into()));
+        self.animated_text = Some(create_signal(None));
+        self
+    }
+
     pub fn animate_border_color(mut self, transition: impl Into<TransitionConfig>) -> Self {
         let initial = self.border_color.get_or_untracked(Color::TRANSPARENT);
         self.anims_mut().border_color = Some(AnimationState::new(initial, transition));
@@ -1036,7 +1066,34 @@ impl Widget for Container {
                     self.effective_transform_target(id),
                 )
             });
+            let text_color_target = crate::reactive::diagnostics::snapshot_zone(|| {
+                self.effective_text_color_target(id)
+            });
+            let animated_text = self.animated_text;
             let anims = self.anims.as_mut().unwrap();
+
+            // Text colour, by hand rather than through `advance_anim!`: every
+            // other animated property is consumed by this container's own
+            // paint, but this one is drawn by a descendant, so each step has
+            // to leave through a signal. The write is what wakes the text.
+            if let Some(ref mut anim) = anims.text_color {
+                anim.animate_to(text_color_target);
+                if anim.is_animating() {
+                    any_animating = true;
+                    let required = if anim.advance().is_changed() {
+                        crate::jobs::RequiredJob::Paint
+                    } else {
+                        crate::jobs::RequiredJob::None
+                    };
+                    request_job(id, JobRequest::Animation(required));
+                }
+                if let Some(signal) = animated_text {
+                    // `None` once settled, so the derived goes back to the
+                    // ordinary fold rather than pinning the last frame.
+                    let current = anim.is_animating().then(|| anim.displayed());
+                    signal.set(current);
+                }
+            }
             // Layout-affecting animations: width, height, padding
             advance_anim!(anims, width, id, any_animating, layout);
             advance_anim!(anims, height, id, any_animating, layout);

--- a/src/widgets/container/style.rs
+++ b/src/widgets/container/style.rs
@@ -125,6 +125,17 @@ impl Container {
         self.resolve_state_value(id, base, |state| state.transform)
     }
 
+    /// The text colour a descendant should see, before any animation.
+    pub(super) fn effective_text_color_target(&self, id: WidgetId) -> Color {
+        let base = self
+            .text
+            .as_ref()
+            .and_then(|t| t.color)
+            .map(|c| c.get())
+            .unwrap_or(Color::WHITE);
+        self.resolve_state_value(id, base, |state| state.text_color)
+    }
+
     /// Elevation is never animated, so the target *is* the drawn value.
     pub(super) fn effective_elevation(&self, id: WidgetId) -> f32 {
         let base = self.elevation.get_or(0.0);
@@ -157,18 +168,22 @@ impl Container {
     /// always: the cost of the feature is paid only where it is used.
     pub(super) fn published_text_style(&mut self, tree: &Tree, id: WidgetId) -> Option<TextStyle> {
         let declared = self.text.as_deref().copied();
-        if !self.has_state_text_color() {
+        let animated = self.animated_text;
+        if !self.has_state_text_color() && animated.is_none() {
             return declared;
         }
 
-        let ix = self
-            .interaction
-            .as_ref()
-            .expect("has_state_text_color implies interaction");
-        let flags = ix.flags;
-        let pressed = ix.pressed_state.as_ref().and_then(|s| s.text_color);
-        let focused = ix.focused_state.as_ref().and_then(|s| s.text_color);
-        let hovered = ix.hover_state.as_ref().and_then(|s| s.text_color);
+        let ix = self.interaction.as_ref();
+        let flags = ix.map(|ix| ix.flags);
+        let pressed = ix
+            .and_then(|ix| ix.pressed_state.as_ref())
+            .and_then(|s| s.text_color);
+        let focused = ix
+            .and_then(|ix| ix.focused_state.as_ref())
+            .and_then(|s| s.text_color);
+        let hovered = ix
+            .and_then(|ix| ix.hover_state.as_ref())
+            .and_then(|s| s.text_color);
 
         // What a descendant would have inherited without us — this container's
         // own declaration, or the nearest ancestor's. Walked once, here: a
@@ -181,7 +196,16 @@ impl Container {
 
         let (color, owner) = with_owner(|| {
             create_derived(move || {
-                let flags = flags.get();
+                // An animation in flight speaks for the whole fold: it is
+                // already travelling from the old resolved colour to the new
+                // one. Reading it here is also what subscribes the text, so it
+                // repaints on every step.
+                if let Some(animated) = animated
+                    && let Some(color) = animated.get()
+                {
+                    return color;
+                }
+                let flags = flags.map(|f| f.get()).unwrap_or_default();
                 if flags.contains(InteractionFlags::PRESSED)
                     && let Some(color) = pressed
                 {
@@ -274,6 +298,7 @@ impl Container {
                 || a.corner_radius.is_some()
                 || a.border_color.is_some()
                 || a.transform.is_some()
+                || a.text_color.is_some()
         })
     }
 
@@ -289,6 +314,7 @@ impl Container {
                 || a.corner_radius.is_some()
                 || a.border_color.is_some()
                 || a.transform.is_some()
+                || a.text_color.is_some()
         })
     }
 }

--- a/src/widgets/container/style.rs
+++ b/src/widgets/container/style.rs
@@ -126,12 +126,17 @@ impl Container {
     }
 
     /// The text colour a descendant should see, before any animation.
+    ///
+    /// The base has to be the same one the published derived folds — this
+    /// container's declaration *or the inherited one* — and not just the
+    /// declaration. Reading only the declaration made an animated container
+    /// with no colour of its own seed and aim at a `WHITE` placeholder, so
+    /// hovering left from a colour the text had never shown.
     pub(super) fn effective_text_color_target(&self, id: WidgetId) -> Color {
         let base = self
-            .text
-            .as_ref()
-            .and_then(|t| t.color)
-            .map(|c| c.get())
+            .text_base
+            .or_else(|| self.text.as_ref().and_then(|t| t.color))
+            .map(|color| color.get())
             .unwrap_or(Color::WHITE);
         self.resolve_state_value(id, base, |state| state.text_color)
     }
@@ -193,6 +198,8 @@ impl Container {
         let base = declared
             .and_then(|s| s.color)
             .or_else(|| tree.inherited_text_style(id).color);
+        // Kept so the animation aims at exactly what this fold falls back to.
+        self.text_base = base;
 
         let (color, owner) = with_owner(|| {
             create_derived(move || {


### PR DESCRIPTION
Stacked on #167.

`animate_text_color`, on the same machinery as every other animated container property: an `AnimationState<Color>` seeded from the effective target, drifting against it in `resync_animation_targets`, advanced with the rest.

## The one step that is different

Every other animated property is consumed by the paint of the container that owns it — it computes the value and draws with it three lines later. This one is drawn by a **descendant**, so the in-flight value has to leave the widget, and only a signal write can do that. The published derived reads that signal first, which is also what subscribes the text and repaints it on every step.

Without the write, the text would jump to the final colour on the first frame while the box eased into it. That looks like a rendering glitch and is really a missing edge in the graph — so the test asserts an **intermediate** value, not just the destination. Asserting only the destination would pass either way.

The signal carries `Option<Color>` and returns to `None` once the animation settles, so the derived falls back to the ordinary base-plus-state fold rather than pinning the last frame it drew. There is a test for that too.

## Frame sequencing needed no work

This was flagged as the thing to measure rather than assume. It turns out `render_surface` already re-distributes and drains the jobs queued *during* job processing:

```rust
// Process follow-up jobs from animation advances and reconciliation
// (they land in the inbox — re-distribute before draining)
jobs::distribute_jobs(tree, active_roots);
let followup = jobs::drain_surface_non_animation_jobs(surface.widget_id);
```

That is exactly where an animation advance writes, and `drain_surface_non_animation_jobs` excludes only Animation jobs — the text's Paint passes. So the label lands in the same frame as the box it sits on, with no skew.

## Known limit

Documented on the builder: a transition declared on two levels — an animated colour whose base is inherited from an ancestor that is itself animating — retargets every frame and gives a damped chase rather than a transition with its own curve. It converges. CSS starts the inner one once, towards the outer's final value; that is the rule to adopt if it ever comes up in practice.

## Note on the tests

Animations step against the wall clock, so the settle loop sleeps real milliseconds between advances. A tight loop advances them by microseconds and never arrives — which is how the first version of the test failed, reporting a colour that had moved 1.6% of the way and stopped.