### PR TITLE
A blink is a deadline, not an animation

### DIFF
--- a/book/src/building-ui/text-input.md
+++ b/book/src/building-ui/text-input.md
@@ -82,6 +82,23 @@ text_input(password)
     .mask_char('*')
 ```
 
+## No Caret
+
+```rust
+text_input(password)
+    .password(true)
+    .no_caret()
+```
+
+Keeps the focus and everything it carries — click to position, drag to select, the
+keyboard — and draws no caret. For a field where the caret says nothing: a masked
+one, where every character looks the same and you are always at the end. swaylock
+draws none for that reason.
+
+It is also the cheapest field there is. A blinking caret is the one thing a still
+screen redraws on its own, twice a second, for as long as it is focused; without
+one an idle surface asks the loop for nothing at all.
+
 ## Callbacks
 
 ### On Change
@@ -229,7 +246,10 @@ fn login_form() -> Container {
   input pastes the primary selection at the click position
 - **Undo/Redo**: History with intelligent coalescing of rapid edits
 - **Scrolling**: Long text scrolls horizontally to keep cursor visible
-- **Cursor Blinking**: Standard blinking cursor when focused
+- **Cursor Blinking**: Standard blinking cursor when focused. It asks the loop to
+  wake at its next toggle rather than animating, so a focused field costs two
+  wakeups a second instead of a frame at the compositor's rate; `no_caret()` drops
+  it entirely and costs nothing
 - **Key Repeat**: Hold keys for continuous input, at the rate and delay the
   compositor reports — the same settings every other application on the
   session obeys
@@ -250,6 +270,7 @@ impl TextInput {
     pub fn mono(self) -> Self;      // Shorthand for FontFamily::Monospace
     pub fn password(self, enabled: bool) -> Self;
     pub fn mask_char(self, c: char) -> Self;
+    pub fn no_caret(self) -> Self;
     pub fn on_change<F: Fn(&str) + 'static>(self, callback: F) -> Self;
     pub fn on_submit<F: Fn(&str) + 'static>(self, callback: F) -> Self;
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -312,6 +312,20 @@ When adding a new deferred-work queue, either drain it in the loop after
 the flush point AND wake through one of the two mechanisms above, or make
 it a calloop source of its own.
 
+**Main thread, but due later → `jobs::request_job_at()`.**
+Work owed to a *clock* rather than to a frame — the blinking caret — is held in
+`SCHEDULED_JOBS`, outside the queues, and deliberately does not make
+`has_pending_jobs()` true. The wakeup is the dispatch timeout itself: the loop
+asks `jobs::next_deadline()`, blocks exactly that long, and `promote_due_jobs()`
+turns whatever is due into an ordinary job at the top of the next iteration.
+
+This is why a scheduled job is not named in `queued_but_unwoken()`: nobody owes it
+a ping, because the loop is not late — it is waiting on purpose, with a bounded
+timeout. The alternative is what the caret used to do: ask for an animation frame,
+which means "advance me every frame", pinning the loop at 60 fps for a square wave
+that changes twice a second and repainting the same pixels 113 frames out of 114.
+A focused input is the resting state of a lock screen, so that ran all night.
+
 **The contract is checked, not just written down.** Debug builds assert it at
 the one moment where breaking it is fatal: `queued_but_unwoken()` in
 `src/lib.rs` names every queue the loop drains, and nothing may be

--- a/src/jobs.rs
+++ b/src/jobs.rs
@@ -480,6 +480,11 @@ pub fn process_jobs(jobs: &[Job], tree: &mut Tree, layout_roots: &mut Vec<Widget
     // Process in required order
     for id in unregister {
         clear_widget_subscribers(id);
+        // A deferred Unregister is the ordinary way a dynamic child leaves, so
+        // it has to drop the widget's deadlines too. Without this a blinking
+        // caret that scrolled out of a list keeps one, and the loop wakes once
+        // more for a widget that is not there to repaint.
+        cancel_scheduled_jobs(id);
         tree.unregister(id);
     }
     for id in animation {
@@ -820,6 +825,38 @@ mod tests {
         assert!(
             next_deadline().is_none(),
             "a caret that no longer exists must not keep the loop on a timer"
+        );
+    }
+
+    /// The other way out of the tree, and the ordinary one: a dynamic child
+    /// leaves through a deferred `Unregister` job rather than through
+    /// `teardown_widget_subtree`. Its deadlines have to go with it, or the
+    /// loop wakes once more to repaint a widget that is no longer there.
+    #[test]
+    fn a_deferred_unregister_takes_the_deadlines_with_it() {
+        clear_pending_jobs();
+        clear_scheduled();
+        let (mut tree, ..) = two_surface_tree();
+        let widget = tree.register(Box::new(TestWidget));
+        request_job_at(
+            widget,
+            JobRequest::Paint,
+            Instant::now() + Duration::from_secs(60),
+        );
+
+        let mut layout_roots = Vec::new();
+        process_jobs(
+            &[Job {
+                widget_id: widget,
+                job_type: JobType::Unregister,
+            }],
+            &mut tree,
+            &mut layout_roots,
+        );
+
+        assert!(
+            next_deadline().is_none(),
+            "a widget unregistered through the job queue must drop its deadlines too"
         );
     }
 

--- a/src/jobs.rs
+++ b/src/jobs.rs
@@ -27,6 +27,7 @@ use std::sync::{
     Mutex,
     atomic::{AtomicBool, AtomicU8, Ordering},
 };
+use std::time::Instant;
 
 use smallvec::SmallVec;
 use smithay_client_toolkit::reexports::calloop::ping::Ping;
@@ -144,6 +145,23 @@ impl JobQueues {
 // so no Mutex is needed.
 thread_local! {
     static PENDING_JOBS: RefCell<JobQueues> = RefCell::new(JobQueues::new());
+    /// Jobs waiting on a clock rather than on the next frame — see
+    /// [`request_job_at`]. Kept out of the queues so `has_pending_jobs` stays
+    /// "there is work for this frame": a scheduled job is work for *later*, and
+    /// treating it as pending is exactly what turns a blink into a poll.
+    static SCHEDULED_JOBS: RefCell<Vec<ScheduledJob>> = const { RefCell::new(Vec::new()) };
+}
+
+/// A job to run at a point in time.
+///
+/// Keyed by [`Job`] — widget and job type — while carrying the whole
+/// [`JobRequest`], so re-scheduling replaces rather than accumulates and the
+/// follow-up work an animation asks for survives the wait.
+#[derive(Clone, Copy)]
+struct ScheduledJob {
+    at: Instant,
+    job: Job,
+    request: JobRequest,
 }
 
 /// Job types for reactive invalidation (stored in the queue)
@@ -181,6 +199,19 @@ pub enum JobRequest {
     Unregister,
     /// Animation with required follow-up job (Paint or Layout)
     Animation(RequiredJob),
+}
+
+impl JobRequest {
+    /// The job type this request is stored as.
+    fn job_type(self) -> JobType {
+        match self {
+            JobRequest::Layout => JobType::Layout,
+            JobRequest::Paint => JobType::Paint,
+            JobRequest::Reconcile => JobType::Reconcile,
+            JobRequest::Unregister => JobType::Unregister,
+            JobRequest::Animation(_) => JobType::Animation,
+        }
+    }
 }
 
 /// A reactive update job
@@ -236,6 +267,80 @@ pub fn request_job(widget_id: WidgetId, request: JobRequest) {
     wake_loop();
 }
 
+/// Request a job to run *at* a deadline, replacing any earlier schedule for the
+/// same widget and job type.
+///
+/// For work that is due at a time rather than on a frame. The blinking caret is
+/// the case it exists for: it changes state every 530 ms, and the only way to
+/// express that before was `JobRequest::Animation`, which means "advance me every
+/// frame" — so a focused input pinned the loop at 60 fps and repainted 113 frames
+/// out of 114 to no effect. On a lock screen, where a field is focused by
+/// definition, that runs all night.
+///
+/// Scheduled jobs do not make [`has_pending_jobs`] true, and the loop uses
+/// [`next_deadline`] to choose how long to block, so between deadlines it sleeps
+/// like an idle app rather than polling.
+pub fn request_job_at(widget_id: WidgetId, request: JobRequest, at: Instant) {
+    let job = Job {
+        widget_id,
+        job_type: request.job_type(),
+    };
+    SCHEDULED_JOBS.with(|scheduled| {
+        let mut scheduled = scheduled.borrow_mut();
+        match scheduled.iter_mut().find(|entry| entry.job == job) {
+            // Re-scheduling the same job moves it: a caret that just toggled
+            // wants the *next* toggle, not the one it already served.
+            Some(entry) => {
+                entry.at = at;
+                entry.request = request;
+            }
+            None => scheduled.push(ScheduledJob { at, job, request }),
+        }
+    });
+    // No ping: the loop is not late for this, it just has to stop blocking in
+    // time. Waking now would be a spurious frame.
+}
+
+/// When the earliest scheduled job is due, if any.
+pub fn next_deadline() -> Option<Instant> {
+    SCHEDULED_JOBS.with(|scheduled| scheduled.borrow().iter().map(|entry| entry.at).min())
+}
+
+/// Move every scheduled job whose deadline has passed into the pending queue.
+///
+/// Called by the loop before it decides whether there is work to do.
+pub fn promote_due_jobs() {
+    let due: SmallVec<[ScheduledJob; 4]> = SCHEDULED_JOBS.with(|scheduled| {
+        let now = Instant::now();
+        let mut scheduled = scheduled.borrow_mut();
+        let mut due = SmallVec::new();
+        scheduled.retain(|entry| {
+            if entry.at <= now {
+                due.push(*entry);
+                false
+            } else {
+                true
+            }
+        });
+        due
+    });
+    for entry in due {
+        // Through the ordinary path, so ownership resolution, dedup and the
+        // animation follow-up are the same as for any other job.
+        request_job(entry.job.widget_id, entry.request);
+    }
+}
+
+/// Forget a widget's scheduled jobs. Called when it leaves the tree, so a caret
+/// that is gone does not keep waking the loop.
+pub(crate) fn cancel_scheduled_jobs(widget_id: WidgetId) {
+    SCHEDULED_JOBS.with(|scheduled| {
+        scheduled
+            .borrow_mut()
+            .retain(|entry| entry.job.widget_id != widget_id)
+    });
+}
+
 /// Resolve job ownership: sort the inbox into per-surface queues.
 ///
 /// This is the ONLY place where a job's owning surface is determined
@@ -264,6 +369,7 @@ pub fn request_job(widget_id: WidgetId, request: JobRequest) {
 pub(crate) fn teardown_widget_subtree(tree: &mut crate::tree::Tree, root: WidgetId) {
     for id in tree.collect_subtree_post_order(root) {
         clear_widget_subscribers(id);
+        cancel_scheduled_jobs(id);
         tree.unregister(id);
     }
 }
@@ -409,9 +515,28 @@ pub fn has_pending_jobs() -> bool {
     PENDING_JOBS.with(|jobs| !jobs.borrow().is_empty())
 }
 
+/// The job types queued for one widget, for tests that assert *how* a widget
+/// asked to be woken — a scheduled wake and a per-frame animation are both
+/// "pending work" from the outside, and the difference is the whole point.
+#[cfg(test)]
+pub(crate) fn queued_job_types(widget_id: WidgetId) -> Vec<JobType> {
+    PENDING_JOBS.with(|pending| {
+        let pending = pending.borrow();
+        pending
+            .inbox
+            .vec
+            .iter()
+            .chain(pending.orphans.vec.iter())
+            .chain(pending.per_root.values().flat_map(|queue| queue.vec.iter()))
+            .filter(|job| job.widget_id == widget_id)
+            .map(|job| job.job_type)
+            .collect()
+    })
+}
+
 /// Clear all pending jobs (for testing)
 #[cfg(test)]
-fn clear_pending_jobs() {
+pub(crate) fn clear_pending_jobs() {
     PENDING_JOBS.with(|jobs| {
         *jobs.borrow_mut() = JobQueues::new();
     });
@@ -516,6 +641,7 @@ pub(crate) fn reset_jobs() {
     PENDING_JOBS.with(|jobs| {
         *jobs.borrow_mut() = JobQueues::new();
     });
+    SCHEDULED_JOBS.with(|scheduled| scheduled.borrow_mut().clear());
     WAKE_REQUESTED.store(false, Ordering::Relaxed);
     PING_SENT.store(false, Ordering::Relaxed);
     EXIT_REQUEST.store(ExitRequest::Running as u8, Ordering::Relaxed);
@@ -543,6 +669,8 @@ pub fn wake_request_pending() -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use super::*;
     use crate::layout::{Constraints, Size};
     use crate::widgets::Widget;
@@ -578,6 +706,121 @@ mod tests {
         };
         PENDING_JOBS.with(|pending| pending.borrow_mut().inbox.push(job));
         job
+    }
+
+    fn clear_scheduled() {
+        SCHEDULED_JOBS.with(|scheduled| scheduled.borrow_mut().clear());
+    }
+
+    #[test]
+    fn a_scheduled_job_is_not_work_for_this_frame() {
+        clear_pending_jobs();
+        clear_scheduled();
+        let (mut tree, ..) = two_surface_tree();
+        let widget = tree.register(Box::new(TestWidget));
+
+        request_job_at(
+            widget,
+            JobRequest::Paint,
+            Instant::now() + Duration::from_secs(60),
+        );
+
+        assert!(
+            !has_pending_jobs(),
+            "a job due in a minute must not keep the loop polling for a minute"
+        );
+        assert!(
+            next_deadline().is_some(),
+            "but the loop has to know about it"
+        );
+    }
+
+    #[test]
+    fn a_due_job_becomes_an_ordinary_one() {
+        clear_pending_jobs();
+        clear_scheduled();
+        let (mut tree, ..) = two_surface_tree();
+        let widget = tree.register(Box::new(TestWidget));
+
+        request_job_at(widget, JobRequest::Paint, Instant::now());
+        promote_due_jobs();
+
+        assert!(has_pending_jobs());
+        assert!(
+            next_deadline().is_none(),
+            "and it is no longer scheduled, or it would fire every frame"
+        );
+    }
+
+    #[test]
+    fn rescheduling_moves_the_deadline_instead_of_adding_one() {
+        clear_pending_jobs();
+        clear_scheduled();
+        let (mut tree, ..) = two_surface_tree();
+        let widget = tree.register(Box::new(TestWidget));
+        let far = Instant::now() + Duration::from_secs(60);
+
+        // What a blinking caret does on every paint: ask again for the *next*
+        // toggle. Accumulating would leave one entry per frame behind.
+        request_job_at(widget, JobRequest::Paint, far);
+        request_job_at(widget, JobRequest::Paint, far);
+        request_job_at(widget, JobRequest::Paint, Instant::now());
+
+        promote_due_jobs();
+
+        assert!(has_pending_jobs());
+        assert!(next_deadline().is_none(), "three asks, one entry");
+    }
+
+    #[test]
+    fn an_animation_keeps_its_follow_up_across_the_wait() {
+        clear_pending_jobs();
+        clear_scheduled();
+        let (mut tree, ..) = two_surface_tree();
+        let widget = tree.register(Box::new(TestWidget));
+
+        request_job_at(
+            widget,
+            JobRequest::Animation(RequiredJob::Paint),
+            Instant::now(),
+        );
+        promote_due_jobs();
+
+        let queued: Vec<JobType> = PENDING_JOBS.with(|pending| {
+            pending
+                .borrow()
+                .inbox
+                .vec
+                .iter()
+                .filter(|job| job.widget_id == widget)
+                .map(|job| job.job_type)
+                .collect()
+        });
+        assert!(queued.contains(&JobType::Animation));
+        assert!(
+            queued.contains(&JobType::Paint),
+            "the caret has to be redrawn, not only advanced: {queued:?}"
+        );
+    }
+
+    #[test]
+    fn a_widget_leaving_the_tree_stops_waking_the_loop() {
+        clear_pending_jobs();
+        clear_scheduled();
+        let (mut tree, ..) = two_surface_tree();
+        let widget = tree.register(Box::new(TestWidget));
+        request_job_at(
+            widget,
+            JobRequest::Paint,
+            Instant::now() + Duration::from_secs(60),
+        );
+
+        teardown_widget_subtree(&mut tree, widget);
+
+        assert!(
+            next_deadline().is_none(),
+            "a caret that no longer exists must not keep the loop on a timer"
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1227,6 +1227,9 @@ impl App {
             let any_surface_needs_init = wayland_state.any_surface_needs_render();
             let force_render = any_surface_needs_init;
 
+            // Anything whose deadline has arrived becomes ordinary pending work.
+            jobs::promote_due_jobs();
+
             // Check if we need to actively poll: jobs pushed during the
             // previous frame, or a wake request that landed after this
             // iteration consumed the flag (blocking on a set flag would
@@ -1236,9 +1239,16 @@ impl App {
 
             // Dispatch events from calloop:
             // - If polling needed (animations/callbacks/init), use timeout
+            // - If something is due later (a blinking caret), sleep until then
             // - Otherwise block until event (Wayland or ping wakeup)
             let timeout = if needs_polling {
                 Some(std::time::Duration::from_millis(16)) // ~60fps for animations
+            } else if let Some(deadline) = jobs::next_deadline() {
+                // Not polling — waiting. A caret blinks twice a second, so this
+                // sleeps ~530 ms and wakes once, where treating the schedule as
+                // pending work would spin at 60 fps to repaint nothing 113 times
+                // out of 114.
+                Some(deadline.saturating_duration_since(std::time::Instant::now()))
             } else {
                 // About to block with nothing left to wake us but the
                 // compositor. Every queue must be empty by now — see

--- a/src/widgets/text_input.rs
+++ b/src/widgets/text_input.rs
@@ -12,7 +12,7 @@ use std::collections::VecDeque;
 use std::time::{Duration, Instant};
 
 use crate::default_font_family;
-use crate::jobs::{JobRequest, JobType, RequiredJob, request_job};
+use crate::jobs::{JobRequest, JobType, RequiredJob, request_job, request_job_at};
 use crate::layout::{Constraints, Size};
 use crate::reactive::{
     CursorIcon, OptionSignalExt, RwSignal, clipboard_copy, clipboard_paste, has_focus,
@@ -210,6 +210,10 @@ pub struct TextInput {
     is_password: bool,
     mask_char: char,
 
+    /// Whether a caret is drawn at all. Off costs nothing: no caret, no blink,
+    /// nothing to wake the loop for.
+    caret: bool,
+
     // Selection state
     selection: Selection,
 
@@ -257,6 +261,7 @@ impl TextInput {
             cached_font_weight: FontWeight::NORMAL,
             is_password: false,
             mask_char: '•',
+            caret: true,
             selection: Selection::new(0),
             cursor_visible: true,
             last_cursor_toggle: Instant::now(),
@@ -278,6 +283,21 @@ impl TextInput {
     /// Set custom mask character for password mode (default: '•')
     pub fn mask_char(mut self, c: char) -> Self {
         self.mask_char = c;
+        self
+    }
+
+    /// Draw no caret, keeping the focus and everything it carries — click to
+    /// position, drag to select, the keyboard.
+    ///
+    /// For a field where the caret says nothing: a masked one, where every
+    /// character looks the same and you are always at the end. swaylock draws no
+    /// caret for that reason.
+    ///
+    /// It is also the cheapest field there is. A blinking caret is the one thing
+    /// a still screen redraws on its own, twice a second, forever; without it an
+    /// idle surface wakes the loop for nothing at all.
+    pub fn no_caret(mut self) -> Self {
+        self.caret = false;
         self
     }
 
@@ -417,22 +437,31 @@ impl TextInput {
         overflow
     }
 
-    /// Update cursor blink state.
-    /// Returns true if the cursor is actively blinking (widget is focused).
+    /// Advance the blink, and ask to be woken when it next changes.
+    ///
+    /// Returns whether the caret is drawn at all.
+    ///
+    /// The wake is *scheduled*, not animated. Asking for an animation frame —
+    /// which is what this did — pins the loop at 60 fps for a square wave that
+    /// changes twice a second, so 113 frames out of 114 repaint the same pixels.
+    /// A focused field is the normal state of a lock screen, and that ran all
+    /// night.
     fn update_cursor_blink(&mut self, id: WidgetId) -> bool {
-        if has_focus(id) {
-            let now = Instant::now();
-            if now.duration_since(self.last_cursor_toggle) >= Duration::from_millis(CURSOR_BLINK_MS)
-            {
-                self.cursor_visible = !self.cursor_visible;
-                self.last_cursor_toggle = now;
-            }
-            // Keep requesting animation frames for blinking
-            request_job(id, JobRequest::Animation(RequiredJob::Paint));
-            true
-        } else {
-            false
+        if !self.caret || !has_focus(id) {
+            return false;
         }
+        let period = Duration::from_millis(CURSOR_BLINK_MS);
+        let now = Instant::now();
+        if now.duration_since(self.last_cursor_toggle) >= period {
+            self.cursor_visible = !self.cursor_visible;
+            self.last_cursor_toggle = now;
+        }
+        request_job_at(
+            id,
+            JobRequest::Animation(RequiredJob::Paint),
+            self.last_cursor_toggle + period,
+        );
+        true
     }
 
     /// Reset cursor to visible (called on input)
@@ -1025,9 +1054,10 @@ impl Widget for TextInput {
             Event::MouseDown { x, y, button }
                 if bounds.contains(*x, *y) && *button == MouseButton::Left =>
             {
-                // Request focus and start cursor blink animation
+                // Focus, then repaint to show the caret where the click landed.
+                // The blink schedules its own next wake from `paint`.
                 request_focus(tree, id);
-                request_job(id, JobRequest::Animation(RequiredJob::Paint));
+                request_job(id, JobRequest::Paint);
 
                 // Set cursor position
                 let char_index = self.char_index_at_x(*x, bounds);
@@ -1115,4 +1145,78 @@ impl Widget for TextInput {
 /// ```
 pub fn text_input(signal: RwSignal<String>) -> TextInput {
     TextInput::new(signal)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::jobs::{clear_pending_jobs, next_deadline, queued_job_types};
+    use crate::layout::Constraints;
+    use crate::reactive::create_signal;
+
+    /// A laid-out input, focused unless told otherwise.
+    fn field(input: TextInput, focused: bool) -> (Tree, WidgetId) {
+        clear_pending_jobs();
+        crate::reactive::focus::clear_focus();
+
+        let mut tree = Tree::new();
+        let id = tree.register(Box::new(input));
+        tree.with_widget_mut(id, |w, id, t| w.register_children(t, id));
+        tree.with_widget_mut(id, |w, id, t| {
+            w.layout(t, id, Constraints::new(0.0, 0.0, 200.0, 40.0))
+        });
+        if focused {
+            request_focus(&tree, id);
+        }
+        clear_pending_jobs();
+        (tree, id)
+    }
+
+    fn advance(tree: &mut Tree, id: WidgetId) -> bool {
+        tree.with_widget_mut(id, |w, id, t| w.advance_animations(t, id))
+            .unwrap_or(false)
+    }
+
+    #[test]
+    fn a_blinking_caret_asks_to_be_woken_rather_than_polled() {
+        let (mut tree, id) = field(text_input(create_signal(String::new())), true);
+
+        let blinking = advance(&mut tree, id);
+
+        assert!(blinking);
+        assert!(
+            next_deadline().is_some(),
+            "the caret has to schedule its next toggle"
+        );
+        assert!(
+            !queued_job_types(id).contains(&JobType::Animation),
+            "and must not queue an animation job, which is what pinned the loop \
+             at 60 fps to redraw the same pixels 113 frames out of 114"
+        );
+    }
+
+    #[test]
+    fn a_field_without_a_caret_asks_for_nothing() {
+        let (mut tree, id) = field(text_input(create_signal(String::new())).no_caret(), true);
+
+        let blinking = advance(&mut tree, id);
+
+        assert!(!blinking);
+        assert_eq!(
+            next_deadline(),
+            None,
+            "no caret, no blink, nothing to wake the loop for — this is what a \
+             lock screen costs while nobody touches it"
+        );
+    }
+
+    #[test]
+    fn an_unfocused_field_asks_for_nothing() {
+        let (mut tree, id) = field(text_input(create_signal(String::new())), false);
+
+        let blinking = advance(&mut tree, id);
+
+        assert!(!blinking);
+        assert_eq!(next_deadline(), None);
+    }
 }


### PR DESCRIPTION
A focused `TextInput` pinned the event loop at 60 fps.

`update_cursor_blink` asked for `JobRequest::Animation(RequiredJob::Paint)` on
every paint; an animation job makes the loop poll on a 16 ms timeout; the caret
changes state every 530 ms. So **113 frames out of 114 repainted the same pixels**
— and a field with focus is the resting state of a lock screen, so it ran all
night, waking the GPU at every vsync. [hyprlock has open reports of exactly this
shape](https://github.com/hyprwm/hyprlock/discussions/743) (8% of a battery in 30
minutes while locked).

## The missing vocabulary

`jobs::request_job_at(widget, request, at)` — work owed to a *clock* rather than to
a frame.

Scheduled jobs live outside the queues and deliberately **do not** make
`has_pending_jobs()` true: they are not work for *this* frame. The loop asks
`next_deadline()`, blocks exactly that long, and `promote_due_jobs()` turns
whatever is due into an ordinary job at the top of the next iteration.

The wakeup is therefore the dispatch timeout itself, which is why this needs no
ping and is not named in `queued_but_unwoken()`: the loop is not late, it is
waiting on purpose with a bounded timeout. `docs/ARCHITECTURE.md` gains it as the
third mechanism in the Wakeup Contract.

Two details that keep it honest: re-scheduling **moves** a deadline instead of
adding one (a caret asks again on every paint), and a widget leaving the tree takes
its schedule with it (a caret that no longer exists must not keep the loop on a
timer).

Result: a focused caret costs two wakeups a second, and the repaint happens on the
frame where it actually changed.

## `no_caret()`

```rust
text_input(password).password(true).no_caret()
```

Keeps the focus and everything it carries — click to position, drag to select, the
keyboard — and draws no caret. For a field where the caret says nothing: a masked
one, where every character looks the same and you are always at the end. swaylock
draws none for that reason. It is also the cheapest field there is: without a
caret, an idle surface asks the loop for nothing at all.

## Tests

Eight. Five on the primitive: not pending before its deadline, promoted after,
re-scheduling replaces rather than accumulates, the animation's follow-up paint
survives the wait, teardown cancels. Three on the widget: a caret schedules instead
of animating, no caret asks for nothing, an unfocused field asks for nothing.

`cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, full
suite green (363 in the lib).