### PR TITLE
Check every pull request, not only the ones aimed at main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+  # Every pull request, whatever it is aimed at. Filtering on `main` left a
+  # pull request stacked on another branch with no checks at all — the two
+  # workflows that do not filter, Labeler and Release Drafter, were the only
+  # thing that ran on it, which looks like a green tick from a distance.
   pull_request:
-    branches:
-      - main
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
`ci.yml` filtered `pull_request` on `main`, so a pull request stacked on another
branch ran none of the four jobs — no format, no clippy, no test, no build.

What it *did* run was Labeler and Release Drafter, which filter on nothing. Two
green ticks and nothing that checks the code, which from the checks list looks
like a pull request that passed.

Found on #191, which is stacked on #190 and came out with exactly those two.

The `push` trigger on `main` is untouched, so a merge is still checked on the
branch it lands on.

Note on ordering: a `pull_request` run uses the workflow file from the merge of
head into base, so #191 will only pick this up once its base carries it — after
this lands and the stack is rebased, or once #190 merges and #191 retargets to
`main`.