### PR TITLE
Salvage from the Part I document: dead code, a name, and baseline alignment

### DIFF
--- a/book/src/concepts/layout.md
+++ b/book/src/concepts/layout.md
@@ -86,6 +86,27 @@ Flex::row().cross_alignment(CrossAlignment::Center)
 | `Center` | Center on cross axis |
 | `End` | Align to end of cross axis |
 | `Stretch` | Stretch to fill cross axis |
+| `Baseline` | Line children up on the baseline of their text |
+
+### Baseline
+
+Text of different sizes in a row does not read as one line when the tops are
+aligned — a 24px label and a 12px one float at unrelated heights. `Baseline`
+puts them on the line they are written on:
+
+```rust
+container()
+    .layout(Flex::row().spacing(8.0).cross_alignment(CrossAlignment::Baseline))
+    .children([
+        container().font_size(24.0).child(text("28")),
+        container().font_size(12.0).child(text("°C")),
+    ])
+```
+
+A box reports no baseline of its own, so it is aligned by its bottom edge,
+which is what CSS does with it. A container takes the baseline of its
+content, so wrapping a text for styling does not lose the alignment. In a
+column there is no shared line to sit on, and `Baseline` behaves as `Start`.
 
 ### Visual Example (Row)
 

--- a/book/src/getting-started/examples.md
+++ b/book/src/getting-started/examples.md
@@ -147,6 +147,22 @@ cargo run --example flex_layout_test
 
 ---
 
+### baseline_alignment
+
+The four cross alignments on the same row, so the difference is visible.
+
+```bash
+cargo run --example baseline_alignment
+```
+
+**Features demonstrated:**
+- `CrossAlignment::Baseline`: text of different sizes reading as one line
+- The pair worth comparing is `End` and `Baseline` — one aligns the boxes,
+  the other the line the text is written on
+- A box carries no baseline, so it aligns by its bottom edge
+
+---
+
 ### component_example
 
 Creating reusable components with the `#[component]` macro.

--- a/examples/baseline_alignment.rs
+++ b/examples/baseline_alignment.rs
@@ -1,0 +1,76 @@
+//! The four cross alignments on the same row, so the difference is visible.
+//!
+//! The row is the ordinary bar module: a big number, a small unit, a longer
+//! label, and a box with no text at all.
+//!
+//! `End` and `Baseline` are the pair worth looking at, and they are only a
+//! few pixels apart: `End` lines up the children's boxes, `Baseline` lines up
+//! the line their text is written on. "umidità 41%" has a taller box than its
+//! visible glyphs because it has to hold the descenders, so under `End` it
+//! rides higher than the rest — under `Baseline` it does not. The dot has no
+//! text at all, so it aligns by its bottom edge either way, which is what CSS
+//! does with a baseline-less box.
+
+use guido::prelude::*;
+
+fn row(label: &str, align: CrossAlignment) -> Container {
+    container()
+        .layout(Flex::row().spacing(10.0).cross_alignment(align))
+        .padding([6.0, 10.0])
+        .background(Color::rgb(0.16, 0.16, 0.22))
+        .corner_radius(8.0)
+        .children([
+            container()
+                .width(96.0)
+                .text_color(Color::rgb(0.55, 0.55, 0.65))
+                .font_size(12.0)
+                .child(text(label.to_string()))
+                .into_any(),
+            container()
+                .text_color(Color::WHITE)
+                .font_size(30.0)
+                .child(text("28"))
+                .into_any(),
+            container()
+                .text_color(Color::rgb(0.9, 0.7, 0.3))
+                .font_size(13.0)
+                .child(text("°C"))
+                .into_any(),
+            container()
+                .text_color(Color::rgb(0.6, 0.8, 1.0))
+                .font_size(18.0)
+                .child(text("umidità 41%"))
+                .into_any(),
+            container()
+                .width(22.0)
+                .height(22.0)
+                .corner_radius(11.0)
+                .background(Color::rgb(0.4, 0.8, 0.5))
+                .into_any(),
+        ])
+}
+
+fn main() {
+    App::new().run(|app| {
+        let view = container()
+            .background(Color::rgb(0.10, 0.10, 0.14))
+            .padding(14.0)
+            .layout(Flex::column().spacing(10.0))
+            .children([
+                row("Start", CrossAlignment::Start),
+                row("Center", CrossAlignment::Center),
+                row("End", CrossAlignment::End),
+                row("Baseline", CrossAlignment::Baseline),
+            ]);
+
+        app.add_surface(
+            SurfaceConfig::new()
+                .width(460)
+                .height(320)
+                .anchor(Anchor::TOP | Anchor::LEFT)
+                .layer(Layer::Overlay)
+                .namespace("zz-baseline"),
+            move || view,
+        );
+    });
+}

--- a/src/layout/flex_layout.rs
+++ b/src/layout/flex_layout.rs
@@ -338,6 +338,19 @@ impl Flex {
             Axis::Vertical => origin.1,
         } + initial_offset;
 
+        // Baseline alignment needs the deepest baseline in the row before it
+        // can place anything: every child shifts down by the difference
+        // between it and its own.
+        let max_baseline = if cross_align == CrossAlignment::Baseline && axis == Axis::Horizontal {
+            children
+                .iter()
+                .enumerate()
+                .map(|(i, &id)| baseline_of(tree, id, self.child_sizes[i].cross_axis(axis)))
+                .fold(0.0f32, f32::max)
+        } else {
+            0.0
+        };
+
         let mut prev_nonzero = false;
         for (i, &child_id) in children.iter().enumerate() {
             let child_size = self.child_sizes[i];
@@ -364,6 +377,13 @@ impl Flex {
                 },
                 CrossAlignment::Stretch => match axis {
                     Axis::Horizontal => origin.1,
+                    Axis::Vertical => origin.0,
+                },
+                CrossAlignment::Baseline => match axis {
+                    Axis::Horizontal => {
+                        origin.1 + max_baseline - baseline_of(tree, child_id, child_cross)
+                    }
+                    // A column has no shared line to sit on.
                     Axis::Vertical => origin.0,
                 },
             };
@@ -396,4 +416,13 @@ impl Layout for Flex {
         let direction = self.direction.get();
         self.layout_axis(tree, children, constraints, origin, direction)
     }
+}
+
+/// Where a child sits on its baseline, for the purpose of lining a row up.
+///
+/// Leaves that draw text report one during layout. Anything else — a box, an
+/// image — is treated as sitting on its own bottom edge, which is how CSS
+/// aligns a baseline-less box among text.
+fn baseline_of(tree: &Tree, id: WidgetId, cross_size: f32) -> f32 {
+    tree.baseline(id).unwrap_or(cross_size)
 }

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -311,4 +311,12 @@ pub enum CrossAlignment {
     Center,
     End,
     Stretch,
+    /// Line the children up on the baseline of their first line of text, so
+    /// labels of different sizes read as one line instead of floating at
+    /// unrelated heights.
+    ///
+    /// Only meaningful across a row; in a column it behaves as `Start`.
+    /// A child that reports no baseline — a box, an image — is aligned by its
+    /// bottom edge, which is what CSS does with it.
+    Baseline,
 }

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -33,8 +33,9 @@ pub use gpu_context::{GpuContext, SurfaceState};
 pub use paint_context::PaintContext;
 pub use render::Renderer;
 pub use text_measurer::{
-    char_index_from_x, char_index_from_x_styled, measure_char_positions_styled, measure_text,
-    measure_text_styled, measure_text_to_char, measure_text_to_char_styled,
+    Measured, char_index_from_x, char_index_from_x_styled, measure_char_positions_styled,
+    measure_text, measure_text_full, measure_text_styled, measure_text_to_char,
+    measure_text_to_char_styled,
 };
 pub use tree::{NodeId, RenderNode};
 pub use types::{Gradient, GradientDir, ImageEntry, Shadow, TextEntry};

--- a/src/renderer/text_measurer.rs
+++ b/src/renderer/text_measurer.rs
@@ -48,9 +48,17 @@ impl MeasureCacheKey {
 /// lifetime (e.g. one entry per text-input prefix ever measured).
 const MEASURE_CACHE_CAP: usize = 8192;
 
+/// What one shaping pass tells us about a piece of text.
+#[derive(Clone, Copy, Debug)]
+pub struct Measured {
+    pub size: Size,
+    /// Distance from the top edge to the baseline of the first line.
+    pub baseline: f32,
+}
+
 pub struct TextMeasurer {
     font_system: FontSystem,
-    measure_cache: FxHashMap<MeasureCacheKey, Size>,
+    measure_cache: FxHashMap<MeasureCacheKey, Measured>,
 }
 
 impl TextMeasurer {
@@ -85,21 +93,41 @@ impl TextMeasurer {
         font_family: &FontFamily,
         font_weight: FontWeight,
     ) -> Size {
+        self.measure_full(text, font_size, max_width, font_family, font_weight)
+            .size
+    }
+
+    /// Measure, and also report where the first line sits on its baseline.
+    ///
+    /// Both come out of the same shaping pass and share one cache entry — a
+    /// baseline is not worth re-shaping for.
+    pub fn measure_full(
+        &mut self,
+        text: &str,
+        font_size: f32,
+        max_width: Option<f32>,
+        font_family: &FontFamily,
+        font_weight: FontWeight,
+    ) -> Measured {
         let cache_key = MeasureCacheKey::new(text, font_size, max_width, font_family, font_weight);
 
         // Check cache first (no allocation on this path)
-        if let Some(&cached_size) = self.measure_cache.get(&cache_key) {
-            return cached_size;
+        if let Some(&cached) = self.measure_cache.get(&cache_key) {
+            return cached;
         }
 
-        let size = {
+        let measured = {
             let buffer = self.shape(text, font_size, max_width, font_family, font_weight);
 
             let mut width = 0.0f32;
             let mut height = 0.0f32;
+            // Where the first line sits: everything a baseline alignment
+            // needs, since that is the line a parent lines its children up on.
+            let mut baseline = None;
             for run in buffer.layout_runs() {
                 width = width.max(run.line_w);
                 height += run.line_height;
+                baseline.get_or_insert(run.line_y);
             }
 
             // Ensure minimum height for empty text
@@ -107,16 +135,21 @@ impl TextMeasurer {
                 height = font_size * 1.2;
             }
 
-            Size::new(width, height)
+            Measured {
+                size: Size::new(width, height),
+                // Empty text still sits on a line, so a lone label in a
+                // baseline row does not jump when its content clears.
+                baseline: baseline.unwrap_or(font_size),
+            }
         };
 
         // Cache the result, with wholesale eviction at the cap
         if self.measure_cache.len() >= MEASURE_CACHE_CAP {
             self.measure_cache.clear();
         }
-        self.measure_cache.insert(cache_key, size);
+        self.measure_cache.insert(cache_key, measured);
 
-        size
+        measured
     }
 
     /// Shape text into a fresh buffer.
@@ -330,6 +363,18 @@ pub fn measure_text_styled(
         .with_borrow_mut(|m| m.measure_styled(text, font_size, max_width, font_family, font_weight))
 }
 
+/// Measure text and report where its first line sits on the baseline.
+pub fn measure_text_full(
+    text: &str,
+    font_size: f32,
+    max_width: Option<f32>,
+    font_family: &FontFamily,
+    font_weight: FontWeight,
+) -> Measured {
+    TEXT_MEASURER
+        .with_borrow_mut(|m| m.measure_full(text, font_size, max_width, font_family, font_weight))
+}
+
 /// Measure text width up to a specific character index (for cursor positioning)
 pub fn measure_text_to_char(text: &str, font_size: f32, char_index: usize) -> f32 {
     TEXT_MEASURER.with_borrow_mut(|m| m.measure_to_char(text, font_size, char_index))
@@ -375,4 +420,34 @@ pub fn char_index_from_x_styled(
 ) -> usize {
     TEXT_MEASURER
         .with_borrow_mut(|m| m.char_from_x_styled(text, font_size, x, font_family, font_weight))
+}
+
+#[cfg(test)]
+mod baseline_tests {
+    use super::*;
+
+    /// A baseline sits below the ascenders and above the descenders — never
+    /// at the very bottom of the line box, which is what "align by the bottom
+    /// edge" would be. If this ever holds `height`, baseline alignment has
+    /// quietly degenerated into bottom alignment and every descender hangs
+    /// below the line the row was supposed to share.
+    #[test]
+    fn a_baseline_sits_inside_the_line_box() {
+        for font_size in [12.0f32, 16.0, 24.0, 48.0] {
+            let m = measure_text_full(
+                "Hxgjp",
+                font_size,
+                None,
+                &FontFamily::default(),
+                FontWeight::NORMAL,
+            );
+            assert!(
+                m.baseline > m.size.height * 0.5 && m.baseline < m.size.height,
+                "at {font_size}px the baseline is {} of a {} line — \
+                 that is not a baseline",
+                m.baseline,
+                m.size.height
+            );
+        }
+    }
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -91,8 +91,14 @@ struct SparseSlot {
     generation: u32,
 }
 
-/// A node in the tree, containing a widget and its metadata.
-struct Node {
+/// One widget's slot in the arena: the widget itself plus everything the tree
+/// knows about it.
+///
+/// Called a slot rather than a node because "node" already means two other
+/// things here — the render tree's `RenderNode`, and informally any widget.
+/// This is neither: it is the arena record, and a widget composed but not yet
+/// registered has none.
+struct Slot {
     /// The widget stored at this node
     widget: Box<dyn Widget>,
     /// Parent widget ID (None for root)
@@ -136,7 +142,7 @@ struct Node {
 /// prevent use-after-free bugs.
 pub struct Tree {
     /// Dense array of nodes (widgets + metadata)
-    dense: Vec<Node>,
+    dense: Vec<Slot>,
     /// Sparse map from index to dense position + generation
     sparse: Vec<SparseSlot>,
     /// Free list of reusable sparse indices
@@ -185,7 +191,7 @@ impl Tree {
         let id = WidgetId::new(sparse_index, generation);
 
         // Create the node (widget ID is passed to methods, not stored in widget)
-        self.dense.push(Node {
+        self.dense.push(Slot {
             widget,
             parent: None,
             children: ChildrenVec::new(),

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -126,6 +126,10 @@ struct Slot {
     /// Boxed because most nodes declare nothing: the miss costs a null check
     /// instead of the ~96 bytes the struct would add to every node.
     text_style: Option<Box<crate::widgets::TextStyle>>,
+    /// Distance from this widget's top edge to the baseline of its first line
+    /// of text, if it has one. Reported by leaves during layout and read by a
+    /// parent aligning on `CrossAlignment::Baseline`.
+    baseline: Option<f32>,
     /// How far this widget paints outside its own bounds, in logical pixels.
     ///
     /// A shadow — a box's or a glyph's — lands outside the box that cast it,
@@ -204,6 +208,7 @@ impl Tree {
             sparse_index,
             cached_paint: None,
             text_style: None,
+            baseline: None,
             paint_overflow: 0.0,
         });
 
@@ -391,6 +396,23 @@ impl Tree {
     ///
     /// Widgets that cast a shadow or stroke set this during layout; it widens
     /// the damage they report without touching the size they occupy.
+    /// Report where this widget's text sits on its baseline.
+    ///
+    /// Only leaves that draw text have one. A parent aligning on
+    /// `CrossAlignment::Baseline` shifts its children so these coincide;
+    /// anything without a baseline is aligned by its bottom edge, as CSS does.
+    pub fn set_baseline(&mut self, id: WidgetId, baseline: f32) {
+        if let Some(idx) = self.get_dense_index(id) {
+            self.dense[idx].baseline = Some(baseline);
+        }
+    }
+
+    /// The widget's baseline, if it reported one.
+    pub fn baseline(&self, id: WidgetId) -> Option<f32> {
+        self.get_dense_index(id)
+            .and_then(|idx| self.dense[idx].baseline)
+    }
+
     pub fn set_paint_overflow(&mut self, id: WidgetId, overflow: f32) {
         if let Some(idx) = self.get_dense_index(id) {
             self.dense[idx].paint_overflow = overflow.max(0.0);

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -1281,6 +1281,21 @@ impl Widget for Container {
             Size::zero()
         };
 
+        // A box sits on the baseline of its content, as CSS has it: without
+        // this a styled label reports nothing, and a parent aligning on the
+        // baseline falls back to its bottom edge — which is how the idiomatic
+        // `container().child(text(..))` would silently miss the alignment it
+        // asked for.
+        // Child origins are stored relative to their parent, so the child's
+        // own offset is all that has to be added.
+        if let Some((child_id, child_baseline)) = children
+            .iter()
+            .find_map(|&cid| tree.baseline(cid).map(|b| (cid, b)))
+            && let Some((_, child_y)) = tree.get_origin(child_id)
+        {
+            tree.set_baseline(id, child_y + child_baseline);
+        }
+
         if self.scroll_axis != ScrollAxis::None {
             let sd = self.scroll_mut();
             sd.scroll_state.content_width = content_size.width + padding.horizontal();

--- a/src/widgets/image.rs
+++ b/src/widgets/image.rs
@@ -12,7 +12,7 @@ use crate::reactive::{IntoSignal, Signal, with_signal_tracking};
 use crate::renderer::PaintContext;
 use crate::tree::{Tree, WidgetId};
 
-use super::widget::{EventResponse, Rect, Widget};
+use super::widget::{Rect, Widget};
 
 /// Source for an image - can be a file path or in-memory bytes.
 #[derive(Debug, Clone, PartialEq)]
@@ -238,15 +238,6 @@ impl Widget for Image {
             let local_bounds = Rect::new(0.0, 0.0, size.width, size.height);
             ctx.draw_image(source.clone(), local_bounds, self.content_fit);
         }
-    }
-
-    fn event(
-        &mut self,
-        _tree: &mut Tree,
-        _id: WidgetId,
-        _event: &super::widget::Event,
-    ) -> EventResponse {
-        EventResponse::Ignored
     }
 }
 

--- a/src/widgets/text.rs
+++ b/src/widgets/text.rs
@@ -2,7 +2,7 @@ use crate::default_font_family;
 use crate::jobs::JobType;
 use crate::layout::{Constraints, Size};
 use crate::reactive::{IntoSignal, OptionSignalExt, Signal, with_signal_tracking};
-use crate::renderer::{PaintContext, measure_text_styled};
+use crate::renderer::{PaintContext, measure_text_full};
 use crate::tree::{Tree, WidgetId};
 
 use super::font::{FontFamily, FontWeight};
@@ -124,7 +124,7 @@ impl Widget for Text {
         };
 
         // Measure text (TextMeasurer caches results internally)
-        let measured = measure_text_styled(
+        let measured = measure_text_full(
             &self.cached_text,
             self.cached_font_size,
             max_width,
@@ -132,12 +132,18 @@ impl Widget for Text {
             self.cached_font_weight,
         );
 
+        // A parent aligning on the baseline needs this; it comes out of the
+        // same shaping pass, so reporting it is free.
+        tree.set_baseline(id, measured.baseline);
+
         let size = Size::new(
             measured
+                .size
                 .width
                 .max(constraints.min_width)
                 .min(constraints.max_width),
             measured
+                .size
                 .height
                 .max(constraints.min_height)
                 .min(constraints.max_height),

--- a/src/widgets/text.rs
+++ b/src/widgets/text.rs
@@ -7,7 +7,7 @@ use crate::tree::{Tree, WidgetId};
 
 use super::font::{FontFamily, FontWeight};
 use super::text_style::{TextShadow, TextStroke};
-use super::widget::{Color, EventResponse, Rect, Widget};
+use super::widget::{Color, Rect, Widget};
 
 /// How far a stroke and a shadow reach past the glyphs they decorate.
 ///
@@ -177,15 +177,6 @@ impl Widget for Text {
             stroke,
             shadow,
         );
-    }
-
-    fn event(
-        &mut self,
-        _tree: &mut Tree,
-        _id: WidgetId,
-        _event: &super::widget::Event,
-    ) -> EventResponse {
-        EventResponse::Ignored
     }
 }
 

--- a/tests/render_snapshots.rs
+++ b/tests/render_snapshots.rs
@@ -553,3 +553,30 @@ fn text_input_clips_overflowing_content() {
         render(view, 400.0, 60.0),
     );
 }
+
+/// Texts of different sizes in a row, aligned on their baselines.
+///
+/// `Start` puts every child's top edge on the same line, so a 24px label and
+/// a 12px one float at unrelated heights. `Baseline` puts them on the line
+/// they are written on, which is what reads as one sentence. The two are
+/// snapshotted together so the difference is visible as geometry, not prose.
+#[test]
+fn baseline_alignment_lines_text_up() {
+    let row = |align: CrossAlignment| {
+        container()
+            .layout(Flex::row().spacing(8.0).cross_alignment(align))
+            .child(container().font_size(24.0).child(text("Big")))
+            .child(container().font_size(12.0).child(text("small")))
+            .child(container().font_size(16.0).child(text("mid")))
+            // A box reports no baseline: it aligns by its bottom edge.
+            .child(swatch(20.0, 30.0, Color::CYAN))
+    };
+
+    let view = container()
+        .layout(Flex::column().spacing(10.0))
+        .padding(8.0)
+        .child(row(CrossAlignment::Start))
+        .child(row(CrossAlignment::Baseline));
+
+    assert_snapshot("baseline_alignment", render(view, 400.0, 160.0));
+}

--- a/tests/snapshots/baseline_alignment.snap
+++ b/tests/snapshots/baseline_alignment.snap
@@ -1,0 +1,25 @@
+node 0,0 160.52x86
+  node 0,0 144.52x30 at 8,8
+    node 0,0 38.37x28.8
+      node 0,0 38.37x28.8
+        draw text <not snapshotted>
+    node 0,0 31.96x14.4 at 46.37,0
+      node 0,0 31.96x14.4
+        draw text <not snapshotted>
+    node 0,0 30.19x19.2 at 86.33,0
+      node 0,0 30.19x19.2
+        draw text <not snapshotted>
+    node 0,0 20x30 at 124.52,0
+      draw rect 0,0 20x30 fill=#00ffffff radius=0/0/0/0
+  node 0,0 144.52x30 at 8,48
+    node 0,0 38.37x28.8 at 0,7.29
+      node 0,0 38.37x28.8
+        draw text <not snapshotted>
+    node 0,0 31.96x14.4 at 46.37,18.65
+      node 0,0 31.96x14.4
+        draw text <not snapshotted>
+    node 0,0 30.19x19.2 at 86.33,14.86
+      node 0,0 30.19x19.2
+        draw text <not snapshotted>
+    node 0,0 20x30 at 124.52,0
+      draw rect 0,0 20x30 fill=#00ffffff radius=0/0/0/0


### PR DESCRIPTION
Three items salvaged from the Part I design document, judged on cleanliness
and semantics rather than performance — the performance case for that
document had already come apart under measurement.

## Dead code

`Text` and `Image` each overrode `event` to return `EventResponse::Ignored`,
which is what the trait's default already does. Twelve lines telling a reader
something happens here, where nothing does.

## `tree::Node` → `tree::Slot`

"Node" was the third meaning of the word in this codebase, beside the render
tree's `RenderNode` and the informal "a node" for any widget. Reading
`self.dense[idx]` as a node invites the wrong picture: it is not a point in
the composition tree, it is the arena's record for one widget — parent,
children, dirty flags, cached layout and paint. A widget composed but not yet
registered has none. Private, so the rename costs nothing outside the file.

## `CrossAlignment::Baseline`

`CrossAlignment` had Start, Center, End and Stretch, none of which makes a row
of differently-sized text read as one line — which is the most ordinary thing
a bar does: a big number beside a small unit.

The document said adding this later would mean touching every leaf, so
`measure` had to grow a `Measurement` type first. **That was not the case.**
The tree already carries per-widget facts that leaves report during layout —
`set_paint_overflow` is the same shape — so `set_baseline` fits beside it and
the `Widget` trait does not move. The baseline itself comes out of the shaping
pass cosmic-text already runs and shares the measurement's cache entry, so
reporting it costs nothing.

Two cases needed deciding, both settled the way CSS does:

- a box has no baseline, so it aligns by its bottom edge
- a container takes the baseline of its content — without which the idiomatic
  `container().font_size(24).child(text(..))` reports nothing, and a row of
  styled labels silently falls back to bottom alignment

That second one was found by the snapshot, not by reasoning. The first blessed
output had every text sitting at exactly its own height — bottom alignment
wearing a baseline's name. After the fix the three texts report baselines at
78.8% of their own height, the same ratio at three different sizes, which is
what one font should give.

A unit test pins the shape a baseline must have (inside the line box, never at
the foot of it) so it cannot quietly degenerate again, and a snapshot pins the
resulting geometry against `Start`.

## Not done, deliberately

**`Container` → `Block`.** The document's argument is that the API already
speaks CSS. True of the properties (`padding`, `corner_radius`, `overflow`),
but `block` in CSS is not the name of a box — it is a display mode opposite
`inline`, `flex` and `grid`. Guido has no such axis, so the name would import
a distinction that does not exist; the first instinct of anyone arriving from
the web would be to look for `inline()`. `Container` is also what Flutter and
Iced call exactly this widget, and needs no CSS background to be understood.

**Styling on leaves** (`text("x").padding(8).background(blue)`). On a container
`.background()` is not a colour: it is `get_animated_value(anims.background, ||
effective_background_target(id))` — a colour that may be animating and may be
overridden by a hover, pressed or focused state layer, with a ripple over it.
1768 lines across `style`, `interaction`, `animations`, `anim_bridge` and
`ripple` sit behind that word. Giving a leaf `.background()` means either a
lesser background that does not animate or react — the same word meaning two
things depending on where it is written — or dragging the whole machine in,
at which point the leaf *is* a container. Style here is not a closed set: the
step after `text("x").background(blue)` is `.hover_state(..)`, and that is a
fair thing to want.

**The Node/Content split.** Answered by experiment rather than argument: a
fifth leaf — a coloured dot, no children, no events — written from *outside*
the crate against the public API compiled first try, in about ten lines, of
which four are protocol. The wide trait is not the obstacle the document took
it for.
