### PR TITLE
Caps lock is a state, not a keystroke

### DIFF
--- a/book/src/interactivity/events.md
+++ b/book/src/interactivity/events.md
@@ -71,6 +71,30 @@ container()
 `on_key_down` fires while the surface has keyboard focus — a layer surface
 with `KeyboardInteractivity` set, or a popup holding a grab.
 
+## Latched Modifiers
+
+The `Modifiers` a key event carries describe *that keystroke*, which is what a
+shortcut needs. Caps lock is a different question: it is latched, so it stays
+on with nothing pressed, and something on screen may need to say so before
+anything has been typed — a password field warning that what goes in will be
+upper case.
+
+That cannot be answered from a key event. The compositor sends the modifier
+update *after* the key that toggled it, so the press of caps lock reports the
+state it had before. Read the signal instead:
+
+```rust
+container().child(move || {
+    keyboard_modifiers()
+        .get()
+        .caps_lock
+        .then(|| text("Caps lock is on"))
+})
+```
+
+Everything is false until the compositor sends the first update, which it does
+when a surface takes keyboard focus.
+
 ## Scroll Events
 
 ```rust

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -1,0 +1,96 @@
+//! The keyboard's modifier state, exposed reactively.
+//!
+//! [`Event::KeyDown`](crate::widgets::Event::KeyDown) already carries the
+//! modifiers that were held for *that* keystroke, which is what a shortcut
+//! needs. A latched modifier is a different question: caps lock is a state the
+//! keyboard is *in*, and something on screen may need to say so before anything
+//! is typed at all — a lock screen warning that the password is about to go in
+//! upper case is the case this exists for.
+//!
+//! It cannot be answered from a key event. The compositor sends the modifier
+//! update *after* the key that caused it, so the press of caps lock reports the
+//! state it had before, and a screen driven from key events would be a
+//! keystroke behind — announcing caps lock only once you had already typed
+//! into it.
+//!
+//! ```ignore
+//! container().child(move || {
+//!     keyboard_modifiers().get().caps_lock.then(|| text("Caps lock is on"))
+//! })
+//! ```
+
+use std::cell::RefCell;
+
+use crate::reactive::{RwSignal, Signal, create_signal};
+use crate::widgets::Modifiers;
+
+thread_local! {
+    /// Lazily created so it works both before and after platform init;
+    /// wiped by `reset_keyboard_modifiers()`.
+    static MODIFIERS: RefCell<Option<RwSignal<Modifiers>>> = const { RefCell::new(None) };
+}
+
+fn modifiers_signal() -> RwSignal<Modifiers> {
+    MODIFIERS.with(|cell| {
+        *cell
+            .borrow_mut()
+            .get_or_insert_with(|| create_signal(Modifiers::default()))
+    })
+}
+
+/// Reactive view of the modifiers the keyboard currently reports.
+///
+/// Everything false until the compositor sends the first modifier update, which
+/// it does when a surface takes keyboard focus — so a surface that never has
+/// focus reads all-false rather than a stale state from whoever had it.
+pub fn keyboard_modifiers() -> Signal<Modifiers> {
+    modifiers_signal().read_only()
+}
+
+/// Publish a modifier update. Called by the platform layer.
+pub(crate) fn set_keyboard_modifiers(modifiers: Modifiers) {
+    let signal = modifiers_signal();
+    // The compositor re-sends the whole state on every change, including ones
+    // that changed nothing we track; writing unconditionally would invalidate
+    // every reader of it for a modifier we do not even expose.
+    if signal.get_untracked() != modifiers {
+        signal.set(modifiers);
+    }
+}
+
+/// Forget the modifier state. Called during `App::drop()`.
+pub(crate) fn reset_keyboard_modifiers() {
+    MODIFIERS.with(|cell| *cell.borrow_mut() = None);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_state_starts_empty_and_follows_the_platform() {
+        reset_keyboard_modifiers();
+        assert_eq!(keyboard_modifiers().get_untracked(), Modifiers::default());
+
+        let latched = Modifiers {
+            caps_lock: true,
+            ..Default::default()
+        };
+        set_keyboard_modifiers(latched);
+
+        assert_eq!(keyboard_modifiers().get_untracked(), latched);
+    }
+
+    #[test]
+    fn a_new_app_does_not_inherit_the_last_one_s_state() {
+        reset_keyboard_modifiers();
+        set_keyboard_modifiers(Modifiers {
+            caps_lock: true,
+            ..Default::default()
+        });
+
+        reset_keyboard_modifiers();
+
+        assert_eq!(keyboard_modifiers().get_untracked(), Modifiers::default());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod compositor;
 pub mod image_metadata;
 mod ingress;
 mod jobs;
+pub mod keyboard;
 pub mod layout;
 pub mod outputs;
 pub mod reactive;
@@ -149,6 +150,7 @@ pub mod prelude {
     pub use crate::animation::{SpringConfig, TimingFunction, Transition, TransitionConfig};
     pub use crate::backdrop::{BackdropBlur, BackdropSources};
     pub use crate::compositor::{CompositorEffects, compositor_effects};
+    pub use crate::keyboard::keyboard_modifiers;
     pub use crate::layout::{
         Axis, Constraints, CrossAlignment, Flex, IntoF32, Length, MainAlignment, Size, ZStack,
         at_least, at_most, fill, fraction,
@@ -1406,6 +1408,7 @@ impl Drop for App {
         widget_ref::reset_widget_refs();
         outputs::reset_outputs();
         compositor::reset_compositor_effects();
+        keyboard::reset_keyboard_modifiers();
         blur::reset_blur();
         session_lock::reset_session_lock();
         FONTS_CONSUMED.with(|f| f.set(false));

--- a/src/platform/input.rs
+++ b/src/platform/input.rs
@@ -665,7 +665,12 @@ impl KeyboardHandler for WaylandState {
             alt: modifiers.alt,
             shift: modifiers.shift,
             logo: modifiers.logo,
+            caps_lock: modifiers.caps_lock,
         };
+        // Published as a signal as well: a latched modifier is a state
+        // something on screen may need to show with nothing pressed and no key
+        // event coming to carry it.
+        crate::keyboard::set_keyboard_modifiers(self.input.modifiers);
     }
 
     fn repeat_key(

--- a/src/widgets/widget.rs
+++ b/src/widgets/widget.rs
@@ -451,6 +451,13 @@ pub struct Modifiers {
     pub alt: bool,
     pub shift: bool,
     pub logo: bool,
+    /// Caps lock, which is latched rather than held: it stays on with nothing
+    /// pressed. To say so on screen, read
+    /// [`keyboard_modifiers()`](crate::keyboard::keyboard_modifiers) instead of
+    /// the copy a key event carries — that one describes the keystroke it came
+    /// with, and the compositor reports the latch only *after* the key that
+    /// toggled it.
+    pub caps_lock: bool,
 }
 
 /// Named keys for special keyboard keys


### PR DESCRIPTION
`Modifiers` had ctrl/alt/shift/logo — the four a shortcut asks about, all of
them held. Caps lock is latched: it stays on with nothing pressed, and a screen
may need to say so before anything has been typed at all. allock's password
field is the case this comes from — it wants to warn that the password is about
to go in upper case.

## Why the field alone is not enough

A key event cannot answer it. The compositor sends the modifier update *after*
the key that toggled the latch, so the press of caps lock reports the state it
had before. A screen driven from `Event::KeyDown` would therefore announce caps
lock one keystroke late — and on a lock screen that keystroke is already part of
the password.

So the whole struct is published into a signal beside the new field, in the
shape `compositor_effects()` established: thread-local, lazily created so it
works both before and after platform init, wiped in `App::drop()` so a second
`App` in the same thread does not inherit the first one's latches.

```rust
container().child(move || {
    keyboard_modifiers().get().caps_lock.then(|| text("Caps lock is on"))
})
```

## Two details

**Unchanged updates are dropped rather than written.** The compositor re-sends
the full modifier state on every change, including changes to modifiers we do
not expose (num lock, the layout group), and each write would invalidate every
reader of the signal.

**Everything reads false until the first update arrives**, which the compositor
sends when a surface takes keyboard focus. A surface that never has focus
reports nothing latched rather than a stale state from whoever had it.

Only `caps_lock` is added, not `num_lock`: sctk offers both, but nothing here
needs the second one and a public field with no consumer is a guess about what
somebody will want.

## Verified

`cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`,
full test suite (356 tests, two of them new here: the state starts empty and
follows the platform; a second `App` does not inherit the first one's latches).
Book section under Interactivity → Events.