### PR TITLE
Delete a file sed wrote by accident

### DIFF
--- a/ith_root_owner(|| create_signal(Modifiers::default())))|            .get_or_insert_with(|| create_signal(Modifiers::default()))|
+++ b/ith_root_owner(|| create_signal(Modifiers::default())))|            .get_or_insert_with(|| create_signal(Modifiers::default()))|
@@ -1,1 +1,0 @@
-|| with_root_owner(|| create_signal(Modifiers::default())))


### PR DESCRIPTION
A 60-byte file whose name is half a sed expression, committed with #175.

The command that made it used `|` as the `s///` delimiter, so sed read the `w` in `with_root_owner` as its own write-to-file flag and created the file. Nothing references it.