### PR TITLE
A masked field must not export what it holds

### DIFF
--- a/src/widgets/text_input.rs
+++ b/src/widgets/text_input.rs
@@ -702,15 +702,40 @@ impl TextInput {
         }
     }
 
+    /// The selection, when it is allowed to leave the widget.
+    ///
+    /// `None` in password mode. What a masked field holds must not reach the
+    /// clipboard or the primary selection, and the leak that matters is not
+    /// Ctrl+C — it is the primary selection, which an ordinary mouse drag fills
+    /// with no keystroke at all, ready for a middle-click anywhere else. GTK4's
+    /// `GtkPasswordEntry` refuses to export for the same reason; GTK3 exported
+    /// the mask instead, which is a row of bullets that is no use to paste.
+    ///
+    /// Pasting *into* the field stays allowed. Blocking that is the security
+    /// theatre banking sites are mocked for: it stops password managers, not
+    /// attackers, and pushes people towards passwords they can type.
+    fn exportable_selection(&self) -> Option<String> {
+        if self.is_password {
+            return None;
+        }
+        self.get_selected_text()
+    }
+
     /// Copy selected text to clipboard
     fn copy_selection(&self) {
-        if let Some(text) = self.get_selected_text() {
+        if let Some(text) = self.exportable_selection() {
             clipboard_copy(&text);
         }
     }
 
     /// Cut selected text (copy and delete)
     fn cut_selection(&mut self, bounds_width: f32) {
+        // A cut that cannot copy is not a cut. Refusing the gesture outright is
+        // what GtkPasswordEntry does, and it keeps Ctrl+X from quietly becoming
+        // a delete while the user believes the clipboard was filled.
+        if self.is_password {
+            return;
+        }
         if self.selection.has_selection() {
             self.copy_selection();
             self.delete(false, bounds_width); // Delete the selection
@@ -1063,7 +1088,7 @@ impl Widget for TextInput {
                 self.is_dragging = false;
                 // Select-to-copy: a completed mouse selection becomes the
                 // primary selection (middle-click paste elsewhere)
-                if let Some(text) = self.get_selected_text() {
+                if let Some(text) = self.exportable_selection() {
                     primary_copy(&text);
                 }
                 return EventResponse::Handled;

--- a/tests/password_never_exports.rs
+++ b/tests/password_never_exports.rs
@@ -1,0 +1,166 @@
+//! A masked field must not hand its contents to anything outside itself.
+//!
+//! Both routes out are tested, because the dangerous one is not the obvious one:
+//! Ctrl+C takes a keystroke, while the *primary selection* is filled by an
+//! ordinary mouse drag and pasted by a middle click anywhere else. A lock screen
+//! is where that matters — the clipboard outlives the unlock.
+//!
+//! Pasting *in* is checked too, and must keep working: blocking it stops
+//! password managers, not attackers.
+
+use guido::layout::Constraints;
+use guido::prelude::*;
+use guido::reactive::clipboard::{
+    clear_system_clipboard, clipboard_paste, primary_paste, set_system_clipboard,
+    take_clipboard_change,
+};
+use guido::reactive::focus::request_focus;
+use guido::tree::{Tree, WidgetId};
+
+const SECRET: &str = "correct horse battery staple";
+
+struct Field {
+    tree: Tree,
+    id: WidgetId,
+    value: RwSignal<String>,
+}
+
+impl Field {
+    /// A focused, laid-out input holding `SECRET`.
+    fn new(password: bool) -> Self {
+        // Anything a previous test left behind would make this one lie.
+        clear_system_clipboard();
+        let _ = take_clipboard_change();
+
+        let value = create_signal(SECRET.to_owned());
+        let input = text_input(value).password(password);
+
+        let mut tree = Tree::new();
+        let id = tree.register(Box::new(input));
+        tree.with_widget_mut(id, |w, id, t| w.register_children(t, id));
+        tree.with_widget_mut(id, |w, id, t| {
+            w.layout(t, id, Constraints::new(0.0, 0.0, 400.0, 40.0))
+        });
+        request_focus(&tree, id);
+
+        Self { tree, id, value }
+    }
+
+    fn key(&mut self, key: Key, ctrl: bool) {
+        let event = Event::KeyDown {
+            key,
+            modifiers: Modifiers {
+                ctrl,
+                ..Default::default()
+            },
+        };
+        self.event(&event);
+    }
+
+    fn event(&mut self, event: &Event) {
+        let id = self.id;
+        self.tree.with_widget_mut(id, |w, id, t| {
+            w.event(t, id, event);
+        });
+    }
+
+    /// Drag across the whole field, which is how the primary selection is filled.
+    fn drag_select_all(&mut self) {
+        // The field is only `font_size * 1.2` tall, so the y has to stay well
+        // inside it or the hit test drops the press and the drag selects nothing.
+        self.event(&Event::MouseDown {
+            x: 0.0,
+            y: 4.0,
+            button: MouseButton::Left,
+        });
+        self.event(&Event::MouseMove { x: 399.0, y: 4.0 });
+        self.event(&Event::MouseUp {
+            x: 399.0,
+            y: 4.0,
+            button: MouseButton::Left,
+        });
+    }
+}
+
+/// Everything that could carry the value out of the widget.
+fn exported() -> Vec<String> {
+    [take_clipboard_change(), clipboard_paste(), primary_paste()]
+        .into_iter()
+        .flatten()
+        .collect()
+}
+
+#[test]
+fn a_password_field_does_not_copy_itself() {
+    let mut field = Field::new(true);
+    field.key(Key::Char('a'), true);
+    field.key(Key::Char('c'), true);
+
+    let exported = exported();
+    assert!(
+        !exported.iter().any(|text| text.contains(SECRET)),
+        "the password left the field: {exported:?}"
+    );
+}
+
+#[test]
+fn a_password_field_does_not_leak_through_the_primary_selection() {
+    // The one nobody presses a key for.
+    let mut field = Field::new(true);
+    field.drag_select_all();
+
+    let exported = exported();
+    assert!(
+        !exported.iter().any(|text| text.contains(SECRET)),
+        "a mouse drag published the password: {exported:?}"
+    );
+}
+
+#[test]
+fn a_password_field_refuses_the_cut_rather_than_deleting_quietly() {
+    let mut field = Field::new(true);
+    field.key(Key::Char('a'), true);
+    field.key(Key::Char('x'), true);
+
+    let exported = exported();
+    assert!(
+        !exported.iter().any(|text| text.contains(SECRET)),
+        "the password left the field: {exported:?}"
+    );
+    assert_eq!(
+        field.value.get_untracked(),
+        SECRET,
+        "a cut that cannot copy must not delete either — otherwise Ctrl+X is a \
+         delete the user believes filled the clipboard"
+    );
+}
+
+#[test]
+fn an_ordinary_field_still_copies() {
+    // The guard has to be about password mode, not about copying.
+    let mut field = Field::new(false);
+    field.key(Key::Char('a'), true);
+    field.key(Key::Char('c'), true);
+
+    assert_eq!(take_clipboard_change().as_deref(), Some(SECRET));
+}
+
+#[test]
+fn an_ordinary_field_still_fills_the_primary_selection() {
+    let mut field = Field::new(false);
+    field.drag_select_all();
+
+    assert_eq!(primary_paste().as_deref(), Some(SECRET));
+}
+
+#[test]
+fn a_password_field_still_takes_a_paste() {
+    let mut field = Field::new(true);
+    field.key(Key::Char('a'), true);
+    field.key(Key::Backspace, false);
+    set_system_clipboard("hunter2".to_owned());
+
+    field.key(Key::Char('v'), true);
+
+    assert_eq!(field.value.get_untracked(), "hunter2");
+}


### PR DESCRIPTION
`TextInput` in password mode copied its real contents. `copy_selection()` and the
select-to-copy path both read `cached_value` — the text, never the mask — without
ever looking at `is_password`.

**The route that matters is not Ctrl+C.** It is the primary selection: dragging
across the field fills it with no keystroke at all, and a middle click anywhere
else pastes it. On a lock screen that leaves the password in a buffer that
outlives the unlock. allock is about to replace its hand-rolled password field
with this widget, which is how it surfaced.

## What changes

One accessor decides whether the selection may leave the widget, and all three
export paths go through it. In password mode:

- copy does nothing
- cut does nothing **at all** — a cut that cannot copy is not a cut, and refusing
  the gesture keeps Ctrl+X from quietly becoming a delete while the user believes
  the clipboard was filled
- a completed drag does not publish the primary selection

Paste stays allowed. Blocking it is the security theatre banking sites are mocked
for: it stops password managers, not attackers, and pushes people towards
passwords they can type.

This is [GTK4 `GtkPasswordEntry`](https://docs.gtk.org/gtk4/class.PasswordEntry.html)
behaviour — it "does not allow to copy it to the clipboard". GTK3's
`visibility = FALSE` exported the *mask* instead: a row of bullets, no use to
paste and confusing to receive.

## Tests

`tests/password_never_exports.rs`, six of them. Three fail without the guard
(copy, cut, primary selection). The other three are the control — an ordinary
field still copies, still fills the primary selection, and a password field still
takes a paste — because otherwise the guard could be "clipboard broken" rather
than "password mode".

`cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`,
full suite green.