### PR TITLE
The ripple grows, fades, and lets the next one overlap it

### DIFF
--- a/book/src/interactivity/ripples.md
+++ b/book/src/interactivity/ripples.md
@@ -52,10 +52,10 @@ Combine ripples with other pressed state changes:
 
 1. **Press** - a disc appears at the click point, already at about a third of
    its final size, and starts spreading
-2. **Release** - the press happened, so the remaining expansion is *completed*
-   rather than interrupted, while the disc fades out
-3. **Or leave without releasing** - nothing was activated, so there is nothing
-   to complete: the disc just fades, quickly
+2. **Release inside** - the press happened, so the remaining expansion is
+   *completed* rather than interrupted, while the disc fades out
+3. **Release elsewhere, or drag off the button** - nothing was activated, and
+   the ripple says the same thing `on_click` does: the disc just fades, quickly
 
 Two properties are worth stating outright, because they are what makes the
 effect read as an acknowledgement rather than a hesitation:
@@ -64,9 +64,13 @@ effect read as an acknowledgement rather than a hesitation:
 - **A short press does not truncate the expansion.** A click lasts 60-150ms
   against a growth measured in hundreds, so the release finishes the growth
   instead of abandoning it half-way.
+- **No press is dimmer for being quicker.** The disc always finishes appearing
+  before it starts to leave, so a 20ms tap is as bright as a held one.
 
 The disc's centre also drifts toward the container's own centre as it grows, so
-a press near a corner settles onto the button instead of staying lopsided.
+a press near a corner settles onto the button instead of staying lopsided. Its
+final size comes from the container, not from where you pressed — every ripple
+on a given button is the same size, and a full one covers it exactly.
 
 The ripple:
 - Respects corner radius and container shape
@@ -90,16 +94,21 @@ own fade.
 
 ## Timing
 
-| Phase | Duration |
-|---|---|
-| Opacity rise on contact | 75ms |
-| Growth while held | 1s |
-| Growth remaining after release | 225ms |
-| Fade after a release | 375ms |
-| Fade after leaving without releasing | 75ms |
+| Phase | Duration | Scaled by |
+|---|---|---|
+| Opacity rise on contact | 75ms | `fade_speed` |
+| Growth while held | 1s | `expand_speed` |
+| Growth remaining after release | 225ms | `expand_speed` |
+| Fade after a release | 375ms | `fade_speed` |
+| Fade after an abandoned press | 75ms | `fade_speed` |
 
-`expand_speed` and `fade_speed` on `RippleConfig` scale the growth and the fade
-respectively:
+The fade never starts before the rise has finished, and the growth after a
+release is never given longer than the fade it overlaps — so no combination of
+the two speeds can put the disc back where it started, half-grown and already
+invisible.
+
+Both speeds are clamped to a sane range, so a zero or a negative one degrades
+instead of stalling the frame loop:
 
 ```rust
 .when_pressed(|s| s.ripple_config(RippleConfig {

--- a/book/src/interactivity/ripples.md
+++ b/book/src/interactivity/ripples.md
@@ -50,15 +50,64 @@ Combine ripples with other pressed state changes:
 
 ## How Ripples Work
 
-1. **Click** - Ripple starts at the click point
-2. **Expand** - Ripple grows to fill the container bounds
-3. **Release** - Ripple contracts toward the release point
-4. **Fade** - Ripple fades out
+1. **Press** - a disc appears at the click point, already at about a third of
+   its final size, and starts spreading
+2. **Release** - the press happened, so the remaining expansion is *completed*
+   rather than interrupted, while the disc fades out
+3. **Or leave without releasing** - nothing was activated, so there is nothing
+   to complete: the disc just fades, quickly
+
+Two properties are worth stating outright, because they are what makes the
+effect read as an acknowledgement rather than a hesitation:
+
+- **The radius never goes backwards.** The exit is a fade, never a contraction.
+- **A short press does not truncate the expansion.** A click lasts 60-150ms
+  against a growth measured in hundreds, so the release finishes the growth
+  instead of abandoning it half-way.
+
+The disc's centre also drifts toward the container's own centre as it grows, so
+a press near a corner settles onto the button instead of staying lopsided.
 
 The ripple:
 - Respects corner radius and container shape
 - Works correctly with transformed containers (rotated, scaled)
 - Renders in the overlay layer (on top of content)
+
+## Several at once
+
+Each press is its own ripple, and they overlap:
+
+```rust
+container()
+    .when_pressed(|s| s.ripple())
+    .on_click(increment)
+```
+
+Clicking this repeatedly layers one disc over the next, because two clicks are
+two events — the second does not erase the first. Up to four are alive at a
+time; past that the oldest is dropped, which is the one furthest through its
+own fade.
+
+## Timing
+
+| Phase | Duration |
+|---|---|
+| Opacity rise on contact | 75ms |
+| Growth while held | 1s |
+| Growth remaining after release | 225ms |
+| Fade after a release | 375ms |
+| Fade after leaving without releasing | 75ms |
+
+`expand_speed` and `fade_speed` on `RippleConfig` scale the growth and the fade
+respectively:
+
+```rust
+.when_pressed(|s| s.ripple_config(RippleConfig {
+    color: Color::rgba(1.0, 1.0, 1.0, 0.3),
+    expand_speed: 1.5,   // faster growth
+    fade_speed: 1.0,
+}))
+```
 
 ## Ripples on Transformed Containers
 

--- a/docs/STATE_LAYER.md
+++ b/docs/STATE_LAYER.md
@@ -171,7 +171,14 @@ Note that a layer *replaces* the base value rather than ranking against it. A pr
 
 ## Ripple Effects
 
-Ripple effects provide Material Design-style touch feedback. The ripple expands from the click point and contracts toward the release point.
+Ripple effects provide Material Design-style touch feedback. The disc appears at
+the click point already at about a third of its final size and spreads from
+there; a release **completes** the expansion while fading the disc out, and the
+pointer leaving without a release fades it quickly without completing anything.
+
+The radius never goes backwards, and a short press does not truncate the growth
+— those two are the whole feel of the effect. Each press is its own ripple and
+they overlap; up to four are alive at a time.
 
 ### Default Ripple
 

--- a/docs/STATE_LAYER.md
+++ b/docs/STATE_LAYER.md
@@ -176,9 +176,11 @@ the click point already at about a third of its final size and spreads from
 there; a release **completes** the expansion while fading the disc out, and the
 pointer leaving without a release fades it quickly without completing anything.
 
-The radius never goes backwards, and a short press does not truncate the growth
-— those two are the whole feel of the effect. Each press is its own ripple and
-they overlap; up to four are alive at a time.
+The radius never goes backwards, a short press does not truncate the growth, and
+the disc always finishes appearing before it starts to leave — those three are
+the whole feel of the effect. Its final size comes from the container rather
+than the contact point, so every ripple on a button is the same size. Each press
+is its own ripple and they overlap; up to four are alive at a time.
 
 ### Default Ripple
 

--- a/src/renderer/tree.rs
+++ b/src/renderer/tree.rs
@@ -93,8 +93,9 @@ pub struct RenderNode {
 
     /// Overlay commands - drawn AFTER all children (for ripples, effects).
     /// These are also in local coordinates.
-    /// SmallVec: most nodes have 0-1 overlay commands (ripple only).
-    pub overlay_commands: SmallVec<[Rc<DrawCommand>; 1]>,
+    /// SmallVec sized for `MAX_LIVE_RIPPLES`: presses overlap, so a container
+    /// being clicked repeatedly holds one command per live ripple.
+    pub overlay_commands: SmallVec<[Rc<DrawCommand>; 4]>,
 
     /// Optional clip region that applies to this node and children.
     /// The clip rect is in local coordinates (0,0 = node origin).

--- a/src/widgets/container/interaction.rs
+++ b/src/widgets/container/interaction.rs
@@ -102,6 +102,8 @@ impl Container {
     /// ancestors from tracking their own hover.
     pub(super) fn track_pointer(&mut self, id: WidgetId, hit: &HitContext, event: &Event) {
         let has_animated = self.has_animated_state_properties();
+        // Read before the mutable borrow: cancelling a ripple below needs it.
+        let ripple_config = self.interaction.as_ref().and_then(|ix| ix.ripple_config());
         let Some(ref mut ix) = self.interaction else {
             return;
         };
@@ -135,6 +137,19 @@ impl Container {
 
                 let was_hovered = ix.is_hovered();
                 ix.set_flag(InteractionFlags::HOVERED, hit.contains(*x, *y));
+
+                // Dragging off the container abandons the press. Only leaving
+                // the whole surface used to say so, which left a ripple
+                // growing at full brightness on a button the pointer had left
+                // several hundred pixels ago.
+                if was_hovered
+                    && !ix.is_hovered()
+                    && ix.ripple.is_active()
+                    && let Some(ref config) = ripple_config
+                {
+                    ix.ripple.cancel(config, Instant::now());
+                    request_job(id, JobRequest::Animation(RequiredJob::Paint));
+                }
 
                 if was_hovered != ix.is_hovered() {
                     if ix.declares(|w| matches!(w, StateWhen::Hovered)) {
@@ -231,11 +246,19 @@ impl Container {
                     let was_pressed = ix.is_pressed();
                     ix.set_flag(InteractionFlags::PRESSED, false);
 
-                    // Released inside: the press happened, so the ripple
-                    // finishes its expansion on the way out. Where the pointer
-                    // ended up does not enter into it.
-                    if ix.ripple.is_active() {
-                        ix.ripple.release(Instant::now());
+                    // The ripple has to say the same thing `on_click` below
+                    // says: a release inside activated something and finishes
+                    // its expansion, a release that wandered off did not and
+                    // simply goes.
+                    if ix.ripple.is_active()
+                        && let Some(config) = ix.ripple_config()
+                    {
+                        let now = Instant::now();
+                        if hit.contains(*x, *y) {
+                            ix.ripple.release(&config, now);
+                        } else {
+                            ix.ripple.cancel(&config, now);
+                        }
                         request_job(id, JobRequest::Animation(RequiredJob::Paint));
                     }
 
@@ -281,8 +304,10 @@ impl Container {
                     // The pointer left without releasing, so nothing was
                     // activated and there is nothing to complete: the ripple
                     // just goes.
-                    if ix.ripple.is_active() {
-                        ix.ripple.cancel(Instant::now());
+                    if ix.ripple.is_active()
+                        && let Some(config) = ix.ripple_config()
+                    {
+                        ix.ripple.cancel(&config, Instant::now());
                         request_job(id, JobRequest::Animation(RequiredJob::Paint));
                     }
 

--- a/src/widgets/container/interaction.rs
+++ b/src/widgets/container/interaction.rs
@@ -15,6 +15,8 @@
 //! [`track_pointer`]: Container::track_pointer
 //! [`handle_own_event`]: Container::handle_own_event
 
+use std::time::Instant;
+
 use super::*;
 
 /// The geometry an event is resolved against: where the container ended up,
@@ -197,7 +199,7 @@ impl Container {
                     if has_ripple {
                         let (screen_x, screen_y) = event.coords().unwrap_or((*x, *y));
                         let (local_x, local_y) = hit.local(screen_x, screen_y);
-                        ix.ripple.start(local_x, local_y);
+                        ix.ripple.start(local_x, local_y, Instant::now());
                         request_job(id, JobRequest::Animation(RequiredJob::Paint));
                     }
 
@@ -229,10 +231,11 @@ impl Container {
                     let was_pressed = ix.is_pressed();
                     ix.set_flag(InteractionFlags::PRESSED, false);
 
+                    // Released inside: the press happened, so the ripple
+                    // finishes its expansion on the way out. Where the pointer
+                    // ended up does not enter into it.
                     if ix.ripple.is_active() {
-                        let (screen_x, screen_y) = event.coords().unwrap_or((*x, *y));
-                        let (local_x, local_y) = hit.local(screen_x, screen_y);
-                        ix.ripple.start_fade(local_x, local_y);
+                        ix.ripple.release(Instant::now());
                         request_job(id, JobRequest::Animation(RequiredJob::Paint));
                     }
 
@@ -275,11 +278,11 @@ impl Container {
                     }
                     ix.set_flag(InteractionFlags::PRESSED, false);
 
-                    // The pointer left without a release, so the ripple has no
-                    // exit point to fade toward — it collapses to the centre.
+                    // The pointer left without releasing, so nothing was
+                    // activated and there is nothing to complete: the ripple
+                    // just goes.
                     if ix.ripple.is_active() {
-                        ix.ripple
-                            .start_fade_to_center(hit.bounds.width, hit.bounds.height);
+                        ix.ripple.cancel(Instant::now());
                         request_job(id, JobRequest::Animation(RequiredJob::Paint));
                     }
 

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -14,7 +14,7 @@ mod characterization;
 pub(crate) use animations::with_measure_final;
 pub use animations::{AdvanceResult, AnimationState, get_animated_value};
 use interaction::{HitContext, untransform_point};
-pub use ripple::RippleState;
+pub use ripple::{RIPPLE_START_RADIUS, RippleState};
 use style::Decoration;
 
 use std::borrow::Cow;
@@ -1232,7 +1232,7 @@ impl Widget for Container {
             && ix.ripple.is_active()
             && let Some(config) = ix.ripple_config()
         {
-            let ripple_animating = ix.ripple.advance(&config);
+            let ripple_animating = ix.ripple.advance(&config, std::time::Instant::now());
             if ripple_animating {
                 // Ripple is paint-only, request animation continuation with paint
                 request_job(id, JobRequest::Animation(RequiredJob::Paint));
@@ -1686,29 +1686,47 @@ impl Widget for Container {
             self.paint_scrollbar_containers(tree, id, ctx);
         }
 
-        // Draw ripple effect as overlay (ripple.center is already in local coordinates)
+        // Ripples, oldest first, in local coordinates. The state holds the
+        // press point and how far along each one is; the geometry is the
+        // container's, so it is resolved here.
         if let Some(ref ix) = self.interaction
-            && let Some((local_cx, local_cy)) = ix.ripple.center
+            && ix.ripple.is_active()
             && let Some(ripple_config) = ix.ripple_config()
-            && ix.ripple.opacity > 0.0
         {
-            // Set overlay clip to container bounds with rounded corners
-            // This clips the ripple without affecting children
+            // Clips the ripples without affecting children.
             ctx.set_overlay_clip(local_bounds, corner_radius, corner_curvature);
+            let (mid_x, mid_y) = (bounds.width / 2.0, bounds.height / 2.0);
 
-            let max_dist_x = local_cx.max(bounds.width - local_cx);
-            let max_dist_y = local_cy.max(bounds.height - local_cy);
-            let max_radius = (max_dist_x * max_dist_x + max_dist_y * max_dist_y).sqrt();
-            let current_radius = max_radius * ix.ripple.progress;
+            for ripple in ix.ripple.iter() {
+                let opacity = ripple.opacity();
+                if opacity <= 0.0 {
+                    continue;
+                }
+                let (origin_x, origin_y) = ripple.origin();
+                let growth = ripple.growth();
 
-            let ripple_color = Color::rgba(
-                ripple_config.color.r,
-                ripple_config.color.g,
-                ripple_config.color.b,
-                ripple_config.color.a * ix.ripple.opacity,
-            );
+                // Far enough to reach the corner furthest from where the
+                // pointer went down, so a full ripple covers the box.
+                let max_dist_x = origin_x.max(bounds.width - origin_x);
+                let max_dist_y = origin_y.max(bounds.height - origin_y);
+                let max_radius = (max_dist_x * max_dist_x + max_dist_y * max_dist_y).sqrt();
+                let radius =
+                    max_radius * (RIPPLE_START_RADIUS + (1.0 - RIPPLE_START_RADIUS) * growth);
 
-            ctx.draw_overlay_circle(local_cx, local_cy, current_radius, ripple_color);
+                // The centre settles onto the container as the disc grows,
+                // which is what stops a corner press from looking lopsided.
+                let center_x = origin_x + (mid_x - origin_x) * growth;
+                let center_y = origin_y + (mid_y - origin_y) * growth;
+
+                let ripple_color = Color::rgba(
+                    ripple_config.color.r,
+                    ripple_config.color.g,
+                    ripple_config.color.b,
+                    ripple_config.color.a * opacity,
+                );
+
+                ctx.draw_overlay_circle(center_x, center_y, radius, ripple_color);
+            }
         }
     }
 }

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -14,7 +14,7 @@ mod characterization;
 pub(crate) use animations::with_measure_final;
 pub use animations::{AdvanceResult, AnimationState, get_animated_value};
 use interaction::{HitContext, untransform_point};
-pub use ripple::{RIPPLE_START_RADIUS, RippleState};
+pub use ripple::{MAX_LIVE_RIPPLES, Ripple, RippleState};
 use style::Decoration;
 
 use std::borrow::Cow;
@@ -1686,37 +1686,22 @@ impl Widget for Container {
             self.paint_scrollbar_containers(tree, id, ctx);
         }
 
-        // Ripples, oldest first, in local coordinates. The state holds the
-        // press point and how far along each one is; the geometry is the
-        // container's, so it is resolved here.
+        // Ripples, oldest first. The state holds how far along each one is;
+        // the geometry it resolves against is the container's.
         if let Some(ref ix) = self.interaction
-            && ix.ripple.is_active()
             && let Some(ripple_config) = ix.ripple_config()
+            && ix.ripple.iter().any(|r| r.opacity() > 0.0)
         {
             // Clips the ripples without affecting children.
             ctx.set_overlay_clip(local_bounds, corner_radius, corner_curvature);
-            let (mid_x, mid_y) = (bounds.width / 2.0, bounds.height / 2.0);
 
             for ripple in ix.ripple.iter() {
                 let opacity = ripple.opacity();
                 if opacity <= 0.0 {
                     continue;
                 }
-                let (origin_x, origin_y) = ripple.origin();
-                let growth = ripple.growth();
-
-                // Far enough to reach the corner furthest from where the
-                // pointer went down, so a full ripple covers the box.
-                let max_dist_x = origin_x.max(bounds.width - origin_x);
-                let max_dist_y = origin_y.max(bounds.height - origin_y);
-                let max_radius = (max_dist_x * max_dist_x + max_dist_y * max_dist_y).sqrt();
-                let radius =
-                    max_radius * (RIPPLE_START_RADIUS + (1.0 - RIPPLE_START_RADIUS) * growth);
-
-                // The centre settles onto the container as the disc grows,
-                // which is what stops a corner press from looking lopsided.
-                let center_x = origin_x + (mid_x - origin_x) * growth;
-                let center_y = origin_y + (mid_y - origin_y) * growth;
+                let (center_x, center_y) = ripple.center(bounds.width, bounds.height);
+                let radius = ripple.radius(bounds.width, bounds.height);
 
                 let ripple_color = Color::rgba(
                     ripple_config.color.r,

--- a/src/widgets/container/ripple.rs
+++ b/src/widgets/container/ripple.rs
@@ -20,16 +20,23 @@
 //! nothing was activated, so there is nothing to complete. It just fades, fast.
 //! That is Flutter's `cancel()`.
 //!
+//! # Where the disc goes
+//!
+//! The radius that counts is the container's, not the contact point's: the disc
+//! ends centred on the container, so what it has to reach is the container's
+//! own farthest corner from there — half the diagonal. Deriving it from the
+//! press instead would make two clicks on the same button different sizes, and
+//! an edge press cover the box a third of the way before the growth ended,
+//! which is the truncation this whole model exists to remove.
+//!
 //! # Several at once
 //!
 //! Each press is its own ripple and they overlap, because that is what the
 //! gesture was: two clicks are two events, and collapsing them into one disc
-//! that restarts loses the second. [`MAX_LIVE`] bounds the work; past it the
+//! that restarts loses the second. [`MAX_LIVE_RIPPLES`] bounds the work; past it the
 //! oldest is dropped, which is the one nearest to invisible anyway.
 
-use std::time::Instant;
-
-use smallvec::SmallVec;
+use std::time::{Duration, Instant};
 
 use crate::widgets::state_layer::RippleConfig;
 
@@ -54,10 +61,29 @@ const CANCEL_FADE: f32 = 0.075;
 
 /// Where the disc starts, as a fraction of its final radius. Material's ripple
 /// appears as a disc rather than growing from a point.
-pub const RIPPLE_START_RADIUS: f32 = 0.3;
+const START_RADIUS: f32 = 0.3;
 
 /// How many ripples may be alive at once.
-pub const MAX_LIVE: usize = 4;
+pub const MAX_LIVE_RIPPLES: usize = 4;
+
+/// A speed multiplier the durations can be divided by without the arithmetic
+/// running away. Zero would make a phase last forever and pin the frame loop;
+/// a negative one would run the eases backwards into a negative radius.
+fn sane_speed(speed: f32) -> f32 {
+    if speed.is_finite() {
+        speed.clamp(0.05, 20.0)
+    } else {
+        1.0
+    }
+}
+
+/// How far through a phase we are, always within 0..=1.
+fn phase(elapsed: f32, duration: f32) -> f32 {
+    if duration <= 0.0 {
+        return 1.0;
+    }
+    (elapsed / duration).clamp(0.0, 1.0)
+}
 
 fn ease_out(t: f32) -> f32 {
     1.0 - (1.0 - t).powi(3)
@@ -72,11 +98,12 @@ fn since(start: Instant, now: Instant) -> f32 {
 enum ExitKind {
     /// Released inside: the press happened, so the expansion completes.
     Confirmed,
-    /// The pointer left without releasing: nothing to complete.
+    /// The press was abandoned — released elsewhere, or the pointer left
+    /// without releasing. Nothing to complete.
     Cancelled,
 }
 
-/// The moment a ripple began to leave, and the state it left from.
+/// The moment a ripple began to leave, and the growth it left from.
 #[derive(Debug, Clone, Copy)]
 struct Exit {
     kind: ExitKind,
@@ -84,7 +111,6 @@ struct Exit {
     /// Growth when the exit began, so the remainder can be compressed into it
     /// instead of restarting from zero.
     growth: f32,
-    opacity: f32,
 }
 
 /// One press.
@@ -94,7 +120,7 @@ pub struct Ripple {
     origin: (f32, f32),
     born: Instant,
     exit: Option<Exit>,
-    /// 0 at the start radius, 1 fully expanded.
+    /// 0 at [`START_RADIUS`], 1 fully expanded.
     growth: f32,
     opacity: f32,
 }
@@ -110,84 +136,142 @@ impl Ripple {
         }
     }
 
-    /// Where the pointer went down, in local container coordinates.
-    pub fn origin(&self) -> (f32, f32) {
-        self.origin
-    }
-
-    /// How far along the expansion is: 0 at [`RIPPLE_START_RADIUS`], 1 covering the
-    /// container. Also drives the drift of the centre — see
-    /// [`RippleState::iter`].
-    pub fn growth(&self) -> f32 {
-        self.growth
-    }
-
     pub fn opacity(&self) -> f32 {
         self.opacity
+    }
+
+    /// The radius the disc reaches when fully grown: enough to cover the
+    /// container from its centre, which is where the disc ends up. Half the
+    /// diagonal, and deliberately not a function of where the press landed —
+    /// see the module docs.
+    fn full_radius(width: f32, height: f32) -> f32 {
+        0.5 * (width * width + height * height).sqrt()
+    }
+
+    /// What to draw, in the container's local coordinates.
+    pub fn radius(&self, width: f32, height: f32) -> f32 {
+        Self::full_radius(width, height) * (START_RADIUS + (1.0 - START_RADIUS) * self.growth)
+    }
+
+    /// The centre settles from the press point onto the container's own as the
+    /// disc grows, which is what stops a press near a corner from looking
+    /// lopsided.
+    pub fn center(&self, width: f32, height: f32) -> (f32, f32) {
+        let (x, y) = self.origin;
+        (
+            x + (width / 2.0 - x) * self.growth,
+            y + (height / 2.0 - y) * self.growth,
+        )
     }
 
     fn is_leaving(&self) -> bool {
         self.exit.is_some()
     }
 
-    fn begin_exit(&mut self, kind: ExitKind, now: Instant) {
+    /// Begin the exit, from the growth the ripple has actually reached.
+    ///
+    /// Advancing first is not tidiness: events are dispatched as a batch before
+    /// the frame's animation pass runs, so a touch tap — down and up in one
+    /// batch — arrives before `advance` has ever run, and the compressed
+    /// remainder has to start from the real growth rather than a stale zero.
+    fn begin_exit(&mut self, kind: ExitKind, config: &RippleConfig, now: Instant) {
         if self.exit.is_some() {
             return;
         }
+        self.advance(config, now);
         self.exit = Some(Exit {
             kind,
             at: now,
             growth: self.growth,
-            opacity: self.opacity,
         });
+    }
+
+    /// How opaque the disc is.
+    ///
+    /// The rise is never cut short: the fall does not begin until the disc has
+    /// finished appearing, so a press reaches full strength however brief it
+    /// was. Cutting the rise off at the release instead — the obvious reading —
+    /// makes every click shorter than the rise dimmer than the one before it,
+    /// and a tap that arrives in a single event batch invisible outright.
+    fn opacity_at(&self, config: &RippleConfig, now: Instant) -> f32 {
+        let fade_speed = sane_speed(config.fade_speed);
+        let rise_over = FADE_IN / fade_speed;
+        let risen = phase(since(self.born, now), rise_over);
+
+        let Some(exit) = self.exit else {
+            return risen;
+        };
+        let falls_over = match exit.kind {
+            ExitKind::Confirmed => FADE_OUT,
+            ExitKind::Cancelled => CANCEL_FADE,
+        } / fade_speed;
+
+        let falls_from = exit.at.max(self.born + Duration::from_secs_f32(rise_over));
+        risen * (1.0 - ease_out(phase(since(falls_from, now), falls_over)))
+    }
+
+    /// When the disc has finished leaving, so it can be dropped.
+    fn gone(&self, config: &RippleConfig, now: Instant) -> bool {
+        let Some(exit) = self.exit else {
+            return false;
+        };
+        let fade_speed = sane_speed(config.fade_speed);
+        let falls_over = match exit.kind {
+            ExitKind::Confirmed => FADE_OUT,
+            ExitKind::Cancelled => CANCEL_FADE,
+        } / fade_speed;
+        let falls_from = exit
+            .at
+            .max(self.born + Duration::from_secs_f32(FADE_IN / fade_speed));
+        phase(since(falls_from, now), falls_over) >= 1.0
     }
 
     /// The growth a ripple nobody has released yet has reached.
     fn held_growth(&self, config: &RippleConfig, now: Instant) -> f32 {
-        let duration = HELD_GROWTH / config.expand_speed;
-        ease_out((since(self.born, now) / duration).min(1.0))
+        let duration = HELD_GROWTH / sane_speed(config.expand_speed);
+        ease_out(phase(since(self.born, now), duration))
     }
 
     /// Advance, and report whether this ripple is still worth drawing.
     fn advance(&mut self, config: &RippleConfig, now: Instant) -> bool {
+        self.opacity = self.opacity_at(config, now);
+
         let Some(exit) = self.exit else {
             self.growth = self.held_growth(config, now);
-            self.opacity = (since(self.born, now) / FADE_IN).min(1.0);
             // A ripple held past its growth is not animating: it just sits
             // there until the release, and the frame loop must be allowed to
             // go quiet.
             return self.growth < 1.0 || self.opacity < 1.0;
         };
 
-        let elapsed = since(exit.at, now);
         match exit.kind {
             ExitKind::Confirmed => {
-                // The remainder of the expansion, compressed. Never backwards:
-                // it starts from where the release found it.
-                let t = (elapsed / (CONFIRM_GROWTH / config.expand_speed)).min(1.0);
+                // The remainder of the expansion, compressed — and never given
+                // longer than the fade it overlaps, or the disc would go
+                // invisible with the growth unfinished, which is the very
+                // truncation the confirm exists to prevent.
+                let fade = FADE_OUT / sane_speed(config.fade_speed);
+                let over = (CONFIRM_GROWTH / sane_speed(config.expand_speed)).min(fade);
+                let t = phase(since(exit.at, now), over);
                 self.growth = exit.growth + (1.0 - exit.growth) * ease_out(t);
-
-                let f = (elapsed / (FADE_OUT / config.fade_speed)).min(1.0);
-                self.opacity = exit.opacity * (1.0 - ease_out(f));
-                f < 1.0
             }
             ExitKind::Cancelled => {
                 // Nothing was activated, so the growth is not finished for it —
                 // it simply carries on at its own pace while the disc leaves.
                 self.growth = self.held_growth(config, now);
-
-                let f = (elapsed / (CANCEL_FADE / config.fade_speed)).min(1.0);
-                self.opacity = exit.opacity * (1.0 - f);
-                f < 1.0
             }
         }
+        !self.gone(config, now)
     }
 }
 
 /// Every ripple currently alive on one container.
 #[derive(Debug, Clone, Default)]
 pub struct RippleState {
-    live: SmallVec<[Ripple; 2]>,
+    /// A plain `Vec`: it allocates on the first press, and the containers that
+    /// never ripple — most of the ones carrying any handler at all — pay three
+    /// words instead of an inline buffer they will not use.
+    live: Vec<Ripple>,
 }
 
 impl RippleState {
@@ -201,7 +285,7 @@ impl RippleState {
     pub fn start(&mut self, local_x: f32, local_y: f32, now: Instant) {
         // At capacity the oldest goes. It is the one furthest through its own
         // fade, so it is the least of them to lose.
-        while self.live.len() >= MAX_LIVE {
+        while self.live.len() >= MAX_LIVE_RIPPLES {
             self.live.remove(0);
         }
         self.live.push(Ripple::new((local_x, local_y), now));
@@ -211,17 +295,16 @@ impl RippleState {
     ///
     /// Only the ripple still being held is confirmed. The others already have
     /// an exit of their own and keep it.
-    pub fn release(&mut self, now: Instant) {
+    pub fn release(&mut self, config: &RippleConfig, now: Instant) {
         if let Some(held) = self.live.iter_mut().rev().find(|r| !r.is_leaving()) {
-            held.begin_exit(ExitKind::Confirmed, now);
+            held.begin_exit(ExitKind::Confirmed, config, now);
         }
     }
 
-    /// The pointer left without releasing: nothing was activated, so every
-    /// ripple still being held just goes.
-    pub fn cancel(&mut self, now: Instant) {
+    /// The press was abandoned: every ripple still being held just goes.
+    pub fn cancel(&mut self, config: &RippleConfig, now: Instant) {
         for ripple in self.live.iter_mut().filter(|r| !r.is_leaving()) {
-            ripple.begin_exit(ExitKind::Cancelled, now);
+            ripple.begin_exit(ExitKind::Cancelled, config, now);
         }
     }
 
@@ -230,20 +313,7 @@ impl RippleState {
         !self.live.is_empty()
     }
 
-    /// Whether anything is still moving.
-    pub fn is_animating(&self) -> bool {
-        self.live
-            .iter()
-            .any(|r| r.is_leaving() || r.growth < 1.0 || r.opacity < 1.0)
-    }
-
     /// The ripples to draw, oldest first.
-    ///
-    /// The caller owns the geometry: the radius is
-    /// `max_radius * (RIPPLE_START_RADIUS + (1 - RIPPLE_START_RADIUS) * growth)`, and the
-    /// centre drifts from [`Ripple::origin`] toward the container's own centre
-    /// by the same `growth` — which is what makes a ripple settle onto the
-    /// button instead of staying lopsided.
     pub fn iter(&self) -> impl Iterator<Item = &Ripple> {
         self.live.iter()
     }
@@ -269,6 +339,7 @@ mod tests {
     use std::time::Duration;
 
     use super::*;
+    use crate::widgets::Color;
 
     fn cfg() -> RippleConfig {
         RippleConfig::default()
@@ -288,8 +359,8 @@ mod tests {
 
         // 80ms of press, the middle of a real click.
         state.advance(&cfg(), at(t0, 80));
-        let at_release = state.iter().next().unwrap().growth();
-        state.release(at(t0, 80));
+        let at_release = state.iter().next().unwrap().growth;
+        state.release(&cfg(), at(t0, 80));
 
         let mut previous = at_release;
         for ms in [100, 140, 200, 260, 320, 400, 460] {
@@ -298,11 +369,11 @@ mod tests {
                 break;
             };
             assert!(
-                ripple.growth() >= previous - f32::EPSILON,
+                ripple.growth >= previous - f32::EPSILON,
                 "growth went backwards at {ms}ms: {previous} -> {}",
-                ripple.growth()
+                ripple.growth
             );
-            previous = ripple.growth();
+            previous = ripple.growth;
         }
     }
 
@@ -314,17 +385,146 @@ mod tests {
         let mut state = RippleState::new();
         state.start(10.0, 10.0, t0);
         state.advance(&cfg(), at(t0, 80));
-        state.release(at(t0, 80));
+        state.release(&cfg(), at(t0, 80));
 
         // The compressed remainder lands well inside the fade it overlaps.
         state.advance(&cfg(), at(t0, 80 + 225));
         let ripple = state.iter().next().expect("still visible");
         assert!(
-            ripple.growth() > 0.99,
+            ripple.growth > 0.99,
             "the expansion has to finish, got {}",
-            ripple.growth()
+            ripple.growth
         );
-        assert!(ripple.opacity() > 0.0, "and still be visible while it does");
+        assert!(ripple.opacity > 0.0, "and still be visible while it does");
+    }
+
+    /// The bug this model shipped with once: events arrive as a batch before
+    /// the frame's animation pass, so a touch tap reaches `release` before
+    /// `advance` has ever run. Cutting the rise off there left the disc at zero
+    /// for its whole life — a ripple that drew nothing, for 375ms of frames.
+    #[test]
+    fn a_tap_released_before_its_first_frame_is_still_seen() {
+        let t0 = Instant::now();
+        let mut state = RippleState::new();
+        state.start(10.0, 10.0, t0);
+        state.release(&cfg(), t0);
+
+        let mut peak: f32 = 0.0;
+        for ms in [8, 16, 32, 60, 75, 100, 160] {
+            state.advance(&cfg(), at(t0, ms));
+            if let Some(ripple) = state.iter().next() {
+                peak = peak.max(ripple.opacity);
+            }
+        }
+        assert!(
+            peak > 0.99,
+            "a tap has to be fully visible at some point, peaked at {peak}"
+        );
+    }
+
+    /// And no click is dimmer than another for being quicker: the rise always
+    /// finishes before the fall starts.
+    #[test]
+    fn a_click_shorter_than_the_rise_still_reaches_full_strength() {
+        for click_ms in [20, 40, 60, 74] {
+            let t0 = Instant::now();
+            let mut state = RippleState::new();
+            state.start(10.0, 10.0, t0);
+            state.advance(&cfg(), at(t0, click_ms));
+            state.release(&cfg(), at(t0, click_ms));
+
+            state.advance(&cfg(), at(t0, 75));
+            let ripple = state.iter().next().expect("still visible");
+            assert!(
+                ripple.opacity > 0.99,
+                "a {click_ms}ms click has to reach full strength, got {}",
+                ripple.opacity
+            );
+        }
+    }
+
+    /// The disc ends centred on the container, so what it has to reach is the
+    /// container's own farthest corner — never the contact point's. Deriving it
+    /// from the press made two clicks on one button different sizes, and an
+    /// edge press cover the box long before the growth ended.
+    #[test]
+    fn the_size_does_not_depend_on_where_the_press_landed() {
+        let t0 = Instant::now();
+        let (w, h) = (200.0, 40.0);
+
+        let mut corner = RippleState::new();
+        corner.start(0.0, 0.0, t0);
+        let mut middle = RippleState::new();
+        middle.start(w / 2.0, h / 2.0, t0);
+
+        for state in [&mut corner, &mut middle] {
+            state.release(&cfg(), t0);
+            state.advance(&cfg(), at(t0, 300));
+        }
+
+        let radius = |s: &RippleState| s.iter().next().unwrap().radius(w, h);
+        assert_eq!(radius(&corner), radius(&middle));
+    }
+
+    /// And at full growth it covers the container exactly: every corner is
+    /// inside, and it was not already inside a third of the way back.
+    #[test]
+    fn a_finished_ripple_covers_the_container_and_not_before() {
+        let t0 = Instant::now();
+        let (w, h) = (200.0, 40.0);
+        let mut state = RippleState::new();
+        state.start(0.0, 0.0, t0);
+        state.release(&cfg(), t0);
+        state.advance(&cfg(), at(t0, 400));
+
+        let ripple = state.iter().next().expect("still visible");
+        assert!(ripple.growth > 0.99, "the growth has to have finished");
+
+        let (cx, cy) = ripple.center(w, h);
+        let radius = ripple.radius(w, h);
+        for (x, y) in [(0.0, 0.0), (w, 0.0), (0.0, h), (w, h)] {
+            let reach = ((x - cx).powi(2) + (y - cy).powi(2)).sqrt();
+            assert!(
+                reach <= radius + 0.01,
+                "corner ({x},{y}) is {reach} away, disc reaches {radius}"
+            );
+        }
+    }
+
+    /// A speed of zero would divide a duration to infinity and pin the frame
+    /// loop; a negative one would run the ease backwards into a negative
+    /// radius. Both are public fields.
+    #[test]
+    fn an_impossible_speed_does_not_stall_or_invert_the_effect() {
+        for (expand, fade) in [(0.0, 0.0), (-2.0, -2.0), (f32::NAN, f32::INFINITY)] {
+            let config = RippleConfig {
+                color: Color::WHITE,
+                expand_speed: expand,
+                fade_speed: fade,
+            };
+            let t0 = Instant::now();
+            let mut state = RippleState::new();
+            state.start(10.0, 10.0, t0);
+            state.release(&config, t0);
+
+            // The slowest a clamped speed can make it: the rise and the fall
+            // both stretched by the 0.05 floor.
+            for ms in [50, 200, 1000, 5000, 10_000] {
+                state.advance(&config, at(t0, ms));
+                for ripple in state.iter() {
+                    assert!(
+                        (0.0..=1.0).contains(&ripple.growth),
+                        "growth left its range with speeds ({expand}, {fade}): {}",
+                        ripple.growth
+                    );
+                    assert!((0.0..=1.0).contains(&ripple.opacity));
+                }
+            }
+            assert!(
+                !state.is_active(),
+                "the ripple has to leave even with speeds ({expand}, {fade})"
+            );
+        }
     }
 
     #[test]
@@ -332,7 +532,7 @@ mod tests {
         let t0 = Instant::now();
         let mut state = RippleState::new();
         state.start(10.0, 10.0, t0);
-        state.release(at(t0, 80));
+        state.release(&cfg(), at(t0, 80));
 
         assert!(state.advance(&cfg(), at(t0, 200)));
         assert!(state.is_active());
@@ -349,13 +549,13 @@ mod tests {
         let mut state = RippleState::new();
         state.start(10.0, 10.0, t0);
         state.advance(&cfg(), at(t0, 80));
-        let at_exit = state.iter().next().unwrap().growth();
+        let at_exit = state.iter().next().unwrap().growth;
 
-        state.cancel(at(t0, 80));
+        state.cancel(&cfg(), at(t0, 80));
         state.advance(&cfg(), at(t0, 80 + 40));
         let ripple = state.iter().next().expect("still fading");
         assert!(
-            ripple.growth() < at_exit + 0.1,
+            ripple.growth < at_exit + 0.1,
             "a cancelled ripple is not rushed to completion"
         );
 
@@ -370,13 +570,13 @@ mod tests {
         let t0 = Instant::now();
         let mut state = RippleState::new();
         state.start(10.0, 10.0, t0);
-        state.release(at(t0, 80));
+        state.release(&cfg(), at(t0, 80));
         state.advance(&cfg(), at(t0, 120));
 
         state.start(90.0, 40.0, at(t0, 120));
         state.advance(&cfg(), at(t0, 160));
 
-        let origins: Vec<_> = state.iter().map(|r| r.origin()).collect();
+        let origins: Vec<_> = state.iter().map(|r| r.origin).collect();
         assert_eq!(origins, vec![(10.0, 10.0), (90.0, 40.0)]);
     }
 
@@ -386,10 +586,10 @@ mod tests {
         let t0 = Instant::now();
         let mut state = RippleState::new();
         state.start(10.0, 10.0, t0);
-        state.release(at(t0, 50));
+        state.release(&cfg(), at(t0, 50));
         state.start(90.0, 40.0, at(t0, 60));
 
-        state.release(at(t0, 100));
+        state.release(&cfg(), at(t0, 100));
 
         let leaving: Vec<_> = state.iter().map(|r| r.is_leaving()).collect();
         assert_eq!(leaving, vec![true, true]);
@@ -402,12 +602,12 @@ mod tests {
     fn the_oldest_goes_when_the_bound_is_reached() {
         let t0 = Instant::now();
         let mut state = RippleState::new();
-        for i in 0..(MAX_LIVE + 2) {
+        for i in 0..(MAX_LIVE_RIPPLES + 2) {
             state.start(i as f32, 0.0, at(t0, i as u64 * 10));
         }
 
-        assert_eq!(state.iter().count(), MAX_LIVE);
-        let origins: Vec<_> = state.iter().map(|r| r.origin().0).collect();
+        assert_eq!(state.iter().count(), MAX_LIVE_RIPPLES);
+        let origins: Vec<_> = state.iter().map(|r| r.origin.0).collect();
         assert_eq!(origins, vec![2.0, 3.0, 4.0, 5.0]);
     }
 

--- a/src/widgets/container/ripple.rs
+++ b/src/widgets/container/ripple.rs
@@ -1,28 +1,193 @@
+//! Material's ripple: a disc that grows from the point of contact and fades.
+//!
+//! Two properties define the effect, and both are load-bearing.
+//!
+//! **The radius never goes backwards.** The exit is a fade of the opacity, not
+//! a contraction of the disc. An ink drop that retreats into the finger says
+//! the opposite of what the gesture did, and it is what every Material
+//! implementation avoids — Flutter fades out, Compose fades out, Android fades
+//! out.
+//!
+//! **A short press does not truncate the growth.** A mouse click lasts 60-150
+//! milliseconds against a growth measured in hundreds, so the release lands
+//! mid-expansion essentially always. Releasing therefore *finishes* the
+//! expansion — the remainder is compressed into the exit — rather than
+//! abandoning it wherever it got to. This is Flutter's `confirm()`, and it is
+//! the difference between a click that reads as accepted and one that reads as
+//! interrupted.
+//!
+//! Leaving without releasing is the other case, and it is not the same one:
+//! nothing was activated, so there is nothing to complete. It just fades, fast.
+//! That is Flutter's `cancel()`.
+//!
+//! # Several at once
+//!
+//! Each press is its own ripple and they overlap, because that is what the
+//! gesture was: two clicks are two events, and collapsing them into one disc
+//! that restarts loses the second. [`MAX_LIVE`] bounds the work; past it the
+//! oldest is dropped, which is the one nearest to invisible anyway.
+
 use std::time::Instant;
+
+use smallvec::SmallVec;
 
 use crate::widgets::state_layer::RippleConfig;
 
-/// Ripple animation state for pressed feedback
+/// Opacity rise, in seconds. Short: the disc should be there on contact, not
+/// arrive after it.
+const FADE_IN: f32 = 0.075;
+
+/// Growth of a ripple nobody has released yet, in seconds. Deliberately slow —
+/// a held button keeps spreading, and the release is what finishes it.
+const HELD_GROWTH: f32 = 1.0;
+
+/// How long the *remaining* growth takes once the press is confirmed.
+const CONFIRM_GROWTH: f32 = 0.225;
+
+/// Opacity fall after a confirmed press. Longer than the growth it overlaps,
+/// so the disc is still visible as it completes.
+const FADE_OUT: f32 = 0.375;
+
+/// Opacity fall after the pointer leaves without releasing. Nothing was
+/// activated, so the feedback should get out of the way.
+const CANCEL_FADE: f32 = 0.075;
+
+/// Where the disc starts, as a fraction of its final radius. Material's ripple
+/// appears as a disc rather than growing from a point.
+pub const RIPPLE_START_RADIUS: f32 = 0.3;
+
+/// How many ripples may be alive at once.
+pub const MAX_LIVE: usize = 4;
+
+fn ease_out(t: f32) -> f32 {
+    1.0 - (1.0 - t).powi(3)
+}
+
+fn since(start: Instant, now: Instant) -> f32 {
+    now.saturating_duration_since(start).as_secs_f32()
+}
+
+/// Why a ripple stopped growing on its own.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ExitKind {
+    /// Released inside: the press happened, so the expansion completes.
+    Confirmed,
+    /// The pointer left without releasing: nothing to complete.
+    Cancelled,
+}
+
+/// The moment a ripple began to leave, and the state it left from.
+#[derive(Debug, Clone, Copy)]
+struct Exit {
+    kind: ExitKind,
+    at: Instant,
+    /// Growth when the exit began, so the remainder can be compressed into it
+    /// instead of restarting from zero.
+    growth: f32,
+    opacity: f32,
+}
+
+/// One press.
+#[derive(Debug, Clone)]
+pub struct Ripple {
+    /// Where the pointer went down, in local container coordinates.
+    origin: (f32, f32),
+    born: Instant,
+    exit: Option<Exit>,
+    /// 0 at the start radius, 1 fully expanded.
+    growth: f32,
+    opacity: f32,
+}
+
+impl Ripple {
+    fn new(origin: (f32, f32), now: Instant) -> Self {
+        Self {
+            origin,
+            born: now,
+            exit: None,
+            growth: 0.0,
+            opacity: 0.0,
+        }
+    }
+
+    /// Where the pointer went down, in local container coordinates.
+    pub fn origin(&self) -> (f32, f32) {
+        self.origin
+    }
+
+    /// How far along the expansion is: 0 at [`RIPPLE_START_RADIUS`], 1 covering the
+    /// container. Also drives the drift of the centre — see
+    /// [`RippleState::iter`].
+    pub fn growth(&self) -> f32 {
+        self.growth
+    }
+
+    pub fn opacity(&self) -> f32 {
+        self.opacity
+    }
+
+    fn is_leaving(&self) -> bool {
+        self.exit.is_some()
+    }
+
+    fn begin_exit(&mut self, kind: ExitKind, now: Instant) {
+        if self.exit.is_some() {
+            return;
+        }
+        self.exit = Some(Exit {
+            kind,
+            at: now,
+            growth: self.growth,
+            opacity: self.opacity,
+        });
+    }
+
+    /// The growth a ripple nobody has released yet has reached.
+    fn held_growth(&self, config: &RippleConfig, now: Instant) -> f32 {
+        let duration = HELD_GROWTH / config.expand_speed;
+        ease_out((since(self.born, now) / duration).min(1.0))
+    }
+
+    /// Advance, and report whether this ripple is still worth drawing.
+    fn advance(&mut self, config: &RippleConfig, now: Instant) -> bool {
+        let Some(exit) = self.exit else {
+            self.growth = self.held_growth(config, now);
+            self.opacity = (since(self.born, now) / FADE_IN).min(1.0);
+            // A ripple held past its growth is not animating: it just sits
+            // there until the release, and the frame loop must be allowed to
+            // go quiet.
+            return self.growth < 1.0 || self.opacity < 1.0;
+        };
+
+        let elapsed = since(exit.at, now);
+        match exit.kind {
+            ExitKind::Confirmed => {
+                // The remainder of the expansion, compressed. Never backwards:
+                // it starts from where the release found it.
+                let t = (elapsed / (CONFIRM_GROWTH / config.expand_speed)).min(1.0);
+                self.growth = exit.growth + (1.0 - exit.growth) * ease_out(t);
+
+                let f = (elapsed / (FADE_OUT / config.fade_speed)).min(1.0);
+                self.opacity = exit.opacity * (1.0 - ease_out(f));
+                f < 1.0
+            }
+            ExitKind::Cancelled => {
+                // Nothing was activated, so the growth is not finished for it —
+                // it simply carries on at its own pace while the disc leaves.
+                self.growth = self.held_growth(config, now);
+
+                let f = (elapsed / (CANCEL_FADE / config.fade_speed)).min(1.0);
+                self.opacity = exit.opacity * (1.0 - f);
+                f < 1.0
+            }
+        }
+    }
+}
+
+/// Every ripple currently alive on one container.
 #[derive(Debug, Clone, Default)]
 pub struct RippleState {
-    /// Center point of the ripple in local container coordinates (start position)
-    pub center: Option<(f32, f32)>,
-    /// Exit center point where ripple contracts toward (release position)
-    pub exit_center: Option<(f32, f32)>,
-    /// Current ripple expansion progress (0.0 = start, 1.0 = fully expanded)
-    pub progress: f32,
-    /// Current ripple opacity (1.0 = visible, 0.0 = faded out)
-    pub opacity: f32,
-    /// Whether the ripple is currently fading out (mouse released)
-    pub fading: bool,
-    /// Time when ripple animation started (for smooth animation)
-    pub start_time: Option<Instant>,
-    /// Time when ripple fade/contraction started
-    pub fade_start_time: Option<Instant>,
-    /// Progress at which fading started (for smooth contraction)
-    pub fade_start_progress: f32,
-    /// Deferred reset flag to ensure final frame is painted before clearing state
-    pending_reset: bool,
+    live: SmallVec<[Ripple; 2]>,
 }
 
 impl RippleState {
@@ -30,124 +195,72 @@ impl RippleState {
         Self::default()
     }
 
-    /// Start a ripple animation at the given local coordinates.
+    /// Begin a ripple at the given local coordinates.
     ///
-    /// The coordinates should be relative to the container's origin (0,0 = top-left).
-    pub fn start(&mut self, local_x: f32, local_y: f32) {
-        self.center = Some((local_x, local_y));
-        self.progress = 0.0;
-        self.opacity = 1.0;
-        self.fading = false;
-        self.start_time = Some(Instant::now());
+    /// The coordinates are relative to the container's origin (0,0 = top-left).
+    pub fn start(&mut self, local_x: f32, local_y: f32, now: Instant) {
+        // At capacity the oldest goes. It is the one furthest through its own
+        // fade, so it is the least of them to lose.
+        while self.live.len() >= MAX_LIVE {
+            self.live.remove(0);
+        }
+        self.live.push(Ripple::new((local_x, local_y), now));
     }
 
-    /// Start fading the ripple, contracting toward the given local exit point.
+    /// The press was released inside: finish its expansion and fade it out.
     ///
-    /// The coordinates should be relative to the container's origin (0,0 = top-left).
-    pub fn start_fade(&mut self, exit_x: f32, exit_y: f32) {
-        if self.center.is_some() && self.opacity > 0.0 {
-            self.exit_center = Some((exit_x, exit_y));
-            self.fading = true;
-            self.fade_start_time = Some(Instant::now());
-            self.fade_start_progress = self.progress;
+    /// Only the ripple still being held is confirmed. The others already have
+    /// an exit of their own and keep it.
+    pub fn release(&mut self, now: Instant) {
+        if let Some(held) = self.live.iter_mut().rev().find(|r| !r.is_leaving()) {
+            held.begin_exit(ExitKind::Confirmed, now);
         }
     }
 
-    /// Start fading using the center of the container (for MouseLeave events)
-    pub fn start_fade_to_center(&mut self, container_width: f32, container_height: f32) {
-        if self.center.is_some() && self.opacity > 0.0 {
-            self.exit_center = Some((container_width / 2.0, container_height / 2.0));
-            self.fading = true;
-            self.fade_start_time = Some(Instant::now());
-            self.fade_start_progress = self.progress;
+    /// The pointer left without releasing: nothing was activated, so every
+    /// ripple still being held just goes.
+    pub fn cancel(&mut self, now: Instant) {
+        for ripple in self.live.iter_mut().filter(|r| !r.is_leaving()) {
+            ripple.begin_exit(ExitKind::Cancelled, now);
         }
     }
 
-    /// Check if ripple is currently active
+    /// Whether anything is on screen.
     pub fn is_active(&self) -> bool {
-        self.center.is_some()
+        !self.live.is_empty()
     }
 
-    /// Check if ripple is currently animating
+    /// Whether anything is still moving.
     pub fn is_animating(&self) -> bool {
-        self.center.is_some() && (self.progress < 1.0 || self.fading)
+        self.live
+            .iter()
+            .any(|r| r.is_leaving() || r.growth < 1.0 || r.opacity < 1.0)
     }
 
-    /// Reset ripple state
-    pub fn reset(&mut self) {
-        self.center = None;
-        self.exit_center = None;
-        self.progress = 0.0;
-        self.opacity = 0.0;
-        self.fading = false;
-        self.start_time = None;
-        self.fade_start_time = None;
-        self.fade_start_progress = 0.0;
-        self.pending_reset = false;
+    /// The ripples to draw, oldest first.
+    ///
+    /// The caller owns the geometry: the radius is
+    /// `max_radius * (RIPPLE_START_RADIUS + (1 - RIPPLE_START_RADIUS) * growth)`, and the
+    /// centre drifts from [`Ripple::origin`] toward the container's own centre
+    /// by the same `growth` — which is what makes a ripple settle onto the
+    /// button instead of staying lopsided.
+    pub fn iter(&self) -> impl Iterator<Item = &Ripple> {
+        self.live.iter()
     }
 
-    /// Advance ripple animation, returns true if still animating
-    pub fn advance(&mut self, ripple_config: &RippleConfig) -> bool {
-        // Handle deferred reset: the previous frame requested reset, now we can safely clear
-        if self.pending_reset {
-            self.reset();
-            return false;
-        }
-
-        let Some(start_time) = self.start_time else {
-            return false;
-        };
-
-        let elapsed = start_time.elapsed().as_secs_f32();
-
-        // Expansion animation (0.4 seconds base, modified by expand_speed)
-        let expand_duration = 0.4 / ripple_config.expand_speed;
-
-        if self.fading {
-            // Reverse animation: contract toward exit point
-            let Some(fade_start) = self.fade_start_time else {
-                return false;
-            };
-            let fade_elapsed = fade_start.elapsed().as_secs_f32();
-            let fade_duration = 0.3 / ripple_config.fade_speed;
-
-            // Calculate contraction progress (0 = just started fading, 1 = fully contracted)
-            let contraction_t = (fade_elapsed / fade_duration).min(1.0);
-            // Use ease-in curve for contraction (accelerates as it shrinks)
-            let eased_t = contraction_t * contraction_t;
-
-            // Shrink the ripple from its current progress back to 0
-            self.progress = self.fade_start_progress * (1.0 - eased_t);
-
-            // Interpolate center from start toward exit point
-            if let (Some((start_x, start_y)), Some((exit_x, exit_y))) =
-                (self.center, self.exit_center)
-            {
-                // The effective center moves toward the exit point as it contracts
-                let current_x = start_x + (exit_x - start_x) * eased_t;
-                let current_y = start_y + (exit_y - start_y) * eased_t;
-                self.center = Some((current_x, current_y));
-            }
-
-            // Fade opacity as well for smooth disappearance
-            self.opacity = (1.0 - eased_t).max(0.0);
-
-            // Schedule reset for next frame to ensure final frame is painted
-            if contraction_t >= 1.0 {
-                self.pending_reset = true;
-                return true;
-            }
-        } else {
-            // Expansion animation
-            if self.progress < 1.0 {
-                self.progress = (elapsed / expand_duration).min(1.0);
-                // Use ease-out curve for expansion
-                self.progress = 1.0 - (1.0 - self.progress).powi(3);
-            }
-        }
-
-        // Still animating if expanding or fading
-        self.progress < 1.0 || self.fading
+    /// Advance every ripple, dropping the ones that have faded out.
+    ///
+    /// Returns whether any is still animating. Dropping a ripple at zero
+    /// opacity needs no deferred frame: it draws nothing at that point, so
+    /// there is no last frame to preserve.
+    pub fn advance(&mut self, config: &RippleConfig, now: Instant) -> bool {
+        let mut animating = false;
+        self.live.retain_mut(|ripple| {
+            let alive = ripple.advance(config, now);
+            animating |= alive;
+            alive || ripple.opacity > 0.0
+        });
+        animating
     }
 }
 
@@ -157,152 +270,158 @@ mod tests {
 
     use super::*;
 
+    fn cfg() -> RippleConfig {
+        RippleConfig::default()
+    }
+
+    fn at(base: Instant, ms: u64) -> Instant {
+        base + Duration::from_millis(ms)
+    }
+
+    /// The property the old model broke: a click grows the disc and never
+    /// pulls it back.
     #[test]
-    fn test_ripple_state_new() {
-        let state = RippleState::new();
-        assert!(state.center.is_none());
-        assert!(!state.is_active());
-        assert!(!state.is_animating());
-        assert_eq!(state.progress, 0.0);
-        assert_eq!(state.opacity, 0.0);
+    fn a_click_never_moves_the_radius_backwards() {
+        let t0 = Instant::now();
+        let mut state = RippleState::new();
+        state.start(10.0, 10.0, t0);
+
+        // 80ms of press, the middle of a real click.
+        state.advance(&cfg(), at(t0, 80));
+        let at_release = state.iter().next().unwrap().growth();
+        state.release(at(t0, 80));
+
+        let mut previous = at_release;
+        for ms in [100, 140, 200, 260, 320, 400, 460] {
+            state.advance(&cfg(), at(t0, ms));
+            let Some(ripple) = state.iter().next() else {
+                break;
+            };
+            assert!(
+                ripple.growth() >= previous - f32::EPSILON,
+                "growth went backwards at {ms}ms: {previous} -> {}",
+                ripple.growth()
+            );
+            previous = ripple.growth();
+        }
+    }
+
+    /// And it gets all the way there: the release finishes the expansion
+    /// instead of abandoning it.
+    #[test]
+    fn a_click_completes_the_expansion_it_started() {
+        let t0 = Instant::now();
+        let mut state = RippleState::new();
+        state.start(10.0, 10.0, t0);
+        state.advance(&cfg(), at(t0, 80));
+        state.release(at(t0, 80));
+
+        // The compressed remainder lands well inside the fade it overlaps.
+        state.advance(&cfg(), at(t0, 80 + 225));
+        let ripple = state.iter().next().expect("still visible");
+        assert!(
+            ripple.growth() > 0.99,
+            "the expansion has to finish, got {}",
+            ripple.growth()
+        );
+        assert!(ripple.opacity() > 0.0, "and still be visible while it does");
     }
 
     #[test]
-    fn test_ripple_start() {
+    fn a_confirmed_ripple_leaves_when_it_has_faded() {
+        let t0 = Instant::now();
         let mut state = RippleState::new();
-        state.start(100.0, 200.0);
+        state.start(10.0, 10.0, t0);
+        state.release(at(t0, 80));
 
-        assert!(state.is_active());
-        assert!(state.is_animating());
-        assert_eq!(state.center, Some((100.0, 200.0)));
-        assert_eq!(state.progress, 0.0);
-        assert_eq!(state.opacity, 1.0);
-        assert!(!state.fading);
-        assert!(state.start_time.is_some());
-    }
-
-    #[test]
-    fn test_ripple_start_fade() {
-        let mut state = RippleState::new();
-        state.start(100.0, 200.0);
-        state.progress = 0.5; // Simulate some progress
-
-        state.start_fade(150.0, 250.0);
-
-        assert!(state.fading);
-        assert_eq!(state.exit_center, Some((150.0, 250.0)));
-        assert_eq!(state.fade_start_progress, 0.5);
-        assert!(state.fade_start_time.is_some());
-    }
-
-    #[test]
-    fn test_ripple_start_fade_inactive() {
-        let mut state = RippleState::new();
-        // Don't start the ripple, try to fade
-        state.start_fade(150.0, 250.0);
-
-        // Should not start fading if ripple is not active
-        assert!(!state.fading);
-        assert!(state.exit_center.is_none());
-    }
-
-    #[test]
-    fn test_ripple_start_fade_to_center() {
-        let mut state = RippleState::new();
-        state.start(100.0, 200.0);
-        state.progress = 0.7;
-
-        state.start_fade_to_center(400.0, 300.0);
-
-        assert!(state.fading);
-        assert_eq!(state.exit_center, Some((200.0, 150.0))); // center of 400x300
-        assert_eq!(state.fade_start_progress, 0.7);
-    }
-
-    #[test]
-    fn test_ripple_reset() {
-        let mut state = RippleState::new();
-        state.start(100.0, 200.0);
-        state.progress = 0.5;
-        state.start_fade(150.0, 250.0);
-        state.pending_reset = true;
-
-        state.reset();
-
-        assert!(state.center.is_none());
-        assert!(state.exit_center.is_none());
-        assert_eq!(state.progress, 0.0);
-        assert_eq!(state.opacity, 0.0);
-        assert!(!state.fading);
-        assert!(state.start_time.is_none());
-        assert!(state.fade_start_time.is_none());
-        assert_eq!(state.fade_start_progress, 0.0);
-        assert!(!state.pending_reset);
-    }
-
-    #[test]
-    fn test_ripple_is_active() {
-        let mut state = RippleState::new();
-        assert!(!state.is_active());
-
-        state.start(0.0, 0.0);
+        assert!(state.advance(&cfg(), at(t0, 200)));
         assert!(state.is_active());
 
-        state.reset();
-        assert!(!state.is_active());
+        state.advance(&cfg(), at(t0, 80 + 400));
+        assert!(!state.is_active(), "a faded ripple is not kept around");
     }
 
-    /// What a real click looks like today, in numbers.
-    ///
-    /// A mouse click lasts 60-150ms against a 400ms expansion, so the release
-    /// always lands mid-growth — and the release *reverses* the growth. The
-    /// disc reaches about half the container and is then pulled back in, while
-    /// the ease-in opacity keeps it bright for exactly as long as it takes to
-    /// collapse.
+    /// Leaving without releasing is a different event and gets a different
+    /// exit: no completion, and a fade short enough to get out of the way.
     #[test]
-    fn a_click_reverses_the_expansion_before_it_covers_anything() {
-        let cfg = RippleConfig::default();
+    fn leaving_without_releasing_does_not_complete_the_expansion() {
+        let t0 = Instant::now();
         let mut state = RippleState::new();
-        state.start(10.0, 10.0);
+        state.start(10.0, 10.0, t0);
+        state.advance(&cfg(), at(t0, 80));
+        let at_exit = state.iter().next().unwrap().growth();
 
-        // 80ms of press: `1 - (1 - 80/400)^3`.
-        state.start_time = Some(Instant::now() - Duration::from_millis(80));
-        state.advance(&cfg);
-        let at_release = state.progress;
+        state.cancel(at(t0, 80));
+        state.advance(&cfg(), at(t0, 80 + 40));
+        let ripple = state.iter().next().expect("still fading");
         assert!(
-            (0.45..0.55).contains(&at_release),
-            "a click reaches about half the radius, got {at_release}"
+            ripple.growth() < at_exit + 0.1,
+            "a cancelled ripple is not rushed to completion"
         );
 
-        state.start_fade(10.0, 10.0);
-        state.fade_start_time = Some(Instant::now() - Duration::from_millis(150));
-        state.advance(&cfg);
+        state.advance(&cfg(), at(t0, 80 + 80));
+        assert!(!state.is_active(), "and it leaves quickly");
+    }
 
-        assert!(
-            state.progress < at_release,
-            "the radius goes backwards after the release: {} -> {}",
-            at_release,
-            state.progress
-        );
-        assert!(
-            state.opacity > 0.5,
-            "and it is still bright while it collapses, got {}",
-            state.opacity
-        );
+    /// Two clicks are two events, and they overlap rather than replacing each
+    /// other.
+    #[test]
+    fn a_second_press_does_not_erase_the_first() {
+        let t0 = Instant::now();
+        let mut state = RippleState::new();
+        state.start(10.0, 10.0, t0);
+        state.release(at(t0, 80));
+        state.advance(&cfg(), at(t0, 120));
+
+        state.start(90.0, 40.0, at(t0, 120));
+        state.advance(&cfg(), at(t0, 160));
+
+        let origins: Vec<_> = state.iter().map(|r| r.origin()).collect();
+        assert_eq!(origins, vec![(10.0, 10.0), (90.0, 40.0)]);
+    }
+
+    /// A release confirms the press being held, not the ones already leaving.
+    #[test]
+    fn a_release_confirms_only_the_ripple_still_held() {
+        let t0 = Instant::now();
+        let mut state = RippleState::new();
+        state.start(10.0, 10.0, t0);
+        state.release(at(t0, 50));
+        state.start(90.0, 40.0, at(t0, 60));
+
+        state.release(at(t0, 100));
+
+        let leaving: Vec<_> = state.iter().map(|r| r.is_leaving()).collect();
+        assert_eq!(leaving, vec![true, true]);
+        // The first one's exit was not restarted by the second release.
+        let first = state.iter().next().unwrap();
+        assert_eq!(first.exit.map(|e| e.at), Some(at(t0, 50)));
     }
 
     #[test]
-    fn test_ripple_is_animating() {
+    fn the_oldest_goes_when_the_bound_is_reached() {
+        let t0 = Instant::now();
         let mut state = RippleState::new();
-        assert!(!state.is_animating());
+        for i in 0..(MAX_LIVE + 2) {
+            state.start(i as f32, 0.0, at(t0, i as u64 * 10));
+        }
 
-        state.start(0.0, 0.0);
-        assert!(state.is_animating()); // progress < 1.0
+        assert_eq!(state.iter().count(), MAX_LIVE);
+        let origins: Vec<_> = state.iter().map(|r| r.origin().0).collect();
+        assert_eq!(origins, vec![2.0, 3.0, 4.0, 5.0]);
+    }
 
-        state.progress = 1.0;
-        assert!(!state.is_animating()); // progress >= 1.0 and not fading
+    #[test]
+    fn a_held_ripple_stops_asking_for_frames_once_it_is_fully_grown() {
+        let t0 = Instant::now();
+        let mut state = RippleState::new();
+        state.start(10.0, 10.0, t0);
 
-        state.fading = true;
-        assert!(state.is_animating()); // fading
+        assert!(state.advance(&cfg(), at(t0, 100)));
+        assert!(
+            !state.advance(&cfg(), at(t0, 2000)),
+            "a held, fully grown ripple must let the loop go quiet"
+        );
+        assert!(state.is_active(), "but it is still on screen");
     }
 }

--- a/src/widgets/container/ripple.rs
+++ b/src/widgets/container/ripple.rs
@@ -153,6 +153,8 @@ impl RippleState {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use super::*;
 
     #[test]
@@ -248,6 +250,45 @@ mod tests {
 
         state.reset();
         assert!(!state.is_active());
+    }
+
+    /// What a real click looks like today, in numbers.
+    ///
+    /// A mouse click lasts 60-150ms against a 400ms expansion, so the release
+    /// always lands mid-growth — and the release *reverses* the growth. The
+    /// disc reaches about half the container and is then pulled back in, while
+    /// the ease-in opacity keeps it bright for exactly as long as it takes to
+    /// collapse.
+    #[test]
+    fn a_click_reverses_the_expansion_before_it_covers_anything() {
+        let cfg = RippleConfig::default();
+        let mut state = RippleState::new();
+        state.start(10.0, 10.0);
+
+        // 80ms of press: `1 - (1 - 80/400)^3`.
+        state.start_time = Some(Instant::now() - Duration::from_millis(80));
+        state.advance(&cfg);
+        let at_release = state.progress;
+        assert!(
+            (0.45..0.55).contains(&at_release),
+            "a click reaches about half the radius, got {at_release}"
+        );
+
+        state.start_fade(10.0, 10.0);
+        state.fade_start_time = Some(Instant::now() - Duration::from_millis(150));
+        state.advance(&cfg);
+
+        assert!(
+            state.progress < at_release,
+            "the radius goes backwards after the release: {} -> {}",
+            at_release,
+            state.progress
+        );
+        assert!(
+            state.opacity > 0.5,
+            "and it is still bright while it collapses, got {}",
+            state.opacity
+        );
     }
 
     #[test]


### PR DESCRIPTION
The ripple stopped half-way and rewound. Two Material invariants explain why,
and the old model broke both.

**The radius never goes backwards.** Releasing ran the expansion in reverse
toward the release point. Worse, the contraction eased *in* on both radius and
opacity, so the disc stayed bright for exactly as long as it took to collapse —
the retreat was the most visible part of the effect. The exit is now a fade of
the opacity, and `exit_center`, a target no Material implementation has, is
gone.

**A short press does not truncate the growth.** A mouse click lasts 60-150ms
against a 400ms expansion, so the release landed mid-growth every single time:

| click | radius reached before | area |
|---|---|---|
| 60ms | 39% | 15% |
| 100ms | 58% | 33% |
| 150ms | 76% | 57% |

It never got near covering the container. A release now *completes* the
expansion — the remainder is compressed into the exit — which is Flutter's
`confirm()`. Leaving without releasing is the other case and not the same one:
nothing was activated, so there is nothing to complete, and it just fades, fast.
That is `cancel()`.

## Several at once

Each press is its own ripple and they overlap. A second click used to reset the
first one's state; two clicks are two events, and the effect should show both.
`MAX_LIVE` (4) bounds the work, dropping the oldest — the one furthest through
its own fade.

## Two smaller pieces of the same look

The disc starts at 30% of its final radius instead of growing from a point, and
its centre settles toward the container's own as it grows, so a press near a
corner stops looking lopsided. Both are Material; neither was there.

## Timing

| Phase | Duration |
|---|---|
| Opacity rise on contact | 75ms |
| Growth while held | 1s |
| Growth remaining after release | 225ms |
| Fade after a release | 375ms |
| Fade after leaving without releasing | 75ms |

`expand_speed` / `fade_speed` still scale growth and fade.

## Testability

`advance` now takes the frame's `Instant` rather than reading the clock per
ripple — every ripple in a frame should agree on what time it is, and it makes
the lifecycle testable without sleeping. The old tests poked `Instant` fields
directly to get anywhere.

Eight tests cover the model: monotonic growth across a release, the release
completing the expansion, a confirmed ripple leaving when it has faded, a
cancelled one not being rushed to completion, two presses overlapping, a
release confirming only the ripple still held, the bound dropping the oldest,
and a held ripple letting the frame loop go quiet once it is fully grown.

The first commit is the "before": the arithmetic of a real click and the
assertion that the radius went backwards while still bright.

Full suite green, render snapshots unchanged, clippy clean, book builds.

## Worth feeling before merging

This is the kind of change numbers cannot settle. `cargo run --example
state_layer_example` has four ripple buttons in the right column — including a
rotated one — and clicking one repeatedly is what shows the overlap.