### PR TITLE
A widget can ask what its control is doing

### DIFF
--- a/book/src/interactivity/states.md
+++ b/book/src/interactivity/states.md
@@ -156,6 +156,50 @@ container()
     .child(text("Wrong password"))
 ```
 
+## Whose Hover?
+
+A label inside a button has to light up while the pointer is on the button's
+*padding*, nowhere near the glyphs. And it has to stay dark while the pointer
+is over a different button in the same row. So neither "my own bounds" nor "any
+ancestor" is the answer.
+
+The answer is the nearest enclosing **control** — the interaction unit the
+widget belongs to:
+
+```rust
+container()
+    .padding(12.0)
+    .on_click(save)
+    .child(text("Save").color(theme.weak).when_hovered(|s| s.color(theme.strong)))
+```
+
+`on_click` makes that container a control, because anything the pointer can act
+on is a unit by necessity. So do `on_hover`, `on_scroll`, `scrollable` and any
+declared state layer. Write `control()` yourself where the boundary is real but
+nothing else announces it:
+
+```rust
+container().control()
+    .child(text("Password").when_focused(|s| s.color(theme.accent)))
+    .child(text_input(password))
+```
+
+That is the case the old rule could not express at all: the focus is in a
+*sibling*, not below the label. Both belong to the same unit, so the label can
+ask about it.
+
+Leaves get `when_hovered`, `when_pressed`, `when_focused` and `state` from the
+`Stateful` trait, and the closure hands back the same builder the widget itself
+uses.
+
+**Nesting scopes resolution, not state.** A list row stays hovered while the
+pointer is over a button nested in it — the pointer is plainly still on the
+row. What the nested control changes is only who a descendant asks.
+
+**With nothing marked above it**, a widget is its own unit and notices the
+pointer over its own bounds. It is never pressed: being pressed means being
+activated, and it has nothing to activate.
+
 ## Which Layer Wins
 
 Layers are resolved in reverse declaration order, one property at a time: the

--- a/docs/REFACTORING.md
+++ b/docs/REFACTORING.md
@@ -18,7 +18,7 @@ and why, and the one design still open.
 | `distribute_jobs` root resolution, damage as a `HashMap` | **Closed** — see below |
 | Three tracking scopes in one paint | **Closed** — see below |
 | Container as a style source | Open — direction settled, not scheduled |
-| **Interaction groups** | **Open — designed, one decision left** |
+| Interaction groups | **Done** (#188), as `control()` |
 
 ---
 
@@ -89,11 +89,14 @@ widget that draws it: see `docs/STYLING.md`.
 
 ---
 
-## Open: interaction groups
+## Shipped: interaction controls
 
 Everything above concerns style. Putting *states* on leaves —
-`text("x").when_hovered(..)` — raises a question style does not, and this is the
-design that answers it. One decision is left: the name.
+`text("x").when_hovered(..)` — raised a question style does not. This is the
+design that answers it, shipped in #188 under the name `control()`: it says
+what the thing *is* rather than what it does, and it is the word accessibility
+uses for the same boundary, which is likely where the role, label and Tab order
+will eventually attach.
 
 ### The question
 
@@ -205,14 +208,21 @@ The third row needed no mechanism, which is why it shipped ahead of the rest.
 - **Precedence is already last-declared-wins** (#183), which is what this
   design needs.
 
+### Settled while building it
+
+- **No enclosing unit**: the widget becomes its own, and notices the pointer
+  over its own bounds — silent declarations are the failure mode this design
+  exists to avoid. It is never *pressed*, though, because being pressed means
+  being activated and it has nothing to activate.
+- **A leaf's state style** is the same partial style it is built with, since
+  `TextStyle` implements `TextStyled`. One vocabulary, three places.
+
 ### Still open
 
-- **The name.** `group()`, `interaction_scope()`, `control()`. To be settled
-  against real call sites, since it will be written everywhere.
-- **No enclosing unit.** A `when_hovered` with nothing above it: silent no-op,
-  or does the widget become its own unit? Probably the latter — silent
-  declarations are the failure mode this design exists to avoid — with the
-  existing reactive diagnostics as the place to warn.
+- **`hover_state`/`pressed_state`/`focused_state` on `Container`** should
+  become `when_hovered`/`when_pressed`/`when_focused` to match the leaves. A
+  mechanical rename across ~290 call sites, deliberately kept out of #188 so
+  the mechanism could be reviewed on its own.
 - **`focus_visible`.** Needed: where an input holds focus essentially always, a
   permanent focus ring is noise. Separate question — it is about how the focus
   arrived, not about who resolves it.

--- a/docs/STATE_LAYER.md
+++ b/docs/STATE_LAYER.md
@@ -54,6 +54,55 @@ container()
 
 The same signal can be read anywhere else that needs it, independently. That is why there is one generic `state` rather than a named method per case.
 
+## Interaction Units
+
+When a text declares a hover style, hover *of what*? Not its own glyphs — a
+button's label has to light up while the pointer is on the button's padding.
+Not any ancestor either — a label inside one button must stay dark while the
+pointer is over a sibling button in the same row.
+
+The unit that holds the state is the nearest enclosing **control**:
+
+```rust
+container().control()
+    .child(text("Password").when_focused(|s| s.color(theme.accent)))
+    .child(text_input(password))
+```
+
+Everything inside asks the same question — *is my control in this state?* —
+whatever the state is. Direction stops being part of the mechanism and becomes
+only how the control notices: the pointer is inside its bounds, the focus is
+inside its subtree. Which is what makes the case above work at all — the focus
+is in a *sibling*, and both belong to the same unit.
+
+`control()` is rarely written by hand. Anything the pointer can act on is a
+unit by necessity, so `on_click`, `on_hover`, `on_scroll`, `scrollable` and a
+declared state layer all imply it. Write it where the boundary is real but
+nothing else announces it — a field's label and input, a row whose highlight
+belongs to the row.
+
+Leaves declare states with `when_hovered`, `when_pressed`, `when_focused` and
+`state`, from the `Stateful` trait. The closure receives the same partial style
+the widget itself is built with, because an override *is* another partial
+style:
+
+```rust
+text("Save").color(theme.weak).when_hovered(|s| s.color(theme.strong))
+```
+
+### Nesting scopes resolution, not state
+
+Every control notices its own state independently: a list row is hovered
+because the pointer is inside the row, even when the pointer is over a button
+nested in it. What the nested control changes is only *who a descendant asks* —
+the label inside the button asks the button, not the row.
+
+### With no control above
+
+The widget is its own unit and notices the pointer over its own bounds. It is
+never *pressed*, though: being pressed means being activated, and a widget that
+is its own unit has nothing to activate.
+
 ## Precedence: last declared wins
 
 Layers are resolved in reverse declaration order, per property. Writing the error after the focus is what makes an error outrank a focus ring on a field that holds the focus essentially always:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,12 +179,12 @@ pub mod prelude {
     pub use crate::transform_origin::{HorizontalAnchor, TransformOrigin, VerticalAnchor};
     pub use crate::widget_ref::{WidgetRef, create_widget_ref};
     pub use crate::widgets::{
-        AnyWidget, Border, Color, Container, ContentFit, CornerRadii, Event, EventResponse,
-        FontFamily, FontWeight, GradientDirection, Image, ImageSource, InputStyle, InputStyled,
-        IntoChildren, Key, LinearGradient, Modifiers, MouseButton, Overflow, Padding, Rect,
-        ScrollAxis, ScrollSource, ScrollbarBuilder, ScrollbarVisibility, Selection, StateStyle,
-        Text, TextInput, TextShadow, TextStroke, TextStyle, TextStyled, Widget, container, image,
-        keyed, text, text_input,
+        AnyWidget, Border, Color, Container, ContentFit, Control, CornerRadii, Event,
+        EventResponse, FontFamily, FontWeight, GradientDirection, Image, ImageSource, InputStyle,
+        InputStyled, IntoChildren, Key, LinearGradient, Modifiers, MouseButton, Overflow, Padding,
+        Rect, ScrollAxis, ScrollSource, ScrollbarBuilder, ScrollbarVisibility, Selection,
+        StateStyle, Stateful, Text, TextInput, TextShadow, TextStroke, TextStyle, TextStyled,
+        Widget, container, image, keyed, text, text_input,
     };
     pub use crate::{
         App, ExitReason, SignalFields, component, default_font_family, load_font, quit_app,

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -130,6 +130,9 @@ struct Slot {
     /// the same reason as `text_style`, and separate from it because only an
     /// input can draw what it holds.
     input_style: Option<Box<crate::widgets::InputStyle>>,
+    /// The interaction unit this node declares, if it is one. Descendants walk
+    /// up to the nearest, and resolve hover, press and focus from it.
+    control: Option<crate::widgets::Control>,
     /// Distance from this widget's top edge to the baseline of its first line
     /// of text, if it has one. Reported by leaves during layout and read by a
     /// parent aligning on `CrossAlignment::Baseline`.
@@ -213,6 +216,7 @@ impl Tree {
             cached_paint: None,
             text_style: None,
             input_style: None,
+            control: None,
             baseline: None,
             paint_overflow: 0.0,
         });
@@ -430,6 +434,34 @@ impl Tree {
         }
 
         resolved
+    }
+
+    /// Record that this node is an interaction unit.
+    ///
+    /// Containers call this as they enter the tree, exactly like the style
+    /// declarations beside it.
+    pub(crate) fn set_control(&mut self, id: WidgetId, control: Option<crate::widgets::Control>) {
+        if let Some(idx) = self.get_dense_index(id) {
+            self.dense[idx].control = control;
+        }
+    }
+
+    /// The interaction unit a widget belongs to: itself if it is one,
+    /// otherwise the nearest ancestor that is.
+    ///
+    /// Returns a handle holding signals, not values, on the same contract as
+    /// the style walks: reading them is what subscribes, so the caller must do
+    /// it inside its own tracking scope.
+    pub fn nearest_control(&self, id: WidgetId) -> Option<crate::widgets::Control> {
+        let mut cursor = Some(id);
+        while let Some(node) = cursor {
+            let idx = self.get_dense_index(node)?;
+            if let Some(control) = self.dense[idx].control {
+                return Some(control);
+            }
+            cursor = self.dense[idx].parent;
+        }
+        None
     }
 
     /// Declare how far this widget paints outside its own bounds.

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -36,6 +36,7 @@ use crate::tree::{Tree, WidgetId};
 use crate::widget_ref::{WidgetRef, register_widget_ref};
 
 use super::children::ChildrenSource;
+use super::control::Control;
 use super::font::{FontFamily, FontWeight};
 use super::input_style::InputStyle;
 use super::into_child::{IntoChild, IntoChildren};
@@ -160,7 +161,7 @@ pub(super) struct ContainerAnims {
 bitflags::bitflags! {
     /// What the pointer is doing to this container.
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-    pub(super) struct InteractionFlags: u8 {
+    pub(crate) struct InteractionFlags: u8 {
         const HOVERED = 1;
         const PRESSED = 2;
     }
@@ -352,6 +353,10 @@ pub struct Container {
     /// `text` because a text cannot draw any of it.
     pub(super) input: Option<Box<InputStyle>>,
 
+    /// Declared with `control()`. A container is an interaction unit for other
+    /// reasons too — see `is_control` — so this is only the explicit half.
+    pub(super) declared_control: bool,
+
     // Owns the derived published in place of the text colour when a state
     // layer declares one. Created at registration, so it belongs to no user
     // scope and has to be torn down by hand when the container goes.
@@ -406,6 +411,7 @@ impl Container {
             backdrop_blur: None,
             text: None,
             input: None,
+            declared_control: false,
             text_owner: None,
             animated_text: None,
             text_base: None,
@@ -1093,6 +1099,56 @@ impl Container {
         self
     }
 
+    /// Declare this container an interaction unit.
+    ///
+    /// Everything inside resolves hover, press and focus from here, until a
+    /// nested `control` takes over. That is what lets a button's label light
+    /// up while the pointer is on the button's padding, and what lets a label
+    /// react to the focus of the input beside it.
+    ///
+    /// Rarely written by hand: anything the pointer can act on is a unit by
+    /// necessity, so `on_click`, `on_hover`, `on_scroll`, `scrollable` and a
+    /// declared state layer all imply it. Write it where the boundary is real
+    /// but nothing else announces it — a form field's label and input, a row
+    /// whose highlight belongs to the row.
+    ///
+    /// # Example
+    /// ```ignore
+    /// container().control()
+    ///     .child(text("Password").when_focused(|s| s.color(theme.accent)))
+    ///     .child(text_input(password))
+    /// ```
+    pub fn control(mut self) -> Self {
+        self.declared_control = true;
+        // The flags a descendant subscribes to live here, so they have to
+        // exist even for a unit that declares no state of its own.
+        self.interact_mut();
+        self
+    }
+
+    /// Whether this container is an interaction unit.
+    ///
+    /// A pointer target *is* one — it has to know whether it is being pointed
+    /// at — so every behaviour implies it rather than merely allowing it. So
+    /// does declaring a state layer, which is what keeps every container
+    /// resolving its own states exactly as it did before controls existed.
+    pub(super) fn is_control(&self) -> bool {
+        if self.declared_control || self.scroll_axis != ScrollAxis::None {
+            return true;
+        }
+        self.interaction.as_ref().is_some_and(|ix| {
+            ix.has_any_state()
+                || ix.on_click.is_some()
+                || ix.on_right_click.is_some()
+                || ix.on_middle_click.is_some()
+                || ix.on_hover.is_some()
+                || ix.on_scroll.is_some()
+                || ix.on_pointer_move.is_some()
+                || ix.on_mouse_down.is_some()
+                || ix.on_mouse_up.is_some()
+        })
+    }
+
     fn push_state<F>(&mut self, when: StateWhen, f: F)
     where
         F: FnOnce(StateStyle) -> StateStyle,
@@ -1291,6 +1347,16 @@ impl Widget for Container {
         let published = self.published_text_style(tree, id);
         tree.set_text_style(id, published);
         tree.set_input_style(id, self.input.as_deref().copied());
+        tree.set_control(
+            id,
+            self.is_control()
+                .then(|| {
+                    self.interaction
+                        .as_ref()
+                        .map(|ix| Control::new(id, ix.flags))
+                })
+                .flatten(),
+        );
 
         // Register pending children
         self.children_source.register_pending(tree, id);

--- a/src/widgets/control.rs
+++ b/src/widgets/control.rs
@@ -1,0 +1,75 @@
+//! The interaction unit a widget resolves its states from.
+//!
+//! When a text declares a hover style, hover *of what*? Not its own glyphs — a
+//! button's label has to light up while the pointer is on the button's
+//! padding, nowhere near them. Not any ancestor either — a label inside one
+//! button must stay dark while the pointer is over a sibling button in the
+//! same highlighted row.
+//!
+//! The answer is a boundary that is written down. A container marked
+//! [`control`](crate::widgets::Container::control) is one interaction unit;
+//! everything inside it resolves hover, press and focus from that unit, until
+//! a nested one takes over. Every widget then asks the same question — *is my
+//! control in this state?* — whatever the state is.
+//!
+//! Direction stops being a property of the mechanism and becomes only how a
+//! control notices:
+//!
+//! - **hover, press** — the pointer is inside my bounds
+//! - **focus** — the focus is inside my subtree
+//!
+//! Which is what makes the case that had no answer work: a label reacting to
+//! the focus of a *sibling* input, the floating label of every form. The two
+//! are in the same control, so the focus is the control's, and the label can
+//! ask about it.
+//!
+//! # Nesting scopes resolution, not state
+//!
+//! Every control notices its own state independently: a list row is hovered
+//! because the pointer is inside the row, full stop, even when the pointer is
+//! over a button nested in it. What the nested control changes is only *who a
+//! descendant asks* — the label inside the button asks the button, not the
+//! row. The other reading, where a nested control blocks the outer one, would
+//! switch the row's highlight off while the pointer is plainly still on it.
+
+use crate::reactive::focus::focus_path;
+use crate::reactive::signal::RwSignal;
+use crate::tree::WidgetId;
+
+use super::container::InteractionFlags;
+
+/// A handle on the interaction unit a widget belongs to.
+///
+/// Reading any of these subscribes the caller, which is the point: a leaf that
+/// asks whether its control is hovered is thereby repainted when it changes.
+#[derive(Clone, Copy)]
+pub struct Control {
+    id: WidgetId,
+    flags: RwSignal<InteractionFlags>,
+}
+
+impl Control {
+    pub(crate) fn new(id: WidgetId, flags: RwSignal<InteractionFlags>) -> Self {
+        Self { id, flags }
+    }
+
+    /// The container that declared the boundary.
+    pub fn widget(&self) -> WidgetId {
+        self.id
+    }
+
+    /// Whether the pointer is inside the control.
+    pub fn is_hovered(&self) -> bool {
+        self.flags.get().contains(InteractionFlags::HOVERED)
+    }
+
+    /// Whether the pointer is down on the control.
+    pub fn is_pressed(&self) -> bool {
+        self.flags.get().contains(InteractionFlags::PRESSED)
+    }
+
+    /// Whether the keyboard focus is inside the control's subtree.
+    pub fn has_focus(&self) -> bool {
+        focus_path().contains(self.id)
+    }
+}

--- a/src/widgets/diagnostic_audit.rs
+++ b/src/widgets/diagnostic_audit.rs
@@ -27,7 +27,9 @@ use crate::renderer::{PaintContext, RenderNode};
 use crate::tree::Tree;
 use crate::widgets::widget::{Event, Key, Modifiers, MouseButton, ScrollSource};
 use crate::widgets::{Color, ImageSource, ScrollAxis};
-use crate::widgets::{InputStyled, TextStyled, Widget, container, image, text, text_input};
+use crate::widgets::{
+    InputStyled, Stateful, TextStyled, Widget, container, image, text, text_input,
+};
 
 /// Put a widget through the whole `Widget` trait and return how many reads the
 /// library performed with no reactive scope.
@@ -267,6 +269,43 @@ fn an_input_that_styles_itself_is_quiet() {
 
     assert_quiet(
         "an input that declares its own caret and placeholder",
+        diagnostics_from_full_lifecycle(widget),
+    );
+}
+
+/// State overrides on a leaf: the control's flags, the focus path and an
+/// app-owned condition are all signal reads, and all three have to happen
+/// inside the leaf's own scope.
+#[test]
+fn a_text_with_state_overrides_is_quiet() {
+    let wrong = create_signal(false);
+
+    let widget = container().control().on_click(|| {}).child(
+        text("ciao")
+            .color(Color::WHITE)
+            .when_hovered(|s| s.color(Color::RED))
+            .when_focused(|s| s.color(Color::GREEN))
+            .state(wrong, |s| s.color(Color::BLUE)),
+    );
+
+    assert_quiet(
+        "a text with state overrides",
+        diagnostics_from_full_lifecycle(widget),
+    );
+}
+
+/// The same with nothing marked above it, which takes the other branch: the
+/// text is its own unit and reads its own hover instead of a control's.
+#[test]
+fn a_text_that_is_its_own_unit_is_quiet() {
+    let widget = container().child(
+        text("ciao")
+            .color(Color::WHITE)
+            .when_hovered(|s| s.color(Color::RED)),
+    );
+
+    assert_quiet(
+        "a text with no control above it",
         diagnostics_from_full_lifecycle(widget),
     );
 }

--- a/src/widgets/input_style.rs
+++ b/src/widgets/input_style.rs
@@ -93,3 +93,11 @@ pub trait InputStyled: Sized {
         self
     }
 }
+
+/// As for [`TextStyle`](crate::widgets::TextStyle): a partial style is
+/// something to declare on.
+impl InputStyled for InputStyle {
+    fn input_style_mut(&mut self) -> &mut InputStyle {
+        self
+    }
+}

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -1,5 +1,6 @@
 pub mod children;
 pub mod container;
+pub mod control;
 pub mod font;
 pub mod image;
 pub mod input_style;
@@ -18,6 +19,7 @@ pub mod widget;
 pub use crate::renderer::CornerRadii;
 pub use children::ChildrenSource;
 pub use container::{Border, Container, GradientDirection, LinearGradient, Overflow, container};
+pub use control::Control;
 pub use font::{FontFamily, FontWeight};
 pub use image::{ContentFit, Image, ImageSource, image};
 pub use input_style::{InputStyle, InputStyled};
@@ -25,7 +27,7 @@ pub use into_child::{
     DynamicChildren, IntoChild, IntoChildren, IntoDynChild, KeyedChildren, StaticChildren, keyed,
 };
 pub use scroll::{ScrollAxis, ScrollbarBuilder, ScrollbarConfig, ScrollbarVisibility};
-pub use state_layer::{BackgroundOverride, RippleConfig, StateStyle, StateWhen};
+pub use state_layer::{BackgroundOverride, RippleConfig, StateStyle, StateWhen, Stateful};
 pub use text::{Text, text};
 pub use text_input::{Selection, TextInput, text_input};
 pub use text_style::{TextShadow, TextStroke, TextStyle, TextStyled};

--- a/src/widgets/state_layer.rs
+++ b/src/widgets/state_layer.rs
@@ -280,3 +280,68 @@ pub fn resolve_background(base: Color, override_: &BackgroundOverride) -> Color 
         BackgroundOverride::Darker(amount) => base.darker(amount.get()),
     }
 }
+
+/// Declaring how a widget looks while its control is in a state.
+///
+/// The unit that holds the state is the widget's
+/// [`Control`](crate::widgets::Control) — the nearest enclosing container
+/// marked as one — so a button's label reacts to the button being hovered, and
+/// a form label reacts to the focus of the input beside it. A widget with no
+/// control above it is its own unit, and notices the pointer over its own
+/// bounds.
+///
+/// The closure receives the same partial style the widget itself is built
+/// with, because an override *is* another partial style:
+///
+/// ```ignore
+/// text("Save").color(theme.weak).when_hovered(|s| s.color(theme.strong))
+/// ```
+///
+/// Layers resolve in reverse declaration order, per property, exactly as a
+/// container's do.
+pub trait Stateful: Sized {
+    /// The partial style an override is written in.
+    type Style: Default;
+
+    #[doc(hidden)]
+    fn push_state_style(&mut self, when: StateWhen, style: Self::Style);
+
+    /// While the pointer is inside the control.
+    fn when_hovered(mut self, f: impl FnOnce(Self::Style) -> Self::Style) -> Self {
+        self.push_state_style(StateWhen::Hovered, f(Self::Style::default()));
+        self
+    }
+
+    /// While the pointer is down on the control.
+    ///
+    /// A widget with no control above it is never pressed: being pressed means
+    /// being activated, and a widget that is its own unit has nothing to
+    /// activate.
+    fn when_pressed(mut self, f: impl FnOnce(Self::Style) -> Self::Style) -> Self {
+        self.push_state_style(StateWhen::Pressed, f(Self::Style::default()));
+        self
+    }
+
+    /// While the keyboard focus is inside the control.
+    ///
+    /// This is the one the direction of the old mechanism could not express:
+    /// the focus is in a *sibling*, and both belong to the same control.
+    fn when_focused(mut self, f: impl FnOnce(Self::Style) -> Self::Style) -> Self {
+        self.push_state_style(StateWhen::Focused, f(Self::Style::default()));
+        self
+    }
+
+    /// While `condition` holds — a state the app owns, needing no control at
+    /// all, since the signal is one the caller already has.
+    fn state<M>(
+        mut self,
+        condition: impl IntoSignal<bool, M>,
+        f: impl FnOnce(Self::Style) -> Self::Style,
+    ) -> Self {
+        self.push_state_style(
+            StateWhen::When(condition.into_signal()),
+            f(Self::Style::default()),
+        );
+        self
+    }
+}

--- a/src/widgets/text.rs
+++ b/src/widgets/text.rs
@@ -1,13 +1,16 @@
 use crate::default_font_family;
 use crate::jobs::JobType;
 use crate::layout::{Constraints, Size};
+use crate::reactive::signal::{RwSignal, create_signal};
 use crate::reactive::{IntoSignal, OptionSignalExt, Signal, with_signal_tracking};
 use crate::renderer::{PaintContext, measure_text_full};
 use crate::tree::{Tree, WidgetId};
 
+use super::control::Control;
 use super::font::{FontFamily, FontWeight};
+use super::state_layer::{StateWhen, Stateful};
 use super::text_style::{TextShadow, TextStroke, TextStyle, TextStyled};
-use super::widget::{Color, Rect, Widget};
+use super::widget::{Color, Event, EventResponse, Rect, Widget};
 
 /// How far a stroke and a shadow reach past the glyphs they decorate.
 ///
@@ -37,6 +40,13 @@ pub struct Text {
     /// What this text declares about itself. Boxed and absent by default: a
     /// text that says nothing pays a null check, not a struct.
     style: Option<Box<TextStyle>>,
+    /// Overrides that apply while this text's control is in a state, in
+    /// declaration order. Empty for almost every text there is.
+    states: Vec<(StateWhen, TextStyle)>,
+    /// Set only once a pointer state is declared, and read only when no
+    /// control encloses this text — the case where it is its own unit and has
+    /// to notice the pointer itself.
+    own_hover: Option<RwSignal<bool>>,
     /// If true, text won't wrap and will be clipped by parent container
     nowrap: bool,
     /// Cached values for painting (avoid re-reading signals)
@@ -56,6 +66,8 @@ impl Text {
         Self {
             content,
             style: None,
+            states: Vec::new(),
+            own_hover: None,
             nowrap: false,
             cached_text: String::new(), // Will be set during first layout
             cached_font_size: 14.0,
@@ -77,11 +89,43 @@ impl Text {
     /// Called inside the caller's tracking scope, like the walk it wraps: the
     /// signals come back unread, and reading them is what subscribes.
     fn resolved_style(&self, tree: &Tree, id: WidgetId) -> TextStyle {
-        let mut style = self.style.as_deref().copied().unwrap_or_default();
+        let mut style = TextStyle::default();
+        // Active overrides first, last declared first, so they outrank the
+        // text's own declaration — and `inherit_from` takes only what is still
+        // missing, which is what makes the whole chain resolve per property.
+        if !self.states.is_empty() {
+            let control = tree.nearest_control(id);
+            for (when, override_) in self.states.iter().rev() {
+                if self.is_state_active(id, control.as_ref(), when) {
+                    style.inherit_from(override_);
+                }
+            }
+        }
+        if let Some(own) = self.style.as_deref() {
+            style.inherit_from(own);
+        }
         if !style.is_complete() {
             style.inherit_from(&tree.inherited_text_style(id));
         }
         style
+    }
+
+    /// Whether an override applies. Reading the answer is what subscribes the
+    /// text to the control, so it is asked only for a state it declares.
+    fn is_state_active(&self, id: WidgetId, control: Option<&Control>, when: &StateWhen) -> bool {
+        match (when, control) {
+            (StateWhen::When(condition), _) => condition.get(),
+            (StateWhen::Hovered, Some(control)) => control.is_hovered(),
+            (StateWhen::Pressed, Some(control)) => control.is_pressed(),
+            (StateWhen::Focused, Some(control)) => control.has_focus(),
+            // No control above: this text is its own unit. It can notice the
+            // pointer over its own bounds, and it can hold the focus if
+            // something gave it — but it cannot be pressed, because being
+            // pressed means being activated and it has nothing to activate.
+            (StateWhen::Hovered, None) => self.own_hover.is_some_and(|h| h.get()),
+            (StateWhen::Focused, None) => crate::reactive::focus::focus_path().contains(id),
+            (StateWhen::Pressed, None) => false,
+        }
     }
 
     /// Refresh cached values from the inherited style.
@@ -101,6 +145,17 @@ impl Text {
             self.cached_font_weight = style.font_weight.get_or(FontWeight::NORMAL);
             decoration_overflow(style.stroke.map(|s| s.get()), style.shadow.map(|s| s.get()))
         })
+    }
+}
+
+impl Stateful for Text {
+    type Style = TextStyle;
+
+    fn push_state_style(&mut self, when: StateWhen, style: TextStyle) {
+        if matches!(when, StateWhen::Hovered) && self.own_hover.is_none() {
+            self.own_hover = Some(create_signal(false));
+        }
+        self.states.push((when, style));
     }
 }
 
@@ -180,6 +235,34 @@ impl Widget for Text {
         tree.clear_needs_layout(id);
 
         size
+    }
+
+    /// Notice the pointer, but only for a text that is its own interaction
+    /// unit. Inside a control it is the control that tracks, and asking twice
+    /// would light this text on its own glyphs rather than on the button whose
+    /// label it is.
+    fn event(&mut self, tree: &mut Tree, id: WidgetId, event: &Event) -> EventResponse {
+        let Some(hover) = self.own_hover else {
+            return EventResponse::Ignored;
+        };
+        if tree.nearest_control(id).is_some() {
+            return EventResponse::Ignored;
+        }
+
+        let inside = match event {
+            Event::MouseMove { x, y } | Event::MouseEnter { x, y } => tree
+                .get_bounds(id)
+                .is_some_and(|bounds| bounds.contains(*x, *y)),
+            Event::MouseLeave => false,
+            _ => return EventResponse::Ignored,
+        };
+        // Written only on a change: an unchanged pointer move must not wake
+        // every subscriber.
+        if hover.get_untracked() != inside {
+            hover.set(inside);
+        }
+        // Never handled: noticing the pointer is not consuming it.
+        EventResponse::Ignored
     }
 
     fn paint(&self, tree: &Tree, id: WidgetId, ctx: &mut PaintContext) {

--- a/src/widgets/text_input.rs
+++ b/src/widgets/text_input.rs
@@ -24,8 +24,10 @@ use crate::renderer::{PaintContext, char_index_from_x_styled};
 use crate::tree::{Tree, WidgetId};
 use crate::widget_ref::{WidgetRef, register_widget_ref};
 
+use super::control::Control;
 use super::font::{FontFamily, FontWeight};
 use super::input_style::{InputStyle, InputStyled};
+use super::state_layer::{StateWhen, Stateful};
 use super::text_style::{TextStyle, TextStyled};
 use super::widget::{Color, Event, EventResponse, Key, MouseButton, Rect, Widget};
 
@@ -246,6 +248,11 @@ pub struct TextInput {
 
     // Mouse hover state (for cursor icon)
     is_hovered: bool,
+    /// The same fact behind a signal, so a state override resolving it
+    /// subscribes. Written next to `is_hovered`, never instead of it: the
+    /// cursor logic reads a bool on the event path, where a subscription
+    /// would be noise.
+    hover: RwSignal<bool>,
 
     // Undo/redo history
     history: History,
@@ -260,6 +267,9 @@ pub struct TextInput {
     /// only it draws. Boxed and absent by default.
     text_style: Option<Box<TextStyle>>,
     input_style: Option<Box<InputStyle>>,
+    /// Overrides that apply while this field's control is in a state, in
+    /// declaration order.
+    states: Vec<(StateWhen, TextStyle)>,
 }
 
 impl TextInput {
@@ -294,23 +304,56 @@ impl TextInput {
             last_cursor_toggle: Instant::now(),
             is_dragging: false,
             is_hovered: false,
+            hover: crate::reactive::signal::create_signal(false),
             history: History::new(),
             scroll_offset: 0.0,
             on_change: None,
             on_submit: None,
             text_style: None,
             input_style: None,
+            states: Vec::new(),
         }
     }
 
     /// This input's own declarations, completed by the ancestors' for whatever
     /// they leave out. Each walk is skipped when nothing is left to find.
     fn resolved_text_style(&self, tree: &Tree, id: WidgetId) -> TextStyle {
-        let mut style = self.text_style.as_deref().copied().unwrap_or_default();
+        let mut style = TextStyle::default();
+        // Active overrides first and last declared first, so they outrank this
+        // field's own declaration; `inherit_from` takes only what is missing,
+        // which resolves the chain per property.
+        if !self.states.is_empty() {
+            let control = tree.nearest_control(id);
+            for (when, override_) in self.states.iter().rev() {
+                if self.is_state_active(id, control.as_ref(), when) {
+                    style.inherit_from(override_);
+                }
+            }
+        }
+        if let Some(own) = self.text_style.as_deref() {
+            style.inherit_from(own);
+        }
         if !style.is_complete() {
             style.inherit_from(&tree.inherited_text_style(id));
         }
         style
+    }
+
+    /// Whether an override applies. Reading the answer subscribes the field to
+    /// its control, so it is asked only for a state it declares.
+    fn is_state_active(&self, id: WidgetId, control: Option<&Control>, when: &StateWhen) -> bool {
+        match (when, control) {
+            (StateWhen::When(condition), _) => condition.get(),
+            (StateWhen::Hovered, Some(control)) => control.is_hovered(),
+            (StateWhen::Pressed, Some(control)) => control.is_pressed(),
+            (StateWhen::Focused, Some(control)) => control.has_focus(),
+            // No control above: the field is its own unit. It already tracks
+            // the pointer for its cursor, and it is the thing that holds the
+            // focus, so both answers are its own.
+            (StateWhen::Hovered, None) => self.hover.get(),
+            (StateWhen::Focused, None) => crate::reactive::focus::focus_path().contains(id),
+            (StateWhen::Pressed, None) => false,
+        }
     }
 
     fn resolved_input_style(&self, tree: &Tree, id: WidgetId) -> InputStyle {
@@ -1038,6 +1081,14 @@ impl TextInput {
     }
 }
 
+impl Stateful for TextInput {
+    type Style = TextStyle;
+
+    fn push_state_style(&mut self, when: StateWhen, style: TextStyle) {
+        self.states.push((when, style));
+    }
+}
+
 impl TextStyled for TextInput {
     fn text_style_mut(&mut self) -> &mut TextStyle {
         self.text_style.get_or_insert_with(Box::default)
@@ -1262,9 +1313,11 @@ impl Widget for TextInput {
                 // Update hover state and cursor
                 if in_bounds && !self.is_hovered {
                     self.is_hovered = true;
+                    self.hover.set(true);
                     set_cursor(CursorIcon::Text);
                 } else if !in_bounds && self.is_hovered {
                     self.is_hovered = false;
+                    self.hover.set(false);
                     set_cursor(CursorIcon::Default);
                 }
 
@@ -1315,6 +1368,7 @@ impl Widget for TextInput {
             }
             Event::MouseLeave if self.is_hovered => {
                 self.is_hovered = false;
+                self.hover.set(false);
                 set_cursor(CursorIcon::Default);
             }
             _ => {}

--- a/src/widgets/text_style.rs
+++ b/src/widgets/text_style.rs
@@ -326,3 +326,12 @@ pub trait TextStyled: Sized {
         self
     }
 }
+
+/// A partial text style is itself something to declare style on, which is what
+/// lets a state override use the same builder as the widget:
+/// `when_hovered(|s| s.color(..))`.
+impl TextStyled for TextStyle {
+    fn text_style_mut(&mut self) -> &mut TextStyle {
+        self
+    }
+}

--- a/tests/interaction_controls.rs
+++ b/tests/interaction_controls.rs
@@ -1,0 +1,225 @@
+//! The interaction unit: which thing's hover a widget is talking about.
+//!
+//! Every case here is one the old rule got wrong or could not express. A
+//! label's hover is not its own glyphs, and it is not any ancestor either —
+//! it is the nearest thing marked as a unit.
+
+use guido::layout::{Constraints, Flex};
+use guido::prelude::*;
+use guido::reactive::focus::{clear_focus, request_focus};
+use guido::renderer::{DrawCommand, PaintContext, RenderNode};
+use guido::tree::{Tree, WidgetId};
+
+struct H {
+    tree: Tree,
+    root: WidgetId,
+}
+
+impl H {
+    fn new(widget: impl Widget + 'static) -> Self {
+        let mut tree = Tree::new();
+        let root = tree.register(Box::new(widget));
+        tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
+        let mut h = Self { tree, root };
+        h.lay_out();
+        h
+    }
+
+    fn lay_out(&mut self) {
+        let root = self.root;
+        self.tree.with_widget_mut(root, |w, id, t| {
+            w.layout(t, id, Constraints::new(0.0, 0.0, 400.0, 200.0))
+        });
+    }
+
+    fn point_at(&mut self, x: f32, y: f32) {
+        let root = self.root;
+        self.tree
+            .with_widget_mut(root, |w, id, t| w.event(t, id, &Event::MouseMove { x, y }));
+    }
+
+    /// Every text drawn, in paint order, as (content, colour).
+    fn texts(&mut self) -> Vec<(String, Color)> {
+        let root = self.root;
+        let mut node = RenderNode::new(root.as_u64());
+        self.tree.with_widget_mut(root, |w, id, t| {
+            let mut ctx = PaintContext::new(&mut node);
+            w.paint(t, id, &mut ctx);
+        });
+        let mut out = Vec::new();
+        collect(&node, &mut out);
+        out
+    }
+
+    fn colour_of(&mut self, content: &str) -> Color {
+        self.texts()
+            .into_iter()
+            .find(|(t, _)| t == content)
+            .unwrap_or_else(|| panic!("no text {content:?}"))
+            .1
+    }
+}
+
+fn collect(node: &RenderNode, out: &mut Vec<(String, Color)>) {
+    for cmd in &node.commands {
+        if let DrawCommand::Text { text, color, .. } = &**cmd {
+            out.push((text.clone(), *color));
+        }
+    }
+    for child in &node.children {
+        collect(child, out);
+    }
+}
+
+const WEAK: Color = Color::rgb(0.5, 0.5, 0.5);
+const STRONG: Color = Color::rgb(1.0, 1.0, 1.0);
+
+/// A label lights up while the pointer is on the button's *padding*, nowhere
+/// near the glyphs. This is the case that rules out "my own bounds".
+#[test]
+fn a_label_follows_the_button_it_is_inside() {
+    let mut h = H::new(
+        container()
+            .padding(20.0)
+            .on_click(|| {})
+            .child(text("Save").color(WEAK).when_hovered(|s| s.color(STRONG))),
+    );
+
+    assert_eq!(h.colour_of("Save"), WEAK);
+
+    // Inside the button, inside the padding — far from any glyph.
+    h.point_at(3.0, 3.0);
+    assert_eq!(h.colour_of("Save"), STRONG);
+
+    h.point_at(-50.0, -50.0);
+    assert_eq!(h.colour_of("Save"), WEAK);
+}
+
+/// And it stays dark while the pointer is over a *sibling* button in the same
+/// row. This is the case that rules out "any ancestor".
+#[test]
+fn a_label_ignores_the_hover_of_a_sibling_button() {
+    let mut h = H::new(
+        container()
+            .layout(Flex::row())
+            .control()
+            .child(
+                container()
+                    .width(100.0)
+                    .height(40.0)
+                    .on_click(|| {})
+                    .child(text("left").color(WEAK).when_hovered(|s| s.color(STRONG))),
+            )
+            .child(
+                container()
+                    .width(100.0)
+                    .height(40.0)
+                    .on_click(|| {})
+                    .child(text("right").color(WEAK).when_hovered(|s| s.color(STRONG))),
+            ),
+    );
+
+    // Over the right-hand button.
+    h.point_at(150.0, 20.0);
+    assert_eq!(h.colour_of("right"), STRONG);
+    assert_eq!(
+        h.colour_of("left"),
+        WEAK,
+        "a label must not follow a sibling button's hover"
+    );
+}
+
+/// A nested control scopes *resolution*, not state: the row is still hovered
+/// while the pointer is over the button inside it, because the pointer is
+/// plainly still on the row.
+#[test]
+fn a_nested_control_does_not_switch_the_outer_one_off() {
+    let mut h = H::new(
+        container()
+            .layout(Flex::row())
+            .width(300.0)
+            .height(40.0)
+            .on_click(|| {})
+            .child(
+                container()
+                    .width(100.0)
+                    .height(40.0)
+                    .on_click(|| {})
+                    .child(text("button").color(WEAK).when_hovered(|s| s.color(STRONG))),
+            )
+            .child(text("row").color(WEAK).when_hovered(|s| s.color(STRONG))),
+    );
+
+    // Over the nested button, which is also over the row.
+    h.point_at(50.0, 20.0);
+    assert_eq!(h.colour_of("button"), STRONG);
+    assert_eq!(
+        h.colour_of("row"),
+        STRONG,
+        "the row is still under the pointer, so its own label still follows it"
+    );
+}
+
+/// The case the old mechanism had no answer for: the focus is in a *sibling*,
+/// not below the label, and both belong to the same unit.
+#[test]
+fn a_label_reacts_to_the_focus_of_the_input_beside_it() {
+    clear_focus();
+    let mut h = H::new(
+        container()
+            .layout(Flex::column())
+            .control()
+            .child(
+                text("Password")
+                    .color(WEAK)
+                    .when_focused(|s| s.color(STRONG)),
+            )
+            .child(text_input(create_signal(String::from("x")))),
+    );
+
+    assert_eq!(h.colour_of("Password"), WEAK);
+
+    let input = h.tree.get_children(h.root)[1];
+    request_focus(&h.tree, input);
+    assert_eq!(h.colour_of("Password"), STRONG);
+
+    clear_focus();
+    assert_eq!(h.colour_of("Password"), WEAK);
+}
+
+/// With nothing marked above it, a text is its own unit and notices the
+/// pointer over its own bounds.
+#[test]
+fn a_text_with_no_control_above_it_is_its_own_unit() {
+    let mut h = H::new(
+        container()
+            .layout(Flex::row())
+            .child(text("solo").color(WEAK).when_hovered(|s| s.color(STRONG))),
+    );
+
+    assert_eq!(h.colour_of("solo"), WEAK);
+
+    h.point_at(2.0, 5.0);
+    assert_eq!(h.colour_of("solo"), STRONG);
+
+    h.point_at(-50.0, -50.0);
+    assert_eq!(h.colour_of("solo"), WEAK);
+}
+
+/// A state the app owns needs no unit at all, so it works wherever it is
+/// written.
+#[test]
+fn a_condition_the_app_owns_needs_no_control() {
+    let wrong = create_signal(false);
+    let mut h = H::new(
+        container().layout(Flex::row()).child(
+            text("Wrong password")
+                .color(WEAK)
+                .state(wrong, |s| s.color(STRONG)),
+        ),
+    );
+
+    assert_eq!(h.colour_of("Wrong password"), WEAK);
+    wrong.set(true);
+    assert_eq!(h.colour_of("Wrong password"), STRONG);
+}


### PR DESCRIPTION
When a text declares a hover style, hover **of what**? Not its own glyphs — a
button's label has to light up while the pointer is on the button's *padding*,
nowhere near them. Not any ancestor either — a label inside one button must stay
dark while the pointer is over a sibling button in the same row. Style never had
to answer this. States do, and it is why states could not live on a leaf.

A container marked `control()` is one **interaction unit**. Everything inside
resolves hover, press and focus from it, until a nested one takes over.

```rust
container().control()
    .child(text("Password").when_focused(|s| s.color(theme.accent)))
    .child(text_input(password))
```

Direction stops being a property of the mechanism and becomes only how a control
notices — the pointer is inside its bounds, the focus is inside its subtree —
after which resolution is identical for both. That is what makes the case with
no previous answer work: the focus is in a *sibling*, and both belong to the
same unit.

Leaves declare with `when_hovered`, `when_pressed`, `when_focused` and `state`
from the new `Stateful` trait. The closure receives the same partial style the
widget itself is built with, because an override *is* another partial style —
`TextStyle` now implements `TextStyled`.

## Almost nothing new had to be built

- `InteractionFlags` was already an `RwSignal`, specifically so a descendant
  resolving a state subscribes to it.
- `FocusPath::contains` was already "the focus is inside my subtree", on a
  signal.
- The lookup is the shape `Tree::inherited_text_style` already uses: a slot on
  the node, a walk from the widget upwards, signals returned unread.
- `track_pointer` already ran on every ancestor *before* the children, so a
  nested unit already scoped resolution without switching the outer one off.

## No behaviour change for existing code

`control()` is rarely written by hand: a pointer target *is* an interaction
unit, so `on_click`, `on_hover`, `on_scroll`, `scrollable` and the rest imply
it — and so does declaring a state layer. That last one is what keeps every
existing container resolving its own states exactly as before, including the
scrollbar handle inside a scrollable view.

Reading a control's state is gated on the widget declaring one, so a text that
declares nothing subscribes to nothing and a hover does not repaint a whole
subtree.

## Decisions settled while building

- **No control above**: the widget is its own unit and notices the pointer over
  its own bounds. It is never *pressed* — being pressed means being activated,
  and it has nothing to activate.
- **The name** is `control()`: it says what the thing is rather than what it
  does, and it is the word accessibility uses for the same boundary.

## Tests

`tests/interaction_controls.rs`, one per case from the design table, all
through the public API: a label following the button's padding, a label
ignoring a sibling button, a nested control not switching the outer one off, a
label reacting to a sibling input's focus, a text with no control being its own
unit, and an app-owned condition needing no control at all. Plus two reactive
diagnostic-audit cases covering both resolution branches.

Full suite green, render snapshots unchanged, clippy clean, book builds.

Deliberately **not** in this PR: renaming `hover_state`/`pressed_state`/
`focused_state` on `Container` to match the leaves. That is ~290 mechanical
call sites and belongs on its own.