### PR TITLE
A widget written elsewhere can own its own reads

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -367,6 +367,23 @@ pub trait Widget {
 
 **Note:** Widget bounds and origins are stored in the `Tree`, not on individual widgets. Use `tree.get_bounds(id)` to retrieve a widget's bounds and `tree.set_origin(id, x, y)` to position widgets during layout.
 
+### Widgets written outside the crate
+
+The trait is implementable from anywhere, and a leaf needs only `layout` and
+`paint`. What it also needs is `with_signal_tracking(id, JobType::Layout, ..)`
+around whatever it measures from, and the same with `JobType::Paint` around
+whatever it draws from — both exported from the prelude for this reason.
+
+Scopes nest and the innermost wins, so a widget that opens its own claims its
+reads back from its parent. One that does not is not unreactive: its reads
+register against the nearest ancestor that opened a scope, usually the enclosing
+container, so a change to its own content marks *that* for layout and every
+sibling is re-laid-out with it. Reactive, but imprecise, and silently so.
+
+`tests/external_widget.rs` is a leaf written against the public API only, and
+`the_innermost_scope_owns_the_read` in `reactive/invalidation.rs` pins the
+ownership rule.
+
 ## Event Flow
 
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,6 +163,9 @@ pub mod prelude {
         create_stored, create_trigger, expect_context, has_context, on_cleanup, provide_context,
         provide_signal_context, set_cursor, use_context, with_context,
     };
+    // For widgets written outside the crate: the scope that makes a widget's
+    // own signal reads its own.
+    pub use crate::reactive::{JobType, with_signal_tracking};
     pub use crate::renderer::{PaintContext, Shadow, measure_text};
     pub use crate::session_lock::{
         LockState, lock_session, lock_state, session_locked, unlock_session,

--- a/src/reactive/invalidation.rs
+++ b/src/reactive/invalidation.rs
@@ -44,7 +44,27 @@ thread_local! {
 }
 
 /// Run a closure while tracking signal reads for a widget.
-/// Any signals read during this closure will register the widget as a subscriber.
+///
+/// Any signal read inside registers `widget_id` as a subscriber for
+/// `job_type`, so a later write to it queues exactly that job for exactly this
+/// widget. A widget implementing [`Widget`](crate::widgets::Widget) opens one
+/// around each of its own phases: `JobType::Layout` around what it measures
+/// from, `JobType::Paint` around what it draws from.
+///
+/// Scopes nest, and the innermost wins, so a widget that opens its own is
+/// claiming its reads back from its parent. One that does not is not
+/// unreactive — its reads land on whichever ancestor opened the enclosing
+/// scope — but it is *imprecise*: a change to its content marks the parent
+/// container for layout, which re-lays-out every sibling as well.
+///
+/// ```ignore
+/// fn layout(&mut self, tree: &mut Tree, id: WidgetId, c: Constraints) -> Size {
+///     with_signal_tracking(id, JobType::Layout, || {
+///         let text = self.content.get();   // subscribes this widget, not its parent
+///         measure(&text, c)
+///     })
+/// }
+/// ```
 pub fn with_signal_tracking<F, R>(widget_id: WidgetId, job_type: JobType, f: F) -> R
 where
     F: FnOnce() -> R,
@@ -359,6 +379,38 @@ mod tests {
 
     fn signal_id(n: u32) -> SignalId {
         SignalId::new(n, 0)
+    }
+
+    /// Which widget a read belongs to is decided by the innermost scope, and
+    /// a widget that opens none inherits its parent's — the whole reason
+    /// `with_signal_tracking` is public. A leaf that skips it is not
+    /// unreactive; it is imprecise, because its parent is what gets marked.
+    #[test]
+    fn the_innermost_scope_owns_the_read() {
+        let parent = widget_id(300);
+        let leaf = widget_id(301);
+
+        with_signal_tracking(parent, JobType::Layout, || {
+            // A leaf that opens its own scope claims the read back.
+            with_signal_tracking(leaf, JobType::Layout, || {
+                record_signal_read(signal_id(70));
+            });
+            // One that does not leaves it with the parent.
+            record_signal_read(signal_id(71));
+        });
+
+        let subscribers = |sig: u32| {
+            REGISTRY.with(|reg| {
+                let reg = reg.borrow();
+                reg.signal_to_widgets
+                    .get(sig as usize)
+                    .map(|s| s.iter().map(|e| e.widget_id).collect::<Vec<_>>())
+                    .unwrap_or_default()
+            })
+        };
+
+        assert_eq!(subscribers(70), vec![leaf]);
+        assert_eq!(subscribers(71), vec![parent]);
     }
 
     #[test]

--- a/src/reactive/mod.rs
+++ b/src/reactive/mod.rs
@@ -38,7 +38,13 @@ pub use into_signal::{
     ClosureMarker, LossyMarker, MemoMarker, RwSignalMarker, SignalMarker, ValueMarker,
 };
 pub use into_signal::{IntoSignal, IntoVal};
-pub(crate) use invalidation::with_signal_tracking;
+// The scope a widget opens around its own signal reads. Public because a
+// widget written outside the crate needs it: without one, its reads attribute
+// to the nearest ancestor that opened a scope — its parent container — so a
+// change to its content re-lays-out every one of its siblings. Reactive, but
+// imprecise, and silently so.
+pub use crate::jobs::JobType;
+pub use invalidation::with_signal_tracking;
 pub use memo::{Memo, create_memo};
 // with_owner and OwnerId are internal and automatically used by the
 // dynamic children system; the public dispose_owner is deferred (safe to

--- a/tests/external_widget.rs
+++ b/tests/external_widget.rs
@@ -1,0 +1,96 @@
+//! A leaf written from outside the crate, against the public API only.
+//!
+//! Two things have to hold for a third-party widget to be a first-class one:
+//! it has to compile without reaching into the crate, and its signal reads
+//! have to belong to *it*. The second is the reason `with_signal_tracking` and
+//! `JobType` are exported — without them a leaf still updates, but its reads
+//! register against the nearest ancestor that opened a scope, so a change to
+//! its own content re-lays-out every sibling it has.
+//!
+//! This file covers the first: everything below uses `guido::prelude` and the
+//! public `tree`, `layout` and `renderer` modules, nothing else.
+
+use guido::layout::{Constraints, Size};
+use guido::prelude::*;
+use guido::renderer::RenderNode;
+use guido::tree::{Tree, WidgetId};
+
+/// A box whose size follows a signal. Deliberately minimal: `layout` and
+/// `paint` are the only required methods, and the tracking scope is the only
+/// thing it needs from the reactive system.
+struct Bar {
+    extent: Signal<f32>,
+    measured: f32,
+}
+
+impl Widget for Bar {
+    fn layout(&mut self, tree: &mut Tree, id: WidgetId, constraints: Constraints) -> Size {
+        let extent = with_signal_tracking(id, JobType::Layout, || self.extent.get());
+        self.measured = extent;
+        let size = Size::new(extent, extent);
+        tree.cache_layout(id, constraints, size);
+        tree.clear_needs_layout(id);
+        size
+    }
+
+    fn paint(&self, _tree: &Tree, _id: WidgetId, ctx: &mut PaintContext) {
+        ctx.draw_rounded_rect(
+            Rect::new(0.0, 0.0, self.measured, self.measured),
+            Color::RED,
+            0.0,
+        );
+    }
+}
+
+fn lay_out(widget: impl Widget + 'static) -> (Tree, WidgetId, Size) {
+    let mut tree = Tree::new();
+    let root = tree.register(Box::new(widget));
+    tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
+    let size = tree
+        .with_widget_mut(root, |w, id, t| {
+            w.layout(t, id, Constraints::new(0.0, 0.0, 400.0, 400.0))
+        })
+        .expect("root is registered");
+    (tree, root, size)
+}
+
+#[test]
+fn a_widget_from_outside_the_crate_lays_out_and_paints() {
+    let extent = create_signal(20.0f32);
+    let (mut tree, root, size) = lay_out(Bar {
+        extent: extent.into(),
+        measured: 0.0,
+    });
+
+    assert_eq!(size, Size::new(20.0, 20.0));
+
+    let mut node = RenderNode::new(root.as_u64());
+    tree.with_widget_mut(root, |w, id, t| {
+        let mut ctx = PaintContext::new(&mut node);
+        w.paint(t, id, &mut ctx);
+    });
+    assert!(!node.commands.is_empty(), "the widget drew nothing");
+}
+
+/// The value follows the signal on a later layout, which is the half of
+/// reactivity this test can see from outside: driving the job queue that turns
+/// a write into `needs_layout` is crate-internal, so *which widget* gets
+/// marked is asserted where that is reachable —
+/// `reactive::invalidation::the_innermost_scope_owns_the_read`.
+#[test]
+fn it_re_measures_from_the_signal_it_read() {
+    let extent = create_signal(20.0f32);
+    let (mut tree, root, _) = lay_out(Bar {
+        extent: extent.into(),
+        measured: 0.0,
+    });
+
+    extent.set(40.0);
+    let size = tree
+        .with_widget_mut(root, |w, id, t| {
+            w.layout(t, id, Constraints::new(0.0, 0.0, 400.0, 400.0))
+        })
+        .expect("root is registered");
+
+    assert_eq!(size, Size::new(40.0, 40.0));
+}


### PR DESCRIPTION
`with_signal_tracking` was `pub(crate)`, so a `Widget` implemented outside the
crate had no way to open a tracking scope for its own signal reads.

It still worked, which is the problem. Scopes nest and the innermost wins, so a
leaf that opens none has its reads registered against the nearest ancestor that
did — normally the enclosing container. A change to the leaf's own content then
marks *that* for layout, and every sibling is re-laid-out with it. Reactive,
imprecise, and nothing anywhere says so.

`with_signal_tracking` and `JobType` are now public and in the prelude, with
the nesting rule documented on the function itself and in
`docs/ARCHITECTURE.md`.

## Tests

- `tests/external_widget.rs`: a leaf built against `guido::prelude` and the
  public `tree`/`layout`/`renderer` modules and nothing else — so reachability
  stays proven rather than assumed. It lays out, paints, and re-measures from
  its signal.
- `the_innermost_scope_owns_the_read` in `reactive/invalidation.rs` pins the
  rule directly: a read inside a nested scope belongs to the inner widget, one
  without belongs to the enclosing one. Driving the job queue is
  crate-internal, so that assertion lives here rather than in the integration
  test.

Full suite green, clippy clean.