### PR TITLE
Share the quad pipeline, and make the wakeup contract structural

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -118,7 +118,7 @@ Hardware-accelerated rendering using wgpu.
 
 *Main loop (once per iteration):*
 1. `flush_bg_writes()` - Drain queued background-thread signal writes
-2. `take_frame_request()` - Check if a frame was requested
+2. `take_wake_request()` - Take the pending wake request
 
 *Per-surface rendering:*
 3. Dispatch events to widgets (queued `MouseMove`s are coalesced to the latest position)
@@ -294,18 +294,18 @@ calloop guarantees a send wakes the next dispatch — the message's existence
 *is* the wakeup, so a lost-wakeup is impossible by construction. Messages
 either carry their payload or act as doorbells for data queued elsewhere
 (e.g. `BgWritesQueued` for the reactive write queue, drained at the loop's
-flush point). Never call `jobs::request_frame()` directly from a background
+flush point). Never call `jobs::wake_loop()` directly from a background
 thread as the *only* wakeup for queued work.
 
-**Main thread → `jobs::request_frame()`.**
+**Main thread → `jobs::wake_loop()`.**
 The frame-request ping is coalesced per loop iteration through a dedicated
 `PING_SENT` flag cleared once per wakeup (`mark_loop_awake`, right after
-dispatch returns). It is intentionally NOT coalesced via `FRAME_REQUESTED`:
+dispatch returns). It is intentionally NOT coalesced via `WAKE_REQUESTED`:
 that flag is consumed mid-iteration by `take_frame_request()`, and gating
 the ping on it once lost wakeups entirely (a request landing while the flag
 was set sent no ping and was then absorbed by the take — the loop blocked
 with work queued until an unrelated Wayland event arrived). Additionally,
-the loop refuses to block indefinitely while `FRAME_REQUESTED` is still set
+the loop refuses to block indefinitely while `WAKE_REQUESTED` is still set
 at iteration start (`frame_request_pending`).
 
 When adding a new deferred-work queue, either drain it in the loop after

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -312,6 +312,20 @@ When adding a new deferred-work queue, either drain it in the loop after
 the flush point AND wake through one of the two mechanisms above, or make
 it a calloop source of its own.
 
+**The contract is checked, not just written down.** Debug builds assert it at
+the one moment where breaking it is fatal: `queued_but_unwoken()` in
+`src/lib.rs` names every queue the loop drains, and nothing may be
+outstanding when the loop is about to block indefinitely. The reasoning is
+that each queue is drained unconditionally once per iteration, so anything
+still queued was produced *after* its own drain — and the only thing that
+brings the loop back is a frame request, which would have kept it from
+blocking. A non-empty queue there means nobody asked to be woken.
+
+So a new queue needs one line in `queued_but_unwoken()` alongside its drain.
+Forget the wakeup and the next idle moment panics with the queue's name,
+instead of the app going quietly deaf until an unrelated compositor event
+happens along. Two of the bugs documented above were exactly that.
+
 ## Widget Trait
 
 All widgets implement this trait:

--- a/src/ingress.rs
+++ b/src/ingress.rs
@@ -8,11 +8,11 @@
 //! suppressed because some flag was already set, then absorbed by an
 //! unrelated consumer) cannot occur by construction.
 //!
-//! Main-thread code keeps using `jobs::request_frame()`, whose ping is
+//! Main-thread code keeps using `jobs::wake_loop()`, whose ping is
 //! coalesced once per loop iteration (see `jobs::mark_loop_awake`).
 //!
 //! When no loop is running (setup phase, tests, teardown) [`notify`] falls
-//! back to the frame-request ping, which degrades to a plain flag there.
+//! back to the wake ping, which degrades to a plain flag there.
 
 use std::sync::Mutex;
 
@@ -52,7 +52,7 @@ pub(crate) fn sender() -> Option<Sender<IngressMessage>> {
     INGRESS_SENDER.lock().ok().and_then(|g| g.as_ref().cloned())
 }
 
-/// Send a message to the main loop, falling back to the frame-request ping
+/// Send a message to the main loop, falling back to the wake ping
 /// when no loop is running.
 pub(crate) fn notify(message: IngressMessage) {
     match sender() {
@@ -60,10 +60,10 @@ pub(crate) fn notify(message: IngressMessage) {
             if tx.send(message).is_err() {
                 // Receiver died (loop shutting down) — fall back so pending
                 // work is at least flagged for a future loop.
-                crate::jobs::request_frame();
+                crate::jobs::wake_loop();
             }
         }
-        None => crate::jobs::request_frame(),
+        None => crate::jobs::wake_loop(),
     }
 }
 

--- a/src/jobs.rs
+++ b/src/jobs.rs
@@ -233,7 +233,7 @@ pub fn request_job(widget_id: WidgetId, request: JobRequest) {
             }
         }
     });
-    request_frame();
+    wake_loop();
 }
 
 /// Resolve job ownership: sort the inbox into per-surface queues.
@@ -453,8 +453,8 @@ pub(crate) fn get_exit_request() -> ExitRequest {
     }
 }
 
-/// Global flag to indicate a frame is requested
-static FRAME_REQUESTED: AtomicBool = AtomicBool::new(false);
+/// Someone poked the loop: make a pass even though no dirty flag says so.
+static WAKE_REQUESTED: AtomicBool = AtomicBool::new(false);
 /// Whether a wakeup ping is already in flight for the current blocked/idle
 /// period. Cleared by `mark_loop_awake()` right after dispatch returns.
 static PING_SENT: AtomicBool = AtomicBool::new(false);
@@ -470,12 +470,23 @@ pub fn init_wakeup(ping: Ping) {
     }
 }
 
-/// Request that the main event loop process a frame
-pub(crate) fn request_frame() {
-    FRAME_REQUESTED.store(true, Ordering::Relaxed);
+/// Wake the main loop and have it make a full pass.
+///
+/// Named for what it does. It used to be `request_frame`, which promised more
+/// than it delivers on both counts: a pass produces a frame only if something
+/// actually needs painting, and four of its five callers — a queued job, a
+/// disposal, a surface command, a copy — want the loop to *turn*, not to
+/// draw. The flag it raises means "someone poked us, do a pass even though no
+/// dirty flag says so"; the loop then skips the paint on its own if there is
+/// nothing to show.
+///
+/// Producers call this from the same function that queues the work, so
+/// queueing and waking are one gesture and the second cannot be forgotten.
+pub(crate) fn wake_loop() {
+    WAKE_REQUESTED.store(true, Ordering::Relaxed);
     // Coalesce pings per loop iteration via a dedicated flag, NOT via
-    // FRAME_REQUESTED: the frame flag is consumed mid-iteration by
-    // take_frame_request(), so gating the ping on it lost wakeups — a
+    // WAKE_REQUESTED: that flag is consumed mid-iteration by
+    // take_wake_request(), so gating the ping on it lost wakeups — a
     // request landing while the flag happened to be set sent no ping, the
     // take then cleared the flag, and the loop blocked indefinitely with
     // work queued (only an unrelated Wayland event like mouse movement
@@ -491,7 +502,7 @@ pub(crate) fn request_frame() {
     }
 }
 
-/// Reset ping coalescing after the event loop woke up. Any `request_frame`
+/// Reset ping coalescing after the event loop woke up. Any `wake_loop`
 /// from here until the next dispatch sends (at most) one fresh ping, which
 /// keeps the eventfd readable so that dispatch returns immediately.
 pub(crate) fn mark_loop_awake() {
@@ -505,7 +516,7 @@ pub(crate) fn reset_jobs() {
     PENDING_JOBS.with(|jobs| {
         *jobs.borrow_mut() = JobQueues::new();
     });
-    FRAME_REQUESTED.store(false, Ordering::Relaxed);
+    WAKE_REQUESTED.store(false, Ordering::Relaxed);
     PING_SENT.store(false, Ordering::Relaxed);
     EXIT_REQUEST.store(ExitRequest::Running as u8, Ordering::Relaxed);
     if let Ok(mut guard) = WAKEUP_PING.lock() {
@@ -513,21 +524,21 @@ pub(crate) fn reset_jobs() {
     }
 }
 
-/// Check if a frame has been requested and clear the flag
-pub fn take_frame_request() -> bool {
-    FRAME_REQUESTED.swap(false, Ordering::Relaxed)
+/// Take the pending wake request, clearing it.
+pub fn take_wake_request() -> bool {
+    WAKE_REQUESTED.swap(false, Ordering::Relaxed)
 }
 
-/// Peek the frame-request flag without clearing it.
+/// Peek the wake request without clearing it.
 ///
 /// Used by the main loop before blocking: a request that landed after this
-/// iteration's `take_frame_request()` (e.g. from a background thread) leaves
-/// the flag set, and `request_frame`'s ping-on-first-request optimization
+/// iteration's `take_wake_request()` (e.g. from a background thread) leaves
+/// the flag set, and `wake_loop`'s ping-on-first-request optimization
 /// then suppresses every later ping — blocking indefinitely on a set flag
 /// would make the app deaf to background wakeups until an unrelated Wayland
 /// event (mouse movement) arrives.
-pub fn frame_request_pending() -> bool {
-    FRAME_REQUESTED.load(Ordering::Relaxed)
+pub fn wake_request_pending() -> bool {
+    WAKE_REQUESTED.load(Ordering::Relaxed)
 }
 
 #[cfg(test)]
@@ -691,9 +702,9 @@ mod wakeup_contract {
 
     /// The one invariant in this file that had no test, and the one that cost
     /// a hung loop once: the wakeup ping must not be gated on
-    /// `FRAME_REQUESTED`.
+    /// `WAKE_REQUESTED`.
     ///
-    /// That flag is consumed mid-iteration by `take_frame_request()`. Gating
+    /// That flag is consumed mid-iteration by `take_wake_request()`. Gating
     /// the ping on it meant a request arriving while the flag happened to be
     /// set sent nothing, the take then cleared the flag, and the loop blocked
     /// with work already queued — until an unrelated Wayland event, a mouse
@@ -725,10 +736,10 @@ mod wakeup_contract {
             let _ = event_loop.dispatch(Some(Duration::ZERO), &mut drained);
 
             // The state the old bug keyed on, set immediately before the call.
-            FRAME_REQUESTED.store(true, Ordering::Relaxed);
+            WAKE_REQUESTED.store(true, Ordering::Relaxed);
             PING_SENT.store(false, Ordering::Relaxed);
 
-            request_frame();
+            wake_loop();
 
             let mut woken = false;
             let _ = event_loop.dispatch(Some(Duration::from_millis(20)), &mut woken);
@@ -747,7 +758,7 @@ mod wakeup_contract {
 
         reset_jobs();
         panic!(
-            "request_frame must ping while FRAME_REQUESTED is set — gating on \
+            "wake_loop must ping while WAKE_REQUESTED is set — gating on \
              that flag is what lost wakeups"
         );
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -528,6 +528,36 @@ fn run_jobs(
     jobs::recycle_job_buffer(followup);
 }
 
+/// Deferred work that is queued and still waiting for the loop to drain it.
+///
+/// The wakeup contract says a producer that queues work must also guarantee a
+/// wakeup that survives until its consumer runs. This is that contract as a
+/// check instead of as prose — prose does not fail a test run.
+///
+/// Why an empty result is the only correct answer at the blocking point: each
+/// of these is drained unconditionally, once per iteration. Anything still
+/// queued was therefore produced *after* its own drain, and the only thing
+/// that can bring the loop back to drain it is a frame request — which would
+/// have kept it from blocking in the first place. So a non-empty queue here
+/// means nobody asked to be woken, and the app is about to go deaf until an
+/// unrelated compositor event happens along. That is precisely the shape of
+/// the lost-wakeup bug this contract exists to prevent.
+///
+/// Returns the name of the offender, because the point is the message.
+fn queued_but_unwoken() -> Option<&'static str> {
+    [
+        ("widget jobs", has_pending_jobs()),
+        ("a frame request", jobs::frame_request_pending()),
+        ("background signal writes", reactive::bg_writes_pending()),
+        ("owner disposals", reactive::owner::disposals_pending()),
+        ("surface commands", surface::surface_commands_pending()),
+        ("a selection change", reactive::selection_change_pending()),
+        ("a cursor change", reactive::cursor_change_pending()),
+    ]
+    .into_iter()
+    .find_map(|(name, pending)| pending.then_some(name))
+}
+
 /// What this surface tells us about itself, read once at the top of a frame.
 ///
 /// Copying it frees the borrow on `wayland_state`, which the phases below
@@ -1208,6 +1238,16 @@ impl App {
             let timeout = if needs_polling {
                 Some(std::time::Duration::from_millis(16)) // ~60fps for animations
             } else {
+                // About to block with nothing left to wake us but the
+                // compositor. Every queue must be empty by now — see
+                // `queued_but_unwoken`.
+                debug_assert!(
+                    queued_but_unwoken().is_none(),
+                    "the loop is about to block indefinitely with {} still queued — \
+                     whatever produced it owes a wakeup. See the Event Loop Wakeup \
+                     Contract in docs/ARCHITECTURE.md.",
+                    queued_but_unwoken().unwrap_or_default()
+                );
                 None // Block indefinitely until event
             };
 
@@ -1397,5 +1437,48 @@ mod font_registry_tests {
             after_second + 1,
             "a different font must still register"
         );
+    }
+}
+
+#[cfg(test)]
+mod wakeup_contract_coverage {
+    use super::*;
+
+    /// A probe that never reports anything would make the check in
+    /// `queued_but_unwoken` silently useless, so each one is pinned to the
+    /// drain it speaks for: queue, see it, drain, see it gone.
+    #[test]
+    fn each_probe_tracks_its_own_queue() {
+        // Clipboard and primary share one probe.
+        let _ = reactive::take_clipboard_change();
+        let _ = reactive::take_primary_change();
+        assert!(!reactive::selection_change_pending());
+
+        reactive::clipboard_copy("queued");
+        assert!(
+            reactive::selection_change_pending(),
+            "a copy must be visible to the wakeup check"
+        );
+        let _ = reactive::take_clipboard_change();
+        assert!(!reactive::selection_change_pending());
+
+        reactive::primary_copy("queued");
+        assert!(
+            reactive::selection_change_pending(),
+            "a primary-selection copy must be visible too"
+        );
+        let _ = reactive::take_primary_change();
+        assert!(!reactive::selection_change_pending());
+
+        // Cursor.
+        let _ = reactive::take_cursor_change();
+        assert!(!reactive::cursor_change_pending());
+        reactive::set_cursor(reactive::CursorIcon::Text);
+        assert!(
+            reactive::cursor_change_pending(),
+            "a cursor change must be visible to the wakeup check"
+        );
+        let _ = reactive::take_cursor_change();
+        assert!(!reactive::cursor_change_pending());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,7 +190,7 @@ use smithay_client_toolkit::reexports::client::QueueHandle;
 use smithay_client_toolkit::reexports::client::protocol::wl_surface::WlSurface;
 
 use crate::{
-    jobs::{get_exit_request, has_pending_jobs, init_wakeup, process_jobs, take_frame_request},
+    jobs::{get_exit_request, has_pending_jobs, init_wakeup, process_jobs, take_wake_request},
     tree::{DamageRegion, Tree, WidgetId},
 };
 
@@ -537,7 +537,7 @@ fn run_jobs(
 /// Why an empty result is the only correct answer at the blocking point: each
 /// of these is drained unconditionally, once per iteration. Anything still
 /// queued was therefore produced *after* its own drain, and the only thing
-/// that can bring the loop back to drain it is a frame request — which would
+/// that can bring the loop back to drain it is a wake request — which would
 /// have kept it from blocking in the first place. So a non-empty queue here
 /// means nobody asked to be woken, and the app is about to go deaf until an
 /// unrelated compositor event happens along. That is precisely the shape of
@@ -547,7 +547,7 @@ fn run_jobs(
 fn queued_but_unwoken() -> Option<&'static str> {
     [
         ("widget jobs", has_pending_jobs()),
-        ("a frame request", jobs::frame_request_pending()),
+        ("a wake request", jobs::wake_request_pending()),
         ("background signal writes", reactive::bg_writes_pending()),
         ("owner disposals", reactive::owner::disposals_pending()),
         ("surface commands", surface::surface_commands_pending()),
@@ -889,7 +889,7 @@ fn paint_and_present(ctx: &mut FrameContext, frame: &Frame, geometry: &Geometry)
         // repainted next frame instead of staying stale, restore full
         // damage, and request that frame.
         tree.set_full_damage(surface.widget_id);
-        jobs::request_frame();
+        jobs::wake_loop();
         return;
     }
 
@@ -934,7 +934,7 @@ struct FrameContext<'a> {
 fn render_surface(
     ctx: &mut FrameContext,
     layout_roots: &mut Vec<WidgetId>,
-    frame_requested: bool,
+    woken: bool,
     active_roots: &rustc_hash::FxHashSet<WidgetId>,
 ) {
     let Some(frame) = open_frame(ctx) else {
@@ -970,7 +970,7 @@ fn render_surface(
     // Nothing moved and nothing is starting up: there is no frame to draw.
     let has_pending_layouts = !layout_roots.is_empty();
     if !(frame.force_render_surface
-        || frame_requested
+        || woken
         || has_pending_layouts
         || geometry.needs_resize
         || geometry.scale_changed
@@ -1226,11 +1226,11 @@ impl App {
             let force_render = any_surface_needs_init;
 
             // Check if we need to actively poll: jobs pushed during the
-            // previous frame, or a frame request that landed after this
+            // previous frame, or a wake request that landed after this
             // iteration consumed the flag (blocking on a set flag would
-            // suppress all later pings — see frame_request_pending).
+            // suppress all later pings — see wake_request_pending).
             let has_pending = has_pending_jobs();
-            let needs_polling = has_pending || force_render || jobs::frame_request_pending();
+            let needs_polling = has_pending || force_render || jobs::wake_request_pending();
 
             // Dispatch events from calloop:
             // - If polling needed (animations/callbacks/init), use timeout
@@ -1258,7 +1258,7 @@ impl App {
                 return ExitReason::Error(platform::PlatformError::ConnectionLost);
             }
 
-            // Reset ping coalescing: the first request_frame from here on
+            // Reset ping coalescing: the first wake_loop from here on
             // sends a fresh ping so the next dispatch can't block on
             // work queued during this iteration.
             jobs::mark_loop_awake();
@@ -1319,12 +1319,12 @@ impl App {
             }
 
             // Flush background-thread signal writes once per frame (queued via WriteSignal).
-            // Must run before take_frame_request() so that signal changes from bg writes
-            // are processed into jobs before we check the frame request flag.
+            // Must run before take_wake_request() so that signal changes from bg writes
+            // are processed into jobs before we check the wake request.
             reactive::flush_bg_writes();
 
-            // Check frame request once for all surfaces (not per-surface)
-            let frame_requested = take_frame_request();
+            // Take the wake request once for all surfaces (not per-surface)
+            let woken = take_wake_request();
 
             // Render each surface (no renderer yet means no surface has a
             // GPU state — nothing can be rendered this iteration)
@@ -1368,7 +1368,7 @@ impl App {
                         tree: &mut self.tree,
                         qh: &qh,
                     };
-                    render_surface(&mut ctx, layout_roots, frame_requested, &active_roots);
+                    render_surface(&mut ctx, layout_roots, woken, &active_roots);
                 }
             }
 

--- a/src/platform/backdrop.rs
+++ b/src/platform/backdrop.rs
@@ -136,7 +136,7 @@ impl Dispatch<ExtBackgroundEffectManagerV1, ()> for WaylandState {
             for surface_state in state.surfaces.values_mut() {
                 surface_state.blur_region = None;
             }
-            crate::jobs::request_frame();
+            crate::jobs::wake_loop();
         }
     }
 }

--- a/src/platform/lock.rs
+++ b/src/platform/lock.rs
@@ -135,7 +135,7 @@ impl SessionLockHandler for WaylandState {
     fn locked(&mut self, _conn: &Connection, _qh: &QueueHandle<Self>, _session_lock: SessionLock) {
         log::info!("Session lock granted by compositor");
         self.lock.lock_events.push(LockEvent::Locked);
-        crate::jobs::request_frame();
+        crate::jobs::wake_loop();
     }
 
     fn finished(
@@ -147,7 +147,7 @@ impl SessionLockHandler for WaylandState {
         log::info!("Session lock finished (denied or ended)");
         self.lock.active_lock = None;
         self.lock.lock_events.push(LockEvent::Finished);
-        crate::jobs::request_frame();
+        crate::jobs::wake_loop();
     }
 
     fn configure(
@@ -181,7 +181,7 @@ impl SessionLockHandler for WaylandState {
                 surface_state.height = height;
             }
             surface_state.configured = true;
-            crate::jobs::request_frame();
+            crate::jobs::wake_loop();
         }
     }
 }

--- a/src/platform/popups.rs
+++ b/src/platform/popups.rs
@@ -353,7 +353,7 @@ impl PopupHandler for WaylandState {
             }
             surface_state.pending_popup_height = None;
             surface_state.configured = true;
-            crate::jobs::request_frame();
+            crate::jobs::wake_loop();
         }
     }
 

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -715,7 +715,7 @@ impl CompositorHandler for WaylandState {
                 surface_state.first_frame_presented = true;
             }
             // Wake the loop so a dirty surface renders promptly
-            crate::jobs::request_frame();
+            crate::jobs::wake_loop();
         }
     }
 }

--- a/src/reactive/clipboard.rs
+++ b/src/reactive/clipboard.rs
@@ -9,8 +9,10 @@ thread_local! {
     /// Internal clipboard buffer
     static CLIPBOARD: RefCell<Option<String>> = const { RefCell::new(None) };
 
-    /// Flag indicating clipboard was changed and needs to be synced to Wayland
-    static CLIPBOARD_CHANGED: RefCell<bool> = const { RefCell::new(false) };
+    /// A copy waiting to be handed to the compositor. Being empty *is* the
+    /// "nothing to sync" state — there is no separate dirty flag to keep in
+    /// step with the value.
+    static OUTGOING_CLIPBOARD: RefCell<Option<String>> = const { RefCell::new(None) };
 
     /// System clipboard contents (prefetched from the Wayland selection offer)
     static SYSTEM_CLIPBOARD: RefCell<Option<String>> = const { RefCell::new(None) };
@@ -18,36 +20,28 @@ thread_local! {
     /// Internal primary-selection buffer (our outgoing content)
     static PRIMARY: RefCell<Option<String>> = const { RefCell::new(None) };
 
-    /// Flag indicating the primary selection changed and needs syncing
-    static PRIMARY_CHANGED: RefCell<bool> = const { RefCell::new(false) };
+    /// A select-to-copy waiting to be handed to the compositor.
+    static OUTGOING_PRIMARY: RefCell<Option<String>> = const { RefCell::new(None) };
 
     /// System primary-selection contents (prefetched from other apps)
     static SYSTEM_PRIMARY: RefCell<Option<String>> = const { RefCell::new(None) };
 }
 
-/// Copy text to the clipboard
+/// Copy text to the clipboard.
 pub fn clipboard_copy(text: &str) {
     CLIPBOARD.with(|c| {
         *c.borrow_mut() = Some(text.to_string());
     });
-    CLIPBOARD_CHANGED.with(|changed| {
-        *changed.borrow_mut() = true;
+    OUTGOING_CLIPBOARD.with(|out| {
+        *out.borrow_mut() = Some(text.to_string());
     });
+    // Queueing and waking are one gesture — see `jobs::wake_loop`.
+    crate::jobs::wake_loop();
 }
 
-/// Take pending clipboard change (returns text if clipboard was changed since last call)
+/// Take the copy waiting to go out to the compositor, if any.
 pub fn take_clipboard_change() -> Option<String> {
-    let changed = CLIPBOARD_CHANGED.with(|c| {
-        let was_changed = *c.borrow();
-        *c.borrow_mut() = false;
-        was_changed
-    });
-
-    if changed {
-        CLIPBOARD.with(|c| c.borrow().clone())
-    } else {
-        None
-    }
+    OUTGOING_CLIPBOARD.with(|out| out.borrow_mut().take())
 }
 
 /// Paste text from the clipboard
@@ -91,24 +85,15 @@ pub fn primary_copy(text: &str) {
     PRIMARY.with(|c| {
         *c.borrow_mut() = Some(text.to_string());
     });
-    PRIMARY_CHANGED.with(|changed| {
-        *changed.borrow_mut() = true;
+    OUTGOING_PRIMARY.with(|out| {
+        *out.borrow_mut() = Some(text.to_string());
     });
+    crate::jobs::wake_loop();
 }
 
-/// Take pending primary-selection change (for syncing to Wayland)
+/// Take the select-to-copy waiting to go out to the compositor, if any.
 pub(crate) fn take_primary_change() -> Option<String> {
-    let changed = PRIMARY_CHANGED.with(|c| {
-        let was_changed = *c.borrow();
-        *c.borrow_mut() = false;
-        was_changed
-    });
-
-    if changed {
-        PRIMARY.with(|c| c.borrow().clone())
-    } else {
-        None
-    }
+    OUTGOING_PRIMARY.with(|out| out.borrow_mut().take())
 }
 
 /// Paste text from the primary selection (middle-click paste).
@@ -133,10 +118,10 @@ pub(crate) fn set_system_primary(text: Option<String>) {
 /// Called during `App::drop()` to wipe clipboard buffers.
 pub(crate) fn reset_clipboard() {
     CLIPBOARD.with(|c| *c.borrow_mut() = None);
-    CLIPBOARD_CHANGED.with(|c| *c.borrow_mut() = false);
+    OUTGOING_CLIPBOARD.with(|o| *o.borrow_mut() = None);
     SYSTEM_CLIPBOARD.with(|c| *c.borrow_mut() = None);
     PRIMARY.with(|c| *c.borrow_mut() = None);
-    PRIMARY_CHANGED.with(|c| *c.borrow_mut() = false);
+    OUTGOING_PRIMARY.with(|o| *o.borrow_mut() = None);
     SYSTEM_PRIMARY.with(|c| *c.borrow_mut() = None);
 }
 
@@ -144,5 +129,6 @@ pub(crate) fn reset_clipboard() {
 ///
 /// Part of the loop's wakeup check — see `queued_but_unwoken` in `lib.rs`.
 pub(crate) fn selection_change_pending() -> bool {
-    CLIPBOARD_CHANGED.with(|c| *c.borrow()) || PRIMARY_CHANGED.with(|c| *c.borrow())
+    OUTGOING_CLIPBOARD.with(|o| o.borrow().is_some())
+        || OUTGOING_PRIMARY.with(|o| o.borrow().is_some())
 }

--- a/src/reactive/clipboard.rs
+++ b/src/reactive/clipboard.rs
@@ -139,3 +139,10 @@ pub(crate) fn reset_clipboard() {
     PRIMARY_CHANGED.with(|c| *c.borrow_mut() = false);
     SYSTEM_PRIMARY.with(|c| *c.borrow_mut() = None);
 }
+
+/// Whether a copy is queued for the compositor and not yet handed over.
+///
+/// Part of the loop's wakeup check — see `queued_but_unwoken` in `lib.rs`.
+pub(crate) fn selection_change_pending() -> bool {
+    CLIPBOARD_CHANGED.with(|c| *c.borrow()) || PRIMARY_CHANGED.with(|c| *c.borrow())
+}

--- a/src/reactive/cursor.rs
+++ b/src/reactive/cursor.rs
@@ -48,38 +48,36 @@ thread_local! {
     /// Current requested cursor
     static CURRENT_CURSOR: RefCell<CursorIcon> = const { RefCell::new(CursorIcon::Default) };
 
-    /// Flag indicating cursor was changed and needs to be synced to Wayland
-    static CURSOR_CHANGED: RefCell<bool> = const { RefCell::new(false) };
+    /// A shape waiting to be handed to the compositor. Being empty *is* the
+    /// "nothing to sync" state — no separate dirty flag to keep in step.
+    static OUTGOING_CURSOR: RefCell<Option<CursorIcon>> = const { RefCell::new(None) };
 }
 
 /// Set the cursor to display.
 /// This should be called by widgets when they want to change the cursor appearance.
 pub fn set_cursor(cursor: CursorIcon) {
-    CURRENT_CURSOR.with(|c| {
+    let changed = CURRENT_CURSOR.with(|c| {
         let current = *c.borrow();
-        if current != cursor {
-            *c.borrow_mut() = cursor;
-            CURSOR_CHANGED.with(|changed| {
-                *changed.borrow_mut() = true;
-            });
+        if current == cursor {
+            return false;
         }
+        *c.borrow_mut() = cursor;
+        true
     });
+    if changed {
+        OUTGOING_CURSOR.with(|out| {
+            *out.borrow_mut() = Some(cursor);
+        });
+        // Queueing and waking are one gesture — see `jobs::wake_loop`.
+        crate::jobs::wake_loop();
+    }
 }
 
-/// Take pending cursor change (returns cursor if it was changed since last call).
-/// Called by the main event loop to sync cursor to Wayland.
+/// Take the shape waiting to go out to the compositor, if any.
+///
+/// Called by the main event loop to sync the cursor to Wayland.
 pub fn take_cursor_change() -> Option<CursorIcon> {
-    let changed = CURSOR_CHANGED.with(|c| {
-        let was_changed = *c.borrow();
-        *c.borrow_mut() = false;
-        was_changed
-    });
-
-    if changed {
-        Some(CURRENT_CURSOR.with(|c| *c.borrow()))
-    } else {
-        None
-    }
+    OUTGOING_CURSOR.with(|out| out.borrow_mut().take())
 }
 
 /// Reset cursor state to defaults.
@@ -87,7 +85,7 @@ pub fn take_cursor_change() -> Option<CursorIcon> {
 /// Called during `App::drop()` to clear cursor state.
 pub(crate) fn reset_cursor() {
     CURRENT_CURSOR.with(|c| *c.borrow_mut() = CursorIcon::Default);
-    CURSOR_CHANGED.with(|c| *c.borrow_mut() = false);
+    OUTGOING_CURSOR.with(|o| *o.borrow_mut() = None);
 }
 
 /// Get the current cursor without clearing the change flag.
@@ -99,5 +97,5 @@ pub fn get_current_cursor() -> CursorIcon {
 ///
 /// Part of the loop's wakeup check — see `queued_but_unwoken` in `lib.rs`.
 pub(crate) fn cursor_change_pending() -> bool {
-    CURSOR_CHANGED.with(|c| *c.borrow())
+    OUTGOING_CURSOR.with(|o| o.borrow().is_some())
 }

--- a/src/reactive/cursor.rs
+++ b/src/reactive/cursor.rs
@@ -94,3 +94,10 @@ pub(crate) fn reset_cursor() {
 pub fn get_current_cursor() -> CursorIcon {
     CURRENT_CURSOR.with(|c| *c.borrow())
 }
+
+/// Whether a cursor shape change is queued for the compositor.
+///
+/// Part of the loop's wakeup check — see `queued_but_unwoken` in `lib.rs`.
+pub(crate) fn cursor_change_pending() -> bool {
+    CURSOR_CHANGED.with(|c| *c.borrow())
+}

--- a/src/reactive/invalidation.rs
+++ b/src/reactive/invalidation.rs
@@ -241,7 +241,7 @@ fn register_subscriber_impl(
 /// Notify all subscribers of a signal change by creating jobs.
 ///
 /// Iterates under the registry borrow: `request_job` only touches the job
-/// queue and frame-request state, never the registry, so no re-entrant
+/// queue and wake state, never the registry, so no re-entrant
 /// borrow is possible and no snapshot allocation is needed.
 pub fn notify_signal_change(signal_id: SignalId) {
     REGISTRY.with(|reg| {

--- a/src/reactive/mod.rs
+++ b/src/reactive/mod.rs
@@ -16,6 +16,7 @@ pub mod signal;
 pub mod storage;
 mod trigger;
 
+pub(crate) use clipboard::selection_change_pending;
 pub(crate) use clipboard::{
     clear_system_clipboard, set_system_clipboard, set_system_primary, take_clipboard_change,
     take_primary_change,
@@ -26,8 +27,8 @@ pub use clipboard::{
 pub use context::{
     expect_context, has_context, provide_context, provide_signal_context, use_context, with_context,
 };
-pub(crate) use cursor::take_cursor_change;
 pub use cursor::{CursorIcon, set_cursor};
+pub(crate) use cursor::{cursor_change_pending, take_cursor_change};
 pub use effect::{Effect, create_effect};
 pub(crate) use focus::{
     focus_path, has_focus, init_focus, release_focus, release_focus_if_within, request_focus,
@@ -54,7 +55,7 @@ pub mod __internal {
     pub use super::runtime::batch;
 }
 pub use callback::Callback;
-pub(crate) use runtime::flush_bg_writes;
+pub(crate) use runtime::{bg_writes_pending, flush_bg_writes};
 pub use service::{Service, ServiceContext, create_service};
 pub use signal::{
     OptionSignalExt, RwSignal, Signal, WriteSignal, create_derived, create_signal, create_stored,

--- a/src/reactive/owner.rs
+++ b/src/reactive/owner.rs
@@ -398,7 +398,7 @@ pub fn dispose_owner(id: OwnerId) {
     PENDING_DISPOSALS.with(|v| v.borrow_mut().push(id));
     // Wake the loop so a disposal requested in a quiet moment (compositor
     // dismissal with no other activity) is not postponed indefinitely
-    crate::jobs::request_frame();
+    crate::jobs::wake_loop();
 }
 
 /// Run every pending deferred disposal. Called by the main loop at a safe

--- a/src/reactive/owner.rs
+++ b/src/reactive/owner.rs
@@ -417,6 +417,13 @@ pub(crate) fn flush_pending_disposals() {
     }
 }
 
+/// Whether any owner is waiting to be disposed.
+///
+/// Part of the loop's wakeup check — see `queued_but_unwoken` in `lib.rs`.
+pub(crate) fn disposals_pending() -> bool {
+    PENDING_DISPOSALS.with(|v| !v.borrow().is_empty())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/reactive/runtime.rs
+++ b/src/reactive/runtime.rs
@@ -583,6 +583,13 @@ pub fn batch<R>(f: impl FnOnce() -> R) -> R {
     result
 }
 
+/// Whether a background thread has queued a signal write not yet flushed.
+///
+/// Part of the loop's wakeup check — see `queued_but_unwoken` in `lib.rs`.
+pub(crate) fn bg_writes_pending() -> bool {
+    WRITE_QUEUE.lock().map(|q| !q.is_empty()).unwrap_or(false)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/renderer/image_quad.rs
+++ b/src/renderer/image_quad.rs
@@ -9,14 +9,15 @@ use std::sync::Arc;
 
 use wgpu::util::DeviceExt;
 use wgpu::{
-    BindGroup, BindGroupLayout, Buffer as WgpuBuffer, Device, Extent3d, Queue, RenderPass,
-    RenderPipeline, Sampler, Texture, TextureDimension, TextureFormat, TextureUsages,
+    BindGroup, Buffer as WgpuBuffer, Device, Extent3d, Queue, RenderPass, Texture,
+    TextureDimension, TextureFormat, TextureUsages,
 };
 
 use super::commands::DrawCommand;
 use super::constants::{IMAGE_HASH_SAMPLE_SIZE, SVG_QUALITY_MULTIPLIER};
 use super::flatten::FlattenedCommand;
 use super::gpu::NO_CLIP_RECT;
+use super::textured_quad::TexturedQuadPipeline;
 use super::textured_vertex::{TexturedVertex, to_ndc};
 use crate::widgets::Rect;
 use crate::widgets::image::{ContentFit, ImageSource};
@@ -69,13 +70,9 @@ impl Hash for CacheKey {
 
 /// Renderer for images as textured quads.
 pub struct ImageQuadRenderer {
-    // Quad rendering pipeline
-    pipeline: RenderPipeline,
-    bind_group_layout: BindGroupLayout,
-    sampler: Sampler,
-
-    // Shared index buffer (vertices are per-quad)
-    index_buffer: WgpuBuffer,
+    /// Pipeline, layout, sampler and index buffer — shared with the text
+    /// renderer, which draws the same quad from a different texture.
+    quad: TexturedQuadPipeline,
 
     // Texture cache
     texture_cache: HashMap<CacheKey, Arc<CachedTexture>>,
@@ -89,113 +86,8 @@ pub struct ImageQuadRenderer {
 
 impl ImageQuadRenderer {
     pub fn new(device: &Device, format: TextureFormat) -> Self {
-        // Load shader from dedicated file
-        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
-            label: Some("ImageQuad Shader"),
-            source: wgpu::ShaderSource::Wgsl(include_str!("textured_quad_shader.wgsl").into()),
-        });
-
-        // Create texture bind group layout
-        let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-            label: Some("ImageQuad Bind Group Layout"),
-            entries: &[
-                wgpu::BindGroupLayoutEntry {
-                    binding: 0,
-                    visibility: wgpu::ShaderStages::FRAGMENT,
-                    ty: wgpu::BindingType::Texture {
-                        multisampled: false,
-                        view_dimension: wgpu::TextureViewDimension::D2,
-                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
-                    },
-                    count: None,
-                },
-                wgpu::BindGroupLayoutEntry {
-                    binding: 1,
-                    visibility: wgpu::ShaderStages::FRAGMENT,
-                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
-                    count: None,
-                },
-            ],
-        });
-
-        // Create pipeline layout
-        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-            label: Some("ImageQuad Pipeline Layout"),
-            bind_group_layouts: &[&bind_group_layout],
-            immediate_size: 0,
-        });
-
-        // Create render pipeline
-        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-            label: Some("ImageQuad Pipeline"),
-            layout: Some(&pipeline_layout),
-            vertex: wgpu::VertexState {
-                module: &shader,
-                entry_point: Some("vs_main"),
-                buffers: &[TexturedVertex::desc()],
-                compilation_options: wgpu::PipelineCompilationOptions::default(),
-            },
-            fragment: Some(wgpu::FragmentState {
-                module: &shader,
-                entry_point: Some("fs_main"),
-                targets: &[Some(wgpu::ColorTargetState {
-                    format,
-                    blend: Some(wgpu::BlendState {
-                        color: wgpu::BlendComponent {
-                            src_factor: wgpu::BlendFactor::SrcAlpha,
-                            dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
-                            operation: wgpu::BlendOperation::Add,
-                        },
-                        alpha: wgpu::BlendComponent {
-                            src_factor: wgpu::BlendFactor::One,
-                            dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
-                            operation: wgpu::BlendOperation::Add,
-                        },
-                    }),
-                    write_mask: wgpu::ColorWrites::ALL,
-                })],
-                compilation_options: wgpu::PipelineCompilationOptions::default(),
-            }),
-            primitive: wgpu::PrimitiveState {
-                topology: wgpu::PrimitiveTopology::TriangleList,
-                strip_index_format: None,
-                front_face: wgpu::FrontFace::Ccw,
-                cull_mode: None,
-                polygon_mode: wgpu::PolygonMode::Fill,
-                unclipped_depth: false,
-                conservative: false,
-            },
-            depth_stencil: None,
-            multisample: wgpu::MultisampleState::default(),
-            multiview_mask: None,
-            cache: None,
-        });
-
-        // Create sampler
-        let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
-            label: Some("ImageQuad Sampler"),
-            address_mode_u: wgpu::AddressMode::ClampToEdge,
-            address_mode_v: wgpu::AddressMode::ClampToEdge,
-            address_mode_w: wgpu::AddressMode::ClampToEdge,
-            mag_filter: wgpu::FilterMode::Linear,
-            min_filter: wgpu::FilterMode::Linear,
-            mipmap_filter: wgpu::MipmapFilterMode::Nearest,
-            ..Default::default()
-        });
-
-        // Create index buffer
-        let indices: [u16; 6] = [0, 1, 2, 1, 3, 2];
-        let index_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: Some("ImageQuad Index Buffer"),
-            contents: bytemuck::cast_slice(&indices),
-            usage: wgpu::BufferUsages::INDEX,
-        });
-
         Self {
-            pipeline,
-            bind_group_layout,
-            sampler,
-            index_buffer,
+            quad: TexturedQuadPipeline::new(device, format, "ImageQuad"),
             texture_cache: HashMap::new(),
             current_frame: 0,
             max_cache_size: 64,
@@ -650,7 +542,7 @@ impl ImageQuadRenderer {
         // Create bind group
         let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
             label: Some("ImageQuad Bind Group"),
-            layout: &self.bind_group_layout,
+            layout: &self.quad.bind_group_layout,
             entries: &[
                 wgpu::BindGroupEntry {
                     binding: 0,
@@ -658,7 +550,7 @@ impl ImageQuadRenderer {
                 },
                 wgpu::BindGroupEntry {
                     binding: 1,
-                    resource: wgpu::BindingResource::Sampler(&self.sampler),
+                    resource: wgpu::BindingResource::Sampler(&self.quad.sampler),
                 },
             ],
         });
@@ -876,8 +768,8 @@ impl ImageQuadRenderer {
             return;
         }
 
-        render_pass.set_pipeline(&self.pipeline);
-        render_pass.set_index_buffer(self.index_buffer.slice(..), wgpu::IndexFormat::Uint16);
+        render_pass.set_pipeline(&self.quad.pipeline);
+        render_pass.set_index_buffer(self.quad.index_buffer.slice(..), wgpu::IndexFormat::Uint16);
 
         for quad in quads {
             render_pass.set_bind_group(0, &quad.bind_group, &[]);

--- a/src/renderer/image_quad.rs
+++ b/src/renderer/image_quad.rs
@@ -17,8 +17,8 @@ use super::commands::DrawCommand;
 use super::constants::{IMAGE_HASH_SAMPLE_SIZE, SVG_QUALITY_MULTIPLIER};
 use super::flatten::FlattenedCommand;
 use super::gpu::NO_CLIP_RECT;
-use super::textured_quad::TexturedQuadPipeline;
-use super::textured_vertex::{TexturedVertex, to_ndc};
+use super::textured_quad::{QuadDraw, TexturedQuadPipeline};
+use super::textured_vertex::TexturedVertex;
 use crate::widgets::Rect;
 use crate::widgets::image::{ContentFit, ImageSource};
 
@@ -29,6 +29,16 @@ pub struct PreparedImageQuad {
     bind_group: BindGroup,
     /// Vertex buffer with pre-computed vertices in NDC
     vertex_buffer: WgpuBuffer,
+}
+
+impl QuadDraw for PreparedImageQuad {
+    fn bind_group(&self) -> &BindGroup {
+        &self.bind_group
+    }
+
+    fn vertex_buffer(&self) -> &WgpuBuffer {
+        &self.vertex_buffer
+    }
 }
 
 /// Cached texture data.
@@ -78,10 +88,6 @@ pub struct ImageQuadRenderer {
     texture_cache: HashMap<CacheKey, Arc<CachedTexture>>,
     current_frame: u64,
     max_cache_size: usize,
-
-    // Screen dimensions for NDC conversion
-    screen_width: f32,
-    screen_height: f32,
 }
 
 impl ImageQuadRenderer {
@@ -91,15 +97,12 @@ impl ImageQuadRenderer {
             texture_cache: HashMap::new(),
             current_frame: 0,
             max_cache_size: 64,
-            screen_width: 800.0,
-            screen_height: 600.0,
         }
     }
 
     /// Update screen dimensions for NDC conversion.
     pub fn set_screen_size(&mut self, width: f32, height: f32) {
-        self.screen_width = width;
-        self.screen_height = height;
+        self.quad.set_screen_size(width, height);
     }
 
     /// Begin a new frame (for cache management).
@@ -540,20 +543,9 @@ impl ImageQuadRenderer {
         )?;
 
         // Create bind group
-        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
-            label: Some("ImageQuad Bind Group"),
-            layout: &self.quad.bind_group_layout,
-            entries: &[
-                wgpu::BindGroupEntry {
-                    binding: 0,
-                    resource: wgpu::BindingResource::TextureView(&cached.view),
-                },
-                wgpu::BindGroupEntry {
-                    binding: 1,
-                    resource: wgpu::BindingResource::Sampler(&self.quad.sampler),
-                },
-            ],
-        });
+        let bind_group = self
+            .quad
+            .bind_texture(device, &cached.view, "ImageQuad Bind Group");
 
         // Calculate display rect and UV coordinates based on content fit
         let (display_rect, uv) = self.calculate_display_rect_and_uv(
@@ -712,48 +704,28 @@ impl ImageQuadRenderer {
         // Convert to NDC and create vertices with clip data
         [
             TexturedVertex {
-                position: to_ndc(
-                    screen_corners[0].0,
-                    screen_corners[0].1,
-                    self.screen_width,
-                    self.screen_height,
-                ),
+                position: self.quad.to_ndc(screen_corners[0].0, screen_corners[0].1),
                 uv: [u_min, v_min],
                 screen_pos: [screen_corners[0].0, screen_corners[0].1],
                 clip_rect,
                 clip_params,
             },
             TexturedVertex {
-                position: to_ndc(
-                    screen_corners[1].0,
-                    screen_corners[1].1,
-                    self.screen_width,
-                    self.screen_height,
-                ),
+                position: self.quad.to_ndc(screen_corners[1].0, screen_corners[1].1),
                 uv: [u_max, v_min],
                 screen_pos: [screen_corners[1].0, screen_corners[1].1],
                 clip_rect,
                 clip_params,
             },
             TexturedVertex {
-                position: to_ndc(
-                    screen_corners[2].0,
-                    screen_corners[2].1,
-                    self.screen_width,
-                    self.screen_height,
-                ),
+                position: self.quad.to_ndc(screen_corners[2].0, screen_corners[2].1),
                 uv: [u_min, v_max],
                 screen_pos: [screen_corners[2].0, screen_corners[2].1],
                 clip_rect,
                 clip_params,
             },
             TexturedVertex {
-                position: to_ndc(
-                    screen_corners[3].0,
-                    screen_corners[3].1,
-                    self.screen_width,
-                    self.screen_height,
-                ),
+                position: self.quad.to_ndc(screen_corners[3].0, screen_corners[3].1),
                 uv: [u_max, v_max],
                 screen_pos: [screen_corners[3].0, screen_corners[3].1],
                 clip_rect,
@@ -764,17 +736,6 @@ impl ImageQuadRenderer {
 
     /// Render the prepared image quads.
     pub fn render<'a>(&'a self, render_pass: &mut RenderPass<'a>, quads: &'a [PreparedImageQuad]) {
-        if quads.is_empty() {
-            return;
-        }
-
-        render_pass.set_pipeline(&self.quad.pipeline);
-        render_pass.set_index_buffer(self.quad.index_buffer.slice(..), wgpu::IndexFormat::Uint16);
-
-        for quad in quads {
-            render_pass.set_bind_group(0, &quad.bind_group, &[]);
-            render_pass.set_vertex_buffer(0, quad.vertex_buffer.slice(..));
-            render_pass.draw_indexed(0..6, 0, 0..1);
-        }
+        self.quad.draw(render_pass, quads);
     }
 }

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -22,6 +22,7 @@ mod render;
 mod text;
 mod text_measurer;
 mod text_quad;
+mod textured_quad;
 mod textured_vertex;
 mod tree;
 mod types;

--- a/src/renderer/text_quad.rs
+++ b/src/renderer/text_quad.rs
@@ -15,13 +15,13 @@ use glyphon::{
 };
 use wgpu::util::DeviceExt;
 use wgpu::{
-    BindGroup, BindGroupLayout, Buffer as WgpuBuffer, Device, Extent3d, MultisampleState, Queue,
-    RenderPass, RenderPipeline, Sampler, Texture, TextureDescriptor, TextureDimension,
-    TextureFormat, TextureUsages,
+    BindGroup, Buffer as WgpuBuffer, Device, Extent3d, MultisampleState, Queue, RenderPass,
+    Texture, TextureDescriptor, TextureDimension, TextureFormat, TextureUsages,
 };
 
 use super::constants::{TEXT_BUFFER_MARGIN_MULTIPLIER, TEXT_TEXTURE_PADDING};
 use super::gpu::NO_CLIP_RECT;
+use super::textured_quad::TexturedQuadPipeline;
 use super::textured_vertex::{TexturedVertex, to_ndc};
 use super::types::TextEntry;
 use crate::widgets::font::FontWeight;
@@ -79,13 +79,9 @@ pub struct TextQuadRenderer {
     text_renderer: TextRenderer,
     viewport: Viewport,
 
-    // Quad rendering pipeline
-    pipeline: RenderPipeline,
-    bind_group_layout: BindGroupLayout,
-    sampler: Sampler,
-
-    // Shared index buffer (vertices are per-quad)
-    index_buffer: WgpuBuffer,
+    /// Pipeline, layout, sampler and index buffer — shared with the image
+    /// renderer, which draws the same quad from a different texture.
+    quad: TexturedQuadPipeline,
 
     // Texture format
     format: TextureFormat,
@@ -111,109 +107,8 @@ impl TextQuadRenderer {
             TextRenderer::new(&mut atlas, device, MultisampleState::default(), None);
         let viewport = Viewport::new(device, &cache);
 
-        // Load shader from dedicated file
-        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
-            label: Some("TextQuad Shader"),
-            source: wgpu::ShaderSource::Wgsl(include_str!("textured_quad_shader.wgsl").into()),
-        });
-
-        // Create texture bind group layout
-        let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-            label: Some("TextQuad Bind Group Layout"),
-            entries: &[
-                wgpu::BindGroupLayoutEntry {
-                    binding: 0,
-                    visibility: wgpu::ShaderStages::FRAGMENT,
-                    ty: wgpu::BindingType::Texture {
-                        multisampled: false,
-                        view_dimension: wgpu::TextureViewDimension::D2,
-                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
-                    },
-                    count: None,
-                },
-                wgpu::BindGroupLayoutEntry {
-                    binding: 1,
-                    visibility: wgpu::ShaderStages::FRAGMENT,
-                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
-                    count: None,
-                },
-            ],
-        });
-
-        // Create pipeline layout
-        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-            label: Some("TextQuad Pipeline Layout"),
-            bind_group_layouts: &[&bind_group_layout],
-            immediate_size: 0,
-        });
-
-        // Create render pipeline
-        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-            label: Some("TextQuad Pipeline"),
-            layout: Some(&pipeline_layout),
-            vertex: wgpu::VertexState {
-                module: &shader,
-                entry_point: Some("vs_main"),
-                buffers: &[TexturedVertex::desc()],
-                compilation_options: wgpu::PipelineCompilationOptions::default(),
-            },
-            fragment: Some(wgpu::FragmentState {
-                module: &shader,
-                entry_point: Some("fs_main"),
-                targets: &[Some(wgpu::ColorTargetState {
-                    format,
-                    blend: Some(wgpu::BlendState {
-                        color: wgpu::BlendComponent {
-                            src_factor: wgpu::BlendFactor::SrcAlpha,
-                            dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
-                            operation: wgpu::BlendOperation::Add,
-                        },
-                        alpha: wgpu::BlendComponent {
-                            src_factor: wgpu::BlendFactor::One,
-                            dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
-                            operation: wgpu::BlendOperation::Add,
-                        },
-                    }),
-                    write_mask: wgpu::ColorWrites::ALL,
-                })],
-                compilation_options: wgpu::PipelineCompilationOptions::default(),
-            }),
-            primitive: wgpu::PrimitiveState {
-                topology: wgpu::PrimitiveTopology::TriangleList,
-                strip_index_format: None,
-                front_face: wgpu::FrontFace::Ccw,
-                cull_mode: None,
-                polygon_mode: wgpu::PolygonMode::Fill,
-                unclipped_depth: false,
-                conservative: false,
-            },
-            depth_stencil: None,
-            multisample: wgpu::MultisampleState::default(),
-            multiview_mask: None,
-            cache: None,
-        });
-
-        // Create sampler
-        let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
-            label: Some("TextQuad Sampler"),
-            address_mode_u: wgpu::AddressMode::ClampToEdge,
-            address_mode_v: wgpu::AddressMode::ClampToEdge,
-            address_mode_w: wgpu::AddressMode::ClampToEdge,
-            mag_filter: wgpu::FilterMode::Linear,
-            min_filter: wgpu::FilterMode::Linear,
-            mipmap_filter: wgpu::MipmapFilterMode::Nearest,
-            ..Default::default()
-        });
-
-        // Create index buffer
-        let indices: [u16; 6] = [0, 1, 2, 1, 3, 2];
-        let index_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: Some("TextQuad Index Buffer"),
-            contents: bytemuck::cast_slice(&indices),
-            usage: wgpu::BufferUsages::INDEX,
-        });
-
         Self {
+            quad: TexturedQuadPipeline::new(device, format, "TextQuad"),
             font_system,
             text_cache: std::collections::HashMap::new(),
             frame_gen: 0,
@@ -222,10 +117,6 @@ impl TextQuadRenderer {
             atlas,
             text_renderer,
             viewport,
-            pipeline,
-            bind_group_layout,
-            sampler,
-            index_buffer,
             format,
             screen_width: 800.0,
             screen_height: 600.0,
@@ -436,7 +327,7 @@ impl TextQuadRenderer {
         // Create bind group
         let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
             label: Some("Text Texture Bind Group"),
-            layout: &self.bind_group_layout,
+            layout: &self.quad.bind_group_layout,
             entries: &[
                 wgpu::BindGroupEntry {
                     binding: 0,
@@ -444,7 +335,7 @@ impl TextQuadRenderer {
                 },
                 wgpu::BindGroupEntry {
                     binding: 1,
-                    resource: wgpu::BindingResource::Sampler(&self.sampler),
+                    resource: wgpu::BindingResource::Sampler(&self.quad.sampler),
                 },
             ],
         });
@@ -610,8 +501,8 @@ impl TextQuadRenderer {
             return;
         }
 
-        render_pass.set_pipeline(&self.pipeline);
-        render_pass.set_index_buffer(self.index_buffer.slice(..), wgpu::IndexFormat::Uint16);
+        render_pass.set_pipeline(&self.quad.pipeline);
+        render_pass.set_index_buffer(self.quad.index_buffer.slice(..), wgpu::IndexFormat::Uint16);
 
         for quad in quads {
             render_pass.set_bind_group(0, &quad.cached.bind_group, &[]);

--- a/src/renderer/text_quad.rs
+++ b/src/renderer/text_quad.rs
@@ -21,8 +21,8 @@ use wgpu::{
 
 use super::constants::{TEXT_BUFFER_MARGIN_MULTIPLIER, TEXT_TEXTURE_PADDING};
 use super::gpu::NO_CLIP_RECT;
-use super::textured_quad::TexturedQuadPipeline;
-use super::textured_vertex::{TexturedVertex, to_ndc};
+use super::textured_quad::{QuadDraw, TexturedQuadPipeline};
+use super::textured_vertex::TexturedVertex;
 use super::types::TextEntry;
 use crate::widgets::font::FontWeight;
 
@@ -37,6 +37,16 @@ pub struct PreparedTextQuad {
     cached: std::rc::Rc<CachedTextTexture>,
     /// Vertex buffer with pre-computed vertices in NDC
     vertex_buffer: WgpuBuffer,
+}
+
+impl QuadDraw for PreparedTextQuad {
+    fn bind_group(&self) -> &BindGroup {
+        &self.cached.bind_group
+    }
+
+    fn vertex_buffer(&self) -> &WgpuBuffer {
+        &self.vertex_buffer
+    }
 }
 
 /// A rasterized text texture, reused across frames.
@@ -85,10 +95,6 @@ pub struct TextQuadRenderer {
 
     // Texture format
     format: TextureFormat,
-
-    // Screen dimensions for NDC conversion
-    screen_width: f32,
-    screen_height: f32,
 }
 
 impl TextQuadRenderer {
@@ -118,15 +124,12 @@ impl TextQuadRenderer {
             text_renderer,
             viewport,
             format,
-            screen_width: 800.0,
-            screen_height: 600.0,
         }
     }
 
     /// Update screen dimensions for NDC conversion.
     pub fn set_screen_size(&mut self, width: f32, height: f32) {
-        self.screen_width = width;
-        self.screen_height = height;
+        self.quad.set_screen_size(width, height);
     }
 
     /// Prepare text entries for rendering as textured quads.
@@ -325,20 +328,9 @@ impl TextQuadRenderer {
         queue.submit(std::iter::once(encoder.finish()));
 
         // Create bind group
-        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
-            label: Some("Text Texture Bind Group"),
-            layout: &self.quad.bind_group_layout,
-            entries: &[
-                wgpu::BindGroupEntry {
-                    binding: 0,
-                    resource: wgpu::BindingResource::TextureView(&view),
-                },
-                wgpu::BindGroupEntry {
-                    binding: 1,
-                    resource: wgpu::BindingResource::Sampler(&self.quad.sampler),
-                },
-            ],
-        });
+        let bind_group = self
+            .quad
+            .bind_texture(device, &view, "Text Texture Bind Group");
 
         let cached = std::rc::Rc::new(CachedTextTexture {
             texture,
@@ -433,48 +425,28 @@ impl TextQuadRenderer {
         // Convert to NDC and create vertices with clip data
         let vertices = [
             TexturedVertex {
-                position: to_ndc(
-                    screen_corners[0].0,
-                    screen_corners[0].1,
-                    self.screen_width,
-                    self.screen_height,
-                ),
+                position: self.quad.to_ndc(screen_corners[0].0, screen_corners[0].1),
                 uv: [0.0, 0.0],
                 screen_pos: [screen_corners[0].0, screen_corners[0].1],
                 clip_rect,
                 clip_params,
             },
             TexturedVertex {
-                position: to_ndc(
-                    screen_corners[1].0,
-                    screen_corners[1].1,
-                    self.screen_width,
-                    self.screen_height,
-                ),
+                position: self.quad.to_ndc(screen_corners[1].0, screen_corners[1].1),
                 uv: [1.0, 0.0],
                 screen_pos: [screen_corners[1].0, screen_corners[1].1],
                 clip_rect,
                 clip_params,
             },
             TexturedVertex {
-                position: to_ndc(
-                    screen_corners[2].0,
-                    screen_corners[2].1,
-                    self.screen_width,
-                    self.screen_height,
-                ),
+                position: self.quad.to_ndc(screen_corners[2].0, screen_corners[2].1),
                 uv: [0.0, 1.0],
                 screen_pos: [screen_corners[2].0, screen_corners[2].1],
                 clip_rect,
                 clip_params,
             },
             TexturedVertex {
-                position: to_ndc(
-                    screen_corners[3].0,
-                    screen_corners[3].1,
-                    self.screen_width,
-                    self.screen_height,
-                ),
+                position: self.quad.to_ndc(screen_corners[3].0, screen_corners[3].1),
                 uv: [1.0, 1.0],
                 screen_pos: [screen_corners[3].0, screen_corners[3].1],
                 clip_rect,
@@ -497,17 +469,6 @@ impl TextQuadRenderer {
 
     /// Render the prepared text quads.
     pub fn render<'a>(&'a self, render_pass: &mut RenderPass<'a>, quads: &'a [PreparedTextQuad]) {
-        if quads.is_empty() {
-            return;
-        }
-
-        render_pass.set_pipeline(&self.quad.pipeline);
-        render_pass.set_index_buffer(self.quad.index_buffer.slice(..), wgpu::IndexFormat::Uint16);
-
-        for quad in quads {
-            render_pass.set_bind_group(0, &quad.cached.bind_group, &[]);
-            render_pass.set_vertex_buffer(0, quad.vertex_buffer.slice(..));
-            render_pass.draw_indexed(0..6, 0, 0..1);
-        }
+        self.quad.draw(render_pass, quads);
     }
 }

--- a/src/renderer/textured_quad.rs
+++ b/src/renderer/textured_quad.rs
@@ -1,0 +1,137 @@
+//! The wgpu side of drawing a textured quad, once.
+//!
+//! Images and text differ entirely in how they *produce* a texture — one
+//! decodes or rasterises a source, the other lays out glyphs into an atlas —
+//! but what they do with it afterwards is the same: the same shader, the same
+//! vertex format, the same premultiplied blend state, the same clamped
+//! bilinear sampler, the same two triangles.
+//!
+//! Both pipelines were written out in full, and the two copies were identical
+//! down to the byte apart from their debug labels. Keeping them apart meant
+//! the blend state could drift on one side and nothing would say so.
+
+use wgpu::util::DeviceExt;
+use wgpu::{BindGroupLayout, Buffer as WgpuBuffer, Device, RenderPipeline, Sampler, TextureFormat};
+
+use super::textured_vertex::TexturedVertex;
+
+/// Pipeline, bind group layout, sampler and index buffer for textured quads.
+pub(super) struct TexturedQuadPipeline {
+    pub(super) pipeline: RenderPipeline,
+    pub(super) bind_group_layout: BindGroupLayout,
+    pub(super) sampler: Sampler,
+    /// Two triangles, shared by every quad — only the vertices are per-quad.
+    pub(super) index_buffer: WgpuBuffer,
+}
+
+impl TexturedQuadPipeline {
+    /// `label` names the caller in wgpu's debug output ("ImageQuad",
+    /// "TextQuad"), which is the only thing that ever differed between the
+    /// two copies.
+    pub(super) fn new(device: &Device, format: TextureFormat, label: &str) -> Self {
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some(&format!("{label} Shader")),
+            source: wgpu::ShaderSource::Wgsl(include_str!("textured_quad_shader.wgsl").into()),
+        });
+
+        let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some(&format!("{label} Bind Group Layout")),
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        multisampled: false,
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                    count: None,
+                },
+            ],
+        });
+
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some(&format!("{label} Pipeline Layout")),
+            bind_group_layouts: &[&bind_group_layout],
+            immediate_size: 0,
+        });
+
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some(&format!("{label} Pipeline")),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_main"),
+                buffers: &[TexturedVertex::desc()],
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_main"),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format,
+                    // Premultiplied alpha: the colour is already scaled, so it
+                    // is added whole and only the destination is attenuated.
+                    blend: Some(wgpu::BlendState {
+                        color: wgpu::BlendComponent {
+                            src_factor: wgpu::BlendFactor::SrcAlpha,
+                            dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
+                            operation: wgpu::BlendOperation::Add,
+                        },
+                        alpha: wgpu::BlendComponent {
+                            src_factor: wgpu::BlendFactor::One,
+                            dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
+                            operation: wgpu::BlendOperation::Add,
+                        },
+                    }),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleList,
+                strip_index_format: None,
+                front_face: wgpu::FrontFace::Ccw,
+                cull_mode: None,
+                polygon_mode: wgpu::PolygonMode::Fill,
+                unclipped_depth: false,
+                conservative: false,
+            },
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            multiview_mask: None,
+            cache: None,
+        });
+
+        let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+            label: Some(&format!("{label} Sampler")),
+            address_mode_u: wgpu::AddressMode::ClampToEdge,
+            address_mode_v: wgpu::AddressMode::ClampToEdge,
+            address_mode_w: wgpu::AddressMode::ClampToEdge,
+            mag_filter: wgpu::FilterMode::Linear,
+            min_filter: wgpu::FilterMode::Linear,
+            mipmap_filter: wgpu::MipmapFilterMode::Nearest,
+            ..Default::default()
+        });
+
+        let indices: [u16; 6] = [0, 1, 2, 1, 3, 2];
+        let index_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some(&format!("{label} Index Buffer")),
+            contents: bytemuck::cast_slice(&indices),
+            usage: wgpu::BufferUsages::INDEX,
+        });
+
+        Self {
+            pipeline,
+            bind_group_layout,
+            sampler,
+            index_buffer,
+        }
+    }
+}

--- a/src/renderer/textured_quad.rs
+++ b/src/renderer/textured_quad.rs
@@ -11,9 +11,12 @@
 //! the blend state could drift on one side and nothing would say so.
 
 use wgpu::util::DeviceExt;
-use wgpu::{BindGroupLayout, Buffer as WgpuBuffer, Device, RenderPipeline, Sampler, TextureFormat};
+use wgpu::{
+    BindGroup, BindGroupLayout, Buffer as WgpuBuffer, Device, RenderPass, RenderPipeline, Sampler,
+    TextureFormat, TextureView,
+};
 
-use super::textured_vertex::TexturedVertex;
+use super::textured_vertex::{TexturedVertex, to_ndc};
 
 /// Pipeline, bind group layout, sampler and index buffer for textured quads.
 pub(super) struct TexturedQuadPipeline {
@@ -22,6 +25,23 @@ pub(super) struct TexturedQuadPipeline {
     pub(super) sampler: Sampler,
     /// Two triangles, shared by every quad — only the vertices are per-quad.
     pub(super) index_buffer: WgpuBuffer,
+
+    /// The surface size the vertices are projected against. Every quad's
+    /// geometry is computed in screen pixels and converted here, so this is
+    /// part of drawing a quad rather than of producing its texture.
+    screen_width: f32,
+    screen_height: f32,
+}
+
+/// A quad ready to draw: the texture to sample, and the four corners its
+/// geometry resolved to.
+///
+/// The two renderers reach the bind group differently — one owns it per quad,
+/// the other shares it through a cached texture — which was the only reason
+/// they each wrote out the same render loop.
+pub(super) trait QuadDraw {
+    fn bind_group(&self) -> &BindGroup;
+    fn vertex_buffer(&self) -> &WgpuBuffer;
 }
 
 impl TexturedQuadPipeline {
@@ -132,6 +152,63 @@ impl TexturedQuadPipeline {
             bind_group_layout,
             sampler,
             index_buffer,
+            screen_width: 800.0,
+            screen_height: 600.0,
+        }
+    }
+
+    /// Update the surface size the vertices are projected against.
+    pub(super) fn set_screen_size(&mut self, width: f32, height: f32) {
+        self.screen_width = width;
+        self.screen_height = height;
+    }
+
+    /// Screen pixels to normalised device coordinates.
+    pub(super) fn to_ndc(&self, x: f32, y: f32) -> [f32; 2] {
+        to_ndc(x, y, self.screen_width, self.screen_height)
+    }
+
+    /// Bind a texture for sampling, with this pipeline's layout and sampler.
+    pub(super) fn bind_texture(
+        &self,
+        device: &Device,
+        view: &TextureView,
+        label: &str,
+    ) -> BindGroup {
+        device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some(label),
+            layout: &self.bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::TextureView(view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::Sampler(&self.sampler),
+                },
+            ],
+        })
+    }
+
+    /// Draw prepared quads: one pipeline and index buffer for all of them,
+    /// then a bind group and vertex buffer per quad.
+    pub(super) fn draw<'a, Q: QuadDraw>(
+        &'a self,
+        render_pass: &mut RenderPass<'a>,
+        quads: &'a [Q],
+    ) {
+        if quads.is_empty() {
+            return;
+        }
+
+        render_pass.set_pipeline(&self.pipeline);
+        render_pass.set_index_buffer(self.index_buffer.slice(..), wgpu::IndexFormat::Uint16);
+
+        for quad in quads {
+            render_pass.set_bind_group(0, quad.bind_group(), &[]);
+            render_pass.set_vertex_buffer(0, quad.vertex_buffer().slice(..));
+            render_pass.draw_indexed(0..6, 0, 0..1);
         }
     }
 }

--- a/src/session_lock.rs
+++ b/src/session_lock.rs
@@ -109,13 +109,13 @@ where
         lock.factory = Some(Box::new(move |info| Box::new(widget_fn(info))));
         lock.lock_requested = true;
     });
-    crate::jobs::request_frame();
+    crate::jobs::wake_loop();
 }
 
 /// Unlock the session and drop all lock surfaces.
 pub fn unlock_session() {
     LOCK.with(|lock| lock.borrow_mut().unlock_requested = true);
-    crate::jobs::request_frame();
+    crate::jobs::wake_loop();
 }
 
 /// Drive the session-lock state machine. Called once per main-loop

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -854,3 +854,10 @@ where
 pub fn surface_handle(id: SurfaceId) -> SurfaceHandle {
     SurfaceHandle { id }
 }
+
+/// Whether any surface command (spawn, close, property change) is queued.
+///
+/// Part of the loop's wakeup check — see `queued_but_unwoken` in `lib.rs`.
+pub(crate) fn surface_commands_pending() -> bool {
+    SURFACE_COMMANDS.with(|cmds| !cmds.borrow().is_empty())
+}

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -661,7 +661,7 @@ pub(crate) fn push_surface_command(cmd: SurfaceCommand) {
     SURFACE_COMMANDS.with(|cmds| {
         cmds.borrow_mut().push(cmd);
     });
-    crate::jobs::request_frame();
+    crate::jobs::wake_loop();
 }
 
 /// Reset the surface command queue.


### PR DESCRIPTION
Two items from the architecture backlog, both about duplication that could
drift and names that promised the wrong thing. The halves are independent —
the first two commits are the renderer, the last two the event loop — and
split cleanly if you would rather review them apart.

## One textured-quad pipeline instead of two

The image and text renderers each wrote out a full wgpu pipeline. With the
debug labels neutralised the two were **identical down to the byte**: same
shader file, same vertex format, same premultiplied blend state, same clamped
bilinear sampler, same two triangles. Three more pieces turned out to be just
as duplicated:

- **the bind group** — the same two entries against the same layout, differing
  only in the label
- **the projection** — both carried `screen_width`/`screen_height`, both
  defaulted them to 800x600, both had the same setter, and both passed the
  pair to `to_ndc` at four call sites each
- **the draw loop** — identical apart from how each reaches its bind group:
  one owns it per quad, the other shares it through a cached texture, which a
  two-method `QuadDraw` trait covers

What stays apart is what genuinely differs: decoding and rasterising an image
source with content-fit and intrinsic size on one side, laying glyphs into an
atlas on the other.

`image_quad` 888 → 741, `text_quad` 622 → 474, plus 214 shared. The point is
less the 80 lines than that the blend state could previously drift on one
side with nothing to say so.

## The event loop's wakeup contract

The backlog asked for one `FrameSideEffects` with a single `drain()`. That
does not survive the code: the drains are not interchangeable, each sits
where it does for a reason written beside it — disposals run where no user
closure is on the stack, background writes must land before the wake request
is consumed, orphan jobs need ownership resolved first — and the clipboard,
primary and cursor syncs are not even the same kind of thing, being outbound
and per-surface. Moving them into one point is the only thing that cannot be
done.

The bug class behind the request is real though, and it has bitten twice. So:

**The contract is now checked, not just written down.** `queued_but_unwoken()`
names every queue the loop drains, and debug builds assert none is
outstanding when the loop is about to block indefinitely. That is sound
rather than arbitrary: each queue is drained unconditionally once per
iteration, so anything still queued was produced after its own drain, and the
only thing that brings the loop back is a wake request — which would have
kept it from blocking. A non-empty queue there means nobody asked to be
woken, which is the shape of both historical bugs. Verified in both
directions: six examples idle for four seconds each with nothing firing, and
stubbing out one drain to simulate a forgotten wakeup panics on the next
idle, naming the queue.

**`request_frame` is now `wake_loop`.** The old name promised more than it
delivers on both counts: a pass produces a frame only if something needs
painting — it reaches the paint and bails there — and four of its five
callers want the loop to *turn*, not to draw. (I first claimed the extra pass
was real work worth splitting the primitive over. Tracing it: both layout
branches are skipped, and what remains is two registry walks that are empty
in any app using neither widget refs nor blur, with `signal.set`
equality-gated so nothing cascades. The name was the whole problem.)

**The three outbound flags become outboxes.** Clipboard, primary and cursor
each kept a value plus a `*_CHANGED` bool to hold in step with it, and each
`take_*` read the flag, cleared it, then went back for the value. An `Option`
already carries that: empty *is* "nothing to sync", and `take()` is one line
instead of six.

**And queueing now wakes, everywhere.** Those three were the only producers
that queued without waking — they worked only because their drain happens to
run a few lines later. Jobs, disposals and surface commands already called
the wakeup from the same function that queues; background writes get it by
construction from the ingress channel. Now the last three do too, so the two
gestures are one and nothing depends on drain order.

What remains as discipline is the *order* of the drains, which genuinely
cannot be made structural. It is documented where each one sits.

## Verified

410 tests. On a live compositor: raster images in all three content-fit modes
plus rotated and scaled, SVG normal/rotated/scaled, transformed text with
rotation, scale, origins and nesting; then clipboard and primary copy *out*
to other applications, paste and cut back in, and the cursor shape over a
text field — the paths the outbox change touched.
