### PR TITLE
WidgetRef learns the verb: focus

### DIFF
--- a/book/src/advanced/widget-ref.md
+++ b/book/src/advanced/widget-ref.md
@@ -1,6 +1,8 @@
 # Widget Ref
 
-The **WidgetRef** API provides reactive access to a widget's layout bounds. This is useful when you need to position one widget relative to another — for example, centering a popup menu under a status bar module.
+A **WidgetRef** is a handle from application code to one widget in the tree. It
+answers two questions the composed view cannot answer on its own: where that
+widget ended up, and where the keyboard should go.
 
 ## Creating a WidgetRef
 
@@ -64,6 +66,49 @@ let popup = container()
     )
     .child(popup_content());
 ```
+
+## Moving the Keyboard
+
+Attach the ref to the widget that takes focus — a `text_input`, since a container
+cannot hold focus — and ask:
+
+```rust
+let field = create_widget_ref();
+
+container()
+    .layout(Flex::column().spacing(8.0))
+    .child(text_input(value).widget_ref(field))
+    .child(
+        container()
+            .on_click(move || field.focus())
+            .child(text("Edit")),
+    )
+```
+
+`focus()` lands on the next frame, not inside the call. Focus is resolved against
+the tree — that is where a widget's ancestors are, and `focused_state` needs them
+— and the composing code has no tree. Every toolkit arrives at the same shape:
+Compose's `FocusRequester` must be called from an effect, iced's
+`text_input::focus(id)` returns a `Task` for the runtime to run, and Flutter tells
+you to request from a post-frame callback because during `initState` the widget is
+not mounted.
+
+Because of that, **asking early is allowed**: a request that names a widget which
+has not been laid out yet waits for it rather than being dropped, so `focus()` in a
+startup effect does what it looks like. Two requests in one frame are two answers
+to the same question, and the later one wins.
+
+The rest of the verb:
+
+```rust
+field.blur();          // give the keyboard back, if this widget has it
+field.is_focused();    // reactive when read in a tracked scope
+field.widget();        // Some(WidgetId) once laid out, None before
+```
+
+For a field that should simply be ready when the screen appears, there is no need
+for a handle at all — use
+[`autofocus()`](../building-ui/text-input.md#initial-focus).
 
 ## When Not to Use It
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -772,6 +772,10 @@ fn layout_pass(
 
     // Update widget ref signals with current bounds after layout
     widget_ref::update_widget_refs(tree);
+
+    // A `WidgetRef::focus()` from application code lands here: after layout, so a
+    // handle attached this very frame has resolved to a widget.
+    reactive::focus::apply_pending_focus(tree);
 }
 
 /// Paint, flatten, hand the frame to the GPU, and re-arm the pacing gate.
@@ -1419,6 +1423,7 @@ impl Drop for App {
         outputs::reset_outputs();
         compositor::reset_compositor_effects();
         keyboard::reset_keyboard_modifiers();
+        reactive::focus::reset_pending_focus();
         blur::reset_blur();
         session_lock::reset_session_lock();
         FONTS_CONSUMED.with(|f| f.set(false));

--- a/src/reactive/focus.rs
+++ b/src/reactive/focus.rs
@@ -113,6 +113,51 @@ pub fn request_focus(tree: &Tree, id: WidgetId) {
     request_job(id, JobRequest::Paint);
 }
 
+thread_local! {
+    /// A focus request from application code, waiting for a tree.
+    ///
+    /// One slot, not a queue: two requests in the same frame are two answers to
+    /// "where should the keyboard be", and the last one is the one the caller
+    /// meant.
+    static PENDING: RefCell<Option<crate::widget_ref::WidgetRef>> = const { RefCell::new(None) };
+}
+
+/// Ask for the focus to move to whatever `widget_ref` names, on the next frame.
+///
+/// The caller has no tree — see
+/// [`WidgetRef::focus`](crate::widget_ref::WidgetRef::focus) — so the request is
+/// parked here and applied by the loop. It is stored as the *handle* rather than
+/// an id so that asking before the widget's first layout works: the id does not
+/// exist yet, and by the time the loop applies the request, it does.
+pub(crate) fn request_focus_deferred(widget_ref: crate::widget_ref::WidgetRef) {
+    PENDING.with(|pending| *pending.borrow_mut() = Some(widget_ref));
+    // The loop may be blocked with nothing else to do, and a focus change is work.
+    crate::jobs::wake_loop();
+}
+
+/// Apply a parked focus request. Called by the loop after layout, where the tree
+/// is complete and a handle attached during this frame has resolved.
+///
+/// Public for the same reason [`request_focus`] is: anything driving frames needs
+/// it, and it is only meaningful with a laid-out tree in hand.
+pub fn apply_pending_focus(tree: &Tree) {
+    let Some(widget_ref) = PENDING.with(|pending| *pending.borrow()) else {
+        return;
+    };
+    // A request naming a widget that is still not in the tree stays parked: the
+    // app asked for a field that has not been built yet, which is the ordinary
+    // shape of `focus()` called from a startup effect.
+    if let Some(id) = widget_ref.widget() {
+        PENDING.with(|pending| *pending.borrow_mut() = None);
+        request_focus(tree, id);
+    }
+}
+
+/// Drop any parked request. Called during `App::drop()`.
+pub(crate) fn reset_pending_focus() {
+    PENDING.with(|pending| *pending.borrow_mut() = None);
+}
+
 /// Release keyboard focus from a widget.
 /// Only releases if the given widget currently has focus, and repaints it.
 pub fn release_focus(id: WidgetId) {

--- a/src/widget_ref.rs
+++ b/src/widget_ref.rs
@@ -1,23 +1,42 @@
-//! WidgetRef — reactive access to a widget's surface-relative bounds.
+//! WidgetRef — a handle from application code to one widget in the tree.
 //!
-//! Attach a `WidgetRef` to a `Container` via `.widget_ref(r)` to track its
-//! bounding rect after layout. The rect is exposed as a `Signal<Rect>` that
-//! updates automatically each frame.
+//! Attach it with `.widget_ref(r)`, then read the widget's surface-relative
+//! bounds as a signal, or move the keyboard focus to it.
+//!
+//! # Why focus goes through a handle
+//!
+//! Focus lives in the tree: [`request_focus`](crate::reactive::focus::request_focus)
+//! resolves the focused widget's ancestors once, when focus moves, because that
+//! is the only moment the tree is at hand. Application code has neither the tree
+//! nor a `WidgetId` — ids are minted when the tree is built, not when the view is
+//! composed — so it needs something to name a widget *with*, and the request has
+//! to wait for the next frame to be applied.
+//!
+//! Every toolkit lands in the same place. Compose has `FocusRequester` and makes
+//! you call it from an effect; iced hands you a widget `Id` and returns a `Task`
+//! for the runtime to run; Flutter gives you a `FocusNode` and tells you to
+//! request from a post-frame callback, because during `initState` the widget is
+//! not mounted yet. Guido already had the handle — this gives it the verb.
 
 use std::cell::RefCell;
 use std::collections::HashMap;
 
+use crate::reactive::focus::{focus_path, release_focus, request_focus_deferred};
 use crate::reactive::{RwSignal, Signal, create_signal};
 use crate::tree::{Tree, WidgetId};
 use crate::widgets::Rect;
 
-/// A handle to a widget's surface-relative bounding rect.
+/// A handle to one widget: its bounds, and its focus.
 ///
-/// Created via [`create_widget_ref()`]. Attach to a container with
-/// `.widget_ref(r)` and read bounds reactively via `.rect().get()`.
+/// Created via [`create_widget_ref()`]. Attach to a container or a text input
+/// with `.widget_ref(r)`.
 #[derive(Clone, Copy)]
 pub struct WidgetRef {
     signal: RwSignal<Rect>,
+    /// Which widget this ref is attached to, filled in when that widget is laid
+    /// out and cleared when it leaves the tree. `None` before the first layout,
+    /// which is why [`focus`](Self::focus) has to survive being called early.
+    widget: RwSignal<Option<WidgetId>>,
 }
 
 impl WidgetRef {
@@ -26,9 +45,40 @@ impl WidgetRef {
         self.signal.read_only()
     }
 
-    /// Internal: get the read-write signal for updating bounds after layout.
-    pub(crate) fn rw_signal(&self) -> RwSignal<Rect> {
-        self.signal
+    /// The widget this ref is attached to, once it has been laid out.
+    pub fn widget(&self) -> Option<WidgetId> {
+        self.widget.get_untracked()
+    }
+
+    /// Move the keyboard focus to this widget.
+    ///
+    /// Applied on the next frame, not inside this call: focus is resolved against
+    /// the tree, and the caller does not have one. Calling it before the widget
+    /// has ever been laid out is fine — the request waits for the widget to exist
+    /// rather than being dropped, so `focus()` from a startup effect works.
+    ///
+    /// A later request replaces an earlier one that has not been applied yet: the
+    /// last thing asked for is what the user asked for.
+    pub fn focus(&self) {
+        request_focus_deferred(*self);
+    }
+
+    /// Take the keyboard focus off this widget, if it has it.
+    pub fn blur(&self) {
+        if let Some(id) = self.widget() {
+            release_focus(id);
+        }
+    }
+
+    /// Whether this widget holds the keyboard focus.
+    ///
+    /// Reads the focus signal, so calling it inside a reactive scope subscribes
+    /// to focus changes like any other signal read.
+    pub fn is_focused(&self) -> bool {
+        match self.widget() {
+            Some(id) => focus_path().widget() == Some(id),
+            None => false,
+        }
     }
 }
 
@@ -36,25 +86,31 @@ impl WidgetRef {
 pub fn create_widget_ref() -> WidgetRef {
     WidgetRef {
         signal: create_signal(Rect::default()),
+        widget: create_signal(None),
     }
 }
 
 // ---------------------------------------------------------------------------
-// Thread-local registry: WidgetId → RwSignal<Rect>
+// Thread-local registry: WidgetId → WidgetRef
 // ---------------------------------------------------------------------------
 
 thread_local! {
-    static WIDGET_REF_REGISTRY: RefCell<HashMap<WidgetId, RwSignal<Rect>>> =
+    static WIDGET_REF_REGISTRY: RefCell<HashMap<WidgetId, WidgetRef>> =
         RefCell::new(HashMap::new());
 }
 
 /// Register (or re-register) a widget ref mapping.
 ///
-/// Called from `Container::layout` each time a container with a `WidgetRef`
-/// is laid out. Idempotent — HashMap insert overwrites.
-pub(crate) fn register_widget_ref(id: WidgetId, signal: RwSignal<Rect>) {
+/// Called from the layout of every widget that carries a `WidgetRef`. Idempotent
+/// — HashMap insert overwrites.
+pub(crate) fn register_widget_ref(id: WidgetId, widget_ref: WidgetRef) {
+    // Cheap when unchanged, and the write is what lets `focus()` resolve: a ref
+    // that has never been laid out has no widget to focus.
+    if widget_ref.widget.get_untracked() != Some(id) {
+        widget_ref.widget.set(Some(id));
+    }
     WIDGET_REF_REGISTRY.with(|reg| {
-        reg.borrow_mut().insert(id, signal);
+        reg.borrow_mut().insert(id, widget_ref);
     });
 }
 
@@ -71,12 +127,16 @@ pub(crate) fn reset_widget_refs() {
 /// Called once per surface after layout completes.
 pub(crate) fn update_widget_refs(tree: &Tree) {
     WIDGET_REF_REGISTRY.with(|reg| {
-        reg.borrow_mut().retain(|&id, signal| {
+        reg.borrow_mut().retain(|&id, widget_ref| {
             if let Some(rect) = tree.get_surface_relative_bounds(id) {
-                signal.set(rect);
+                widget_ref.signal.set(rect);
                 true
             } else {
-                // Widget removed from tree — drop registry entry
+                // Widget removed from tree — drop registry entry, and stop
+                // claiming the handle points at something.
+                if widget_ref.widget.get_untracked() == Some(id) {
+                    widget_ref.widget.set(None);
+                }
                 false
             }
         });

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -1326,7 +1326,7 @@ impl Widget for Container {
 
         // Register widget ref so update_widget_refs() can refresh bounds
         if let Some(ref wr) = self.widget_ref {
-            register_widget_ref(id, wr.rw_signal());
+            register_widget_ref(id, *wr);
         }
 
         size

--- a/src/widgets/text_input.rs
+++ b/src/widgets/text_input.rs
@@ -21,6 +21,7 @@ use crate::reactive::{
 };
 use crate::renderer::{PaintContext, char_index_from_x_styled};
 use crate::tree::{Tree, WidgetId};
+use crate::widget_ref::{WidgetRef, register_widget_ref};
 
 use super::font::{FontFamily, FontWeight};
 use super::widget::{Color, Event, EventResponse, Key, MouseButton, Rect, Widget};
@@ -215,6 +216,9 @@ pub struct TextInput {
     /// nothing to wake the loop for.
     caret: bool,
 
+    /// Handle for application code to reach this input — to focus it, mostly.
+    widget_ref: Option<WidgetRef>,
+
     /// An unmade offer of the initial focus. Cleared once made, so autofocus is
     /// a *first layout* behaviour rather than something that fights the user on
     /// every relayout.
@@ -268,6 +272,7 @@ impl TextInput {
             is_password: false,
             mask_char: '•',
             caret: true,
+            widget_ref: None,
             autofocus_pending: false,
             selection: Selection::new(0),
             cursor_visible: true,
@@ -290,6 +295,21 @@ impl TextInput {
     /// Set custom mask character for password mode (default: '•')
     pub fn mask_char(mut self, c: char) -> Self {
         self.mask_char = c;
+        self
+    }
+
+    /// Attach a handle, so application code can move the keyboard here.
+    ///
+    /// The container has the same builder; put the ref on the *input* when what
+    /// you mean is "focus this field", since a container cannot take focus.
+    ///
+    /// ```ignore
+    /// let field = create_widget_ref();
+    /// // ...
+    /// container().on_click(move || field.focus())
+    /// ```
+    pub fn widget_ref(mut self, widget_ref: WidgetRef) -> Self {
+        self.widget_ref = Some(widget_ref);
         self
     }
 
@@ -1011,6 +1031,10 @@ impl Widget for TextInput {
 
         // Clear needs_layout flag since layout is complete
         tree.clear_needs_layout(id);
+
+        if let Some(widget_ref) = self.widget_ref {
+            register_widget_ref(id, widget_ref);
+        }
 
         // Here rather than at construction because focus needs the tree, and
         // this is the first moment the input is in one — the same reason Flutter

--- a/tests/widget_ref_focus.rs
+++ b/tests/widget_ref_focus.rs
@@ -1,0 +1,135 @@
+//! `WidgetRef::focus()`: moving the keyboard from application code.
+//!
+//! The interesting case is the early one. Focus is resolved against the tree, so
+//! a request from a startup effect names a widget that does not exist yet — it has
+//! to wait rather than be dropped. Compose, iced and Flutter all have a version of
+//! this problem; the tests here pin guido's answer to it.
+
+use guido::layout::Constraints;
+use guido::prelude::*;
+use guido::reactive::focus::{apply_pending_focus, clear_focus, focused_widget, has_focus};
+use guido::tree::{Tree, WidgetId};
+
+struct Screen {
+    tree: Tree,
+}
+
+impl Screen {
+    fn new() -> Self {
+        clear_focus();
+        Self { tree: Tree::new() }
+    }
+
+    fn add(&mut self, input: TextInput) -> WidgetId {
+        let id = self.tree.register(Box::new(input));
+        self.tree
+            .with_widget_mut(id, |w, id, t| w.register_children(t, id));
+        id
+    }
+
+    /// One frame: lay the widget out, then apply whatever focus was asked for —
+    /// the order the loop uses, and the reason a handle attached this frame works.
+    fn frame(&mut self, id: WidgetId) {
+        self.tree.with_widget_mut(id, |w, id, t| {
+            w.layout(t, id, Constraints::new(0.0, 0.0, 400.0, 40.0))
+        });
+        apply_pending_focus(&self.tree);
+    }
+}
+
+#[test]
+fn focus_moves_the_keyboard_to_the_named_input() {
+    let mut screen = Screen::new();
+    let handle = create_widget_ref();
+    let field = screen.add(text_input(create_signal(String::new())).widget_ref(handle));
+    let other = screen.add(text_input(create_signal(String::new())));
+    screen.frame(field);
+    screen.frame(other);
+
+    handle.focus();
+    screen.frame(field);
+
+    assert!(has_focus(field));
+    assert!(!has_focus(other));
+}
+
+#[test]
+fn a_request_before_the_first_layout_waits_instead_of_being_dropped() {
+    // What `focus()` from a startup effect looks like: the view is composed, the
+    // handle exists, the widget does not.
+    let mut screen = Screen::new();
+    let handle = create_widget_ref();
+
+    handle.focus();
+    assert_eq!(
+        focused_widget(),
+        None,
+        "there is nothing to focus yet, and nothing should have been invented"
+    );
+
+    let field = screen.add(text_input(create_signal(String::new())).widget_ref(handle));
+    screen.frame(field);
+
+    assert!(
+        has_focus(field),
+        "the request has to survive until the widget it names exists"
+    );
+}
+
+#[test]
+fn the_last_request_of_a_frame_is_the_one_that_lands() {
+    let mut screen = Screen::new();
+    let first = create_widget_ref();
+    let second = create_widget_ref();
+    let field_a = screen.add(text_input(create_signal(String::new())).widget_ref(first));
+    let field_b = screen.add(text_input(create_signal(String::new())).widget_ref(second));
+    screen.frame(field_a);
+    screen.frame(field_b);
+
+    first.focus();
+    second.focus();
+    screen.frame(field_a);
+
+    assert!(has_focus(field_b), "two answers, the later one wins");
+    assert!(!has_focus(field_a));
+}
+
+#[test]
+fn blur_gives_the_keyboard_back() {
+    let mut screen = Screen::new();
+    let handle = create_widget_ref();
+    let field = screen.add(text_input(create_signal(String::new())).widget_ref(handle));
+    screen.frame(field);
+    handle.focus();
+    screen.frame(field);
+    assert!(has_focus(field));
+
+    handle.blur();
+
+    assert_eq!(focused_widget(), None);
+}
+
+#[test]
+fn a_handle_reports_whether_it_holds_the_focus() {
+    let mut screen = Screen::new();
+    let handle = create_widget_ref();
+    let field = screen.add(text_input(create_signal(String::new())).widget_ref(handle));
+    screen.frame(field);
+
+    assert!(!handle.is_focused());
+
+    handle.focus();
+    screen.frame(field);
+
+    assert!(handle.is_focused());
+}
+
+#[test]
+fn an_unattached_handle_answers_rather_than_panicking() {
+    // Nothing has ever been laid out with this handle.
+    let handle = create_widget_ref();
+
+    assert_eq!(handle.widget(), None);
+    assert!(!handle.is_focused());
+    handle.blur(); // must be a no-op, not a panic
+}


### PR DESCRIPTION
`.autofocus()` (#178) covers a field that should be ready when the screen appears.
It says nothing about the other half — a button that moves the keyboard to a field,
a form that jumps to the first invalid one — and there was no way to express that at
all: `request_focus` needs a `&Tree` and a `WidgetId`, and application code has
neither. Ids are minted when the tree is built, not when the view is composed.

```rust
let field = create_widget_ref();

container()
    .child(text_input(value).widget_ref(field))
    .child(container().on_click(move || field.focus()).child(text("Edit")))
```

`WidgetRef` gains `focus()`, `blur()`, `is_focused()` and `widget()`; `TextInput`
gains `.widget_ref(r)`, so the handle can sit on the thing that actually takes
focus rather than on a container that cannot.

## Why it lands next frame

The request is parked and applied by the loop after layout. Same shape every
toolkit converges on, for the same reason: Compose's `FocusRequester` must be
called from an effect, iced's `text_input::focus(id)` returns a `Task` for the
runtime to run, and Flutter tells you to request from a post-frame callback because
during `initState` the widget is not mounted yet.

It is parked as the **handle**, not as an id, and that is what makes the early call
work: `focus()` from a startup effect names a widget that does not exist yet, so the
request waits for it rather than being dropped. One slot, not a queue — two requests
in one frame are two answers to "where should the keyboard be", and the later one is
the one the caller meant.

## Registry change

`WIDGET_REF_REGISTRY` maps id → the whole `WidgetRef` instead of id → its rect
signal, so a handle learns which widget it is attached to when that widget is laid
out, and forgets when it leaves the tree. A `blur()` on a dead handle is then a
no-op rather than something that touches whichever id got recycled.

## Tests

Six, in `tests/widget_ref_focus.rs`: focus moves the keyboard, a request before the
first layout waits instead of being dropped, the last request of a frame is the one
that lands, blur gives the keyboard back, a handle reports whether it holds focus,
and an unattached handle answers rather than panicking.

`cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, full
suite green (364 in the lib).