### PR TITLE
An input can ask for the keyboard when it first appears

### DIFF
--- a/book/src/building-ui/text-input.md
+++ b/book/src/building-ui/text-input.md
@@ -82,6 +82,27 @@ text_input(password)
     .mask_char('*')
 ```
 
+## Initial Focus
+
+A screen that exists to be typed into should not make the user click first — and
+on a surface with no pointer there may be nothing to click *with*:
+
+```rust
+text_input(password)
+    .password(true)
+    .autofocus()
+```
+
+The input takes the keyboard at its first layout, and only if no widget already
+holds focus. That second condition is what makes it safe: an input appearing
+later never pulls focus off the one being typed into, two autofocusing inputs do
+not fight (the first laid out wins), and the same view built once per output — a
+lock screen with two monitors — ends up with one focused field rather than
+whichever was laid out last.
+
+The offer is made once. A relayout does not ask again, so a resize or a scale
+change cannot drag focus back from wherever the user has since put it.
+
 ## Callbacks
 
 ### On Change
@@ -240,16 +261,9 @@ fn login_form() -> Container {
 text_input(signal: Signal<String>) -> TextInput
 
 impl TextInput {
-    pub fn text_color<M>(self, color: impl IntoSignal<Color, M>) -> Self;
-    pub fn cursor_color<M>(self, color: impl IntoSignal<Color, M>) -> Self;
-    pub fn selection_color<M>(self, color: impl IntoSignal<Color, M>) -> Self;
-    pub fn font_size<M>(self, size: impl IntoSignal<f32, M>) -> Self;
-    pub fn font_family<M>(self, family: impl IntoSignal<FontFamily, M>) -> Self;
-    pub fn font_weight<M>(self, weight: impl IntoSignal<FontWeight, M>) -> Self;
-    pub fn bold(self) -> Self;      // Shorthand for FontWeight::BOLD
-    pub fn mono(self) -> Self;      // Shorthand for FontFamily::Monospace
     pub fn password(self, enabled: bool) -> Self;
     pub fn mask_char(self, c: char) -> Self;
+    pub fn autofocus(self) -> Self;
     pub fn on_change<F: Fn(&str) + 'static>(self, callback: F) -> Self;
     pub fn on_submit<F: Fn(&str) + 'static>(self, callback: F) -> Self;
 }

--- a/src/widgets/text_input.rs
+++ b/src/widgets/text_input.rs
@@ -14,6 +14,7 @@ use std::time::{Duration, Instant};
 use crate::default_font_family;
 use crate::jobs::{JobRequest, JobType, RequiredJob, request_job};
 use crate::layout::{Constraints, Size};
+use crate::reactive::focus::focused_widget;
 use crate::reactive::{
     CursorIcon, OptionSignalExt, RwSignal, clipboard_copy, clipboard_paste, has_focus,
     primary_copy, primary_paste, release_focus, request_focus, set_cursor, with_signal_tracking,
@@ -210,6 +211,11 @@ pub struct TextInput {
     is_password: bool,
     mask_char: char,
 
+    /// An unmade offer of the initial focus. Cleared once made, so autofocus is
+    /// a *first layout* behaviour rather than something that fights the user on
+    /// every relayout.
+    autofocus_pending: bool,
+
     // Selection state
     selection: Selection,
 
@@ -257,6 +263,7 @@ impl TextInput {
             cached_font_weight: FontWeight::NORMAL,
             is_password: false,
             mask_char: '•',
+            autofocus_pending: false,
             selection: Selection::new(0),
             cursor_visible: true,
             last_cursor_toggle: Instant::now(),
@@ -278,6 +285,30 @@ impl TextInput {
     /// Set custom mask character for password mode (default: '•')
     pub fn mask_char(mut self, c: char) -> Self {
         self.mask_char = c;
+        self
+    }
+
+    /// Take keyboard focus when this input first appears, if nothing else has it.
+    ///
+    /// For a screen that exists to be typed into — a lock screen, a search
+    /// overlay, a dialog with one field — where making the user click first is
+    /// the wrong answer, and where there is no cursor to click *with* on a
+    /// surface that has no pointer.
+    ///
+    /// The offer is made once, at the input's first layout, and only when no
+    /// widget holds focus. Both halves matter:
+    ///
+    /// - *once*, so a relayout does not drag focus back from wherever the user
+    ///   has since put it
+    /// - *only when free*, so two autofocusing inputs do not fight — the first
+    ///   laid out wins — and one on a second surface does not pull focus off the
+    ///   surface being typed into. That last case is what a lock screen with two
+    ///   monitors is: the same view built per output, all of them asking.
+    ///
+    /// The equivalent elsewhere: Flutter's `autofocus: true`, Floem's
+    /// `autofocus` focus-nav flag, `forward-focus` on a Slint window.
+    pub fn autofocus(mut self) -> Self {
+        self.autofocus_pending = true;
         self
     }
 
@@ -931,6 +962,16 @@ impl Widget for TextInput {
 
         // Clear needs_layout flag since layout is complete
         tree.clear_needs_layout(id);
+
+        // Here rather than at construction because focus needs the tree, and
+        // this is the first moment the input is in one — the same reason Flutter
+        // makes you wait for a post-frame callback to request focus by hand.
+        if self.autofocus_pending {
+            self.autofocus_pending = false;
+            if focused_widget().is_none() {
+                request_focus(tree, id);
+            }
+        }
 
         size
     }

--- a/tests/autofocus.rs
+++ b/tests/autofocus.rs
@@ -1,0 +1,113 @@
+//! `.autofocus()`: an input that takes the keyboard when it first appears.
+//!
+//! The rule has two halves, and each has a test here because each is what makes
+//! the other safe: the offer is made *once*, at the first layout, and only when
+//! no widget already holds focus.
+
+use guido::layout::Constraints;
+use guido::prelude::*;
+use guido::reactive::focus::{clear_focus, focused_widget, has_focus, request_focus};
+use guido::tree::{Tree, WidgetId};
+
+/// A tree the test can lay out repeatedly, as a running app does.
+struct Screen {
+    tree: Tree,
+}
+
+impl Screen {
+    fn new() -> Self {
+        clear_focus();
+        Self { tree: Tree::new() }
+    }
+
+    fn add(&mut self, input: TextInput) -> WidgetId {
+        let id = self.tree.register(Box::new(input));
+        self.tree
+            .with_widget_mut(id, |w, id, t| w.register_children(t, id));
+        id
+    }
+
+    fn layout(&mut self, id: WidgetId) {
+        self.tree.with_widget_mut(id, |w, id, t| {
+            w.layout(t, id, Constraints::new(0.0, 0.0, 400.0, 40.0))
+        });
+    }
+}
+
+#[test]
+fn an_autofocused_input_takes_the_keyboard_when_it_is_laid_out() {
+    let mut screen = Screen::new();
+    let field = screen.add(text_input(create_signal(String::new())).autofocus());
+
+    assert_eq!(
+        focused_widget(),
+        None,
+        "nothing should be focused before the first layout — the tree is where \
+         focus lives, and the widget is not in one yet"
+    );
+
+    screen.layout(field);
+
+    assert!(has_focus(field));
+}
+
+#[test]
+fn an_input_without_autofocus_waits_to_be_clicked() {
+    let mut screen = Screen::new();
+    let field = screen.add(text_input(create_signal(String::new())));
+
+    screen.layout(field);
+
+    assert_eq!(focused_widget(), None);
+}
+
+#[test]
+fn autofocus_does_not_take_focus_from_whoever_has_it() {
+    let mut screen = Screen::new();
+    let clicked = screen.add(text_input(create_signal(String::new())));
+    let latecomer = screen.add(text_input(create_signal(String::new())).autofocus());
+    screen.layout(clicked);
+    request_focus(&screen.tree, clicked);
+
+    screen.layout(latecomer);
+
+    assert!(
+        has_focus(clicked),
+        "an input appearing later must not pull the keyboard out from under the \
+         one being typed into"
+    );
+}
+
+#[test]
+fn the_first_of_several_autofocusing_inputs_wins() {
+    // A lock screen with two monitors is this: the same view built per output,
+    // every copy asking for the focus.
+    let mut screen = Screen::new();
+    let first = screen.add(text_input(create_signal(String::new())).autofocus());
+    let second = screen.add(text_input(create_signal(String::new())).autofocus());
+
+    screen.layout(first);
+    screen.layout(second);
+
+    assert!(has_focus(first));
+    assert!(!has_focus(second));
+}
+
+#[test]
+fn a_relayout_does_not_ask_again() {
+    let mut screen = Screen::new();
+    let field = screen.add(text_input(create_signal(String::new())).autofocus());
+    let other = screen.add(text_input(create_signal(String::new())));
+    screen.layout(field);
+    screen.layout(other);
+    request_focus(&screen.tree, other);
+
+    // Whatever a running app relayouts for — a resize, a scale change, an edit.
+    screen.layout(field);
+
+    assert!(
+        has_focus(other),
+        "autofocus is about appearing, not about being laid out; asking again on \
+         every relayout would drag focus back on any resize"
+    );
+}


### PR DESCRIPTION
A screen that exists to be typed into should not make the user click first, and on
a surface with no pointer there may be nothing to click *with*. allock's lock
screen is the case that asked for this: it takes keys at the root of the tree, by
hand, precisely because no field could take focus on its own.

```rust
text_input(password)
    .password(true)
    .autofocus()
```

## When it fires

At the input's **first layout** — the first moment it is in a tree, which is what
focus needs. It is the same constraint Flutter has, where requesting focus by hand
means waiting for a post-frame callback.

Two conditions, and each is what makes the other safe:

- **only if nothing has focus.** An input appearing later never pulls focus off the
  one being typed into; two autofocusing inputs do not fight, the first laid out
  wins; and the same view built once per output — a lock screen with two monitors —
  focuses one field rather than whichever was laid out last.
- **once.** A relayout does not ask again, so a resize or a scale change cannot
  drag focus back from wherever the user has since put it.

The name is [Flutter's](https://docs.flutter.dev/cookbook/forms/focus) and
[Floem's](https://lapce.dev/floem/floem/struct.FocusNavMeta.html), which both call
this autofocus; Slint spells the same idea `forward-focus` on a window.

## Tests

Five, one per half of the rule: it takes focus at layout, it does not without the
call, it does not steal from whoever has it, the first of several wins, and a
relayout does not ask again.

## Drive-by

`TextInput`'s API reference in the book still listed the eight styling setters
that moved to the container in 1d71323 — `text_color`, `cursor_color`,
`selection_color`, `font_size`, `font_family`, `font_weight`, `bold`, `mono`. The
prose sections on the same page were already updated; only the reference block was
left behind, so it now lists what the type actually has.

`cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`,
full suite green.