### PR TITLE
Caret, selection and placeholder leave the text style

### DIFF
--- a/docs/STYLING.md
+++ b/docs/STYLING.md
@@ -233,7 +233,9 @@ container()
 ```
 
 The same declarations style a `text_input`, which additionally reads
-`cursor_color` and `selection_color`:
+`cursor_color`, `selection_color` and `placeholder_color`. Those three are
+`InputStyle`, not `TextStyle`, and resolve on their own walk — a `text` never
+looks for properties it cannot draw:
 
 ```rust
 container()

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -126,6 +126,10 @@ struct Slot {
     /// Boxed because most nodes declare nothing: the miss costs a null check
     /// instead of the ~96 bytes the struct would add to every node.
     text_style: Option<Box<crate::widgets::TextStyle>>,
+    /// Input style this node declares for its descendants, if any. Boxed for
+    /// the same reason as `text_style`, and separate from it because only an
+    /// input can draw what it holds.
+    input_style: Option<Box<crate::widgets::InputStyle>>,
     /// Distance from this widget's top edge to the baseline of its first line
     /// of text, if it has one. Reported by leaves during layout and read by a
     /// parent aligning on `CrossAlignment::Baseline`.
@@ -208,6 +212,7 @@ impl Tree {
             sparse_index,
             cached_paint: None,
             text_style: None,
+            input_style: None,
             baseline: None,
             paint_overflow: 0.0,
         });
@@ -381,6 +386,41 @@ impl Tree {
                 break;
             };
             if let Some(declared) = self.dense[idx].text_style.as_deref() {
+                resolved.inherit_from(declared);
+                if resolved.is_complete() {
+                    break;
+                }
+            }
+            cursor = self.dense[idx].parent;
+        }
+
+        resolved
+    }
+
+    /// Record the input style a node declares for its descendants.
+    ///
+    /// The counterpart of [`set_text_style`](Self::set_text_style), with the
+    /// same empty-clears-the-slot rule.
+    pub fn set_input_style(&mut self, id: WidgetId, style: Option<crate::widgets::InputStyle>) {
+        if let Some(idx) = self.get_dense_index(id) {
+            self.dense[idx].input_style = style.filter(|s| !s.is_empty()).map(Box::new);
+        }
+    }
+
+    /// Resolve the input style that applies to a widget, per property.
+    ///
+    /// Same walk and same contract as
+    /// [`inherited_text_style`](Self::inherited_text_style): the result holds
+    /// signals, and the caller reads them inside its own tracking scope.
+    pub fn inherited_input_style(&self, id: WidgetId) -> crate::widgets::InputStyle {
+        let mut resolved = crate::widgets::InputStyle::default();
+        let mut cursor = self.get_parent(id);
+
+        while let Some(ancestor) = cursor {
+            let Some(idx) = self.get_dense_index(ancestor) else {
+                break;
+            };
+            if let Some(declared) = self.dense[idx].input_style.as_deref() {
                 resolved.inherit_from(declared);
                 if resolved.is_complete() {
                     break;
@@ -1342,6 +1382,50 @@ mod tests {
         assert_eq!(resolved.color.map(|c| c.get()), Some(Color::RED));
     }
 
+    /// The two walks are separate slots, so a container that dresses the text
+    /// does not have to answer for the caret, and the other way round.
+    #[test]
+    fn input_style_resolves_independently_of_text_style() {
+        let mut tree = Tree::new();
+        let ids = chain(&mut tree, 4);
+        tree.set_text_style(ids[0], Some(colored(Color::RED)));
+        tree.set_input_style(
+            ids[1],
+            Some(crate::widgets::InputStyle {
+                cursor_color: Some(create_stored(Color::BLUE)),
+                ..Default::default()
+            }),
+        );
+
+        let text = tree.inherited_text_style(ids[3]);
+        let input = tree.inherited_input_style(ids[3]);
+        assert_eq!(text.color.map(|c| c.get()), Some(Color::RED));
+        assert_eq!(input.cursor_color.map(|c| c.get()), Some(Color::BLUE));
+        // Neither walk sees the other's declaration.
+        assert!(input.placeholder_color.is_none());
+    }
+
+    #[test]
+    fn nearest_input_declaration_wins() {
+        let mut tree = Tree::new();
+        let ids = chain(&mut tree, 3);
+        for (id, color) in [(ids[0], Color::RED), (ids[1], Color::BLUE)] {
+            tree.set_input_style(
+                id,
+                Some(crate::widgets::InputStyle {
+                    placeholder_color: Some(create_stored(color)),
+                    ..Default::default()
+                }),
+            );
+        }
+
+        let resolved = tree.inherited_input_style(ids[2]);
+        assert_eq!(
+            resolved.placeholder_color.map(|c| c.get()),
+            Some(Color::BLUE)
+        );
+    }
+
     #[test]
     fn nearest_declaration_wins() {
         let mut tree = Tree::new();
@@ -1440,9 +1524,6 @@ mod tests {
                     2.0,
                     Color::BLACK,
                 ))),
-                cursor_color: Some(create_stored(Color::WHITE)),
-                selection_color: Some(create_stored(Color::BLACK)),
-                placeholder_color: Some(create_stored(Color::WHITE)),
             }),
         );
 

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -37,6 +37,7 @@ use crate::widget_ref::{WidgetRef, register_widget_ref};
 
 use super::children::ChildrenSource;
 use super::font::{FontFamily, FontWeight};
+use super::input_style::InputStyle;
 use super::into_child::{IntoChild, IntoChildren};
 use super::paint_children::{ChildPaintOptions, paint_children};
 use super::scroll::{
@@ -347,6 +348,10 @@ pub struct Container {
     // text and pay one pointer for the whole feature.
     pub(super) text: Option<Box<TextStyle>>,
 
+    /// What this container declares for the inputs below it. Separate from
+    /// `text` because a text cannot draw any of it.
+    pub(super) input: Option<Box<InputStyle>>,
+
     // Owns the derived published in place of the text colour when a state
     // layer declares one. Created at registration, so it belongs to no user
     // scope and has to be torn down by hand when the container goes.
@@ -400,6 +405,7 @@ impl Container {
             widget_ref: None,
             backdrop_blur: None,
             text: None,
+            input: None,
             text_owner: None,
             animated_text: None,
             text_base: None,
@@ -510,6 +516,10 @@ impl Container {
         self.text.get_or_insert_with(Box::default)
     }
 
+    fn input_mut(&mut self) -> &mut InputStyle {
+        self.input.get_or_insert_with(Box::default)
+    }
+
     /// Set the colour of text in this container and its descendants.
     ///
     /// Named `text_color` rather than `color` because `color` on a box reads
@@ -583,14 +593,14 @@ impl Container {
     /// Set the caret colour of any [`TextInput`](crate::widgets::TextInput)
     /// below this container. Defaults to the text colour.
     pub fn cursor_color<M>(mut self, color: impl IntoSignal<Color, M>) -> Self {
-        self.text_mut().cursor_color = Some(color.into_signal());
+        self.input_mut().cursor_color = Some(color.into_signal());
         self
     }
 
     /// Set the selection highlight colour of any
     /// [`TextInput`](crate::widgets::TextInput) below this container.
     pub fn selection_color<M>(mut self, color: impl IntoSignal<Color, M>) -> Self {
-        self.text_mut().selection_color = Some(color.into_signal());
+        self.input_mut().selection_color = Some(color.into_signal());
         self
     }
 
@@ -600,7 +610,7 @@ impl Container {
     /// Defaults to the inherited text colour at reduced alpha, which is what a
     /// placeholder is: the same text, quieter.
     pub fn placeholder_color<M>(mut self, color: impl IntoSignal<Color, M>) -> Self {
-        self.text_mut().placeholder_color = Some(color.into_signal());
+        self.input_mut().placeholder_color = Some(color.into_signal());
         self
     }
 
@@ -1280,6 +1290,7 @@ impl Widget for Container {
         // re-registers anyway.
         let published = self.published_text_style(tree, id);
         tree.set_text_style(id, published);
+        tree.set_input_style(id, self.input.as_deref().copied());
 
         // Register pending children
         self.children_source.register_pending(tree, id);

--- a/src/widgets/input_style.rs
+++ b/src/widgets/input_style.rs
@@ -1,0 +1,65 @@
+//! How an input's own furniture looks — caret, selection, placeholder.
+//!
+//! These three are not text style. A [`Text`](crate::widgets::Text) draws
+//! glyphs and nothing else; only a [`TextInput`](crate::widgets::TextInput)
+//! draws a caret, a selection band or a placeholder. They lived in
+//! [`TextStyle`](crate::widgets::TextStyle) for a while, each with a doc
+//! comment admitting that only one widget ever read it, which is the shape of
+//! a property in the wrong struct.
+//!
+//! Splitting them out costs nothing at the call site and buys two things: a
+//! text no longer walks its ancestors looking for properties it cannot draw,
+//! and the next property belonging to an input has an obvious place to go.
+//!
+//! Resolution works exactly like [`TextStyle`]'s — per property, nearest
+//! declaration wins, walked from the input itself so the subscription lands
+//! where the value is read. See that module for why the walk starts there.
+//!
+//! [`TextStyle`]: crate::widgets::TextStyle
+
+use crate::reactive::Signal;
+
+use super::widget::Color;
+
+/// The input style a container declares for the inputs below it.
+///
+/// Every field is optional and resolved independently, so a container setting
+/// only the caret colour leaves the selection to whatever an ancestor said.
+#[derive(Clone, Copy, Default, PartialEq)]
+pub struct InputStyle {
+    /// Colour of the caret. Defaults to the resolved text colour — an input
+    /// that only sets `text_color` should not sprout a blue cursor.
+    pub cursor_color: Option<Signal<Color>>,
+    /// Colour of the selection band drawn behind the selected glyphs.
+    pub selection_color: Option<Signal<Color>>,
+    /// Colour of the placeholder. Defaults to the text colour at reduced
+    /// alpha — a placeholder is the same text, quieter.
+    pub placeholder_color: Option<Signal<Color>>,
+}
+
+impl InputStyle {
+    /// Whether nothing at all is declared.
+    ///
+    /// A container in this state is not recorded on its node, so the walk
+    /// skips it with a null check instead of a dereference.
+    pub fn is_empty(&self) -> bool {
+        *self == Self::default()
+    }
+
+    /// Take from `outer` every property this style does not already declare.
+    ///
+    /// Called as the walk moves away from the input, so a nearer container
+    /// always wins: whatever is already set was found closer.
+    pub(crate) fn inherit_from(&mut self, outer: &Self) {
+        self.cursor_color = self.cursor_color.or(outer.cursor_color);
+        self.selection_color = self.selection_color.or(outer.selection_color);
+        self.placeholder_color = self.placeholder_color.or(outer.placeholder_color);
+    }
+
+    /// Whether every property has been resolved, so the walk can stop early.
+    pub(crate) fn is_complete(&self) -> bool {
+        self.cursor_color.is_some()
+            && self.selection_color.is_some()
+            && self.placeholder_color.is_some()
+    }
+}

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -2,6 +2,7 @@ pub mod children;
 pub mod container;
 pub mod font;
 pub mod image;
+pub mod input_style;
 pub mod into_child;
 mod paint_children;
 
@@ -19,6 +20,7 @@ pub use children::ChildrenSource;
 pub use container::{Border, Container, GradientDirection, LinearGradient, Overflow, container};
 pub use font::{FontFamily, FontWeight};
 pub use image::{ContentFit, Image, ImageSource, image};
+pub use input_style::InputStyle;
 pub use into_child::{
     DynamicChildren, IntoChild, IntoChildren, IntoDynChild, KeyedChildren, StaticChildren, keyed,
 };

--- a/src/widgets/text_input.rs
+++ b/src/widgets/text_input.rs
@@ -1084,6 +1084,7 @@ impl Widget for TextInput {
         let (text_color, selection_color, cursor_color, stroke, shadow, placeholder) =
             with_signal_tracking(id, JobType::Paint, || {
                 let style = tree.inherited_text_style(id);
+                let input = tree.inherited_input_style(id);
                 let text_color = style.color.get_or(Color::WHITE);
                 // Only when there is nothing to show instead. Read inside the
                 // tracking scope like every other paint input, so a prompt that
@@ -1092,7 +1093,7 @@ impl Widget for TextInput {
                     .placeholder
                     .filter(|_| self.cached_value.is_empty())
                     .map(|signal| {
-                        let color = style.placeholder_color.get_or(Color::rgba(
+                        let color = input.placeholder_color.get_or(Color::rgba(
                             text_color.r,
                             text_color.g,
                             text_color.b,
@@ -1102,12 +1103,12 @@ impl Widget for TextInput {
                     });
                 (
                     text_color,
-                    style
+                    input
                         .selection_color
                         .get_or(Color::rgba(0.4, 0.6, 1.0, 0.4)),
                     // The caret defaults to the text colour: an input that
                     // only sets `text_color` should not sprout a blue cursor.
-                    style.cursor_color.get_or(text_color),
+                    input.cursor_color.get_or(text_color),
                     style.stroke.map(|s| s.get()),
                     style.shadow.map(|s| s.get()),
                     placeholder,

--- a/src/widgets/text_style.rs
+++ b/src/widgets/text_style.rs
@@ -225,15 +225,6 @@ pub struct TextStyle {
     pub stroke: Option<Signal<TextStroke>>,
     /// Soft shadow cast by the glyphs.
     pub shadow: Option<Signal<TextShadow>>,
-    /// Caret colour. Only [`TextInput`](crate::widgets::TextInput) reads it.
-    pub cursor_color: Option<Signal<Color>>,
-    /// Selection highlight colour. Only
-    /// [`TextInput`](crate::widgets::TextInput) reads it.
-    pub selection_color: Option<Signal<Color>>,
-    /// Colour of an input's placeholder. Only
-    /// [`TextInput`](crate::widgets::TextInput) reads it, and it falls back to the
-    /// text colour at reduced alpha — a placeholder is the same text, quieter.
-    pub placeholder_color: Option<Signal<Color>>,
 }
 
 impl TextStyle {
@@ -256,9 +247,6 @@ impl TextStyle {
         self.font_weight = self.font_weight.or(outer.font_weight);
         self.stroke = self.stroke.or(outer.stroke);
         self.shadow = self.shadow.or(outer.shadow);
-        self.cursor_color = self.cursor_color.or(outer.cursor_color);
-        self.selection_color = self.selection_color.or(outer.selection_color);
-        self.placeholder_color = self.placeholder_color.or(outer.placeholder_color);
     }
 
     /// Whether every property has been resolved, so the walk can stop early.
@@ -269,8 +257,5 @@ impl TextStyle {
             && self.font_weight.is_some()
             && self.stroke.is_some()
             && self.shadow.is_some()
-            && self.cursor_color.is_some()
-            && self.selection_color.is_some()
-            && self.placeholder_color.is_some()
     }
 }


### PR DESCRIPTION
`TextStyle` carried three properties whose own doc comments admitted what
they were:

```rust
/// Caret colour. Only `TextInput` reads it.
pub cursor_color: Option<Signal<Color>>,
```

That is the shape of a property in the wrong struct, and it had a cost past
tidiness. Every `text` walked its ancestors carrying three slots it cannot
draw, and `is_complete` — the early-out that ends the walk — could not fire
until all three were filled, so a text with a fully declared style kept
climbing looking for a caret colour it would never use.

They become `InputStyle`: its own slot on the node, its own walk, resolved
exactly like the text style — per property, nearest declaration wins, started
at the input itself so the subscription lands where the value is read.

## Not an API change

Nothing moves at the call site. `container().placeholder_color(..)` says what
it said, and `tests/placeholder.rs` passes untouched. Where those declarations
*belong* is a separate question; this only stops the two vocabularies from
sharing one struct, so that question can be answered without dragging the text
style along with it.

## Tests

Two tree tests for the new walk: that the two slots resolve independently
(neither sees the other's declaration) and that the nearest input declaration
wins. Full suite green, render snapshots unchanged, clippy clean.