### PR TITLE
A state layer can follow a signal, and say when it applies

### DIFF
--- a/book/src/interactivity/states.md
+++ b/book/src/interactivity/states.md
@@ -2,6 +2,10 @@
 
 Define visual changes for different interaction states.
 
+Every value inside a state layer is reactive, like the base property it covers.
+`hover_state(|s| s.background(theme.accent))` follows the theme; it does not
+take a snapshot of it when the widget is built.
+
 ## Hover State
 
 Applied when the mouse cursor is over the widget:
@@ -126,6 +130,61 @@ from an ancestor that is itself animating — currently retargets every frame,
 which gives a damped chase rather than a transition with its own curve. It
 converges either way; CSS instead starts the inner one once, towards the
 outer's final value.
+
+## States Your App Owns
+
+Hover, pressed and focus are noticed by the container. The rest — the last
+submit failed, this row is selected, this value is out of range — are
+conditions your app already holds, so there is nothing to propagate: pass the
+signal and it is read where the style is resolved.
+
+```rust
+let wrong_password = create_signal(false);
+
+container()
+    .border(1.0, theme.line)
+    .state(wrong_password, |s| s.border(2.0, theme.error))
+    .child(text_input(password))
+```
+
+Because it is just a signal, anything else that needs it reads the same one,
+independently — a label beside the field does not have to be told:
+
+```rust
+container()
+    .state(wrong_password, |s| s.border(2.0, theme.error))
+    .child(text("Wrong password"))
+```
+
+## Which Layer Wins
+
+Layers are resolved in reverse declaration order, one property at a time: the
+last one you wrote that is active and speaks about that property wins.
+
+This is what lets a field say that its error outranks its focus ring — which
+matters on a password field, where the focus is held essentially all the time:
+
+```rust
+container()
+    .border(1.0, theme.line)
+    .focused_state(|s| s.border(2.0, theme.accent))
+    .state(wrong_password, |s| s.border(2.0, theme.error))   // written after,
+    .child(text_input(password))                             // so it wins
+```
+
+Swap the two lines and the focus ring wins instead. A layer that says nothing
+about a property is skipped rather than ending the search, so the pressed layer
+below only takes over the transform and leaves the hover's background alone:
+
+```rust
+container()
+    .hover_state(|s| s.lighter(0.1))
+    .pressed_state(|s| s.transform(Transform::scale(0.98)))
+```
+
+Keep in mind that a layer *replaces* the base rather than ranking against it. A
+border that already carries a meaning does not belong in the base — put it in a
+layer with a condition, where the ordering above can speak about it.
 
 ## Combining Multiple Overrides
 

--- a/docs/STATE_LAYER.md
+++ b/docs/STATE_LAYER.md
@@ -8,8 +8,11 @@ State layers allow containers to define how they should look when:
 - **Hovered**: Mouse cursor is over the widget
 - **Pressed**: Mouse button is held down on the widget
 - **Focused**: Any child widget has keyboard focus (e.g., text input)
+- **A condition the app owns**: `state(condition, |s| ...)` — the last submit failed, this row is selected
 
 Style changes are defined declaratively using builder methods, and the framework handles all state transitions, animations, and rendering automatically.
+
+Every value inside a state layer is a signal, exactly like the base property it covers, so a state override follows a theme instead of taking a snapshot of it.
 
 ## Basic Usage
 
@@ -35,6 +38,36 @@ container()
     .focused_state(|s| s.border(2.0, Color::rgb(0.4, 0.8, 1.0)))  // Highlight when focused
     .child(text_input(value))
 ```
+
+### App-Declared States
+
+The first three states are noticed by the container. The fourth is a condition the app already holds, so it needs no propagation — the container just reads the signal:
+
+```rust
+let wrong_password = create_signal(false);
+
+container()
+    .border(1.0, theme.line)
+    .state(wrong_password, |s| s.border(2.0, theme.error))
+    .child(text_input(password))
+```
+
+The same signal can be read anywhere else that needs it, independently. That is why there is one generic `state` rather than a named method per case.
+
+## Precedence: last declared wins
+
+Layers are resolved in reverse declaration order, per property. Writing the error after the focus is what makes an error outrank a focus ring on a field that holds the focus essentially always:
+
+```rust
+container()
+    .border(1.0, theme.line)
+    .focused_state(|s| s.border(2.0, theme.accent))
+    .state(wrong_password, |s| s.border(2.0, theme.error))  // wins while it holds
+```
+
+A layer that says nothing about a property is passed over rather than ending the search, so a pressed layer that only scales still lets the hover's background through.
+
+Note that a layer *replaces* the base value rather than ranking against it. A property that already carries a meaning of its own belongs in a layer with a condition, not in the base.
 
 ## State Style Methods
 
@@ -170,14 +203,29 @@ The `StateStyle` struct holds all possible overrides:
 ```rust
 pub struct StateStyle {
     pub background: Option<BackgroundOverride>,
-    pub border_width: Option<f32>,
-    pub border_color: Option<Color>,
-    pub corner_radius: Option<f32>,
-    pub transform: Option<Transform>,
-    pub elevation: Option<f32>,
+    pub border_width: Option<Signal<f32>>,
+    pub border_color: Option<Signal<Color>>,
+    pub corner_radius: Option<Signal<f32>>,
+    pub transform: Option<Signal<Transform>>,
+    pub elevation: Option<Signal<f32>>,
+    pub text_color: Option<Signal<Color>>,
+    pub alpha: Option<Signal<f32>>,
     pub ripple: Option<RippleConfig>,
 }
 ```
+
+Each layer is stored with the trigger that turns it on, in declaration order:
+
+```rust
+pub enum StateWhen {
+    Hovered,
+    Pressed,
+    Focused,
+    When(Signal<bool>),
+}
+```
+
+A trigger is read only where a layer uses it, so a container carrying a single `state(..)` subscribes to neither the pointer flags nor the focus path.
 
 ### BackgroundOverride Enum
 
@@ -185,9 +233,9 @@ Background can be set absolutely or relatively:
 
 ```rust
 pub enum BackgroundOverride {
-    Exact(Color),      // Use this exact color
-    Lighter(f32),      // Blend toward white by amount (0.0-1.0)
-    Darker(f32),       // Blend toward black by amount (0.0-1.0)
+    Exact(Signal<Color>),   // Use this exact color
+    Lighter(Signal<f32>),   // Blend toward white by amount (0.0-1.0)
+    Darker(Signal<f32>),    // Blend toward black by amount (0.0-1.0)
 }
 ```
 

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -1168,6 +1168,35 @@ fn a_border_colour_that_asks_a_handle_follows_the_focus() {
     assert_eq!(borders(&h.paint())[0], (2.0, Color::RED));
 }
 
+/// A state override holds a signal, so it follows a theme the way the base does.
+///
+/// Before this it held a plain `Color`, taken once when the builder ran. A
+/// themed button tracked the theme through `background(..)` and stopped
+/// tracking it the moment the pointer arrived, because the layer covering the
+/// base had no way to say it depended on anything.
+#[test]
+fn a_state_override_follows_the_signal_it_was_given() {
+    let accent = create_signal(Color::RED);
+    let mut h = H::new(
+        box_of(50.0, 50.0)
+            .background(Color::BLACK)
+            .hover_state(move |s: StateStyle| s.background(accent)),
+    );
+    h.fit(100.0, 100.0);
+
+    set_hover(&mut h, true);
+    assert_eq!(rects(&h.paint())[0].1, Color::RED);
+
+    // Reading the override is what subscribes to it: nothing else would tell
+    // this container that a colour it draws has moved.
+    let queued = h.jobs_from(|| accent.set(Color::BLUE));
+    assert!(
+        queued.contains(&JobType::Paint),
+        "the active override has to subscribe, got {queued:?}"
+    );
+    assert_eq!(rects(&h.paint())[0].1, Color::BLUE);
+}
+
 // ---------------------------------------------------------------------------
 // An animated text colour
 // ---------------------------------------------------------------------------

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -1197,6 +1197,87 @@ fn a_state_override_follows_the_signal_it_was_given() {
     assert_eq!(rects(&h.paint())[0].1, Color::BLUE);
 }
 
+/// A state the app owns needs no mechanism: it is a signal, read where the
+/// style is resolved.
+#[test]
+fn a_state_layer_may_hang_on_a_condition_the_app_owns() {
+    let wrong = create_signal(false);
+    let mut h = H::new(
+        box_of(50.0, 50.0)
+            .background(Color::BLACK)
+            .state(wrong, |s| s.background(Color::RED)),
+    );
+    h.fit(100.0, 100.0);
+
+    assert_eq!(rects(&h.paint())[0].1, Color::BLACK);
+
+    let queued = h.jobs_from(|| wrong.set(true));
+    assert!(
+        queued.contains(&JobType::Paint),
+        "the condition has to subscribe, got {queued:?}"
+    );
+    assert_eq!(rects(&h.paint())[0].1, Color::RED);
+}
+
+/// The answer to the field whose focus ring hid its error: declaration order
+/// decides, so the error written last outranks the focus.
+#[test]
+fn the_last_layer_declared_wins_over_the_ones_before_it() {
+    use crate::reactive::focus::clear_focus;
+    use crate::reactive::request_focus;
+    use crate::widgets::text_input;
+
+    clear_focus();
+    let wrong = create_signal(false);
+    let mut h = H::new(
+        container()
+            .width(50.0)
+            .height(50.0)
+            .border(1.5, Color::WHITE)
+            .focused_state(|s| s.border(1.5, Color::BLUE))
+            .state(wrong, |s| s.border(1.5, Color::RED))
+            .child(text_input(create_signal(String::new()))),
+    );
+    h.fit(100.0, 100.0);
+    let input = h.children()[0];
+
+    request_focus(&h.tree, input);
+    assert_eq!(borders(&h.paint())[0].1, Color::BLUE);
+
+    wrong.set(true);
+    assert_eq!(
+        borders(&h.paint())[0].1,
+        Color::RED,
+        "declared after the focused layer, so it outranks it"
+    );
+
+    // And it is the order, not the kind: the focus is still held.
+    wrong.set(false);
+    assert_eq!(borders(&h.paint())[0].1, Color::BLUE);
+}
+
+/// A layer is passed over for a property it says nothing about, rather than
+/// ending the search — otherwise a pressed layer that only scales would drop
+/// the hover's background on the way down.
+#[test]
+fn a_layer_silent_on_a_property_does_not_shadow_the_one_below_it() {
+    let mut h = H::new(
+        box_of(50.0, 50.0)
+            .background(Color::BLACK)
+            .hover_state(|s| s.background(Color::RED))
+            .pressed_state(|s| s.transform(Transform::scale(0.5))),
+    );
+    h.fit(100.0, 100.0);
+
+    set_hover(&mut h, true);
+    h.send(Event::MouseDown {
+        x: 5.0,
+        y: 5.0,
+        button: MouseButton::Left,
+    });
+    assert_eq!(rects(&h.paint())[0].1, Color::RED);
+}
+
 // ---------------------------------------------------------------------------
 // An animated text colour
 // ---------------------------------------------------------------------------

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -125,6 +125,20 @@ fn rects(node: &RenderNode) -> Vec<(Rect, Color)> {
         .collect()
 }
 
+/// The width and colour of every border drawn, in paint order.
+fn borders(node: &RenderNode) -> Vec<(f32, Color)> {
+    node.commands
+        .iter()
+        .filter_map(|c| match &**c {
+            DrawCommand::RoundedRect {
+                border: Some(border),
+                ..
+            } => Some((border.width, border.color)),
+            _ => None,
+        })
+        .collect()
+}
+
 // ---------------------------------------------------------------------------
 // Sizing — the box model matrix
 // ---------------------------------------------------------------------------
@@ -1069,6 +1083,89 @@ fn a_focused_state_applies_while_a_descendant_holds_focus() {
     assert_eq!(rects(&h.paint())[0].1, Color::BLUE);
     clear_focus();
     assert_eq!(rects(&h.paint())[0].1, Color::RED);
+}
+
+/// A state layer *overrides* the base; it does not rank against it.
+///
+/// Which is the whole answer to "why would a field not use `focused_state` for
+/// its focus ring". A border that already carries a meaning — an error colour
+/// here — puts that meaning in the base, and the base is exactly what the layer
+/// replaces. On a field that holds the focus essentially all the time, that is
+/// an error colour that never appears.
+#[test]
+fn a_focused_state_replaces_the_base_rather_than_ranking_against_it() {
+    use crate::reactive::focus::clear_focus;
+    use crate::reactive::request_focus;
+    use crate::widgets::text_input;
+
+    clear_focus();
+    let mut h = H::new(
+        container()
+            .width(50.0)
+            .height(50.0)
+            .border(1.5, Color::RED)
+            .focused_state(|s| s.border(1.5, Color::BLUE))
+            .child(text_input(create_signal(String::new()))),
+    );
+    h.fit(100.0, 100.0);
+    let input = h.children()[0];
+
+    assert_eq!(borders(&h.paint())[0].1, Color::RED);
+
+    request_focus(&h.tree, input);
+    assert_eq!(
+        borders(&h.paint())[0].1,
+        Color::BLUE,
+        "the layer wins, and the base has no way to say it should not"
+    );
+}
+
+/// The other way to follow the focus, for when it has to rank *below* something:
+/// a colour that asks a handle instead of a state layer that overrides.
+///
+/// It works because the closure is read inside paint's tracking scope — asking
+/// about the focus is what subscribes the container to it, with no
+/// `focused_state` declared anywhere.
+#[test]
+fn a_border_colour_that_asks_a_handle_follows_the_focus() {
+    use crate::reactive::focus::clear_focus;
+    use crate::reactive::request_focus;
+    use crate::widget_ref::create_widget_ref;
+    use crate::widgets::text_input;
+
+    clear_focus();
+    let handle = create_widget_ref();
+    let mut h = H::new(
+        container()
+            .width(50.0)
+            .height(50.0)
+            .border(2.0, move || {
+                if handle.is_focused() {
+                    Color::BLUE
+                } else {
+                    Color::RED
+                }
+            })
+            .child(text_input(create_signal(String::new())).widget_ref(handle)),
+    );
+    h.fit(100.0, 100.0);
+    let input = h.children()[0];
+
+    assert_eq!(borders(&h.paint())[0], (2.0, Color::RED));
+
+    request_focus(&h.tree, input);
+    assert_eq!(borders(&h.paint())[0], (2.0, Color::BLUE));
+
+    // And the container has to *hear* about a focus change. Nothing else would
+    // repaint a border whose colour is a closure: the two repaints
+    // `request_focus` asks for name the input and the widget losing the focus,
+    // neither of which is this container.
+    let queued = h.jobs_from(clear_focus);
+    assert!(
+        queued.contains(&JobType::Paint),
+        "asking about the focus has to subscribe to it, got {queued:?}"
+    );
+    assert_eq!(borders(&h.paint())[0], (2.0, Color::RED));
 }
 
 // ---------------------------------------------------------------------------

--- a/src/widgets/container/interaction.rs
+++ b/src/widgets/container/interaction.rs
@@ -114,7 +114,7 @@ impl Container {
         match event {
             Event::MouseEnter { x, y } if hit.contains(*x, *y) && !ix.is_hovered() => {
                 ix.set_flag(InteractionFlags::HOVERED, true);
-                if ix.hover_state.is_some() {
+                if ix.declares(|w| matches!(w, StateWhen::Hovered)) {
                     request_repaint(id);
                 }
                 if let Some(ref callback) = ix.on_hover {
@@ -135,7 +135,7 @@ impl Container {
                 ix.set_flag(InteractionFlags::HOVERED, hit.contains(*x, *y));
 
                 if was_hovered != ix.is_hovered() {
-                    if ix.hover_state.is_some() {
+                    if ix.declares(|w| matches!(w, StateWhen::Hovered)) {
                         request_repaint(id);
                     }
                     if let Some(ref callback) = ix.on_hover {
@@ -191,9 +191,9 @@ impl Container {
                     ix.set_flag(InteractionFlags::PRESSED, true);
 
                     let has_ripple = ix
-                        .pressed_state
-                        .as_ref()
-                        .is_some_and(|s| s.ripple.is_some());
+                        .states
+                        .iter()
+                        .any(|(w, s)| matches!(w, StateWhen::Pressed) && s.ripple.is_some());
                     if has_ripple {
                         let (screen_x, screen_y) = event.coords().unwrap_or((*x, *y));
                         let (local_x, local_y) = hit.local(screen_x, screen_y);
@@ -201,7 +201,7 @@ impl Container {
                         request_job(id, JobRequest::Animation(RequiredJob::Paint));
                     }
 
-                    if !was_pressed && ix.pressed_state.is_some() {
+                    if !was_pressed && ix.declares(|w| matches!(w, StateWhen::Pressed)) {
                         self.request_state_change_repaint(id);
                     }
                     if let Some(ref ix) = self.interaction
@@ -236,7 +236,7 @@ impl Container {
                         request_job(id, JobRequest::Animation(RequiredJob::Paint));
                     }
 
-                    if was_pressed && ix.pressed_state.is_some() {
+                    if was_pressed && ix.declares(|w| matches!(w, StateWhen::Pressed)) {
                         self.request_state_change_repaint(id);
                     }
 
@@ -283,8 +283,8 @@ impl Container {
                         request_job(id, JobRequest::Animation(RequiredJob::Paint));
                     }
 
-                    if (was_hovered && ix.hover_state.is_some())
-                        || (was_pressed && ix.pressed_state.is_some())
+                    if (was_hovered && ix.declares(|w| matches!(w, StateWhen::Hovered)))
+                        || (was_pressed && ix.declares(|w| matches!(w, StateWhen::Pressed)))
                     {
                         self.request_state_change_repaint(id);
                     }

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -42,7 +42,7 @@ use super::paint_children::{ChildPaintOptions, paint_children};
 use super::scroll::{
     ScrollAxis, ScrollState, ScrollbarBuilder, ScrollbarConfig, ScrollbarVisibility,
 };
-use super::state_layer::{StateStyle, resolve_background};
+use super::state_layer::{RippleConfig, StateStyle, StateWhen, resolve_background};
 use super::text_style::{TextShadow, TextStroke, TextStyle};
 use super::widget::{
     Color, Event, EventResponse, Key, LayoutHints, Modifiers, MouseButton, Padding, Rect,
@@ -190,9 +190,11 @@ pub(super) struct InteractionState {
     /// *behaviour* (drag capture, ripple) and a subscription would be noise;
     /// with `get` from style resolution, where the subscription is the point.
     pub(super) flags: RwSignal<InteractionFlags>,
-    pub(super) hover_state: Option<StateStyle>,
-    pub(super) pressed_state: Option<StateStyle>,
-    pub(super) focused_state: Option<StateStyle>,
+    /// State layers in declaration order. Resolution walks it backwards, so
+    /// the last one declared wins wherever two of them speak about the same
+    /// property — CSS's rule at equal specificity, and the only one that lets
+    /// a caller decide that an error outranks the focus.
+    pub(super) states: Vec<(StateWhen, StateStyle)>,
     pub(super) ripple: RippleState,
 }
 
@@ -209,9 +211,7 @@ impl Default for InteractionState {
             on_mouse_down: None,
             on_mouse_up: None,
             flags: create_signal(InteractionFlags::empty()),
-            hover_state: None,
-            pressed_state: None,
-            focused_state: None,
+            states: Vec::new(),
             ripple: RippleState::new(),
         }
     }
@@ -246,7 +246,38 @@ impl InteractionState {
     /// `on_click` has nothing to resolve, and must not start repainting on
     /// every hover just because the flags became reactive.
     pub(super) fn has_any_state(&self) -> bool {
-        self.hover_state.is_some() || self.pressed_state.is_some() || self.focused_state.is_some()
+        !self.states.is_empty()
+    }
+
+    /// Whether a layer with this trigger is declared, without reading any
+    /// signal — the gate event handling uses before asking for a repaint.
+    pub(super) fn declares(&self, when: impl Fn(&StateWhen) -> bool) -> bool {
+        self.states.iter().any(|(w, _)| when(w))
+    }
+
+    /// The ripple a pressed layer declares, if one does.
+    ///
+    /// By value: the caller advances `self.ripple` while holding it, and a
+    /// borrow of the whole `InteractionState` would stand in the way of a
+    /// borrow of one of its fields.
+    pub(super) fn ripple_config(&self) -> Option<RippleConfig> {
+        self.states
+            .iter()
+            .rev()
+            .find(|(when, s)| matches!(when, StateWhen::Pressed) && s.ripple.is_some())
+            .and_then(|(_, s)| s.ripple.clone())
+    }
+
+    /// Whether the layer is active right now. Reading this is what subscribes
+    /// the caller to the state, which is why it is not asked for layers that
+    /// declare nothing about the property being resolved.
+    pub(super) fn is_active(&self, id: WidgetId, when: &StateWhen) -> bool {
+        match when {
+            StateWhen::Hovered => self.flags.get().contains(InteractionFlags::HOVERED),
+            StateWhen::Pressed => self.flags.get().contains(InteractionFlags::PRESSED),
+            StateWhen::Focused => Container::has_child_focus(id),
+            StateWhen::When(condition) => condition.get(),
+        }
     }
 }
 
@@ -994,7 +1025,7 @@ impl Container {
     where
         F: FnOnce(StateStyle) -> StateStyle,
     {
-        self.interact_mut().hover_state = Some(f(StateStyle::new()));
+        self.push_state(StateWhen::Hovered, f);
         self
     }
 
@@ -1003,7 +1034,7 @@ impl Container {
     where
         F: FnOnce(StateStyle) -> StateStyle,
     {
-        self.interact_mut().pressed_state = Some(f(StateStyle::new()));
+        self.push_state(StateWhen::Pressed, f);
         self
     }
 
@@ -1022,8 +1053,43 @@ impl Container {
     where
         F: FnOnce(StateStyle) -> StateStyle,
     {
-        self.interact_mut().focused_state = Some(f(StateStyle::new()));
+        self.push_state(StateWhen::Focused, f);
         self
+    }
+
+    /// Set style overrides for while `condition` holds.
+    ///
+    /// For the states the app owns rather than the pointer: the last submit
+    /// failed, this row is selected, this value is out of range. The condition
+    /// is an ordinary signal, so nothing propagates and nothing is inferred —
+    /// whoever draws the style reads the same signal the app already has.
+    ///
+    /// Declaration order decides ties, so writing this after `focused_state`
+    /// is how an error keeps its colour on a field that holds the focus.
+    ///
+    /// # Example
+    /// ```ignore
+    /// container()
+    ///     .border(1.0, theme.line)
+    ///     .focused_state(|s| s.border(2.0, theme.accent))
+    ///     .state(wrong_password, |s| s.border(2.0, theme.error))
+    ///     .child(text_input(password))
+    /// ```
+    pub fn state<M, F>(mut self, condition: impl IntoSignal<bool, M>, f: F) -> Self
+    where
+        F: FnOnce(StateStyle) -> StateStyle,
+    {
+        self.push_state(StateWhen::When(condition.into_signal()), f);
+        self
+    }
+
+    fn push_state<F>(&mut self, when: StateWhen, f: F)
+    where
+        F: FnOnce(StateStyle) -> StateStyle,
+    {
+        self.interact_mut()
+            .states
+            .push((when, f(StateStyle::new())));
     }
 }
 
@@ -1156,10 +1222,9 @@ impl Widget for Container {
         // Advance ripple animation
         if let Some(ref mut ix) = self.interaction
             && ix.ripple.is_active()
-            && let Some(ref state) = ix.pressed_state
-            && let Some(ref config) = state.ripple
+            && let Some(config) = ix.ripple_config()
         {
-            let ripple_animating = ix.ripple.advance(config);
+            let ripple_animating = ix.ripple.advance(&config);
             if ripple_animating {
                 // Ripple is paint-only, request animation continuation with paint
                 request_job(id, JobRequest::Animation(RequiredJob::Paint));
@@ -1605,8 +1670,7 @@ impl Widget for Container {
         // Draw ripple effect as overlay (ripple.center is already in local coordinates)
         if let Some(ref ix) = self.interaction
             && let Some((local_cx, local_cy)) = ix.ripple.center
-            && let Some(ref pressed_state) = ix.pressed_state
-            && let Some(ref ripple_config) = pressed_state.ripple
+            && let Some(ripple_config) = ix.ripple_config()
             && ix.ripple.opacity > 0.0
         {
             // Set overlay clip to container bounds with rounded corners

--- a/src/widgets/container/style.rs
+++ b/src/widgets/container/style.rs
@@ -89,7 +89,7 @@ impl Container {
                 .background
                 .as_ref()
                 .map(|bg| resolve_background(base, bg));
-            match (bg_color, state.alpha) {
+            match (bg_color, state.alpha.map(|s| s.get())) {
                 (Some(mut c), Some(a)) => {
                     c.a = a;
                     Some(c)
@@ -107,22 +107,22 @@ impl Container {
 
     pub(super) fn effective_border_width_target(&self, id: WidgetId) -> f32 {
         let base = self.border_width.get_or(0.0);
-        self.resolve_state_value(id, base, |state| state.border_width)
+        self.resolve_state_value(id, base, |state| state.border_width.map(|s| s.get()))
     }
 
     pub(super) fn effective_border_color_target(&self, id: WidgetId) -> Color {
         let base = self.border_color.get_or(Color::TRANSPARENT);
-        self.resolve_state_value(id, base, |state| state.border_color)
+        self.resolve_state_value(id, base, |state| state.border_color.map(|s| s.get()))
     }
 
     pub(super) fn effective_corner_radius_target(&self, id: WidgetId) -> f32 {
         let base = self.corner_radius.get_or(0.0);
-        self.resolve_state_value(id, base, |state| state.corner_radius)
+        self.resolve_state_value(id, base, |state| state.corner_radius.map(|s| s.get()))
     }
 
     pub(super) fn effective_transform_target(&self, id: WidgetId) -> Transform {
         let base = self.transform.get_or(Transform::IDENTITY);
-        self.resolve_state_value(id, base, |state| state.transform)
+        self.resolve_state_value(id, base, |state| state.transform.map(|s| s.get()))
     }
 
     /// The text colour a descendant should see, before any animation.
@@ -138,13 +138,13 @@ impl Container {
             .or_else(|| self.text.as_ref().and_then(|t| t.color))
             .map(|color| color.get())
             .unwrap_or(Color::WHITE);
-        self.resolve_state_value(id, base, |state| state.text_color)
+        self.resolve_state_value(id, base, |state| state.text_color.map(|s| s.get()))
     }
 
     /// Elevation is never animated, so the target *is* the drawn value.
     pub(super) fn effective_elevation(&self, id: WidgetId) -> f32 {
         let base = self.elevation.get_or(0.0);
-        self.resolve_state_value(id, base, |state| state.elevation)
+        self.resolve_state_value(id, base, |state| state.elevation.map(|s| s.get()))
     }
 
     // -----------------------------------------------------------------------
@@ -216,19 +216,19 @@ impl Container {
                 if flags.contains(InteractionFlags::PRESSED)
                     && let Some(color) = pressed
                 {
-                    return color;
+                    return color.get();
                 }
                 // `focused` first: with no focused state there is nothing to
                 // resolve, and no reason to subscribe to the focus path.
                 if let Some(color) = focused
                     && Self::has_child_focus(id)
                 {
-                    return color;
+                    return color.get();
                 }
                 if flags.contains(InteractionFlags::HOVERED)
                     && let Some(color) = hovered
                 {
-                    return color;
+                    return color.get();
                 }
                 base.map(|base| base.get()).unwrap_or(Color::WHITE)
             })

--- a/src/widgets/container/style.rs
+++ b/src/widgets/container/style.rs
@@ -57,25 +57,17 @@ impl Container {
             return base;
         }
 
-        let flags = ix.flags.get();
-        if flags.contains(InteractionFlags::PRESSED)
-            && let Some(ref state) = ix.pressed_state
-            && let Some(value) = extractor(state)
-        {
-            return value;
-        }
-        if ix.focused_state.is_some()
-            && Self::has_child_focus(id)
-            && let Some(ref state) = ix.focused_state
-            && let Some(value) = extractor(state)
-        {
-            return value;
-        }
-        if flags.contains(InteractionFlags::HOVERED)
-            && let Some(ref state) = ix.hover_state
-            && let Some(value) = extractor(state)
-        {
-            return value;
+        // Backwards: the last layer declared wins. A layer that says nothing
+        // about *this* property is passed over rather than ending the search,
+        // so `hover_state(|s| s.lighter(0.1))` still lightens under a pressed
+        // layer that only scales.
+        for (when, state) in ix.states.iter().rev() {
+            let Some(value) = extractor(state) else {
+                continue;
+            };
+            if ix.is_active(id, when) {
+                return value;
+            }
         }
         base
     }
@@ -153,12 +145,9 @@ impl Container {
 
     /// Whether any state layer declares a text colour.
     fn has_state_text_color(&self) -> bool {
-        self.interaction.as_ref().is_some_and(|ix| {
-            [&ix.hover_state, &ix.pressed_state, &ix.focused_state]
-                .into_iter()
-                .flatten()
-                .any(|s| s.text_color.is_some())
-        })
+        self.interaction
+            .as_ref()
+            .is_some_and(|ix| ix.states.iter().any(|(_, s)| s.text_color.is_some()))
     }
 
     /// The text style this container publishes to its descendants.
@@ -180,15 +169,17 @@ impl Container {
 
         let ix = self.interaction.as_ref();
         let flags = ix.map(|ix| ix.flags);
-        let pressed = ix
-            .and_then(|ix| ix.pressed_state.as_ref())
-            .and_then(|s| s.text_color);
-        let focused = ix
-            .and_then(|ix| ix.focused_state.as_ref())
-            .and_then(|s| s.text_color);
-        let hovered = ix
-            .and_then(|ix| ix.hover_state.as_ref())
-            .and_then(|s| s.text_color);
+        // Only the layers that speak about text, in declaration order. A
+        // derived closure has no container to ask later, so the fold below
+        // walks this instead of `states`.
+        let text_states: Vec<(StateWhen, Signal<Color>)> = ix
+            .map(|ix| {
+                ix.states
+                    .iter()
+                    .filter_map(|(when, s)| s.text_color.map(|c| (*when, c)))
+                    .collect()
+            })
+            .unwrap_or_default();
 
         // What a descendant would have inherited without us — this container's
         // own declaration, or the nearest ancestor's. Walked once, here: a
@@ -212,23 +203,26 @@ impl Container {
                 {
                     return color;
                 }
-                let flags = flags.map(|f| f.get()).unwrap_or_default();
-                if flags.contains(InteractionFlags::PRESSED)
-                    && let Some(color) = pressed
-                {
-                    return color.get();
-                }
-                // `focused` first: with no focused state there is nothing to
-                // resolve, and no reason to subscribe to the focus path.
-                if let Some(color) = focused
-                    && Self::has_child_focus(id)
-                {
-                    return color.get();
-                }
-                if flags.contains(InteractionFlags::HOVERED)
-                    && let Some(color) = hovered
-                {
-                    return color.get();
+                // Backwards, and each trigger read only when a layer uses it:
+                // with no focused layer there is no reason to subscribe to the
+                // focus path, and with no hover layer none to subscribe to the
+                // flags.
+                for (when, color) in text_states.iter().rev() {
+                    let active = match when {
+                        StateWhen::Hovered => flags
+                            .map(|f| f.get())
+                            .unwrap_or_default()
+                            .contains(InteractionFlags::HOVERED),
+                        StateWhen::Pressed => flags
+                            .map(|f| f.get())
+                            .unwrap_or_default()
+                            .contains(InteractionFlags::PRESSED),
+                        StateWhen::Focused => Self::has_child_focus(id),
+                        StateWhen::When(condition) => condition.get(),
+                    };
+                    if active {
+                        return color.get();
+                    }
                 }
                 base.map(|base| base.get()).unwrap_or(Color::WHITE)
             })

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -23,7 +23,7 @@ pub use into_child::{
     DynamicChildren, IntoChild, IntoChildren, IntoDynChild, KeyedChildren, StaticChildren, keyed,
 };
 pub use scroll::{ScrollAxis, ScrollbarBuilder, ScrollbarConfig, ScrollbarVisibility};
-pub use state_layer::{BackgroundOverride, RippleConfig, StateStyle};
+pub use state_layer::{BackgroundOverride, RippleConfig, StateStyle, StateWhen};
 pub use text::{Text, text};
 pub use text_input::{Selection, TextInput, text_input};
 pub use text_style::{TextShadow, TextStroke, TextStyle};

--- a/src/widgets/state_layer.rs
+++ b/src/widgets/state_layer.rs
@@ -1,8 +1,9 @@
 //! State layer system for interaction-based style overrides.
 //!
-//! This module provides types for defining style changes based on widget state
-//! (hover, pressed, etc.). State styles allow containers to redefine properties
-//! like background color, border, transform, and more when in specific states.
+//! A state layer redefines properties — background, border, transform and the
+//! rest — while the container is in a given state. Every value is a
+//! [`Signal`], like the base properties they override: a state layer that
+//! could not follow the theme would be a second, quieter styling system.
 //!
 //! # Example
 //! ```ignore
@@ -13,6 +14,7 @@
 //!     .child(text("Interactive button"))
 //! ```
 
+use crate::reactive::{IntoSignal, Signal};
 use crate::transform::Transform;
 use crate::widgets::Color;
 
@@ -53,41 +55,43 @@ impl RippleConfig {
 }
 
 /// How to override the background color in a state.
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy)]
 pub enum BackgroundOverride {
     /// Use an explicit color
-    Exact(Color),
+    Exact(Signal<Color>),
     /// Lighten the base background by amount (0.0-1.0)
-    Lighter(f32),
+    Lighter(Signal<f32>),
     /// Darken the base background by amount (0.0-1.0)
-    Darker(f32),
+    Darker(Signal<f32>),
 }
 
 /// Style overrides to apply during a specific interaction state.
 ///
-/// All fields are optional - `None` means use the base value from the container.
-#[derive(Clone, Default, Debug)]
+/// All fields are optional — `None` means use the base value from the
+/// container — and all of them hold signals, so an override tracks whatever it
+/// was given just as the base property does.
+#[derive(Clone, Default)]
 pub struct StateStyle {
     /// Background color override
     pub background: Option<BackgroundOverride>,
     /// Border width override
-    pub border_width: Option<f32>,
+    pub border_width: Option<Signal<f32>>,
     /// Border color override
-    pub border_color: Option<Color>,
+    pub border_color: Option<Signal<Color>>,
     /// Corner radius override
-    pub corner_radius: Option<f32>,
+    pub corner_radius: Option<Signal<f32>>,
     /// Transform override (e.g., scale on press)
-    pub transform: Option<Transform>,
+    pub transform: Option<Signal<Transform>>,
     /// Elevation (shadow) override
-    pub elevation: Option<f32>,
+    pub elevation: Option<Signal<f32>>,
     /// Colour of the text below this container while the state is active.
     ///
     /// Reaches the glyphs, not just the box: the container publishes its text
     /// colour to descendants as a derived over the interaction flags, so a
     /// text that inherited it is subscribed to the flip.
-    pub text_color: Option<Color>,
+    pub text_color: Option<Signal<Color>>,
     /// Override the background alpha channel (applied after background override)
-    pub alpha: Option<f32>,
+    pub alpha: Option<Signal<f32>>,
     /// Ripple effect configuration (typically used in pressed_state)
     pub ripple: Option<RippleConfig>,
 }
@@ -99,8 +103,8 @@ impl StateStyle {
     }
 
     /// Set an explicit background color for this state.
-    pub fn background(mut self, color: impl Into<Color>) -> Self {
-        self.background = Some(BackgroundOverride::Exact(color.into()));
+    pub fn background<M>(mut self, color: impl IntoSignal<Color, M>) -> Self {
+        self.background = Some(BackgroundOverride::Exact(color.into_signal()));
         self
     }
 
@@ -112,8 +116,8 @@ impl StateStyle {
     ///     .hover_state(|s| s.text_color(theme.text))
     ///     .child(text("Label"))
     /// ```
-    pub fn text_color(mut self, color: impl Into<Color>) -> Self {
-        self.text_color = Some(color.into());
+    pub fn text_color<M>(mut self, color: impl IntoSignal<Color, M>) -> Self {
+        self.text_color = Some(color.into_signal());
         self
     }
 
@@ -128,15 +132,12 @@ impl StateStyle {
     ///     .background(Color::rgb(0.2, 0.2, 0.3))
     ///     .hover_state(|s| s.lighter(0.1)) // 10% lighter on hover
     /// ```
-    pub fn lighter(mut self, amount: f32) -> Self {
-        self.background = Some(BackgroundOverride::Lighter(amount));
+    pub fn lighter<M>(mut self, amount: impl IntoSignal<f32, M>) -> Self {
+        self.background = Some(BackgroundOverride::Lighter(amount.into_signal()));
         self
     }
 
     /// Darken the base background by amount (0.0-1.0).
-    ///
-    /// This computes a darker color from the container's base background
-    /// by blending toward black.
     ///
     /// # Example
     /// ```ignore
@@ -144,33 +145,37 @@ impl StateStyle {
     ///     .background(Color::rgb(0.2, 0.2, 0.3))
     ///     .pressed_state(|s| s.darker(0.1)) // 10% darker on press
     /// ```
-    pub fn darker(mut self, amount: f32) -> Self {
-        self.background = Some(BackgroundOverride::Darker(amount));
+    pub fn darker<M>(mut self, amount: impl IntoSignal<f32, M>) -> Self {
+        self.background = Some(BackgroundOverride::Darker(amount.into_signal()));
         self
     }
 
     /// Set the border width and color for this state.
-    pub fn border(mut self, width: f32, color: impl Into<Color>) -> Self {
-        self.border_width = Some(width);
-        self.border_color = Some(color.into());
+    pub fn border<M1, M2>(
+        mut self,
+        width: impl IntoSignal<f32, M1>,
+        color: impl IntoSignal<Color, M2>,
+    ) -> Self {
+        self.border_width = Some(width.into_signal());
+        self.border_color = Some(color.into_signal());
         self
     }
 
     /// Set just the border width for this state.
-    pub fn border_width(mut self, width: f32) -> Self {
-        self.border_width = Some(width);
+    pub fn border_width<M>(mut self, width: impl IntoSignal<f32, M>) -> Self {
+        self.border_width = Some(width.into_signal());
         self
     }
 
     /// Set just the border color for this state.
-    pub fn border_color(mut self, color: impl Into<Color>) -> Self {
-        self.border_color = Some(color.into());
+    pub fn border_color<M>(mut self, color: impl IntoSignal<Color, M>) -> Self {
+        self.border_color = Some(color.into_signal());
         self
     }
 
     /// Set the corner radius for this state.
-    pub fn corner_radius(mut self, radius: f32) -> Self {
-        self.corner_radius = Some(radius);
+    pub fn corner_radius<M>(mut self, radius: impl IntoSignal<f32, M>) -> Self {
+        self.corner_radius = Some(radius.into_signal());
         self
     }
 
@@ -183,14 +188,14 @@ impl StateStyle {
     /// container()
     ///     .pressed_state(|s| s.transform(Transform::scale(0.98)))
     /// ```
-    pub fn transform(mut self, transform: Transform) -> Self {
-        self.transform = Some(transform);
+    pub fn transform<M>(mut self, transform: impl IntoSignal<Transform, M>) -> Self {
+        self.transform = Some(transform.into_signal());
         self
     }
 
     /// Set the elevation (shadow level) for this state.
-    pub fn elevation(mut self, elevation: f32) -> Self {
-        self.elevation = Some(elevation);
+    pub fn elevation<M>(mut self, elevation: impl IntoSignal<f32, M>) -> Self {
+        self.elevation = Some(elevation.into_signal());
         self
     }
 
@@ -205,8 +210,8 @@ impl StateStyle {
     ///     .background(Color::rgba(1.0, 0.5, 0.0, 0.4))
     ///     .hover_state(|s| s.lighter(0.1).alpha(0.7)) // boost alpha on hover
     /// ```
-    pub fn alpha(mut self, alpha: f32) -> Self {
-        self.alpha = Some(alpha);
+    pub fn alpha<M>(mut self, alpha: impl IntoSignal<f32, M>) -> Self {
+        self.alpha = Some(alpha.into_signal());
         self
     }
 
@@ -246,10 +251,13 @@ impl StateStyle {
 }
 
 /// Resolve a background override to an actual color.
+///
+/// Reads the override's signal, so the caller's tracking scope subscribes to
+/// it — the same contract the base property has.
 pub fn resolve_background(base: Color, override_: &BackgroundOverride) -> Color {
     match override_ {
-        BackgroundOverride::Exact(color) => *color,
-        BackgroundOverride::Lighter(amount) => base.lighter(*amount),
-        BackgroundOverride::Darker(amount) => base.darker(*amount),
+        BackgroundOverride::Exact(color) => color.get(),
+        BackgroundOverride::Lighter(amount) => base.lighter(amount.get()),
+        BackgroundOverride::Darker(amount) => base.darker(amount.get()),
     }
 }

--- a/src/widgets/state_layer.rs
+++ b/src/widgets/state_layer.rs
@@ -54,6 +54,25 @@ impl RippleConfig {
     }
 }
 
+/// When a state layer applies.
+///
+/// The first three are noticed by the container itself — the pointer is inside
+/// it, the pointer is down on it, the focus is somewhere below it. The fourth
+/// is a condition the app already holds: "the last submit failed", "this row
+/// is selected". Nothing has to propagate for that one, so it needs no
+/// mechanism beyond reading the signal where the style is resolved.
+#[derive(Clone, Copy)]
+pub enum StateWhen {
+    /// The pointer is inside the container's shape.
+    Hovered,
+    /// The pointer is down on the container.
+    Pressed,
+    /// The container, or anything below it, holds the keyboard focus.
+    Focused,
+    /// A condition the app owns.
+    When(Signal<bool>),
+}
+
 /// How to override the background color in a state.
 #[derive(Clone, Copy)]
 pub enum BackgroundOverride {


### PR DESCRIPTION
The state layer system had two limits that met in the same place: a
password field whose border already carries a meaning.

**The values were not reactive.** Every field of `StateStyle` held a plain
`Color`/`f32`/`Transform`, read once when the builder ran, while the base
properties underneath have taken `IntoSignal` since the beginning. So
`background(theme)` followed the theme and `hover_state(|s| s.background(theme))`
stopped following it the moment the pointer arrived. They are signals now,
read where the override is resolved — inside the caller's tracking scope —
so the subscription lands on whoever draws the value, and only while the
state is actually active.

**The precedence was cabled in, and there were only three states.** Resolution
went pressed, then focused, then hovered, with no way for a caller to reach
past it. The three `Option<StateStyle>` fields become one ordered
`Vec<(StateWhen, StateStyle)>` resolved backwards: last declared wins, CSS's
rule at equal specificity. With the trigger a value rather than a field name,
`state(condition, ..)` falls out — the family of states the app owns, which
needs no propagation at all because the condition is a signal the caller
already holds.

Together they answer the case that started this:

```rust
container()
    .border(1.0, theme.line)
    .focused_state(|s| s.border(2.0, theme.accent))
    .state(wrong_password, |s| s.border(2.0, theme.error))  // written after, so it wins
    .child(text_input(password))
```

Two incidental improvements from the same shape. A layer silent about a
property is now passed over rather than ending the search, so a pressed layer
that only scales no longer drops the hover's background. And each trigger is
read only where a layer uses it: a container carrying a single `state(..)`
subscribes to neither the pointer flags nor the focus path.

## Compatibility

No call site changes anywhere — `src/`, `examples/`, `book/` all compile
untouched. The blanket `IntoSignal<T, ValueMarker>` covers every `Into<T>`,
so the literal colours and numbers everything is written with convert exactly
as before, and no existing site declares `pressed_state` before `hover_state`,
which is the only ordering the new rule would read differently.

## Tests

Four characterizations added, two of them written before the change as the
"before": that a layer replaces the base rather than ranking against it, and
the `WidgetRef` closure that was the only way out. Then: an override that
follows its signal (asserting the invalidation, not just the value), a
condition the app owns, last-declared-wins over a held focus, and a layer
silent on a property not shadowing the one below.

Full suite green, render snapshots unchanged, clippy clean.