### PR TITLE
A text can say what colour it is

### DIFF
--- a/book/src/building-ui/text-input.md
+++ b/book/src/building-ui/text-input.md
@@ -27,13 +27,15 @@ container().text_color(Color::WHITE).child(text_input(value))
 ### Cursor Color
 
 ```rust
+text_input(value).cursor_color(Color::rgb(0.4, 0.8, 1.0))
+// or, for every input below one container:
 container().cursor_color(Color::rgb(0.4, 0.8, 1.0)).child(text_input(value))
 ```
 
 ### Selection Color
 
 ```rust
-container().selection_color(Color::rgba(0.4, 0.6, 1.0, 0.4)).child(text_input(value))
+text_input(value).selection_color(Color::rgba(0.4, 0.6, 1.0, 0.4))
 ```
 
 ### Font Size
@@ -124,7 +126,8 @@ text_input(answer).placeholder(move || prompt.get())
 ```
 
 The colour is the inherited text colour at reduced alpha — a placeholder is the
-same text, quieter. Declare `placeholder_color` on a container to override it:
+same text, quieter. Declare `placeholder_color` on the field, or on a
+container to cover every field below it:
 
 ```rust
 container()

--- a/book/src/building-ui/text.md
+++ b/book/src/building-ui/text.md
@@ -8,19 +8,23 @@ The Text widget renders text content with support for reactive updates.
 text("Hello, World!")
 ```
 
-## Where styling lives
+## Styling
 
-Guido has one styling widget. A `text` carries the string and nothing else —
-how it looks is declared on an enclosing container, next to that container's
-background, border and animations:
+A text declares how it looks:
 
 ```rust
-container().font_size(24.0).text_color(theme.text).child(text("Hello"))
+text("Hello").font_size(24.0).color(theme.text).bold()
 ```
 
-Each property is inherited by everything below, until a nearer container
-overrides it. Resolution is per property, so overriding the size leaves a
-colour set further up alone:
+The methods come from the `TextStyled` trait — `color`, `font_size`,
+`font_family`, `font_weight`, `bold`, `mono`, `text_stroke`, `text_shadow` —
+implemented by the two widgets that draw glyphs, `Text` and `TextInput`.
+
+### Dressing a whole subtree
+
+The same properties can be declared on a container instead, where everything
+below inherits them. Resolution is per property, so overriding the size leaves
+a colour set further up alone:
 
 ```rust
 container()
@@ -32,8 +36,35 @@ container()
 ```
 
 Containers that say nothing about text are transparent to this, so layout
-wrappers do not interrupt it. Properties nothing declares fall back to white,
-14 logical pixels, the registered default family and normal weight.
+wrappers do not interrupt it. A declaration on the text itself is the nearest
+one there is, so it wins over every container above it:
+
+```rust
+container().text_color(theme.weak)
+    .child(text("quiet"))
+    .child(text("loud").color(theme.strong))
+```
+
+Properties nothing declares fall back to white, 14 logical pixels, the
+registered default family and normal weight.
+
+### Repeating a style
+
+For "the same kind of label, many times", write a function rather than reaching
+for a wrapper:
+
+```rust
+let label = |s: &str| text(s).color(theme.weak).font_size(12.0);
+
+container()
+    .layout(Flex::row().spacing(8.0))
+    .children([label("one"), label("two"), label("three")])
+```
+
+The style keeps a name, stays next to the widget that draws it, and costs no
+extra node. A container's inherited declaration is the right tool when the
+texts are not yours to write — inside a component you are calling — or when
+there are too many to name.
 
 ## Legibility over an image
 

--- a/docs/STYLING.md
+++ b/docs/STYLING.md
@@ -206,14 +206,28 @@ container()
 
 ## Text Styling
 
-Text carries content; how it looks is declared on the container, alongside
-every other visual property:
+How a text looks can be declared on the text itself:
+
+```rust
+text("Hello").font_size(16.0).color(Color::WHITE).bold()
+```
+
+`color`, `font_size`, `font_family`, `font_weight`, `bold`, `mono`,
+`text_stroke` and `text_shadow` come from the `TextStyled` trait, implemented
+by `Text` and `TextInput` — the two widgets that draw glyphs. A `TextInput`
+also implements `InputStyled` for `cursor_color`, `selection_color` and
+`placeholder_color`, which only it can draw.
+
+### One declaration for a group
+
+The same properties can be declared on a container, where they are inherited
+by everything below it:
 
 ```rust
 container()
     .font_size(16.0)
     .text_color(Color::WHITE)
-    .bold()                          // font weight
+    .bold()
     .child(text("Hello").nowrap())   // nowrap is about wrapping, not looks
 ```
 
@@ -245,8 +259,37 @@ container()
     .child(text_input(value))
 ```
 
+A declaration on the text itself is the nearest one there is, so it wins over
+every container above it — per property, like everything else:
+
+```rust
+container().text_color(theme.weak).font_size(14.0)
+    .child(text("quiet"))
+    .child(text("loud").color(theme.strong))   // own colour, inherited size
+```
+
 Properties nothing declares fall back to white, 14 logical pixels, the
 registered default family and normal weight.
+
+### Repeating a style: write a function
+
+Inheritance is for dressing a subtree you do not otherwise touch. For "the same
+kind of label, many times", the cheaper tool is the one the language already
+gives you:
+
+```rust
+let label = |s: &str| text(s).color(theme.weak).font_size(12.0);
+
+container()
+    .layout(Flex::row().spacing(8.0))
+    .children([label("one"), label("two"), label("three")])
+```
+
+That keeps the declaration next to the widget that draws it, costs no wrapper
+node, and gives the style a name. Reach for a container's inherited
+declaration when the texts are not yours to write — inside a component you are
+calling, say — or when there are enough of them that naming each one is the
+noise.
 
 ### Stroke and shadow
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,10 +177,11 @@ pub mod prelude {
     pub use crate::widget_ref::{WidgetRef, create_widget_ref};
     pub use crate::widgets::{
         AnyWidget, Border, Color, Container, ContentFit, CornerRadii, Event, EventResponse,
-        FontFamily, FontWeight, GradientDirection, Image, ImageSource, IntoChildren, Key,
-        LinearGradient, Modifiers, MouseButton, Overflow, Padding, Rect, ScrollAxis, ScrollSource,
-        ScrollbarBuilder, ScrollbarVisibility, Selection, StateStyle, Text, TextInput, TextShadow,
-        TextStroke, TextStyle, Widget, container, image, keyed, text, text_input,
+        FontFamily, FontWeight, GradientDirection, Image, ImageSource, InputStyle, InputStyled,
+        IntoChildren, Key, LinearGradient, Modifiers, MouseButton, Overflow, Padding, Rect,
+        ScrollAxis, ScrollSource, ScrollbarBuilder, ScrollbarVisibility, Selection, StateStyle,
+        Text, TextInput, TextShadow, TextStroke, TextStyle, TextStyled, Widget, container, image,
+        keyed, text, text_input,
     };
     pub use crate::{
         App, ExitReason, SignalFields, component, default_font_family, load_font, quit_app,

--- a/src/widgets/diagnostic_audit.rs
+++ b/src/widgets/diagnostic_audit.rs
@@ -27,7 +27,7 @@ use crate::renderer::{PaintContext, RenderNode};
 use crate::tree::Tree;
 use crate::widgets::widget::{Event, Key, Modifiers, MouseButton, ScrollSource};
 use crate::widgets::{Color, ImageSource, ScrollAxis};
-use crate::widgets::{Widget, container, image, text, text_input};
+use crate::widgets::{InputStyled, TextStyled, Widget, container, image, text, text_input};
 
 /// Put a widget through the whole `Widget` trait and return how many reads the
 /// library performed with no reactive scope.
@@ -211,6 +211,62 @@ fn a_fully_reactive_text_is_quiet() {
 
     assert_quiet(
         "a fully reactive text",
+        diagnostics_from_full_lifecycle(widget),
+    );
+}
+
+/// The same properties declared on the text itself rather than above it: the
+/// closures have to be read inside the text's own scope too, or a leaf that
+/// styles itself would be quietly unreactive.
+#[test]
+fn a_text_that_styles_itself_is_quiet() {
+    let n = create_signal(0.0f32);
+
+    let widget = container().child(
+        text("ciao")
+            .color(move || {
+                if n.get() > 0.0 {
+                    Color::RED
+                } else {
+                    Color::WHITE
+                }
+            })
+            .font_size(move || n.get() + 12.0),
+    );
+
+    assert_quiet(
+        "a text that declares its own style",
+        diagnostics_from_full_lifecycle(widget),
+    );
+}
+
+/// And the furniture only an input draws, declared on the input.
+#[test]
+fn an_input_that_styles_itself_is_quiet() {
+    let n = create_signal(0.0f32);
+    let value = create_signal(String::new());
+
+    let widget = container().child(
+        text_input(value)
+            .placeholder("prompt")
+            .placeholder_color(move || {
+                if n.get() > 0.0 {
+                    Color::RED
+                } else {
+                    Color::WHITE
+                }
+            })
+            .cursor_color(move || {
+                if n.get() > 0.0 {
+                    Color::RED
+                } else {
+                    Color::WHITE
+                }
+            }),
+    );
+
+    assert_quiet(
+        "an input that declares its own caret and placeholder",
         diagnostics_from_full_lifecycle(widget),
     );
 }

--- a/src/widgets/input_style.rs
+++ b/src/widgets/input_style.rs
@@ -17,7 +17,7 @@
 //!
 //! [`TextStyle`]: crate::widgets::TextStyle
 
-use crate::reactive::Signal;
+use crate::reactive::{IntoSignal, Signal};
 
 use super::widget::Color;
 
@@ -61,5 +61,35 @@ impl InputStyle {
         self.cursor_color.is_some()
             && self.selection_color.is_some()
             && self.placeholder_color.is_some()
+    }
+}
+
+/// The vocabulary for declaring an input's own furniture, written once.
+///
+/// Implemented by [`TextInput`](crate::widgets::TextInput) alone, because it
+/// is the only widget that draws any of it. That is the whole point of the
+/// trait existing separately from
+/// [`TextStyled`](crate::widgets::TextStyled): a placeholder colour has
+/// nowhere to land except on the widget that draws the placeholder.
+pub trait InputStyled: Sized {
+    #[doc(hidden)]
+    fn input_style_mut(&mut self) -> &mut InputStyle;
+
+    /// Colour of the caret.
+    fn cursor_color<M>(mut self, color: impl IntoSignal<Color, M>) -> Self {
+        self.input_style_mut().cursor_color = Some(color.into_signal());
+        self
+    }
+
+    /// Colour of the selection band behind the selected glyphs.
+    fn selection_color<M>(mut self, color: impl IntoSignal<Color, M>) -> Self {
+        self.input_style_mut().selection_color = Some(color.into_signal());
+        self
+    }
+
+    /// Colour of the placeholder.
+    fn placeholder_color<M>(mut self, color: impl IntoSignal<Color, M>) -> Self {
+        self.input_style_mut().placeholder_color = Some(color.into_signal());
+        self
     }
 }

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -20,7 +20,7 @@ pub use children::ChildrenSource;
 pub use container::{Border, Container, GradientDirection, LinearGradient, Overflow, container};
 pub use font::{FontFamily, FontWeight};
 pub use image::{ContentFit, Image, ImageSource, image};
-pub use input_style::InputStyle;
+pub use input_style::{InputStyle, InputStyled};
 pub use into_child::{
     DynamicChildren, IntoChild, IntoChildren, IntoDynChild, KeyedChildren, StaticChildren, keyed,
 };
@@ -28,7 +28,7 @@ pub use scroll::{ScrollAxis, ScrollbarBuilder, ScrollbarConfig, ScrollbarVisibil
 pub use state_layer::{BackgroundOverride, RippleConfig, StateStyle, StateWhen};
 pub use text::{Text, text};
 pub use text_input::{Selection, TextInput, text_input};
-pub use text_style::{TextShadow, TextStroke, TextStyle};
+pub use text_style::{TextShadow, TextStroke, TextStyle, TextStyled};
 pub use widget::{
     AnyWidget, Color, Event, EventResponse, Key, LayoutHints, Modifiers, MouseButton, Padding,
     Rect, ScrollSource, Widget,

--- a/src/widgets/text.rs
+++ b/src/widgets/text.rs
@@ -6,7 +6,7 @@ use crate::renderer::{PaintContext, measure_text_full};
 use crate::tree::{Tree, WidgetId};
 
 use super::font::{FontFamily, FontWeight};
-use super::text_style::{TextShadow, TextStroke};
+use super::text_style::{TextShadow, TextStroke, TextStyle, TextStyled};
 use super::widget::{Color, Rect, Widget};
 
 /// How far a stroke and a shadow reach past the glyphs they decorate.
@@ -23,16 +23,20 @@ pub(crate) fn decoration_overflow(stroke: Option<TextStroke>, shadow: Option<Tex
 
 /// A run of text.
 ///
-/// Content only: colour, size, family and weight are declared on an enclosing
-/// container and inherited from the nearest one that sets them — see
-/// [`TextStyle`](super::TextStyle).
+/// Style may be declared here — [`TextStyled`](super::TextStyled) — or on an
+/// enclosing container, in which case it is inherited from the nearest one
+/// that sets each property. A declaration on the text itself is the nearest
+/// there is, so it wins.
 ///
 /// ```ignore
-/// container().font_size(21.0).text_color(theme.text)
-///     .child(text("Hello"))
+/// text("Hello").font_size(21.0).color(theme.text)
+/// container().font_size(21.0).child(text("Hello"))   // same, for a group
 /// ```
 pub struct Text {
     content: Signal<String>,
+    /// What this text declares about itself. Boxed and absent by default: a
+    /// text that says nothing pays a null check, not a struct.
+    style: Option<Box<TextStyle>>,
     /// If true, text won't wrap and will be clipped by parent container
     nowrap: bool,
     /// Cached values for painting (avoid re-reading signals)
@@ -51,6 +55,7 @@ impl Text {
         let default_family = default_font_family();
         Self {
             content,
+            style: None,
             nowrap: false,
             cached_text: String::new(), // Will be set during first layout
             cached_font_size: 14.0,
@@ -66,6 +71,19 @@ impl Text {
         self
     }
 
+    /// This text's own declaration, completed by the ancestors' for whatever
+    /// it leaves out. The walk is skipped when nothing is left to find.
+    ///
+    /// Called inside the caller's tracking scope, like the walk it wraps: the
+    /// signals come back unread, and reading them is what subscribes.
+    fn resolved_style(&self, tree: &Tree, id: WidgetId) -> TextStyle {
+        let mut style = self.style.as_deref().copied().unwrap_or_default();
+        if !style.is_complete() {
+            style.inherit_from(&tree.inherited_text_style(id));
+        }
+        style
+    }
+
     /// Refresh cached values from the inherited style.
     ///
     /// The signals are read here, inside this widget's tracking scope, so the
@@ -76,13 +94,19 @@ impl Text {
     /// caller records as damage slop.
     fn refresh(&mut self, tree: &Tree, id: WidgetId) -> f32 {
         with_signal_tracking(id, JobType::Layout, || {
-            let style = tree.inherited_text_style(id);
+            let style = self.resolved_style(tree, id);
             self.cached_text = self.content.get();
             self.cached_font_size = style.font_size.get_or(14.0);
             self.cached_font_family = style.font_family.get_or_else(default_font_family);
             self.cached_font_weight = style.font_weight.get_or(FontWeight::NORMAL);
             decoration_overflow(style.stroke.map(|s| s.get()), style.shadow.map(|s| s.get()))
         })
+    }
+}
+
+impl TextStyled for Text {
+    fn text_style_mut(&mut self) -> &mut TextStyle {
+        self.style.get_or_insert_with(Box::default)
     }
 }
 
@@ -166,7 +190,7 @@ impl Widget for Text {
         // Read the painted properties with tracking so a change on whichever
         // ancestor supplied them repaints this text and nothing else.
         let (color, stroke, shadow) = with_signal_tracking(id, JobType::Paint, || {
-            let style = tree.inherited_text_style(id);
+            let style = self.resolved_style(tree, id);
             (
                 style.color.get_or(Color::WHITE),
                 style.stroke.map(|s| s.get()),
@@ -213,6 +237,7 @@ mod tests {
     use crate::reactive::create_signal;
     use crate::renderer::{DrawCommand, RenderNode};
     use crate::widgets::container;
+    use crate::widgets::text_style::TextStyled;
 
     /// Lay out and paint, returning the first text command's colour and size.
     ///
@@ -281,5 +306,38 @@ mod tests {
             "a change to an inherited declaration must re-measure and repaint \
              the text that read it"
         );
+    }
+
+    /// A declaration on the text is the nearest one there is, per property:
+    /// the size below comes from the text, the colour from the container.
+    #[test]
+    fn a_texts_own_declaration_wins_over_its_ancestors() {
+        let mut tree = Tree::new();
+        let root = tree.register(Box::new(
+            container()
+                .font_size(10.0)
+                .text_color(Color::RED)
+                .child(text("hi").font_size(40.0)),
+        ));
+        tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
+
+        assert_eq!(frame(&mut tree, root), (Color::RED, 40.0));
+    }
+
+    /// And it is reactive on the same terms as an inherited one: the signal is
+    /// read where the style is resolved, inside the text's own scope.
+    #[test]
+    fn a_texts_own_declaration_follows_its_signal() {
+        let color = create_signal(Color::RED);
+
+        let mut tree = Tree::new();
+        let root = tree.register(Box::new(
+            container().child(text("hi").color(move || color.get())),
+        ));
+        tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
+
+        assert_eq!(frame(&mut tree, root).0, Color::RED);
+        color.set(Color::BLUE);
+        assert_eq!(frame(&mut tree, root).0, Color::BLUE);
     }
 }

--- a/src/widgets/text_input.rs
+++ b/src/widgets/text_input.rs
@@ -25,6 +25,8 @@ use crate::tree::{Tree, WidgetId};
 use crate::widget_ref::{WidgetRef, register_widget_ref};
 
 use super::font::{FontFamily, FontWeight};
+use super::input_style::{InputStyle, InputStyled};
+use super::text_style::{TextStyle, TextStyled};
 use super::widget::{Color, Event, EventResponse, Key, MouseButton, Rect, Widget};
 
 /// Cursor blink interval in milliseconds
@@ -254,6 +256,10 @@ pub struct TextInput {
     // Callbacks
     on_change: Option<TextCallback>,
     on_submit: Option<TextCallback>,
+    /// What this input declares about its own text, and about the furniture
+    /// only it draws. Boxed and absent by default.
+    text_style: Option<Box<TextStyle>>,
+    input_style: Option<Box<InputStyle>>,
 }
 
 impl TextInput {
@@ -292,7 +298,27 @@ impl TextInput {
             scroll_offset: 0.0,
             on_change: None,
             on_submit: None,
+            text_style: None,
+            input_style: None,
         }
+    }
+
+    /// This input's own declarations, completed by the ancestors' for whatever
+    /// they leave out. Each walk is skipped when nothing is left to find.
+    fn resolved_text_style(&self, tree: &Tree, id: WidgetId) -> TextStyle {
+        let mut style = self.text_style.as_deref().copied().unwrap_or_default();
+        if !style.is_complete() {
+            style.inherit_from(&tree.inherited_text_style(id));
+        }
+        style
+    }
+
+    fn resolved_input_style(&self, tree: &Tree, id: WidgetId) -> InputStyle {
+        let mut style = self.input_style.as_deref().copied().unwrap_or_default();
+        if !style.is_complete() {
+            style.inherit_from(&tree.inherited_input_style(id));
+        }
+        style
     }
 
     /// Enable password mode (masks text with bullet characters)
@@ -470,7 +496,7 @@ impl TextInput {
     fn refresh(&mut self, tree: &Tree, id: WidgetId) -> f32 {
         let (new_value, new_font_size, new_font_family, new_font_weight, overflow) =
             with_signal_tracking(id, JobType::Layout, || {
-                let style = tree.inherited_text_style(id);
+                let style = self.resolved_text_style(tree, id);
                 (
                     self.value.get(),
                     style.font_size.get_or(14.0),
@@ -1012,6 +1038,18 @@ impl TextInput {
     }
 }
 
+impl TextStyled for TextInput {
+    fn text_style_mut(&mut self) -> &mut TextStyle {
+        self.text_style.get_or_insert_with(Box::default)
+    }
+}
+
+impl InputStyled for TextInput {
+    fn input_style_mut(&mut self) -> &mut InputStyle {
+        self.input_style.get_or_insert_with(Box::default)
+    }
+}
+
 impl Widget for TextInput {
     fn advance_animations(&mut self, _tree: &mut Tree, id: WidgetId) -> bool {
         self.update_cursor_blink(id)
@@ -1083,8 +1121,8 @@ impl Widget for TextInput {
         // ancestor supplied them repaints this input and nothing else.
         let (text_color, selection_color, cursor_color, stroke, shadow, placeholder) =
             with_signal_tracking(id, JobType::Paint, || {
-                let style = tree.inherited_text_style(id);
-                let input = tree.inherited_input_style(id);
+                let style = self.resolved_text_style(tree, id);
+                let input = self.resolved_input_style(tree, id);
                 let text_color = style.color.get_or(Color::WHITE);
                 // Only when there is nothing to show instead. Read inside the
                 // tracking scope like every other paint input, so a prompt that

--- a/src/widgets/text_style.rs
+++ b/src/widgets/text_style.rs
@@ -56,7 +56,7 @@
 
 use smallvec::SmallVec;
 
-use crate::reactive::Signal;
+use crate::reactive::{IntoSignal, Signal};
 
 use super::font::{FontFamily, FontWeight};
 use super::widget::Color;
@@ -257,5 +257,72 @@ impl TextStyle {
             && self.font_weight.is_some()
             && self.stroke.is_some()
             && self.shadow.is_some()
+    }
+}
+
+/// The vocabulary for declaring text style, written once.
+///
+/// Implemented by whoever *draws* glyphs — [`Text`](crate::widgets::Text) and
+/// [`TextInput`](crate::widgets::TextInput). A container declares text style
+/// for its descendants through setters of its own, and deliberately does not
+/// implement this trait: it draws a box, and the rule that keeps properties
+/// where they belong is that a widget declares what it draws.
+///
+/// A declaration here is the nearest one there is, so it wins over every
+/// ancestor:
+///
+/// ```ignore
+/// container().text_color(theme.weak)
+///     .child(text("quiet"))
+///     .child(text("loud").color(theme.strong))
+/// ```
+pub trait TextStyled: Sized {
+    #[doc(hidden)]
+    fn text_style_mut(&mut self) -> &mut TextStyle;
+
+    /// Colour of the glyphs.
+    fn color<M>(mut self, color: impl IntoSignal<Color, M>) -> Self {
+        self.text_style_mut().color = Some(color.into_signal());
+        self
+    }
+
+    /// Font size in logical pixels.
+    fn font_size<M>(mut self, size: impl IntoSignal<f32, M>) -> Self {
+        self.text_style_mut().font_size = Some(size.into_signal());
+        self
+    }
+
+    /// Font family.
+    fn font_family<M>(mut self, family: impl IntoSignal<FontFamily, M>) -> Self {
+        self.text_style_mut().font_family = Some(family.into_signal());
+        self
+    }
+
+    /// Font weight on the CSS 100-900 scale.
+    fn font_weight<M>(mut self, weight: impl IntoSignal<FontWeight, M>) -> Self {
+        self.text_style_mut().font_weight = Some(weight.into_signal());
+        self
+    }
+
+    /// Shorthand for [`font_weight`](Self::font_weight) at `FontWeight::BOLD`.
+    fn bold(self) -> Self {
+        self.font_weight(FontWeight::BOLD)
+    }
+
+    /// Shorthand for [`font_family`](Self::font_family) at the monospace family.
+    fn mono(self) -> Self {
+        self.font_family(FontFamily::Monospace)
+    }
+
+    /// Contour drawn around the glyphs, under the fill.
+    fn text_stroke<M>(mut self, stroke: impl IntoSignal<TextStroke, M>) -> Self {
+        self.text_style_mut().stroke = Some(stroke.into_signal());
+        self
+    }
+
+    /// Soft shadow cast by the glyphs.
+    fn text_shadow<M>(mut self, shadow: impl IntoSignal<TextShadow, M>) -> Self {
+        self.text_style_mut().shadow = Some(shadow.into_signal());
+        self
     }
 }

--- a/tests/placeholder.rs
+++ b/tests/placeholder.rs
@@ -131,6 +131,25 @@ fn a_container_can_declare_the_placeholder_colour() {
     assert_eq!(texts[0].1, declared);
 }
 
+/// The field draws the placeholder, so the field can say what colour it is —
+/// and being the nearest declaration, it wins over the container's.
+#[test]
+fn a_field_can_declare_its_own_placeholder_colour() {
+    let own = Color::rgba(0.0, 1.0, 0.0, 1.0);
+    let texts = drawn(
+        container()
+            .text_color(Color::rgba(1.0, 1.0, 1.0, 1.0))
+            .placeholder_color(Color::rgba(1.0, 0.0, 0.0, 1.0))
+            .child(
+                text_input(create_signal(String::new()))
+                    .placeholder("Password")
+                    .placeholder_color(own),
+            ),
+    );
+
+    assert_eq!(texts[0].1, own);
+}
+
 #[test]
 fn an_empty_field_without_a_placeholder_draws_no_text_at_all() {
     let texts = drawn(text_input(create_signal(String::new())));


### PR DESCRIPTION
Style has only been declarable on a container, with the leaf resolving it by
walking up. That is the right tool for dressing a subtree and the wrong one for
a single label: it costs a wrapper node, puts the declaration somewhere other
than the widget that draws it, and — the reason this matters — it is what
forced `placeholder_color` onto the container, a property no container can
draw.

```rust
text("Hello").font_size(24.0).color(theme.text).bold()
text_input(value).placeholder("Search").placeholder_color(theme.weak)
```

`TextStyled` writes the vocabulary once as default methods — `color`,
`font_size`, `font_family`, `font_weight`, `bold`, `mono`, `text_stroke`,
`text_shadow` — implemented by `Text` and `TextInput`. `InputStyled` does the
same for `cursor_color`, `selection_color` and `placeholder_color`, implemented
by `TextInput` alone.

Resolution gains one step in front of the existing walk: the widget's own
declaration, then the ancestors', per property as before. A leaf that declares
everything skips the walk entirely — `is_complete` was already there to end it
early, and now it can end it before it starts.

## Additive

Nothing at the call site changes. `Container` deliberately does not implement
either trait, and its existing setters are untouched — `src/`, `examples/` and
`book/` compile as they were. Where those setters belong is the next question;
this PR does not answer it.

## Tests

- A text's own declaration wins over its ancestors', per property.
- It is reactive on the same terms: the signal is read where the style is
  resolved, inside the leaf's own scope.
- A field declaring its own placeholder colour outranks the container's.
- Two new cases in the reactive diagnostic audit — a text that styles itself
  and an input that declares its own caret and placeholder — so a
  self-declared closure that failed to subscribe would be caught by the same
  net that guards the inherited path.

Full suite green, render snapshots unchanged, clippy clean, book builds.