### PR TITLE
A spring keeps its momentum when it is sent somewhere else

### DIFF
--- a/book/src/animations/springs.md
+++ b/book/src/animations/springs.md
@@ -157,6 +157,31 @@ fn spring_button() -> Container {
 }
 ```
 
+## Interruption
+
+A spring that is retargeted mid-flight keeps its momentum: the new segment
+starts with the speed the old one had, so a value sent back where it came from
+*turns around* rather than stopping first. That is what makes a spring feel
+physical when a hover reverses halfway, and it is also the cheapest wobble
+there is — send a value out and then back, and the overshoot on the way home
+is a shake nobody had to choreograph:
+
+```rust
+let angle = create_signal(0.0);
+
+container()
+    .transform(move || Transform::rotate_degrees(angle.get()))
+    .animate_transform(Transition::spring(SpringConfig::BOUNCY))
+
+// out, and back a moment later: the return leg crosses zero and comes back
+angle.set(2.0);
+// ...one short delay...
+angle.set(0.0);
+```
+
+Timed transitions have no momentum to keep: a retarget there starts from the
+current value at whatever the curve says, as it always has.
+
 ## API Reference
 
 ```rust

--- a/book/src/animations/springs.md
+++ b/book/src/animations/springs.md
@@ -164,23 +164,35 @@ starts with the speed the old one had, so a value sent back where it came from
 *turns around* rather than stopping first. That is what makes a spring feel
 physical when a hover reverses halfway, and it is also the cheapest wobble
 there is — send a value out and then back, and the overshoot on the way home
-is a shake nobody had to choreograph:
+is a shake nobody had to choreograph.
+
+It has to be two *different* frames, though. A press and its release are two,
+so a button shakes itself:
 
 ```rust
-let angle = create_signal(0.0);
-
-container()
-    .transform(move || Transform::rotate_degrees(angle.get()))
-    .animate_transform(Transition::spring(SpringConfig::BOUNCY))
-
-// out, and back a moment later: the return leg crosses zero and comes back
-angle.set(2.0);
-// ...one short delay...
-angle.set(0.0);
+fn nudge(angle: RwSignal<f32>) -> Container {
+    container()
+        .transform(move || Transform::rotate_degrees(angle.get()))
+        .animate_transform(Transition::spring(SpringConfig::BOUNCY))
+        .on_mouse_down(move |_, _| angle.set(2.0))
+        .on_mouse_up(move |_, _| angle.set(0.0))
+        .child(text("shake me"))
+}
 ```
+
+Two writes inside one frame would not do it: the loop reads the signal once, so
+it only ever sees the last of them and the spring is never sent anywhere.
 
 Timed transitions have no momentum to keep: a retarget there starts from the
 current value at whatever the curve says, as it always has.
+
+### What it carries, and what it does not
+
+The momentum that crosses into the new segment is the part of the old motion
+pointing along it. A translation interrupted by a pure scale change carries
+nothing, because the two have no direction in common — momentum stays in the
+channel it belonged to. And a spring that has already settled is at rest, so
+the next animation starts from a stop however small the residue was.
 
 ## API Reference
 

--- a/examples/animation_example.rs
+++ b/examples/animation_example.rs
@@ -1,168 +1,181 @@
+//! What each animatable property looks like while it moves.
+//!
+//! One card per property, each with room to travel: the animated element is a
+//! bare bar or swatch with nothing inside it, so its size is exactly the value
+//! being animated rather than whatever its text needs. Springs overshoot, and
+//! every target here leaves headroom for the overshoot to be seen — a value
+//! animated into a constraint it is already touching just stops.
+
 use guido::prelude::*;
+
+const BG: Color = Color::rgb(0.08, 0.08, 0.12);
+const CARD: Color = Color::rgb(0.15, 0.15, 0.21);
+const TRACK: Color = Color::rgb(0.11, 0.11, 0.16);
+const INK: Color = Color::rgb(0.35, 0.62, 0.95);
+const HOT: Color = Color::rgb(0.95, 0.55, 0.25);
+const LABEL: Color = Color::rgb(0.90, 0.90, 0.95);
+const MUTED: Color = Color::rgb(0.60, 0.62, 0.72);
+
+/// Wide enough that a spring's overshoot lands inside the track instead of
+/// against its edge.
+const NARROW: f32 = 60.0;
+const WIDE: f32 = 620.0;
 
 fn main() {
     App::new().run(|app| {
-        // State signals for animations
-        let expanded = create_signal(false);
-
         app.add_surface(
             SurfaceConfig::new()
-                .width(800)
-                .height(400)
+                .width(900)
+                .height(620)
                 .anchor(Anchor::TOP | Anchor::LEFT)
-                .background_color(Color::rgb(0.08, 0.08, 0.12)),
+                .background_color(BG),
             move || {
                 container()
-                    .background(Color::rgb(0.08, 0.08, 0.12))
-                    .padding(20.0)
-                    .layout(Flex::column().spacing(20.0))
+                    .background(BG)
+                    .padding(16.0)
+                    .layout(Flex::column().spacing(10.0))
                     .children([
-                        // Row 1
-                        container().layout(Flex::row().spacing(20.0)).children([
-                            create_width_animation_card(expanded),
-                            create_color_animation_card(),
-                        ]),
-                        // Row 2
-                        container().layout(Flex::row().spacing(20.0)).children([
-                            create_combined_animation_card(),
-                            create_border_animation_card(),
-                        ]),
+                        text("Animated properties — click a card to drive it")
+                            .font_size(16.0)
+                            .bold()
+                            .color(Color::WHITE)
+                            .into_any(),
+                        width_card().into_any(),
+                        colour_card().into_any(),
+                        corner_and_size_card().into_any(),
+                        border_card().into_any(),
                     ])
             },
         );
     });
 }
 
-/// Card demonstrating width animation with spring physics
-fn create_width_animation_card(expanded: RwSignal<bool>) -> Container {
+fn card(title: &str, hint: impl Into<String>, body: Container) -> Container {
     container()
-        .width(move || at_least(if expanded.get() { 600.0 } else { 50.0 }))
-        .animate_width(Transition::spring(SpringConfig::DEFAULT))
-        .height(at_least(80.0))
-        .background(Color::rgb(0.2, 0.25, 0.35))
+        .background(CARD)
         .corner_radius(12.0)
-        .padding(20.0)
+        .padding(12.0)
+        .layout(Flex::column().spacing(7.0))
+        .when_hovered(|s| s.lighter(0.04))
         .animate_background(Transition::new(150.0, TimingFunction::EaseOut))
-        .when_hovered(|s| s.lighter(0.08))
-        .when_pressed(|s| s.ripple())
-        .on_click(move || expanded.update(|e| *e = !*e))
-        .child(
-            container().layout(Flex::column().spacing(8.0)).children([
-                container()
-                    .font_size(18.0)
-                    .text_color(Color::rgb(0.9, 0.9, 0.95))
-                    .child(text("Width Animation with Spring")),
-                container()
-                    .font_size(14.0)
-                    .text_color(Color::rgb(0.6, 0.6, 0.7))
-                    .child(text(move || {
-                        if expanded.get() {
-                            "Click to collapse (watch the spring bounce!)".to_string()
-                        } else {
-                            "Click to expand (watch the spring bounce!)".to_string()
-                        }
-                    })),
-            ]),
-        )
+        .children([
+            text(title.to_string())
+                .font_size(14.0)
+                .bold()
+                .color(LABEL)
+                .into_any(),
+            body.into_any(),
+            text(hint.into()).font_size(12.0).color(MUTED).into_any(),
+        ])
 }
 
-/// Card demonstrating background color animation with state layer
-fn create_color_animation_card() -> Container {
+/// A dark strip for something to travel along.
+fn track(height: f32, body: Container) -> Container {
     container()
-        .width(at_least(400.0))
-        .height(at_least(80.0))
-        .background(Color::rgb(0.25, 0.2, 0.3))
-        .animate_background(Transition::spring(SpringConfig::DEFAULT))
-        .corner_radius(12.0)
-        .padding(20.0)
-        .when_hovered(|s| s.background(Color::rgb(0.4, 0.25, 0.35)))
-        .when_pressed(|s| s.ripple())
-        .child(
-            container().layout(Flex::column().spacing(8.0)).children([
-                container()
-                    .font_size(18.0)
-                    .text_color(Color::rgb(0.9, 0.9, 0.95))
-                    .child(text("Background Color Animation")),
-                container()
-                    .font_size(14.0)
-                    .text_color(Color::rgb(0.6, 0.6, 0.7))
-                    .child(text("Hover to see smooth color transition")),
-            ]),
-        )
+        .width(fill())
+        .height(height)
+        .background(TRACK)
+        .corner_radius(8.0)
+        .padding(5.0)
+        .child(body)
 }
 
-/// Card demonstrating combined animations
-fn create_combined_animation_card() -> Container {
-    let clicked = create_signal(false);
+/// Width, on a spring. The bar carries nothing, so its width *is* the animated
+/// value — with a label inside, the text would set a floor and the narrow end
+/// would never be narrow.
+fn width_card() -> Container {
+    let wide = create_signal(false);
 
-    container()
-        .width(move || at_least(if clicked.get() { 500.0 } else { 350.0 }))
-        .animate_width(Transition::spring(SpringConfig::SNAPPY))
-        .height(at_least(100.0))
-        .background(Color::rgb(0.2, 0.25, 0.2))
-        .animate_background(Transition::new(200.0, TimingFunction::EaseOut))
-        .corner_radius(move || if clicked.get() { 20.0 } else { 12.0 })
-        .animate_corner_radius(Transition::new(250.0, TimingFunction::EaseInOut))
-        .padding(20.0)
-        .when_hovered(|s| s.lighter(0.1))
-        .when_pressed(|s| s.ripple())
-        .on_click(move || clicked.update(|c| *c = !*c))
-        .child(
-            container().layout(Flex::column().spacing(8.0)).children([
-                container()
-                    .font_size(18.0)
-                    .text_color(Color::rgb(0.9, 0.9, 0.95))
-                    .child(text("Combined Animations")),
-                container()
-                    .font_size(14.0)
-                    .text_color(Color::rgb(0.6, 0.6, 0.7))
-                    .child(text(move || {
-                        if clicked.get() {
-                            "Width, color, and corner radius all animating!".to_string()
-                        } else {
-                            "Click to see multiple properties animate together".to_string()
-                        }
-                    })),
-            ]),
+    card(
+        "Width — spring",
+        "Click. The bar carries nothing, so it really reaches 60px — and it \
+         passes 620 before settling on it.",
+        track(
+            36.0,
+            container()
+                .width(move || if wide.get() { WIDE } else { NARROW })
+                .animate_width(Transition::spring(SpringConfig::DEFAULT))
+                .height(fill())
+                .background(INK)
+                .corner_radius(6.0),
         )
+        .on_click(move || wide.update(|w| *w = !*w)),
+    )
 }
 
-/// Card demonstrating border animations
-fn create_border_animation_card() -> Container {
-    let clicked = create_signal(false);
+/// The same colour change under a spring and under a curve, side by side —
+/// which is the only way to see what the spring is actually doing to it.
+fn colour_card() -> Container {
+    let swatch = |transition: Transition| {
+        container()
+            .width(280.0)
+            .height(48.0)
+            .corner_radius(8.0)
+            .background(Color::rgb(0.22, 0.20, 0.30))
+            .animate_background(transition)
+            .when_hovered(|s| s.background(HOT))
+    };
 
-    container()
-        .width(at_least(400.0))
-        .height(at_least(100.0))
-        .background(Color::rgb(0.15, 0.15, 0.2))
-        // Reactive border width: 2px normally, 6px when clicked
-        .border(
-            move || if clicked.get() { 6.0 } else { 2.0 },
-            Color::rgb(0.4, 0.5, 0.7),
+    card(
+        "Background colour — spring against a curve",
+        "Hover both. Left is a bouncy spring — it arrives past the colour and \
+         comes back; right is a 220ms curve, which stops on it.",
+        container().layout(Flex::row().spacing(16.0)).children([
+            swatch(Transition::spring(SpringConfig::BOUNCY)),
+            swatch(Transition::new(220.0, TimingFunction::EaseOut)),
+        ]),
+    )
+}
+
+/// Several properties moving at once, each on its own transition.
+fn corner_and_size_card() -> Container {
+    let open = create_signal(false);
+
+    card(
+        "Width, corner radius and colour together",
+        "Click. Three properties, three transitions — the corner is on a curve \
+         and the width on a spring, so they do not arrive together.",
+        track(
+            56.0,
+            container()
+                .width(move || if open.get() { 520.0 } else { 120.0 })
+                .animate_width(Transition::spring(SpringConfig::SNAPPY))
+                .height(fill())
+                .background(move || {
+                    if open.get() {
+                        Color::rgb(0.25, 0.55, 0.40)
+                    } else {
+                        Color::rgb(0.25, 0.30, 0.45)
+                    }
+                })
+                .animate_background(Transition::new(200.0, TimingFunction::EaseOut))
+                .corner_radius(move || if open.get() { 30.0 } else { 6.0 })
+                .animate_corner_radius(Transition::new(250.0, TimingFunction::EaseInOut)),
         )
-        .animate_border_width(Transition::spring(SpringConfig::BOUNCY))
-        .animate_border_color(Transition::new(300.0, TimingFunction::EaseOut))
-        .corner_radius(12.0)
-        .padding(20.0)
-        .when_hovered(|s| s.border(3.0, Color::rgb(0.4, 0.8, 0.6)))
-        .when_pressed(|s| s.ripple())
-        .on_click(move || clicked.update(|c| *c = !*c))
-        .child(
-            container().layout(Flex::column().spacing(8.0)).children([
-                container()
-                    .font_size(18.0)
-                    .text_color(Color::rgb(0.9, 0.9, 0.95))
-                    .child(text("Border Animation")),
-                container()
-                    .font_size(14.0)
-                    .text_color(Color::rgb(0.6, 0.6, 0.7))
-                    .child(text(move || {
-                        if clicked.get() {
-                            "Border width and color animating! Click to reset.".to_string()
-                        } else {
-                            "Hover for color change, click for width + color".to_string()
-                        }
-                    })),
-            ]),
-        )
+        .on_click(move || open.update(|o| *o = !*o)),
+    )
+}
+
+/// Border width on a bouncy spring, where the overshoot is the whole effect.
+fn border_card() -> Container {
+    let thick = create_signal(false);
+
+    card(
+        "Border width — bouncy spring",
+        "Click. 2px to 14px on a bouncy spring wobbles before it settles; \
+         hovering changes the colour on a curve underneath.",
+        container()
+            .width(fill())
+            .height(56.0)
+            .background(Color::rgb(0.13, 0.13, 0.18))
+            .corner_radius(10.0)
+            .border(
+                move || if thick.get() { 14.0 } else { 2.0 },
+                Color::rgb(0.40, 0.50, 0.70),
+            )
+            .animate_border_width(Transition::spring(SpringConfig::BOUNCY))
+            .animate_border_color(Transition::new(300.0, TimingFunction::EaseOut))
+            .when_hovered(|s| s.border_color(Color::rgb(0.40, 0.80, 0.60)))
+            .on_click(move || thick.update(|t| *t = !*t)),
+    )
 }

--- a/examples/spring_momentum.rs
+++ b/examples/spring_momentum.rs
@@ -1,0 +1,190 @@
+//! What a spring does when it is interrupted.
+//!
+//! Every panel is one property of the carried momentum, and every one of them
+//! is something you have to *interrupt by hand* to see — which is why this is
+//! an example and not a test. Each says what to do to it and what should
+//! happen.
+
+use guido::prelude::*;
+
+const BG: Color = Color::rgb(0.08, 0.08, 0.12);
+const CARD: Color = Color::rgb(0.16, 0.16, 0.22);
+const INK: Color = Color::rgb(0.35, 0.62, 0.95);
+const HOT: Color = Color::rgb(0.95, 0.55, 0.25);
+
+fn main() {
+    App::new().run(|app| {
+        app.add_surface(
+            SurfaceConfig::new()
+                .width(900)
+                .height(620)
+                .anchor(Anchor::TOP | Anchor::LEFT)
+                .background_color(BG),
+            move || {
+                container()
+                    .background(BG)
+                    .padding(24.0)
+                    .layout(Flex::column().spacing(16.0))
+                    .children([
+                        text("Spring momentum — interrupt each one by hand")
+                            .font_size(18.0)
+                            .bold()
+                            .color(Color::WHITE)
+                            .into_any(),
+                        turn_around().into_any(),
+                        past_the_overshoot().into_any(),
+                        own_channel().into_any(),
+                        from_rest().into_any(),
+                        shake().into_any(),
+                    ])
+            },
+        );
+    });
+}
+
+fn panel(title: &str, what_to_do: &str, body: Container) -> Container {
+    container()
+        .background(CARD)
+        .corner_radius(10.0)
+        .padding(14.0)
+        .layout(Flex::column().spacing(8.0))
+        .children([
+            text(title.to_string())
+                .font_size(14.0)
+                .bold()
+                .color(Color::WHITE)
+                .into_any(),
+            text(what_to_do.to_string())
+                .font_size(12.0)
+                .color(Color::rgb(0.62, 0.64, 0.74))
+                .into_any(),
+            body.into_any(),
+        ])
+}
+
+/// A track with a dot that slides along it.
+fn track(dot: Container) -> Container {
+    container()
+        .width(fill())
+        .height(46.0)
+        .background(Color::rgb(0.11, 0.11, 0.16))
+        .corner_radius(8.0)
+        .padding(6.0)
+        .child(dot)
+}
+
+fn dot(color: Color) -> Container {
+    container()
+        .width(34.0)
+        .height(34.0)
+        .background(color)
+        .corner_radius(17.0)
+}
+
+/// The headline: reversed mid-flight, the spring turns around instead of
+/// stopping first.
+fn turn_around() -> Container {
+    let out = create_signal(false);
+    panel(
+        "1 — It turns around",
+        "Hover the strip, then leave it while the dot is still travelling. It \
+         should reverse without pausing at the point you left it.",
+        track(
+            dot(INK)
+                .transform(move || Transform::translate(if out.get() { 760.0 } else { 0.0 }, 0.0))
+                .animate_transform(Transition::spring(SpringConfig::GENTLE)),
+        )
+        .control()
+        .on_hover(move |hovered| out.set(hovered)),
+    )
+}
+
+/// The case the old code inverted: interrupt *after* the overshoot, while the
+/// dot is already falling back toward its target.
+fn past_the_overshoot() -> Container {
+    let out = create_signal(false);
+    panel(
+        "2 — Interrupted past its overshoot",
+        "Same, but this spring overshoots hard. Leave the strip just *after* \
+         the dot has shot past the end and is settling back — it should carry \
+         on the way it was going, not lurch forward first.",
+        track(
+            dot(HOT)
+                .transform(move || Transform::translate(if out.get() { 700.0 } else { 0.0 }, 0.0))
+                .animate_transform(Transition::spring(SpringConfig::BOUNCY)),
+        )
+        .control()
+        .on_hover(move |hovered| out.set(hovered)),
+    )
+}
+
+/// Momentum stays in the channel it belonged to.
+fn own_channel() -> Container {
+    let out = create_signal(false);
+    let big = create_signal(false);
+    panel(
+        "3 — Momentum stays in its own channel",
+        "Hover to send it sliding, then press while it is still moving. The \
+         press only scales it: the slide's speed must not leak into the size \
+         and make it jump.",
+        track(
+            dot(INK)
+                .transform(move || {
+                    let slide = Transform::translate(if out.get() { 700.0 } else { 0.0 }, 0.0);
+                    if big.get() {
+                        Transform::scale(1.6).then(&slide)
+                    } else {
+                        slide
+                    }
+                })
+                .animate_transform(Transition::spring(SpringConfig::GENTLE)),
+        )
+        .control()
+        .on_hover(move |hovered| out.set(hovered))
+        .on_mouse_down(move |_, _| big.set(true))
+        .on_mouse_up(move |_, _| big.set(false)),
+    )
+}
+
+/// A spring that has settled is at rest, so the next leg starts from a stop.
+fn from_rest() -> Container {
+    let out = create_signal(false);
+    panel(
+        "4 — A settled spring starts from rest",
+        "Hover and wait for the dot to come to a complete stop at the far end, \
+         then leave. It should ease away, not start with a kick.",
+        track(
+            dot(INK)
+                .transform(move || Transform::translate(if out.get() { 760.0 } else { 0.0 }, 0.0))
+                .animate_transform(Transition::spring(SpringConfig::SNAPPY)),
+        )
+        .control()
+        .on_hover(move |hovered| out.set(hovered)),
+    )
+}
+
+/// Out and back on two different frames: the return leg overshoots on its own.
+fn shake() -> Container {
+    let angle = create_signal(0.0_f32);
+    panel(
+        "5 — Out and back is a wobble",
+        "Press and release the tile. A press and its release are two frames, \
+         so the return leg crosses zero and comes back — a shake nobody \
+         choreographed.",
+        container()
+            .width(140.0)
+            .height(46.0)
+            .background(HOT)
+            .corner_radius(8.0)
+            .padding(10.0)
+            .transform(move || Transform::rotate_degrees(angle.get()))
+            .animate_transform(Transition::spring(SpringConfig::BOUNCY))
+            .on_mouse_down(move |_, _| angle.set(6.0))
+            .on_mouse_up(move |_, _| angle.set(0.0))
+            .child(
+                text("press me")
+                    .font_size(13.0)
+                    .color(Color::rgb(0.1, 0.08, 0.05)),
+            ),
+    )
+}

--- a/src/animation/animatable.rs
+++ b/src/animation/animatable.rs
@@ -17,6 +17,15 @@ pub trait Animatable: Copy + PartialEq + Send + Sync + 'static {
     fn is_reverse(_from: &Self, _to: &Self) -> bool {
         false
     }
+
+    /// How far apart two values are, in whatever unit the type animates in.
+    ///
+    /// Only the ratio between two distances is ever used, so the unit does not
+    /// matter — what matters is that it is proportional to how much of the
+    /// animation is left. A spring integrates in a space normalised over its
+    /// own segment, and carrying its momentum into a new segment means
+    /// rescaling by the two lengths.
+    fn distance(from: &Self, to: &Self) -> f32;
 }
 
 impl Animatable for f32 {
@@ -26,6 +35,10 @@ impl Animatable for f32 {
 
     fn is_reverse(from: &Self, to: &Self) -> bool {
         to < from
+    }
+
+    fn distance(from: &Self, to: &Self) -> f32 {
+        (to - from).abs()
     }
 }
 
@@ -44,6 +57,16 @@ impl Animatable for Color {
         // or when darkening (luminance decreasing) at same alpha
         (to.a, to.luminance()) < (from.a, from.luminance())
     }
+
+    fn distance(from: &Self, to: &Self) -> f32 {
+        // The largest channel move: a colour that has travelled most of the
+        // way in red and none in blue is most of the way there.
+        (to.r - from.r)
+            .abs()
+            .max((to.g - from.g).abs())
+            .max((to.b - from.b).abs())
+            .max((to.a - from.a).abs())
+    }
 }
 
 impl Animatable for Padding {
@@ -61,6 +84,14 @@ impl Animatable for Padding {
         let from_total = from.left + from.right + from.top + from.bottom;
         to_total < from_total
     }
+
+    fn distance(from: &Self, to: &Self) -> f32 {
+        (to.left - from.left)
+            .abs()
+            .max((to.right - from.right).abs())
+            .max((to.top - from.top).abs())
+            .max((to.bottom - from.bottom).abs())
+    }
 }
 
 impl Animatable for Transform {
@@ -74,6 +105,18 @@ impl Animatable for Transform {
 
     fn is_reverse(from: &Self, to: &Self) -> bool {
         to.extract_scale() < from.extract_scale()
+    }
+
+    fn distance(from: &Self, to: &Self) -> f32 {
+        // Over the matrix the animation actually interpolates, since that is
+        // the space the spring is normalised in. The translation terms are in
+        // pixels and the rest is unitless, so this is not a length in any
+        // geometric sense — only a ratio between two of them is ever used.
+        from.data
+            .iter()
+            .zip(to.data.iter())
+            .map(|(a, b)| (b - a).abs())
+            .fold(0.0f32, f32::max)
     }
 }
 

--- a/src/animation/animatable.rs
+++ b/src/animation/animatable.rs
@@ -1,5 +1,11 @@
+use smallvec::SmallVec;
+
 use crate::transform::Transform;
 use crate::widgets::{Color, Padding};
+
+/// The channels of one animatable value. Six is `Transform`, the widest there
+/// is, so nothing here allocates.
+pub type Channels = SmallVec<[f32; 6]>;
 
 /// Trait for types that can be animated by interpolating between values
 pub trait Animatable: Copy + PartialEq + Send + Sync + 'static {
@@ -18,14 +24,78 @@ pub trait Animatable: Copy + PartialEq + Send + Sync + 'static {
         false
     }
 
-    /// How far apart two values are, in whatever unit the type animates in.
+    /// The value as the vector of numbers the animation interpolates.
     ///
-    /// Only the ratio between two distances is ever used, so the unit does not
-    /// matter — what matters is that it is proportional to how much of the
-    /// animation is left. A spring integrates in a space normalised over its
-    /// own segment, and carrying its momentum into a new segment means
-    /// rescaling by the two lengths.
-    fn distance(from: &Self, to: &Self) -> f32;
+    /// Only [`carry_velocity`] reads this, and only as a direction: a spring's
+    /// momentum is a vector in this space, and what a new segment inherits is
+    /// the part of it pointing along itself. The channels may be in different
+    /// units — `Transform` mixes pixels with unitless coefficients — and that
+    /// is fine precisely because they are never summed into a length that is
+    /// used on its own.
+    fn channels(&self) -> Channels;
+}
+
+/// How fast the new segment should start, given the speed of the old one.
+///
+/// A spring integrates in a space normalised over its own segment, so its
+/// velocity means "segments per second" of *that* segment. In the property's
+/// own units the motion is `(target - start) * velocity`; the new segment
+/// inherits the part of that vector that points along it:
+///
+/// ```text
+/// v' = velocity * <old, new> / |new|²
+/// ```
+///
+/// One projection does three jobs. It gets the **direction** right, sign
+/// included — a negative result is a spring that still has to be turned
+/// around, and keeping it is the whole point. It keeps **units apart**: a
+/// translation interrupted by a pure scale change projects to nothing, because
+/// the two directions are orthogonal, so momentum cannot leak between channels
+/// that have nothing to do with each other. And the **overshoot it produces is
+/// bounded** in the property's own units however short the new segment is,
+/// since `v' * |new|` is the projected speed rather than an amplification of
+/// it.
+///
+/// The cap is not for that: it is for a segment so short that the normalised
+/// velocity, while physically harmless, would keep the spring from ever
+/// reading as settled.
+pub(crate) fn carry_velocity<T: Animatable>(
+    velocity: f32,
+    start: &T,
+    target: &T,
+    current: &T,
+    new_target: &T,
+) -> f32 {
+    /// Crossing the whole segment once per frame at 60fps. Past this the
+    /// motion is not something anyone can see, and the normalised units stop
+    /// being meaningful.
+    const MAX_CARRIED: f32 = 60.0;
+
+    if !velocity.is_finite() || velocity == 0.0 {
+        return 0.0;
+    }
+
+    let (from, to) = (start.channels(), target.channels());
+    let (here, there) = (current.channels(), new_target.channels());
+
+    let mut dot = 0.0;
+    let mut new_len_sq = 0.0;
+    for i in 0..here.len() {
+        let old_axis = to[i] - from[i];
+        let new_axis = there[i] - here[i];
+        dot += old_axis * new_axis;
+        new_len_sq += new_axis * new_axis;
+    }
+
+    if new_len_sq <= f32::MIN_POSITIVE {
+        return 0.0;
+    }
+    let carried = velocity * dot / new_len_sq;
+    if carried.is_finite() {
+        carried.clamp(-MAX_CARRIED, MAX_CARRIED)
+    } else {
+        0.0
+    }
 }
 
 impl Animatable for f32 {
@@ -37,8 +107,8 @@ impl Animatable for f32 {
         to < from
     }
 
-    fn distance(from: &Self, to: &Self) -> f32 {
-        (to - from).abs()
+    fn channels(&self) -> Channels {
+        Channels::from_slice(&[*self])
     }
 }
 
@@ -58,14 +128,8 @@ impl Animatable for Color {
         (to.a, to.luminance()) < (from.a, from.luminance())
     }
 
-    fn distance(from: &Self, to: &Self) -> f32 {
-        // The largest channel move: a colour that has travelled most of the
-        // way in red and none in blue is most of the way there.
-        (to.r - from.r)
-            .abs()
-            .max((to.g - from.g).abs())
-            .max((to.b - from.b).abs())
-            .max((to.a - from.a).abs())
+    fn channels(&self) -> Channels {
+        Channels::from_slice(&[self.r, self.g, self.b, self.a])
     }
 }
 
@@ -85,12 +149,8 @@ impl Animatable for Padding {
         to_total < from_total
     }
 
-    fn distance(from: &Self, to: &Self) -> f32 {
-        (to.left - from.left)
-            .abs()
-            .max((to.right - from.right).abs())
-            .max((to.top - from.top).abs())
-            .max((to.bottom - from.bottom).abs())
+    fn channels(&self) -> Channels {
+        Channels::from_slice(&[self.left, self.right, self.top, self.bottom])
     }
 }
 
@@ -107,16 +167,8 @@ impl Animatable for Transform {
         to.extract_scale() < from.extract_scale()
     }
 
-    fn distance(from: &Self, to: &Self) -> f32 {
-        // Over the matrix the animation actually interpolates, since that is
-        // the space the spring is normalised in. The translation terms are in
-        // pixels and the rest is unitless, so this is not a length in any
-        // geometric sense — only a ratio between two of them is ever used.
-        from.data
-            .iter()
-            .zip(to.data.iter())
-            .map(|(a, b)| (b - a).abs())
-            .fold(0.0f32, f32::max)
+    fn channels(&self) -> Channels {
+        Channels::from_slice(&self.data)
     }
 }
 
@@ -152,5 +204,74 @@ mod tests {
         assert_eq!(mid.right, 5.0);
         assert_eq!(mid.top, 5.0);
         assert_eq!(mid.bottom, 5.0);
+    }
+
+    #[test]
+    fn channels_are_the_numbers_the_lerp_moves() {
+        assert_eq!(Color::WHITE.channels().len(), 4);
+        assert_eq!(Padding::all(2.0).channels().len(), 4);
+        assert_eq!(Transform::IDENTITY.channels().len(), 6);
+        assert_eq!(3.0_f32.channels().as_slice(), &[3.0]);
+    }
+
+    /// The velocity a new segment inherits is the part of the old motion that
+    /// points along it — so the same speed sent the same way is kept whole.
+    #[test]
+    fn carrying_the_same_way_keeps_the_speed() {
+        // 0 -> 1 at 2 spans/sec, retargeted to 2 from halfway: the remaining
+        // segment is half as long, so the same physical speed is twice the
+        // normalised one.
+        let carried = carry_velocity(2.0, &0.0_f32, &1.0, &0.5, &1.5);
+        assert!((carried - 2.0).abs() < 1e-5, "got {carried}");
+    }
+
+    /// And sent the other way it comes back negative, which is a spring that
+    /// still has to be turned around.
+    #[test]
+    fn carrying_the_other_way_comes_back_negative() {
+        let carried = carry_velocity(2.0, &0.0_f32, &1.0, &0.5, &-0.5);
+        assert!(carried < 0.0, "got {carried}");
+    }
+
+    /// A motion that was going backwards along its own segment is going
+    /// backwards in the property too — the integrator's sign is not something
+    /// the geometry can be asked to re-derive.
+    #[test]
+    fn a_negative_velocity_is_read_as_the_motion_it_is() {
+        // Past the target and falling back toward it: retargeting *below* the
+        // current value is retargeting the way it is already moving.
+        let carried = carry_velocity(-1.0, &0.0_f32, &1.0, &1.2, &0.0);
+        assert!(
+            carried > 0.0,
+            "already falling, so the new segment is closing: got {carried}"
+        );
+    }
+
+    /// Directions that share no channel share no momentum.
+    #[test]
+    fn orthogonal_directions_carry_nothing() {
+        let moved = Transform::translate(200.0, 0.0);
+        let mut scaled = moved;
+        scaled.data[0] += 0.05;
+        scaled.data[4] += 0.05;
+
+        let carried = carry_velocity(10.0, &Transform::IDENTITY, &moved, &moved, &scaled);
+        assert_eq!(carried, 0.0);
+    }
+
+    /// A retarget that asks for no movement at all has nothing to carry, and
+    /// must not divide by it.
+    #[test]
+    fn a_degenerate_segment_carries_nothing() {
+        assert_eq!(carry_velocity(5.0, &0.0_f32, &1.0, &0.5, &0.5), 0.0);
+        assert_eq!(carry_velocity(f32::NAN, &0.0_f32, &1.0, &0.5, &1.0), 0.0);
+    }
+
+    /// A segment short enough to make the normalised velocity meaningless is
+    /// capped rather than left to keep the spring from ever settling.
+    #[test]
+    fn an_almost_zero_segment_is_capped() {
+        let carried = carry_velocity(10.0, &0.0_f32, &1.0, &0.5, &0.500001);
+        assert!(carried.is_finite() && carried <= 60.0, "got {carried}");
     }
 }

--- a/src/animation/mod.rs
+++ b/src/animation/mod.rs
@@ -2,7 +2,8 @@ mod animatable;
 mod spring;
 mod timing;
 
-pub use animatable::Animatable;
+pub(crate) use animatable::carry_velocity;
+pub use animatable::{Animatable, Channels};
 pub use spring::{SpringConfig, SpringState};
 pub use timing::TimingFunction;
 

--- a/src/animation/spring.rs
+++ b/src/animation/spring.rs
@@ -85,11 +85,20 @@ pub struct SpringState {
 }
 
 impl SpringState {
-    /// Create a new spring state starting at position 0.0
+    /// Create a new spring state starting at position 0.0, at rest.
     pub fn new() -> Self {
+        Self::moving_at(0.0)
+    }
+
+    /// The same, already moving.
+    ///
+    /// For a spring that inherits the momentum of the one it interrupted:
+    /// velocity is in units of the segment per second, so a value of 1.0 is
+    /// "crossing the whole distance every second".
+    pub fn moving_at(velocity: f32) -> Self {
         Self {
             position: 0.0,
-            velocity: 0.0,
+            velocity,
             last_t: 0.0,
         }
     }

--- a/src/widgets/container/animations.rs
+++ b/src/widgets/container/animations.rs
@@ -100,15 +100,60 @@ impl<T: Animatable> AnimationState<T> {
             crate::animation::TimingFunction::Spring(_)
         );
 
+        let carried = if is_spring {
+            self.carried_velocity(&new_target)
+        } else {
+            0.0
+        };
+
         self.start = self.current;
         self.target = new_target;
         self.progress = 0.0;
         self.start_time = Instant::now();
         self.spring_state = if is_spring {
-            Some(SpringState::new())
+            Some(SpringState::moving_at(carried))
         } else {
             None
         };
+    }
+
+    /// The velocity the running spring should carry into the new segment.
+    ///
+    /// A spring integrates in a space normalised over its own segment, so a
+    /// new target means a new space: the speed is converted back into the
+    /// property's own units, then into the new segment's. The sign says
+    /// whether the motion is already heading towards the new target — a
+    /// negative one is a spring that has to be turned around, which is the
+    /// whole point of keeping it.
+    ///
+    /// Zero unless a spring is actually in flight. Starting from rest is right
+    /// for a value that was standing still, and is what this did for every
+    /// target change before: a hover reversed mid-flight restarted from a stop
+    /// instead of turning around, and a spring that never keeps its momentum
+    /// is an easing curve wearing a spring's name.
+    fn carried_velocity(&self, new_target: &T) -> f32 {
+        let Some(spring) = &self.spring_state else {
+            return 0.0;
+        };
+        let old_span = T::distance(&self.start, &self.target);
+        let new_span = T::distance(&self.current, new_target);
+        if old_span <= f32::EPSILON || new_span <= f32::EPSILON {
+            return 0.0;
+        }
+
+        // Normalised velocity is per unit of the old segment; the property
+        // moves `speed` of its own units per second.
+        let speed = spring.velocity * old_span;
+
+        // Which way that is going, against the new target: a step further
+        // along the direction of travel either closes the distance or opens
+        // it. `lerp` and `distance` are all this needs, so it holds for every
+        // animatable type rather than just the scalar ones.
+        let ahead = T::lerp(&self.start, &self.target, spring.position + 0.01);
+        let closing = T::distance(&ahead, new_target) < T::distance(&self.current, new_target);
+
+        let magnitude = speed.abs() / new_span;
+        if closing { magnitude } else { -magnitude }
     }
 
     /// Advance the animation and return whether the value changed
@@ -412,6 +457,108 @@ mod tests {
         assert_eq!(fired.get(), 2, "a new completed run fires again");
     }
     use crate::animation::TimingFunction;
+
+    /// Step a spring for `ms`, in frames, returning the extreme value reached.
+    fn run(anim: &mut AnimationState<f32>, ms: u64) -> (f32, f32) {
+        let (mut low, mut high) = (*anim.current(), *anim.current());
+        for _ in 0..(ms / 8) {
+            std::thread::sleep(std::time::Duration::from_millis(8));
+            anim.advance();
+            low = low.min(*anim.current());
+            high = high.max(*anim.current());
+        }
+        (low, high)
+    }
+
+    fn spring(config: crate::animation::SpringConfig) -> Transition {
+        Transition::new(0.0, TimingFunction::Spring(config))
+    }
+
+    /// A spring interrupted mid-flight turns around; it does not stop and
+    /// start again. Every target change used to hand the integrator a fresh
+    /// `SpringState`, velocity zero, so an animation reversed halfway through
+    /// snapped to a halt first — a spring in name and an easing curve in
+    /// behaviour.
+    #[test]
+    fn a_spring_reversed_in_flight_carries_its_momentum() {
+        use crate::animation::SpringConfig;
+
+        let mut anim = AnimationState::new(0.0_f32, spring(SpringConfig::BOUNCY));
+        anim.set_immediate(0.0);
+        anim.animate_to(1.0);
+        run(&mut anim, 40);
+        assert!(
+            *anim.current() > 0.0,
+            "the spring has to be moving before it can be interrupted"
+        );
+
+        anim.animate_to(0.0);
+        let velocity = anim.spring_state.as_ref().expect("a spring").velocity;
+        assert!(
+            velocity < 0.0,
+            "still travelling away from the new target, so the new segment \
+             starts with the spring having to turn around, got {velocity}"
+        );
+    }
+
+    /// And that momentum is what a wobble is made of: sent back to where it
+    /// came from, the spring overshoots past it rather than easing into it.
+    #[test]
+    fn the_carried_momentum_overshoots_the_way_back() {
+        use crate::animation::SpringConfig;
+
+        let mut anim = AnimationState::new(0.0_f32, spring(SpringConfig::BOUNCY));
+        anim.set_immediate(0.0);
+        anim.animate_to(1.0);
+        run(&mut anim, 40);
+        anim.animate_to(0.0);
+        let (low, _) = run(&mut anim, 400);
+
+        assert!(
+            low < -0.02,
+            "the return leg should cross zero and come back, got {low} at its \
+             furthest"
+        );
+    }
+
+    /// Retargeted the way it was already going, the spring keeps closing.
+    #[test]
+    fn a_spring_sent_further_the_same_way_keeps_closing() {
+        use crate::animation::SpringConfig;
+
+        let mut anim = AnimationState::new(0.0_f32, spring(SpringConfig::DEFAULT));
+        anim.set_immediate(0.0);
+        anim.animate_to(1.0);
+        run(&mut anim, 40);
+
+        anim.animate_to(2.0);
+        let velocity = anim.spring_state.as_ref().expect("a spring").velocity;
+        assert!(velocity > 0.0, "still heading there, got {velocity}");
+    }
+
+    /// A value that was standing still starts from rest, as it always did.
+    #[test]
+    fn a_settled_spring_starts_from_rest() {
+        use crate::animation::SpringConfig;
+
+        let mut anim = AnimationState::new(0.0_f32, spring(SpringConfig::DEFAULT));
+        anim.set_immediate(0.0);
+
+        anim.animate_to(1.0);
+        assert_eq!(anim.spring_state.as_ref().expect("a spring").velocity, 0.0);
+    }
+
+    /// Nothing of this touches the timed transitions, which have no momentum
+    /// to keep.
+    #[test]
+    fn a_timed_transition_has_no_spring_to_carry() {
+        let mut anim = AnimationState::new(0.0_f32, Transition::new(100.0, TimingFunction::Linear));
+        anim.set_immediate(0.0);
+        anim.animate_to(1.0);
+        run(&mut anim, 24);
+        anim.animate_to(0.0);
+        assert!(anim.spring_state.is_none());
+    }
 
     #[test]
     fn test_animation_state_new() {

--- a/src/widgets/container/animations.rs
+++ b/src/widgets/container/animations.rs
@@ -1,6 +1,6 @@
 use std::time::Instant;
 
-use crate::animation::{Animatable, SpringState, Transition, TransitionConfig};
+use crate::animation::{Animatable, SpringState, Transition, TransitionConfig, carry_velocity};
 
 /// Result of advancing an animation, indicating whether the value changed
 #[derive(Debug, Clone, PartialEq)]
@@ -119,41 +119,32 @@ impl<T: Animatable> AnimationState<T> {
 
     /// The velocity the running spring should carry into the new segment.
     ///
-    /// A spring integrates in a space normalised over its own segment, so a
-    /// new target means a new space: the speed is converted back into the
-    /// property's own units, then into the new segment's. The sign says
-    /// whether the motion is already heading towards the new target — a
-    /// negative one is a spring that has to be turned around, which is the
-    /// whole point of keeping it.
-    ///
     /// Zero unless a spring is actually in flight. Starting from rest is right
     /// for a value that was standing still, and is what this did for every
     /// target change before: a hover reversed mid-flight restarted from a stop
     /// instead of turning around, and a spring that never keeps its momentum
     /// is an easing curve wearing a spring's name.
+    ///
+    /// The projection is in [`carry_velocity`]; what belongs here is the one
+    /// case where the answer is "none of it": a transition that has not
+    /// started moving yet. Its spring is created now and stepped only after
+    /// the delay, so whatever the value is doing at this instant is stale by
+    /// the time it would be released — at full strength, and against a value
+    /// that has not moved in the meantime.
     fn carried_velocity(&self, new_target: &T) -> f32 {
         let Some(spring) = &self.spring_state else {
             return 0.0;
         };
-        let old_span = T::distance(&self.start, &self.target);
-        let new_span = T::distance(&self.current, new_target);
-        if old_span <= f32::EPSILON || new_span <= f32::EPSILON {
+        if self.active_transition().delay_ms > 0.0 {
             return 0.0;
         }
-
-        // Normalised velocity is per unit of the old segment; the property
-        // moves `speed` of its own units per second.
-        let speed = spring.velocity * old_span;
-
-        // Which way that is going, against the new target: a step further
-        // along the direction of travel either closes the distance or opens
-        // it. `lerp` and `distance` are all this needs, so it holds for every
-        // animatable type rather than just the scalar ones.
-        let ahead = T::lerp(&self.start, &self.target, spring.position + 0.01);
-        let closing = T::distance(&ahead, new_target) < T::distance(&self.current, new_target);
-
-        let magnitude = speed.abs() / new_span;
-        if closing { magnitude } else { -magnitude }
+        carry_velocity(
+            spring.velocity,
+            &self.start,
+            &self.target,
+            &self.current,
+            new_target,
+        )
     }
 
     /// Advance the animation and return whether the value changed
@@ -202,12 +193,19 @@ impl<T: Animatable> AnimationState<T> {
 
         // Interpolate
         let mut new_value = T::lerp(&self.start, &self.target, eased_t);
+        let mut settled = false;
 
         // Update progress
         if let Some(ref state) = self.spring_state {
             // For spring animations, only mark complete when spring has settled
             if state.is_settled(0.01) {
                 self.progress = 1.0;
+                // Settled means at rest. Keeping the state would let the next
+                // retarget inherit whatever velocity was still under the
+                // threshold, and rescale it by however short the new segment
+                // is — a spring that had visibly stopped starting the next one
+                // with a kick.
+                settled = true;
                 // Snap to exact target to avoid floating-point drift.
                 // The spring settles within 0.01 of the target, but downstream
                 // checks (e.g. Transform::is_translation_only) use much tighter
@@ -221,6 +219,10 @@ impl<T: Animatable> AnimationState<T> {
             // For non-spring animations, use time-based progress
             let t = (adjusted_elapsed / duration_ms).min(1.0);
             self.progress = t;
+        }
+
+        if settled {
+            self.spring_state = None;
         }
 
         // Check if value actually changed
@@ -458,16 +460,33 @@ mod tests {
     }
     use crate::animation::TimingFunction;
 
-    /// Step a spring for `ms`, in frames, returning the extreme value reached.
+    /// Step an animation to `ms` after its segment began.
+    ///
+    /// `advance` reads the clock through `start_time`, so moving that back is
+    /// the whole simulation. Sleeping instead would make the interruption
+    /// point depend on how loaded the machine is — and the interesting half of
+    /// a spring's phase space is on the far side of its overshoot, which a
+    /// stretched sleep wanders into by accident.
+    fn at<T: Animatable>(anim: &mut AnimationState<T>, ms: u64) {
+        anim.start_time = Instant::now() - std::time::Duration::from_millis(ms);
+        anim.advance();
+    }
+
+    /// Step through `ms` in 8ms frames, returning the extremes reached.
     fn run(anim: &mut AnimationState<f32>, ms: u64) -> (f32, f32) {
         let (mut low, mut high) = (*anim.current(), *anim.current());
-        for _ in 0..(ms / 8) {
-            std::thread::sleep(std::time::Duration::from_millis(8));
-            anim.advance();
+        for frame in 1..=(ms / 8) {
+            at(anim, frame * 8);
             low = low.min(*anim.current());
             high = high.max(*anim.current());
         }
         (low, high)
+    }
+
+    /// The spring's own state, for the tests that assert on the momentum
+    /// rather than on what it produced.
+    fn velocity_of<T: Animatable>(anim: &AnimationState<T>) -> f32 {
+        anim.spring_state.as_ref().expect("a spring").velocity
     }
 
     fn spring(config: crate::animation::SpringConfig) -> Transition {
@@ -493,7 +512,7 @@ mod tests {
         );
 
         anim.animate_to(0.0);
-        let velocity = anim.spring_state.as_ref().expect("a spring").velocity;
+        let velocity = velocity_of(&anim);
         assert!(
             velocity < 0.0,
             "still travelling away from the new target, so the new segment \
@@ -532,20 +551,143 @@ mod tests {
         run(&mut anim, 40);
 
         anim.animate_to(2.0);
-        let velocity = anim.spring_state.as_ref().expect("a spring").velocity;
-        assert!(velocity > 0.0, "still heading there, got {velocity}");
+        assert!(
+            velocity_of(&anim) > 0.0,
+            "still heading there, got {}",
+            velocity_of(&anim)
+        );
     }
 
-    /// A value that was standing still starts from rest, as it always did.
+    /// A value that was standing still starts from rest.
+    ///
+    /// The obvious version of this test — `set_immediate` then `animate_to` —
+    /// asserts nothing: `start == target` makes the segment degenerate, so it
+    /// returns before ever reading the velocity. This one lets a spring
+    /// genuinely settle first, which is where the residue actually lives.
     #[test]
-    fn a_settled_spring_starts_from_rest() {
+    fn a_spring_that_has_settled_starts_the_next_one_from_rest() {
+        use crate::animation::SpringConfig;
+
+        let mut anim = AnimationState::new(0.0_f32, spring(SpringConfig::DEFAULT));
+        anim.set_immediate(0.0);
+        anim.animate_to(1.0);
+        run(&mut anim, 1200);
+        assert!(!anim.is_animating(), "it has to have settled first");
+
+        anim.animate_to(1.0001);
+        assert_eq!(
+            velocity_of(&anim),
+            0.0,
+            "a settled spring is at rest, whatever was left under the threshold"
+        );
+    }
+
+    /// Interrupted *after* its overshoot — the half of the phase space every
+    /// preset spends time in — the spring is travelling backwards along its own
+    /// segment, and the momentum it carries has to reflect that.
+    ///
+    /// Reading the direction off the segment instead of off the integrator
+    /// inverts it here: the value is already falling toward the new target and
+    /// would be kicked back up, away from it.
+    #[test]
+    fn a_spring_interrupted_past_its_overshoot_carries_the_way_it_is_moving() {
+        use crate::animation::SpringConfig;
+
+        let mut anim = AnimationState::new(0.0_f32, spring(SpringConfig::BOUNCY));
+        anim.set_immediate(0.0);
+        anim.animate_to(1.0);
+        run(&mut anim, 184);
+
+        assert!(
+            *anim.current() > 1.0 && velocity_of(&anim) < 0.0,
+            "the setup needs a spring past its target and coming back, got \
+             value {} velocity {}",
+            anim.current(),
+            velocity_of(&anim)
+        );
+
+        // Falling toward 1.0 from above is falling toward 0.0 as well.
+        anim.animate_to(0.0);
+        assert!(
+            velocity_of(&anim) > 0.0,
+            "it was already heading that way, so the new segment closes on its \
+             target, got {}",
+            velocity_of(&anim)
+        );
+    }
+
+    /// Momentum does not leak between channels that have nothing to do with
+    /// each other: a translation interrupted by a pure scale change projects
+    /// to nothing, because the two directions are orthogonal.
+    #[test]
+    fn momentum_does_not_cross_from_one_channel_to_another() {
+        use crate::animation::SpringConfig;
+        use crate::transform::Transform;
+
+        let mut anim = AnimationState::new(Transform::IDENTITY, spring(SpringConfig::DEFAULT));
+        anim.set_immediate(Transform::IDENTITY);
+        anim.animate_to(Transform::translate(200.0, 0.0));
+        at(&mut anim, 40);
+        assert!(velocity_of(&anim) > 0.0, "it has to be moving first");
+
+        // A pure scale change from wherever the translation got to: the two
+        // scale terms move, the two translation terms do not.
+        let mut scaled = *anim.current();
+        scaled.data[0] += 0.05;
+        scaled.data[4] += 0.05;
+        anim.animate_to(scaled);
+
+        assert!(
+            velocity_of(&anim).abs() < 0.5,
+            "a translation's momentum has no business driving a scale, got {}",
+            velocity_of(&anim)
+        );
+    }
+
+    /// A target that moves every frame — a field growing as it is typed into —
+    /// converges instead of building speed without bound.
+    #[test]
+    fn a_spring_following_a_moving_target_stays_bounded() {
         use crate::animation::SpringConfig;
 
         let mut anim = AnimationState::new(0.0_f32, spring(SpringConfig::DEFAULT));
         anim.set_immediate(0.0);
 
+        // 40 frames of the target creeping upward, then it stops.
+        for frame in 1..=40u64 {
+            anim.animate_to(frame as f32);
+            at(&mut anim, 8);
+        }
+        let (_, high) = run(&mut anim, 800);
+
+        assert!(
+            high < 60.0,
+            "following a target that stopped at 40 must not fly past it, \
+             reached {high}"
+        );
+        assert!(
+            (*anim.current() - 40.0).abs() < 0.5,
+            "and it has to arrive, got {}",
+            anim.current()
+        );
+    }
+
+    /// A transition that has not started moving yet has nothing to carry: its
+    /// spring is stepped only after the delay, so a velocity stored now would
+    /// be released at full strength against a value that had not moved since.
+    #[test]
+    fn a_delayed_transition_starts_from_rest() {
+        use crate::animation::SpringConfig;
+
+        let delayed = Transition::new(0.0, TimingFunction::Spring(SpringConfig::BOUNCY)).delay(200);
+        let mut anim = AnimationState::new(0.0_f32, delayed);
+        anim.set_immediate(0.0);
         anim.animate_to(1.0);
-        assert_eq!(anim.spring_state.as_ref().expect("a spring").velocity, 0.0);
+        run(&mut anim, 400);
+        assert!(*anim.current() > 0.0, "past the delay and moving");
+
+        anim.animate_to(0.0);
+        assert_eq!(velocity_of(&anim), 0.0);
     }
 
     /// Nothing of this touches the timed transitions, which have no momentum


### PR DESCRIPTION
`AnimationState::animate_to` handed the integrator a fresh `SpringState` on
every target change — position zero, **velocity zero**. A spring interrupted
mid-flight therefore came to a dead stop and started again.

It has a symptom today, with no new feature involved: a hover that reverses
halfway snaps before it turns. What guido calls a spring has been an easing
curve shaped like one.

Compose's `Animatable` promises the opposite explicitly (continuity of value
*and* velocity across `animateTo`), and so do iOS's and SwiftUI's springs.

## What changed

The velocity crosses over into the new segment. The integrator normalises over
its own segment, so the speed is converted back into the property's own units
and then into the new segment's; the sign says whether the motion is already
heading towards the new target, and a negative one is a spring that has to turn
around — which is the whole reason to keep it.

- A value that was standing still still starts from rest.
- A timed transition has no momentum to carry, and is untouched.

`Animatable` gains `distance(from, to) -> f32` for the rescaling. Only the
ratio of two distances is ever used, so it is a magnitude and not a metric:
largest channel for a `Color`, largest side for a `Padding`, largest matrix
term for a `Transform`.

## Why it is worth more than the turn

A wobble comes free with it. Send a value out and back a moment later and the
return leg overshoots and settles — the shake a lock screen wants after a wrong
password, with no keyframes, no sequence and no timer loop. Before this, the
same two writes produced a dead stop and a slow return, which is why the shake
in the app that prompted this is currently six timed writes.

## Verified

- `a_spring_reversed_in_flight_carries_its_momentum` — the new segment starts
  with a negative velocity, i.e. still travelling away from the new target.
- `the_carried_momentum_overshoots_the_way_back` — sent back where it came
  from, the value crosses the target and returns.
- `a_spring_sent_further_the_same_way_keeps_closing`, and rest/timed cases
  pinned so the old behaviour survives where it was right.
- 399 lib tests green, clippy clean, book's springs chapter documents the
  interruption rule.