### PR TITLE
A text shadow is a disc, not two rings

### DIFF
--- a/book/src/building-ui/text.md
+++ b/book/src/building-ui/text.md
@@ -56,11 +56,16 @@ The shadow is usually the more effective of the two: it darkens the whole
 neighbourhood the glyph sits in rather than only its edge. Both are drawn
 *under* the fill, so a stroke outlines the text instead of eating into it.
 
-Both are approximated by re-drawing the glyphs at offsets, which costs fill
-rate but no extra rasterization — the glyph atlas is keyed on glyph, size and
-weight, and takes colour per draw. The approximation shows first in a thick
-stroke, whose corners begin to scallop past a few pixels; a shadow hides it
-completely, being soft and low-contrast to begin with.
+Both are approximated by re-drawing the glyphs at offsets, which costs fill rate
+but no extra rasterization — the glyph atlas is keyed on glyph, size and weight,
+and takes colour per draw. What decides whether the approximation shows is the
+*spacing* between copies: more than a couple of pixels apart and they stop
+blending, so the square features of a glyph — a colon's dots, the stem of a 4 —
+read as separate copies rather than one halo. The shadow therefore fills a disc
+whose sample count grows with the radius (about a hundred copies at blur 10), and
+a very wide blur spreads a fixed budget thinner instead of costing more. A thick
+stroke is the case with a visible ceiling: its corners begin to scallop past a
+few pixels, where the honest fix is a dilate on an offscreen mask, not more taps.
 
 Neither changes how much room the text takes, so adding a shadow never moves
 its neighbours.

--- a/src/widgets/text_style.rs
+++ b/src/widgets/text_style.rs
@@ -104,6 +104,18 @@ impl TextStroke {
     }
 }
 
+/// How far apart neighbouring shadow copies may land, in logical pixels.
+///
+/// Wider than this and the copies stop blending into one halo — see
+/// [`TextShadow::samples`].
+const SAMPLE_SPACING: f32 = 2.0;
+
+/// Roughly the most copies one shadow may cost. The spacing is derived from it,
+/// so a larger radius spreads the same budget thinner instead of costing more —
+/// the realised count lands about a third above this, since each ring rounds its
+/// tap count up and none goes below eight.
+const SAMPLE_BUDGET: usize = 128;
+
 /// A soft shadow cast by the glyphs, as CSS `text-shadow`.
 ///
 /// Usually the better of the two for legibility over a photograph: it darkens
@@ -129,13 +141,25 @@ impl TextShadow {
 
     /// The offsets and colours to draw the glyphs at, back to front.
     ///
-    /// Same trick as the stroke, and the approximation lands far better here:
-    /// a shadow is already soft and low-contrast, so the banding a ring of
-    /// samples produces is invisible where a scalloped stroke would not be.
-    /// The rings composite with ordinary source-over blending, so they do not
-    /// sum to a gaussian — they saturate towards the centre, which is the
-    /// shape a shadow wants anyway.
-    pub(crate) fn samples(&self) -> SmallVec<[(f32, f32, Color); 25]> {
+    /// Same trick as the stroke, applied to a *disc* rather than a couple of
+    /// rings: rings every [`SAMPLE_SPACING`] out to the radius, each with enough
+    /// taps that neighbouring copies land that far apart along it too. Alpha
+    /// falls off with distance, and the copies composite with ordinary
+    /// source-over blending, so they do not sum to a gaussian — they saturate
+    /// towards the centre, which is the shape a shadow wants anyway.
+    ///
+    /// The spacing is the whole game. Two rings of twelve taps — what this used
+    /// to be — leaves five-pixel gaps at blur 10, and then the copies stop
+    /// reading as one halo: a glyph's square features, a colon's dots or the
+    /// stem of a 4, come out as a mosaic of separate rectangles. Round glyphs
+    /// hide it, which is why it survived review. Filling the disc costs about
+    /// four times the draws (fill rate only — every copy re-uses the same glyph
+    /// rasters, only the position differs), and past [`SAMPLE_BUDGET`] the
+    /// spacing widens rather than the count growing without bound, so a very
+    /// large radius degrades towards the old look instead of costing hundreds of
+    /// draws. That ceiling is where the honest fix takes over: a dilate and blur
+    /// on an offscreen mask, not more taps.
+    pub(crate) fn samples(&self) -> SmallVec<[(f32, f32, Color); 32]> {
         let (ox, oy) = self.offset;
         let mut out = SmallVec::new();
 
@@ -144,21 +168,39 @@ impl TextShadow {
             return out;
         }
 
-        // Outermost first: the faint wide ring, then the tighter one, then the
-        // solid core on top.
-        let taps = (self.blur * 1.5).clamp(8.0, 12.0) as usize;
-        for (radius, alpha) in [(self.blur, 0.35), (self.blur * 0.5, 0.6)] {
+        // A disc of radius r at this spacing holds about πr²/spacing² samples,
+        // so this is the spacing that fits the budget for the radius asked for.
+        let spacing =
+            SAMPLE_SPACING.max(self.blur * (std::f32::consts::PI / SAMPLE_BUDGET as f32).sqrt());
+        let rings = (self.blur / spacing).ceil().max(1.0);
+
+        // Outermost first: each copy paints over the ones before it, so the
+        // faint wide ones have to go down before the core.
+        for ring in (1..=rings as usize).rev() {
+            let radius = self.blur * ring as f32 / rings;
+            let taps = ((std::f32::consts::TAU * radius / spacing).ceil() as usize).max(8);
+            let color = self.color.with_alpha(self.ring_alpha(radius, rings));
             for i in 0..taps {
                 let angle = std::f32::consts::TAU * i as f32 / taps as f32;
-                out.push((
-                    ox + radius * angle.cos(),
-                    oy + radius * angle.sin(),
-                    self.color.with_alpha(self.color.a * alpha),
-                ));
+                out.push((ox + radius * angle.cos(), oy + radius * angle.sin(), color));
             }
         }
+        // The core keeps the colour as asked, unscaled: it sits under the fill,
+        // so it is not what the eye reads as the shadow's strength, and dimming
+        // it only made a tight blur weaker than the same shadow with none.
         out.push((ox, oy, self.color));
         out
+    }
+
+    /// How opaque one copy on the ring at `radius` is.
+    ///
+    /// A gaussian in the distance, divided by how many rings there are to stack:
+    /// without that, a wide blur — many more rings, all overlapping — would come
+    /// out as a slab where a tight one is a halo.
+    fn ring_alpha(&self, radius: f32, rings: f32) -> f32 {
+        const PEAK: f32 = 0.6;
+        let t = radius / self.blur;
+        (self.color.a * PEAK / rings.sqrt() * (-2.0 * t * t).exp()).min(self.color.a)
     }
 }
 

--- a/tests/text_decoration.rs
+++ b/tests/text_decoration.rs
@@ -186,6 +186,82 @@ fn a_blurred_shadow_spreads_around_the_offset() {
     assert!(shadow.iter().any(|(_, _, c)| c.a < core.2.a));
 }
 
+/// Every copy of a black shadow, as offsets from the glyph.
+fn shadow_copies(blur: f32) -> Vec<(f32, f32)> {
+    draws(
+        container()
+            .text_color(Color::WHITE)
+            .text_shadow(TextShadow::new(0.0, 0.0, blur, Color::BLACK))
+            .child(text("hi")),
+    )
+    .into_iter()
+    .filter(|(_, _, c)| c.r == 0.0 && c.g == 0.0 && c.b == 0.0)
+    .map(|(x, y, _)| (x, y))
+    .collect()
+}
+
+#[test]
+fn a_blurred_shadow_leaves_no_gaps_between_its_copies() {
+    // The regression: two rings of twelve taps left five-pixel gaps at blur 10,
+    // and the copies then read as a mosaic of separate rectangles instead of one
+    // halo — worst on the square features of a glyph, a colon's dots or the stem
+    // of a 4. Round glyphs hid it, which is how it shipped.
+    let copies = shadow_copies(10.0);
+    assert!(copies.len() > 40, "got {} copies", copies.len());
+
+    for (x, y) in &copies {
+        let nearest = copies
+            .iter()
+            .filter(|copy| *copy != &(*x, *y))
+            .map(|(ox, oy)| (ox - x).hypot(oy - y))
+            .fold(f32::INFINITY, f32::min);
+        assert!(
+            nearest <= 3.0,
+            "the copy at ({x}, {y}) is {nearest} from its nearest neighbour; \
+             wider than a couple of pixels and the copies stop blending"
+        );
+    }
+}
+
+#[test]
+fn a_blurred_shadow_fills_the_disc_rather_than_ringing_it() {
+    // Rings at the radius and at half of it leave the space between them empty,
+    // which is a shadow with a hole in it.
+    let copies = shadow_copies(10.0);
+    for band in 0..5 {
+        let (near, far) = (band as f32 * 2.0, band as f32 * 2.0 + 2.0);
+        assert!(
+            copies
+                .iter()
+                .any(|(x, y)| (near..=far).contains(&x.hypot(*y))),
+            "nothing between {near} and {far} from the glyph"
+        );
+    }
+    assert!(
+        copies.iter().all(|(x, y)| x.hypot(*y) <= 10.0 + 1e-3),
+        "no copy may reach past the blur radius, which is what the damage slop \
+         is computed from"
+    );
+}
+
+#[test]
+fn a_huge_blur_spreads_the_budget_instead_of_spending_more() {
+    // Filling a disc at a fixed spacing would cost hundreds of draws at a large
+    // radius. Past the budget the spacing widens, so the count levels off.
+    let counts: Vec<usize> = [10.0, 20.0, 40.0, 80.0]
+        .iter()
+        .map(|blur| shadow_copies(*blur).len())
+        .collect();
+    assert!(
+        counts.iter().all(|count| *count < 200),
+        "counts were {counts:?}"
+    );
+    assert!(
+        counts[3] <= counts[1] + 8,
+        "the count has to level off, not keep climbing: {counts:?}"
+    );
+}
+
 #[test]
 fn a_zero_width_stroke_draws_nothing_extra() {
     assert_eq!(


### PR DESCRIPTION
`text_decoration_example` shows it: past about eight pixels of blur the shadow is
a mosaic of hard rectangles rather than a halo, worst around a colon and the stem
of a 4, while the round `0` and `9` beside them look fine.

## What it actually was

Not rasterization, not the atlas, not this library's draw grouping. **The
rectangles are the copies.** Two rings of twelve taps at blur 10 puts neighbours
five pixels apart, and a glyph's square features are only a couple of pixels
wide, so each copy reads as its own rectangle. Round glyphs overlap continuously
and hide it — which is how it passed review.

Bisected outside guido, with wgpu offscreen and glyphon alone (no compositor, so
it can run anywhere):

| variant | result |
| --- | --- |
| 25 copies at the ring's offsets | mosaic |
| the same ring rounded to whole pixels | mosaic, identical |
| 25 copies all at one position | clean |
| one copy | clean |

Spread copies break, stacked copies do not, and whole-pixel offsets change
nothing — so the subpixel bins the old comment worried about were never the
cause (`cosmic_text::CacheKey` does bin them, but that costs rasterizations, not
correctness), and neither was mid-frame atlas growth.

## The fix

Fill the disc: rings every two logical pixels out to the radius, each with enough
taps that neighbours along it are two pixels apart as well. Alpha falls off as a
gaussian in the distance, divided by the ring count — without that a wide blur,
with many more rings stacking, comes out as a slab where a tight one is a halo.
The core keeps the colour as asked: it sits under the fill, and dimming it made a
tight blur *weaker* than before the change.

About a hundred copies at blur 10 against twenty-five, so four times the draws —
fill rate only, since every copy re-uses the same glyph rasters and differs only
in position. Past a budget of ~128 the spacing widens instead of the count
growing with the area, so a huge radius degrades towards the old look rather than
costing hundreds of draws. That ceiling is where the honest fix takes over: a
dilate and blur on an offscreen mask.

Verified by rendering blur 2, 4, 6, 10 and 16 offscreen and looking at all five:
each is a crisp core with a halo that grows, and no mosaic anywhere.

## Tests

Three, each pinning what the old code got wrong:

- no copy is further than three pixels from its nearest neighbour
- every two-pixel band of the disc is occupied — rings at the radius and half of
  it leave a hole between them
- the count levels off as the radius grows, instead of climbing with the area

`cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`,
full suite green (13 in `text_decoration`, 354 in the lib). The book's legibility
section no longer claims a shadow hides the approximation, because that was the
wrong half of the story.