### PR TITLE
An empty field can say what it wants

### DIFF
--- a/book/src/building-ui/text-input.md
+++ b/book/src/building-ui/text-input.md
@@ -103,6 +103,36 @@ whichever was laid out last.
 The offer is made once. A relayout does not ask again, so a resize or a scale
 change cannot drag focus back from wherever the user has since put it.
 
+## Placeholder
+
+What the field says while it is empty:
+
+```rust
+text_input(password)
+    .password(true)
+    .placeholder("Password")
+```
+
+It is a **label, not a value**: never masked, so a password field shows the word
+rather than eight bullets, and it stands *in place of* the text rather than beside
+it — there is nothing to overlap, because it is only drawn when the value is empty.
+
+Reactive, so a prompt that changes changes the empty field with it:
+
+```rust
+text_input(answer).placeholder(move || prompt.get())
+```
+
+The colour is the inherited text colour at reduced alpha — a placeholder is the
+same text, quieter. Declare `placeholder_color` on a container to override it:
+
+```rust
+container()
+    .text_color(theme.text)
+    .placeholder_color(theme.text_weak)
+    .child(text_input(value).placeholder("Search"))
+```
+
 ## No Caret
 
 ```rust
@@ -285,6 +315,7 @@ impl TextInput {
     pub fn mask_char(self, c: char) -> Self;
     pub fn autofocus(self) -> Self;
     pub fn no_caret(self) -> Self;
+    pub fn placeholder<M>(self, text: impl IntoSignal<String, M>) -> Self;
     pub fn on_change<F: Fn(&str) + 'static>(self, callback: F) -> Self;
     pub fn on_submit<F: Fn(&str) + 'static>(self, callback: F) -> Self;
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1442,6 +1442,7 @@ mod tests {
                 ))),
                 cursor_color: Some(create_stored(Color::WHITE)),
                 selection_color: Some(create_stored(Color::BLACK)),
+                placeholder_color: Some(create_stored(Color::WHITE)),
             }),
         );
 

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -563,6 +563,16 @@ impl Container {
         self
     }
 
+    /// Set the placeholder colour of any
+    /// [`TextInput`](crate::widgets::TextInput) below this container.
+    ///
+    /// Defaults to the inherited text colour at reduced alpha, which is what a
+    /// placeholder is: the same text, quieter.
+    pub fn placeholder_color<M>(mut self, color: impl IntoSignal<Color, M>) -> Self {
+        self.text_mut().placeholder_color = Some(color.into_signal());
+        self
+    }
+
     /// Set the corner radius in logical pixels.
     ///
     /// Combined with [`corner_curvature()`](Self::corner_curvature) to control corner shape.

--- a/src/widgets/text_input.rs
+++ b/src/widgets/text_input.rs
@@ -16,8 +16,9 @@ use crate::jobs::{JobRequest, JobType, RequiredJob, request_job, request_job_at}
 use crate::layout::{Constraints, Size};
 use crate::reactive::focus::focused_widget;
 use crate::reactive::{
-    CursorIcon, OptionSignalExt, RwSignal, clipboard_copy, clipboard_paste, has_focus,
-    primary_copy, primary_paste, release_focus, request_focus, set_cursor, with_signal_tracking,
+    CursorIcon, IntoSignal, OptionSignalExt, RwSignal, Signal, clipboard_copy, clipboard_paste,
+    has_focus, primary_copy, primary_paste, release_focus, request_focus, set_cursor,
+    with_signal_tracking,
 };
 use crate::renderer::{PaintContext, char_index_from_x_styled};
 use crate::tree::{Tree, WidgetId};
@@ -28,6 +29,10 @@ use super::widget::{Color, Event, EventResponse, Key, MouseButton, Rect, Widget}
 
 /// Cursor blink interval in milliseconds
 const CURSOR_BLINK_MS: u64 = 530;
+
+/// How much of the text colour a placeholder keeps when nothing overrides it.
+/// A placeholder is the same text, quieter — not a different colour to pick.
+const PLACEHOLDER_ALPHA: f32 = 0.45;
 
 /// Maximum number of undo history entries
 const MAX_HISTORY_SIZE: usize = 100;
@@ -218,6 +223,9 @@ pub struct TextInput {
 
     /// Handle for application code to reach this input — to focus it, mostly.
     widget_ref: Option<WidgetRef>,
+    /// Shown while the value is empty. Reactive: a prompt that changes — PAM
+    /// asking a different question — changes what the empty field says.
+    placeholder: Option<Signal<String>>,
 
     /// An unmade offer of the initial focus. Cleared once made, so autofocus is
     /// a *first layout* behaviour rather than something that fights the user on
@@ -273,6 +281,7 @@ impl TextInput {
             mask_char: '•',
             caret: true,
             widget_ref: None,
+            placeholder: None,
             autofocus_pending: false,
             selection: Selection::new(0),
             cursor_visible: true,
@@ -310,6 +319,20 @@ impl TextInput {
     /// ```
     pub fn widget_ref(mut self, widget_ref: WidgetRef) -> Self {
         self.widget_ref = Some(widget_ref);
+        self
+    }
+
+    /// Text to show while the field is empty.
+    ///
+    /// Drawn in the placeholder colour — the inherited text colour at reduced
+    /// alpha unless a container declares
+    /// [`placeholder_color`](crate::widgets::Container::placeholder_color) — and
+    /// never masked, since it is a label rather than a value: a password field
+    /// with a placeholder shows the word, not bullets.
+    ///
+    /// Reactive, so a prompt that changes changes the empty field with it.
+    pub fn placeholder<M>(mut self, text: impl IntoSignal<String, M>) -> Self {
+        self.placeholder = Some(text.into_signal());
         self
     }
 
@@ -1058,10 +1081,25 @@ impl Widget for TextInput {
 
         // Read the inherited colours with tracking so a change on whichever
         // ancestor supplied them repaints this input and nothing else.
-        let (text_color, selection_color, cursor_color, stroke, shadow) =
+        let (text_color, selection_color, cursor_color, stroke, shadow, placeholder) =
             with_signal_tracking(id, JobType::Paint, || {
                 let style = tree.inherited_text_style(id);
                 let text_color = style.color.get_or(Color::WHITE);
+                // Only when there is nothing to show instead. Read inside the
+                // tracking scope like every other paint input, so a prompt that
+                // changes repaints the field.
+                let placeholder = self
+                    .placeholder
+                    .filter(|_| self.cached_value.is_empty())
+                    .map(|signal| {
+                        let color = style.placeholder_color.get_or(Color::rgba(
+                            text_color.r,
+                            text_color.g,
+                            text_color.b,
+                            text_color.a * PLACEHOLDER_ALPHA,
+                        ));
+                        (signal.get(), color)
+                    });
                 (
                     text_color,
                     style
@@ -1072,6 +1110,7 @@ impl Widget for TextInput {
                     style.cursor_color.get_or(text_color),
                     style.stroke.map(|s| s.get()),
                     style.shadow.map(|s| s.get()),
+                    placeholder,
                 )
             });
 
@@ -1107,10 +1146,16 @@ impl Widget for TextInput {
             self.cached_text_width.max(bounds.width),
             bounds.height,
         );
+        // The placeholder stands in for the text, never beside it: it is only
+        // resolved when the value is empty, so there is nothing to overlap.
+        let (drawn, drawn_color) = match &placeholder {
+            Some((text, color)) => (text.as_str(), *color),
+            None => (display, text_color),
+        };
         ctx.draw_text_decorated(
-            display,
+            drawn,
             text_bounds,
-            text_color,
+            drawn_color,
             self.cached_font_size,
             self.cached_font_family.clone(),
             self.cached_font_weight,

--- a/src/widgets/text_style.rs
+++ b/src/widgets/text_style.rs
@@ -230,6 +230,10 @@ pub struct TextStyle {
     /// Selection highlight colour. Only
     /// [`TextInput`](crate::widgets::TextInput) reads it.
     pub selection_color: Option<Signal<Color>>,
+    /// Colour of an input's placeholder. Only
+    /// [`TextInput`](crate::widgets::TextInput) reads it, and it falls back to the
+    /// text colour at reduced alpha — a placeholder is the same text, quieter.
+    pub placeholder_color: Option<Signal<Color>>,
 }
 
 impl TextStyle {
@@ -254,6 +258,7 @@ impl TextStyle {
         self.shadow = self.shadow.or(outer.shadow);
         self.cursor_color = self.cursor_color.or(outer.cursor_color);
         self.selection_color = self.selection_color.or(outer.selection_color);
+        self.placeholder_color = self.placeholder_color.or(outer.placeholder_color);
     }
 
     /// Whether every property has been resolved, so the walk can stop early.
@@ -266,5 +271,6 @@ impl TextStyle {
             && self.shadow.is_some()
             && self.cursor_color.is_some()
             && self.selection_color.is_some()
+            && self.placeholder_color.is_some()
     }
 }

--- a/tests/placeholder.rs
+++ b/tests/placeholder.rs
@@ -1,0 +1,143 @@
+//! `placeholder`: what an empty field says.
+//!
+//! Asserted on the draw commands, since the whole feature is "which text, in which
+//! colour" — including the one that matters for a password field: a placeholder is
+//! a label, not a value, so it is never masked.
+
+use guido::layout::Constraints;
+use guido::prelude::*;
+use guido::renderer::{DrawCommand, PaintContext, RenderNode};
+use guido::tree::Tree;
+
+/// Every text this widget draws, as (content, colour).
+fn drawn(widget: impl Widget + 'static) -> Vec<(String, Color)> {
+    let mut tree = Tree::new();
+    let root = tree.register(Box::new(widget));
+    tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
+    tree.with_widget_mut(root, |w, id, t| {
+        w.layout(t, id, Constraints::new(0.0, 0.0, 400.0, 40.0))
+    });
+
+    let mut node = RenderNode::new(root.as_u64());
+    tree.with_widget_mut(root, |w, id, t| {
+        let mut ctx = PaintContext::new(&mut node);
+        w.paint(t, id, &mut ctx);
+    });
+
+    let mut out = Vec::new();
+    collect(&node, &mut out);
+    out
+}
+
+fn collect(node: &RenderNode, out: &mut Vec<(String, Color)>) {
+    for cmd in &node.commands {
+        if let DrawCommand::Text { text, color, .. } = &**cmd {
+            out.push((text.clone(), *color));
+        }
+    }
+    for child in &node.children {
+        collect(child, out);
+    }
+}
+
+#[test]
+fn an_empty_field_says_its_placeholder() {
+    let texts = drawn(text_input(create_signal(String::new())).placeholder("Password"));
+
+    assert_eq!(
+        texts
+            .iter()
+            .map(|(text, _)| text.as_str())
+            .collect::<Vec<_>>(),
+        ["Password"]
+    );
+}
+
+#[test]
+fn a_field_with_a_value_says_the_value() {
+    let texts = drawn(text_input(create_signal("zibo".to_owned())).placeholder("Username"));
+
+    assert_eq!(
+        texts
+            .iter()
+            .map(|(text, _)| text.as_str())
+            .collect::<Vec<_>>(),
+        ["zibo"],
+        "the placeholder must stand in for the text, not sit beside it"
+    );
+}
+
+#[test]
+fn a_password_placeholder_is_not_masked() {
+    // It is a label, not a value. Masking it would draw eight bullets where the
+    // field is supposed to say what it wants.
+    let texts = drawn(
+        text_input(create_signal(String::new()))
+            .password(true)
+            .placeholder("Password"),
+    );
+
+    assert_eq!(texts[0].0, "Password");
+}
+
+#[test]
+fn the_value_of_a_password_field_still_is() {
+    let texts = drawn(
+        text_input(create_signal("hunter2".to_owned()))
+            .password(true)
+            .placeholder("Password"),
+    );
+
+    assert_eq!(texts[0].0, "•••••••");
+}
+
+#[test]
+fn a_placeholder_is_quieter_than_the_text() {
+    let text_color = Color::rgba(1.0, 1.0, 1.0, 1.0);
+    let empty = drawn(
+        container()
+            .text_color(text_color)
+            .child(text_input(create_signal(String::new())).placeholder("Password")),
+    );
+    let filled = drawn(
+        container()
+            .text_color(text_color)
+            .child(text_input(create_signal("x".to_owned())).placeholder("Password")),
+    );
+
+    let placeholder_alpha = empty[0].1.a;
+    let value_alpha = filled[0].1.a;
+    assert!(
+        placeholder_alpha < value_alpha,
+        "placeholder was {placeholder_alpha}, value {value_alpha}"
+    );
+    assert_eq!(
+        (empty[0].1.r, empty[0].1.g, empty[0].1.b),
+        (text_color.r, text_color.g, text_color.b),
+        "and it is the same colour, only quieter — not a colour of its own"
+    );
+}
+
+#[test]
+fn a_container_can_declare_the_placeholder_colour() {
+    let declared = Color::rgba(1.0, 0.0, 0.0, 1.0);
+    let texts = drawn(
+        container()
+            .text_color(Color::rgba(1.0, 1.0, 1.0, 1.0))
+            .placeholder_color(declared)
+            .child(text_input(create_signal(String::new())).placeholder("Password")),
+    );
+
+    assert_eq!(texts[0].1, declared);
+}
+
+#[test]
+fn an_empty_field_without_a_placeholder_draws_no_text_at_all() {
+    let texts = drawn(text_input(create_signal(String::new())));
+
+    assert!(
+        texts.is_empty(),
+        "empty text is not drawn, so the placeholder is the only thing that can \
+         put something there: {texts:?}"
+    );
+}


### PR DESCRIPTION
`TextInput` had no placeholder, so a field with nothing in it said nothing. allock
draws PAM's own prompt there — "Password", or whatever the stack asks for — which is
one of the reasons it kept a hand-rolled field instead of using this widget.

```rust
text_input(password)
    .password(true)
    .placeholder("Password")
```

## Two decisions, both from "a placeholder is a label, not a value"

- **Never masked.** A password field with a placeholder shows the word, not eight
  bullets.
- **In place of the text, not beside it.** It is resolved only when the value is
  empty, so there is nothing to overlap and no draw order to get wrong.

It is reactive, because the case that asked for it is: PAM changes the question, and
the empty field changes with it.

```rust
text_input(answer).placeholder(move || prompt.get())
```

## Colour

The inherited text colour at reduced alpha — a placeholder is the same text,
quieter, not a colour to choose. `placeholder_color` on a container overrides it,
next to `cursor_color` and `selection_color`, the other two properties only an input
reads.

## Tests

Seven, over the draw commands, since "which text, in which colour" is the whole
feature. Including: the mask does not apply, the value of a password field still
does, the fallback alpha is quieter but the same hue, the container override wins,
and an empty field with no placeholder draws no text command at all — which is what
makes the placeholder the only thing that can put something there.

`cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, full
suite green (364 in the lib).
