### PR TITLE
Split the Wayland platform layer by concern

### DIFF
--- a/book/src/building-ui/text-input.md
+++ b/book/src/building-ui/text-input.md
@@ -230,7 +230,9 @@ fn login_form() -> Container {
 - **Undo/Redo**: History with intelligent coalescing of rapid edits
 - **Scrolling**: Long text scrolls horizontally to keep cursor visible
 - **Cursor Blinking**: Standard blinking cursor when focused
-- **Key Repeat**: Hold keys for continuous input
+- **Key Repeat**: Hold keys for continuous input, at the rate and delay the
+  compositor reports — the same settings every other application on the
+  session obeys
 
 ## API Reference
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -174,6 +174,22 @@ Layer shell protocol implementation for desktop widgets.
 - Event loop via calloop
 - Dynamic surface property modification via `SurfaceHandle`
 
+**Module layout.** `wayland.rs` holds the connection, the surface registry and
+the layer shell; everything else is one file per concern, each owning its own
+state and the protocol handlers that drive it. The `delegate_*` macros need
+those handlers implemented on `WaylandState`, which is why the `impl` blocks
+live beside their state rather than all in one file.
+
+| File | Concern |
+|------|---------|
+| `platform/wayland.rs` | Connection, surfaces, layer shell, compositor handler |
+| `platform/input.rs` | Seat: pointer, touch, keyboard, cursor shape, key repeat |
+| `platform/selections.rs` | Clipboard and primary selection, async prefetch |
+| `platform/outputs.rs` | Stable `OutputId` per `wl_output`, hotplug |
+| `platform/popups.rs` | xdg popups: positioning, grabs, ordered teardown |
+| `platform/lock.rs` | `ext-session-lock-v1` grant and lifecycle events |
+| `platform/backdrop.rs` | `ext-background-effect-v1` compositor-side blur |
+
 ### `surface.rs` - Surface Management
 
 Handles surface creation, configuration, and runtime modification.
@@ -462,7 +478,8 @@ The feature has zero overhead when disabled (code is completely compiled out).
 | `src/renderer/shader.wgsl` | GPU shaders for instanced SDF rendering |
 | `src/reactive/signal.rs` | Signal implementation |
 | `src/transform.rs` | Transform matrix operations |
-| `src/platform/mod.rs` | Wayland layer shell integration |
+| `src/platform/wayland.rs` | Wayland connection, surfaces and layer shell |
+| `src/platform/input.rs` | Seat input: pointer, touch, keyboard |
 
 ## Adding New Features
 

--- a/src/ingress.rs
+++ b/src/ingress.rs
@@ -31,7 +31,7 @@ pub(crate) enum IngressMessage {
     /// Applied by the channel callback (generation-checked against the
     /// current offer in `WaylandState::apply_clipboard_update`).
     ClipboardUpdate {
-        kind: crate::platform::wayland::SelectionKind,
+        kind: crate::platform::SelectionKind,
         generation: u64,
         content: Option<String>,
     },

--- a/src/jobs.rs
+++ b/src/jobs.rs
@@ -682,3 +682,80 @@ mod tests {
         assert_eq!(drain_surface_jobs(roots[0]), vec![job]);
     }
 }
+
+#[cfg(test)]
+mod wakeup_contract {
+    use super::*;
+    use smithay_client_toolkit::reexports::calloop::{EventLoop, ping::make_ping};
+    use std::time::Duration;
+
+    /// The one invariant in this file that had no test, and the one that
+    /// cost a hung loop once: the wakeup ping must not be gated on
+    /// `FRAME_REQUESTED`.
+    ///
+    /// That flag is consumed mid-iteration by `take_frame_request()`. Gating
+    /// the ping on it meant a request arriving while the flag happened to be
+    /// set sent nothing, the take then cleared the flag, and the loop blocked
+    /// with work already queued — until an unrelated Wayland event, a mouse
+    /// movement, happened to wake it.
+    ///
+    /// So: with `FRAME_REQUESTED` already set and the loop having woken since
+    /// the last ping, a request must still ping.
+    ///
+    /// The globals are process-wide and other tests in this binary reach
+    /// `request_frame` too. An interfering ping can only mask a failure here,
+    /// never cause one, and the window between arming and dispatching is a
+    /// few microseconds.
+    #[test]
+    fn a_request_pings_even_when_the_frame_flag_is_already_set() {
+        let mut event_loop: EventLoop<bool> = EventLoop::try_new().expect("event loop");
+        let (ping, source) = make_ping().expect("ping");
+        event_loop
+            .handle()
+            .insert_source(source, |_, _, woken: &mut bool| *woken = true)
+            .expect("insert ping source");
+
+        init_wakeup(ping);
+
+        // Drain anything already pending so the assertion below can only be
+        // satisfied by our own request.
+        let mut woken = false;
+        let _ = event_loop.dispatch(Some(Duration::ZERO), &mut woken);
+
+        // The state the old bug keyed on: a frame is already requested.
+        FRAME_REQUESTED.store(true, Ordering::Relaxed);
+        // The loop has woken since the last ping, so coalescing is reset.
+        mark_loop_awake();
+
+        request_frame();
+
+        let mut woken = false;
+        event_loop
+            .dispatch(Some(Duration::from_millis(50)), &mut woken)
+            .expect("dispatch");
+        assert!(
+            woken,
+            "request_frame must ping while FRAME_REQUESTED is set — gating on \
+             that flag is what lost wakeups"
+        );
+
+        reset_jobs();
+    }
+
+    /// The other half: within one awake iteration the ping is coalesced, so a
+    /// burst of requests does not write the eventfd once per signal.
+    #[test]
+    fn further_requests_in_the_same_iteration_do_not_re_ping() {
+        reset_jobs();
+        mark_loop_awake();
+
+        request_frame();
+        assert!(PING_SENT.load(Ordering::Relaxed));
+
+        // Already armed: the swap reports a ping is in flight, so no second
+        // one is sent until the loop wakes and clears the flag.
+        assert!(PING_SENT.swap(true, Ordering::Relaxed));
+
+        reset_jobs();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -929,13 +929,21 @@ impl App {
             );
         }
 
-        let (connection, mut event_queue, mut wayland_state, qh) = match create_wayland_app() {
-            Ok(app) => app,
-            Err(e) => {
-                log::error!("Cannot start: {e}");
-                return ExitReason::Error(e);
-            }
-        };
+        // The loop is created before the connection because the keyboard is
+        // built during the first dispatch, and it needs the loop handle to arm
+        // its key-repeat timer.
+        let mut event_loop: EventLoop<platform::WaylandState> =
+            EventLoop::try_new().expect("Failed to create event loop");
+        let loop_handle = event_loop.handle();
+
+        let (connection, mut event_queue, mut wayland_state, qh) =
+            match create_wayland_app(loop_handle.clone()) {
+                Ok(app) => app,
+                Err(e) => {
+                    log::error!("Cannot start: {e}");
+                    return ExitReason::Error(e);
+                }
+            };
 
         // Create surfaces from add_surface() calls
         for def in &self.surface_definitions {
@@ -998,11 +1006,6 @@ impl App {
 
             surface_manager.add(managed);
         }
-
-        // Create calloop event loop for event-driven execution
-        let mut event_loop: EventLoop<platform::WaylandState> =
-            EventLoop::try_new().expect("Failed to create event loop");
-        let loop_handle = event_loop.handle();
 
         // Create ping mechanism for wakeup on signal changes
         let (ping, ping_source) = make_ping().expect("Failed to create ping");

--- a/src/platform/backdrop.rs
+++ b/src/platform/backdrop.rs
@@ -1,0 +1,144 @@
+//! Compositor-side backdrop blur (`ext-background-effect-v1`).
+//!
+//! This is the half of `backdrop_blur` the client cannot do itself: blurring
+//! what sits *behind* a translucent surface, which only the compositor can
+//! see. It is advertised as a capability that can appear and disappear at
+//! runtime, so everything here degrades to a no-op rather than failing.
+
+use smithay_client_toolkit::compositor::Region;
+use smithay_client_toolkit::reexports::client::{
+    Connection, Dispatch, QueueHandle, WEnum, delegate_noop,
+};
+use wayland_protocols::ext::background_effect::v1::client::{
+    ext_background_effect_manager_v1::{
+        self, Capability as BgCapability, ExtBackgroundEffectManagerV1,
+    },
+    ext_background_effect_surface_v1::ExtBackgroundEffectSurfaceV1,
+};
+
+use super::wayland::WaylandState;
+use crate::blur::BlurRect;
+use crate::surface::SurfaceId;
+
+/// The compositor's background-effect manager and what it currently offers.
+pub struct Backdrop {
+    /// `None` where the protocol is unsupported — the feature simply no-ops.
+    pub(super) bg_effect_manager: Option<ExtBackgroundEffectManagerV1>,
+    /// Whether the compositor currently advertises the Blur capability.
+    pub(super) bg_effect_supports_blur: bool,
+}
+
+impl Backdrop {
+    pub(super) fn new(bg_effect_manager: Option<ExtBackgroundEffectManagerV1>) -> Self {
+        Self {
+            bg_effect_manager,
+            bg_effect_supports_blur: false,
+        }
+    }
+}
+
+impl WaylandState {
+    /// Push a surface's blur region to the compositor if it changed.
+    ///
+    /// The `set_blur_region` request is double-buffered: with `commit: false`
+    /// it rides the buffer commit performed inside the upcoming present, so
+    /// region and content change in the same frame. Pass `commit: true` on
+    /// paths that skip presenting (e.g. a capability change without repaint).
+    ///
+    /// Surfaces that never requested blur are left untouched — declaring an
+    /// empty region would override compositor-side blur rules (e.g. blur by
+    /// namespace). Once a surface has blurred, dropping to zero rects sends
+    /// an *empty* region, never NULL: NULL only withdraws our opinion and
+    /// lets such a rule blur the whole surface, where an empty region says
+    /// "blur exactly nothing".
+    pub(crate) fn sync_blur_region(
+        &mut self,
+        id: SurfaceId,
+        rects: Vec<BlurRect>,
+        qh: &QueueHandle<Self>,
+        commit: bool,
+    ) {
+        if !self.backdrop.bg_effect_supports_blur {
+            return;
+        }
+        let Some(manager) = self.backdrop.bg_effect_manager.clone() else {
+            return;
+        };
+        let Some(surface_state) = self.surfaces.get_mut(&id) else {
+            return;
+        };
+
+        // Never used blur and still doesn't — don't claim the surface.
+        if rects.is_empty()
+            && surface_state.blur_region.is_none()
+            && surface_state.bg_effect_surface.is_none()
+        {
+            return;
+        }
+
+        if surface_state.blur_region.as_deref() == Some(rects.as_slice()) {
+            return;
+        }
+
+        // Asking the manager twice for the same surface is a protocol error.
+        let effect = surface_state.bg_effect_surface.get_or_insert_with(|| {
+            manager.get_background_effect(&surface_state.wl_surface, qh, ())
+        });
+
+        let Ok(region) = Region::new(&self.compositor_state) else {
+            log::warn!("Failed to create wl_region for blur");
+            return;
+        };
+        for r in &rects {
+            region.add(r.x, r.y, r.width, r.height);
+        }
+        effect.set_blur_region(Some(region.wl_region()));
+
+        log::debug!(
+            "Surface {:?} blur region set to {} rect(s)",
+            id,
+            rects.len()
+        );
+        surface_state.blur_region = Some(rects);
+
+        if commit {
+            surface_state.wl_surface.commit();
+        }
+    }
+}
+
+impl Dispatch<ExtBackgroundEffectManagerV1, ()> for WaylandState {
+    fn event(
+        state: &mut Self,
+        _proxy: &ExtBackgroundEffectManagerV1,
+        event: ext_background_effect_manager_v1::Event,
+        _data: &(),
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+    ) {
+        if let ext_background_effect_manager_v1::Event::Capabilities { flags } = event {
+            let blur = match flags {
+                WEnum::Value(c) => c.contains(BgCapability::Blur),
+                WEnum::Unknown(_) => false,
+            };
+            if blur == state.backdrop.bg_effect_supports_blur {
+                return;
+            }
+            log::info!(
+                "Compositor blur capability {}",
+                if blur { "available" } else { "lost" }
+            );
+            state.backdrop.bg_effect_supports_blur = blur;
+            crate::compositor::set_blur_capability(blur);
+
+            // The compositor drops its regions when the capability goes away:
+            // forget ours and wake the loop to push them again if it's back.
+            for surface_state in state.surfaces.values_mut() {
+                surface_state.blur_region = None;
+            }
+            crate::jobs::request_frame();
+        }
+    }
+}
+
+delegate_noop!(WaylandState: ignore ExtBackgroundEffectSurfaceV1);

--- a/src/platform/input.rs
+++ b/src/platform/input.rs
@@ -723,32 +723,46 @@ fn keysym_to_key(keysym: Keysym, utf8: Option<&str>, is_press: bool) -> Option<K
         _ => {}
     }
 
-    // Character input - use utf8 if available
+    // Character input: utf8 carries the composed result, so it wins whenever
+    // it holds something printable.
     if let Some(text) = utf8
         && let Some(c) = text.chars().next()
     {
-        // Only return printable characters or control characters we care about
         if !c.is_control() || c == '\n' || c == '\r' || c == '\t' {
             return Some(Key::Char(c));
         }
+
+        // A control character here means a modifier ate the letter: Ctrl+C
+        // arrives as U+0003, not as 'c'. The keysym still carries the letter,
+        // so fall through to it — otherwise every Ctrl chord is dropped and
+        // copy, cut and paste never reach a widget.
+        return keysym_char(keysym);
     }
 
-    // Fallback: convert keysym directly for release events where utf8 is always None.
-    // On press, utf8 = None means a compose sequence is in progress — don't insert anything.
+    // No utf8 on a press means a compose sequence is still open: there is
+    // nothing to insert yet. On release utf8 is always absent, so the keysym
+    // is all there is.
     if !is_press {
-        let raw = keysym.raw();
+        return keysym_char(keysym);
+    }
 
-        // Printable ASCII range (space through tilde): 0x20-0x7E
-        // XKB keysyms for these characters have the same value as ASCII
-        if (0x20..=0x7e).contains(&raw) {
-            return Some(Key::Char(char::from_u32(raw)?));
-        }
+    None
+}
 
-        // Handle keypad numbers (KP_0 through KP_9)
-        // XKB_KEY_KP_0 = 0xffb0, XKB_KEY_KP_9 = 0xffb9
-        if (0xffb0..=0xffb9).contains(&raw) {
-            return Some(Key::Char(char::from_u32(raw - 0xffb0 + 0x30)?)); // Convert to '0'-'9'
-        }
+/// The character a keysym stands for, ignoring any composition.
+fn keysym_char(keysym: Keysym) -> Option<Key> {
+    let raw = keysym.raw();
+
+    // Printable ASCII range (space through tilde): 0x20-0x7E
+    // XKB keysyms for these characters have the same value as ASCII
+    if (0x20..=0x7e).contains(&raw) {
+        return Some(Key::Char(char::from_u32(raw)?));
+    }
+
+    // Handle keypad numbers (KP_0 through KP_9)
+    // XKB_KEY_KP_0 = 0xffb0, XKB_KEY_KP_9 = 0xffb9
+    if (0xffb0..=0xffb9).contains(&raw) {
+        return Some(Key::Char(char::from_u32(raw - 0xffb0 + 0x30)?)); // Convert to '0'-'9'
     }
 
     None
@@ -758,3 +772,47 @@ delegate_seat!(WaylandState);
 delegate_pointer!(WaylandState);
 delegate_touch!(WaylandState);
 delegate_keyboard!(WaylandState);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A held modifier replaces the character xkb reports: Ctrl+C arrives as
+    /// U+0003, not as 'c'. The keysym still carries the letter, and dropping
+    /// the event here means copy, cut, paste, undo and select-all never reach
+    /// a widget at all.
+    #[test]
+    fn a_ctrl_chord_keeps_its_letter() {
+        let c = Keysym::new(0x63); // 'c'
+        assert_eq!(
+            keysym_to_key(c, Some("\u{3}"), true),
+            Some(Key::Char('c')),
+            "Ctrl+C must arrive as 'c'"
+        );
+    }
+
+    /// The case the control-character guard exists for: while a compose
+    /// sequence is open xkb reports no text, and nothing should be inserted
+    /// until it resolves.
+    #[test]
+    fn an_open_compose_sequence_inserts_nothing() {
+        let e = Keysym::new(0x65); // 'e'
+        assert_eq!(keysym_to_key(e, None, true), None);
+    }
+
+    /// Release events never carry text, so the keysym is all there is —
+    /// that is how a composed key is matched back to the press that made it.
+    #[test]
+    fn a_release_falls_back_to_the_keysym() {
+        let e = Keysym::new(0x65);
+        assert_eq!(keysym_to_key(e, None, false), Some(Key::Char('e')));
+    }
+
+    /// Ordinary typing still goes through the text, not the keysym: that is
+    /// what carries an accented or composed character.
+    #[test]
+    fn plain_typing_uses_the_composed_text() {
+        let e = Keysym::new(0x65); // 'e', composed into 'é'
+        assert_eq!(keysym_to_key(e, Some("é"), true), Some(Key::Char('é')));
+    }
+}

--- a/src/platform/input.rs
+++ b/src/platform/input.rs
@@ -1,0 +1,760 @@
+//! Pointer, touch and keyboard: everything the seat hands us.
+//!
+//! The three devices arrive together with the seat's capabilities and are
+//! released together when it loses them, which is why they are kept in one
+//! place rather than one struct each.
+//!
+//! Widgets only understand pointer events, so touch is folded into the same
+//! pipeline: the first finger down drives it, and a tap becomes a click.
+
+use std::collections::HashMap;
+
+use smithay_client_toolkit::{
+    delegate_keyboard, delegate_pointer, delegate_seat, delegate_touch,
+    seat::{
+        Capability, SeatHandler, SeatState,
+        keyboard::{KeyEvent, KeyboardHandler, Keysym, Modifiers as WlModifiers, RawModifiers},
+        pointer::{
+            PointerEvent, PointerEventKind, PointerHandler, cursor_shape::CursorShapeManager,
+        },
+        touch::TouchHandler,
+    },
+};
+
+use smithay_client_toolkit::reexports::calloop::LoopHandle;
+use smithay_client_toolkit::reexports::client::{
+    Connection, Proxy, QueueHandle,
+    protocol::{wl_keyboard, wl_pointer, wl_seat, wl_surface, wl_touch},
+};
+use smithay_client_toolkit::reexports::protocols::wp::cursor_shape::v1::client::wp_cursor_shape_device_v1::Shape as WpCursorShape;
+
+use super::wayland::WaylandState;
+use crate::reactive::CursorIcon;
+use crate::surface::SurfaceId;
+use crate::widgets::{Event, Key, Modifiers, MouseButton, ScrollSource};
+
+/// Pixels per line for discrete scroll (mouse wheel)
+const SCROLL_PIXELS_PER_LINE: f32 = 40.0;
+
+/// The seat's three devices and the state that tracks them.
+pub struct InputState {
+    // Pointer
+    pub(super) pointer: Option<wl_pointer::WlPointer>,
+    pub(super) pointer_x: f32,
+    pub(super) pointer_y: f32,
+    pub(super) pointer_over_surface: bool,
+    pub(super) pointer_enter_serial: u32,
+
+    // Touch
+    pub(super) touch: Option<wl_touch::WlTouch>,
+    /// Fingers currently down: id → (surface, x, y).
+    pub(super) touch_fingers: HashMap<i32, (SurfaceId, f32, f32)>,
+    /// The finger driving pointer emulation (the first one down). Widgets
+    /// only understand pointer events, so the primary finger synthesizes
+    /// MouseMove/MouseDown/MouseUp — a tap becomes a click.
+    pub(super) primary_finger: Option<i32>,
+
+    // Cursor shape
+    pub(super) cursor_shape_manager: Option<CursorShapeManager>,
+
+    // Keyboard
+    pub(super) keyboard: Option<wl_keyboard::WlKeyboard>,
+    pub(super) modifiers: Modifiers,
+    pub(super) keyboard_serial: u32,
+    /// Track raw_code → Key for press/release matching (handles compose sequences)
+    pub(super) pressed_keys: HashMap<u32, Key>,
+    /// Key repeat runs on a calloop timer owned by the toolkit, armed with the
+    /// rate and delay the compositor reports. The keyboard is created inside a
+    /// seat capability callback, which has no other route to the loop.
+    pub(super) loop_handle: LoopHandle<'static, WaylandState>,
+
+    /// Serial of the most recent input event. Claiming a selection or taking a
+    /// popup grab needs one the compositor still considers recent.
+    pub(super) latest_input_serial: u32,
+}
+
+impl InputState {
+    pub(super) fn new(
+        cursor_shape_manager: Option<CursorShapeManager>,
+        loop_handle: LoopHandle<'static, WaylandState>,
+    ) -> Self {
+        Self {
+            pointer: None,
+            pointer_x: 0.0,
+            pointer_y: 0.0,
+            pointer_over_surface: false,
+            pointer_enter_serial: 0,
+            touch: None,
+            touch_fingers: HashMap::new(),
+            primary_finger: None,
+            cursor_shape_manager,
+            keyboard: None,
+            modifiers: Modifiers::default(),
+            keyboard_serial: 0,
+            pressed_keys: HashMap::new(),
+            loop_handle,
+            latest_input_serial: 0,
+        }
+    }
+}
+
+impl WaylandState {
+    /// Set the cursor shape
+    pub fn set_cursor(&self, cursor: CursorIcon, qh: &QueueHandle<Self>) {
+        let Some(ref manager) = self.input.cursor_shape_manager else {
+            return;
+        };
+        let Some(ref pointer) = self.input.pointer else {
+            return;
+        };
+
+        // Convert our CursorIcon to Wayland cursor shape
+        let shape = match cursor {
+            CursorIcon::Default => WpCursorShape::Default,
+            CursorIcon::Text => WpCursorShape::Text,
+            CursorIcon::Pointer => WpCursorShape::Pointer,
+            CursorIcon::Crosshair => WpCursorShape::Crosshair,
+            CursorIcon::Move => WpCursorShape::Move,
+            CursorIcon::NotAllowed => WpCursorShape::NotAllowed,
+            CursorIcon::Grab => WpCursorShape::Grab,
+            CursorIcon::Grabbing => WpCursorShape::Grabbing,
+            CursorIcon::ResizeNorth => WpCursorShape::NResize,
+            CursorIcon::ResizeSouth => WpCursorShape::SResize,
+            CursorIcon::ResizeEast => WpCursorShape::EResize,
+            CursorIcon::ResizeWest => WpCursorShape::WResize,
+            CursorIcon::ResizeNorthEast => WpCursorShape::NeResize,
+            CursorIcon::ResizeNorthWest => WpCursorShape::NwResize,
+            CursorIcon::ResizeSouthEast => WpCursorShape::SeResize,
+            CursorIcon::ResizeSouthWest => WpCursorShape::SwResize,
+            CursorIcon::ColResize => WpCursorShape::ColResize,
+            CursorIcon::RowResize => WpCursorShape::RowResize,
+            CursorIcon::Wait => WpCursorShape::Wait,
+            CursorIcon::Progress => WpCursorShape::Progress,
+        };
+
+        // Get cursor shape device and set shape
+        let device = manager.get_shape_device(pointer, qh);
+        device.set_shape(self.input.pointer_enter_serial, shape);
+    }
+}
+
+impl SeatHandler for WaylandState {
+    fn seat_state(&mut self) -> &mut SeatState {
+        &mut self.seat_state
+    }
+
+    fn new_seat(&mut self, _conn: &Connection, _qh: &QueueHandle<Self>, _seat: wl_seat::WlSeat) {}
+
+    fn new_capability(
+        &mut self,
+        _conn: &Connection,
+        qh: &QueueHandle<Self>,
+        seat: wl_seat::WlSeat,
+        capability: Capability,
+    ) {
+        // Handle pointer capability
+        if capability == Capability::Pointer && self.input.pointer.is_none() {
+            log::info!("Pointer capability available, creating pointer");
+            match self.seat_state.get_pointer(qh, &seat) {
+                Ok(pointer) => self.input.pointer = Some(pointer),
+                Err(e) => {
+                    // A capability race at seat init is not fatal — the app
+                    // just runs without pointer input until the seat updates
+                    log::warn!("Failed to get pointer: {e}");
+                    return;
+                }
+            }
+        }
+
+        // Handle touch capability
+        if capability == Capability::Touch && self.input.touch.is_none() {
+            log::info!("Touch capability available, creating touch");
+            match self.seat_state.get_touch(qh, &seat) {
+                Ok(touch) => self.input.touch = Some(touch),
+                Err(e) => {
+                    log::warn!("Failed to get touch: {e}");
+                }
+            }
+        }
+
+        // Handle keyboard capability
+        if capability == Capability::Keyboard && self.input.keyboard.is_none() {
+            log::info!("Keyboard capability available, creating keyboard");
+            let loop_handle = self.input.loop_handle.clone();
+            let keyboard = match self.seat_state.get_keyboard_with_repeat(
+                qh,
+                &seat,
+                None,
+                loop_handle,
+                Box::new(|state: &mut WaylandState, _kbd, event| state.emit_key_repeat(event)),
+            ) {
+                Ok(keyboard) => keyboard,
+                Err(e) => {
+                    log::warn!("Failed to get keyboard: {e}");
+                    return;
+                }
+            };
+            self.input.keyboard = Some(keyboard);
+
+            // Selections hang off the seat, so they cannot be created with
+            // their managers at startup.
+            self.selections.attach_devices(qh, &seat);
+        }
+    }
+
+    fn remove_capability(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _seat: wl_seat::WlSeat,
+        capability: Capability,
+    ) {
+        if capability == Capability::Pointer {
+            log::info!("Pointer capability removed");
+            if let Some(pointer) = self.input.pointer.take() {
+                pointer.release();
+            }
+        }
+        if capability == Capability::Keyboard {
+            log::info!("Keyboard capability removed");
+            if let Some(keyboard) = self.input.keyboard.take() {
+                keyboard.release();
+            }
+        }
+        if capability == Capability::Touch {
+            log::info!("Touch capability removed");
+            if let Some(touch) = self.input.touch.take() {
+                touch.release();
+            }
+            self.input.touch_fingers.clear();
+            self.input.primary_finger = None;
+        }
+    }
+
+    fn remove_seat(&mut self, _conn: &Connection, _qh: &QueueHandle<Self>, _seat: wl_seat::WlSeat) {
+    }
+}
+
+impl TouchHandler for WaylandState {
+    fn down(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _touch: &wl_touch::WlTouch,
+        serial: u32,
+        _time: u32,
+        surface: wl_surface::WlSurface,
+        id: i32,
+        position: (f64, f64),
+    ) {
+        self.input.latest_input_serial = serial;
+        let Some(surface_id) = self.surface_lookup.get(&surface.id()).copied() else {
+            return;
+        };
+        let (x, y) = (position.0 as f32, position.1 as f32);
+        self.input.touch_fingers.insert(id, (surface_id, x, y));
+
+        // The first finger down drives pointer emulation: move + press so
+        // hover and pressed state layers respond, and a tap becomes a click.
+        if self.input.primary_finger.is_none() {
+            self.input.primary_finger = Some(id);
+            if let Some(surface_state) = self.surfaces.get_mut(&surface_id) {
+                surface_state.pending_events.push(Event::MouseMove { x, y });
+                surface_state.pending_events.push(Event::MouseDown {
+                    x,
+                    y,
+                    button: MouseButton::Left,
+                });
+            }
+        }
+    }
+
+    fn up(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _touch: &wl_touch::WlTouch,
+        _serial: u32,
+        _time: u32,
+        id: i32,
+    ) {
+        let Some((surface_id, x, y)) = self.input.touch_fingers.remove(&id) else {
+            return;
+        };
+        if self.input.primary_finger == Some(id) {
+            self.input.primary_finger = None;
+            if let Some(surface_state) = self.surfaces.get_mut(&surface_id) {
+                surface_state.pending_events.push(Event::MouseUp {
+                    x,
+                    y,
+                    button: MouseButton::Left,
+                });
+                // Unlike a real pointer, nothing hovers after lifting the
+                // finger — clear hover state.
+                surface_state.pending_events.push(Event::MouseLeave);
+            }
+        }
+    }
+
+    fn motion(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _touch: &wl_touch::WlTouch,
+        _time: u32,
+        id: i32,
+        position: (f64, f64),
+    ) {
+        let Some(finger) = self.input.touch_fingers.get_mut(&id) else {
+            return;
+        };
+        let (x, y) = (position.0 as f32, position.1 as f32);
+        finger.1 = x;
+        finger.2 = y;
+        let surface_id = finger.0;
+
+        if self.input.primary_finger == Some(id)
+            && let Some(surface_state) = self.surfaces.get_mut(&surface_id)
+        {
+            // Coalesce runs of MouseMove like the pointer path does.
+            let events = &mut surface_state.pending_events;
+            if let Some(last @ Event::MouseMove { .. }) = events.last_mut() {
+                *last = Event::MouseMove { x, y };
+            } else {
+                events.push(Event::MouseMove { x, y });
+            }
+        }
+    }
+
+    fn shape(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _touch: &wl_touch::WlTouch,
+        _id: i32,
+        _major: f64,
+        _minor: f64,
+    ) {
+    }
+
+    fn orientation(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _touch: &wl_touch::WlTouch,
+        _id: i32,
+        _orientation: f64,
+    ) {
+    }
+
+    fn cancel(&mut self, _conn: &Connection, _qh: &QueueHandle<Self>, _touch: &wl_touch::WlTouch) {
+        // The compositor took over the gesture: release the synthesized
+        // press and clear hover so no widget is stuck pressed.
+        if let Some(id) = self.input.primary_finger.take()
+            && let Some((surface_id, x, y)) = self.input.touch_fingers.get(&id).copied()
+            && let Some(surface_state) = self.surfaces.get_mut(&surface_id)
+        {
+            surface_state.pending_events.push(Event::MouseUp {
+                x,
+                y,
+                button: MouseButton::Left,
+            });
+            surface_state.pending_events.push(Event::MouseLeave);
+        }
+        self.input.touch_fingers.clear();
+    }
+}
+
+impl PointerHandler for WaylandState {
+    fn pointer_frame(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _pointer: &wl_pointer::WlPointer,
+        events: &[PointerEvent],
+    ) {
+        for event in events {
+            // Try to find the surface ID for this event's wl_surface
+            let surface_id = self.surface_lookup.get(&event.surface.id()).copied();
+
+            // Get the target event queue for this surface
+            let target_events: Option<&mut Vec<Event>> = if let Some(id) = surface_id {
+                self.surfaces.get_mut(&id).map(|s| &mut s.pending_events)
+            } else if !matches!(event.kind, PointerEventKind::Leave { .. }) {
+                // Not our surface and not a leave event, skip
+                continue;
+            } else {
+                None
+            };
+
+            match event.kind {
+                PointerEventKind::Enter { serial } => {
+                    self.input.pointer_over_surface = true;
+                    self.input.pointer_enter_serial = serial;
+                    self.input.latest_input_serial = serial;
+                    self.input.pointer_x = event.position.0 as f32;
+                    self.input.pointer_y = event.position.1 as f32;
+
+                    // Track which surface has pointer focus
+                    self.current_pointer_surface = surface_id;
+
+                    if let Some(events) = target_events {
+                        events.push(Event::MouseEnter {
+                            x: self.input.pointer_x,
+                            y: self.input.pointer_y,
+                        });
+                        events.push(Event::MouseMove {
+                            x: self.input.pointer_x,
+                            y: self.input.pointer_y,
+                        });
+                    }
+                }
+                PointerEventKind::Leave { .. } => {
+                    if self.input.pointer_over_surface {
+                        self.input.pointer_over_surface = false;
+
+                        // Send leave event to the surface that had focus
+                        if let Some(id) = self.current_pointer_surface
+                            && let Some(surface_state) = self.surfaces.get_mut(&id)
+                        {
+                            surface_state.pending_events.push(Event::MouseLeave);
+                        }
+
+                        self.current_pointer_surface = None;
+                    }
+                }
+                PointerEventKind::Motion { .. } => {
+                    self.input.pointer_x = event.position.0 as f32;
+                    self.input.pointer_y = event.position.1 as f32;
+                    if let Some(events) = target_events {
+                        // Coalesce runs of MouseMove: only the latest position
+                        // matters for hover state, and every queued move costs
+                        // a full event-dispatch walk of the widget tree.
+                        if let Some(last @ Event::MouseMove { .. }) = events.last_mut() {
+                            *last = Event::MouseMove {
+                                x: self.input.pointer_x,
+                                y: self.input.pointer_y,
+                            };
+                        } else {
+                            events.push(Event::MouseMove {
+                                x: self.input.pointer_x,
+                                y: self.input.pointer_y,
+                            });
+                        }
+                    }
+                }
+                PointerEventKind::Press { button, serial, .. } => {
+                    self.input.latest_input_serial = serial;
+                    if let Some(mouse_button) = wayland_button_to_mouse_button(button)
+                        && let Some(events) = target_events
+                    {
+                        events.push(Event::MouseDown {
+                            x: self.input.pointer_x,
+                            y: self.input.pointer_y,
+                            button: mouse_button,
+                        });
+                    }
+                }
+                PointerEventKind::Release { button, .. } => {
+                    if let Some(mouse_button) = wayland_button_to_mouse_button(button)
+                        && let Some(events) = target_events
+                    {
+                        events.push(Event::MouseUp {
+                            x: self.input.pointer_x,
+                            y: self.input.pointer_y,
+                            button: mouse_button,
+                        });
+                    }
+                }
+                PointerEventKind::Axis {
+                    horizontal,
+                    vertical,
+                    source,
+                    ..
+                } => {
+                    // Determine scroll source
+                    let scroll_source = match source {
+                        Some(wl_pointer::AxisSource::Wheel) => ScrollSource::Wheel,
+                        Some(wl_pointer::AxisSource::Finger) => ScrollSource::Finger,
+                        Some(wl_pointer::AxisSource::Continuous) => ScrollSource::Continuous,
+                        Some(wl_pointer::AxisSource::WheelTilt) => ScrollSource::Wheel,
+                        _ => ScrollSource::Wheel,
+                    };
+
+                    // Calculate delta in pixels.
+                    // Wheel steps by preference: value120 (wl_pointer v8+,
+                    // fractional steps from high-resolution wheels) then
+                    // legacy discrete. Touchpad/finger scroll has neither
+                    // and uses absolute (already in pixels).
+                    let wheel_steps =
+                        |scroll: &smithay_client_toolkit::seat::pointer::AxisScroll| {
+                            if scroll.value120 != 0 {
+                                scroll.value120 as f32 / 120.0
+                            } else {
+                                scroll.discrete as f32
+                            }
+                        };
+
+                    let steps_x = wheel_steps(&horizontal);
+                    let delta_x = if steps_x != 0.0 {
+                        steps_x * SCROLL_PIXELS_PER_LINE
+                    } else {
+                        horizontal.absolute as f32
+                    };
+
+                    let steps_y = wheel_steps(&vertical);
+                    let delta_y = if steps_y != 0.0 {
+                        steps_y * SCROLL_PIXELS_PER_LINE
+                    } else {
+                        vertical.absolute as f32
+                    };
+
+                    // Only emit scroll event if there's actual scroll delta
+                    if (delta_x != 0.0 || delta_y != 0.0)
+                        && let Some(events) = target_events
+                    {
+                        events.push(Event::Scroll {
+                            x: self.input.pointer_x,
+                            y: self.input.pointer_y,
+                            delta_x,
+                            delta_y,
+                            source: scroll_source,
+                        });
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Convert Wayland button code to MouseButton
+fn wayland_button_to_mouse_button(button: u32) -> Option<MouseButton> {
+    // Linux input event codes (from linux/input-event-codes.h)
+    const BTN_LEFT: u32 = 0x110;
+    const BTN_RIGHT: u32 = 0x111;
+    const BTN_MIDDLE: u32 = 0x112;
+
+    match button {
+        BTN_LEFT => Some(MouseButton::Left),
+        BTN_RIGHT => Some(MouseButton::Right),
+        BTN_MIDDLE => Some(MouseButton::Middle),
+        _ => None,
+    }
+}
+
+impl KeyboardHandler for WaylandState {
+    fn enter(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _keyboard: &wl_keyboard::WlKeyboard,
+        surface: &wl_surface::WlSurface,
+        _serial: u32,
+        _raw: &[u32],
+        _keysyms: &[Keysym],
+    ) {
+        log::debug!("Keyboard focus entered");
+
+        // Track which surface has keyboard focus
+        let surface_id = self.surface_lookup.get(&surface.id()).copied();
+        self.current_keyboard_surface = surface_id;
+
+        // Route event to correct surface
+        if let Some(id) = surface_id
+            && let Some(surface_state) = self.surfaces.get_mut(&id)
+        {
+            surface_state.pending_events.push(Event::FocusIn);
+        }
+    }
+
+    fn leave(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _keyboard: &wl_keyboard::WlKeyboard,
+        surface: &wl_surface::WlSurface,
+        _serial: u32,
+    ) {
+        log::debug!("Keyboard focus left");
+
+        // Route event to correct surface
+        let surface_id = self.surface_lookup.get(&surface.id()).copied();
+        if let Some(id) = surface_id
+            && let Some(surface_state) = self.surfaces.get_mut(&id)
+        {
+            surface_state.pending_events.push(Event::FocusOut);
+        }
+
+        self.current_keyboard_surface = None;
+    }
+
+    fn press_key(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _keyboard: &wl_keyboard::WlKeyboard,
+        serial: u32,
+        event: KeyEvent,
+    ) {
+        // Track serial for clipboard operations
+        self.input.keyboard_serial = serial;
+        self.input.latest_input_serial = serial;
+
+        if let Some(key) = keysym_to_key(event.keysym, event.utf8.as_deref(), true) {
+            // Store raw_code → Key mapping so release_key can emit the correct Key
+            // (e.g., composed 'é' instead of raw 'e' after a compose sequence)
+            self.input.pressed_keys.insert(event.raw_code, key);
+
+            let key_event = Event::KeyDown {
+                key,
+                modifiers: self.input.modifiers,
+            };
+
+            // Route to the surface with keyboard focus
+            if let Some(id) = self.current_keyboard_surface
+                && let Some(surface_state) = self.surfaces.get_mut(&id)
+            {
+                surface_state.pending_events.push(key_event);
+            }
+        }
+    }
+
+    fn release_key(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _keyboard: &wl_keyboard::WlKeyboard,
+        _serial: u32,
+        event: KeyEvent,
+    ) {
+        // Use the stored key from press_key if available (handles compose sequences
+        // where the composed character differs from the raw keysym on release)
+        let key = self
+            .input
+            .pressed_keys
+            .remove(&event.raw_code)
+            .or_else(|| keysym_to_key(event.keysym, event.utf8.as_deref(), false));
+
+        if let Some(key) = key {
+            let key_event = Event::KeyUp {
+                key,
+                modifiers: self.input.modifiers,
+            };
+
+            // Route to the surface with keyboard focus
+            if let Some(id) = self.current_keyboard_surface
+                && let Some(surface_state) = self.surfaces.get_mut(&id)
+            {
+                surface_state.pending_events.push(key_event);
+            }
+        }
+    }
+
+    fn update_modifiers(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _keyboard: &wl_keyboard::WlKeyboard,
+        _serial: u32,
+        modifiers: WlModifiers,
+        _raw_modifiers: RawModifiers,
+        _layout: u32,
+    ) {
+        self.input.modifiers = Modifiers {
+            ctrl: modifiers.ctrl,
+            alt: modifiers.alt,
+            shift: modifiers.shift,
+            logo: modifiers.logo,
+        };
+    }
+
+    fn repeat_key(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _keyboard: &wl_keyboard::WlKeyboard,
+        _serial: u32,
+        event: KeyEvent,
+    ) {
+        self.emit_key_repeat(event);
+    }
+}
+
+impl WaylandState {
+    /// Deliver a repeated key as an ordinary press.
+    ///
+    /// Two sources reach here: the toolkit's calloop timer, armed from the
+    /// compositor's `repeat_info`, and the protocol's own repeated key state.
+    /// Neither is visible to widgets — a held key looks exactly like someone
+    /// pressing it very fast.
+    fn emit_key_repeat(&mut self, event: KeyEvent) {
+        let Some(key) = keysym_to_key(event.keysym, event.utf8.as_deref(), true) else {
+            return;
+        };
+        let key_event = Event::KeyDown {
+            key,
+            modifiers: self.input.modifiers,
+        };
+
+        // Route to the surface with keyboard focus
+        if let Some(id) = self.current_keyboard_surface
+            && let Some(surface_state) = self.surfaces.get_mut(&id)
+        {
+            surface_state.pending_events.push(key_event);
+        }
+    }
+}
+
+/// Convert XKB keysym to our Key type
+fn keysym_to_key(keysym: Keysym, utf8: Option<&str>, is_press: bool) -> Option<Key> {
+    // Named keys first
+    match keysym {
+        Keysym::BackSpace => return Some(Key::Backspace),
+        Keysym::Delete => return Some(Key::Delete),
+        Keysym::Return | Keysym::KP_Enter => return Some(Key::Enter),
+        Keysym::Tab | Keysym::ISO_Left_Tab => return Some(Key::Tab),
+        Keysym::Escape => return Some(Key::Escape),
+        Keysym::Left => return Some(Key::Left),
+        Keysym::Right => return Some(Key::Right),
+        Keysym::Up => return Some(Key::Up),
+        Keysym::Down => return Some(Key::Down),
+        Keysym::Home => return Some(Key::Home),
+        Keysym::End => return Some(Key::End),
+        _ => {}
+    }
+
+    // Character input - use utf8 if available
+    if let Some(text) = utf8
+        && let Some(c) = text.chars().next()
+    {
+        // Only return printable characters or control characters we care about
+        if !c.is_control() || c == '\n' || c == '\r' || c == '\t' {
+            return Some(Key::Char(c));
+        }
+    }
+
+    // Fallback: convert keysym directly for release events where utf8 is always None.
+    // On press, utf8 = None means a compose sequence is in progress — don't insert anything.
+    if !is_press {
+        let raw = keysym.raw();
+
+        // Printable ASCII range (space through tilde): 0x20-0x7E
+        // XKB keysyms for these characters have the same value as ASCII
+        if (0x20..=0x7e).contains(&raw) {
+            return Some(Key::Char(char::from_u32(raw)?));
+        }
+
+        // Handle keypad numbers (KP_0 through KP_9)
+        // XKB_KEY_KP_0 = 0xffb0, XKB_KEY_KP_9 = 0xffb9
+        if (0xffb0..=0xffb9).contains(&raw) {
+            return Some(Key::Char(char::from_u32(raw - 0xffb0 + 0x30)?)); // Convert to '0'-'9'
+        }
+    }
+
+    None
+}
+
+delegate_seat!(WaylandState);
+delegate_pointer!(WaylandState);
+delegate_touch!(WaylandState);
+delegate_keyboard!(WaylandState);

--- a/src/platform/lock.rs
+++ b/src/platform/lock.rs
@@ -1,0 +1,189 @@
+//! Session lock (`ext-session-lock-v1`).
+//!
+//! Locking is a grant, not a request that succeeds locally: the compositor
+//! answers asynchronously and may refuse. Until it answers there is no lock,
+//! and the surfaces that cover the outputs cannot be created yet — which is
+//! why the outcome arrives as an event the main loop drains rather than as a
+//! return value.
+
+use smithay_client_toolkit::{
+    delegate_session_lock,
+    session_lock::{
+        SessionLock, SessionLockHandler, SessionLockState, SessionLockSurface,
+        SessionLockSurfaceConfigure,
+    },
+};
+
+use smithay_client_toolkit::reexports::client::{Connection, Proxy, QueueHandle};
+
+use super::wayland::{SurfaceRole, WaylandState, WaylandSurfaceState};
+use crate::outputs::OutputId;
+use crate::surface::SurfaceId;
+
+/// Events from the session-lock protocol, drained by the main loop.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LockEvent {
+    /// The compositor granted the lock; lock surfaces may be created.
+    Locked,
+    /// The lock ended: denied outright, or unlocked/aborted later.
+    Finished,
+}
+
+/// The lock grant and the events it produces.
+pub struct Lock {
+    pub(super) session_lock_state: SessionLockState,
+    /// The active lock grant. Written when `start_session_lock` succeeds so a
+    /// synchronous double-lock check can reject a second call; cleared by
+    /// `finished` or `unlock_session`.
+    pub(super) active_lock: Option<SessionLock>,
+    /// Lock lifecycle events, drained by the main loop.
+    pub(super) lock_events: Vec<LockEvent>,
+}
+
+impl Lock {
+    pub(super) fn new(session_lock_state: SessionLockState) -> Self {
+        Self {
+            session_lock_state,
+            active_lock: None,
+            lock_events: Vec::new(),
+        }
+    }
+}
+
+impl WaylandState {
+    /// Request a session lock from the compositor.
+    ///
+    /// Returns false when a lock is already active or the compositor lacks
+    /// ext-session-lock-v1. The grant (or denial) arrives asynchronously as
+    /// a [`LockEvent`].
+    pub fn start_session_lock(&mut self, qh: &QueueHandle<Self>) -> bool {
+        if self.lock.active_lock.is_some() {
+            log::warn!("Session lock requested while a lock is already active");
+            return false;
+        }
+        match self.lock.session_lock_state.lock(qh) {
+            Ok(lock) => {
+                self.lock.active_lock = Some(lock);
+                log::info!("Session lock requested");
+                true
+            }
+            Err(e) => {
+                log::error!("Compositor does not support ext-session-lock-v1: {e}");
+                false
+            }
+        }
+    }
+
+    /// Unlock the session (no-op when not locked).
+    pub fn unlock_session(&mut self) {
+        if let Some(lock) = self.lock.active_lock.take() {
+            lock.unlock();
+            log::info!("Session unlocked");
+        }
+    }
+
+    /// Whether a session lock is currently held and granted.
+    pub fn is_session_locked(&self) -> bool {
+        self.lock
+            .active_lock
+            .as_ref()
+            .is_some_and(|l| l.is_locked())
+    }
+
+    /// Create a lock surface for `output` with a specific SurfaceId.
+    ///
+    /// The surface starts at 0×0 — its real size arrives with the first
+    /// lock-surface configure. Returns false without an active lock or when
+    /// the output disconnected.
+    pub fn create_lock_surface_with_id(
+        &mut self,
+        qh: &QueueHandle<Self>,
+        id: SurfaceId,
+        output: OutputId,
+    ) -> bool {
+        let Some(lock) = self.lock.active_lock.clone() else {
+            log::warn!("Cannot create lock surface without an active session lock");
+            return false;
+        };
+        let Some(wl_output) = self.wl_output_for(output) else {
+            log::warn!(
+                "Cannot create lock surface: output {:?} is not connected",
+                output
+            );
+            return false;
+        };
+
+        let wl_surface = self.compositor_state.create_surface(qh);
+        let lock_surface = lock.create_lock_surface(wl_surface.clone(), &wl_output, qh);
+
+        self.surface_lookup.insert(wl_surface.id(), id);
+        let surface_state =
+            WaylandSurfaceState::new(SurfaceRole::Lock(lock_surface), wl_surface, 0, 0);
+        self.surfaces.insert(id, surface_state);
+
+        log::info!("Created lock surface {:?} on output {:?}", id, output);
+        true
+    }
+
+    /// Drain pending session-lock lifecycle events.
+    pub fn take_lock_events(&mut self) -> Vec<LockEvent> {
+        std::mem::take(&mut self.lock.lock_events)
+    }
+}
+
+impl SessionLockHandler for WaylandState {
+    fn locked(&mut self, _conn: &Connection, _qh: &QueueHandle<Self>, _session_lock: SessionLock) {
+        log::info!("Session lock granted by compositor");
+        self.lock.lock_events.push(LockEvent::Locked);
+        crate::jobs::request_frame();
+    }
+
+    fn finished(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _session_lock: SessionLock,
+    ) {
+        log::info!("Session lock finished (denied or ended)");
+        self.lock.active_lock = None;
+        self.lock.lock_events.push(LockEvent::Finished);
+        crate::jobs::request_frame();
+    }
+
+    fn configure(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        surface: SessionLockSurface,
+        configure: SessionLockSurfaceConfigure,
+        _serial: u32,
+    ) {
+        // Route to the matching surface state, mirroring the layer-shell
+        // configure path so the same render machinery applies. sctk has
+        // already acked the configure.
+        let surface_id = self.surface_lookup.get(&surface.wl_surface().id()).copied();
+        if let Some(id) = surface_id
+            && let Some(surface_state) = self.surfaces.get_mut(&id)
+        {
+            let (width, height) = configure.new_size;
+            log::info!(
+                "Lock surface {:?} configure: {}x{} (current {}x{})",
+                id,
+                width,
+                height,
+                surface_state.width,
+                surface_state.height
+            );
+            if width > 0 {
+                surface_state.width = width;
+            }
+            if height > 0 {
+                surface_state.height = height;
+            }
+            surface_state.configured = true;
+            crate::jobs::request_frame();
+        }
+    }
+}
+
+delegate_session_lock!(WaylandState);

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -1,4 +1,5 @@
 pub mod input;
+pub mod outputs;
 pub mod selections;
 pub mod wayland;
 

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -1,11 +1,14 @@
 pub mod input;
+pub mod lock;
 pub mod outputs;
+pub mod popups;
 pub mod selections;
 pub mod wayland;
 
+pub use lock::LockEvent;
 pub use selections::SelectionKind;
 pub use wayland::{
-    LockEvent, PlatformError, SurfaceRole, WaylandState, WaylandSurfaceState, WaylandWindowWrapper,
+    PlatformError, SurfaceRole, WaylandState, WaylandSurfaceState, WaylandWindowWrapper,
     create_wayland_app,
 };
 

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -1,5 +1,7 @@
+pub mod selections;
 pub mod wayland;
 
+pub use selections::SelectionKind;
 pub use wayland::{
     LockEvent, PlatformError, SurfaceRole, WaylandState, WaylandSurfaceState, WaylandWindowWrapper,
     create_wayland_app,

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -1,3 +1,4 @@
+pub mod backdrop;
 pub mod input;
 pub mod lock;
 pub mod outputs;

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -1,3 +1,4 @@
+pub mod input;
 pub mod selections;
 pub mod wayland;
 

--- a/src/platform/outputs.rs
+++ b/src/platform/outputs.rs
@@ -1,0 +1,131 @@
+//! Stable identity for the compositor's outputs.
+//!
+//! `wl_output` globals come and go as monitors are plugged, unplugged or
+//! remoded, and the protocol object itself carries no identity across that.
+//! This registry hands each one a `OutputId` that stays put for as long as the
+//! global lives, and never reuses it afterwards: a monitor that comes back is
+//! a new output, so a surface pinned to the old one does not silently land on
+//! it.
+
+use std::collections::HashMap;
+
+use smithay_client_toolkit::{
+    delegate_output,
+    output::{OutputHandler, OutputState},
+};
+
+use smithay_client_toolkit::reexports::client::{
+    Connection, Proxy, QueueHandle, protocol::wl_output,
+};
+use wayland_backend::sys::client::ObjectId;
+
+use super::wayland::WaylandState;
+use crate::outputs::{self, OutputId, OutputInfo};
+
+/// The `OutputId` assigned to each live `wl_output`.
+pub struct OutputRegistry {
+    /// Stable OutputId for each wl_output global. Ids are never reused: a
+    /// reconnected monitor gets a fresh id.
+    pub(super) output_ids: HashMap<ObjectId, OutputId>,
+    /// Next OutputId to allocate.
+    pub(super) next_output_id: u32,
+}
+
+impl OutputRegistry {
+    pub(super) fn new() -> Self {
+        Self {
+            output_ids: HashMap::new(),
+            next_output_id: 0,
+        }
+    }
+}
+
+impl WaylandState {
+    /// Get (or allocate) the stable OutputId for a wl_output.
+    pub(super) fn ensure_output_id(&mut self, output: &wl_output::WlOutput) -> OutputId {
+        let object_id = output.id();
+        if let Some(id) = self.outputs.output_ids.get(&object_id) {
+            return *id;
+        }
+        let id = OutputId::from_raw(self.outputs.next_output_id);
+        self.outputs.next_output_id += 1;
+        self.outputs.output_ids.insert(object_id, id);
+        id
+    }
+
+    /// Find the wl_output for a stable OutputId, if still connected.
+    pub(super) fn wl_output_for(&self, id: OutputId) -> Option<wl_output::WlOutput> {
+        self.output_state
+            .outputs()
+            .find(|o| self.outputs.output_ids.get(&o.id()) == Some(&id))
+    }
+
+    /// Rebuild the reactive output list from current compositor state.
+    fn sync_outputs(&mut self) {
+        let wl_outputs: Vec<wl_output::WlOutput> = self.output_state.outputs().collect();
+        let mut list: Vec<OutputInfo> = wl_outputs
+            .iter()
+            .filter_map(|o| {
+                let id = self.ensure_output_id(o);
+                let info = self.output_state.info(o)?;
+                Some(OutputInfo {
+                    id,
+                    name: info.name,
+                    description: info.description,
+                    make: info.make,
+                    model: info.model,
+                    scale_factor: info.scale_factor,
+                    logical_size: info.logical_size,
+                    logical_position: info.logical_position,
+                })
+            })
+            .collect();
+        list.sort_by_key(|o| o.id);
+        outputs::sync_outputs(list);
+    }
+}
+
+impl OutputHandler for WaylandState {
+    fn output_state(&mut self) -> &mut OutputState {
+        &mut self.output_state
+    }
+
+    fn new_output(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        output: wl_output::WlOutput,
+    ) {
+        let id = self.ensure_output_id(&output);
+        log::info!(
+            "Output {:?} connected: {:?}",
+            id,
+            self.output_state.info(&output).and_then(|i| i.name)
+        );
+        self.sync_outputs();
+    }
+
+    fn update_output(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _output: wl_output::WlOutput,
+    ) {
+        self.sync_outputs();
+    }
+
+    fn output_destroyed(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        output: wl_output::WlOutput,
+    ) {
+        if let Some(id) = self.outputs.output_ids.remove(&output.id()) {
+            log::info!("Output {:?} disconnected", id);
+            outputs::output_removed(id);
+        }
+        self.sync_outputs();
+    }
+}
+
+delegate_output!(WaylandState);

--- a/src/platform/popups.rs
+++ b/src/platform/popups.rs
@@ -1,0 +1,399 @@
+//! xdg popups anchored to a layer surface.
+//!
+//! Unlike every other surface here, a popup does not choose where it goes: the
+//! client describes an anchor, a gravity and how it may be adjusted, and the
+//! compositor decides, so a menu near a screen edge flips instead of falling
+//! off. That answer arrives as a configure, which is also why growing a popup
+//! means asking to be repositioned rather than simply resizing.
+
+use smithay_client_toolkit::{
+    delegate_xdg_popup,
+    shell::xdg::{
+        XdgPositioner, XdgShell,
+        popup::{Popup, PopupConfigure, PopupHandler},
+    },
+};
+
+use smithay_client_toolkit::reexports::client::{Connection, Dispatch, Proxy, QueueHandle};
+use smithay_client_toolkit::reexports::protocols::xdg::shell::client::xdg_positioner;
+
+use super::wayland::{SurfaceRole, WaylandState, WaylandSurfaceState};
+use crate::surface::SurfaceId;
+
+/// The xdg shell and the state popups need across configures.
+pub struct Popups {
+    /// `None` where xdg_wm_base is unavailable — popups then fail with a log.
+    pub(super) xdg_shell: Option<XdgShell>,
+    /// Monotonic token for xdg_popup.reposition requests.
+    pub(super) reposition_token: u32,
+}
+
+impl Popups {
+    pub(super) fn new(xdg_shell: Option<XdgShell>) -> Self {
+        Self {
+            xdg_shell,
+            reposition_token: 0,
+        }
+    }
+}
+
+impl WaylandState {
+    /// Build an xdg_positioner for a popup config at the given size.
+    fn build_popup_positioner(
+        xdg_shell: &XdgShell,
+        config: &crate::surface::PopupConfig,
+        size: (u32, u32),
+    ) -> Option<XdgPositioner> {
+        let positioner = match XdgPositioner::new(xdg_shell) {
+            Ok(p) => p,
+            Err(e) => {
+                log::error!("Failed to create xdg_positioner: {e}");
+                return None;
+            }
+        };
+        positioner.set_size(size.0.max(1) as i32, size.1.max(1) as i32);
+        let r = config.anchor_rect;
+        positioner.set_anchor_rect(
+            r.x.floor() as i32,
+            r.y.floor() as i32,
+            (r.width.ceil() as i32).max(1),
+            (r.height.ceil() as i32).max(1),
+        );
+        positioner.set_anchor(popup_point_to_anchor(config.anchor));
+        positioner.set_gravity(popup_point_to_gravity(config.gravity));
+        positioner.set_offset(config.offset.0, config.offset.1);
+        // Let the compositor keep the popup on screen: flip at the screen
+        // edge on either axis, slide where flipping doesn't help.
+        positioner.set_constraint_adjustment(
+            xdg_positioner::ConstraintAdjustment::FlipX
+                | xdg_positioner::ConstraintAdjustment::FlipY
+                | xdg_positioner::ConstraintAdjustment::SlideX
+                | xdg_positioner::ConstraintAdjustment::SlideY,
+        );
+        Some(positioner)
+    }
+
+    /// Create an xdg popup anchored to `parent` with a specific SurfaceId.
+    ///
+    /// `size` is the resolved popup size (config height, or the measured
+    /// content height for auto-height popups). The actual size/position
+    /// arrive with the popup configure (the compositor may flip/slide it to
+    /// stay on screen). Returns false when xdg_wm_base is missing or the
+    /// parent can't host popups.
+    pub fn create_popup_surface_with_id(
+        &mut self,
+        qh: &QueueHandle<Self>,
+        id: SurfaceId,
+        parent: SurfaceId,
+        config: &crate::surface::PopupConfig,
+        size: (u32, u32),
+    ) -> bool {
+        let Some(ref xdg_shell) = self.popups.xdg_shell else {
+            log::error!("Cannot create popup: compositor lacks xdg_wm_base");
+            return false;
+        };
+        let Some(parent_state) = self.surfaces.get(&parent) else {
+            log::warn!("Cannot create popup: parent surface {:?} is gone", parent);
+            return false;
+        };
+
+        let Some(positioner) = Self::build_popup_positioner(xdg_shell, config, size) else {
+            return false;
+        };
+
+        let wl_surface = self.compositor_state.create_surface(qh);
+        let popup = match &parent_state.role {
+            SurfaceRole::Layer(layer_surface) => {
+                let popup =
+                    match Popup::from_surface(None, &positioner, qh, wl_surface.clone(), xdg_shell)
+                    {
+                        Ok(popup) => popup,
+                        Err(e) => {
+                            log::error!("Failed to create xdg popup: {e}");
+                            return false;
+                        }
+                    };
+                // Assign the layer surface as the popup parent BEFORE the
+                // initial commit (required for parentless xdg popups)
+                layer_surface.get_popup(popup.xdg_popup());
+                popup
+            }
+            SurfaceRole::Popup {
+                popup: parent_popup,
+                ..
+            } => {
+                // Nested popup (submenu): ordinary xdg parent
+                let parent_xdg = parent_popup.xdg_surface().clone();
+                match Popup::from_surface(
+                    Some(&parent_xdg),
+                    &positioner,
+                    qh,
+                    wl_surface.clone(),
+                    xdg_shell,
+                ) {
+                    Ok(popup) => popup,
+                    Err(e) => {
+                        log::error!("Failed to create nested xdg popup: {e}");
+                        return false;
+                    }
+                }
+            }
+            SurfaceRole::Lock(_) => {
+                log::warn!("Cannot anchor a popup to a session-lock surface");
+                return false;
+            }
+        };
+
+        // Menu semantics: an input grab dismisses the popup on outside
+        // click. Must be requested before mapping, with a recent serial.
+        if config.grab
+            && let Some(seat) = self.seat_state.seats().next()
+        {
+            popup
+                .xdg_popup()
+                .grab(&seat, self.input.latest_input_serial);
+        }
+
+        wl_surface.commit();
+
+        self.surface_lookup.insert(wl_surface.id(), id);
+        let surface_state = WaylandSurfaceState::new(
+            SurfaceRole::Popup {
+                popup,
+                config: config.clone(),
+                parent,
+            },
+            wl_surface,
+            size.0,
+            size.1,
+        );
+        self.surfaces.insert(id, surface_state);
+
+        log::info!(
+            "Created popup {:?} on parent {:?} ({}x{}, grab: {})",
+            id,
+            parent,
+            size.0,
+            size.1,
+            config.grab
+        );
+        true
+    }
+
+    /// Live popup descendants of `root`, deepest first — the order the
+    /// protocol demands for teardown (a popup must be destroyed before its
+    /// parent, or the compositor raises `not_the_topmost_popup`).
+    pub(crate) fn popup_descendants_bottom_up(&self, root: SurfaceId) -> Vec<SurfaceId> {
+        let mut out = Vec::new();
+        let mut frontier = vec![root];
+        while let Some(current) = frontier.pop() {
+            for (id, state) in &self.surfaces {
+                if let SurfaceRole::Popup { parent, .. } = &state.role
+                    && *parent == current
+                {
+                    out.push(*id);
+                    frontier.push(*id);
+                }
+            }
+        }
+        out.reverse(); // deepest first
+        out
+    }
+
+    /// Grabbing popups that would make a new grab on `new_parent` illegal:
+    /// xdg-shell requires a new grab to nest under the current grab holder,
+    /// so any live grabbing popup that is not `new_parent` itself (or one
+    /// of its ancestors) must be destroyed before the new popup is created.
+    /// Returned deepest-chain-first, ready for ordered teardown.
+    pub(crate) fn conflicting_grab_popups(&self, new_parent: SurfaceId) -> Vec<SurfaceId> {
+        // Ancestor chain of the new popup (surfaces a nested grab may sit on)
+        let mut ancestors = vec![new_parent];
+        let mut current = new_parent;
+        while let Some(state) = self.surfaces.get(&current) {
+            match &state.role {
+                SurfaceRole::Popup { parent, .. } => {
+                    ancestors.push(*parent);
+                    current = *parent;
+                }
+                _ => break,
+            }
+        }
+
+        let mut conflicts: Vec<SurfaceId> = self
+            .surfaces
+            .iter()
+            .filter(|(id, state)| {
+                matches!(&state.role, SurfaceRole::Popup { config, .. } if config.grab)
+                    && !ancestors.contains(id)
+            })
+            .map(|(id, _)| *id)
+            .collect();
+        // Close whole chains children-first: append descendants and dedup
+        let mut ordered = Vec::new();
+        for id in conflicts.drain(..) {
+            for d in self.popup_descendants_bottom_up(id) {
+                if !ordered.contains(&d) {
+                    ordered.push(d);
+                }
+            }
+            if !ordered.contains(&id) {
+                ordered.push(id);
+            }
+        }
+        ordered
+    }
+
+    /// For auto-height popups: the width to measure content at.
+    /// Returns `None` for non-popup surfaces or fixed-height popups.
+    pub(crate) fn popup_auto_width(&self, id: SurfaceId) -> Option<u32> {
+        match &self.surfaces.get(&id)?.role {
+            SurfaceRole::Popup { config, .. } if config.height.is_none() => Some(config.width),
+            _ => None,
+        }
+    }
+
+    /// Reposition an auto-height popup when its content height changed.
+    /// The compositor answers with a new configure carrying the final size.
+    pub(crate) fn reposition_popup_if_changed(
+        &mut self,
+        id: SurfaceId,
+        new_height: u32,
+        qh: &QueueHandle<Self>,
+    ) {
+        let _ = qh;
+        let Some(ref xdg_shell) = self.popups.xdg_shell else {
+            return;
+        };
+        let Some(surface_state) = self.surfaces.get_mut(&id) else {
+            return;
+        };
+        if surface_state.height == new_height
+            || surface_state.pending_popup_height == Some(new_height)
+        {
+            return;
+        }
+        let SurfaceRole::Popup { popup, config, .. } = &surface_state.role else {
+            return;
+        };
+        // xdg_popup.reposition needs protocol v3
+        if popup.xdg_popup().version() < 3 {
+            return;
+        }
+        let Some(positioner) =
+            Self::build_popup_positioner(xdg_shell, config, (config.width, new_height))
+        else {
+            return;
+        };
+        self.popups.reposition_token = self.popups.reposition_token.wrapping_add(1);
+        popup.reposition(&positioner, self.popups.reposition_token);
+        surface_state.pending_popup_height = Some(new_height);
+        log::debug!("Popup {:?} repositioning to height {}", id, new_height);
+    }
+}
+
+/// Map guido's popup anchor point to the xdg_positioner anchor.
+fn popup_point_to_anchor(point: crate::surface::PopupAnchor) -> xdg_positioner::Anchor {
+    use crate::surface::PopupAnchor as P;
+    match point {
+        P::None => xdg_positioner::Anchor::None,
+        P::Top => xdg_positioner::Anchor::Top,
+        P::Bottom => xdg_positioner::Anchor::Bottom,
+        P::Left => xdg_positioner::Anchor::Left,
+        P::Right => xdg_positioner::Anchor::Right,
+        P::TopLeft => xdg_positioner::Anchor::TopLeft,
+        P::BottomLeft => xdg_positioner::Anchor::BottomLeft,
+        P::TopRight => xdg_positioner::Anchor::TopRight,
+        P::BottomRight => xdg_positioner::Anchor::BottomRight,
+    }
+}
+
+/// Map guido's popup gravity to the xdg_positioner gravity.
+fn popup_point_to_gravity(point: crate::surface::PopupAnchor) -> xdg_positioner::Gravity {
+    use crate::surface::PopupAnchor as P;
+    match point {
+        P::None => xdg_positioner::Gravity::None,
+        P::Top => xdg_positioner::Gravity::Top,
+        P::Bottom => xdg_positioner::Gravity::Bottom,
+        P::Left => xdg_positioner::Gravity::Left,
+        P::Right => xdg_positioner::Gravity::Right,
+        P::TopLeft => xdg_positioner::Gravity::TopLeft,
+        P::BottomLeft => xdg_positioner::Gravity::BottomLeft,
+        P::TopRight => xdg_positioner::Gravity::TopRight,
+        P::BottomRight => xdg_positioner::Gravity::BottomRight,
+    }
+}
+
+impl PopupHandler for WaylandState {
+    fn configure(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        popup: &Popup,
+        config: PopupConfigure,
+    ) {
+        // Route to the matching surface state, like the layer-shell path.
+        // sctk has already acked; the compositor may have adjusted size and
+        // position to keep the popup on screen.
+        let surface_id = self.surface_lookup.get(&popup.wl_surface().id()).copied();
+        if let Some(id) = surface_id
+            && let Some(surface_state) = self.surfaces.get_mut(&id)
+        {
+            log::info!(
+                "Popup {:?} configure: {}x{} at {:?}",
+                id,
+                config.width,
+                config.height,
+                config.position
+            );
+            if config.width > 0 {
+                surface_state.width = config.width as u32;
+            }
+            if config.height > 0 {
+                surface_state.height = config.height as u32;
+            }
+            surface_state.pending_popup_height = None;
+            surface_state.configured = true;
+            crate::jobs::request_frame();
+        }
+    }
+
+    fn done(&mut self, _conn: &Connection, _qh: &QueueHandle<Self>, popup: &Popup) {
+        // Compositor dismissed the popup (outside click on a grab, parent
+        // gone). Flip the reactive dismissal signal and route through the
+        // normal close command for full teardown.
+        if let Some(id) = self.surface_lookup.get(&popup.wl_surface().id()).copied() {
+            log::info!("Popup {:?} dismissed by compositor", id);
+            crate::surface::mark_popup_dismissed(id);
+            crate::surface::push_surface_command(crate::surface::SurfaceCommand::Close(id));
+        }
+    }
+}
+
+// Not delegate_xdg_shell!: that macro (and sctk's decoration dispatches)
+// drag in WindowHandler bounds — guido has no toplevel windows. Popups need
+// only xdg_wm_base (ping/pong), plus an inert stub for the decoration
+// manager that XdgShell::bind insists on binding (the protocol object has
+// no events).
+smithay_client_toolkit::reexports::client::delegate_dispatch!(WaylandState: [
+    smithay_client_toolkit::reexports::protocols::xdg::shell::client::xdg_wm_base::XdgWmBase: smithay_client_toolkit::globals::GlobalData
+] => XdgShell);
+
+impl
+    Dispatch<
+        smithay_client_toolkit::reexports::protocols::xdg::decoration::zv1::client::zxdg_decoration_manager_v1::ZxdgDecorationManagerV1,
+        smithay_client_toolkit::globals::GlobalData,
+    > for WaylandState
+{
+    fn event(
+        _: &mut Self,
+        _: &smithay_client_toolkit::reexports::protocols::xdg::decoration::zv1::client::zxdg_decoration_manager_v1::ZxdgDecorationManagerV1,
+        _: smithay_client_toolkit::reexports::protocols::xdg::decoration::zv1::client::zxdg_decoration_manager_v1::Event,
+        _: &smithay_client_toolkit::globals::GlobalData,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        unreachable!("zxdg_decoration_manager_v1 has no events");
+    }
+}
+
+delegate_xdg_popup!(WaylandState);

--- a/src/platform/selections.rs
+++ b/src/platform/selections.rs
@@ -129,7 +129,7 @@ impl WaylandState {
 
             // Set selection using the keyboard serial
             if let Some(ref device) = self.selections.data_device {
-                source.set_selection(device, self.keyboard_serial);
+                source.set_selection(device, self.input.keyboard_serial);
                 self.selections.clipboard_source = Some(source);
             }
         }
@@ -155,7 +155,7 @@ impl WaylandState {
             vec!["text/plain;charset=utf-8", "UTF8_STRING", "TEXT", "STRING"],
         );
         self.selections.primary_content = Some(text);
-        source.set_selection(device, self.latest_input_serial);
+        source.set_selection(device, self.input.latest_input_serial);
         self.selections.primary_source = Some(source);
     }
 

--- a/src/platform/selections.rs
+++ b/src/platform/selections.rs
@@ -1,0 +1,541 @@
+//! The two system selections: the clipboard and the primary selection.
+//!
+//! Both work the same way — an offer arrives, a reader thread pulls the
+//! content through a pipe, and the result comes back on the calloop ingress
+//! channel — so they are kept together and share one prefetch path.
+//!
+//! Reading a selection means blocking on a pipe until the owning application
+//! answers, which is why it never happens on the UI thread. Generation
+//! counters drop any result that a newer offer has already made stale.
+
+use std::fs::File;
+use std::io::{Read, Write};
+use std::os::fd::OwnedFd;
+use std::time::{Duration, Instant};
+
+use smithay_client_toolkit::{
+    data_device_manager::{
+        DataDeviceManagerState, ReadPipe,
+        data_device::{DataDevice, DataDeviceHandler},
+        data_offer::DataOfferHandler,
+        data_source::{CopyPasteSource, DataSourceHandler},
+    },
+    delegate_data_device, delegate_primary_selection,
+    primary_selection::{
+        PrimarySelectionManagerState,
+        device::{PrimarySelectionDevice, PrimarySelectionDeviceHandler},
+        selection::{PrimarySelectionSource, PrimarySelectionSourceHandler},
+    },
+};
+
+use smithay_client_toolkit::reexports::client::{
+    Connection, Proxy, QueueHandle,
+    protocol::{
+        wl_data_device::WlDataDevice, wl_data_device_manager::DndAction,
+        wl_data_source::WlDataSource, wl_seat, wl_surface,
+    },
+};
+
+use super::wayland::WaylandState;
+
+/// Which system selection a prefetched content update belongs to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SelectionKind {
+    /// The regular clipboard (Ctrl+C / Ctrl+V).
+    Clipboard,
+    /// The primary selection (select-to-copy / middle-click paste).
+    Primary,
+}
+
+/// Everything the two selections own.
+///
+/// The managers are bound once at startup and are `None` on a compositor that
+/// does not advertise the protocol — the feature then no-ops rather than
+/// failing. The devices arrive later, with the seat.
+pub struct Selections {
+    pub(super) data_device_manager: Option<DataDeviceManagerState>,
+    pub(super) data_device: Option<DataDevice>,
+    pub(super) clipboard_content: Option<String>,
+    pub(super) clipboard_source: Option<CopyPasteSource>,
+
+    pub(super) primary_selection_manager: Option<PrimarySelectionManagerState>,
+    pub(super) primary_selection_device: Option<PrimarySelectionDevice>,
+    pub(super) primary_content: Option<String>,
+    pub(super) primary_source: Option<PrimarySelectionSource>,
+
+    /// Bumped on every new offer. A reader thread stamps its result with the
+    /// generation it started from, and a result that no longer matches is
+    /// dropped: the selection moved on while the pipe was still open.
+    pub(super) selection_generation: u64,
+    pub(super) primary_generation: u64,
+}
+
+impl Selections {
+    pub(super) fn new(
+        data_device_manager: Option<DataDeviceManagerState>,
+        primary_selection_manager: Option<PrimarySelectionManagerState>,
+    ) -> Self {
+        Self {
+            data_device_manager,
+            data_device: None,
+            clipboard_content: None,
+            clipboard_source: None,
+            primary_selection_manager,
+            primary_selection_device: None,
+            primary_content: None,
+            primary_source: None,
+            selection_generation: 0,
+            primary_generation: 0,
+        }
+    }
+
+    /// Bind both devices to a seat that just reported a keyboard.
+    ///
+    /// Selections hang off the seat, so they cannot be created at startup with
+    /// the managers — they wait for the capability.
+    pub(super) fn attach_devices(
+        &mut self,
+        qh: &QueueHandle<WaylandState>,
+        seat: &wl_seat::WlSeat,
+    ) {
+        if self.data_device.is_none()
+            && let Some(ref manager) = self.data_device_manager
+        {
+            log::info!("Creating data device for clipboard");
+            self.data_device = Some(manager.get_data_device(qh, seat));
+        }
+
+        if self.primary_selection_device.is_none()
+            && let Some(ref manager) = self.primary_selection_manager
+        {
+            log::info!("Creating primary selection device");
+            self.primary_selection_device = Some(manager.get_selection_device(qh, seat));
+        }
+    }
+}
+
+impl WaylandState {
+    /// Set clipboard content (copy)
+    pub fn set_clipboard(&mut self, text: String, qh: &QueueHandle<Self>) {
+        if let Some(ref manager) = self.selections.data_device_manager {
+            // Create a data source for the clipboard
+            let source = manager.create_copy_paste_source(
+                qh,
+                vec!["text/plain;charset=utf-8", "UTF8_STRING", "TEXT", "STRING"],
+            );
+
+            // Store the text to write when compositor requests it
+            self.selections.clipboard_content = Some(text);
+
+            // Set selection using the keyboard serial
+            if let Some(ref device) = self.selections.data_device {
+                source.set_selection(device, self.keyboard_serial);
+                self.selections.clipboard_source = Some(source);
+            }
+        }
+    }
+
+    /// Get clipboard content (paste)
+    /// Returns the content if available, or None if clipboard is empty
+    pub fn get_clipboard(&self) -> Option<String> {
+        self.selections.clipboard_content.clone()
+    }
+
+    /// Set the primary selection content (select-to-copy).
+    pub fn set_primary(&mut self, text: String, qh: &QueueHandle<Self>) {
+        let Some(ref manager) = self.selections.primary_selection_manager else {
+            return;
+        };
+        let Some(ref device) = self.selections.primary_selection_device else {
+            return;
+        };
+
+        let source = manager.create_selection_source(
+            qh,
+            vec!["text/plain;charset=utf-8", "UTF8_STRING", "TEXT", "STRING"],
+        );
+        self.selections.primary_content = Some(text);
+        source.set_selection(device, self.latest_input_serial);
+        self.selections.primary_source = Some(source);
+    }
+
+    /// Apply a prefetched clipboard/primary content update (from the loop's
+    /// ingress channel callback). Reads made stale by a newer offer are
+    /// dropped via the generation check.
+    pub(crate) fn apply_clipboard_update(
+        &mut self,
+        kind: SelectionKind,
+        generation: u64,
+        content: Option<String>,
+    ) {
+        let current = match kind {
+            SelectionKind::Clipboard => self.selections.selection_generation,
+            SelectionKind::Primary => self.selections.primary_generation,
+        };
+        if generation != current {
+            log::debug!("Dropping stale {kind:?} content (gen {generation} != {current})");
+            return;
+        }
+        match kind {
+            SelectionKind::Clipboard => match content {
+                Some(text) => crate::reactive::set_system_clipboard(text),
+                None => crate::reactive::clear_system_clipboard(),
+            },
+            SelectionKind::Primary => crate::reactive::set_system_primary(content),
+        }
+    }
+
+    /// Start an async prefetch of an offer's content on a reader thread.
+    /// `receive` turns a chosen mime type into a read pipe. The result comes
+    /// back through the calloop ingress channel — the message itself wakes
+    /// the loop, no hand-rolled wakeup involved.
+    fn prefetch_selection<R>(&mut self, kind: SelectionKind, mimes: Vec<String>, receive: R)
+    where
+        R: FnOnce(&str) -> Option<ReadPipe>,
+    {
+        let generation = match kind {
+            SelectionKind::Clipboard => {
+                self.selections.selection_generation += 1;
+                self.selections.selection_generation
+            }
+            SelectionKind::Primary => {
+                self.selections.primary_generation += 1;
+                self.selections.primary_generation
+            }
+        };
+
+        // Preferred mime order; take the first one offered.
+        const PREFERRED: [&str; 5] = [
+            "text/plain;charset=utf-8",
+            "UTF8_STRING",
+            "text/plain",
+            "TEXT",
+            "STRING",
+        ];
+        let mime = PREFERRED
+            .iter()
+            .find(|m| mimes.iter().any(|t| t == *m))
+            .copied();
+
+        let Some(pipe) = mime.and_then(receive) else {
+            // Nothing readable as text — treat as cleared. We're on the main
+            // thread (called from a selection handler), so apply directly.
+            self.apply_clipboard_update(kind, generation, None);
+            return;
+        };
+
+        let Some(sender) = crate::ingress::sender() else {
+            // No running event loop to deliver the result to.
+            log::warn!("Selection prefetch skipped: no event loop running");
+            return;
+        };
+
+        if let Err(e) = std::thread::Builder::new()
+            .name("guido-clipboard-read".into())
+            .spawn(move || {
+                let content = read_pipe_with_deadline(pipe, Duration::from_secs(3));
+                let _ = sender.send(crate::ingress::IngressMessage::ClipboardUpdate {
+                    kind,
+                    generation,
+                    content,
+                });
+            })
+        {
+            log::warn!("Failed to spawn clipboard reader thread: {e}");
+        }
+    }
+}
+
+/// Read a selection pipe to EOF with a total deadline. Runs on a reader
+/// thread — never on the UI thread.
+fn read_pipe_with_deadline(pipe: ReadPipe, deadline: Duration) -> Option<String> {
+    use std::os::unix::io::AsRawFd;
+
+    let fd = OwnedFd::from(pipe);
+    let mut file = File::from(fd);
+    let raw_fd = file.as_raw_fd();
+    let mut buf = Vec::new();
+    let end = Instant::now() + deadline;
+
+    loop {
+        let remaining = end.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            log::warn!("Clipboard read timed out after {:?}", deadline);
+            return None;
+        }
+
+        let mut poll_fd = libc::pollfd {
+            fd: raw_fd,
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        let timeout_ms = remaining.as_millis().min(i32::MAX as u128) as i32;
+        let ret = unsafe { libc::poll(&mut poll_fd, 1, timeout_ms) };
+        if ret < 0 {
+            let err = std::io::Error::last_os_error();
+            if err.kind() == std::io::ErrorKind::Interrupted {
+                continue;
+            }
+            log::warn!("Clipboard read poll failed: {err}");
+            return None;
+        }
+        if ret == 0 {
+            log::warn!("Clipboard read timed out after {:?}", deadline);
+            return None;
+        }
+
+        // POLLIN or POLLHUP: data available or writer closed — read either way
+        let mut chunk = [0u8; 8192];
+        match file.read(&mut chunk) {
+            Ok(0) => break, // EOF
+            Ok(n) => buf.extend_from_slice(&chunk[..n]),
+            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(e) => {
+                log::warn!("Clipboard read failed: {e}");
+                return None;
+            }
+        }
+    }
+
+    let text = String::from_utf8_lossy(&buf).into_owned();
+    (!text.is_empty()).then_some(text)
+}
+
+impl DataDeviceHandler for WaylandState {
+    fn enter(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _data_device: &WlDataDevice,
+        _x: f64,
+        _y: f64,
+        _surface: &wl_surface::WlSurface,
+    ) {
+        // Drag and drop enter - not used for clipboard
+    }
+
+    fn leave(&mut self, _conn: &Connection, _qh: &QueueHandle<Self>, _data_device: &WlDataDevice) {
+        // Drag and drop leave - not used for clipboard
+    }
+
+    fn motion(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _data_device: &WlDataDevice,
+        _x: f64,
+        _y: f64,
+    ) {
+        // Drag and drop motion - not used for clipboard
+    }
+
+    fn drop_performed(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _data_device: &WlDataDevice,
+    ) {
+        // Drag and drop performed - not used for clipboard
+    }
+
+    fn selection(
+        &mut self,
+        conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _data_device: &WlDataDevice,
+    ) {
+        log::debug!("Clipboard selection changed");
+        // Prefetch the new selection's content on a reader thread so paste
+        // is instant and never blocks the UI thread.
+        let offer = self
+            .selections
+            .data_device
+            .as_ref()
+            .and_then(|device| device.data().selection_offer());
+        match offer {
+            None => {
+                // Selection cleared — main thread, apply directly.
+                self.selections.selection_generation += 1;
+                let generation = self.selections.selection_generation;
+                self.apply_clipboard_update(SelectionKind::Clipboard, generation, None);
+            }
+            Some(offer) => {
+                let mimes = offer.with_mime_types(|t| t.to_vec());
+                self.prefetch_selection(SelectionKind::Clipboard, mimes, |mime| {
+                    offer
+                        .receive(mime.to_string())
+                        .map_err(|e| log::debug!("Failed to receive clipboard as {mime}: {e:?}"))
+                        .ok()
+                });
+                // Send the receive request out now so the source app starts
+                // writing before the next loop-iteration flush.
+                let _ = conn.flush();
+            }
+        }
+    }
+}
+
+impl PrimarySelectionDeviceHandler for WaylandState {
+    fn selection(
+        &mut self,
+        conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        device: &smithay_client_toolkit::reexports::protocols::wp::primary_selection::zv1::client::zwp_primary_selection_device_v1::ZwpPrimarySelectionDeviceV1,
+    ) {
+        log::debug!("Primary selection changed");
+        let offer = device
+            .data::<smithay_client_toolkit::primary_selection::device::PrimarySelectionDeviceData>()
+            .and_then(|data| data.selection_offer());
+        match offer {
+            None => {
+                // Primary selection cleared — main thread, apply directly.
+                self.selections.primary_generation += 1;
+                let generation = self.selections.primary_generation;
+                self.apply_clipboard_update(SelectionKind::Primary, generation, None);
+            }
+            Some(offer) => {
+                let mimes = offer.with_mime_types(|t| t.to_vec());
+                self.prefetch_selection(SelectionKind::Primary, mimes, |mime| {
+                    offer
+                        .receive(mime.to_string())
+                        .map_err(|e| log::debug!("Failed to receive primary as {mime}: {e:?}"))
+                        .ok()
+                });
+                let _ = conn.flush();
+            }
+        }
+    }
+}
+
+impl PrimarySelectionSourceHandler for WaylandState {
+    fn send_request(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _source: &smithay_client_toolkit::reexports::protocols::wp::primary_selection::zv1::client::zwp_primary_selection_source_v1::ZwpPrimarySelectionSourceV1,
+        mime: String,
+        write_pipe: smithay_client_toolkit::data_device_manager::WritePipe,
+    ) {
+        log::debug!("Primary selection send request for mime type: {mime}");
+        if let Some(ref content) = self.selections.primary_content {
+            let content = content.clone();
+            let owned_fd = OwnedFd::from(write_pipe);
+            if let Err(e) = std::thread::Builder::new()
+                .name("guido-primary-send".into())
+                .spawn(move || {
+                    let mut file = File::from(owned_fd);
+                    if let Err(e) = file.write_all(content.as_bytes()) {
+                        log::warn!("Failed to write primary selection content: {e}");
+                    }
+                })
+            {
+                log::warn!("Failed to spawn primary selection writer thread: {e}");
+            }
+        }
+    }
+
+    fn cancelled(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _source: &smithay_client_toolkit::reexports::protocols::wp::primary_selection::zv1::client::zwp_primary_selection_source_v1::ZwpPrimarySelectionSourceV1,
+    ) {
+        log::debug!("Primary selection source cancelled");
+        self.selections.primary_source = None;
+    }
+}
+
+impl DataOfferHandler for WaylandState {
+    fn source_actions(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _offer: &mut smithay_client_toolkit::data_device_manager::data_offer::DragOffer,
+        _actions: DndAction,
+    ) {
+        // Drag and drop actions - not used for clipboard
+    }
+
+    fn selected_action(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _offer: &mut smithay_client_toolkit::data_device_manager::data_offer::DragOffer,
+        _action: DndAction,
+    ) {
+        // Drag and drop selected action - not used for clipboard
+    }
+}
+
+impl DataSourceHandler for WaylandState {
+    fn accept_mime(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _source: &WlDataSource,
+        _mime: Option<String>,
+    ) {
+        // Mime type accepted notification
+    }
+
+    fn send_request(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _source: &WlDataSource,
+        mime: String,
+        fd: smithay_client_toolkit::data_device_manager::WritePipe,
+    ) {
+        log::debug!("Clipboard send request for mime type: {}", mime);
+
+        // Write clipboard content on a short-lived thread: a payload larger
+        // than the pipe buffer with a slow reader would otherwise block the
+        // UI thread indefinitely inside write_all.
+        if let Some(ref content) = self.selections.clipboard_content {
+            let content = content.clone();
+            let owned_fd = OwnedFd::from(fd);
+            if let Err(e) = std::thread::Builder::new()
+                .name("guido-clipboard-send".into())
+                .spawn(move || {
+                    let mut file = File::from(owned_fd);
+                    if let Err(e) = file.write_all(content.as_bytes()) {
+                        log::warn!("Failed to write clipboard content: {}", e);
+                    }
+                })
+            {
+                log::warn!("Failed to spawn clipboard writer thread: {e}");
+            }
+        }
+    }
+
+    fn cancelled(&mut self, _conn: &Connection, _qh: &QueueHandle<Self>, _source: &WlDataSource) {
+        log::debug!("Clipboard source cancelled");
+        self.selections.clipboard_source = None;
+    }
+
+    fn dnd_dropped(&mut self, _conn: &Connection, _qh: &QueueHandle<Self>, _source: &WlDataSource) {
+        // Drag and drop completed - not used for clipboard
+    }
+
+    fn dnd_finished(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _source: &WlDataSource,
+    ) {
+        // Drag and drop finished - not used for clipboard
+    }
+
+    fn action(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _source: &WlDataSource,
+        _action: DndAction,
+    ) {
+        // Action notification - not used for clipboard
+    }
+}
+
+delegate_data_device!(WaylandState);
+delegate_primary_selection!(WaylandState);

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -4,19 +4,9 @@ use raw_window_handle::{
 };
 use smithay_client_toolkit::{
     compositor::{CompositorHandler, CompositorState, Region},
-    data_device_manager::{
-        data_device::{DataDevice, DataDeviceHandler},
-        data_offer::DataOfferHandler,
-        data_source::{CopyPasteSource, DataSourceHandler},
-        DataDeviceManagerState, ReadPipe,
-    },
-    delegate_primary_selection,
-    primary_selection::{
-        device::{PrimarySelectionDevice, PrimarySelectionDeviceHandler},
-        selection::{PrimarySelectionSource, PrimarySelectionSourceHandler},
-        PrimarySelectionManagerState,
-    },
-    delegate_compositor, delegate_data_device, delegate_keyboard, delegate_layer, delegate_output,
+    data_device_manager::DataDeviceManagerState,
+    primary_selection::PrimarySelectionManagerState,
+    delegate_compositor, delegate_keyboard, delegate_layer, delegate_output,
     delegate_pointer, delegate_registry, delegate_seat,
     output::{OutputHandler, OutputState},
     registry::{ProvidesRegistryState, RegistryState},
@@ -52,8 +42,7 @@ use smithay_client_toolkit::reexports::protocols::xdg::shell::client::xdg_positi
 use smithay_client_toolkit::reexports::client::{
     globals::registry_queue_init,
     protocol::{
-        wl_data_device::WlDataDevice, wl_data_device_manager::DndAction,
-        wl_data_source::WlDataSource, wl_keyboard, wl_output, wl_pointer, wl_seat, wl_surface,
+        wl_keyboard, wl_output, wl_pointer, wl_seat, wl_surface,
         wl_touch,
     },
     Connection, Dispatch, EventQueue, Proxy, QueueHandle, WEnum, delegate_noop,
@@ -66,11 +55,8 @@ use wayland_protocols::ext::background_effect::v1::client::{
 };
 
 use std::collections::HashMap;
-use std::fs::File;
-use std::io::{Read, Write};
-use std::os::unix::io::OwnedFd;
-use std::time::{Duration, Instant};
 
+use super::selections::Selections;
 use crate::blur::BlurRect;
 use crate::outputs::{self, OutputId, OutputInfo};
 use crate::reactive::CursorIcon;
@@ -245,7 +231,7 @@ pub struct WaylandState {
     // Keyboard state
     keyboard: Option<wl_keyboard::WlKeyboard>,
     modifiers: Modifiers,
-    keyboard_serial: u32,
+    pub(super) keyboard_serial: u32,
     /// Track raw_code → Key for press/release matching (handles compose sequences)
     pressed_keys: HashMap<u32, Key>,
     /// Key repeat runs on a calloop timer owned by the toolkit, armed with the
@@ -253,34 +239,11 @@ pub struct WaylandState {
     /// seat capability callback, which has no other route to the loop.
     loop_handle: LoopHandle<'static, WaylandState>,
 
-    // Clipboard state
-    data_device_manager: Option<DataDeviceManagerState>,
-    data_device: Option<DataDevice>,
-    clipboard_content: Option<String>,
-    clipboard_source: Option<CopyPasteSource>,
+    /// Clipboard and primary selection — see [`super::selections`].
+    pub(super) selections: Selections,
 
-    // Primary selection (select-to-copy / middle-click paste)
-    primary_selection_manager: Option<PrimarySelectionManagerState>,
-    primary_selection_device: Option<PrimarySelectionDevice>,
-    primary_content: Option<String>,
-    primary_source: Option<PrimarySelectionSource>,
-
-    // Async clipboard prefetch: whenever a selection offer changes, a reader
-    // thread fetches its content and delivers it through the calloop ingress
-    // channel. Generation counters drop results made stale by a newer offer.
-    selection_generation: u64,
-    primary_generation: u64,
     /// Serial of the most recent input event, needed to claim selections.
-    latest_input_serial: u32,
-}
-
-/// Which system selection a prefetched content update belongs to.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SelectionKind {
-    /// The regular clipboard (Ctrl+C / Ctrl+V).
-    Clipboard,
-    /// The primary selection (select-to-copy / middle-click paste).
-    Primary,
+    pub(super) latest_input_serial: u32,
 }
 
 /// Why the platform layer could not start or continue.
@@ -420,16 +383,7 @@ pub fn create_wayland_app(
         keyboard_serial: 0,
         pressed_keys: HashMap::new(),
         loop_handle,
-        data_device_manager,
-        data_device: None,
-        clipboard_content: None,
-        clipboard_source: None,
-        primary_selection_manager,
-        primary_selection_device: None,
-        primary_content: None,
-        primary_source: None,
-        selection_generation: 0,
-        primary_generation: 0,
+        selections: Selections::new(data_device_manager, primary_selection_manager),
         latest_input_serial: 0,
     };
 
@@ -1154,136 +1108,6 @@ impl WaylandState {
             .any(|s| !s.first_frame_presented || !s.scale_factor_received)
     }
 
-    /// Set clipboard content (copy)
-    pub fn set_clipboard(&mut self, text: String, qh: &QueueHandle<Self>) {
-        if let Some(ref manager) = self.data_device_manager {
-            // Create a data source for the clipboard
-            let source = manager.create_copy_paste_source(
-                qh,
-                vec!["text/plain;charset=utf-8", "UTF8_STRING", "TEXT", "STRING"],
-            );
-
-            // Store the text to write when compositor requests it
-            self.clipboard_content = Some(text);
-
-            // Set selection using the keyboard serial
-            if let Some(ref device) = self.data_device {
-                source.set_selection(device, self.keyboard_serial);
-                self.clipboard_source = Some(source);
-            }
-        }
-    }
-
-    /// Get clipboard content (paste)
-    /// Returns the content if available, or None if clipboard is empty
-    pub fn get_clipboard(&self) -> Option<String> {
-        self.clipboard_content.clone()
-    }
-
-    /// Set the primary selection content (select-to-copy).
-    pub fn set_primary(&mut self, text: String, qh: &QueueHandle<Self>) {
-        let Some(ref manager) = self.primary_selection_manager else {
-            return;
-        };
-        let Some(ref device) = self.primary_selection_device else {
-            return;
-        };
-
-        let source = manager.create_selection_source(
-            qh,
-            vec!["text/plain;charset=utf-8", "UTF8_STRING", "TEXT", "STRING"],
-        );
-        self.primary_content = Some(text);
-        source.set_selection(device, self.latest_input_serial);
-        self.primary_source = Some(source);
-    }
-
-    /// Apply a prefetched clipboard/primary content update (from the loop's
-    /// ingress channel callback). Reads made stale by a newer offer are
-    /// dropped via the generation check.
-    pub(crate) fn apply_clipboard_update(
-        &mut self,
-        kind: SelectionKind,
-        generation: u64,
-        content: Option<String>,
-    ) {
-        let current = match kind {
-            SelectionKind::Clipboard => self.selection_generation,
-            SelectionKind::Primary => self.primary_generation,
-        };
-        if generation != current {
-            log::debug!("Dropping stale {kind:?} content (gen {generation} != {current})");
-            return;
-        }
-        match kind {
-            SelectionKind::Clipboard => match content {
-                Some(text) => crate::reactive::set_system_clipboard(text),
-                None => crate::reactive::clear_system_clipboard(),
-            },
-            SelectionKind::Primary => crate::reactive::set_system_primary(content),
-        }
-    }
-
-    /// Start an async prefetch of an offer's content on a reader thread.
-    /// `receive` turns a chosen mime type into a read pipe. The result comes
-    /// back through the calloop ingress channel — the message itself wakes
-    /// the loop, no hand-rolled wakeup involved.
-    fn prefetch_selection<R>(&mut self, kind: SelectionKind, mimes: Vec<String>, receive: R)
-    where
-        R: FnOnce(&str) -> Option<ReadPipe>,
-    {
-        let generation = match kind {
-            SelectionKind::Clipboard => {
-                self.selection_generation += 1;
-                self.selection_generation
-            }
-            SelectionKind::Primary => {
-                self.primary_generation += 1;
-                self.primary_generation
-            }
-        };
-
-        // Preferred mime order; take the first one offered.
-        const PREFERRED: [&str; 5] = [
-            "text/plain;charset=utf-8",
-            "UTF8_STRING",
-            "text/plain",
-            "TEXT",
-            "STRING",
-        ];
-        let mime = PREFERRED
-            .iter()
-            .find(|m| mimes.iter().any(|t| t == *m))
-            .copied();
-
-        let Some(pipe) = mime.and_then(receive) else {
-            // Nothing readable as text — treat as cleared. We're on the main
-            // thread (called from a selection handler), so apply directly.
-            self.apply_clipboard_update(kind, generation, None);
-            return;
-        };
-
-        let Some(sender) = crate::ingress::sender() else {
-            // No running event loop to deliver the result to.
-            log::warn!("Selection prefetch skipped: no event loop running");
-            return;
-        };
-
-        if let Err(e) = std::thread::Builder::new()
-            .name("guido-clipboard-read".into())
-            .spawn(move || {
-                let content = read_pipe_with_deadline(pipe, Duration::from_secs(3));
-                let _ = sender.send(crate::ingress::IngressMessage::ClipboardUpdate {
-                    kind,
-                    generation,
-                    content,
-                });
-            })
-        {
-            log::warn!("Failed to spawn clipboard reader thread: {e}");
-        }
-    }
-
     /// Set the cursor shape
     pub fn set_cursor(&self, cursor: CursorIcon, qh: &QueueHandle<Self>) {
         let Some(ref manager) = self.cursor_shape_manager else {
@@ -1321,61 +1145,6 @@ impl WaylandState {
         let device = manager.get_shape_device(pointer, qh);
         device.set_shape(self.pointer_enter_serial, shape);
     }
-}
-
-/// Read a selection pipe to EOF with a total deadline. Runs on a reader
-/// thread — never on the UI thread.
-fn read_pipe_with_deadline(pipe: ReadPipe, deadline: Duration) -> Option<String> {
-    use std::os::unix::io::AsRawFd;
-
-    let fd = OwnedFd::from(pipe);
-    let mut file = File::from(fd);
-    let raw_fd = file.as_raw_fd();
-    let mut buf = Vec::new();
-    let end = Instant::now() + deadline;
-
-    loop {
-        let remaining = end.saturating_duration_since(Instant::now());
-        if remaining.is_zero() {
-            log::warn!("Clipboard read timed out after {:?}", deadline);
-            return None;
-        }
-
-        let mut poll_fd = libc::pollfd {
-            fd: raw_fd,
-            events: libc::POLLIN,
-            revents: 0,
-        };
-        let timeout_ms = remaining.as_millis().min(i32::MAX as u128) as i32;
-        let ret = unsafe { libc::poll(&mut poll_fd, 1, timeout_ms) };
-        if ret < 0 {
-            let err = std::io::Error::last_os_error();
-            if err.kind() == std::io::ErrorKind::Interrupted {
-                continue;
-            }
-            log::warn!("Clipboard read poll failed: {err}");
-            return None;
-        }
-        if ret == 0 {
-            log::warn!("Clipboard read timed out after {:?}", deadline);
-            return None;
-        }
-
-        // POLLIN or POLLHUP: data available or writer closed — read either way
-        let mut chunk = [0u8; 8192];
-        match file.read(&mut chunk) {
-            Ok(0) => break, // EOF
-            Ok(n) => buf.extend_from_slice(&chunk[..n]),
-            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
-            Err(e) => {
-                log::warn!("Clipboard read failed: {e}");
-                return None;
-            }
-        }
-    }
-
-    let text = String::from_utf8_lossy(&buf).into_owned();
-    (!text.is_empty()).then_some(text)
 }
 
 pub struct WaylandWindowWrapper {
@@ -1667,22 +1436,9 @@ impl SeatHandler for WaylandState {
             };
             self.keyboard = Some(keyboard);
 
-            // Create data device for clipboard when we have a seat
-            if self.data_device.is_none()
-                && let Some(ref manager) = self.data_device_manager
-            {
-                log::info!("Creating data device for clipboard");
-                let data_device = manager.get_data_device(qh, &seat);
-                self.data_device = Some(data_device);
-            }
-
-            // Create primary selection device alongside it
-            if self.primary_selection_device.is_none()
-                && let Some(ref manager) = self.primary_selection_manager
-            {
-                log::info!("Creating primary selection device");
-                self.primary_selection_device = Some(manager.get_selection_device(qh, &seat));
-            }
+            // Selections hang off the seat, so they cannot be created with
+            // their managers at startup.
+            self.selections.attach_devices(qh, &seat);
         }
     }
 
@@ -2445,241 +2201,6 @@ impl ProvidesRegistryState for WaylandState {
     registry_handlers![OutputState, SeatState];
 }
 
-impl DataDeviceHandler for WaylandState {
-    fn enter(
-        &mut self,
-        _conn: &Connection,
-        _qh: &QueueHandle<Self>,
-        _data_device: &WlDataDevice,
-        _x: f64,
-        _y: f64,
-        _surface: &wl_surface::WlSurface,
-    ) {
-        // Drag and drop enter - not used for clipboard
-    }
-
-    fn leave(&mut self, _conn: &Connection, _qh: &QueueHandle<Self>, _data_device: &WlDataDevice) {
-        // Drag and drop leave - not used for clipboard
-    }
-
-    fn motion(
-        &mut self,
-        _conn: &Connection,
-        _qh: &QueueHandle<Self>,
-        _data_device: &WlDataDevice,
-        _x: f64,
-        _y: f64,
-    ) {
-        // Drag and drop motion - not used for clipboard
-    }
-
-    fn drop_performed(
-        &mut self,
-        _conn: &Connection,
-        _qh: &QueueHandle<Self>,
-        _data_device: &WlDataDevice,
-    ) {
-        // Drag and drop performed - not used for clipboard
-    }
-
-    fn selection(
-        &mut self,
-        conn: &Connection,
-        _qh: &QueueHandle<Self>,
-        _data_device: &WlDataDevice,
-    ) {
-        log::debug!("Clipboard selection changed");
-        // Prefetch the new selection's content on a reader thread so paste
-        // is instant and never blocks the UI thread.
-        let offer = self
-            .data_device
-            .as_ref()
-            .and_then(|device| device.data().selection_offer());
-        match offer {
-            None => {
-                // Selection cleared — main thread, apply directly.
-                self.selection_generation += 1;
-                let generation = self.selection_generation;
-                self.apply_clipboard_update(SelectionKind::Clipboard, generation, None);
-            }
-            Some(offer) => {
-                let mimes = offer.with_mime_types(|t| t.to_vec());
-                self.prefetch_selection(SelectionKind::Clipboard, mimes, |mime| {
-                    offer
-                        .receive(mime.to_string())
-                        .map_err(|e| log::debug!("Failed to receive clipboard as {mime}: {e:?}"))
-                        .ok()
-                });
-                // Send the receive request out now so the source app starts
-                // writing before the next loop-iteration flush.
-                let _ = conn.flush();
-            }
-        }
-    }
-}
-
-impl PrimarySelectionDeviceHandler for WaylandState {
-    fn selection(
-        &mut self,
-        conn: &Connection,
-        _qh: &QueueHandle<Self>,
-        device: &smithay_client_toolkit::reexports::protocols::wp::primary_selection::zv1::client::zwp_primary_selection_device_v1::ZwpPrimarySelectionDeviceV1,
-    ) {
-        log::debug!("Primary selection changed");
-        let offer = device
-            .data::<smithay_client_toolkit::primary_selection::device::PrimarySelectionDeviceData>()
-            .and_then(|data| data.selection_offer());
-        match offer {
-            None => {
-                // Primary selection cleared — main thread, apply directly.
-                self.primary_generation += 1;
-                let generation = self.primary_generation;
-                self.apply_clipboard_update(SelectionKind::Primary, generation, None);
-            }
-            Some(offer) => {
-                let mimes = offer.with_mime_types(|t| t.to_vec());
-                self.prefetch_selection(SelectionKind::Primary, mimes, |mime| {
-                    offer
-                        .receive(mime.to_string())
-                        .map_err(|e| log::debug!("Failed to receive primary as {mime}: {e:?}"))
-                        .ok()
-                });
-                let _ = conn.flush();
-            }
-        }
-    }
-}
-
-impl PrimarySelectionSourceHandler for WaylandState {
-    fn send_request(
-        &mut self,
-        _conn: &Connection,
-        _qh: &QueueHandle<Self>,
-        _source: &smithay_client_toolkit::reexports::protocols::wp::primary_selection::zv1::client::zwp_primary_selection_source_v1::ZwpPrimarySelectionSourceV1,
-        mime: String,
-        write_pipe: smithay_client_toolkit::data_device_manager::WritePipe,
-    ) {
-        log::debug!("Primary selection send request for mime type: {mime}");
-        if let Some(ref content) = self.primary_content {
-            let content = content.clone();
-            let owned_fd = OwnedFd::from(write_pipe);
-            if let Err(e) = std::thread::Builder::new()
-                .name("guido-primary-send".into())
-                .spawn(move || {
-                    let mut file = File::from(owned_fd);
-                    if let Err(e) = file.write_all(content.as_bytes()) {
-                        log::warn!("Failed to write primary selection content: {e}");
-                    }
-                })
-            {
-                log::warn!("Failed to spawn primary selection writer thread: {e}");
-            }
-        }
-    }
-
-    fn cancelled(
-        &mut self,
-        _conn: &Connection,
-        _qh: &QueueHandle<Self>,
-        _source: &smithay_client_toolkit::reexports::protocols::wp::primary_selection::zv1::client::zwp_primary_selection_source_v1::ZwpPrimarySelectionSourceV1,
-    ) {
-        log::debug!("Primary selection source cancelled");
-        self.primary_source = None;
-    }
-}
-
-impl DataOfferHandler for WaylandState {
-    fn source_actions(
-        &mut self,
-        _conn: &Connection,
-        _qh: &QueueHandle<Self>,
-        _offer: &mut smithay_client_toolkit::data_device_manager::data_offer::DragOffer,
-        _actions: DndAction,
-    ) {
-        // Drag and drop actions - not used for clipboard
-    }
-
-    fn selected_action(
-        &mut self,
-        _conn: &Connection,
-        _qh: &QueueHandle<Self>,
-        _offer: &mut smithay_client_toolkit::data_device_manager::data_offer::DragOffer,
-        _action: DndAction,
-    ) {
-        // Drag and drop selected action - not used for clipboard
-    }
-}
-
-impl DataSourceHandler for WaylandState {
-    fn accept_mime(
-        &mut self,
-        _conn: &Connection,
-        _qh: &QueueHandle<Self>,
-        _source: &WlDataSource,
-        _mime: Option<String>,
-    ) {
-        // Mime type accepted notification
-    }
-
-    fn send_request(
-        &mut self,
-        _conn: &Connection,
-        _qh: &QueueHandle<Self>,
-        _source: &WlDataSource,
-        mime: String,
-        fd: smithay_client_toolkit::data_device_manager::WritePipe,
-    ) {
-        log::debug!("Clipboard send request for mime type: {}", mime);
-
-        // Write clipboard content on a short-lived thread: a payload larger
-        // than the pipe buffer with a slow reader would otherwise block the
-        // UI thread indefinitely inside write_all.
-        if let Some(ref content) = self.clipboard_content {
-            let content = content.clone();
-            let owned_fd = OwnedFd::from(fd);
-            if let Err(e) = std::thread::Builder::new()
-                .name("guido-clipboard-send".into())
-                .spawn(move || {
-                    let mut file = File::from(owned_fd);
-                    if let Err(e) = file.write_all(content.as_bytes()) {
-                        log::warn!("Failed to write clipboard content: {}", e);
-                    }
-                })
-            {
-                log::warn!("Failed to spawn clipboard writer thread: {e}");
-            }
-        }
-    }
-
-    fn cancelled(&mut self, _conn: &Connection, _qh: &QueueHandle<Self>, _source: &WlDataSource) {
-        log::debug!("Clipboard source cancelled");
-        self.clipboard_source = None;
-    }
-
-    fn dnd_dropped(&mut self, _conn: &Connection, _qh: &QueueHandle<Self>, _source: &WlDataSource) {
-        // Drag and drop completed - not used for clipboard
-    }
-
-    fn dnd_finished(
-        &mut self,
-        _conn: &Connection,
-        _qh: &QueueHandle<Self>,
-        _source: &WlDataSource,
-    ) {
-        // Drag and drop finished - not used for clipboard
-    }
-
-    fn action(
-        &mut self,
-        _conn: &Connection,
-        _qh: &QueueHandle<Self>,
-        _source: &WlDataSource,
-        _action: DndAction,
-    ) {
-        // Action notification - not used for clipboard
-    }
-}
-
 delegate_compositor!(WaylandState);
 delegate_output!(WaylandState);
 delegate_layer!(WaylandState);
@@ -2687,6 +2208,4 @@ delegate_seat!(WaylandState);
 delegate_pointer!(WaylandState);
 delegate_touch!(WaylandState);
 delegate_keyboard!(WaylandState);
-delegate_data_device!(WaylandState);
-delegate_primary_selection!(WaylandState);
 delegate_registry!(WaylandState);

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -8,31 +8,23 @@ use smithay_client_toolkit::reexports::client::{
     globals::registry_queue_init,
     protocol::{wl_output, wl_surface},
 };
-use smithay_client_toolkit::reexports::protocols::xdg::shell::client::xdg_positioner;
 use smithay_client_toolkit::{
     compositor::{CompositorHandler, CompositorState, Region},
     data_device_manager::DataDeviceManagerState,
-    delegate_compositor, delegate_layer, delegate_registry, delegate_session_lock,
-    delegate_xdg_popup,
+    delegate_compositor, delegate_layer, delegate_registry,
     output::OutputState,
     primary_selection::PrimarySelectionManagerState,
     registry::{ProvidesRegistryState, RegistryState},
     registry_handlers,
     seat::{SeatState, pointer::cursor_shape::CursorShapeManager},
-    session_lock::{
-        SessionLock, SessionLockHandler, SessionLockState, SessionLockSurface,
-        SessionLockSurfaceConfigure,
-    },
+    session_lock::{SessionLockState, SessionLockSurface},
     shell::{
         WaylandSurface,
         wlr_layer::{
             Anchor, KeyboardInteractivity, Layer, LayerShell, LayerShellHandler, LayerSurface,
             LayerSurfaceConfigure,
         },
-        xdg::{
-            XdgPositioner, XdgShell,
-            popup::{Popup, PopupConfigure, PopupHandler},
-        },
+        xdg::{XdgShell, popup::Popup},
     },
 };
 use wayland_backend::sys::client::ObjectId;
@@ -46,10 +38,12 @@ use wayland_protocols::ext::background_effect::v1::client::{
 use std::collections::HashMap;
 
 use super::input::InputState;
+use super::lock::Lock;
 use super::outputs::OutputRegistry;
+use super::popups::Popups;
 use super::selections::Selections;
 use crate::blur::BlurRect;
-use crate::outputs::{self, OutputId};
+use crate::outputs::{self};
 use crate::surface::SurfaceId;
 use crate::widgets::{Event, Rect};
 
@@ -114,7 +108,7 @@ pub struct WaylandSurfaceState {
     blur_region: Option<Vec<BlurRect>>,
     /// Height sent in an in-flight popup reposition (cleared by the popup
     /// configure), so repeated content measurements don't re-send it.
-    pending_popup_height: Option<u32>,
+    pub(super) pending_popup_height: Option<u32>,
 }
 
 impl WaylandSurfaceState {
@@ -177,20 +171,11 @@ pub struct WaylandState {
     /// Whether the compositor currently advertises the Blur capability.
     bg_effect_supports_blur: bool,
 
-    // xdg shell (popups anchored to layer surfaces)
-    /// `None` where xdg_wm_base is unavailable — popups then fail with a log.
-    xdg_shell: Option<XdgShell>,
-    /// Monotonic token for xdg_popup.reposition requests.
-    reposition_token: u32,
+    /// xdg popups anchored to a surface — see [`super::popups`].
+    pub(super) popups: Popups,
 
-    // Session lock (ext-session-lock-v1)
-    session_lock_state: SessionLockState,
-    /// The active lock grant. Written when `start_session_lock` succeeds so a
-    /// synchronous double-lock check can reject a second call; cleared by
-    /// `finished` or `unlock_session`.
-    active_lock: Option<SessionLock>,
-    /// Lock lifecycle events, drained by the main loop.
-    lock_events: Vec<LockEvent>,
+    /// Session lock grant and events — see [`super::lock`].
+    pub(super) lock: Lock,
 
     /// Pointer, touch and keyboard — see [`super::input`].
     pub(super) input: InputState,
@@ -316,11 +301,8 @@ pub fn create_wayland_app(
         outputs: OutputRegistry::new(),
         bg_effect_manager,
         bg_effect_supports_blur: false,
-        xdg_shell,
-        reposition_token: 0,
-        session_lock_state,
-        active_lock: None,
-        lock_events: Vec::new(),
+        popups: Popups::new(xdg_shell),
+        lock: Lock::new(session_lock_state),
         input: InputState::new(cursor_shape_manager, loop_handle),
         selections: Selections::new(data_device_manager, primary_selection_manager),
     };
@@ -377,334 +359,6 @@ impl WaylandState {
                 }
             );
         }
-    }
-
-    /// Request a session lock from the compositor.
-    ///
-    /// Returns false when a lock is already active or the compositor lacks
-    /// ext-session-lock-v1. The grant (or denial) arrives asynchronously as
-    /// a [`LockEvent`].
-    pub fn start_session_lock(&mut self, qh: &QueueHandle<Self>) -> bool {
-        if self.active_lock.is_some() {
-            log::warn!("Session lock requested while a lock is already active");
-            return false;
-        }
-        match self.session_lock_state.lock(qh) {
-            Ok(lock) => {
-                self.active_lock = Some(lock);
-                log::info!("Session lock requested");
-                true
-            }
-            Err(e) => {
-                log::error!("Compositor does not support ext-session-lock-v1: {e}");
-                false
-            }
-        }
-    }
-
-    /// Unlock the session (no-op when not locked).
-    pub fn unlock_session(&mut self) {
-        if let Some(lock) = self.active_lock.take() {
-            lock.unlock();
-            log::info!("Session unlocked");
-        }
-    }
-
-    /// Whether a session lock is currently held and granted.
-    pub fn is_session_locked(&self) -> bool {
-        self.active_lock.as_ref().is_some_and(|l| l.is_locked())
-    }
-
-    /// Create a lock surface for `output` with a specific SurfaceId.
-    ///
-    /// The surface starts at 0×0 — its real size arrives with the first
-    /// lock-surface configure. Returns false without an active lock or when
-    /// the output disconnected.
-    pub fn create_lock_surface_with_id(
-        &mut self,
-        qh: &QueueHandle<Self>,
-        id: SurfaceId,
-        output: OutputId,
-    ) -> bool {
-        let Some(lock) = self.active_lock.clone() else {
-            log::warn!("Cannot create lock surface without an active session lock");
-            return false;
-        };
-        let Some(wl_output) = self.wl_output_for(output) else {
-            log::warn!(
-                "Cannot create lock surface: output {:?} is not connected",
-                output
-            );
-            return false;
-        };
-
-        let wl_surface = self.compositor_state.create_surface(qh);
-        let lock_surface = lock.create_lock_surface(wl_surface.clone(), &wl_output, qh);
-
-        self.surface_lookup.insert(wl_surface.id(), id);
-        let surface_state =
-            WaylandSurfaceState::new(SurfaceRole::Lock(lock_surface), wl_surface, 0, 0);
-        self.surfaces.insert(id, surface_state);
-
-        log::info!("Created lock surface {:?} on output {:?}", id, output);
-        true
-    }
-
-    /// Drain pending session-lock lifecycle events.
-    pub fn take_lock_events(&mut self) -> Vec<LockEvent> {
-        std::mem::take(&mut self.lock_events)
-    }
-
-    /// Build an xdg_positioner for a popup config at the given size.
-    fn build_popup_positioner(
-        xdg_shell: &XdgShell,
-        config: &crate::surface::PopupConfig,
-        size: (u32, u32),
-    ) -> Option<XdgPositioner> {
-        let positioner = match XdgPositioner::new(xdg_shell) {
-            Ok(p) => p,
-            Err(e) => {
-                log::error!("Failed to create xdg_positioner: {e}");
-                return None;
-            }
-        };
-        positioner.set_size(size.0.max(1) as i32, size.1.max(1) as i32);
-        let r = config.anchor_rect;
-        positioner.set_anchor_rect(
-            r.x.floor() as i32,
-            r.y.floor() as i32,
-            (r.width.ceil() as i32).max(1),
-            (r.height.ceil() as i32).max(1),
-        );
-        positioner.set_anchor(popup_point_to_anchor(config.anchor));
-        positioner.set_gravity(popup_point_to_gravity(config.gravity));
-        positioner.set_offset(config.offset.0, config.offset.1);
-        // Let the compositor keep the popup on screen: flip at the screen
-        // edge on either axis, slide where flipping doesn't help.
-        positioner.set_constraint_adjustment(
-            xdg_positioner::ConstraintAdjustment::FlipX
-                | xdg_positioner::ConstraintAdjustment::FlipY
-                | xdg_positioner::ConstraintAdjustment::SlideX
-                | xdg_positioner::ConstraintAdjustment::SlideY,
-        );
-        Some(positioner)
-    }
-
-    /// Create an xdg popup anchored to `parent` with a specific SurfaceId.
-    ///
-    /// `size` is the resolved popup size (config height, or the measured
-    /// content height for auto-height popups). The actual size/position
-    /// arrive with the popup configure (the compositor may flip/slide it to
-    /// stay on screen). Returns false when xdg_wm_base is missing or the
-    /// parent can't host popups.
-    pub fn create_popup_surface_with_id(
-        &mut self,
-        qh: &QueueHandle<Self>,
-        id: SurfaceId,
-        parent: SurfaceId,
-        config: &crate::surface::PopupConfig,
-        size: (u32, u32),
-    ) -> bool {
-        let Some(ref xdg_shell) = self.xdg_shell else {
-            log::error!("Cannot create popup: compositor lacks xdg_wm_base");
-            return false;
-        };
-        let Some(parent_state) = self.surfaces.get(&parent) else {
-            log::warn!("Cannot create popup: parent surface {:?} is gone", parent);
-            return false;
-        };
-
-        let Some(positioner) = Self::build_popup_positioner(xdg_shell, config, size) else {
-            return false;
-        };
-
-        let wl_surface = self.compositor_state.create_surface(qh);
-        let popup = match &parent_state.role {
-            SurfaceRole::Layer(layer_surface) => {
-                let popup =
-                    match Popup::from_surface(None, &positioner, qh, wl_surface.clone(), xdg_shell)
-                    {
-                        Ok(popup) => popup,
-                        Err(e) => {
-                            log::error!("Failed to create xdg popup: {e}");
-                            return false;
-                        }
-                    };
-                // Assign the layer surface as the popup parent BEFORE the
-                // initial commit (required for parentless xdg popups)
-                layer_surface.get_popup(popup.xdg_popup());
-                popup
-            }
-            SurfaceRole::Popup {
-                popup: parent_popup,
-                ..
-            } => {
-                // Nested popup (submenu): ordinary xdg parent
-                let parent_xdg = parent_popup.xdg_surface().clone();
-                match Popup::from_surface(
-                    Some(&parent_xdg),
-                    &positioner,
-                    qh,
-                    wl_surface.clone(),
-                    xdg_shell,
-                ) {
-                    Ok(popup) => popup,
-                    Err(e) => {
-                        log::error!("Failed to create nested xdg popup: {e}");
-                        return false;
-                    }
-                }
-            }
-            SurfaceRole::Lock(_) => {
-                log::warn!("Cannot anchor a popup to a session-lock surface");
-                return false;
-            }
-        };
-
-        // Menu semantics: an input grab dismisses the popup on outside
-        // click. Must be requested before mapping, with a recent serial.
-        if config.grab
-            && let Some(seat) = self.seat_state.seats().next()
-        {
-            popup
-                .xdg_popup()
-                .grab(&seat, self.input.latest_input_serial);
-        }
-
-        wl_surface.commit();
-
-        self.surface_lookup.insert(wl_surface.id(), id);
-        let surface_state = WaylandSurfaceState::new(
-            SurfaceRole::Popup {
-                popup,
-                config: config.clone(),
-                parent,
-            },
-            wl_surface,
-            size.0,
-            size.1,
-        );
-        self.surfaces.insert(id, surface_state);
-
-        log::info!(
-            "Created popup {:?} on parent {:?} ({}x{}, grab: {})",
-            id,
-            parent,
-            size.0,
-            size.1,
-            config.grab
-        );
-        true
-    }
-
-    /// Live popup descendants of `root`, deepest first — the order the
-    /// protocol demands for teardown (a popup must be destroyed before its
-    /// parent, or the compositor raises `not_the_topmost_popup`).
-    pub(crate) fn popup_descendants_bottom_up(&self, root: SurfaceId) -> Vec<SurfaceId> {
-        let mut out = Vec::new();
-        let mut frontier = vec![root];
-        while let Some(current) = frontier.pop() {
-            for (id, state) in &self.surfaces {
-                if let SurfaceRole::Popup { parent, .. } = &state.role
-                    && *parent == current
-                {
-                    out.push(*id);
-                    frontier.push(*id);
-                }
-            }
-        }
-        out.reverse(); // deepest first
-        out
-    }
-
-    /// Grabbing popups that would make a new grab on `new_parent` illegal:
-    /// xdg-shell requires a new grab to nest under the current grab holder,
-    /// so any live grabbing popup that is not `new_parent` itself (or one
-    /// of its ancestors) must be destroyed before the new popup is created.
-    /// Returned deepest-chain-first, ready for ordered teardown.
-    pub(crate) fn conflicting_grab_popups(&self, new_parent: SurfaceId) -> Vec<SurfaceId> {
-        // Ancestor chain of the new popup (surfaces a nested grab may sit on)
-        let mut ancestors = vec![new_parent];
-        let mut current = new_parent;
-        while let Some(state) = self.surfaces.get(&current) {
-            match &state.role {
-                SurfaceRole::Popup { parent, .. } => {
-                    ancestors.push(*parent);
-                    current = *parent;
-                }
-                _ => break,
-            }
-        }
-
-        let mut conflicts: Vec<SurfaceId> = self
-            .surfaces
-            .iter()
-            .filter(|(id, state)| {
-                matches!(&state.role, SurfaceRole::Popup { config, .. } if config.grab)
-                    && !ancestors.contains(id)
-            })
-            .map(|(id, _)| *id)
-            .collect();
-        // Close whole chains children-first: append descendants and dedup
-        let mut ordered = Vec::new();
-        for id in conflicts.drain(..) {
-            for d in self.popup_descendants_bottom_up(id) {
-                if !ordered.contains(&d) {
-                    ordered.push(d);
-                }
-            }
-            if !ordered.contains(&id) {
-                ordered.push(id);
-            }
-        }
-        ordered
-    }
-
-    /// For auto-height popups: the width to measure content at.
-    /// Returns `None` for non-popup surfaces or fixed-height popups.
-    pub(crate) fn popup_auto_width(&self, id: SurfaceId) -> Option<u32> {
-        match &self.surfaces.get(&id)?.role {
-            SurfaceRole::Popup { config, .. } if config.height.is_none() => Some(config.width),
-            _ => None,
-        }
-    }
-
-    /// Reposition an auto-height popup when its content height changed.
-    /// The compositor answers with a new configure carrying the final size.
-    pub(crate) fn reposition_popup_if_changed(
-        &mut self,
-        id: SurfaceId,
-        new_height: u32,
-        qh: &QueueHandle<Self>,
-    ) {
-        let _ = qh;
-        let Some(ref xdg_shell) = self.xdg_shell else {
-            return;
-        };
-        let Some(surface_state) = self.surfaces.get_mut(&id) else {
-            return;
-        };
-        if surface_state.height == new_height
-            || surface_state.pending_popup_height == Some(new_height)
-        {
-            return;
-        }
-        let SurfaceRole::Popup { popup, config, .. } = &surface_state.role else {
-            return;
-        };
-        // xdg_popup.reposition needs protocol v3
-        if popup.xdg_popup().version() < 3 {
-            return;
-        }
-        let Some(positioner) =
-            Self::build_popup_positioner(xdg_shell, config, (config.width, new_height))
-        else {
-            return;
-        };
-        self.reposition_token = self.reposition_token.wrapping_add(1);
-        popup.reposition(&positioner, self.reposition_token);
-        surface_state.pending_popup_height = Some(new_height);
-        log::debug!("Popup {:?} repositioning to height {}", id, new_height);
     }
 
     /// Push a surface's blur region to the compositor if it changed.
@@ -1193,170 +847,6 @@ impl LayerShellHandler for WaylandState {
         }
     }
 }
-
-/// Map guido's popup anchor point to the xdg_positioner anchor.
-fn popup_point_to_anchor(point: crate::surface::PopupAnchor) -> xdg_positioner::Anchor {
-    use crate::surface::PopupAnchor as P;
-    match point {
-        P::None => xdg_positioner::Anchor::None,
-        P::Top => xdg_positioner::Anchor::Top,
-        P::Bottom => xdg_positioner::Anchor::Bottom,
-        P::Left => xdg_positioner::Anchor::Left,
-        P::Right => xdg_positioner::Anchor::Right,
-        P::TopLeft => xdg_positioner::Anchor::TopLeft,
-        P::BottomLeft => xdg_positioner::Anchor::BottomLeft,
-        P::TopRight => xdg_positioner::Anchor::TopRight,
-        P::BottomRight => xdg_positioner::Anchor::BottomRight,
-    }
-}
-
-/// Map guido's popup gravity to the xdg_positioner gravity.
-fn popup_point_to_gravity(point: crate::surface::PopupAnchor) -> xdg_positioner::Gravity {
-    use crate::surface::PopupAnchor as P;
-    match point {
-        P::None => xdg_positioner::Gravity::None,
-        P::Top => xdg_positioner::Gravity::Top,
-        P::Bottom => xdg_positioner::Gravity::Bottom,
-        P::Left => xdg_positioner::Gravity::Left,
-        P::Right => xdg_positioner::Gravity::Right,
-        P::TopLeft => xdg_positioner::Gravity::TopLeft,
-        P::BottomLeft => xdg_positioner::Gravity::BottomLeft,
-        P::TopRight => xdg_positioner::Gravity::TopRight,
-        P::BottomRight => xdg_positioner::Gravity::BottomRight,
-    }
-}
-
-impl SessionLockHandler for WaylandState {
-    fn locked(&mut self, _conn: &Connection, _qh: &QueueHandle<Self>, _session_lock: SessionLock) {
-        log::info!("Session lock granted by compositor");
-        self.lock_events.push(LockEvent::Locked);
-        crate::jobs::request_frame();
-    }
-
-    fn finished(
-        &mut self,
-        _conn: &Connection,
-        _qh: &QueueHandle<Self>,
-        _session_lock: SessionLock,
-    ) {
-        log::info!("Session lock finished (denied or ended)");
-        self.active_lock = None;
-        self.lock_events.push(LockEvent::Finished);
-        crate::jobs::request_frame();
-    }
-
-    fn configure(
-        &mut self,
-        _conn: &Connection,
-        _qh: &QueueHandle<Self>,
-        surface: SessionLockSurface,
-        configure: SessionLockSurfaceConfigure,
-        _serial: u32,
-    ) {
-        // Route to the matching surface state, mirroring the layer-shell
-        // configure path so the same render machinery applies. sctk has
-        // already acked the configure.
-        let surface_id = self.surface_lookup.get(&surface.wl_surface().id()).copied();
-        if let Some(id) = surface_id
-            && let Some(surface_state) = self.surfaces.get_mut(&id)
-        {
-            let (width, height) = configure.new_size;
-            log::info!(
-                "Lock surface {:?} configure: {}x{} (current {}x{})",
-                id,
-                width,
-                height,
-                surface_state.width,
-                surface_state.height
-            );
-            if width > 0 {
-                surface_state.width = width;
-            }
-            if height > 0 {
-                surface_state.height = height;
-            }
-            surface_state.configured = true;
-            crate::jobs::request_frame();
-        }
-    }
-}
-
-delegate_session_lock!(WaylandState);
-
-impl PopupHandler for WaylandState {
-    fn configure(
-        &mut self,
-        _conn: &Connection,
-        _qh: &QueueHandle<Self>,
-        popup: &Popup,
-        config: PopupConfigure,
-    ) {
-        // Route to the matching surface state, like the layer-shell path.
-        // sctk has already acked; the compositor may have adjusted size and
-        // position to keep the popup on screen.
-        let surface_id = self.surface_lookup.get(&popup.wl_surface().id()).copied();
-        if let Some(id) = surface_id
-            && let Some(surface_state) = self.surfaces.get_mut(&id)
-        {
-            log::info!(
-                "Popup {:?} configure: {}x{} at {:?}",
-                id,
-                config.width,
-                config.height,
-                config.position
-            );
-            if config.width > 0 {
-                surface_state.width = config.width as u32;
-            }
-            if config.height > 0 {
-                surface_state.height = config.height as u32;
-            }
-            surface_state.pending_popup_height = None;
-            surface_state.configured = true;
-            crate::jobs::request_frame();
-        }
-    }
-
-    fn done(&mut self, _conn: &Connection, _qh: &QueueHandle<Self>, popup: &Popup) {
-        // Compositor dismissed the popup (outside click on a grab, parent
-        // gone). Flip the reactive dismissal signal and route through the
-        // normal close command for full teardown.
-        if let Some(id) = self.surface_lookup.get(&popup.wl_surface().id()).copied() {
-            log::info!("Popup {:?} dismissed by compositor", id);
-            crate::surface::mark_popup_dismissed(id);
-            crate::surface::push_surface_command(crate::surface::SurfaceCommand::Close(id));
-        }
-    }
-}
-
-// Not delegate_xdg_shell!: that macro (and sctk's decoration dispatches)
-// drag in WindowHandler bounds — guido has no toplevel windows. Popups need
-// only xdg_wm_base (ping/pong), plus an inert stub for the decoration
-// manager that XdgShell::bind insists on binding (the protocol object has
-// no events).
-smithay_client_toolkit::reexports::client::delegate_dispatch!(WaylandState: [
-    smithay_client_toolkit::reexports::protocols::xdg::shell::client::xdg_wm_base::XdgWmBase: smithay_client_toolkit::globals::GlobalData
-] => XdgShell);
-
-impl
-    Dispatch<
-        smithay_client_toolkit::reexports::protocols::xdg::decoration::zv1::client::zxdg_decoration_manager_v1::ZxdgDecorationManagerV1,
-        smithay_client_toolkit::globals::GlobalData,
-    > for WaylandState
-{
-    fn event(
-        _: &mut Self,
-        _: &smithay_client_toolkit::reexports::protocols::xdg::decoration::zv1::client::zxdg_decoration_manager_v1::ZxdgDecorationManagerV1,
-        _: smithay_client_toolkit::reexports::protocols::xdg::decoration::zv1::client::zxdg_decoration_manager_v1::Event,
-        _: &smithay_client_toolkit::globals::GlobalData,
-        _: &Connection,
-        _: &QueueHandle<Self>,
-    ) {
-        unreachable!("zxdg_decoration_manager_v1 has no events");
-    }
-}
-
-delegate_xdg_popup!(WaylandState);
 
 impl Dispatch<ExtBackgroundEffectManagerV1, ()> for WaylandState {
     fn event(

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -2,29 +2,27 @@ use raw_window_handle::{
     DisplayHandle, HandleError, HasDisplayHandle, HasWindowHandle, RawDisplayHandle,
     RawWindowHandle, WaylandDisplayHandle, WaylandWindowHandle, WindowHandle,
 };
+use smithay_client_toolkit::reexports::calloop::LoopHandle;
+use smithay_client_toolkit::reexports::client::{
+    Connection, Dispatch, EventQueue, Proxy, QueueHandle, WEnum, delegate_noop,
+    globals::registry_queue_init,
+    protocol::{wl_output, wl_surface},
+};
+use smithay_client_toolkit::reexports::protocols::xdg::shell::client::xdg_positioner;
 use smithay_client_toolkit::{
     compositor::{CompositorHandler, CompositorState, Region},
     data_device_manager::DataDeviceManagerState,
-    primary_selection::PrimarySelectionManagerState,
-    delegate_compositor, delegate_keyboard, delegate_layer, delegate_output,
-    delegate_pointer, delegate_registry, delegate_seat,
+    delegate_compositor, delegate_layer, delegate_output, delegate_registry, delegate_session_lock,
+    delegate_xdg_popup,
     output::{OutputHandler, OutputState},
+    primary_selection::PrimarySelectionManagerState,
     registry::{ProvidesRegistryState, RegistryState},
     registry_handlers,
-    seat::{
-        keyboard::{KeyEvent, KeyboardHandler, Keysym, Modifiers as WlModifiers, RawModifiers},
-        pointer::{
-            cursor_shape::CursorShapeManager, PointerEvent, PointerEventKind, PointerHandler,
-        },
-        Capability, SeatHandler, SeatState,
-        touch::TouchHandler,
-    },
-    delegate_session_lock, delegate_touch,
+    seat::{SeatState, pointer::cursor_shape::CursorShapeManager},
     session_lock::{
         SessionLock, SessionLockHandler, SessionLockState, SessionLockSurface,
         SessionLockSurfaceConfigure,
     },
-    delegate_xdg_popup,
     shell::{
         WaylandSurface,
         wlr_layer::{
@@ -37,34 +35,22 @@ use smithay_client_toolkit::{
         },
     },
 };
-use smithay_client_toolkit::reexports::calloop::LoopHandle;
-use smithay_client_toolkit::reexports::protocols::xdg::shell::client::xdg_positioner;
-use smithay_client_toolkit::reexports::client::{
-    globals::registry_queue_init,
-    protocol::{
-        wl_keyboard, wl_output, wl_pointer, wl_seat, wl_surface,
-        wl_touch,
-    },
-    Connection, Dispatch, EventQueue, Proxy, QueueHandle, WEnum, delegate_noop,
-};
-use smithay_client_toolkit::reexports::protocols::wp::cursor_shape::v1::client::wp_cursor_shape_device_v1::Shape as WpCursorShape;
 use wayland_backend::sys::client::ObjectId;
 use wayland_protocols::ext::background_effect::v1::client::{
-    ext_background_effect_manager_v1::{self, Capability as BgCapability, ExtBackgroundEffectManagerV1},
+    ext_background_effect_manager_v1::{
+        self, Capability as BgCapability, ExtBackgroundEffectManagerV1,
+    },
     ext_background_effect_surface_v1::ExtBackgroundEffectSurfaceV1,
 };
 
 use std::collections::HashMap;
 
+use super::input::InputState;
 use super::selections::Selections;
 use crate::blur::BlurRect;
 use crate::outputs::{self, OutputId, OutputInfo};
-use crate::reactive::CursorIcon;
 use crate::surface::SurfaceId;
-use crate::widgets::{Event, Key, Modifiers, MouseButton, Rect, ScrollSource};
-
-/// Pixels per line for discrete scroll (mouse wheel)
-const SCROLL_PIXELS_PER_LINE: f32 = 40.0;
+use crate::widgets::{Event, Rect};
 
 /// The shell role of a surface: an ordinary layer-shell surface or an
 /// ext-session-lock-v1 lock surface. Both share the same widget tree, GPU
@@ -209,41 +195,11 @@ pub struct WaylandState {
     /// Lock lifecycle events, drained by the main loop.
     lock_events: Vec<LockEvent>,
 
-    // Pointer state
-    pointer: Option<wl_pointer::WlPointer>,
-    pointer_x: f32,
-    pointer_y: f32,
-    pointer_over_surface: bool,
-    pointer_enter_serial: u32,
-
-    // Touch state
-    touch: Option<wl_touch::WlTouch>,
-    /// Fingers currently down: id → (surface, x, y).
-    touch_fingers: HashMap<i32, (SurfaceId, f32, f32)>,
-    /// The finger driving pointer emulation (the first one down). Widgets
-    /// only understand pointer events, so the primary finger synthesizes
-    /// MouseMove/MouseDown/MouseUp — a tap becomes a click.
-    primary_finger: Option<i32>,
-
-    // Cursor shape
-    cursor_shape_manager: Option<CursorShapeManager>,
-
-    // Keyboard state
-    keyboard: Option<wl_keyboard::WlKeyboard>,
-    modifiers: Modifiers,
-    pub(super) keyboard_serial: u32,
-    /// Track raw_code → Key for press/release matching (handles compose sequences)
-    pressed_keys: HashMap<u32, Key>,
-    /// Key repeat runs on a calloop timer owned by the toolkit, armed with the
-    /// rate and delay the compositor reports. The keyboard is created inside a
-    /// seat capability callback, which has no other route to the loop.
-    loop_handle: LoopHandle<'static, WaylandState>,
+    /// Pointer, touch and keyboard — see [`super::input`].
+    pub(super) input: InputState,
 
     /// Clipboard and primary selection — see [`super::selections`].
     pub(super) selections: Selections,
-
-    /// Serial of the most recent input event, needed to claim selections.
-    pub(super) latest_input_serial: u32,
 }
 
 /// Why the platform layer could not start or continue.
@@ -369,22 +325,8 @@ pub fn create_wayland_app(
         session_lock_state,
         active_lock: None,
         lock_events: Vec::new(),
-        pointer: None,
-        pointer_x: 0.0,
-        pointer_y: 0.0,
-        pointer_over_surface: false,
-        pointer_enter_serial: 0,
-        touch: None,
-        touch_fingers: HashMap::new(),
-        primary_finger: None,
-        cursor_shape_manager,
-        keyboard: None,
-        modifiers: Modifiers::default(),
-        keyboard_serial: 0,
-        pressed_keys: HashMap::new(),
-        loop_handle,
+        input: InputState::new(cursor_shape_manager, loop_handle),
         selections: Selections::new(data_device_manager, primary_selection_manager),
-        latest_input_serial: 0,
     };
 
     Ok((connection, event_queue, state, qh))
@@ -647,7 +589,9 @@ impl WaylandState {
         if config.grab
             && let Some(seat) = self.seat_state.seats().next()
         {
-            popup.xdg_popup().grab(&seat, self.latest_input_serial);
+            popup
+                .xdg_popup()
+                .grab(&seat, self.input.latest_input_serial);
         }
 
         wl_surface.commit();
@@ -1107,44 +1051,6 @@ impl WaylandState {
             .values()
             .any(|s| !s.first_frame_presented || !s.scale_factor_received)
     }
-
-    /// Set the cursor shape
-    pub fn set_cursor(&self, cursor: CursorIcon, qh: &QueueHandle<Self>) {
-        let Some(ref manager) = self.cursor_shape_manager else {
-            return;
-        };
-        let Some(ref pointer) = self.pointer else {
-            return;
-        };
-
-        // Convert our CursorIcon to Wayland cursor shape
-        let shape = match cursor {
-            CursorIcon::Default => WpCursorShape::Default,
-            CursorIcon::Text => WpCursorShape::Text,
-            CursorIcon::Pointer => WpCursorShape::Pointer,
-            CursorIcon::Crosshair => WpCursorShape::Crosshair,
-            CursorIcon::Move => WpCursorShape::Move,
-            CursorIcon::NotAllowed => WpCursorShape::NotAllowed,
-            CursorIcon::Grab => WpCursorShape::Grab,
-            CursorIcon::Grabbing => WpCursorShape::Grabbing,
-            CursorIcon::ResizeNorth => WpCursorShape::NResize,
-            CursorIcon::ResizeSouth => WpCursorShape::SResize,
-            CursorIcon::ResizeEast => WpCursorShape::EResize,
-            CursorIcon::ResizeWest => WpCursorShape::WResize,
-            CursorIcon::ResizeNorthEast => WpCursorShape::NeResize,
-            CursorIcon::ResizeNorthWest => WpCursorShape::NwResize,
-            CursorIcon::ResizeSouthEast => WpCursorShape::SeResize,
-            CursorIcon::ResizeSouthWest => WpCursorShape::SwResize,
-            CursorIcon::ColResize => WpCursorShape::ColResize,
-            CursorIcon::RowResize => WpCursorShape::RowResize,
-            CursorIcon::Wait => WpCursorShape::Wait,
-            CursorIcon::Progress => WpCursorShape::Progress,
-        };
-
-        // Get cursor shape device and set shape
-        let device = manager.get_shape_device(pointer, qh);
-        device.set_shape(self.pointer_enter_serial, shape);
-    }
 }
 
 pub struct WaylandWindowWrapper {
@@ -1378,395 +1284,6 @@ impl LayerShellHandler for WaylandState {
     }
 }
 
-impl SeatHandler for WaylandState {
-    fn seat_state(&mut self) -> &mut SeatState {
-        &mut self.seat_state
-    }
-
-    fn new_seat(&mut self, _conn: &Connection, _qh: &QueueHandle<Self>, _seat: wl_seat::WlSeat) {}
-
-    fn new_capability(
-        &mut self,
-        _conn: &Connection,
-        qh: &QueueHandle<Self>,
-        seat: wl_seat::WlSeat,
-        capability: Capability,
-    ) {
-        // Handle pointer capability
-        if capability == Capability::Pointer && self.pointer.is_none() {
-            log::info!("Pointer capability available, creating pointer");
-            match self.seat_state.get_pointer(qh, &seat) {
-                Ok(pointer) => self.pointer = Some(pointer),
-                Err(e) => {
-                    // A capability race at seat init is not fatal — the app
-                    // just runs without pointer input until the seat updates
-                    log::warn!("Failed to get pointer: {e}");
-                    return;
-                }
-            }
-        }
-
-        // Handle touch capability
-        if capability == Capability::Touch && self.touch.is_none() {
-            log::info!("Touch capability available, creating touch");
-            match self.seat_state.get_touch(qh, &seat) {
-                Ok(touch) => self.touch = Some(touch),
-                Err(e) => {
-                    log::warn!("Failed to get touch: {e}");
-                }
-            }
-        }
-
-        // Handle keyboard capability
-        if capability == Capability::Keyboard && self.keyboard.is_none() {
-            log::info!("Keyboard capability available, creating keyboard");
-            let loop_handle = self.loop_handle.clone();
-            let keyboard = match self.seat_state.get_keyboard_with_repeat(
-                qh,
-                &seat,
-                None,
-                loop_handle,
-                Box::new(|state: &mut WaylandState, _kbd, event| state.emit_key_repeat(event)),
-            ) {
-                Ok(keyboard) => keyboard,
-                Err(e) => {
-                    log::warn!("Failed to get keyboard: {e}");
-                    return;
-                }
-            };
-            self.keyboard = Some(keyboard);
-
-            // Selections hang off the seat, so they cannot be created with
-            // their managers at startup.
-            self.selections.attach_devices(qh, &seat);
-        }
-    }
-
-    fn remove_capability(
-        &mut self,
-        _conn: &Connection,
-        _qh: &QueueHandle<Self>,
-        _seat: wl_seat::WlSeat,
-        capability: Capability,
-    ) {
-        if capability == Capability::Pointer {
-            log::info!("Pointer capability removed");
-            if let Some(pointer) = self.pointer.take() {
-                pointer.release();
-            }
-        }
-        if capability == Capability::Keyboard {
-            log::info!("Keyboard capability removed");
-            if let Some(keyboard) = self.keyboard.take() {
-                keyboard.release();
-            }
-        }
-        if capability == Capability::Touch {
-            log::info!("Touch capability removed");
-            if let Some(touch) = self.touch.take() {
-                touch.release();
-            }
-            self.touch_fingers.clear();
-            self.primary_finger = None;
-        }
-    }
-
-    fn remove_seat(&mut self, _conn: &Connection, _qh: &QueueHandle<Self>, _seat: wl_seat::WlSeat) {
-    }
-}
-
-impl TouchHandler for WaylandState {
-    fn down(
-        &mut self,
-        _conn: &Connection,
-        _qh: &QueueHandle<Self>,
-        _touch: &wl_touch::WlTouch,
-        serial: u32,
-        _time: u32,
-        surface: wl_surface::WlSurface,
-        id: i32,
-        position: (f64, f64),
-    ) {
-        self.latest_input_serial = serial;
-        let Some(surface_id) = self.surface_lookup.get(&surface.id()).copied() else {
-            return;
-        };
-        let (x, y) = (position.0 as f32, position.1 as f32);
-        self.touch_fingers.insert(id, (surface_id, x, y));
-
-        // The first finger down drives pointer emulation: move + press so
-        // hover and pressed state layers respond, and a tap becomes a click.
-        if self.primary_finger.is_none() {
-            self.primary_finger = Some(id);
-            if let Some(surface_state) = self.surfaces.get_mut(&surface_id) {
-                surface_state.pending_events.push(Event::MouseMove { x, y });
-                surface_state.pending_events.push(Event::MouseDown {
-                    x,
-                    y,
-                    button: MouseButton::Left,
-                });
-            }
-        }
-    }
-
-    fn up(
-        &mut self,
-        _conn: &Connection,
-        _qh: &QueueHandle<Self>,
-        _touch: &wl_touch::WlTouch,
-        _serial: u32,
-        _time: u32,
-        id: i32,
-    ) {
-        let Some((surface_id, x, y)) = self.touch_fingers.remove(&id) else {
-            return;
-        };
-        if self.primary_finger == Some(id) {
-            self.primary_finger = None;
-            if let Some(surface_state) = self.surfaces.get_mut(&surface_id) {
-                surface_state.pending_events.push(Event::MouseUp {
-                    x,
-                    y,
-                    button: MouseButton::Left,
-                });
-                // Unlike a real pointer, nothing hovers after lifting the
-                // finger — clear hover state.
-                surface_state.pending_events.push(Event::MouseLeave);
-            }
-        }
-    }
-
-    fn motion(
-        &mut self,
-        _conn: &Connection,
-        _qh: &QueueHandle<Self>,
-        _touch: &wl_touch::WlTouch,
-        _time: u32,
-        id: i32,
-        position: (f64, f64),
-    ) {
-        let Some(finger) = self.touch_fingers.get_mut(&id) else {
-            return;
-        };
-        let (x, y) = (position.0 as f32, position.1 as f32);
-        finger.1 = x;
-        finger.2 = y;
-        let surface_id = finger.0;
-
-        if self.primary_finger == Some(id)
-            && let Some(surface_state) = self.surfaces.get_mut(&surface_id)
-        {
-            // Coalesce runs of MouseMove like the pointer path does.
-            let events = &mut surface_state.pending_events;
-            if let Some(last @ Event::MouseMove { .. }) = events.last_mut() {
-                *last = Event::MouseMove { x, y };
-            } else {
-                events.push(Event::MouseMove { x, y });
-            }
-        }
-    }
-
-    fn shape(
-        &mut self,
-        _conn: &Connection,
-        _qh: &QueueHandle<Self>,
-        _touch: &wl_touch::WlTouch,
-        _id: i32,
-        _major: f64,
-        _minor: f64,
-    ) {
-    }
-
-    fn orientation(
-        &mut self,
-        _conn: &Connection,
-        _qh: &QueueHandle<Self>,
-        _touch: &wl_touch::WlTouch,
-        _id: i32,
-        _orientation: f64,
-    ) {
-    }
-
-    fn cancel(&mut self, _conn: &Connection, _qh: &QueueHandle<Self>, _touch: &wl_touch::WlTouch) {
-        // The compositor took over the gesture: release the synthesized
-        // press and clear hover so no widget is stuck pressed.
-        if let Some(id) = self.primary_finger.take()
-            && let Some((surface_id, x, y)) = self.touch_fingers.get(&id).copied()
-            && let Some(surface_state) = self.surfaces.get_mut(&surface_id)
-        {
-            surface_state.pending_events.push(Event::MouseUp {
-                x,
-                y,
-                button: MouseButton::Left,
-            });
-            surface_state.pending_events.push(Event::MouseLeave);
-        }
-        self.touch_fingers.clear();
-    }
-}
-
-impl PointerHandler for WaylandState {
-    fn pointer_frame(
-        &mut self,
-        _conn: &Connection,
-        _qh: &QueueHandle<Self>,
-        _pointer: &wl_pointer::WlPointer,
-        events: &[PointerEvent],
-    ) {
-        for event in events {
-            // Try to find the surface ID for this event's wl_surface
-            let surface_id = self.surface_lookup.get(&event.surface.id()).copied();
-
-            // Get the target event queue for this surface
-            let target_events: Option<&mut Vec<Event>> = if let Some(id) = surface_id {
-                self.surfaces.get_mut(&id).map(|s| &mut s.pending_events)
-            } else if !matches!(event.kind, PointerEventKind::Leave { .. }) {
-                // Not our surface and not a leave event, skip
-                continue;
-            } else {
-                None
-            };
-
-            match event.kind {
-                PointerEventKind::Enter { serial } => {
-                    self.pointer_over_surface = true;
-                    self.pointer_enter_serial = serial;
-                    self.latest_input_serial = serial;
-                    self.pointer_x = event.position.0 as f32;
-                    self.pointer_y = event.position.1 as f32;
-
-                    // Track which surface has pointer focus
-                    self.current_pointer_surface = surface_id;
-
-                    if let Some(events) = target_events {
-                        events.push(Event::MouseEnter {
-                            x: self.pointer_x,
-                            y: self.pointer_y,
-                        });
-                        events.push(Event::MouseMove {
-                            x: self.pointer_x,
-                            y: self.pointer_y,
-                        });
-                    }
-                }
-                PointerEventKind::Leave { .. } => {
-                    if self.pointer_over_surface {
-                        self.pointer_over_surface = false;
-
-                        // Send leave event to the surface that had focus
-                        if let Some(id) = self.current_pointer_surface
-                            && let Some(surface_state) = self.surfaces.get_mut(&id)
-                        {
-                            surface_state.pending_events.push(Event::MouseLeave);
-                        }
-
-                        self.current_pointer_surface = None;
-                    }
-                }
-                PointerEventKind::Motion { .. } => {
-                    self.pointer_x = event.position.0 as f32;
-                    self.pointer_y = event.position.1 as f32;
-                    if let Some(events) = target_events {
-                        // Coalesce runs of MouseMove: only the latest position
-                        // matters for hover state, and every queued move costs
-                        // a full event-dispatch walk of the widget tree.
-                        if let Some(last @ Event::MouseMove { .. }) = events.last_mut() {
-                            *last = Event::MouseMove {
-                                x: self.pointer_x,
-                                y: self.pointer_y,
-                            };
-                        } else {
-                            events.push(Event::MouseMove {
-                                x: self.pointer_x,
-                                y: self.pointer_y,
-                            });
-                        }
-                    }
-                }
-                PointerEventKind::Press { button, serial, .. } => {
-                    self.latest_input_serial = serial;
-                    if let Some(mouse_button) = wayland_button_to_mouse_button(button)
-                        && let Some(events) = target_events
-                    {
-                        events.push(Event::MouseDown {
-                            x: self.pointer_x,
-                            y: self.pointer_y,
-                            button: mouse_button,
-                        });
-                    }
-                }
-                PointerEventKind::Release { button, .. } => {
-                    if let Some(mouse_button) = wayland_button_to_mouse_button(button)
-                        && let Some(events) = target_events
-                    {
-                        events.push(Event::MouseUp {
-                            x: self.pointer_x,
-                            y: self.pointer_y,
-                            button: mouse_button,
-                        });
-                    }
-                }
-                PointerEventKind::Axis {
-                    horizontal,
-                    vertical,
-                    source,
-                    ..
-                } => {
-                    // Determine scroll source
-                    let scroll_source = match source {
-                        Some(wl_pointer::AxisSource::Wheel) => ScrollSource::Wheel,
-                        Some(wl_pointer::AxisSource::Finger) => ScrollSource::Finger,
-                        Some(wl_pointer::AxisSource::Continuous) => ScrollSource::Continuous,
-                        Some(wl_pointer::AxisSource::WheelTilt) => ScrollSource::Wheel,
-                        _ => ScrollSource::Wheel,
-                    };
-
-                    // Calculate delta in pixels.
-                    // Wheel steps by preference: value120 (wl_pointer v8+,
-                    // fractional steps from high-resolution wheels) then
-                    // legacy discrete. Touchpad/finger scroll has neither
-                    // and uses absolute (already in pixels).
-                    let wheel_steps =
-                        |scroll: &smithay_client_toolkit::seat::pointer::AxisScroll| {
-                            if scroll.value120 != 0 {
-                                scroll.value120 as f32 / 120.0
-                            } else {
-                                scroll.discrete as f32
-                            }
-                        };
-
-                    let steps_x = wheel_steps(&horizontal);
-                    let delta_x = if steps_x != 0.0 {
-                        steps_x * SCROLL_PIXELS_PER_LINE
-                    } else {
-                        horizontal.absolute as f32
-                    };
-
-                    let steps_y = wheel_steps(&vertical);
-                    let delta_y = if steps_y != 0.0 {
-                        steps_y * SCROLL_PIXELS_PER_LINE
-                    } else {
-                        vertical.absolute as f32
-                    };
-
-                    // Only emit scroll event if there's actual scroll delta
-                    if (delta_x != 0.0 || delta_y != 0.0)
-                        && let Some(events) = target_events
-                    {
-                        events.push(Event::Scroll {
-                            x: self.pointer_x,
-                            y: self.pointer_y,
-                            delta_x,
-                            delta_y,
-                            source: scroll_source,
-                        });
-                    }
-                }
-            }
-        }
-    }
-}
-
 /// Map guido's popup anchor point to the xdg_positioner anchor.
 fn popup_point_to_anchor(point: crate::surface::PopupAnchor) -> xdg_positioner::Anchor {
     use crate::surface::PopupAnchor as P;
@@ -1797,232 +1314,6 @@ fn popup_point_to_gravity(point: crate::surface::PopupAnchor) -> xdg_positioner:
         P::TopRight => xdg_positioner::Gravity::TopRight,
         P::BottomRight => xdg_positioner::Gravity::BottomRight,
     }
-}
-
-/// Convert Wayland button code to MouseButton
-fn wayland_button_to_mouse_button(button: u32) -> Option<MouseButton> {
-    // Linux input event codes (from linux/input-event-codes.h)
-    const BTN_LEFT: u32 = 0x110;
-    const BTN_RIGHT: u32 = 0x111;
-    const BTN_MIDDLE: u32 = 0x112;
-
-    match button {
-        BTN_LEFT => Some(MouseButton::Left),
-        BTN_RIGHT => Some(MouseButton::Right),
-        BTN_MIDDLE => Some(MouseButton::Middle),
-        _ => None,
-    }
-}
-
-impl KeyboardHandler for WaylandState {
-    fn enter(
-        &mut self,
-        _conn: &Connection,
-        _qh: &QueueHandle<Self>,
-        _keyboard: &wl_keyboard::WlKeyboard,
-        surface: &wl_surface::WlSurface,
-        _serial: u32,
-        _raw: &[u32],
-        _keysyms: &[Keysym],
-    ) {
-        log::debug!("Keyboard focus entered");
-
-        // Track which surface has keyboard focus
-        let surface_id = self.surface_lookup.get(&surface.id()).copied();
-        self.current_keyboard_surface = surface_id;
-
-        // Route event to correct surface
-        if let Some(id) = surface_id
-            && let Some(surface_state) = self.surfaces.get_mut(&id)
-        {
-            surface_state.pending_events.push(Event::FocusIn);
-        }
-    }
-
-    fn leave(
-        &mut self,
-        _conn: &Connection,
-        _qh: &QueueHandle<Self>,
-        _keyboard: &wl_keyboard::WlKeyboard,
-        surface: &wl_surface::WlSurface,
-        _serial: u32,
-    ) {
-        log::debug!("Keyboard focus left");
-
-        // Route event to correct surface
-        let surface_id = self.surface_lookup.get(&surface.id()).copied();
-        if let Some(id) = surface_id
-            && let Some(surface_state) = self.surfaces.get_mut(&id)
-        {
-            surface_state.pending_events.push(Event::FocusOut);
-        }
-
-        self.current_keyboard_surface = None;
-    }
-
-    fn press_key(
-        &mut self,
-        _conn: &Connection,
-        _qh: &QueueHandle<Self>,
-        _keyboard: &wl_keyboard::WlKeyboard,
-        serial: u32,
-        event: KeyEvent,
-    ) {
-        // Track serial for clipboard operations
-        self.keyboard_serial = serial;
-        self.latest_input_serial = serial;
-
-        if let Some(key) = keysym_to_key(event.keysym, event.utf8.as_deref(), true) {
-            // Store raw_code → Key mapping so release_key can emit the correct Key
-            // (e.g., composed 'é' instead of raw 'e' after a compose sequence)
-            self.pressed_keys.insert(event.raw_code, key);
-
-            let key_event = Event::KeyDown {
-                key,
-                modifiers: self.modifiers,
-            };
-
-            // Route to the surface with keyboard focus
-            if let Some(id) = self.current_keyboard_surface
-                && let Some(surface_state) = self.surfaces.get_mut(&id)
-            {
-                surface_state.pending_events.push(key_event);
-            }
-        }
-    }
-
-    fn release_key(
-        &mut self,
-        _conn: &Connection,
-        _qh: &QueueHandle<Self>,
-        _keyboard: &wl_keyboard::WlKeyboard,
-        _serial: u32,
-        event: KeyEvent,
-    ) {
-        // Use the stored key from press_key if available (handles compose sequences
-        // where the composed character differs from the raw keysym on release)
-        let key = self
-            .pressed_keys
-            .remove(&event.raw_code)
-            .or_else(|| keysym_to_key(event.keysym, event.utf8.as_deref(), false));
-
-        if let Some(key) = key {
-            let key_event = Event::KeyUp {
-                key,
-                modifiers: self.modifiers,
-            };
-
-            // Route to the surface with keyboard focus
-            if let Some(id) = self.current_keyboard_surface
-                && let Some(surface_state) = self.surfaces.get_mut(&id)
-            {
-                surface_state.pending_events.push(key_event);
-            }
-        }
-    }
-
-    fn update_modifiers(
-        &mut self,
-        _conn: &Connection,
-        _qh: &QueueHandle<Self>,
-        _keyboard: &wl_keyboard::WlKeyboard,
-        _serial: u32,
-        modifiers: WlModifiers,
-        _raw_modifiers: RawModifiers,
-        _layout: u32,
-    ) {
-        self.modifiers = Modifiers {
-            ctrl: modifiers.ctrl,
-            alt: modifiers.alt,
-            shift: modifiers.shift,
-            logo: modifiers.logo,
-        };
-    }
-
-    fn repeat_key(
-        &mut self,
-        _conn: &Connection,
-        _qh: &QueueHandle<Self>,
-        _keyboard: &wl_keyboard::WlKeyboard,
-        _serial: u32,
-        event: KeyEvent,
-    ) {
-        self.emit_key_repeat(event);
-    }
-}
-
-impl WaylandState {
-    /// Deliver a repeated key as an ordinary press.
-    ///
-    /// Two sources reach here: the toolkit's calloop timer, armed from the
-    /// compositor's `repeat_info`, and the protocol's own repeated key state.
-    /// Neither is visible to widgets — a held key looks exactly like someone
-    /// pressing it very fast.
-    fn emit_key_repeat(&mut self, event: KeyEvent) {
-        let Some(key) = keysym_to_key(event.keysym, event.utf8.as_deref(), true) else {
-            return;
-        };
-        let key_event = Event::KeyDown {
-            key,
-            modifiers: self.modifiers,
-        };
-
-        // Route to the surface with keyboard focus
-        if let Some(id) = self.current_keyboard_surface
-            && let Some(surface_state) = self.surfaces.get_mut(&id)
-        {
-            surface_state.pending_events.push(key_event);
-        }
-    }
-}
-
-/// Convert XKB keysym to our Key type
-fn keysym_to_key(keysym: Keysym, utf8: Option<&str>, is_press: bool) -> Option<Key> {
-    // Named keys first
-    match keysym {
-        Keysym::BackSpace => return Some(Key::Backspace),
-        Keysym::Delete => return Some(Key::Delete),
-        Keysym::Return | Keysym::KP_Enter => return Some(Key::Enter),
-        Keysym::Tab | Keysym::ISO_Left_Tab => return Some(Key::Tab),
-        Keysym::Escape => return Some(Key::Escape),
-        Keysym::Left => return Some(Key::Left),
-        Keysym::Right => return Some(Key::Right),
-        Keysym::Up => return Some(Key::Up),
-        Keysym::Down => return Some(Key::Down),
-        Keysym::Home => return Some(Key::Home),
-        Keysym::End => return Some(Key::End),
-        _ => {}
-    }
-
-    // Character input - use utf8 if available
-    if let Some(text) = utf8
-        && let Some(c) = text.chars().next()
-    {
-        // Only return printable characters or control characters we care about
-        if !c.is_control() || c == '\n' || c == '\r' || c == '\t' {
-            return Some(Key::Char(c));
-        }
-    }
-
-    // Fallback: convert keysym directly for release events where utf8 is always None.
-    // On press, utf8 = None means a compose sequence is in progress — don't insert anything.
-    if !is_press {
-        let raw = keysym.raw();
-
-        // Printable ASCII range (space through tilde): 0x20-0x7E
-        // XKB keysyms for these characters have the same value as ASCII
-        if (0x20..=0x7e).contains(&raw) {
-            return Some(Key::Char(char::from_u32(raw)?));
-        }
-
-        // Handle keypad numbers (KP_0 through KP_9)
-        // XKB_KEY_KP_0 = 0xffb0, XKB_KEY_KP_9 = 0xffb9
-        if (0xffb0..=0xffb9).contains(&raw) {
-            return Some(Key::Char(char::from_u32(raw - 0xffb0 + 0x30)?)); // Convert to '0'-'9'
-        }
-    }
-
-    None
 }
 
 impl SessionLockHandler for WaylandState {
@@ -2204,8 +1495,4 @@ impl ProvidesRegistryState for WaylandState {
 delegate_compositor!(WaylandState);
 delegate_output!(WaylandState);
 delegate_layer!(WaylandState);
-delegate_seat!(WaylandState);
-delegate_pointer!(WaylandState);
-delegate_touch!(WaylandState);
-delegate_keyboard!(WaylandState);
 delegate_registry!(WaylandState);

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -12,9 +12,9 @@ use smithay_client_toolkit::reexports::protocols::xdg::shell::client::xdg_positi
 use smithay_client_toolkit::{
     compositor::{CompositorHandler, CompositorState, Region},
     data_device_manager::DataDeviceManagerState,
-    delegate_compositor, delegate_layer, delegate_output, delegate_registry, delegate_session_lock,
+    delegate_compositor, delegate_layer, delegate_registry, delegate_session_lock,
     delegate_xdg_popup,
-    output::{OutputHandler, OutputState},
+    output::OutputState,
     primary_selection::PrimarySelectionManagerState,
     registry::{ProvidesRegistryState, RegistryState},
     registry_handlers,
@@ -46,9 +46,10 @@ use wayland_protocols::ext::background_effect::v1::client::{
 use std::collections::HashMap;
 
 use super::input::InputState;
+use super::outputs::OutputRegistry;
 use super::selections::Selections;
 use crate::blur::BlurRect;
-use crate::outputs::{self, OutputId, OutputInfo};
+use crate::outputs::{self, OutputId};
 use crate::surface::SurfaceId;
 use crate::widgets::{Event, Rect};
 
@@ -167,12 +168,8 @@ pub struct WaylandState {
     /// Which surface currently has keyboard focus
     pub current_keyboard_surface: Option<SurfaceId>,
 
-    // Output tracking
-    /// Stable OutputId for each wl_output global. Ids are never reused: a
-    /// reconnected monitor gets a fresh id.
-    output_ids: HashMap<ObjectId, OutputId>,
-    /// Next OutputId to allocate.
-    next_output_id: u32,
+    /// Stable identity for the compositor's outputs — see [`super::outputs`].
+    pub(super) outputs: OutputRegistry,
 
     // Background effect (blur)
     /// `None` where the protocol is unsupported — the feature simply no-ops.
@@ -316,8 +313,7 @@ pub fn create_wayland_app(
         surface_lookup: HashMap::new(),
         current_pointer_surface: None,
         current_keyboard_surface: None,
-        output_ids: HashMap::new(),
-        next_output_id: 0,
+        outputs: OutputRegistry::new(),
         bg_effect_manager,
         bg_effect_supports_blur: false,
         xdg_shell,
@@ -333,25 +329,6 @@ pub fn create_wayland_app(
 }
 
 impl WaylandState {
-    /// Get (or allocate) the stable OutputId for a wl_output.
-    fn ensure_output_id(&mut self, output: &wl_output::WlOutput) -> OutputId {
-        let object_id = output.id();
-        if let Some(id) = self.output_ids.get(&object_id) {
-            return *id;
-        }
-        let id = OutputId::from_raw(self.next_output_id);
-        self.next_output_id += 1;
-        self.output_ids.insert(object_id, id);
-        id
-    }
-
-    /// Find the wl_output for a stable OutputId, if still connected.
-    fn wl_output_for(&self, id: OutputId) -> Option<wl_output::WlOutput> {
-        self.output_state
-            .outputs()
-            .find(|o| self.output_ids.get(&o.id()) == Some(&id))
-    }
-
     /// Build a wl_region from logical-coordinate rects, rounded outward so a
     /// fractional widget bound never loses its edge pixels.
     fn build_region(&self, rects: &[Rect]) -> Option<Region> {
@@ -798,30 +775,6 @@ impl WaylandState {
         }
     }
 
-    /// Rebuild the reactive output list from current compositor state.
-    fn sync_outputs(&mut self) {
-        let wl_outputs: Vec<wl_output::WlOutput> = self.output_state.outputs().collect();
-        let mut list: Vec<OutputInfo> = wl_outputs
-            .iter()
-            .filter_map(|o| {
-                let id = self.ensure_output_id(o);
-                let info = self.output_state.info(o)?;
-                Some(OutputInfo {
-                    id,
-                    name: info.name,
-                    description: info.description,
-                    make: info.make,
-                    model: info.model,
-                    scale_factor: info.scale_factor,
-                    logical_size: info.logical_size,
-                    logical_position: info.logical_position,
-                })
-            })
-            .collect();
-        list.sort_by_key(|o| o.id);
-        outputs::sync_outputs(list);
-    }
-
     /// Create a layer surface with a specific SurfaceId.
     pub fn create_surface_with_id(
         &mut self,
@@ -1153,7 +1106,7 @@ impl CompositorHandler for WaylandState {
         output: &wl_output::WlOutput,
     ) {
         if let Some(surface_id) = self.surface_lookup.get(&surface.id()).copied()
-            && let Some(output_id) = self.output_ids.get(&output.id()).copied()
+            && let Some(output_id) = self.outputs.output_ids.get(&output.id()).copied()
         {
             log::debug!("Surface {:?} left output {:?}", surface_id, output_id);
             outputs::surface_left_output(surface_id, output_id);
@@ -1184,49 +1137,6 @@ impl CompositorHandler for WaylandState {
             // Wake the loop so a dirty surface renders promptly
             crate::jobs::request_frame();
         }
-    }
-}
-
-impl OutputHandler for WaylandState {
-    fn output_state(&mut self) -> &mut OutputState {
-        &mut self.output_state
-    }
-
-    fn new_output(
-        &mut self,
-        _conn: &Connection,
-        _qh: &QueueHandle<Self>,
-        output: wl_output::WlOutput,
-    ) {
-        let id = self.ensure_output_id(&output);
-        log::info!(
-            "Output {:?} connected: {:?}",
-            id,
-            self.output_state.info(&output).and_then(|i| i.name)
-        );
-        self.sync_outputs();
-    }
-
-    fn update_output(
-        &mut self,
-        _conn: &Connection,
-        _qh: &QueueHandle<Self>,
-        _output: wl_output::WlOutput,
-    ) {
-        self.sync_outputs();
-    }
-
-    fn output_destroyed(
-        &mut self,
-        _conn: &Connection,
-        _qh: &QueueHandle<Self>,
-        output: wl_output::WlOutput,
-    ) {
-        if let Some(id) = self.output_ids.remove(&output.id()) {
-            log::info!("Output {:?} disconnected", id);
-            outputs::output_removed(id);
-        }
-        self.sync_outputs();
     }
 }
 
@@ -1493,6 +1403,5 @@ impl ProvidesRegistryState for WaylandState {
 }
 
 delegate_compositor!(WaylandState);
-delegate_output!(WaylandState);
 delegate_layer!(WaylandState);
 delegate_registry!(WaylandState);

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -4,7 +4,7 @@ use raw_window_handle::{
 };
 use smithay_client_toolkit::reexports::calloop::LoopHandle;
 use smithay_client_toolkit::reexports::client::{
-    Connection, Dispatch, EventQueue, Proxy, QueueHandle, WEnum, delegate_noop,
+    Connection, EventQueue, Proxy, QueueHandle,
     globals::registry_queue_init,
     protocol::{wl_output, wl_surface},
 };
@@ -29,14 +29,13 @@ use smithay_client_toolkit::{
 };
 use wayland_backend::sys::client::ObjectId;
 use wayland_protocols::ext::background_effect::v1::client::{
-    ext_background_effect_manager_v1::{
-        self, Capability as BgCapability, ExtBackgroundEffectManagerV1,
-    },
+    ext_background_effect_manager_v1::ExtBackgroundEffectManagerV1,
     ext_background_effect_surface_v1::ExtBackgroundEffectSurfaceV1,
 };
 
 use std::collections::HashMap;
 
+use super::backdrop::Backdrop;
 use super::input::InputState;
 use super::lock::Lock;
 use super::outputs::OutputRegistry;
@@ -101,11 +100,11 @@ pub struct WaylandSurfaceState {
     pub pending_events: Vec<Event>,
     /// Blur proxy for this surface, created lazily on first use (asking the
     /// manager twice for the same surface is a protocol error).
-    bg_effect_surface: Option<ExtBackgroundEffectSurfaceV1>,
+    pub(super) bg_effect_surface: Option<ExtBackgroundEffectSurfaceV1>,
     /// Last blur rects pushed to the compositor. `None` means nothing has
     /// been pushed yet (also reset when the blur capability changes, so the
     /// region is re-sent if it comes back).
-    blur_region: Option<Vec<BlurRect>>,
+    pub(super) blur_region: Option<Vec<BlurRect>>,
     /// Height sent in an in-flight popup reposition (cleared by the popup
     /// configure), so repeated content measurements don't re-send it.
     pub(super) pending_popup_height: Option<u32>,
@@ -165,11 +164,8 @@ pub struct WaylandState {
     /// Stable identity for the compositor's outputs — see [`super::outputs`].
     pub(super) outputs: OutputRegistry,
 
-    // Background effect (blur)
-    /// `None` where the protocol is unsupported — the feature simply no-ops.
-    bg_effect_manager: Option<ExtBackgroundEffectManagerV1>,
-    /// Whether the compositor currently advertises the Blur capability.
-    bg_effect_supports_blur: bool,
+    /// Compositor-side backdrop blur — see [`super::backdrop`].
+    pub(super) backdrop: Backdrop,
 
     /// xdg popups anchored to a surface — see [`super::popups`].
     pub(super) popups: Popups,
@@ -299,8 +295,7 @@ pub fn create_wayland_app(
         current_pointer_surface: None,
         current_keyboard_surface: None,
         outputs: OutputRegistry::new(),
-        bg_effect_manager,
-        bg_effect_supports_blur: false,
+        backdrop: Backdrop::new(bg_effect_manager),
         popups: Popups::new(xdg_shell),
         lock: Lock::new(session_lock_state),
         input: InputState::new(cursor_shape_manager, loop_handle),
@@ -360,75 +355,6 @@ impl WaylandState {
             );
         }
     }
-
-    /// Push a surface's blur region to the compositor if it changed.
-    ///
-    /// The `set_blur_region` request is double-buffered: with `commit: false`
-    /// it rides the buffer commit performed inside the upcoming present, so
-    /// region and content change in the same frame. Pass `commit: true` on
-    /// paths that skip presenting (e.g. a capability change without repaint).
-    ///
-    /// Surfaces that never requested blur are left untouched — declaring an
-    /// empty region would override compositor-side blur rules (e.g. blur by
-    /// namespace). Once a surface has blurred, dropping to zero rects sends
-    /// an *empty* region, never NULL: NULL only withdraws our opinion and
-    /// lets such a rule blur the whole surface, where an empty region says
-    /// "blur exactly nothing".
-    pub(crate) fn sync_blur_region(
-        &mut self,
-        id: SurfaceId,
-        rects: Vec<BlurRect>,
-        qh: &QueueHandle<Self>,
-        commit: bool,
-    ) {
-        if !self.bg_effect_supports_blur {
-            return;
-        }
-        let Some(manager) = self.bg_effect_manager.clone() else {
-            return;
-        };
-        let Some(surface_state) = self.surfaces.get_mut(&id) else {
-            return;
-        };
-
-        // Never used blur and still doesn't — don't claim the surface.
-        if rects.is_empty()
-            && surface_state.blur_region.is_none()
-            && surface_state.bg_effect_surface.is_none()
-        {
-            return;
-        }
-
-        if surface_state.blur_region.as_deref() == Some(rects.as_slice()) {
-            return;
-        }
-
-        // Asking the manager twice for the same surface is a protocol error.
-        let effect = surface_state.bg_effect_surface.get_or_insert_with(|| {
-            manager.get_background_effect(&surface_state.wl_surface, qh, ())
-        });
-
-        let Ok(region) = Region::new(&self.compositor_state) else {
-            log::warn!("Failed to create wl_region for blur");
-            return;
-        };
-        for r in &rects {
-            region.add(r.x, r.y, r.width, r.height);
-        }
-        effect.set_blur_region(Some(region.wl_region()));
-
-        log::debug!(
-            "Surface {:?} blur region set to {} rect(s)",
-            id,
-            rects.len()
-        );
-        surface_state.blur_region = Some(rects);
-
-        if commit {
-            surface_state.wl_surface.commit();
-        }
-    }
-
     /// Create a layer surface with a specific SurfaceId.
     pub fn create_surface_with_id(
         &mut self,
@@ -847,42 +773,6 @@ impl LayerShellHandler for WaylandState {
         }
     }
 }
-
-impl Dispatch<ExtBackgroundEffectManagerV1, ()> for WaylandState {
-    fn event(
-        state: &mut Self,
-        _proxy: &ExtBackgroundEffectManagerV1,
-        event: ext_background_effect_manager_v1::Event,
-        _data: &(),
-        _conn: &Connection,
-        _qh: &QueueHandle<Self>,
-    ) {
-        if let ext_background_effect_manager_v1::Event::Capabilities { flags } = event {
-            let blur = match flags {
-                WEnum::Value(c) => c.contains(BgCapability::Blur),
-                WEnum::Unknown(_) => false,
-            };
-            if blur == state.bg_effect_supports_blur {
-                return;
-            }
-            log::info!(
-                "Compositor blur capability {}",
-                if blur { "available" } else { "lost" }
-            );
-            state.bg_effect_supports_blur = blur;
-            crate::compositor::set_blur_capability(blur);
-
-            // The compositor drops its regions when the capability goes away:
-            // forget ours and wake the loop to push them again if it's back.
-            for surface_state in state.surfaces.values_mut() {
-                surface_state.blur_region = None;
-            }
-            crate::jobs::request_frame();
-        }
-    }
-}
-
-delegate_noop!(WaylandState: ignore ExtBackgroundEffectSurfaceV1);
 
 impl ProvidesRegistryState for WaylandState {
     fn registry(&mut self) -> &mut RegistryState {

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -47,6 +47,7 @@ use smithay_client_toolkit::{
         },
     },
 };
+use smithay_client_toolkit::reexports::calloop::LoopHandle;
 use smithay_client_toolkit::reexports::protocols::xdg::shell::client::xdg_positioner;
 use smithay_client_toolkit::reexports::client::{
     globals::registry_queue_init,
@@ -247,6 +248,10 @@ pub struct WaylandState {
     keyboard_serial: u32,
     /// Track raw_code → Key for press/release matching (handles compose sequences)
     pressed_keys: HashMap<u32, Key>,
+    /// Key repeat runs on a calloop timer owned by the toolkit, armed with the
+    /// rate and delay the compositor reports. The keyboard is created inside a
+    /// seat capability callback, which has no other route to the loop.
+    loop_handle: LoopHandle<'static, WaylandState>,
 
     // Clipboard state
     data_device_manager: Option<DataDeviceManagerState>,
@@ -317,7 +322,9 @@ impl std::fmt::Display for PlatformError {
 impl std::error::Error for PlatformError {}
 
 #[allow(clippy::type_complexity)]
-pub fn create_wayland_app() -> Result<
+pub fn create_wayland_app(
+    loop_handle: LoopHandle<'static, WaylandState>,
+) -> Result<
     (
         Connection,
         EventQueue<WaylandState>,
@@ -412,6 +419,7 @@ pub fn create_wayland_app() -> Result<
         modifiers: Modifiers::default(),
         keyboard_serial: 0,
         pressed_keys: HashMap::new(),
+        loop_handle,
         data_device_manager,
         data_device: None,
         clipboard_content: None,
@@ -1643,7 +1651,14 @@ impl SeatHandler for WaylandState {
         // Handle keyboard capability
         if capability == Capability::Keyboard && self.keyboard.is_none() {
             log::info!("Keyboard capability available, creating keyboard");
-            let keyboard = match self.seat_state.get_keyboard(qh, &seat, None) {
+            let loop_handle = self.loop_handle.clone();
+            let keyboard = match self.seat_state.get_keyboard_with_repeat(
+                qh,
+                &seat,
+                None,
+                loop_handle,
+                Box::new(|state: &mut WaylandState, _kbd, event| state.emit_key_repeat(event)),
+            ) {
                 Ok(keyboard) => keyboard,
                 Err(e) => {
                     log::warn!("Failed to get keyboard: {e}");
@@ -2176,19 +2191,31 @@ impl KeyboardHandler for WaylandState {
         _serial: u32,
         event: KeyEvent,
     ) {
-        // Treat key repeat as a new key press
-        if let Some(key) = keysym_to_key(event.keysym, event.utf8.as_deref(), true) {
-            let key_event = Event::KeyDown {
-                key,
-                modifiers: self.modifiers,
-            };
+        self.emit_key_repeat(event);
+    }
+}
 
-            // Route to the surface with keyboard focus
-            if let Some(id) = self.current_keyboard_surface
-                && let Some(surface_state) = self.surfaces.get_mut(&id)
-            {
-                surface_state.pending_events.push(key_event);
-            }
+impl WaylandState {
+    /// Deliver a repeated key as an ordinary press.
+    ///
+    /// Two sources reach here: the toolkit's calloop timer, armed from the
+    /// compositor's `repeat_info`, and the protocol's own repeated key state.
+    /// Neither is visible to widgets — a held key looks exactly like someone
+    /// pressing it very fast.
+    fn emit_key_repeat(&mut self, event: KeyEvent) {
+        let Some(key) = keysym_to_key(event.keysym, event.utf8.as_deref(), true) else {
+            return;
+        };
+        let key_event = Event::KeyDown {
+            key,
+            modifiers: self.modifiers,
+        };
+
+        // Route to the surface with keyboard focus
+        if let Some(id) = self.current_keyboard_surface
+            && let Some(surface_state) = self.surfaces.get_mut(&id)
+        {
+            surface_state.pending_events.push(key_event);
         }
     }
 }

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -1405,6 +1405,7 @@ impl Widget for Container {
             transform_origin,
             border_width,
             border_color,
+            per_corner_radii,
         ) = with_signal_tracking(id, JobType::Paint, || {
             (
                 self.animated_background(id),
@@ -1415,6 +1416,7 @@ impl Widget for Container {
                 self.transform_origin.get_or(TransformOrigin::CENTER),
                 self.animated_border_width(id),
                 self.animated_border_color(id),
+                self.corner_radii.as_ref().map(|s| s.get()),
             )
         });
 
@@ -1423,12 +1425,8 @@ impl Widget for Container {
         // Per-corner radii override the uniform (animated) radius for
         // drawing. Clip, blur region and rounded hit testing stay uniform,
         // approximated by the largest corner.
-        let corner_radii = with_signal_tracking(id, JobType::Paint, || {
-            self.corner_radii
-                .as_ref()
-                .map(|s| s.get())
-                .unwrap_or_else(|| crate::renderer::CornerRadii::uniform(corner_radius))
-        });
+        let corner_radii = per_corner_radii
+            .unwrap_or_else(|| crate::renderer::CornerRadii::uniform(corner_radius));
         let corner_radius = corner_radius.max(corner_radii.max());
 
         // Publish the compositor blur region: bounds are read fresh from the

--- a/src/widgets/text_input.rs
+++ b/src/widgets/text_input.rs
@@ -22,16 +22,10 @@ use crate::renderer::{PaintContext, char_index_from_x_styled};
 use crate::tree::{Tree, WidgetId};
 
 use super::font::{FontFamily, FontWeight};
-use super::widget::{Color, Event, EventResponse, Key, Modifiers, MouseButton, Rect, Widget};
+use super::widget::{Color, Event, EventResponse, Key, MouseButton, Rect, Widget};
 
 /// Cursor blink interval in milliseconds
 const CURSOR_BLINK_MS: u64 = 530;
-
-/// Key repeat delay (time before repeat starts) in milliseconds
-const KEY_REPEAT_DELAY_MS: u64 = 400;
-
-/// Key repeat interval (time between repeats) in milliseconds
-const KEY_REPEAT_INTERVAL_MS: u64 = 35;
 
 /// Maximum number of undo history entries
 const MAX_HISTORY_SIZE: usize = 100;
@@ -223,11 +217,6 @@ pub struct TextInput {
     cursor_visible: bool,
     last_cursor_toggle: Instant,
 
-    // Key repeat state
-    pressed_key: Option<(Key, Modifiers)>,
-    key_press_time: Instant,
-    last_repeat_time: Instant,
-
     // Mouse drag selection
     is_dragging: bool,
 
@@ -271,9 +260,6 @@ impl TextInput {
             selection: Selection::new(0),
             cursor_visible: true,
             last_cursor_toggle: Instant::now(),
-            pressed_key: None,
-            key_press_time: Instant::now(),
-            last_repeat_time: Instant::now(),
             is_dragging: false,
             is_hovered: false,
             history: History::new(),
@@ -453,33 +439,6 @@ impl TextInput {
     fn reset_cursor_blink(&mut self) {
         self.cursor_visible = true;
         self.last_cursor_toggle = Instant::now();
-    }
-
-    /// Handle key repeat for held keys
-    fn handle_key_repeat(&mut self, tree: &Tree, id: WidgetId) {
-        if !has_focus(id) {
-            self.pressed_key = None;
-            return;
-        }
-
-        if let Some((key, modifiers)) = self.pressed_key {
-            let now = Instant::now();
-            let since_press = now.duration_since(self.key_press_time);
-            let since_repeat = now.duration_since(self.last_repeat_time);
-
-            // Check if we're past the initial delay
-            if since_press >= Duration::from_millis(KEY_REPEAT_DELAY_MS) {
-                // Check if it's time for another repeat
-                if since_repeat >= Duration::from_millis(KEY_REPEAT_INTERVAL_MS) {
-                    let bounds_width = tree.cached_size(id).map(|s| s.width).unwrap_or(0.0);
-                    self.handle_key(&key, modifiers.ctrl, modifiers.shift, bounds_width);
-                    self.last_repeat_time = now;
-                }
-            }
-
-            // Keep requesting layout while a key is held so handle_key_repeat() runs each frame
-            request_job(id, JobRequest::Layout);
-        }
     }
 
     /// Get character index from x coordinate relative to text start.
@@ -944,9 +903,6 @@ impl Widget for TextInput {
         let overflow = self.refresh(tree, id);
         tree.set_paint_overflow(id, overflow);
 
-        // Handle key repeat for held keys
-        self.handle_key_repeat(tree, id);
-
         // Update measurement cache (has internal dirty check)
         self.update_measurements();
 
@@ -1114,25 +1070,11 @@ impl Widget for TextInput {
                 return EventResponse::Handled;
             }
             Event::KeyDown { key, modifiers } if has_focus(id) => {
-                // Track key for repeat
-                let now = Instant::now();
-                self.pressed_key = Some((*key, *modifiers));
-                self.key_press_time = now;
-                self.last_repeat_time = now;
-
                 let response = self.handle_key(key, modifiers.ctrl, modifiers.shift, bounds.width);
                 if response == EventResponse::Handled {
                     request_job(id, JobRequest::Paint);
                 }
                 return response;
-            }
-            Event::KeyUp { key, .. } => {
-                // Stop repeating when key is released
-                if let Some((pressed_key, _)) = self.pressed_key
-                    && pressed_key == *key
-                {
-                    self.pressed_key = None;
-                }
             }
             Event::FocusOut if has_focus(id) => {
                 release_focus(id);

--- a/src/widgets/text_input.rs
+++ b/src/widgets/text_input.rs
@@ -961,7 +961,20 @@ impl Widget for TextInput {
                 )
             });
 
-        // TODO: Clipping temporarily disabled - will be re-implemented in a future PR
+        // The text scrolls horizontally under a fixed viewport, so whatever
+        // slid past either edge has to be cut at the widget's bounds.
+        //
+        // Horizontally only: the vertical axis never scrolls, and closing it
+        // would trim descenders and any glyph stroke or shadow, which the
+        // viewport is not meant to touch. One em of slack each way is past
+        // anything a single line can reach.
+        let slack = self.cached_font_size;
+        ctx.set_clip_rect(Rect::new(
+            0.0,
+            -slack,
+            bounds.width,
+            bounds.height + slack * 2.0,
+        ));
 
         // Draw selection highlight if focused and has selection (LOCAL coords)
         if is_focused && self.selection.has_selection() {

--- a/tests/render_snapshots.rs
+++ b/tests/render_snapshots.rs
@@ -524,3 +524,32 @@ fn bar_like_composition() {
 
     assert_snapshot("bar_like_composition", render(view, 600.0, 36.0));
 }
+
+/// After `examples/text_input_example.rs`: a text input narrower than its own
+/// content. The field is a viewport — the glyphs that do not fit are cut at
+/// its horizontal edges, and only there, so descenders and any glyph
+/// decoration survive.
+///
+/// This is the case that went unwatched: clipping was dropped from the input
+/// when the V2 renderer landed, and no snapshot covered the widget, so the
+/// text simply drew across whatever sat beside it.
+#[test]
+fn text_input_clips_overflowing_content() {
+    let value = create_signal("gggggggggggggggggggggggggggggggggggggg".to_string());
+
+    let view = container().padding(8.0).child(
+        container()
+            .width(180.0)
+            .padding(8.0)
+            .background(Color::rgb(0.18, 0.18, 0.24))
+            .corner_radius(6.0)
+            .text_color(Color::WHITE)
+            .font_size(14.0)
+            .child(text_input(value)),
+    );
+
+    assert_snapshot(
+        "text_input_clips_overflowing_content",
+        render(view, 400.0, 60.0),
+    );
+}

--- a/tests/snapshots/text_input_clips_overflowing_content.snap
+++ b/tests/snapshots/text_input_clips_overflowing_content.snap
@@ -1,0 +1,5 @@
+node 0,0 196x48.8
+  node 0,0 180x32.8 at 8,8
+    draw rect 0,0 180x32.8 fill=#2e2e3dff radius=6/6/6/6
+    node 0,0 164x16.8 at 8,8 clip(0,-14 164x44.8 r=0)
+      draw text <not snapshotted>


### PR DESCRIPTION
`src/platform/wayland.rs` was 2665 lines and one struct with 50 fields whose
only common theme was the word "Wayland": registry, outputs, layer shell,
popups, session lock, pointer, touch, keyboard, cursor, clipboard, primary
selection, blur. This splits it by concern, and fixes three bugs found while
doing it.

**wayland.rs 2665 → 787 lines, 50 → 16 fields.**

## The split

One file per concern, each owning its state and the protocol handlers that
drive it. The `delegate_*` macros need those handlers implemented on
`WaylandState`, but an `impl` can live in any module of the crate — so the
code travels with the state instead of only the fields moving, which is the
whole point.

| File | Lines | Concern |
|------|------:|---------|
| `platform/wayland.rs` | 787 | Connection, surfaces, layer shell, compositor handler |
| `platform/input.rs` | 818 | Seat: pointer, touch, keyboard, cursor shape, key repeat |
| `platform/selections.rs` | 541 | Clipboard and primary selection, async prefetch |
| `platform/popups.rs` | 399 | xdg popups: positioning, grabs, ordered teardown |
| `platform/lock.rs` | 189 | `ext-session-lock-v1` grant and lifecycle |
| `platform/outputs.rs` | 131 | Stable `OutputId` per `wl_output`, hotplug |
| `platform/backdrop.rs` | 144 | `ext-background-effect-v1` compositor-side blur |

The sixteen remaining fields are five toolkit state handles, `exit`, four
surface-registry fields and six named sub-structs. Nothing is "Wayland
stuff" any more.

Boundaries that moved with the code rather than staying as scattered
comments: `latest_input_serial` belongs to input and the selections *borrow*
it; `LockEvent` sits next to what produces it; the NULL-versus-empty-region
rule lives in `backdrop.rs`.

## Three bugs, all pre-existing

Each was checked against `main` before touching it — none is a regression
from this refactor.

**Key repeat was invented locally.** The platform layer already had the
right handler: `repeat_key` turns a repeat into an ordinary `KeyDown`, so no
widget needs to know repeat exists. It was dead code — the keyboard was
built with `get_keyboard`, which never arms the toolkit's repeat timer. What
actually ran was a second implementation inside `TextInput`: 400ms/35ms
hard-coded, polled from `layout`, and *pinning the surface to a layout job
every frame for as long as a key was held*. Now the rate and delay come from
the compositor — the ones the user configured — keys xkb marks as
non-repeating no longer repeat, and it applies to every focusable widget
rather than to `TextInput` alone, which is what toggle and checkbox will
need.

**Every Ctrl chord was dropped before reaching a widget.** Holding a
modifier changes the text xkb reports: Ctrl+C arrives as U+0003, not 'c'.
`keysym_to_key` rejected it as a control character, then fell through to a
keysym fallback gated behind `if !is_press` — so on press it returned `None`
and no event was produced at all. Copy, cut, paste, select-all, undo, redo
and word-jump have all been unreachable; the code handling them in
`TextInput` was never called. The guard was protecting a real case, just too
broadly: *absent* text on a press means an open compose sequence, a *control
character* means a modifier ate the letter and the keysym still has it.

**The text input did not clip.** It scrolls its text horizontally under a
fixed-width field, but nothing cut it: typing past the width painted over
the neighbouring widgets, and scrolling to the end spilled the text out of
the left border. Clipping was disabled in the widget when the V2 instanced
renderer landed (48a03c0) with a note saying it would come back;
`PaintContext::set_clip` has been available again for a while. Horizontally
only — closing the vertical axis would trim descenders and glyph decoration.

## Tests

410 pass. New coverage where it was missing, which is why these bugs lived
so long:

- `text_input_clips_overflowing_content` — no snapshot covered `text_input`
  at all, even though the snapshot format records clips, so a clip that
  stopped being emitted was invisible to the suite.
- Four cases on `keysym_to_key`, including the compose sequence the guard
  legitimately protects.
- The wakeup contract: the ping must not be gated on `FRAME_REQUESTED`.
  ARCHITECTURE.md explains at length why — it hung the loop once — and it
  was the only documented bug in that subsystem without a regression test.
  Prose does not fail CI. A real calloop ping and event loop are enough, no
  compositor involved.

Also folded in: `Container::paint` opened three signal-tracking scopes where
two do (the third only existed because its fallback needs a value the second
produces). The visibility scope stays separate on purpose — it guards an
early return, and folding it in would subscribe an invisible container to
every paint property before discovering it has nothing to draw.

## Verified on a live compositor

niri, one example per extracted module: `text_input_example` (input +
selections), `popup_example` (open, outside-click dismiss, nested submenus),
`blur_example`, `multi_output`, `simple_lock` (lock granted, unlock
returns the screen). Plus the three fixes exercised by hand.
