### PR TITLE
A stroke on glass is a contour

### DIFF
--- a/book/src/advanced/wayland.md
+++ b/book/src/advanced/wayland.md
@@ -550,7 +550,10 @@ The **surface** side is guido's own: the frame is drawn into an
 offscreen target, each region is downsampled, blurred with a separable
 gaussian and composited back masked to the container's rounded shape.
 Frames with no backdrop blur skip all of it and draw straight to the
-swapchain.
+swapchain. A text can ask for the same thing with the shape of its
+glyphs as the mask — see [Frosted glass](../building-ui/text.md#frosted-glass)
+— and that one is surface-side only, since a `wl_region` cannot hold a
+letter.
 
 Two skips keep that honest, and both are unobservable — they drop work
 that could not have changed a pixel, so they may switch on and off

--- a/book/src/building-ui/text.md
+++ b/book/src/building-ui/text.md
@@ -135,8 +135,13 @@ Three things to know before reaching for it:
   container for the subtree below it; this one cannot, because each frosted
   text ends the render pass to filter the target. It is asked for one text at
   a time on purpose.
-- **It is not legibility.** Frost softens the background where a shadow darkens
-  it, so over a busy photograph the shadow still does more. They compose.
+- **It is not legibility, and it does not combine with what is.** Frost softens
+  the background where a shadow darkens it, so over a busy photograph a shadow
+  still does more — but you cannot have both. A stroke and a shadow are drawn
+  as copies of the glyphs *under* the fill, so they cover the letter's own area
+  and not only its edge: invisible under an opaque fill, and an opaque letter
+  over frost, which is the one thing the frost was cut out of. What holds a
+  frosted text together is its tint.
 - **Rotation and scale skip it**, since the mask is rasterized square. A frost
   sitting beside its own letters would be worse than none.
 

--- a/book/src/building-ui/text.md
+++ b/book/src/building-ui/text.md
@@ -103,6 +103,45 @@ its neighbours.
 
 `cargo run --example text_decoration_example` shows both against a control.
 
+## Frosted glass
+
+The third way to sit a text on a picture is to make the letters a window onto
+it, blurred:
+
+```rust
+text("09:41")
+    .font_size(76.0)
+    // The tint over the glass; without one the glyphs are the blur alone.
+    .color(Color::rgba(1.0, 1.0, 1.0, 0.35))
+    .backdrop_blur(16.0)
+```
+
+This is the same effect a container gets from
+[`backdrop_blur`](../concepts/container.md), with the shape of the letters in
+place of the shape of the box — CSS's `backdrop-filter` together with
+`background-clip: text`. The renderer rasterizes the glyphs into a coverage
+mask, blurs the region they cover, and composites the result back through the
+mask; the text is then drawn over its own frost, which is why the colour reads
+as a tint.
+
+It filters what *this surface* has already drawn — a wallpaper, a photo, the
+panel underneath. A container's blur can also reach what the compositor puts
+behind the surface, through `ext-background-effect-v1`; that protocol takes a
+region, and regions are rectangles, so glyphs cannot be expressed in it.
+
+Three things to know before reaching for it:
+
+- **It is not inherited.** Every other text property can be declared on a
+  container for the subtree below it; this one cannot, because each frosted
+  text ends the render pass to filter the target. It is asked for one text at
+  a time on purpose.
+- **It is not legibility.** Frost softens the background where a shadow darkens
+  it, so over a busy photograph the shadow still does more. They compose.
+- **Rotation and scale skip it**, since the mask is rasterized square. A frost
+  sitting beside its own letters would be worse than none.
+
+`cargo run --example frosted_text` puts it beside a shadow and a control.
+
 ## Styling
 
 ### Font Size

--- a/book/src/building-ui/text.md
+++ b/book/src/building-ui/text.md
@@ -135,17 +135,26 @@ Three things to know before reaching for it:
   container for the subtree below it; this one cannot, because each frosted
   text ends the render pass to filter the target. It is asked for one text at
   a time on purpose.
-- **It is not legibility, and it does not combine with what is.** Frost softens
-  the background where a shadow darkens it, so over a busy photograph a shadow
-  still does more — but you cannot have both. A stroke and a shadow are drawn
-  as copies of the glyphs *under* the fill, so they cover the letter's own area
-  and not only its edge: invisible under an opaque fill, and an opaque letter
-  over frost, which is the one thing the frost was cut out of. What holds a
-  frosted text together is its tint.
+- **It is not legibility on its own.** Frost softens the background where a
+  stroke and a shadow darken it. A stroke composes with it — over frost it is
+  drawn as a true contour, dilated from the same coverage mask and laid outside
+  the letter, which is what the glass needs and what a thick stroke wanted
+  anyway. A shadow does not: it is still copies of the glyphs *under* the fill,
+  so it covers the letter's own area as well as its edge, which is invisible
+  under an opaque fill and an opaque letter over frost.
 - **Rotation and scale skip it**, since the mask is rasterized square. A frost
   sitting beside its own letters would be worse than none.
 
-`cargo run --example frosted_text` puts it beside a shadow and a control.
+```rust
+text("09:41")
+    .color(Color::rgba(1.0, 1.0, 1.0, 0.3))
+    .backdrop_blur(16.0)
+    // A contour, because this text is glass. Elsewhere the same declaration is
+    // the cheap approximation, and under an opaque fill the two look alike.
+    .text_stroke(TextStroke::new(2.0, Color::BLACK))
+```
+
+`cargo run --example frosted_text` puts all of it beside a control.
 
 ## Styling
 

--- a/docs/RENDERER.md
+++ b/docs/RENDERER.md
@@ -251,6 +251,15 @@ gaussian passes ping-ponging between two working textures, then a composite
 back over the scene masked by the container's rounded-rect SDF. See
 `src/renderer/backdrop_pass.rs`.
 
+The mask is the one part a caller replaces. `Text::backdrop_blur` emits
+`DrawCommand::TextBackdropBlur`, which resolves to the same blur with a
+coverage texture in place of the SDF: the glyphs are rasterized into it by
+`src/renderer/text_mask.rs`, shaped exactly as `TextRenderState` shapes the
+text drawn afterwards, one texel per pixel of a region snapped to the pixel
+grid. Sub-pixel position is handed to the mask as its glyph origin rather than
+rounded away, and a text under a rotation or scale is skipped — the mask is
+axis-aligned.
+
 ### FlattenedCommand
 
 The output of tree flattening:

--- a/examples/frosted_text.rs
+++ b/examples/frosted_text.rs
@@ -8,11 +8,13 @@
 //! together with `background-clip: text`.
 //!
 //! The colour is the tint laid over the glass, which is why every panel here
-//! but the first is translucent. The last panel is the trap: a stroke and a
-//! shadow are drawn as copies of the glyphs *under* the fill, so they cover the
-//! letter's own area and not only its edge. Under an opaque fill that is
-//! invisible and free; over frost it is an opaque letter where the picture
-//! should be.
+//! but the first is translucent. The fourth adds a stroke, which over frost is
+//! drawn as a true contour — outside the letter, leaving the glass alone.
+//!
+//! The last panel is the trap, and it is a shadow: shadows are still copies of
+//! the glyphs drawn *under* the fill, so they cover the letter's own area and
+//! not only its edge. Under an opaque fill that is invisible and free; over
+//! frost it is an opaque letter where the picture should be.
 
 use guido::prelude::*;
 
@@ -76,6 +78,13 @@ fn main() {
                 text(LABEL).color(Color::TRANSPARENT).backdrop_blur(16.0),
             ))
             .child(panel(
+                "frost + stroke 2",
+                text(LABEL)
+                    .color(Color::rgba(1.0, 1.0, 1.0, 0.3))
+                    .backdrop_blur(16.0)
+                    .text_stroke(TextStroke::new(2.0, Color::BLACK)),
+            ))
+            .child(panel(
                 "frost under a shadow — buried",
                 text(LABEL)
                     .color(Color::rgba(1.0, 1.0, 1.0, 0.35))
@@ -90,7 +99,7 @@ fn main() {
 
         app.add_surface(
             SurfaceConfig::new()
-                .width(1080)
+                .width(1360)
                 .height(210)
                 .anchor(Anchor::TOP | Anchor::LEFT)
                 .layer(Layer::Top)

--- a/examples/frosted_text.rs
+++ b/examples/frosted_text.rs
@@ -8,9 +8,11 @@
 //! together with `background-clip: text`.
 //!
 //! The colour is the tint laid over the glass, which is why every panel here
-//! but the first is translucent. The last one is the honest comparison: frost
-//! softens the background, a shadow darkens it, and only the second is about
-//! legibility.
+//! but the first is translucent. The last panel is the trap: a stroke and a
+//! shadow are drawn as copies of the glyphs *under* the fill, so they cover the
+//! letter's own area and not only its edge. Under an opaque fill that is
+//! invisible and free; over frost it is an opaque letter where the picture
+//! should be.
 
 use guido::prelude::*;
 
@@ -74,7 +76,7 @@ fn main() {
                 text(LABEL).color(Color::TRANSPARENT).backdrop_blur(16.0),
             ))
             .child(panel(
-                "frost and shadow",
+                "frost under a shadow — buried",
                 text(LABEL)
                     .color(Color::rgba(1.0, 1.0, 1.0, 0.35))
                     .backdrop_blur(16.0)

--- a/examples/frosted_text.rs
+++ b/examples/frosted_text.rs
@@ -1,0 +1,100 @@
+//! Text as frosted glass: the glyphs are the window.
+//!
+//! Run with: cargo run --example frosted_text
+//!
+//! A container's `backdrop_blur` softens what is behind a box. On a text the
+//! same declaration cuts the shape of the letters out of the blur instead, so
+//! the picture shows through them, out of focus — CSS's `backdrop-filter`
+//! together with `background-clip: text`.
+//!
+//! The colour is the tint laid over the glass, which is why every panel here
+//! but the first is translucent. The last one is the honest comparison: frost
+//! softens the background, a shadow darkens it, and only the second is about
+//! legibility.
+
+use guido::prelude::*;
+
+const LABEL: &str = "09:41";
+
+fn photo() -> Container {
+    container().width(fill()).height(fill()).child(
+        image(ImageSource::Path("examples/assets/photo.webp".into()))
+            .content_fit(ContentFit::Cover),
+    )
+}
+
+/// One sample: the same reading over the same photograph, styled differently.
+fn panel(caption: &'static str, label: Text) -> Container {
+    container()
+        .layout(Flex::column().spacing(8.0))
+        .child(
+            container()
+                .width(240.0)
+                .height(120.0)
+                .corner_radius(8.0)
+                .overflow(Overflow::Hidden)
+                .layout(ZStack::new())
+                .child(photo())
+                .child(
+                    container()
+                        .width(fill())
+                        .height(fill())
+                        .layout(
+                            Flex::column()
+                                .main_alignment(MainAlignment::Center)
+                                .cross_alignment(CrossAlignment::Center),
+                        )
+                        .child(label.font_size(52.0).nowrap()),
+                ),
+        )
+        .child(
+            container()
+                .font_size(12.0)
+                .text_color(Color::rgb(0.7, 0.7, 0.75))
+                .child(text(caption)),
+        )
+}
+
+fn main() {
+    env_logger::init();
+
+    App::new().run(|app| {
+        let view = container()
+            .padding(24.0)
+            .layout(Flex::row().spacing(20.0))
+            .child(panel("nothing", text(LABEL).color(Color::WHITE)))
+            .child(panel(
+                "frost 16",
+                text(LABEL)
+                    .color(Color::rgba(1.0, 1.0, 1.0, 0.35))
+                    .backdrop_blur(16.0),
+            ))
+            .child(panel(
+                "frost 16, no tint",
+                text(LABEL).color(Color::TRANSPARENT).backdrop_blur(16.0),
+            ))
+            .child(panel(
+                "frost and shadow",
+                text(LABEL)
+                    .color(Color::rgba(1.0, 1.0, 1.0, 0.35))
+                    .backdrop_blur(16.0)
+                    .text_shadow(TextShadow::new(
+                        0.0,
+                        2.0,
+                        10.0,
+                        Color::rgba(0.0, 0.0, 0.0, 0.6),
+                    )),
+            ));
+
+        app.add_surface(
+            SurfaceConfig::new()
+                .width(1080)
+                .height(210)
+                .anchor(Anchor::TOP | Anchor::LEFT)
+                .layer(Layer::Top)
+                .namespace("frosted-text")
+                .background_color(Color::rgb(0.1, 0.1, 0.15)),
+            || view,
+        );
+    });
+}

--- a/src/renderer/backdrop_pass.rs
+++ b/src/renderer/backdrop_pass.rs
@@ -20,7 +20,7 @@
 
 use wgpu::util::DeviceExt;
 
-use crate::widgets::Rect;
+use crate::widgets::{Color, Rect};
 
 use super::commands::CornerRadii;
 
@@ -52,7 +52,18 @@ struct Params {
     /// UV. The whole mask unless the region runs off the target, where the
     /// viewport is clipped and the mask must be read clipped with it.
     mask_rect: [f32; 4],
+    /// Colour of the contour `fs_outline` draws, and how far out it reaches
+    /// from the glyph edge in physical pixels.
+    stroke_color: [f32; 4],
+    stroke_width: f32,
+    _pad1: f32,
+    _pad2: f32,
+    _pad3: f32,
 }
+
+/// Where a region lands on the target — viewport in physical pixels — and the
+/// sub-rectangle of a coverage mask that covers it, in normalised uv.
+type Placement = ((u32, u32, u32, u32), [f32; 4]);
 
 /// A blur to apply, resolved to physical pixels.
 #[derive(Debug, Clone, Copy)]
@@ -129,6 +140,7 @@ pub struct BackdropRenderer {
     blur: wgpu::RenderPipeline,
     composite: wgpu::RenderPipeline,
     composite_mask: wgpu::RenderPipeline,
+    outline: wgpu::RenderPipeline,
     blit: wgpu::RenderPipeline,
     targets: Option<Targets>,
     idle_frames: u32,
@@ -300,6 +312,12 @@ impl BackdropRenderer {
             composite_mask: build(
                 "Backdrop Composite Mask",
                 "fs_composite_mask",
+                Some(composite_blend),
+                &mask_layout,
+            ),
+            outline: build(
+                "Text Outline",
+                "fs_outline",
                 Some(composite_blend),
                 &mask_layout,
             ),
@@ -475,6 +493,80 @@ impl BackdropRenderer {
         self.filter(device, encoder, region, Some(mask));
     }
 
+    /// Where a region lands on the target, and which part of a mask covers it.
+    ///
+    /// The two go together: the viewport is the region clipped to what is on
+    /// show, and the mask covers the region whole, so anything the clip took
+    /// off has to come off the mask's uv as well.
+    fn placement(&self, region: &BackdropRegion) -> Option<Placement> {
+        let targets = self.targets.as_ref()?;
+        let (x, y, width, height) = region.clamped(targets.width, targets.height)?;
+        let mask_rect = [
+            (x as f32 - region.rect.x) / region.rect.width.max(1.0),
+            (y as f32 - region.rect.y) / region.rect.height.max(1.0),
+            width as f32 / region.rect.width.max(1.0),
+            height as f32 / region.rect.height.max(1.0),
+        ];
+        Some(((x, y, width, height), mask_rect))
+    }
+
+    /// Draw a contour just outside `mask`'s coverage.
+    ///
+    /// A stroke, for the one case the cheap approximation cannot serve: copies
+    /// of the glyphs drawn under the fill ring the letter *and* fill it, which
+    /// is invisible under an opaque fill and opaque over frost. This dilates
+    /// the coverage instead and draws only the band the dilate added.
+    ///
+    /// Ordered after the frost and before the glyphs, so the letter keeps what
+    /// the frost put in it.
+    pub fn apply_outline(
+        &self,
+        device: &wgpu::Device,
+        encoder: &mut wgpu::CommandEncoder,
+        region: &BackdropRegion,
+        mask: &wgpu::TextureView,
+        color: Color,
+        width: f32,
+    ) {
+        let Some(targets) = &self.targets else {
+            return;
+        };
+        let Some((viewport, mask_rect)) = self.placement(region) else {
+            return;
+        };
+        let (_, _, dst_width, dst_height) = viewport;
+
+        let params = Params {
+            src_rect: [0.0, 0.0, 1.0, 1.0],
+            direction: [0.0, 0.0],
+            sigma: 0.0,
+            taps: 0.0,
+            dst_size: [dst_width as f32, dst_height as f32],
+            curvature: 1.0,
+            _pad: 0.0,
+            radii: [0.0; 4],
+            mask_rect,
+            stroke_color: [color.r, color.g, color.b, color.a],
+            stroke_width: width,
+            _pad1: 0.0,
+            _pad2: 0.0,
+            _pad3: 0.0,
+        };
+        // Binding 0 goes unread by this pipeline; the working texture fills it
+        // because the scene is the target and may not be bound as a resource
+        // at the same time.
+        let bind = self.bind_masked(device, &targets.working_views[0], mask, params);
+        self.pass(
+            encoder,
+            &self.outline,
+            &targets.scene_view,
+            wgpu::LoadOp::Load,
+            &bind,
+            viewport,
+            "Text Outline",
+        );
+    }
+
     fn filter(
         &self,
         device: &wgpu::Device,
@@ -485,7 +577,7 @@ impl BackdropRenderer {
         let Some(targets) = &self.targets else {
             return;
         };
-        let Some((x, y, width, height)) = region.clamped(targets.width, targets.height) else {
+        let Some(((x, y, width, height), mask_rect)) = self.placement(region) else {
             return;
         };
 
@@ -513,16 +605,6 @@ impl BackdropRenderer {
             work_height as f32 / targets.work_height as f32,
         ];
 
-        // The mask covers the region; the viewport covers whatever of it is on
-        // the target. When a text runs off the edge they differ, and reading
-        // the whole mask across a clipped viewport would squash the letters.
-        let mask_rect = [
-            (x as f32 - region.rect.x) / region.rect.width.max(1.0),
-            (y as f32 - region.rect.y) / region.rect.height.max(1.0),
-            width as f32 / region.rect.width.max(1.0),
-            height as f32 / region.rect.height.max(1.0),
-        ];
-
         let base = Params {
             src_rect: scene_rect,
             direction: [0.0, 0.0],
@@ -533,6 +615,11 @@ impl BackdropRenderer {
             _pad: 0.0,
             radii: region.radii.to_array(),
             mask_rect,
+            stroke_color: [0.0; 4],
+            stroke_width: 0.0,
+            _pad1: 0.0,
+            _pad2: 0.0,
+            _pad3: 0.0,
         };
 
         // 1. Scene region → working[0], shrunk.
@@ -624,6 +711,11 @@ impl BackdropRenderer {
                 _pad: 0.0,
                 radii: [0.0; 4],
                 mask_rect: [0.0, 0.0, 1.0, 1.0],
+                stroke_color: [0.0; 4],
+                stroke_width: 0.0,
+                _pad1: 0.0,
+                _pad2: 0.0,
+                _pad3: 0.0,
             },
         );
         self.pass(

--- a/src/renderer/backdrop_pass.rs
+++ b/src/renderer/backdrop_pass.rs
@@ -63,16 +63,34 @@ pub struct BackdropRegion {
     pub radius: f32,
     pub radii: CornerRadii,
     pub curvature: f32,
+    /// What the effect is allowed to write, in physical pixels: the clip it
+    /// was flattened under, if any. The mask says which pixels of the region
+    /// are filtered; this says which of them are on show at all.
+    pub clip: Option<Rect>,
 }
 
 impl BackdropRegion {
     /// Clamp to the target so a card running off-screen cannot ask for a
     /// viewport wgpu will reject.
     fn clamped(&self, width: u32, height: u32) -> Option<(u32, u32, u32, u32)> {
-        let x = self.rect.x.floor().max(0.0) as u32;
-        let y = self.rect.y.floor().max(0.0) as u32;
-        let right = (self.rect.x + self.rect.width).ceil().max(0.0) as u32;
-        let bottom = (self.rect.y + self.rect.height).ceil().max(0.0) as u32;
+        // The clip comes first: a region scrolled out of its container has
+        // nothing on show, and filtering it would leave a blurred rectangle
+        // where the content is not.
+        let mut left = self.rect.x;
+        let mut top = self.rect.y;
+        let mut right_f = self.rect.x + self.rect.width;
+        let mut bottom_f = self.rect.y + self.rect.height;
+        if let Some(clip) = self.clip {
+            left = left.max(clip.x);
+            top = top.max(clip.y);
+            right_f = right_f.min(clip.x + clip.width);
+            bottom_f = bottom_f.min(clip.y + clip.height);
+        }
+
+        let x = left.floor().max(0.0) as u32;
+        let y = top.floor().max(0.0) as u32;
+        let right = right_f.ceil().max(0.0) as u32;
+        let bottom = bottom_f.ceil().max(0.0) as u32;
         let right = right.min(width);
         let bottom = bottom.min(height);
         if x >= right || y >= bottom {

--- a/src/renderer/backdrop_pass.rs
+++ b/src/renderer/backdrop_pass.rs
@@ -12,6 +12,11 @@
 //! gaussian passes, then composite back masked by the container's rounded
 //! shape. Working at a quarter resolution is what keeps a wide radius cheap —
 //! the same reason compositors downsample before blurring.
+//!
+//! The mask is the only part a caller can replace. [`apply`](BackdropRenderer::apply)
+//! shapes the result with the region's own corners; [`apply_masked`](BackdropRenderer::apply_masked)
+//! takes a coverage texture instead, which is what lets glyphs be the window
+//! rather than a box — see [`text_mask`](super::text_mask).
 
 use wgpu::util::DeviceExt;
 
@@ -43,6 +48,10 @@ struct Params {
     curvature: f32,
     _pad: f32,
     radii: [f32; 4],
+    /// Sub-rectangle of the coverage mask this viewport covers, in normalised
+    /// UV. The whole mask unless the region runs off the target, where the
+    /// viewport is clipped and the mask must be read clipped with it.
+    mask_rect: [f32; 4],
 }
 
 /// A blur to apply, resolved to physical pixels.
@@ -95,9 +104,13 @@ pub struct BackdropRenderer {
     format: wgpu::TextureFormat,
     sampler: wgpu::Sampler,
     bind_group_layout: wgpu::BindGroupLayout,
+    /// The same three bindings plus the coverage texture the masked composite
+    /// reads. Kept apart so the three shape passes bind nothing they never use.
+    mask_bind_group_layout: wgpu::BindGroupLayout,
     downsample: wgpu::RenderPipeline,
     blur: wgpu::RenderPipeline,
     composite: wgpu::RenderPipeline,
+    composite_mask: wgpu::RenderPipeline,
     blit: wgpu::RenderPipeline,
     targets: Option<Targets>,
     idle_frames: u32,
@@ -154,16 +167,69 @@ impl BackdropRenderer {
             ],
         });
 
+        // The masked composite reads one more texture; everything else would
+        // only be declaring a binding it never touches.
+        let mask_bind_group_layout =
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("Backdrop Mask Bind Group Layout"),
+                entries: &[
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 0,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Texture {
+                            multisampled: false,
+                            view_dimension: wgpu::TextureViewDimension::D2,
+                            sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                        },
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 1,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 2,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Buffer {
+                            ty: wgpu::BufferBindingType::Uniform,
+                            has_dynamic_offset: false,
+                            min_binding_size: None,
+                        },
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 3,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Texture {
+                            multisampled: false,
+                            view_dimension: wgpu::TextureViewDimension::D2,
+                            sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                        },
+                        count: None,
+                    },
+                ],
+            });
+
         let layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: Some("Backdrop Pipeline Layout"),
             bind_group_layouts: &[&bind_group_layout],
             immediate_size: 0,
         });
+        let mask_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("Backdrop Mask Pipeline Layout"),
+            bind_group_layouts: &[&mask_bind_group_layout],
+            immediate_size: 0,
+        });
 
-        let pipeline = |label: &str, entry: &str, blend: Option<wgpu::BlendState>| {
+        let build = |label: &str,
+                     entry: &str,
+                     blend: Option<wgpu::BlendState>,
+                     layout: &wgpu::PipelineLayout| {
             device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
                 label: Some(label),
-                layout: Some(&layout),
+                layout: Some(layout),
                 vertex: wgpu::VertexState {
                     module: &shader,
                     entry_point: Some("vs_main"),
@@ -186,6 +252,9 @@ impl BackdropRenderer {
                 multiview_mask: None,
                 cache: None,
             })
+        };
+        let pipeline = |label: &str, entry: &str, blend: Option<wgpu::BlendState>| {
+            build(label, entry, blend, &layout)
         };
 
         // The composite is the only step that blends: it lays the blurred
@@ -210,8 +279,15 @@ impl BackdropRenderer {
             downsample: pipeline("Backdrop Downsample", "fs_downsample", None),
             blur: pipeline("Backdrop Blur", "fs_blur", None),
             composite: pipeline("Backdrop Composite", "fs_composite", Some(composite_blend)),
+            composite_mask: build(
+                "Backdrop Composite Mask",
+                "fs_composite_mask",
+                Some(composite_blend),
+                &mask_layout,
+            ),
             blit: pipeline("Backdrop Blit", "fs_downsample", None),
             bind_group_layout,
+            mask_bind_group_layout,
             targets: None,
             idle_frames: 0,
         }
@@ -283,6 +359,43 @@ impl BackdropRenderer {
         })
     }
 
+    /// The same bindings plus a coverage texture, for the masked composite.
+    fn bind_masked(
+        &self,
+        device: &wgpu::Device,
+        view: &wgpu::TextureView,
+        mask: &wgpu::TextureView,
+        params: Params,
+    ) -> wgpu::BindGroup {
+        let buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("Backdrop Params"),
+            contents: bytemuck::cast_slice(&[params]),
+            usage: wgpu::BufferUsages::UNIFORM,
+        });
+        device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("Backdrop Mask Bind Group"),
+            layout: &self.mask_bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::TextureView(view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::Sampler(&self.sampler),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 3,
+                    resource: wgpu::BindingResource::TextureView(mask),
+                },
+            ],
+        })
+    }
+
     /// Run one full-screen-triangle pass into `target` over `viewport`.
     #[allow(clippy::too_many_arguments)]
     fn pass(
@@ -318,12 +431,38 @@ impl BackdropRenderer {
         pass.draw(0..3, 0..1);
     }
 
-    /// Blur one region of the scene target, in place.
+    /// Blur one region of the scene target, in place, cut out by the region's
+    /// own corners.
     pub fn apply(
         &self,
         device: &wgpu::Device,
         encoder: &mut wgpu::CommandEncoder,
         region: &BackdropRegion,
+    ) {
+        self.filter(device, encoder, region, None);
+    }
+
+    /// The same, cut out by `mask`'s alpha instead of the corners.
+    ///
+    /// The mask covers the region one texel per destination pixel, so what it
+    /// leaves opaque is what shows the blur — glyph coverage, in the only
+    /// caller. The region's radii are ignored: the shape is entirely the mask's.
+    pub fn apply_masked(
+        &self,
+        device: &wgpu::Device,
+        encoder: &mut wgpu::CommandEncoder,
+        region: &BackdropRegion,
+        mask: &wgpu::TextureView,
+    ) {
+        self.filter(device, encoder, region, Some(mask));
+    }
+
+    fn filter(
+        &self,
+        device: &wgpu::Device,
+        encoder: &mut wgpu::CommandEncoder,
+        region: &BackdropRegion,
+        mask: Option<&wgpu::TextureView>,
     ) {
         let Some(targets) = &self.targets else {
             return;
@@ -356,6 +495,16 @@ impl BackdropRenderer {
             work_height as f32 / targets.work_height as f32,
         ];
 
+        // The mask covers the region; the viewport covers whatever of it is on
+        // the target. When a text runs off the edge they differ, and reading
+        // the whole mask across a clipped viewport would squash the letters.
+        let mask_rect = [
+            (x as f32 - region.rect.x) / region.rect.width.max(1.0),
+            (y as f32 - region.rect.y) / region.rect.height.max(1.0),
+            width as f32 / region.rect.width.max(1.0),
+            height as f32 / region.rect.height.max(1.0),
+        ];
+
         let base = Params {
             src_rect: scene_rect,
             direction: [0.0, 0.0],
@@ -365,6 +514,7 @@ impl BackdropRenderer {
             curvature: region.curvature,
             _pad: 0.0,
             radii: region.radii.to_array(),
+            mask_rect,
         };
 
         // 1. Scene region → working[0], shrunk.
@@ -405,23 +555,31 @@ impl BackdropRenderer {
             );
         }
 
-        // 3. Back over the scene, masked to the container's shape.
-        let bind = self.bind(
-            device,
-            &targets.working_views[0],
-            Params {
-                src_rect: work_rect,
-                ..base
-            },
-        );
+        // 3. Back over the scene, cut out by the shape or by the mask.
+        let params = Params {
+            src_rect: work_rect,
+            ..base
+        };
+        let (pipeline, bind, label) = match mask {
+            Some(mask) => (
+                &self.composite_mask,
+                self.bind_masked(device, &targets.working_views[0], mask, params),
+                "Backdrop Composite Mask",
+            ),
+            None => (
+                &self.composite,
+                self.bind(device, &targets.working_views[0], params),
+                "Backdrop Composite",
+            ),
+        };
         self.pass(
             encoder,
-            &self.composite,
+            pipeline,
             &targets.scene_view,
             wgpu::LoadOp::Load,
             &bind,
             (x, y, width, height),
-            "Backdrop Composite",
+            label,
         );
     }
 
@@ -447,6 +605,7 @@ impl BackdropRenderer {
                 curvature: 1.0,
                 _pad: 0.0,
                 radii: [0.0; 4],
+                mask_rect: [0.0, 0.0, 1.0, 1.0],
             },
         );
         self.pass(

--- a/src/renderer/backdrop_shader.wgsl
+++ b/src/renderer/backdrop_shader.wgsl
@@ -19,11 +19,16 @@ struct Params {
     // Corner radii in physical pixels: top-left, top-right, bottom-right,
     // bottom-left.
     radii: vec4<f32>,
+    // Sub-rectangle of the coverage mask this viewport covers, normalised.
+    mask_rect: vec4<f32>,
 }
 
 @group(0) @binding(0) var t_source: texture_2d<f32>;
 @group(0) @binding(1) var s_source: sampler;
 @group(0) @binding(2) var<uniform> params: Params;
+// Coverage mask for `fs_composite_mask`, one texel per destination pixel.
+// Declared for every entry point, bound only by the pipeline that reads it.
+@group(0) @binding(3) var t_mask: texture_2d<f32>;
 
 struct VertexOutput {
     @builtin(position) clip_position: vec4<f32>,
@@ -111,4 +116,17 @@ fn fs_composite(in: VertexOutput) -> @location(0) vec4<f32> {
     let mask = 1.0 - smoothstep(-0.5, 0.5, distance);
 
     return vec4<f32>(blurred.rgb, blurred.a * mask);
+}
+
+// The same composite, shaped by a coverage mask instead of a rectangle: what
+// the glyphs cover shows the blurred backdrop, everything else is left alone.
+// The mask lines up one texel per destination pixel, so it is read with the
+// destination uv rather than the source rect.
+@fragment
+fn fs_composite_mask(in: VertexOutput) -> @location(0) vec4<f32> {
+    let blurred = textureSample(t_source, s_source, source_uv(in.uv));
+    let mask_uv = params.mask_rect.xy + in.uv * params.mask_rect.zw;
+    let coverage = textureSample(t_mask, s_source, mask_uv).a;
+
+    return vec4<f32>(blurred.rgb, blurred.a * coverage);
 }

--- a/src/renderer/backdrop_shader.wgsl
+++ b/src/renderer/backdrop_shader.wgsl
@@ -21,6 +21,13 @@ struct Params {
     radii: vec4<f32>,
     // Sub-rectangle of the coverage mask this viewport covers, normalised.
     mask_rect: vec4<f32>,
+    // Colour of the outline drawn by `fs_outline`, and how far it reaches out
+    // from the glyph edge in physical pixels.
+    stroke_color: vec4<f32>,
+    stroke_width: f32,
+    _pad1: f32,
+    _pad2: f32,
+    _pad3: f32,
 }
 
 @group(0) @binding(0) var t_source: texture_2d<f32>;
@@ -116,6 +123,40 @@ fn fs_composite(in: VertexOutput) -> @location(0) vec4<f32> {
     let mask = 1.0 - smoothstep(-0.5, 0.5, distance);
 
     return vec4<f32>(blurred.rgb, blurred.a * mask);
+}
+
+// A contour around the coverage, drawn outside it.
+//
+// The dilate is the largest coverage within `stroke_width` of the pixel;
+// subtracting the pixel's own coverage leaves a band that starts at the glyph
+// edge and reaches outwards, which is what a stroke is. Drawing copies of the
+// glyphs instead — the cheap approximation, and the right one under an opaque
+// fill — would fill the letter as well as ring it, and over frost the letter is
+// exactly what must stay clear.
+@fragment
+fn fs_outline(in: VertexOutput) -> @location(0) vec4<f32> {
+    let mask_uv = params.mask_rect.xy + in.uv * params.mask_rect.zw;
+    let own = textureSample(t_mask, s_source, mask_uv).a;
+
+    // One physical pixel, in mask uv.
+    let px = params.mask_rect.zw / max(params.dst_size, vec2<f32>(1.0));
+    let taps = 16;
+    let tau = 6.2831855;
+
+    var dilated = own;
+    // Two rings: the outer one decides how far the contour reaches, the inner
+    // one keeps a thick contour solid rather than hollow at the corners.
+    for (var ring = 1; ring <= 2; ring = ring + 1) {
+        let radius = params.stroke_width * f32(ring) * 0.5;
+        for (var i = 0; i < taps; i = i + 1) {
+            let angle = tau * f32(i) / f32(taps);
+            let offset = vec2<f32>(cos(angle), sin(angle)) * radius * px;
+            dilated = max(dilated, textureSample(t_mask, s_source, mask_uv + offset).a);
+        }
+    }
+
+    let contour = clamp(dilated - own, 0.0, 1.0);
+    return vec4<f32>(params.stroke_color.rgb, params.stroke_color.a * contour);
 }
 
 // The same composite, shaped by a coverage mask instead of a rectangle: what

--- a/src/renderer/commands.rs
+++ b/src/renderer/commands.rs
@@ -3,6 +3,7 @@
 use super::types::{Gradient, Shadow};
 use crate::widgets::font::{FontFamily, FontWeight};
 use crate::widgets::image::{ContentFit, ImageSource};
+use crate::widgets::text_style::TextStroke;
 use crate::widgets::{Color, Rect};
 
 /// Border definition for shapes.
@@ -203,6 +204,12 @@ pub enum DrawCommand {
     TextBackdropBlur {
         /// The text whose coverage is the mask.
         text: String,
+        /// A contour to draw around that coverage, once the blur is composited
+        /// and before the glyphs land on it. Carried here because the mask it
+        /// needs is the one this command already rasterizes — and because the
+        /// cheap stroke, copies of the glyphs under the fill, would fill the
+        /// letter the frost just cut out.
+        stroke: Option<TextStroke>,
         /// The text's layout box in local coordinates.
         rect: Rect,
         /// Blur radius in logical pixels.

--- a/src/renderer/commands.rs
+++ b/src/renderer/commands.rs
@@ -191,6 +191,30 @@ pub enum DrawCommand {
         curvature: f32,
     },
 
+    /// Filter what has already been drawn beneath the glyphs of `text`.
+    ///
+    /// The rectangular sibling above filters a box; this one filters the shape
+    /// of the letters, which no formula describes — the renderer rasterizes
+    /// them into a coverage mask. Ordered before the text itself, so the glyphs
+    /// are painted over their own blurred backdrop.
+    ///
+    /// Everything needed to shape the mask is repeated here, because the mask
+    /// has to come out identical to the text drawn after it.
+    TextBackdropBlur {
+        /// The text whose coverage is the mask.
+        text: String,
+        /// The text's layout box in local coordinates.
+        rect: Rect,
+        /// Blur radius in logical pixels.
+        radius: f32,
+        /// The font size in logical pixels.
+        font_size: f32,
+        /// The font family.
+        font_family: FontFamily,
+        /// The font weight.
+        font_weight: FontWeight,
+    },
+
     /// Draw an image.
     Image {
         /// Image source (path or bytes)

--- a/src/renderer/flatten.rs
+++ b/src/renderer/flatten.rs
@@ -437,7 +437,9 @@ fn flatten_node(
         let layer = match &**cmd {
             DrawCommand::Text { .. } => RenderLayer::Text,
             DrawCommand::Image { .. } => RenderLayer::Images,
-            DrawCommand::BackdropBlur { .. } => RenderLayer::Backdrop,
+            DrawCommand::BackdropBlur { .. } | DrawCommand::TextBackdropBlur { .. } => {
+                RenderLayer::Backdrop
+            }
             _ => RenderLayer::Shapes,
         };
         out.push(FlattenedCommand {
@@ -557,6 +559,9 @@ fn world_bounds(cmd: &FlattenedCommand) -> Option<Rect> {
         DrawCommand::Image { rect, .. } => *rect,
         DrawCommand::BackdropBlur { rect, .. } => *rect,
         DrawCommand::Text {
+            rect, font_size, ..
+        }
+        | DrawCommand::TextBackdropBlur {
             rect, font_size, ..
         } => {
             // Glyphs overshoot their layout box — descenders, italics, marks.

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -20,6 +20,7 @@ mod image_quad;
 mod paint_context;
 mod render;
 mod text;
+mod text_mask;
 mod text_measurer;
 mod text_quad;
 mod textured_quad;

--- a/src/renderer/paint_context.rs
+++ b/src/renderer/paint_context.rs
@@ -340,6 +340,37 @@ impl<'a> PaintContext<'a> {
         }));
     }
 
+    /// Blur whatever is already drawn beneath the glyphs of `text`, so the
+    /// text can be painted over its own blurred backdrop.
+    ///
+    /// Emitted before the text and its decorations. The arguments have to be
+    /// the ones the text is drawn with: the mask is shaped from them, and a
+    /// mask shaped differently is a halo.
+    #[allow(clippy::too_many_arguments)]
+    pub fn draw_text_backdrop_blur(
+        &mut self,
+        text: &str,
+        rect: Rect,
+        radius: f32,
+        font_size: f32,
+        font_family: FontFamily,
+        font_weight: FontWeight,
+    ) {
+        if text.is_empty() || radius <= 0.0 {
+            return;
+        }
+        self.node
+            .commands
+            .push(Rc::new(DrawCommand::TextBackdropBlur {
+                text: text.to_owned(),
+                rect,
+                radius,
+                font_size,
+                font_family,
+                font_weight,
+            }));
+    }
+
     pub fn draw_circle(&mut self, cx: f32, cy: f32, radius: f32, color: Color) {
         self.node.commands.push(Rc::new(DrawCommand::Circle {
             center: (cx, cy),

--- a/src/renderer/paint_context.rs
+++ b/src/renderer/paint_context.rs
@@ -352,6 +352,7 @@ impl<'a> PaintContext<'a> {
         text: &str,
         rect: Rect,
         radius: f32,
+        stroke: Option<TextStroke>,
         font_size: f32,
         font_family: FontFamily,
         font_weight: FontWeight,
@@ -363,6 +364,7 @@ impl<'a> PaintContext<'a> {
             .commands
             .push(Rc::new(DrawCommand::TextBackdropBlur {
                 text: text.to_owned(),
+                stroke: stroke.filter(|s| s.width > 0.0),
                 rect,
                 radius,
                 font_size,

--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -374,6 +374,18 @@ impl Renderer {
                                     &frost.region,
                                     &mask,
                                 );
+                                // After the blur and before the glyphs: a
+                                // contour on the glass, not under it.
+                                if let Some((color, width)) = frost.outline {
+                                    self.backdrop.apply_outline(
+                                        &self.device,
+                                        &mut encoder,
+                                        &frost.region,
+                                        &mask,
+                                        color,
+                                        width,
+                                    );
+                                }
                             }
                         }
                     }
@@ -636,6 +648,8 @@ fn command_to_backdrop_region(cmd: &FlattenedCommand, scale: f32) -> Option<Back
 struct TextBackdrop<'a> {
     region: BackdropRegion,
     spec: MaskSpec<'a>,
+    /// The contour to draw around the coverage, in physical pixels.
+    outline: Option<(Color, f32)>,
 }
 
 /// Resolve a text backdrop command to its region and the mask to shape it with.
@@ -646,6 +660,7 @@ struct TextBackdrop<'a> {
 fn command_to_text_backdrop(cmd: &FlattenedCommand, scale: f32) -> Option<TextBackdrop<'_>> {
     let DrawCommand::TextBackdropBlur {
         text,
+        stroke,
         rect,
         radius,
         font_size,
@@ -665,8 +680,10 @@ fn command_to_text_backdrop(cmd: &FlattenedCommand, scale: f32) -> Option<TextBa
 
     let (world_x, world_y) = cmd.world_transform.transform_point(rect.x, rect.y);
     // Glyphs overshoot their layout box — descenders, italics, marks — and the
-    // slack here is the one the flattener already uses for a text's bounds.
-    let slack = font_size * 0.5;
+    // slack here is the one the flattener already uses for a text's bounds. A
+    // contour reaches further still, and what falls outside the region is not
+    // drawn at all.
+    let slack = font_size * 0.5 + stroke.map(|s| s.width).unwrap_or(0.0);
     let left = (world_x - slack) * scale;
     let top = (world_y - slack) * scale;
     let right = (world_x + rect.width + slack) * scale;
@@ -697,6 +714,7 @@ fn command_to_text_backdrop(cmd: &FlattenedCommand, scale: f32) -> Option<TextBa
             offset: (world_x * scale - x, world_y * scale - y),
             scale_factor: scale,
         },
+        outline: stroke.map(|s| (s.color, s.width * scale)),
     })
 }
 
@@ -817,6 +835,7 @@ mod tests {
         FlattenedCommand {
             command: Rc::new(DrawCommand::TextBackdropBlur {
                 text: "09:41".to_owned(),
+                stroke: None,
                 rect,
                 radius: 10.0,
                 font_size: 20.0,

--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -144,7 +144,7 @@ impl Renderer {
 
         // Initialize transformed text renderer
         let text_quad_renderer = TextQuadRenderer::new(&device, &queue, format);
-        let text_mask = TextMaskRenderer::new(&device, &queue, format);
+        let text_mask = TextMaskRenderer::new(format);
 
         // Initialize image renderer
         let image_quad_renderer = ImageQuadRenderer::new(&device, format);

--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -11,12 +11,13 @@ use wgpu::{
 };
 
 use super::backdrop_pass::{BackdropRegion, BackdropRenderer};
-use super::commands::DrawCommand;
+use super::commands::{CornerRadii, DrawCommand};
 use super::flatten::{CommandLayer, FlattenedCommand};
 use super::gpu::{QUAD_INDICES, QUAD_VERTICES, QuadVertex, ShaderUniforms, ShapeInstance};
 use super::gpu_context::SurfaceState;
 use super::image_quad::{ImageQuadRenderer, PreparedImageQuad};
 use super::text::TextRenderState;
+use super::text_mask::{MaskSpec, TextMaskRenderer};
 use super::text_quad::{PreparedTextQuad, TextQuadRenderer};
 use super::types::TextEntry;
 use crate::widgets::{Color, Rect};
@@ -49,6 +50,9 @@ pub struct Renderer {
 
     // Transformed text rendering (renders text to textures for rotation/scale)
     text_quad_renderer: TextQuadRenderer,
+
+    /// Glyph coverage for texts that frost their own backdrop.
+    text_mask: TextMaskRenderer,
 
     // Image rendering
     image_quad_renderer: ImageQuadRenderer,
@@ -140,6 +144,7 @@ impl Renderer {
 
         // Initialize transformed text renderer
         let text_quad_renderer = TextQuadRenderer::new(&device, &queue, format);
+        let text_mask = TextMaskRenderer::new(&device, &queue, format);
 
         // Initialize image renderer
         let image_quad_renderer = ImageQuadRenderer::new(&device, format);
@@ -159,6 +164,7 @@ impl Renderer {
             instance_buffer_capacity: initial_capacity,
             text_state,
             text_quad_renderer,
+            text_mask,
             image_quad_renderer,
             shape_instance_buf: Vec::new(),
             text_entry_buf: Vec::new(),
@@ -355,6 +361,20 @@ impl Renderer {
                     for command in &commands[layers[index].backdrop.clone()] {
                         if let Some(region) = command_to_backdrop_region(command, scale) {
                             self.backdrop.apply(&self.device, &mut encoder, &region);
+                        } else if let Some(frost) = command_to_text_backdrop(command, scale) {
+                            // The mask is rasterized and submitted on its own
+                            // encoder, so it is ready by the time this frame's
+                            // encoder reaches the composite below.
+                            if let Some(mask) =
+                                self.text_mask.mask(&self.device, &self.queue, &frost.spec)
+                            {
+                                self.backdrop.apply_masked(
+                                    &self.device,
+                                    &mut encoder,
+                                    &frost.region,
+                                    &mask,
+                                );
+                            }
                         }
                     }
                     render_pass = begin_pass(&mut encoder, target, load);
@@ -418,6 +438,7 @@ impl Renderer {
         self.image_quads.clear();
         self.text_quads.clear();
         self.image_quad_renderer.begin_frame();
+        self.text_mask.begin_frame();
         self.text_state.begin_frame(
             &self.queue,
             (self.screen_width as u32, self.screen_height as u32),
@@ -595,6 +616,73 @@ fn command_to_backdrop_region(cmd: &FlattenedCommand, scale: f32) -> Option<Back
     })
 }
 
+/// A frosted text resolved to the region it filters and the mask that cuts it.
+struct TextBackdrop<'a> {
+    region: BackdropRegion,
+    spec: MaskSpec<'a>,
+}
+
+/// Resolve a text backdrop command to its region and the mask to shape it with.
+///
+/// The region is snapped to whole pixels so the mask is one texel per pixel of
+/// it; whatever the snap moved is handed back to the mask as the glyph origin,
+/// which is why a text half a pixel off the grid still frosts its own shape.
+fn command_to_text_backdrop(cmd: &FlattenedCommand, scale: f32) -> Option<TextBackdrop<'_>> {
+    let DrawCommand::TextBackdropBlur {
+        text,
+        rect,
+        radius,
+        font_size,
+        font_family,
+        font_weight,
+    } = &*cmd.command
+    else {
+        return None;
+    };
+
+    // A rotated or scaled text is drawn from a texture, at an angle an
+    // axis-aligned mask cannot follow. Skipping is the honest answer: a frost
+    // that sits beside its letters is worse than none.
+    if !cmd.world_transform.is_translation_only() {
+        return None;
+    }
+
+    let (world_x, world_y) = cmd.world_transform.transform_point(rect.x, rect.y);
+    // Glyphs overshoot their layout box — descenders, italics, marks — and the
+    // slack here is the one the flattener already uses for a text's bounds.
+    let slack = font_size * 0.5;
+    let left = (world_x - slack) * scale;
+    let top = (world_y - slack) * scale;
+    let right = (world_x + rect.width + slack) * scale;
+    let bottom = (world_y + rect.height + slack) * scale;
+
+    let x = left.floor();
+    let y = top.floor();
+    let width = (right.ceil() - x).max(1.0);
+    let height = (bottom.ceil() - y).max(1.0);
+
+    Some(TextBackdrop {
+        region: BackdropRegion {
+            rect: Rect::new(x, y, width, height),
+            radius: radius * scale,
+            // The shape is entirely the mask's; these are what the rectangular
+            // composite would have used.
+            radii: CornerRadii::uniform(0.0),
+            curvature: 1.0,
+        },
+        spec: MaskSpec {
+            text,
+            font_size: *font_size,
+            font_family,
+            font_weight: *font_weight,
+            logical: (rect.width, rect.height),
+            size: (width as u32, height as u32),
+            offset: (world_x * scale - x, world_y * scale - y),
+            scale_factor: scale,
+        },
+    })
+}
+
 /// Convert a single flattened command to a shape instance.
 fn command_to_instance(cmd: &FlattenedCommand, scale: f32) -> Option<ShapeInstance> {
     match &*cmd.command {
@@ -663,7 +751,7 @@ fn command_to_instance(cmd: &FlattenedCommand, scale: f32) -> Option<ShapeInstan
         DrawCommand::Text { .. } => None,
         // Filters the target rather than adding geometry; handled between
         // draw groups, not as an instance.
-        DrawCommand::BackdropBlur { .. } => None,
+        DrawCommand::BackdropBlur { .. } | DrawCommand::TextBackdropBlur { .. } => None,
         // Image commands are handled separately via ImageQuadRenderer
         DrawCommand::Image { .. } => None,
     }
@@ -696,5 +784,94 @@ fn command_to_text_entry(cmd: &FlattenedCommand) -> Option<TextEntry> {
             })
         }
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::rc::Rc;
+
+    use crate::renderer::flatten::RenderLayer;
+    use crate::transform::Transform;
+    use crate::widgets::FontFamily;
+
+    fn frosted(rect: Rect, transform: Transform) -> FlattenedCommand {
+        FlattenedCommand {
+            command: Rc::new(DrawCommand::TextBackdropBlur {
+                text: "09:41".to_owned(),
+                rect,
+                radius: 10.0,
+                font_size: 20.0,
+                font_family: FontFamily::default(),
+                font_weight: Default::default(),
+            }),
+            world_transform: transform,
+            world_transform_origin: None,
+            layer: RenderLayer::Backdrop,
+            clip: None,
+            clip_is_local: false,
+        }
+    }
+
+    /// The mask is one texel per pixel of the region, which only works if the
+    /// region lands on the pixel grid. What the snap moves has to come back as
+    /// the glyph origin, or the frost sits beside its own letters.
+    #[test]
+    fn the_region_is_snapped_and_the_remainder_goes_to_the_mask() {
+        let cmd = frosted(Rect::new(10.3, 20.6, 100.0, 30.0), Transform::IDENTITY);
+        let frost = command_to_text_backdrop(&cmd, 1.0).expect("a frost");
+
+        let rect = frost.region.rect;
+        assert_eq!(rect.x, rect.x.floor(), "x is a whole pixel, got {}", rect.x);
+        assert_eq!(rect.y, rect.y.floor(), "y is a whole pixel, got {}", rect.y);
+        assert_eq!(rect.width, rect.width.floor());
+        assert_eq!(rect.height, rect.height.floor());
+        assert_eq!(frost.spec.size, (rect.width as u32, rect.height as u32));
+
+        // The glyph origin, measured from the snapped corner, still lands on
+        // the text's own position.
+        assert!((rect.x + frost.spec.offset.0 - 10.3).abs() < 1e-3);
+        assert!((rect.y + frost.spec.offset.1 - 20.6).abs() < 1e-3);
+    }
+
+    /// Descenders and italics reach past the layout box, and so must the frost:
+    /// the same slack the flattener gives a text's bounds.
+    #[test]
+    fn the_region_covers_more_than_the_layout_box() {
+        let cmd = frosted(Rect::new(10.0, 20.0, 100.0, 30.0), Transform::IDENTITY);
+        let frost = command_to_text_backdrop(&cmd, 1.0).expect("a frost");
+        assert!(frost.region.rect.width >= 110.0, "{:?}", frost.region.rect);
+        assert!(frost.region.rect.height >= 40.0, "{:?}", frost.region.rect);
+    }
+
+    #[test]
+    fn the_scale_factor_reaches_the_region_and_the_radius() {
+        let cmd = frosted(Rect::new(10.0, 20.0, 100.0, 30.0), Transform::IDENTITY);
+        let one = command_to_text_backdrop(&cmd, 1.0).expect("a frost");
+        let two = command_to_text_backdrop(&cmd, 2.0).expect("a frost");
+        assert_eq!(two.region.radius, one.region.radius * 2.0);
+        assert!(two.region.rect.width >= one.region.rect.width * 2.0 - 1.0);
+        assert_eq!(two.spec.scale_factor, 2.0);
+    }
+
+    /// A translated text is still axis-aligned, so the mask can follow it.
+    #[test]
+    fn a_translated_text_is_frosted_where_it_ends_up() {
+        let cmd = frosted(
+            Rect::new(10.0, 20.0, 100.0, 30.0),
+            Transform::translate(40.0, 5.0),
+        );
+        let frost = command_to_text_backdrop(&cmd, 1.0).expect("a frost");
+        assert!((frost.region.rect.x + frost.spec.offset.0 - 50.0).abs() < 1e-3);
+        assert!((frost.region.rect.y + frost.spec.offset.1 - 25.0).abs() < 1e-3);
+    }
+
+    /// A rotated or scaled one is not: the mask is rasterized square, and a
+    /// frost beside its letters is worse than no frost.
+    #[test]
+    fn a_rotated_text_is_left_alone() {
+        let cmd = frosted(Rect::new(10.0, 20.0, 100.0, 30.0), Transform::rotate(0.4));
+        assert!(command_to_text_backdrop(&cmd, 1.0).is_none());
     }
 }

--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -568,6 +568,21 @@ fn begin_pass<'a>(
     })
 }
 
+/// The clip a command was flattened under, in physical pixels.
+///
+/// The axis-aligned rect of it: a rounded or rotated clip is approximated by
+/// its box, which is one pixel of slack at the corners against a blurred
+/// rectangle where the content has been scrolled away.
+fn clip_rect(cmd: &FlattenedCommand, scale: f32) -> Option<Rect> {
+    let clip = cmd.clip.as_ref()?.rect;
+    Some(Rect::new(
+        clip.x * scale,
+        clip.y * scale,
+        clip.width * scale,
+        clip.height * scale,
+    ))
+}
+
 /// Resolve a backdrop command to the physical-pixel region it filters.
 fn command_to_backdrop_region(cmd: &FlattenedCommand, scale: f32) -> Option<BackdropRegion> {
     let DrawCommand::BackdropBlur {
@@ -613,6 +628,7 @@ fn command_to_backdrop_region(cmd: &FlattenedCommand, scale: f32) -> Option<Back
         radius: radius * scale,
         radii: corner_radii.scaled(scale),
         curvature: *curvature,
+        clip: clip_rect(cmd, scale),
     })
 }
 
@@ -669,6 +685,7 @@ fn command_to_text_backdrop(cmd: &FlattenedCommand, scale: f32) -> Option<TextBa
             // composite would have used.
             radii: CornerRadii::uniform(0.0),
             curvature: 1.0,
+            clip: clip_rect(cmd, scale),
         },
         spec: MaskSpec {
             text,
@@ -865,6 +882,24 @@ mod tests {
         let frost = command_to_text_backdrop(&cmd, 1.0).expect("a frost");
         assert!((frost.region.rect.x + frost.spec.offset.0 - 50.0).abs() < 1e-3);
         assert!((frost.region.rect.y + frost.spec.offset.1 - 25.0).abs() < 1e-3);
+    }
+
+    /// A frost inside a scroll view must not paint where the text has been
+    /// scrolled away to: the clip is what the effect is allowed to write.
+    #[test]
+    fn the_clip_reaches_the_region() {
+        let mut cmd = frosted(Rect::new(10.0, 20.0, 100.0, 30.0), Transform::IDENTITY);
+        cmd.clip = Some(crate::renderer::flatten::WorldClip {
+            rect: Rect::new(0.0, 0.0, 200.0, 200.0),
+            corner_radius: 0.0,
+            curvature: 1.0,
+        });
+        let frost = command_to_text_backdrop(&cmd, 2.0).expect("a frost");
+        assert_eq!(
+            frost.region.clip,
+            Some(Rect::new(0.0, 0.0, 400.0, 400.0)),
+            "in physical pixels, like the region it bounds"
+        );
     }
 
     /// A rotated or scaled one is not: the mask is rasterized square, and a

--- a/src/renderer/text_mask.rs
+++ b/src/renderer/text_mask.rs
@@ -80,8 +80,11 @@ struct CachedMask {
     last_used: Cell<u64>,
 }
 
-/// Rasterizes glyph coverage, and remembers it.
-pub struct TextMaskRenderer {
+/// The glyphon side, built on the first frosted text and not before.
+///
+/// A `FontSystem` scans the machine's fonts to construct, which is not a cost
+/// to put on every app for an effect most of them never ask for.
+struct Shaper {
     font_system: FontSystem,
     swash_cache: SwashCache,
     #[allow(dead_code)] // Held for the atlas and viewport.
@@ -89,13 +92,10 @@ pub struct TextMaskRenderer {
     atlas: TextAtlas,
     text_renderer: TextRenderer,
     viewport: Viewport,
-    format: TextureFormat,
-    masks: HashMap<MaskKey, Rc<CachedMask>>,
-    frame_gen: u64,
 }
 
-impl TextMaskRenderer {
-    pub fn new(device: &Device, queue: &Queue, format: TextureFormat) -> Self {
+impl Shaper {
+    fn new(device: &Device, queue: &Queue, format: TextureFormat) -> Self {
         let mut font_system = FontSystem::new();
         for data in crate::get_registered_fonts() {
             font_system
@@ -115,6 +115,22 @@ impl TextMaskRenderer {
             atlas,
             text_renderer,
             viewport,
+        }
+    }
+}
+
+/// Rasterizes glyph coverage, and remembers it.
+pub struct TextMaskRenderer {
+    shaper: Option<Shaper>,
+    format: TextureFormat,
+    masks: HashMap<MaskKey, Rc<CachedMask>>,
+    frame_gen: u64,
+}
+
+impl TextMaskRenderer {
+    pub fn new(format: TextureFormat) -> Self {
+        Self {
+            shaper: None,
             format,
             masks: HashMap::new(),
             frame_gen: 0,
@@ -176,19 +192,24 @@ impl TextMaskRenderer {
             return Some(Rc::clone(&cached.view));
         }
 
+        let format = self.format;
+        let shaper = self
+            .shaper
+            .get_or_insert_with(|| Shaper::new(device, queue, format));
+
         // Shaped the way the on-screen text is shaped, or the hole would not be
         // the shape of the letters that land in it.
         let mut buffer = Buffer::new(
-            &mut self.font_system,
+            &mut shaper.font_system,
             Metrics::new(font_size, font_size * 1.2),
         );
         buffer.set_size(
-            &mut self.font_system,
+            &mut shaper.font_system,
             Some(spec.logical.0.max(200.0) * spec.scale_factor),
             Some(spec.logical.1.max(50.0) * spec.scale_factor),
         );
         buffer.set_text(
-            &mut self.font_system,
+            &mut shaper.font_system,
             spec.text,
             &Attrs::new()
                 .family(spec.font_family.to_cosmic())
@@ -196,7 +217,7 @@ impl TextMaskRenderer {
             Shaping::Advanced,
             None,
         );
-        buffer.shape_until_scroll(&mut self.font_system, true);
+        buffer.shape_until_scroll(&mut shaper.font_system, true);
 
         let texture = device.create_texture(&wgpu::TextureDescriptor {
             label: Some("Text Mask"),
@@ -208,13 +229,13 @@ impl TextMaskRenderer {
             mip_level_count: 1,
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
-            format: self.format,
+            format,
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::TEXTURE_BINDING,
             view_formats: &[],
         });
         let view = texture.create_view(&Default::default());
 
-        self.viewport.update(queue, Resolution { width, height });
+        shaper.viewport.update(queue, Resolution { width, height });
 
         let area = TextArea {
             buffer: &buffer,
@@ -233,14 +254,14 @@ impl TextMaskRenderer {
             custom_glyphs: &[],
         };
 
-        if let Err(e) = self.text_renderer.prepare(
+        if let Err(e) = shaper.text_renderer.prepare(
             device,
             queue,
-            &mut self.font_system,
-            &mut self.atlas,
-            &self.viewport,
+            &mut shaper.font_system,
+            &mut shaper.atlas,
+            &shaper.viewport,
             vec![area],
-            &mut self.swash_cache,
+            &mut shaper.swash_cache,
         ) {
             log::error!("text mask prepare failed: {e:?}");
             return None;
@@ -266,9 +287,9 @@ impl TextMaskRenderer {
                 occlusion_query_set: None,
                 multiview_mask: None,
             });
-            if let Err(e) = self
+            if let Err(e) = shaper
                 .text_renderer
-                .render(&self.atlas, &self.viewport, &mut pass)
+                .render(&shaper.atlas, &shaper.viewport, &mut pass)
             {
                 log::error!("text mask render failed: {e:?}");
             }

--- a/src/renderer/text_mask.rs
+++ b/src/renderer/text_mask.rs
@@ -1,0 +1,289 @@
+//! Glyph coverage as a texture: the shape a frosted text cuts out of its
+//! background.
+//!
+//! A container's backdrop blur is masked by a rounded rectangle, which the
+//! composite shader can evaluate from four radii. Glyphs have no such formula —
+//! the only thing that knows their shape is the rasterizer. So a text that asks
+//! for a backdrop blur is shaped once into a texture, in white on nothing, and
+//! the composite reads its alpha where it would otherwise evaluate an SDF.
+//!
+//! The mask is rasterized to cover exactly the region being filtered, one texel
+//! per physical pixel, so the composite can sample it with the destination uv.
+//! Shaping mirrors [`TextRenderState`](super::text::TextRenderState) exactly —
+//! same metrics, same buffer size — because the glyphs drawn over the frost come
+//! from there, and two shapings that disagree would show as a halo.
+//!
+//! Colour is deliberately absent from the cache key: the frost of a white label
+//! and a red one is the same hole.
+
+use std::cell::Cell;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use glyphon::{
+    Attrs, Buffer, Cache, Color as GlyphonColor, ColorMode, FontSystem, Metrics, Resolution,
+    Shaping, SwashCache, TextArea, TextAtlas, TextBounds, TextRenderer, Viewport,
+};
+use wgpu::{Device, MultisampleState, Queue, TextureFormat};
+
+use crate::widgets::FontFamily;
+use crate::widgets::font::FontWeight;
+
+/// Masks kept before the unused ones are dropped.
+///
+/// A surface frosting more than a handful of texts at once is not the case this
+/// is for — each one costs a pass break — so the ceiling is low and the sweep
+/// keeps whatever the current frame touched.
+const MAX_CACHED: usize = 32;
+
+/// Refuse a mask larger than this per side. A frost is an effect on a label, and
+/// an accidental one over a full-screen text would allocate a second framebuffer
+/// with no warning.
+const MAX_SIDE: u32 = 2048;
+
+/// What a mask has to be rasterized from.
+pub struct MaskSpec<'a> {
+    pub text: &'a str,
+    pub font_size: f32,
+    pub font_family: &'a FontFamily,
+    pub font_weight: FontWeight,
+    /// The text's layout box in logical pixels — the buffer is sized from it,
+    /// exactly as the on-screen shaping is.
+    pub logical: (f32, f32),
+    /// Mask size in physical pixels: the region the composite will cover.
+    pub size: (u32, u32),
+    /// Where the glyph origin sits inside that region, in physical pixels.
+    /// Sub-pixel, because the region is snapped to the pixel grid and the text
+    /// is not.
+    pub offset: (f32, f32),
+    pub scale_factor: f32,
+}
+
+#[derive(PartialEq, Eq, Hash)]
+struct MaskKey {
+    text: String,
+    font_size_bits: u32,
+    weight: u16,
+    family: FontFamily,
+    width: u32,
+    height: u32,
+    /// The sub-pixel offset, in quarter pixels. Quantised because it varies
+    /// continuously while a surface is dragged, and a mask per unique float
+    /// would never hit.
+    offset: (i32, i32),
+}
+
+struct CachedMask {
+    #[allow(dead_code)] // Held to keep the view alive.
+    texture: wgpu::Texture,
+    view: Rc<wgpu::TextureView>,
+    last_used: Cell<u64>,
+}
+
+/// Rasterizes glyph coverage, and remembers it.
+pub struct TextMaskRenderer {
+    font_system: FontSystem,
+    swash_cache: SwashCache,
+    #[allow(dead_code)] // Held for the atlas and viewport.
+    cache: Cache,
+    atlas: TextAtlas,
+    text_renderer: TextRenderer,
+    viewport: Viewport,
+    format: TextureFormat,
+    masks: HashMap<MaskKey, Rc<CachedMask>>,
+    frame_gen: u64,
+}
+
+impl TextMaskRenderer {
+    pub fn new(device: &Device, queue: &Queue, format: TextureFormat) -> Self {
+        let mut font_system = FontSystem::new();
+        for data in crate::get_registered_fonts() {
+            font_system
+                .db_mut()
+                .load_font_source(glyphon::fontdb::Source::Binary(data));
+        }
+        let cache = Cache::new(device);
+        let mut atlas = TextAtlas::with_color_mode(device, queue, &cache, format, ColorMode::Web);
+        let text_renderer =
+            TextRenderer::new(&mut atlas, device, MultisampleState::default(), None);
+        let viewport = Viewport::new(device, &cache);
+
+        Self {
+            font_system,
+            swash_cache: SwashCache::new(),
+            cache,
+            atlas,
+            text_renderer,
+            viewport,
+            format,
+            masks: HashMap::new(),
+            frame_gen: 0,
+        }
+    }
+
+    /// Note a new frame, and drop masks nothing has asked for in a while.
+    pub fn begin_frame(&mut self) {
+        self.frame_gen += 1;
+        if self.masks.len() > MAX_CACHED {
+            let current = self.frame_gen;
+            self.masks
+                .retain(|_, mask| mask.last_used.get() + 1 >= current);
+        }
+    }
+
+    /// The coverage of `spec`, rasterized or recalled.
+    ///
+    /// Renders and submits on its own encoder, so the mask is ready before the
+    /// frame that samples it is submitted.
+    pub fn mask(
+        &mut self,
+        device: &Device,
+        queue: &Queue,
+        spec: &MaskSpec<'_>,
+    ) -> Option<Rc<wgpu::TextureView>> {
+        let (width, height) = spec.size;
+        if spec.text.is_empty() || width == 0 || height == 0 {
+            return None;
+        }
+        if width > MAX_SIDE || height > MAX_SIDE {
+            log::warn!(
+                "text backdrop blur skipped: mask would be {width}x{height}, over the {MAX_SIDE} limit"
+            );
+            return None;
+        }
+
+        let font_size = spec.font_size * spec.scale_factor;
+        let weight = if spec.font_weight == FontWeight::default() {
+            FontWeight::NORMAL
+        } else {
+            spec.font_weight
+        };
+        let key = MaskKey {
+            text: spec.text.to_owned(),
+            font_size_bits: font_size.to_bits(),
+            weight: weight.0,
+            family: spec.font_family.clone(),
+            width,
+            height,
+            offset: (
+                (spec.offset.0 * 4.0).round() as i32,
+                (spec.offset.1 * 4.0).round() as i32,
+            ),
+        };
+
+        if let Some(cached) = self.masks.get(&key) {
+            cached.last_used.set(self.frame_gen);
+            return Some(Rc::clone(&cached.view));
+        }
+
+        // Shaped the way the on-screen text is shaped, or the hole would not be
+        // the shape of the letters that land in it.
+        let mut buffer = Buffer::new(
+            &mut self.font_system,
+            Metrics::new(font_size, font_size * 1.2),
+        );
+        buffer.set_size(
+            &mut self.font_system,
+            Some(spec.logical.0.max(200.0) * spec.scale_factor),
+            Some(spec.logical.1.max(50.0) * spec.scale_factor),
+        );
+        buffer.set_text(
+            &mut self.font_system,
+            spec.text,
+            &Attrs::new()
+                .family(spec.font_family.to_cosmic())
+                .weight(weight.to_cosmic()),
+            Shaping::Advanced,
+            None,
+        );
+        buffer.shape_until_scroll(&mut self.font_system, true);
+
+        let texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("Text Mask"),
+            size: wgpu::Extent3d {
+                width,
+                height,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: self.format,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::TEXTURE_BINDING,
+            view_formats: &[],
+        });
+        let view = texture.create_view(&Default::default());
+
+        self.viewport.update(queue, Resolution { width, height });
+
+        let area = TextArea {
+            buffer: &buffer,
+            left: spec.offset.0,
+            top: spec.offset.1,
+            scale: 1.0,
+            bounds: TextBounds {
+                left: 0,
+                top: 0,
+                right: width as i32,
+                bottom: height as i32,
+            },
+            // Opaque white: what is wanted is coverage, and a translucent text
+            // would otherwise thin its own hole.
+            default_color: GlyphonColor::rgb(255, 255, 255),
+            custom_glyphs: &[],
+        };
+
+        if let Err(e) = self.text_renderer.prepare(
+            device,
+            queue,
+            &mut self.font_system,
+            &mut self.atlas,
+            &self.viewport,
+            vec![area],
+            &mut self.swash_cache,
+        ) {
+            log::error!("text mask prepare failed: {e:?}");
+            return None;
+        }
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("Text Mask Encoder"),
+        });
+        {
+            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("Text Mask Pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &view,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                        store: wgpu::StoreOp::Store,
+                    },
+                    depth_slice: None,
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+                multiview_mask: None,
+            });
+            if let Err(e) = self
+                .text_renderer
+                .render(&self.atlas, &self.viewport, &mut pass)
+            {
+                log::error!("text mask render failed: {e:?}");
+            }
+        }
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let view = Rc::new(view);
+        self.masks.insert(
+            key,
+            Rc::new(CachedMask {
+                texture,
+                view: Rc::clone(&view),
+                last_used: Cell::new(self.frame_gen),
+            }),
+        );
+        Some(view)
+    }
+}

--- a/src/widgets/text.rs
+++ b/src/widgets/text.rs
@@ -112,10 +112,12 @@ impl Text {
     /// so it is asked for one text at a time rather than dressed onto a subtree.
     /// A rotated or scaled text ignores it — the mask is axis-aligned.
     ///
-    /// Legibility is not what it buys. Frost softens the background instead of
-    /// darkening it, so over a busy photograph
-    /// [`text_shadow`](super::TextStyled::text_shadow) still does more; the two
-    /// compose.
+    /// Legibility is not what it buys, and the two decorations that would give
+    /// it cannot be added on top. A [`text_stroke`](super::TextStyled::text_stroke)
+    /// and a [`text_shadow`](super::TextStyled::text_shadow) are drawn as copies
+    /// of the glyphs *under* the fill, so they cover the letter's own area and
+    /// not only its edge — invisible under an opaque fill, and an opaque letter
+    /// over frost. A frosted text is held together by its tint instead.
     pub fn backdrop_blur<M>(mut self, radius: impl IntoSignal<f32, M>) -> Self {
         self.backdrop_blur = Some(radius.into_signal());
         self

--- a/src/widgets/text.rs
+++ b/src/widgets/text.rs
@@ -112,12 +112,15 @@ impl Text {
     /// so it is asked for one text at a time rather than dressed onto a subtree.
     /// A rotated or scaled text ignores it — the mask is axis-aligned.
     ///
-    /// Legibility is not what it buys, and the two decorations that would give
-    /// it cannot be added on top. A [`text_stroke`](super::TextStyled::text_stroke)
-    /// and a [`text_shadow`](super::TextStyled::text_shadow) are drawn as copies
-    /// of the glyphs *under* the fill, so they cover the letter's own area and
-    /// not only its edge — invisible under an opaque fill, and an opaque letter
-    /// over frost. A frosted text is held together by its tint instead.
+    /// Legibility is not what it buys on its own, and of the two decorations
+    /// that give it, one composes and one does not.
+    ///
+    /// A [`text_stroke`](super::TextStyled::text_stroke) does: over frost it is
+    /// drawn as a true contour — dilated from the same coverage mask, laid
+    /// outside the letter — rather than as copies of the glyphs under the fill.
+    /// A [`text_shadow`](super::TextStyled::text_shadow) does not: it is still
+    /// copies, so it covers the letter's own area as well as its edge, which is
+    /// invisible under an opaque fill and an opaque letter over glass.
     pub fn backdrop_blur<M>(mut self, radius: impl IntoSignal<f32, M>) -> Self {
         self.backdrop_blur = Some(radius.into_signal());
         self
@@ -321,12 +324,16 @@ impl Widget for Text {
                 self.backdrop_blur.map(|radius| radius.get()),
             )
         });
-        // First, so the glyphs and their decorations land over the frost.
+        // A frosted text takes its stroke as a contour instead: drawn from the
+        // same coverage mask, outside the letter rather than under it, so the
+        // glass keeps what the frost put in it.
+        let frosted = blur.filter(|radius| *radius > 0.0).is_some();
         if let Some(radius) = blur {
             ctx.draw_text_backdrop_blur(
                 &self.cached_text,
                 local_bounds,
                 radius,
+                stroke,
                 self.cached_font_size,
                 self.cached_font_family.clone(),
                 self.cached_font_weight,
@@ -339,7 +346,7 @@ impl Widget for Text {
             self.cached_font_size,
             self.cached_font_family.clone(),
             self.cached_font_weight,
-            stroke,
+            if frosted { None } else { stroke },
             shadow,
         );
     }
@@ -414,6 +421,25 @@ mod tests {
         find(&node).expect("a text command")
     }
 
+    /// The stroke carried by the paint's frost command, if there is one.
+    fn frost_stroke(widget: impl Widget + 'static) -> Option<TextStroke> {
+        let mut tree = Tree::new();
+        let root = tree.register(Box::new(widget));
+        tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
+        tree.with_widget_mut(root, |w, id, t| {
+            w.layout(t, id, Constraints::new(0.0, 0.0, 800.0, 600.0))
+        });
+        let mut node = RenderNode::new(root.as_u64());
+        tree.with_widget_mut(root, |w, id, t| {
+            let mut ctx = PaintContext::new(&mut node);
+            w.paint(t, id, &mut ctx);
+        });
+        node.commands.iter().find_map(|cmd| match &**cmd {
+            DrawCommand::TextBackdropBlur { stroke, .. } => *stroke,
+            _ => None,
+        })
+    }
+
     /// Every command a paint produced, in order, as short names.
     fn commands(widget: impl Widget + 'static) -> Vec<&'static str> {
         let mut tree = Tree::new();
@@ -446,15 +472,50 @@ mod tests {
             commands(text("hi").backdrop_blur(8.0)),
             vec!["frost", "text"]
         );
-        let stroked = commands(
-            text("hi")
-                .backdrop_blur(8.0)
-                .text_stroke(TextStroke::new(1.0, Color::BLACK)),
-        );
-        assert_eq!(stroked[0], "frost");
+        let shadowed = commands(text("hi").backdrop_blur(8.0).text_shadow(TextShadow::new(
+            0.0,
+            2.0,
+            4.0,
+            Color::BLACK,
+        )));
+        assert_eq!(shadowed[0], "frost");
         assert!(
-            stroked[1..].iter().all(|cmd| *cmd == "text"),
-            "a stroke is more glyphs, and they go over the frost too: {stroked:?}"
+            shadowed[1..].iter().all(|cmd| *cmd == "text"),
+            "a shadow is more glyphs, and they go over the frost too: {shadowed:?}"
+        );
+    }
+
+    /// The stroke of a frosted text is not more glyphs. Copies under the fill
+    /// ring the letter *and* fill it, which over frost is an opaque letter
+    /// where the picture should be — so it rides on the frost command instead
+    /// and is drawn from the same coverage mask.
+    #[test]
+    fn a_frosted_text_takes_its_stroke_as_a_contour() {
+        let stroke = TextStroke::new(2.0, Color::BLACK);
+        assert_eq!(
+            commands(text("hi").backdrop_blur(8.0).text_stroke(stroke)),
+            vec!["frost", "text"],
+            "one frost, one fill, and no copies in between"
+        );
+
+        assert_eq!(
+            frost_stroke(text("hi").backdrop_blur(8.0).text_stroke(stroke)).map(|s| s.width),
+            Some(2.0)
+        );
+        assert!(
+            frost_stroke(text("hi").backdrop_blur(8.0)).is_none(),
+            "and nothing is invented for a text that declared none"
+        );
+    }
+
+    /// Without frost the cheap stroke is still the right one: under an opaque
+    /// fill the copies are invisible, and they cost no rasterization.
+    #[test]
+    fn an_unfrosted_text_keeps_the_sampled_stroke() {
+        let drawn = commands(text("hi").text_stroke(TextStroke::new(1.0, Color::BLACK)));
+        assert!(
+            drawn.len() > 2 && drawn.iter().all(|cmd| *cmd == "text"),
+            "copies of the glyphs, no frost command: {drawn:?}"
         );
     }
 

--- a/src/widgets/text.rs
+++ b/src/widgets/text.rs
@@ -49,6 +49,9 @@ pub struct Text {
     own_hover: Option<RwSignal<bool>>,
     /// If true, text won't wrap and will be clipped by parent container
     nowrap: bool,
+    /// Blur radius for the backdrop the glyphs cut out of what is behind them.
+    /// `None` for every text that is not made of glass.
+    backdrop_blur: Option<Signal<f32>>,
     /// Cached values for painting (avoid re-reading signals)
     cached_text: String,
     cached_font_size: f32,
@@ -69,6 +72,7 @@ impl Text {
             states: Vec::new(),
             own_hover: None,
             nowrap: false,
+            backdrop_blur: None,
             cached_text: String::new(), // Will be set during first layout
             cached_font_size: 14.0,
             cached_font_family: default_family,
@@ -80,6 +84,40 @@ impl Text {
     /// Use this for text inside animated containers to prevent re-wrapping during animation.
     pub fn nowrap(mut self) -> Self {
         self.nowrap = true;
+        self
+    }
+
+    /// Blur what is behind the glyphs, so the text reads as frosted glass.
+    ///
+    /// The letters become the window: what they cover is drawn blurred, and the
+    /// text's own colour is the tint laid over it — which is why this is usually
+    /// paired with a translucent one.
+    ///
+    /// ```ignore
+    /// text("09:41")
+    ///     .font_size(76.0)
+    ///     .color(Color::rgba(1.0, 1.0, 1.0, 0.35))
+    ///     .backdrop_blur(16.0)
+    /// ```
+    ///
+    /// It filters what *this surface* has already drawn — a wallpaper, a photo,
+    /// the panel underneath — and only that. A container's
+    /// [`backdrop_blur`](super::Container::backdrop_blur) can also reach the
+    /// desktop behind the surface, through `ext-background-effect-v1`; that
+    /// protocol takes a region, and regions are rectangles, so glyphs cannot be
+    /// expressed in it.
+    ///
+    /// Unlike the rest of a text's style this is not inherited from a container,
+    /// on purpose: each frosted text ends the render pass to filter the target,
+    /// so it is asked for one text at a time rather than dressed onto a subtree.
+    /// A rotated or scaled text ignores it — the mask is axis-aligned.
+    ///
+    /// Legibility is not what it buys. Frost softens the background instead of
+    /// darkening it, so over a busy photograph
+    /// [`text_shadow`](super::TextStyled::text_shadow) still does more; the two
+    /// compose.
+    pub fn backdrop_blur<M>(mut self, radius: impl IntoSignal<f32, M>) -> Self {
+        self.backdrop_blur = Some(radius.into_signal());
         self
     }
 
@@ -272,14 +310,26 @@ impl Widget for Text {
         let local_bounds = Rect::new(0.0, 0.0, size.width, size.height);
         // Read the painted properties with tracking so a change on whichever
         // ancestor supplied them repaints this text and nothing else.
-        let (color, stroke, shadow) = with_signal_tracking(id, JobType::Paint, || {
+        let (color, stroke, shadow, blur) = with_signal_tracking(id, JobType::Paint, || {
             let style = self.resolved_style(tree, id);
             (
                 style.color.get_or(Color::WHITE),
                 style.stroke.map(|s| s.get()),
                 style.shadow.map(|s| s.get()),
+                self.backdrop_blur.map(|radius| radius.get()),
             )
         });
+        // First, so the glyphs and their decorations land over the frost.
+        if let Some(radius) = blur {
+            ctx.draw_text_backdrop_blur(
+                &self.cached_text,
+                local_bounds,
+                radius,
+                self.cached_font_size,
+                self.cached_font_family.clone(),
+                self.cached_font_weight,
+            );
+        }
         ctx.draw_text_decorated(
             &self.cached_text,
             local_bounds,
@@ -360,6 +410,96 @@ mod tests {
             node.children.iter().find_map(|c| find(c))
         }
         find(&node).expect("a text command")
+    }
+
+    /// Every command a paint produced, in order, as short names.
+    fn commands(widget: impl Widget + 'static) -> Vec<&'static str> {
+        let mut tree = Tree::new();
+        let root = tree.register(Box::new(widget));
+        tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
+        tree.with_widget_mut(root, |w, id, t| {
+            w.layout(t, id, Constraints::new(0.0, 0.0, 800.0, 600.0))
+        });
+        let mut node = RenderNode::new(root.as_u64());
+        tree.with_widget_mut(root, |w, id, t| {
+            let mut ctx = PaintContext::new(&mut node);
+            w.paint(t, id, &mut ctx);
+        });
+        node.commands
+            .iter()
+            .map(|cmd| match &**cmd {
+                DrawCommand::Text { .. } => "text",
+                DrawCommand::TextBackdropBlur { .. } => "frost",
+                _ => "other",
+            })
+            .collect()
+    }
+
+    /// The frost filters what is already drawn, so it has to be asked for
+    /// before the glyphs that sit on it — and before their decorations, which
+    /// are glyphs too.
+    #[test]
+    fn a_frosted_text_asks_for_its_backdrop_before_it_draws() {
+        assert_eq!(
+            commands(text("hi").backdrop_blur(8.0)),
+            vec!["frost", "text"]
+        );
+        let stroked = commands(
+            text("hi")
+                .backdrop_blur(8.0)
+                .text_stroke(TextStroke::new(1.0, Color::BLACK)),
+        );
+        assert_eq!(stroked[0], "frost");
+        assert!(
+            stroked[1..].iter().all(|cmd| *cmd == "text"),
+            "a stroke is more glyphs, and they go over the frost too: {stroked:?}"
+        );
+    }
+
+    #[test]
+    fn a_text_asks_for_nothing_it_would_not_use() {
+        assert_eq!(commands(text("hi")), vec!["text"], "no blur, no command");
+        assert_eq!(
+            commands(text("hi").backdrop_blur(0.0)),
+            vec!["text"],
+            "a radius of zero is not an effect"
+        );
+        assert_eq!(
+            commands(text("").backdrop_blur(8.0)),
+            Vec::<&str>::new(),
+            "nothing to cut a hole in the shape of"
+        );
+    }
+
+    #[test]
+    fn the_frost_radius_is_reactive_like_every_other_declaration() {
+        let radius = create_signal(0.0f32);
+        let mut tree = Tree::new();
+        let root = tree.register(Box::new(text("hi").backdrop_blur(move || radius.get())));
+        tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
+
+        let paint = |tree: &mut Tree| {
+            tree.with_widget_mut(root, |w, id, t| {
+                w.layout(t, id, Constraints::new(0.0, 0.0, 800.0, 600.0))
+            });
+            let mut node = RenderNode::new(root.as_u64());
+            tree.with_widget_mut(root, |w, id, t| {
+                let mut ctx = PaintContext::new(&mut node);
+                w.paint(t, id, &mut ctx);
+            });
+            node.commands
+                .iter()
+                .filter(|cmd| matches!(&***cmd, DrawCommand::TextBackdropBlur { .. }))
+                .count()
+        };
+
+        assert_eq!(paint(&mut tree), 0);
+        radius.set(12.0);
+        assert_eq!(
+            paint(&mut tree),
+            1,
+            "the radius is read where it is painted"
+        );
     }
 
     #[test]

--- a/src/widgets/text_style.rs
+++ b/src/widgets/text_style.rs
@@ -93,6 +93,12 @@ impl TextStroke {
     /// exceed a pixel — so the tap count grows with the width instead of being
     /// fixed at the usual eight. Past a few pixels the honest fix is a dilate
     /// on an offscreen mask, not more taps.
+    ///
+    /// That fix exists for one case: a text with a
+    /// [`backdrop_blur`](crate::widgets::Text::backdrop_blur) has a coverage
+    /// mask already, and takes its stroke as a contour dilated from it — which
+    /// it must, since copies under the fill would fill the glass as well as
+    /// ring it.
     pub(crate) fn samples(&self) -> SmallVec<[(f32, f32); 24]> {
         let taps = (self.width * 6.0).clamp(8.0, 24.0) as usize;
         (0..taps)

--- a/tests/render_snapshots.rs
+++ b/tests/render_snapshots.rs
@@ -212,6 +212,9 @@ fn dump_command(cmd: &DrawCommand, depth: usize, kind: &str, out: &mut String) {
         DrawCommand::Text { .. } => {
             let _ = writeln!(out, "{pad}{kind} text <not snapshotted>");
         }
+        DrawCommand::TextBackdropBlur { radius, .. } => {
+            let _ = writeln!(out, "{pad}{kind} text backdrop blur r={}", n(*radius));
+        }
         DrawCommand::Image { rect: r, .. } => {
             let _ = writeln!(out, "{pad}{kind} image {}", rect(r));
         }


### PR DESCRIPTION
Stacked on #190.

Frost and a stroke could not be used together, and the stroke was the reason:
guido approximates one by redrawing the glyphs at offsets *under* the fill, so
it rings the letter and fills it. Under an opaque fill nobody can tell — which
is why it has been fine since the beginning. Over frost the filled part is
exactly the part that was supposed to show the picture, and the glass came out
solid black.

```rust
text("09:41")
    .color(Color::rgba(1.0, 1.0, 1.0, 0.3))
    .backdrop_blur(16.0)
    .text_stroke(TextStroke::new(2.0, Color::BLACK))   // now a real contour
```

## How

A frosted text has a coverage mask already. The stroke is drawn from it: dilate
the coverage by the stroke's width — two rings of sixteen taps, so a thick
contour stays solid at the corners instead of scalloping — subtract the
coverage itself, and what is left is a band starting at the glyph edge and
reaching outwards. It goes on after the blur composite and before the glyphs,
which is where a stroke belongs.

This is the "dilate on an offscreen mask" that `TextStroke::samples` has named
as the honest fix in its own docs for a while. It needed a mask, and #190
brought one.

## Only where it is needed

Only a frosted text takes this path. Everywhere else the copies stay: they are
invisible under an opaque fill, they reuse the rasterization already in the
glyph atlas, and they need no pass of their own. The declaration is identical
either way — `text_stroke(width, colour)` — which is the point: you ask for a
stroke and get one that works.

A **shadow** still does not compose with frost, and the example's last panel
says so. Same mechanism, same interior fill; giving it the same treatment means
blurring the mask, which is a separate change.

## Verified

- `cargo run --example frosted_text` — the new "frost + stroke 2" panel has a
  crisp contour with the mountains still blurred inside the letters, beside the
  shadow panel that buries them.
- Widget tests: a frosted stroked text emits one frost command carrying the
  stroke and one fill — no copies in between; an unfrosted one still emits the
  copies; nothing is invented for a text that declared no stroke.