### PR TITLE
A stroke on glass is a contour

### DIFF
--- a/book/src/building-ui/text.md
+++ b/book/src/building-ui/text.md
@@ -135,17 +135,26 @@ Three things to know before reaching for it:
   container for the subtree below it; this one cannot, because each frosted
   text ends the render pass to filter the target. It is asked for one text at
   a time on purpose.
-- **It is not legibility, and it does not combine with what is.** Frost softens
-  the background where a shadow darkens it, so over a busy photograph a shadow
-  still does more — but you cannot have both. A stroke and a shadow are drawn
-  as copies of the glyphs *under* the fill, so they cover the letter's own area
-  and not only its edge: invisible under an opaque fill, and an opaque letter
-  over frost, which is the one thing the frost was cut out of. What holds a
-  frosted text together is its tint.
+- **It is not legibility on its own.** Frost softens the background where a
+  stroke and a shadow darken it. A stroke composes with it — over frost it is
+  drawn as a true contour, dilated from the same coverage mask and laid outside
+  the letter, which is what the glass needs and what a thick stroke wanted
+  anyway. A shadow does not: it is still copies of the glyphs *under* the fill,
+  so it covers the letter's own area as well as its edge, which is invisible
+  under an opaque fill and an opaque letter over frost.
 - **Rotation and scale skip it**, since the mask is rasterized square. A frost
   sitting beside its own letters would be worse than none.
 
-`cargo run --example frosted_text` puts it beside a shadow and a control.
+```rust
+text("09:41")
+    .color(Color::rgba(1.0, 1.0, 1.0, 0.3))
+    .backdrop_blur(16.0)
+    // A contour, because this text is glass. Elsewhere the same declaration is
+    // the cheap approximation, and under an opaque fill the two look alike.
+    .text_stroke(TextStroke::new(2.0, Color::BLACK))
+```
+
+`cargo run --example frosted_text` puts all of it beside a control.
 
 ## Styling
 

--- a/examples/frosted_text.rs
+++ b/examples/frosted_text.rs
@@ -8,11 +8,13 @@
 //! together with `background-clip: text`.
 //!
 //! The colour is the tint laid over the glass, which is why every panel here
-//! but the first is translucent. The last panel is the trap: a stroke and a
-//! shadow are drawn as copies of the glyphs *under* the fill, so they cover the
-//! letter's own area and not only its edge. Under an opaque fill that is
-//! invisible and free; over frost it is an opaque letter where the picture
-//! should be.
+//! but the first is translucent. The fourth adds a stroke, which over frost is
+//! drawn as a true contour — outside the letter, leaving the glass alone.
+//!
+//! The last panel is the trap, and it is a shadow: shadows are still copies of
+//! the glyphs drawn *under* the fill, so they cover the letter's own area and
+//! not only its edge. Under an opaque fill that is invisible and free; over
+//! frost it is an opaque letter where the picture should be.
 
 use guido::prelude::*;
 
@@ -76,6 +78,13 @@ fn main() {
                 text(LABEL).color(Color::TRANSPARENT).backdrop_blur(16.0),
             ))
             .child(panel(
+                "frost + stroke 2",
+                text(LABEL)
+                    .color(Color::rgba(1.0, 1.0, 1.0, 0.3))
+                    .backdrop_blur(16.0)
+                    .text_stroke(TextStroke::new(2.0, Color::BLACK)),
+            ))
+            .child(panel(
                 "frost under a shadow — buried",
                 text(LABEL)
                     .color(Color::rgba(1.0, 1.0, 1.0, 0.35))
@@ -90,7 +99,7 @@ fn main() {
 
         app.add_surface(
             SurfaceConfig::new()
-                .width(1080)
+                .width(1360)
                 .height(210)
                 .anchor(Anchor::TOP | Anchor::LEFT)
                 .layer(Layer::Top)

--- a/src/renderer/backdrop_pass.rs
+++ b/src/renderer/backdrop_pass.rs
@@ -20,7 +20,7 @@
 
 use wgpu::util::DeviceExt;
 
-use crate::widgets::Rect;
+use crate::widgets::{Color, Rect};
 
 use super::commands::CornerRadii;
 
@@ -52,7 +52,18 @@ struct Params {
     /// UV. The whole mask unless the region runs off the target, where the
     /// viewport is clipped and the mask must be read clipped with it.
     mask_rect: [f32; 4],
+    /// Colour of the contour `fs_outline` draws, and how far out it reaches
+    /// from the glyph edge in physical pixels.
+    stroke_color: [f32; 4],
+    stroke_width: f32,
+    _pad1: f32,
+    _pad2: f32,
+    _pad3: f32,
 }
+
+/// Where a region lands on the target — viewport in physical pixels — and the
+/// sub-rectangle of a coverage mask that covers it, in normalised uv.
+type Placement = ((u32, u32, u32, u32), [f32; 4]);
 
 /// A blur to apply, resolved to physical pixels.
 #[derive(Debug, Clone, Copy)]
@@ -129,6 +140,7 @@ pub struct BackdropRenderer {
     blur: wgpu::RenderPipeline,
     composite: wgpu::RenderPipeline,
     composite_mask: wgpu::RenderPipeline,
+    outline: wgpu::RenderPipeline,
     blit: wgpu::RenderPipeline,
     targets: Option<Targets>,
     idle_frames: u32,
@@ -300,6 +312,12 @@ impl BackdropRenderer {
             composite_mask: build(
                 "Backdrop Composite Mask",
                 "fs_composite_mask",
+                Some(composite_blend),
+                &mask_layout,
+            ),
+            outline: build(
+                "Text Outline",
+                "fs_outline",
                 Some(composite_blend),
                 &mask_layout,
             ),
@@ -475,6 +493,80 @@ impl BackdropRenderer {
         self.filter(device, encoder, region, Some(mask));
     }
 
+    /// Where a region lands on the target, and which part of a mask covers it.
+    ///
+    /// The two go together: the viewport is the region clipped to what is on
+    /// show, and the mask covers the region whole, so anything the clip took
+    /// off has to come off the mask's uv as well.
+    fn placement(&self, region: &BackdropRegion) -> Option<Placement> {
+        let targets = self.targets.as_ref()?;
+        let (x, y, width, height) = region.clamped(targets.width, targets.height)?;
+        let mask_rect = [
+            (x as f32 - region.rect.x) / region.rect.width.max(1.0),
+            (y as f32 - region.rect.y) / region.rect.height.max(1.0),
+            width as f32 / region.rect.width.max(1.0),
+            height as f32 / region.rect.height.max(1.0),
+        ];
+        Some(((x, y, width, height), mask_rect))
+    }
+
+    /// Draw a contour just outside `mask`'s coverage.
+    ///
+    /// A stroke, for the one case the cheap approximation cannot serve: copies
+    /// of the glyphs drawn under the fill ring the letter *and* fill it, which
+    /// is invisible under an opaque fill and opaque over frost. This dilates
+    /// the coverage instead and draws only the band the dilate added.
+    ///
+    /// Ordered after the frost and before the glyphs, so the letter keeps what
+    /// the frost put in it.
+    pub fn apply_outline(
+        &self,
+        device: &wgpu::Device,
+        encoder: &mut wgpu::CommandEncoder,
+        region: &BackdropRegion,
+        mask: &wgpu::TextureView,
+        color: Color,
+        width: f32,
+    ) {
+        let Some(targets) = &self.targets else {
+            return;
+        };
+        let Some((viewport, mask_rect)) = self.placement(region) else {
+            return;
+        };
+        let (_, _, dst_width, dst_height) = viewport;
+
+        let params = Params {
+            src_rect: [0.0, 0.0, 1.0, 1.0],
+            direction: [0.0, 0.0],
+            sigma: 0.0,
+            taps: 0.0,
+            dst_size: [dst_width as f32, dst_height as f32],
+            curvature: 1.0,
+            _pad: 0.0,
+            radii: [0.0; 4],
+            mask_rect,
+            stroke_color: [color.r, color.g, color.b, color.a],
+            stroke_width: width,
+            _pad1: 0.0,
+            _pad2: 0.0,
+            _pad3: 0.0,
+        };
+        // Binding 0 goes unread by this pipeline; the working texture fills it
+        // because the scene is the target and may not be bound as a resource
+        // at the same time.
+        let bind = self.bind_masked(device, &targets.working_views[0], mask, params);
+        self.pass(
+            encoder,
+            &self.outline,
+            &targets.scene_view,
+            wgpu::LoadOp::Load,
+            &bind,
+            viewport,
+            "Text Outline",
+        );
+    }
+
     fn filter(
         &self,
         device: &wgpu::Device,
@@ -485,7 +577,7 @@ impl BackdropRenderer {
         let Some(targets) = &self.targets else {
             return;
         };
-        let Some((x, y, width, height)) = region.clamped(targets.width, targets.height) else {
+        let Some(((x, y, width, height), mask_rect)) = self.placement(region) else {
             return;
         };
 
@@ -513,16 +605,6 @@ impl BackdropRenderer {
             work_height as f32 / targets.work_height as f32,
         ];
 
-        // The mask covers the region; the viewport covers whatever of it is on
-        // the target. When a text runs off the edge they differ, and reading
-        // the whole mask across a clipped viewport would squash the letters.
-        let mask_rect = [
-            (x as f32 - region.rect.x) / region.rect.width.max(1.0),
-            (y as f32 - region.rect.y) / region.rect.height.max(1.0),
-            width as f32 / region.rect.width.max(1.0),
-            height as f32 / region.rect.height.max(1.0),
-        ];
-
         let base = Params {
             src_rect: scene_rect,
             direction: [0.0, 0.0],
@@ -533,6 +615,11 @@ impl BackdropRenderer {
             _pad: 0.0,
             radii: region.radii.to_array(),
             mask_rect,
+            stroke_color: [0.0; 4],
+            stroke_width: 0.0,
+            _pad1: 0.0,
+            _pad2: 0.0,
+            _pad3: 0.0,
         };
 
         // 1. Scene region → working[0], shrunk.
@@ -624,6 +711,11 @@ impl BackdropRenderer {
                 _pad: 0.0,
                 radii: [0.0; 4],
                 mask_rect: [0.0, 0.0, 1.0, 1.0],
+                stroke_color: [0.0; 4],
+                stroke_width: 0.0,
+                _pad1: 0.0,
+                _pad2: 0.0,
+                _pad3: 0.0,
             },
         );
         self.pass(

--- a/src/renderer/backdrop_shader.wgsl
+++ b/src/renderer/backdrop_shader.wgsl
@@ -21,6 +21,13 @@ struct Params {
     radii: vec4<f32>,
     // Sub-rectangle of the coverage mask this viewport covers, normalised.
     mask_rect: vec4<f32>,
+    // Colour of the outline drawn by `fs_outline`, and how far it reaches out
+    // from the glyph edge in physical pixels.
+    stroke_color: vec4<f32>,
+    stroke_width: f32,
+    _pad1: f32,
+    _pad2: f32,
+    _pad3: f32,
 }
 
 @group(0) @binding(0) var t_source: texture_2d<f32>;
@@ -116,6 +123,40 @@ fn fs_composite(in: VertexOutput) -> @location(0) vec4<f32> {
     let mask = 1.0 - smoothstep(-0.5, 0.5, distance);
 
     return vec4<f32>(blurred.rgb, blurred.a * mask);
+}
+
+// A contour around the coverage, drawn outside it.
+//
+// The dilate is the largest coverage within `stroke_width` of the pixel;
+// subtracting the pixel's own coverage leaves a band that starts at the glyph
+// edge and reaches outwards, which is what a stroke is. Drawing copies of the
+// glyphs instead — the cheap approximation, and the right one under an opaque
+// fill — would fill the letter as well as ring it, and over frost the letter is
+// exactly what must stay clear.
+@fragment
+fn fs_outline(in: VertexOutput) -> @location(0) vec4<f32> {
+    let mask_uv = params.mask_rect.xy + in.uv * params.mask_rect.zw;
+    let own = textureSample(t_mask, s_source, mask_uv).a;
+
+    // One physical pixel, in mask uv.
+    let px = params.mask_rect.zw / max(params.dst_size, vec2<f32>(1.0));
+    let taps = 16;
+    let tau = 6.2831855;
+
+    var dilated = own;
+    // Two rings: the outer one decides how far the contour reaches, the inner
+    // one keeps a thick contour solid rather than hollow at the corners.
+    for (var ring = 1; ring <= 2; ring = ring + 1) {
+        let radius = params.stroke_width * f32(ring) * 0.5;
+        for (var i = 0; i < taps; i = i + 1) {
+            let angle = tau * f32(i) / f32(taps);
+            let offset = vec2<f32>(cos(angle), sin(angle)) * radius * px;
+            dilated = max(dilated, textureSample(t_mask, s_source, mask_uv + offset).a);
+        }
+    }
+
+    let contour = clamp(dilated - own, 0.0, 1.0);
+    return vec4<f32>(params.stroke_color.rgb, params.stroke_color.a * contour);
 }
 
 // The same composite, shaped by a coverage mask instead of a rectangle: what

--- a/src/renderer/commands.rs
+++ b/src/renderer/commands.rs
@@ -3,6 +3,7 @@
 use super::types::{Gradient, Shadow};
 use crate::widgets::font::{FontFamily, FontWeight};
 use crate::widgets::image::{ContentFit, ImageSource};
+use crate::widgets::text_style::TextStroke;
 use crate::widgets::{Color, Rect};
 
 /// Border definition for shapes.
@@ -203,6 +204,12 @@ pub enum DrawCommand {
     TextBackdropBlur {
         /// The text whose coverage is the mask.
         text: String,
+        /// A contour to draw around that coverage, once the blur is composited
+        /// and before the glyphs land on it. Carried here because the mask it
+        /// needs is the one this command already rasterizes — and because the
+        /// cheap stroke, copies of the glyphs under the fill, would fill the
+        /// letter the frost just cut out.
+        stroke: Option<TextStroke>,
         /// The text's layout box in local coordinates.
         rect: Rect,
         /// Blur radius in logical pixels.

--- a/src/renderer/paint_context.rs
+++ b/src/renderer/paint_context.rs
@@ -352,6 +352,7 @@ impl<'a> PaintContext<'a> {
         text: &str,
         rect: Rect,
         radius: f32,
+        stroke: Option<TextStroke>,
         font_size: f32,
         font_family: FontFamily,
         font_weight: FontWeight,
@@ -363,6 +364,7 @@ impl<'a> PaintContext<'a> {
             .commands
             .push(Rc::new(DrawCommand::TextBackdropBlur {
                 text: text.to_owned(),
+                stroke: stroke.filter(|s| s.width > 0.0),
                 rect,
                 radius,
                 font_size,

--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -374,6 +374,18 @@ impl Renderer {
                                     &frost.region,
                                     &mask,
                                 );
+                                // After the blur and before the glyphs: a
+                                // contour on the glass, not under it.
+                                if let Some((color, width)) = frost.outline {
+                                    self.backdrop.apply_outline(
+                                        &self.device,
+                                        &mut encoder,
+                                        &frost.region,
+                                        &mask,
+                                        color,
+                                        width,
+                                    );
+                                }
                             }
                         }
                     }
@@ -636,6 +648,8 @@ fn command_to_backdrop_region(cmd: &FlattenedCommand, scale: f32) -> Option<Back
 struct TextBackdrop<'a> {
     region: BackdropRegion,
     spec: MaskSpec<'a>,
+    /// The contour to draw around the coverage, in physical pixels.
+    outline: Option<(Color, f32)>,
 }
 
 /// Resolve a text backdrop command to its region and the mask to shape it with.
@@ -646,6 +660,7 @@ struct TextBackdrop<'a> {
 fn command_to_text_backdrop(cmd: &FlattenedCommand, scale: f32) -> Option<TextBackdrop<'_>> {
     let DrawCommand::TextBackdropBlur {
         text,
+        stroke,
         rect,
         radius,
         font_size,
@@ -665,8 +680,10 @@ fn command_to_text_backdrop(cmd: &FlattenedCommand, scale: f32) -> Option<TextBa
 
     let (world_x, world_y) = cmd.world_transform.transform_point(rect.x, rect.y);
     // Glyphs overshoot their layout box — descenders, italics, marks — and the
-    // slack here is the one the flattener already uses for a text's bounds.
-    let slack = font_size * 0.5;
+    // slack here is the one the flattener already uses for a text's bounds. A
+    // contour reaches further still, and what falls outside the region is not
+    // drawn at all.
+    let slack = font_size * 0.5 + stroke.map(|s| s.width).unwrap_or(0.0);
     let left = (world_x - slack) * scale;
     let top = (world_y - slack) * scale;
     let right = (world_x + rect.width + slack) * scale;
@@ -697,6 +714,7 @@ fn command_to_text_backdrop(cmd: &FlattenedCommand, scale: f32) -> Option<TextBa
             offset: (world_x * scale - x, world_y * scale - y),
             scale_factor: scale,
         },
+        outline: stroke.map(|s| (s.color, s.width * scale)),
     })
 }
 
@@ -817,6 +835,7 @@ mod tests {
         FlattenedCommand {
             command: Rc::new(DrawCommand::TextBackdropBlur {
                 text: "09:41".to_owned(),
+                stroke: None,
                 rect,
                 radius: 10.0,
                 font_size: 20.0,

--- a/src/widgets/text.rs
+++ b/src/widgets/text.rs
@@ -112,12 +112,15 @@ impl Text {
     /// so it is asked for one text at a time rather than dressed onto a subtree.
     /// A rotated or scaled text ignores it — the mask is axis-aligned.
     ///
-    /// Legibility is not what it buys, and the two decorations that would give
-    /// it cannot be added on top. A [`text_stroke`](super::TextStyled::text_stroke)
-    /// and a [`text_shadow`](super::TextStyled::text_shadow) are drawn as copies
-    /// of the glyphs *under* the fill, so they cover the letter's own area and
-    /// not only its edge — invisible under an opaque fill, and an opaque letter
-    /// over frost. A frosted text is held together by its tint instead.
+    /// Legibility is not what it buys on its own, and of the two decorations
+    /// that give it, one composes and one does not.
+    ///
+    /// A [`text_stroke`](super::TextStyled::text_stroke) does: over frost it is
+    /// drawn as a true contour — dilated from the same coverage mask, laid
+    /// outside the letter — rather than as copies of the glyphs under the fill.
+    /// A [`text_shadow`](super::TextStyled::text_shadow) does not: it is still
+    /// copies, so it covers the letter's own area as well as its edge, which is
+    /// invisible under an opaque fill and an opaque letter over glass.
     pub fn backdrop_blur<M>(mut self, radius: impl IntoSignal<f32, M>) -> Self {
         self.backdrop_blur = Some(radius.into_signal());
         self
@@ -321,12 +324,16 @@ impl Widget for Text {
                 self.backdrop_blur.map(|radius| radius.get()),
             )
         });
-        // First, so the glyphs and their decorations land over the frost.
+        // A frosted text takes its stroke as a contour instead: drawn from the
+        // same coverage mask, outside the letter rather than under it, so the
+        // glass keeps what the frost put in it.
+        let frosted = blur.filter(|radius| *radius > 0.0).is_some();
         if let Some(radius) = blur {
             ctx.draw_text_backdrop_blur(
                 &self.cached_text,
                 local_bounds,
                 radius,
+                stroke,
                 self.cached_font_size,
                 self.cached_font_family.clone(),
                 self.cached_font_weight,
@@ -339,7 +346,7 @@ impl Widget for Text {
             self.cached_font_size,
             self.cached_font_family.clone(),
             self.cached_font_weight,
-            stroke,
+            if frosted { None } else { stroke },
             shadow,
         );
     }
@@ -414,6 +421,25 @@ mod tests {
         find(&node).expect("a text command")
     }
 
+    /// The stroke carried by the paint's frost command, if there is one.
+    fn frost_stroke(widget: impl Widget + 'static) -> Option<TextStroke> {
+        let mut tree = Tree::new();
+        let root = tree.register(Box::new(widget));
+        tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
+        tree.with_widget_mut(root, |w, id, t| {
+            w.layout(t, id, Constraints::new(0.0, 0.0, 800.0, 600.0))
+        });
+        let mut node = RenderNode::new(root.as_u64());
+        tree.with_widget_mut(root, |w, id, t| {
+            let mut ctx = PaintContext::new(&mut node);
+            w.paint(t, id, &mut ctx);
+        });
+        node.commands.iter().find_map(|cmd| match &**cmd {
+            DrawCommand::TextBackdropBlur { stroke, .. } => *stroke,
+            _ => None,
+        })
+    }
+
     /// Every command a paint produced, in order, as short names.
     fn commands(widget: impl Widget + 'static) -> Vec<&'static str> {
         let mut tree = Tree::new();
@@ -446,15 +472,50 @@ mod tests {
             commands(text("hi").backdrop_blur(8.0)),
             vec!["frost", "text"]
         );
-        let stroked = commands(
-            text("hi")
-                .backdrop_blur(8.0)
-                .text_stroke(TextStroke::new(1.0, Color::BLACK)),
-        );
-        assert_eq!(stroked[0], "frost");
+        let shadowed = commands(text("hi").backdrop_blur(8.0).text_shadow(TextShadow::new(
+            0.0,
+            2.0,
+            4.0,
+            Color::BLACK,
+        )));
+        assert_eq!(shadowed[0], "frost");
         assert!(
-            stroked[1..].iter().all(|cmd| *cmd == "text"),
-            "a stroke is more glyphs, and they go over the frost too: {stroked:?}"
+            shadowed[1..].iter().all(|cmd| *cmd == "text"),
+            "a shadow is more glyphs, and they go over the frost too: {shadowed:?}"
+        );
+    }
+
+    /// The stroke of a frosted text is not more glyphs. Copies under the fill
+    /// ring the letter *and* fill it, which over frost is an opaque letter
+    /// where the picture should be — so it rides on the frost command instead
+    /// and is drawn from the same coverage mask.
+    #[test]
+    fn a_frosted_text_takes_its_stroke_as_a_contour() {
+        let stroke = TextStroke::new(2.0, Color::BLACK);
+        assert_eq!(
+            commands(text("hi").backdrop_blur(8.0).text_stroke(stroke)),
+            vec!["frost", "text"],
+            "one frost, one fill, and no copies in between"
+        );
+
+        assert_eq!(
+            frost_stroke(text("hi").backdrop_blur(8.0).text_stroke(stroke)).map(|s| s.width),
+            Some(2.0)
+        );
+        assert!(
+            frost_stroke(text("hi").backdrop_blur(8.0)).is_none(),
+            "and nothing is invented for a text that declared none"
+        );
+    }
+
+    /// Without frost the cheap stroke is still the right one: under an opaque
+    /// fill the copies are invisible, and they cost no rasterization.
+    #[test]
+    fn an_unfrosted_text_keeps_the_sampled_stroke() {
+        let drawn = commands(text("hi").text_stroke(TextStroke::new(1.0, Color::BLACK)));
+        assert!(
+            drawn.len() > 2 && drawn.iter().all(|cmd| *cmd == "text"),
+            "copies of the glyphs, no frost command: {drawn:?}"
         );
     }
 

--- a/src/widgets/text_style.rs
+++ b/src/widgets/text_style.rs
@@ -93,6 +93,12 @@ impl TextStroke {
     /// exceed a pixel — so the tap count grows with the width instead of being
     /// fixed at the usual eight. Past a few pixels the honest fix is a dilate
     /// on an offscreen mask, not more taps.
+    ///
+    /// That fix exists for one case: a text with a
+    /// [`backdrop_blur`](crate::widgets::Text::backdrop_blur) has a coverage
+    /// mask already, and takes its stroke as a contour dilated from it — which
+    /// it must, since copies under the fill would fill the glass as well as
+    /// ring it.
     pub(crate) fn samples(&self) -> SmallVec<[(f32, f32); 24]> {
         let taps = (self.width * 6.0).clamp(8.0, 24.0) as usize;
         (0..taps)


### PR DESCRIPTION
Reopened from #191, which GitHub closed when its base branch was deleted by the
merge of #190. Same branch, rebased onto `main`.

Frost and a stroke could not be used together, and the stroke was the reason:
guido approximates one by redrawing the glyphs at offsets *under* the fill, so
it rings the letter and fills it. Under an opaque fill nobody can tell — which
is why it has been fine since the beginning. Over frost the filled part is
exactly the part that was supposed to show the picture, and the glass came out
solid black.

```rust
text("09:41")
    .color(Color::rgba(1.0, 1.0, 1.0, 0.3))
    .backdrop_blur(16.0)
    .text_stroke(TextStroke::new(2.0, Color::BLACK))   // now a real contour
```

## How

A frosted text has a coverage mask already. The stroke is drawn from it: dilate
the coverage by the stroke's width — two rings of sixteen taps, so a thick
contour stays solid at the corners instead of scalloping — subtract the
coverage itself, and what is left is a band starting at the glyph edge and
reaching outwards. It goes on after the blur composite and before the glyphs,
which is where a stroke belongs.

This is the "dilate on an offscreen mask" that `TextStroke::samples` has named
as the honest fix in its own docs for a while. It needed a mask, and #190
brought one.

## Only where it is needed

Only a frosted text takes this path. Everywhere else the copies stay: they are
invisible under an opaque fill, they reuse the rasterization already in the
glyph atlas, and they need no pass of their own. The declaration is identical
either way — `text_stroke(width, colour)` — which is the point: you ask for a
stroke and get one that works.

A **shadow** still does not compose with frost, and the example's last panel
says so. Same mechanism, same interior fill; giving it the same treatment means
blurring the mask, which is a separate change.

## Verified

- `cargo run --example frosted_text` — the "frost + stroke 2" panel has a crisp
  contour with the mountains still blurred inside the letters, beside the
  shadow panel that buries them.
- Widget tests: a frosted stroked text emits one frost command carrying the
  stroke and one fill — no copies in between; an unfrosted one still emits the
  copies; nothing is invented for a text that declared no stroke.