### PR TITLE
Process-wide state belongs to the root, not to its first reader

### DIFF
--- a/ith_root_owner(|| create_signal(Modifiers::default())))|            .get_or_insert_with(|| create_signal(Modifiers::default()))|
+++ b/ith_root_owner(|| create_signal(Modifiers::default())))|            .get_or_insert_with(|| create_signal(Modifiers::default()))|
@@ -1,0 +1,1 @@
+|| with_root_owner(|| create_signal(Modifiers::default())))

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -8,6 +8,7 @@
 
 use std::cell::RefCell;
 
+use crate::reactive::owner::with_root_owner;
 use crate::reactive::{RwSignal, Signal, create_signal};
 
 /// Compositor-side effects currently on offer.
@@ -31,7 +32,7 @@ fn effects_signal() -> RwSignal<CompositorEffects> {
     EFFECTS.with(|cell| {
         *cell
             .borrow_mut()
-            .get_or_insert_with(|| create_signal(CompositorEffects::default()))
+            .get_or_insert_with(|| with_root_owner(|| create_signal(CompositorEffects::default())))
     })
 }
 

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -21,6 +21,7 @@
 
 use std::cell::RefCell;
 
+use crate::reactive::owner::with_root_owner;
 use crate::reactive::{RwSignal, Signal, create_signal};
 use crate::widgets::Modifiers;
 
@@ -34,7 +35,7 @@ fn modifiers_signal() -> RwSignal<Modifiers> {
     MODIFIERS.with(|cell| {
         *cell
             .borrow_mut()
-            .get_or_insert_with(|| create_signal(Modifiers::default()))
+            .get_or_insert_with(|| with_root_owner(|| create_signal(Modifiers::default())))
     })
 }
 
@@ -79,6 +80,33 @@ mod tests {
         set_keyboard_modifiers(latched);
 
         assert_eq!(keyboard_modifiers().get_untracked(), latched);
+    }
+
+    #[test]
+    fn the_first_reader_does_not_get_to_own_it() {
+        // The crash this pins: allock's caps-lock indicator reads this from
+        // inside a widget's reactive closure, which on that screen is the first
+        // read in the process. The signal was created under the closure's owner,
+        // died with it, and the read after that panicked with "signal was
+        // disposed" — the thread-local was still holding the dead handle.
+        use crate::reactive::owner::{create_root_owner, dispose_owner_now, with_owner};
+
+        create_root_owner();
+        reset_keyboard_modifiers();
+
+        let (_, scope) = with_owner(|| keyboard_modifiers().get_untracked());
+        dispose_owner_now(scope);
+
+        assert_eq!(
+            keyboard_modifiers().get_untracked(),
+            Modifiers::default(),
+            "the state has to outlive whichever scope happened to read it first"
+        );
+        set_keyboard_modifiers(Modifiers {
+            caps_lock: true,
+            ..Default::default()
+        });
+        assert!(keyboard_modifiers().get_untracked().caps_lock);
     }
 
     #[test]

--- a/src/outputs.rs
+++ b/src/outputs.rs
@@ -22,6 +22,7 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
 
+use crate::reactive::owner::with_root_owner;
 use crate::reactive::{RwSignal, Signal, create_signal};
 use crate::surface::SurfaceId;
 
@@ -79,7 +80,7 @@ fn outputs_signal() -> RwSignal<Vec<OutputInfo>> {
     OUTPUTS.with(|cell| {
         *cell
             .borrow_mut()
-            .get_or_insert_with(|| create_signal(Vec::new()))
+            .get_or_insert_with(|| with_root_owner(|| create_signal(Vec::new())))
     })
 }
 
@@ -87,7 +88,7 @@ fn surface_outputs_signal() -> RwSignal<HashMap<SurfaceId, OutputId>> {
     SURFACE_OUTPUTS.with(|cell| {
         *cell
             .borrow_mut()
-            .get_or_insert_with(|| create_signal(HashMap::new()))
+            .get_or_insert_with(|| with_root_owner(|| create_signal(HashMap::new())))
     })
 }
 

--- a/src/reactive/owner.rs
+++ b/src/reactive/owner.rs
@@ -34,7 +34,7 @@
 //! // All signals, effects, and cleanup callbacks are now disposed
 //! ```
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 
 use super::invalidation::clear_signal_subscribers;
@@ -149,6 +149,8 @@ impl OwnerArena {
 thread_local! {
     static CURRENT_OWNER: RefCell<Option<OwnerId>> = const { RefCell::new(None) };
     static OWNERS: RefCell<OwnerArena> = RefCell::new(OwnerArena::new());
+    /// Remembered so [`with_root_owner`] can reach it from any depth.
+    static ROOT_OWNER: Cell<Option<OwnerId>> = const { Cell::new(None) };
 }
 
 /// Create a root owner and set it as the current owner.
@@ -159,6 +161,7 @@ thread_local! {
 pub(crate) fn create_root_owner() -> OwnerId {
     let id = OWNERS.with(|owners| owners.borrow_mut().allocate(None));
     CURRENT_OWNER.with(|current| *current.borrow_mut() = Some(id));
+    ROOT_OWNER.with(|root| root.set(Some(id)));
     id
 }
 
@@ -168,7 +171,31 @@ pub(crate) fn create_root_owner() -> OwnerId {
 /// reactive graph. This wipes the arena so the next `App` run starts fresh.
 pub(crate) fn reset_owners() {
     CURRENT_OWNER.with(|c| *c.borrow_mut() = None);
+    ROOT_OWNER.with(|root| root.set(None));
     OWNERS.with(|o| *o.borrow_mut() = OwnerArena::new());
+}
+
+/// Run `f` under the root owner instead of whatever scope is current.
+///
+/// For process-wide state built on first use — the modifier state, the output
+/// list, the compositor's capabilities. Each lives in a thread-local behind a
+/// lazily created signal, and *whoever reads it first* decides the owner. When
+/// that first reader is a widget's reactive closure, the signal belongs to a
+/// scope that is disposed on the closure's next run, while the thread-local goes
+/// on holding the dead handle: the read after that panics with "signal was
+/// disposed". Anchoring the creation at the root makes the lifetime match what
+/// the thing actually is.
+///
+/// With no `App` — unit tests — there is no root, and the current scope is used
+/// as before.
+pub(crate) fn with_root_owner<T>(f: impl FnOnce() -> T) -> T {
+    let Some(root) = ROOT_OWNER.with(|root| root.get()) else {
+        return f();
+    };
+    let previous = CURRENT_OWNER.with(|current| current.replace(Some(root)));
+    let value = f();
+    CURRENT_OWNER.with(|current| current.replace(previous));
+    value
 }
 
 /// Execute a closure within a new owner scope.


### PR DESCRIPTION
allock's lock screen crashes as soon as the caps-lock indicator is on screen:

```
thread 'main' panicked at src/reactive/storage.rs:
Signal 145v0 was disposed - cannot read after owner cleanup.
```

## Why

The modifier state, the output list and the compositor's capabilities are built
the same way — a thread-local holding a signal created on first use:

```rust
fn modifiers_signal() -> RwSignal<Modifiers> {
    MODIFIERS.with(|cell| *cell.borrow_mut().get_or_insert_with(|| create_signal(..)))
}
```

That makes **whoever reads it first** the owner. When the first reader is a
widget's reactive closure — which is exactly what the caps-lock indicator is —
the signal belongs to a scope that gets disposed on the closure's next run, while
the thread-local goes on holding the handle. The next read panics.

This was already latent in `outputs()` and `compositor_effects()`: both are
normally touched by the platform layer during startup, outside any widget scope,
so the owner happened to be the root and nobody noticed. `keyboard_modifiers()`
has no early writer — nothing publishes a modifier update until the compositor
sends one — so the widget gets there first and the latent bug becomes a reliable
crash.

## The fix

`with_root_owner` runs the lazy creation under the root owner, so the lifetime
matches what the thing is: process-wide state, not a widget's. The root owner is
remembered when it is created (it was only ever set as *current*), so any depth
can reach it. With no `App` — unit tests — there is no root and the current scope
is used exactly as before.

All three sites are anchored, not just the one that crashed.

## Test

`the_first_reader_does_not_get_to_own_it` builds the crash on purpose: read the
state inside a scope, dispose the scope, read again. Without the fix it panics
with the same message from `storage.rs`; with it, the state is intact and still
writable.

`cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`,
full suite green (355 in the lib).