### PR TITLE
Two corrections to the caret: one that would not go, one that never came

### DIFF
--- a/src/jobs.rs
+++ b/src/jobs.rs
@@ -539,6 +539,12 @@ pub(crate) fn queued_job_types(widget_id: WidgetId) -> Vec<JobType> {
     })
 }
 
+/// Forget every scheduled job (for testing).
+#[cfg(test)]
+pub(crate) fn clear_scheduled_jobs() {
+    SCHEDULED_JOBS.with(|scheduled| scheduled.borrow_mut().clear());
+}
+
 /// Clear all pending jobs (for testing)
 #[cfg(test)]
 pub(crate) fn clear_pending_jobs() {

--- a/src/reactive/invalidation.rs
+++ b/src/reactive/invalidation.rs
@@ -110,6 +110,10 @@ where
 }
 
 /// Whether a widget tracking scope is currently active (layout/paint/reconcile).
+///
+/// Only the non-reactive-read diagnostic asks, and that lives behind
+/// `debug_assertions` — so does this, or release builds warn about it.
+#[cfg(debug_assertions)]
 pub(crate) fn widget_tracking_active() -> bool {
     TRACKING_CONTEXT.with(|ctx| !ctx.borrow().is_empty())
 }

--- a/src/reactive/runtime.rs
+++ b/src/reactive/runtime.rs
@@ -129,6 +129,10 @@ fn vec_remove<T: PartialEq>(vec: &mut Vec<T>, value: &T) {
 }
 
 /// Whether an effect (or memo) is currently executing and collecting reads.
+///
+/// Behind `debug_assertions` like its only caller, the non-reactive-read
+/// diagnostic; without that, release builds warn about it.
+#[cfg(debug_assertions)]
 pub(crate) fn effect_tracking_active() -> bool {
     EFFECT_TRACKING.with(|stack| stack.try_borrow().map(|s| !s.is_empty()).unwrap_or(true))
 }

--- a/src/widgets/text_input.rs
+++ b/src/widgets/text_input.rs
@@ -1099,8 +1099,12 @@ impl Widget for TextInput {
             shadow,
         );
 
-        // Draw cursor if focused and visible (LOCAL coords)
-        if is_focused && self.cursor_visible {
+        // Draw cursor if focused and visible (LOCAL coords).
+        //
+        // `self.caret` gates the *drawing*, not only the blink: stopping the blink
+        // leaves `cursor_visible` at whatever it last was — true, from the
+        // constructor — and a field asked for no caret got a permanent one.
+        if self.caret && is_focused && self.cursor_visible {
             let cursor_x = self.cached_width_at_char(self.selection.cursor) - self.scroll_offset;
             let cursor_rect = Rect::new(
                 cursor_x,

--- a/src/widgets/text_input.rs
+++ b/src/widgets/text_input.rs
@@ -487,11 +487,6 @@ impl TextInput {
             self.cursor_visible = !self.cursor_visible;
             self.last_cursor_toggle = now;
         }
-        request_job_at(
-            id,
-            JobRequest::Animation(RequiredJob::Paint),
-            self.last_cursor_toggle + period,
-        );
         true
     }
 
@@ -1099,20 +1094,35 @@ impl Widget for TextInput {
             shadow,
         );
 
-        // Draw cursor if focused and visible (LOCAL coords).
+        // The caret, and the wake that keeps it blinking.
         //
         // `self.caret` gates the *drawing*, not only the blink: stopping the blink
         // leaves `cursor_visible` at whatever it last was — true, from the
         // constructor — and a field asked for no caret got a permanent one.
-        if self.caret && is_focused && self.cursor_visible {
-            let cursor_x = self.cached_width_at_char(self.selection.cursor) - self.scroll_offset;
-            let cursor_rect = Rect::new(
-                cursor_x,
-                0.0,
-                1.5, // cursor width
-                bounds.height,
+        if self.caret && is_focused {
+            // The toggle happens in `advance_animations`, and this is what asks
+            // for the wake that runs it. It has to be here, not at the moment
+            // focus arrives: focus comes from a click, from `autofocus`, or from
+            // `WidgetRef::focus()`, and all three only queue a repaint. Asking
+            // from the repaint covers every one of them, and covers the half of
+            // the cycle where the caret is hidden and there is nothing to draw.
+            request_job_at(
+                id,
+                JobRequest::Animation(RequiredJob::Paint),
+                self.last_cursor_toggle + Duration::from_millis(CURSOR_BLINK_MS),
             );
-            ctx.draw_rounded_rect(cursor_rect, cursor_color, 0.0);
+
+            if self.cursor_visible {
+                let cursor_x =
+                    self.cached_width_at_char(self.selection.cursor) - self.scroll_offset;
+                let cursor_rect = Rect::new(
+                    cursor_x,
+                    0.0,
+                    1.5, // cursor width
+                    bounds.height,
+                );
+                ctx.draw_rounded_rect(cursor_rect, cursor_color, 0.0);
+            }
         }
     }
 
@@ -1220,13 +1230,14 @@ pub fn text_input(signal: RwSignal<String>) -> TextInput {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::jobs::{clear_pending_jobs, next_deadline, queued_job_types};
+    use crate::jobs::{clear_pending_jobs, clear_scheduled_jobs, next_deadline, queued_job_types};
     use crate::layout::Constraints;
     use crate::reactive::create_signal;
 
     /// A laid-out input, focused unless told otherwise.
     fn field(input: TextInput, focused: bool) -> (Tree, WidgetId) {
         clear_pending_jobs();
+        clear_scheduled_jobs();
         crate::reactive::focus::clear_focus();
 
         let mut tree = Tree::new();
@@ -1247,21 +1258,84 @@ mod tests {
             .unwrap_or(false)
     }
 
+    fn paint_once(tree: &mut Tree, id: WidgetId) {
+        let mut node = crate::renderer::RenderNode::new(id.as_u64());
+        tree.with_widget_mut(id, |w, id, t| {
+            let mut ctx = crate::renderer::PaintContext::new(&mut node);
+            w.paint(t, id, &mut ctx);
+        });
+    }
+
     #[test]
-    fn a_blinking_caret_asks_to_be_woken_rather_than_polled() {
+    fn painting_a_focused_caret_asks_for_the_wake_that_toggles_it() {
+        // The regression: the toggle lives in `advance_animations`, which the loop
+        // only calls for an Animation job, and *nothing* asked for one — focus from
+        // a click, from `autofocus` or from `WidgetRef::focus()` all queue a plain
+        // repaint. So the caret never blinked at all, while the tests that called
+        // `advance_animations` by hand were happy: they skipped the broken part.
+        let (mut tree, id) = field(text_input(create_signal(String::new())), true);
+        assert_eq!(next_deadline(), None, "nothing has been drawn yet");
+
+        paint_once(&mut tree, id);
+
+        assert!(
+            next_deadline().is_some(),
+            "a caret on screen has to ask to be woken, or it stays as it is forever"
+        );
+    }
+
+    #[test]
+    fn the_blink_keeps_asking_after_each_toggle() {
+        // One wake is a blink that stops after half a cycle.
+        let (mut tree, id) = field(text_input(create_signal(String::new())), true);
+        paint_once(&mut tree, id);
+
+        advance(&mut tree, id);
+        clear_pending_jobs();
+        clear_scheduled_jobs();
+        paint_once(&mut tree, id);
+
+        assert!(next_deadline().is_some());
+    }
+
+    #[test]
+    fn painting_a_field_without_a_caret_asks_for_nothing() {
+        let (mut tree, id) = field(text_input(create_signal(String::new())).no_caret(), true);
+
+        paint_once(&mut tree, id);
+
+        assert_eq!(
+            next_deadline(),
+            None,
+            "no caret, no wake — this is what a lock screen costs while nobody \
+             touches it"
+        );
+    }
+
+    #[test]
+    fn painting_an_unfocused_field_asks_for_nothing() {
+        let (mut tree, id) = field(text_input(create_signal(String::new())), false);
+
+        paint_once(&mut tree, id);
+
+        assert_eq!(next_deadline(), None);
+    }
+
+    #[test]
+    fn advancing_a_blinking_caret_never_asks_for_a_frame() {
+        // The division of labour: `advance_animations` applies the toggle, `paint`
+        // asks for the next wake. What neither may do is request an animation job,
+        // which means "advance me every frame" and is what pinned the loop at
+        // 60 fps to redraw the same pixels 113 frames out of 114.
         let (mut tree, id) = field(text_input(create_signal(String::new())), true);
 
         let blinking = advance(&mut tree, id);
 
-        assert!(blinking);
-        assert!(
-            next_deadline().is_some(),
-            "the caret has to schedule its next toggle"
-        );
+        assert!(blinking, "a focused caret is a blinking one");
         assert!(
             !queued_job_types(id).contains(&JobType::Animation),
-            "and must not queue an animation job, which is what pinned the loop \
-             at 60 fps to redraw the same pixels 113 frames out of 114"
+            "queued: {:?}",
+            queued_job_types(id)
         );
     }
 

--- a/tests/no_caret.rs
+++ b/tests/no_caret.rs
@@ -1,0 +1,82 @@
+//! `no_caret()`: nothing drawn, not merely nothing blinking.
+//!
+//! The first version of this option only stopped the blink. `cursor_visible`
+//! stayed at what the constructor left it — true — so a field asked for no caret
+//! got a permanent one instead: still, and still there. Scheduling tests could not
+//! see that, because the wakeups were correctly absent. These look at what is
+//! drawn.
+
+use guido::layout::Constraints;
+use guido::prelude::*;
+use guido::reactive::focus::{clear_focus, request_focus};
+use guido::renderer::{DrawCommand, PaintContext, RenderNode};
+use guido::tree::Tree;
+
+/// Every rectangle a focused input draws. With no selection, the caret is the
+/// only one there can be.
+fn rects(input: TextInput) -> Vec<Rect> {
+    clear_focus();
+    let mut tree = Tree::new();
+    let id = tree.register(Box::new(input));
+    tree.with_widget_mut(id, |w, id, t| w.register_children(t, id));
+    tree.with_widget_mut(id, |w, id, t| {
+        w.layout(t, id, Constraints::new(0.0, 0.0, 200.0, 40.0))
+    });
+    request_focus(&tree, id);
+
+    let mut node = RenderNode::new(id.as_u64());
+    tree.with_widget_mut(id, |w, id, t| {
+        let mut ctx = PaintContext::new(&mut node);
+        w.paint(t, id, &mut ctx);
+    });
+
+    let mut out = Vec::new();
+    collect(&node, &mut out);
+    out
+}
+
+fn collect(node: &RenderNode, out: &mut Vec<Rect>) {
+    for cmd in &node.commands {
+        if let DrawCommand::RoundedRect { rect, .. } = &**cmd {
+            out.push(*rect);
+        }
+    }
+    for child in &node.children {
+        collect(child, out);
+    }
+}
+
+#[test]
+fn a_focused_field_draws_its_caret() {
+    let drawn = rects(text_input(create_signal("hi".to_owned())));
+
+    assert_eq!(drawn.len(), 1, "the caret, and nothing else: {drawn:?}");
+}
+
+#[test]
+fn no_caret_draws_no_caret() {
+    let drawn = rects(text_input(create_signal("hi".to_owned())).no_caret());
+
+    assert!(
+        drawn.is_empty(),
+        "asked for no caret and got one anyway: {drawn:?}"
+    );
+}
+
+#[test]
+fn no_caret_still_takes_the_focus() {
+    // The point of the option is losing the caret, not losing the keyboard.
+    clear_focus();
+    let mut tree = Tree::new();
+    let id = tree.register(Box::new(
+        text_input(create_signal(String::new()))
+            .no_caret()
+            .autofocus(),
+    ));
+    tree.with_widget_mut(id, |w, id, t| w.register_children(t, id));
+    tree.with_widget_mut(id, |w, id, t| {
+        w.layout(t, id, Constraints::new(0.0, 0.0, 200.0, 40.0))
+    });
+
+    assert!(guido::reactive::focus::has_focus(id));
+}


### PR DESCRIPTION
Two things #179 got wrong, both found by looking at the screen rather than at the
tests.

## The caret that would not go

`no_caret()` only stopped the blink. `update_cursor_blink` returned early, which
left `cursor_visible` at what the constructor set — `true` — and paint drew the
caret anyway. A field that asked for no caret got a **permanent** one.

## The caret that never moved

Worse, and it applies to every input: **nothing blinked at all.**

The toggle lives in `advance_animations`, which the loop calls only for an Animation
job. #179 removed the per-frame animation request — that was the point — but the
*first* one had been coming from the same place, the MouseDown handler, and it
became a plain repaint. Focus from `autofocus` or `WidgetRef::focus()` queues a
repaint too. So nothing ever asked for an animation job, `update_cursor_blink` never
ran, and the caret stayed exactly as the constructor left it.

The wake is now asked for from `paint`, inside the branch that draws the caret. That
covers every way focus can arrive, since all of them end in a repaint, and it covers
the half of the cycle where the caret is hidden and there is nothing to draw.
`advance_animations` keeps the toggle; `paint` asks for the wake that runs it.

## Why the tests missed both

The scheduling tests called `advance_animations` by hand — the exact step nothing was
reaching — and asserted wakeups, which were correctly absent for a caret that was
sitting still on screen.

So the new ones start where the loop starts. Seven in total:

- painting a focused caret asks for the wake that toggles it *(fails without the
  second fix)*
- the blink keeps asking after each toggle
- painting a field with no caret, or with no focus, asks for nothing
- a focused field draws one rectangle; a `no_caret()` field draws none *(fails
  without the first fix)*
- `no_caret()` still takes the focus, because losing the caret is the point and
  losing the keyboard is not

## Measured

`text_input_example`, twelve samples 170 ms apart: they alternate between two frames
in runs of two to three — a 530 ms half-cycle — and the difference between the two
is a **3×33 pixel box**. That is the caret and nothing else, so the repaint stays
inside its own damage rect instead of touching the surface.

## Drive-by

`#[cfg(debug_assertions)]` on `widget_tracking_active` and `effect_tracking_active`.
Their only caller is the non-reactive-read diagnostic, already gated that way, so
**release** builds warned about two functions nobody could call — visible to anyone
building a release binary against guido.

`cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, full
suite green (368 in the lib), `cargo build --release` with zero warnings.
