### PR TITLE
A sequence can be played, not only aimed at

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -42,6 +42,7 @@
     - [Transitions](animations/transitions.md)
     - [Timing Functions](animations/timing.md)
     - [Spring Physics](animations/springs.md)
+    - [Keyframes](animations/keyframes.md)
     - [Animatable Properties](animations/properties.md)
 
 # Transforms

--- a/book/src/animations/keyframes.md
+++ b/book/src/animations/keyframes.md
@@ -68,8 +68,28 @@ container()
     .keyframes_transform(shake(), rejections)
 ```
 
-The hover is still declared while the shake runs; it simply is not being drawn,
-and it has the property back the moment the sequence ends.
+The hover is still declared while the shake runs; it simply is not being drawn.
+When the sequence ends the property is handed back **through its declared
+transition**, from wherever the sequence left it — so a pointer that arrived
+mid-shake gets its spring, rather than the card jumping to the hovered size on
+the sequence's last frame. A callback on that transition fires as it normally
+would, for the same reason.
+
+The builders do not care which order you write them in: declaring a transition
+after a sequence keeps the sequence, and the other way round too.
+
+## What a segment cannot be eased with
+
+A spring. A keyframe segment is a fixed slice of a fixed duration, which is
+exactly what a spring has not got — it settles when it settles. Passing one to
+`at_with` substitutes `EaseInOut` and says so in debug builds, rather than
+quietly playing the segment as a straight line.
+
+```rust
+Keyframes::new(320.0)
+    .at_with(0.0, Transform::IDENTITY, TimingFunction::EaseOut)
+    .at(1.0, Transform::rotate_degrees(2.0))
+```
 
 ## When not to use them
 

--- a/book/src/animations/keyframes.md
+++ b/book/src/animations/keyframes.md
@@ -1,0 +1,83 @@
+# Keyframes
+
+Every other animation in guido moves *towards* something: a property gets a new
+value and a transition carries it there. That is the whole of what a state
+change looks like, and none of what a sequence looks like — a shake, a flash, a
+bounce, anything that has to pass through somewhere on its way and end where it
+started.
+
+A timeline is the other shape. It has no target: it plays.
+
+```rust
+container()
+    .keyframes_transform(
+        Keyframes::new(320.0)
+            .at(0.0, Transform::IDENTITY)
+            .at(0.15, Transform::rotate_degrees(2.0))
+            .at(0.40, Transform::rotate_degrees(-1.6))
+            .at(0.65, Transform::rotate_degrees(0.9))
+            .at(1.0, Transform::IDENTITY),
+        rejections,
+    )
+```
+
+## What plays it
+
+The second argument is a signal, and **every change to it plays the sequence
+once**. A count rather than a flag, because two refusals in a row are two
+events and a signal that stays equal notifies nobody — the second wrong
+password has to shake as loudly as the first. SwiftUI's keyframe animator takes
+its trigger the same way.
+
+Nothing plays on the first frame: the container remembers what the signal held
+when it was built. Played again while it is still running, a sequence starts
+over from the top rather than continuing — half a shake is not what a second
+refusal means.
+
+## Offsets and easing
+
+An offset is a fraction of one run, `0.0` to `1.0`, and `duration` is how long
+one run takes. The easing declared at a stop governs the segment that *starts*
+there, which is CSS's rule for a timing function written inside a keyframe:
+
+```rust
+Keyframes::new(360.0)
+    .at_with(0.0, Transform::IDENTITY, TimingFunction::EaseIn)
+    .at_with(0.35, Transform::translate(0.0, 14.0), TimingFunction::EaseOut)
+    .at(1.0, Transform::IDENTITY)
+```
+
+Before the first stop and after the last one the nearest stop holds — a
+timeline whose first stop is at `0.25` is not a timeline that starts undefined.
+`repeat(n)` plays the whole run `n` times.
+
+## What it does to the declared value
+
+**A running timeline replaces it.** For as long as the sequence plays, it is
+what the property is; when it ends, the property goes back to whatever is
+declared *now* — including a value that changed while it was playing. This is
+the rule CSS settled on, where an animation outranks a normal declaration for
+as long as it runs and hands the property back afterwards.
+
+So a card can hover and shake without the two arguing:
+
+```rust
+container()
+    .when_hovered(|s| s.transform(Transform::scale(1.03)))
+    .animate_transform(Transition::spring(SpringConfig::SNAPPY))
+    .keyframes_transform(shake(), rejections)
+```
+
+The hover is still declared while the shake runs; it simply is not being drawn,
+and it has the property back the moment the sequence ends.
+
+## When not to use them
+
+A timeline is a choreography, and most motion is not. If what you want is
+"go there, springily", a spring already does it — and since a spring keeps its
+momentum when it is retargeted, out-and-back is a wobble without a timeline at
+all. Reach for keyframes when the shape of the motion is the point, not the
+destination.
+
+`cargo run --example keyframes_example` plays both a shake and a nod from the
+same trigger, over a hover that stays declared throughout.

--- a/examples/keyframes_example.rs
+++ b/examples/keyframes_example.rs
@@ -11,7 +11,6 @@
 //! there, it just does not argue with the sequence while it runs, and it has
 //! the property back the moment the sequence ends.
 
-use guido::animation::Keyframes;
 use guido::prelude::*;
 
 /// Left, decaying: out, back past, out again, still.
@@ -54,13 +53,8 @@ fn card(label: &'static str, keyframes: Keyframes<Transform>, plays: RwSignal<u3
         .when_hovered(|s| s.transform(Transform::scale(1.03)))
         .animate_transform(Transition::spring(SpringConfig::SNAPPY))
         .keyframes_transform(keyframes, plays)
-        .on_click(move || plays.set(plays.get_untracked() + 1))
-        .child(
-            container()
-                .text_color(Color::WHITE)
-                .font_size(16.0)
-                .child(text(label)),
-        )
+        .on_click(move || plays.update(|p| *p += 1))
+        .child(text(label).color(Color::WHITE).font_size(16.0))
 }
 
 fn main() {

--- a/examples/keyframes_example.rs
+++ b/examples/keyframes_example.rs
@@ -1,0 +1,89 @@
+//! A sequence played on a trigger, rather than a value animated towards.
+//!
+//! Run with: cargo run --example keyframes_example
+//!
+//! Click either card. The left one shakes its head — the motion a lock screen
+//! wants after a wrong password — and the right one takes the same trigger and
+//! nods, to show that what a timeline does is entirely in its stops.
+//!
+//! Both cards also declare a hover transform. That is the point of the rule
+//! that a playing timeline *replaces* the declared value: the hover is still
+//! there, it just does not argue with the sequence while it runs, and it has
+//! the property back the moment the sequence ends.
+
+use guido::animation::Keyframes;
+use guido::prelude::*;
+
+/// Left, decaying: out, back past, out again, still.
+fn shake() -> Keyframes<Transform> {
+    Keyframes::new(320.0)
+        .at(0.0, Transform::IDENTITY)
+        .at(0.15, Transform::rotate_degrees(2.0))
+        .at(0.40, Transform::rotate_degrees(-1.6))
+        .at(0.65, Transform::rotate_degrees(0.9))
+        .at(0.85, Transform::rotate_degrees(-0.4))
+        .at(1.0, Transform::IDENTITY)
+}
+
+/// Right, one dip and a rebound, eased so the fall is quicker than the rise.
+fn nod() -> Keyframes<Transform> {
+    Keyframes::new(360.0)
+        .at_with(0.0, Transform::IDENTITY, TimingFunction::EaseIn)
+        .at_with(
+            0.35,
+            Transform::translate(0.0, 14.0),
+            TimingFunction::EaseOut,
+        )
+        .at(0.7, Transform::translate(0.0, -4.0))
+        .at(1.0, Transform::IDENTITY)
+}
+
+fn card(label: &'static str, keyframes: Keyframes<Transform>, plays: RwSignal<u32>) -> Container {
+    container()
+        .width(220.0)
+        .height(120.0)
+        .corner_radius(12.0)
+        .background(Color::rgb(0.18, 0.18, 0.24))
+        .border(1.0, Color::rgb(0.32, 0.32, 0.4))
+        .layout(
+            Flex::column()
+                .main_alignment(MainAlignment::Center)
+                .cross_alignment(CrossAlignment::Center),
+        )
+        // Declared, animated, and quietly stood aside while a sequence runs.
+        .when_hovered(|s| s.transform(Transform::scale(1.03)))
+        .animate_transform(Transition::spring(SpringConfig::SNAPPY))
+        .keyframes_transform(keyframes, plays)
+        .on_click(move || plays.set(plays.get_untracked() + 1))
+        .child(
+            container()
+                .text_color(Color::WHITE)
+                .font_size(16.0)
+                .child(text(label)),
+        )
+}
+
+fn main() {
+    env_logger::init();
+
+    App::new().run(|app| {
+        let plays = create_signal(0u32);
+
+        let view = container()
+            .padding(24.0)
+            .layout(Flex::row().spacing(20.0))
+            .child(card("shake", shake(), plays))
+            .child(card("nod", nod(), plays));
+
+        app.add_surface(
+            SurfaceConfig::new()
+                .width(540)
+                .height(190)
+                .anchor(Anchor::TOP | Anchor::LEFT)
+                .layer(Layer::Top)
+                .namespace("keyframes-example")
+                .background_color(Color::rgb(0.1, 0.1, 0.15)),
+            || view,
+        );
+    });
+}

--- a/src/animation/keyframes.rs
+++ b/src/animation/keyframes.rs
@@ -1,0 +1,214 @@
+//! Keyframes: a value written down at points along a run, rather than aimed at.
+//!
+//! Every other animation in guido moves *towards* something: a property gets a
+//! new value and a transition carries it there. That covers the whole of what a
+//! state change looks like, and none of what a sequence looks like — a shake, a
+//! flash, a bounce, anything that has to pass through somewhere on its way and
+//! end where it started.
+//!
+//! A timeline is the other shape. It has no target; it plays, from a trigger,
+//! and while it plays it *replaces* the declared value — the same rule CSS
+//! settled on, where an animation outranks a normal declaration for as long as
+//! it runs and hands the property back afterwards.
+//!
+//! ```ignore
+//! container()
+//!     .keyframes_transform(
+//!         Keyframes::new(320.0)
+//!             .at(0.0, Transform::IDENTITY)
+//!             .at(0.2, Transform::rotate_degrees(1.5))
+//!             .at(0.5, Transform::rotate_degrees(-1.0))
+//!             .at(0.8, Transform::rotate_degrees(0.4))
+//!             .at(1.0, Transform::IDENTITY),
+//!         rejections,
+//!     )
+//! ```
+//!
+//! # What the offsets mean
+//!
+//! An offset is a fraction of one run, `0.0` to `1.0`, and the easing declared
+//! at a stop governs the segment that *starts* there — CSS's rule, where
+//! `animation-timing-function` inside a keyframe applies from that keyframe
+//! onwards. Before the first stop and after the last one the nearest one holds.
+
+use crate::animation::{Animatable, TimingFunction};
+use crate::layout::IntoF32;
+
+/// One point on a timeline: where it sits, what the value is there, and how the
+/// segment leaving it is eased.
+#[derive(Clone)]
+struct Stop<T> {
+    offset: f32,
+    value: T,
+    easing: TimingFunction,
+}
+
+/// A sequence of values over a fixed duration, played on a trigger.
+#[derive(Clone)]
+pub struct Keyframes<T> {
+    stops: Vec<Stop<T>>,
+    duration_ms: f32,
+    repeat: u32,
+}
+
+impl<T: Animatable> Keyframes<T> {
+    /// A timeline that takes `duration_ms` to play once.
+    pub fn new(duration_ms: impl IntoF32) -> Self {
+        Self {
+            stops: Vec::new(),
+            duration_ms: duration_ms.into_f32().max(1.0),
+            repeat: 1,
+        }
+    }
+
+    /// A stop, at a fraction of the run. The segment leaving it is linear.
+    pub fn at(self, offset: f32, value: T) -> Self {
+        self.at_with(offset, value, TimingFunction::Linear)
+    }
+
+    /// A stop whose outgoing segment is eased.
+    pub fn at_with(mut self, offset: f32, value: T, easing: TimingFunction) -> Self {
+        let offset = offset.clamp(0.0, 1.0);
+        let stop = Stop {
+            offset,
+            value,
+            easing,
+        };
+        // Kept sorted on the way in: written out of order is a mistake worth
+        // absorbing rather than a shape worth honouring.
+        let at = self
+            .stops
+            .iter()
+            .position(|existing| existing.offset > offset)
+            .unwrap_or(self.stops.len());
+        self.stops.insert(at, stop);
+        self
+    }
+
+    /// Play it `times` times in a row. Once by default.
+    pub fn repeat(mut self, times: u32) -> Self {
+        self.repeat = times.max(1);
+        self
+    }
+
+    /// How long the whole thing lasts, repeats included.
+    pub fn total_ms(&self) -> f32 {
+        self.duration_ms * self.repeat as f32
+    }
+
+    /// Whether there is anything to play.
+    pub fn is_empty(&self) -> bool {
+        self.stops.is_empty()
+    }
+
+    /// The value `elapsed_ms` into the run, or `None` once it is over.
+    pub fn value_at(&self, elapsed_ms: f32) -> Option<T> {
+        if self.stops.is_empty() || elapsed_ms >= self.total_ms() {
+            return None;
+        }
+        let within = (elapsed_ms.max(0.0) % self.duration_ms) / self.duration_ms;
+        Some(self.sample(within))
+    }
+
+    /// The value at `t` in `0.0..=1.0` of a single run.
+    fn sample(&self, t: f32) -> T {
+        let first = &self.stops[0];
+        if t <= first.offset {
+            return first.value;
+        }
+        let last = &self.stops[self.stops.len() - 1];
+        if t >= last.offset {
+            return last.value;
+        }
+
+        // The pair this sits between. Timelines are short by nature — a
+        // handful of stops — so a scan is the whole search.
+        let next = self
+            .stops
+            .iter()
+            .position(|stop| stop.offset > t)
+            .unwrap_or(self.stops.len() - 1);
+        let from = &self.stops[next - 1];
+        let to = &self.stops[next];
+
+        let span = to.offset - from.offset;
+        if span <= f32::EPSILON {
+            return to.value;
+        }
+        let local = (t - from.offset) / span;
+        T::lerp(&from.value, &to.value, from.easing.evaluate(local))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn shake() -> Keyframes<f32> {
+        Keyframes::new(300.0)
+            .at(0.0, 0.0)
+            .at(0.5, 10.0)
+            .at(1.0, 0.0)
+    }
+
+    #[test]
+    fn a_timeline_passes_through_its_stops() {
+        let kf = shake();
+        assert_eq!(kf.value_at(0.0), Some(0.0));
+        assert_eq!(kf.value_at(150.0), Some(10.0));
+        assert_eq!(kf.value_at(75.0), Some(5.0), "halfway up the first segment");
+        assert_eq!(kf.value_at(225.0), Some(5.0), "and halfway back down");
+    }
+
+    /// The end is what hands the property back to whatever declared it.
+    #[test]
+    fn a_finished_timeline_has_no_value_of_its_own() {
+        assert_eq!(shake().value_at(300.0), None);
+        assert_eq!(shake().value_at(1000.0), None);
+    }
+
+    #[test]
+    fn stops_written_out_of_order_are_put_in_order() {
+        let kf = Keyframes::new(100.0)
+            .at(1.0, 0.0)
+            .at(0.0, 0.0)
+            .at(0.5, 10.0);
+        assert_eq!(kf.value_at(50.0), Some(10.0));
+    }
+
+    /// Before the first stop and after the last, the nearest one holds — a
+    /// timeline that starts at 0.25 is not a timeline that starts undefined.
+    #[test]
+    fn the_ends_hold_rather_than_extrapolate() {
+        let kf = Keyframes::new(100.0).at(0.25, 4.0).at(0.75, 8.0);
+        assert_eq!(kf.value_at(0.0), Some(4.0));
+        assert_eq!(kf.value_at(90.0), Some(8.0));
+    }
+
+    #[test]
+    fn a_repeat_plays_the_same_run_again() {
+        let kf = shake().repeat(2);
+        assert_eq!(kf.total_ms(), 600.0);
+        assert_eq!(kf.value_at(150.0), Some(10.0));
+        assert_eq!(kf.value_at(450.0), Some(10.0), "the peak of the second run");
+        assert_eq!(kf.value_at(600.0), None);
+    }
+
+    #[test]
+    fn easing_declared_at_a_stop_governs_the_segment_leaving_it() {
+        // EaseIn starts slow, so a quarter of the way through the first
+        // segment is less than a quarter of the way up.
+        let eased = Keyframes::new(100.0)
+            .at_with(0.0, 0.0, TimingFunction::EaseIn)
+            .at(1.0, 10.0);
+        let linear = Keyframes::new(100.0).at(0.0, 0.0).at(1.0, 10.0);
+        assert!(eased.value_at(25.0).unwrap() < linear.value_at(25.0).unwrap());
+    }
+
+    #[test]
+    fn an_empty_timeline_plays_nothing() {
+        let kf: Keyframes<f32> = Keyframes::new(100.0);
+        assert!(kf.is_empty());
+        assert_eq!(kf.value_at(0.0), None);
+    }
+}

--- a/src/animation/keyframes.rs
+++ b/src/animation/keyframes.rs
@@ -68,7 +68,32 @@ impl<T: Animatable> Keyframes<T> {
 
     /// A stop whose outgoing segment is eased.
     pub fn at_with(mut self, offset: f32, value: T, easing: TimingFunction) -> Self {
-        let offset = offset.clamp(0.0, 1.0);
+        // `f32::clamp` passes NaN straight through, and an offset that
+        // compares false against everything makes the search below find no
+        // stop at all. An offset is usually computed — `i as f32 / count` with
+        // an empty count is all it takes — so this is absorbed at the door
+        // rather than left to surface as an index one place before the first.
+        let offset = if offset.is_nan() {
+            0.0
+        } else {
+            offset.clamp(0.0, 1.0)
+        };
+
+        // A spring has no duration, and a keyframe segment is nothing but one.
+        // `TimingFunction::evaluate` returns `t` unchanged for a spring, so
+        // taking it at face value would play the segment dead linear and say
+        // nothing about it.
+        let easing = match easing {
+            TimingFunction::Spring(_) => {
+                #[cfg(debug_assertions)]
+                log::warn!(
+                    "keyframes: a spring cannot ease a segment of fixed \
+                     duration; using EaseInOut for the stop at {offset}"
+                );
+                TimingFunction::EaseInOut
+            }
+            other => other,
+        };
         let stop = Stop {
             offset,
             value,
@@ -123,11 +148,18 @@ impl<T: Animatable> Keyframes<T> {
 
         // The pair this sits between. Timelines are short by nature — a
         // handful of stops — so a scan is the whole search.
+        //
+        // Never zero: `stops[next - 1]` is the stop before this one, and the
+        // two early returns above have already covered every `t` that could
+        // land before the first. The floor makes that structural rather than
+        // an argument, since the only way past them was a comparison that
+        // answered false to everything.
         let next = self
             .stops
             .iter()
             .position(|stop| stop.offset > t)
-            .unwrap_or(self.stops.len() - 1);
+            .unwrap_or(self.stops.len() - 1)
+            .max(1);
         let from = &self.stops[next - 1];
         let to = &self.stops[next];
 
@@ -210,5 +242,45 @@ mod tests {
         let kf: Keyframes<f32> = Keyframes::new(100.0);
         assert!(kf.is_empty());
         assert_eq!(kf.value_at(0.0), None);
+    }
+
+    /// An offset that compares false against everything used to send the
+    /// search one place before the first stop.
+    #[test]
+    fn a_nan_offset_does_not_walk_off_the_front() {
+        let kf = Keyframes::new(100.0).at(f32::NAN, 7.0_f32);
+        assert_eq!(kf.value_at(0.0), Some(7.0));
+        assert_eq!(kf.value_at(50.0), Some(7.0));
+    }
+
+    #[test]
+    fn a_nan_offset_lands_at_the_start() {
+        let kf = Keyframes::new(100.0).at(f32::NAN, 0.0_f32).at(1.0, 10.0);
+        assert_eq!(kf.value_at(0.0), Some(0.0));
+        assert_eq!(kf.value_at(99.0).map(|v| v > 9.0), Some(true));
+    }
+
+    /// A spring has no duration and a segment is nothing but one, so it cannot
+    /// be the easing — and it must not quietly become a straight line either.
+    #[test]
+    fn a_spring_easing_is_replaced_rather_than_played_flat() {
+        use crate::animation::SpringConfig;
+
+        let sprung = Keyframes::new(100.0)
+            .at_with(0.0, 0.0_f32, TimingFunction::Spring(SpringConfig::BOUNCY))
+            .at(1.0, 10.0);
+        let eased = Keyframes::new(100.0)
+            .at_with(0.0, 0.0_f32, TimingFunction::EaseInOut)
+            .at(1.0, 10.0);
+
+        assert_eq!(sprung.value_at(25.0), eased.value_at(25.0));
+        assert_ne!(
+            sprung.value_at(25.0),
+            Keyframes::new(100.0)
+                .at(0.0, 0.0_f32)
+                .at(1.0, 10.0)
+                .value_at(25.0),
+            "and it is not the linear one either"
+        );
     }
 }

--- a/src/animation/mod.rs
+++ b/src/animation/mod.rs
@@ -1,8 +1,10 @@
 mod animatable;
+mod keyframes;
 mod spring;
 mod timing;
 
 pub use animatable::Animatable;
+pub use keyframes::Keyframes;
 pub use spring::{SpringConfig, SpringState};
 pub use timing::TimingFunction;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,7 +147,9 @@ pub fn quit_app() {
 }
 
 pub mod prelude {
-    pub use crate::animation::{SpringConfig, TimingFunction, Transition, TransitionConfig};
+    pub use crate::animation::{
+        Keyframes, SpringConfig, TimingFunction, Transition, TransitionConfig,
+    };
     pub use crate::backdrop::{BackdropBlur, BackdropSources};
     pub use crate::compositor::{CompositorEffects, compositor_effects};
     pub use crate::keyboard::keyboard_modifiers;

--- a/src/widgets/container/anim_bridge.rs
+++ b/src/widgets/container/anim_bridge.rs
@@ -243,9 +243,10 @@ impl Container {
             }
             // The timeline's trigger, read here for the same reason as the
             // targets: reading it is the subscription, so a container that
-            // plays on a signal is woken by it.
-            if let Some(trigger) = &anims.transform_plays {
-                drift |= trigger.signal.get() != trigger.last;
+            // plays on a signal is woken by it. Asking and committing are the
+            // same comparison in the same place — see `take_play`.
+            if let Some(anim) = &anims.transform {
+                drift |= anim.wants_play();
             }
             drift
         });

--- a/src/widgets/container/anim_bridge.rs
+++ b/src/widgets/container/anim_bridge.rs
@@ -241,6 +241,12 @@ impl Container {
                     *a.target() == self.effective_text_color_target(id),
                 );
             }
+            // The timeline's trigger, read here for the same reason as the
+            // targets: reading it is the subscription, so a container that
+            // plays on a signal is woken by it.
+            if let Some(trigger) = &anims.transform_plays {
+                drift |= trigger.signal.get() != trigger.last;
+            }
             drift
         });
 

--- a/src/widgets/container/animations.rs
+++ b/src/widgets/container/animations.rs
@@ -3,6 +3,27 @@ use std::time::Instant;
 use crate::animation::{
     Animatable, Keyframes, SpringState, Transition, TransitionConfig, carry_velocity,
 };
+use crate::reactive::Signal;
+
+/// A sequence a property can be told to play, and the signal that tells it.
+///
+/// Unlike everything else in an `AnimationState` this has no target: while it
+/// runs it *replaces* the declared value, and when it ends the property is
+/// handed back — the rule CSS gives an animation over a normal declaration.
+struct Timeline<T> {
+    keyframes: Keyframes<T>,
+    /// When the current run started, if one is running.
+    playing: Option<Instant>,
+    /// A signal whose every change plays the sequence once, and the count last
+    /// acted on.
+    ///
+    /// A count rather than a flag, because two refusals in a row are two
+    /// events and a signal that stays equal notifies nobody. Reading it and
+    /// committing to it live in one place, so the pass that subscribes and the
+    /// pass that plays cannot disagree about what has been seen.
+    trigger: Option<Signal<u32>>,
+    last_play: u32,
+}
 
 /// Result of advancing an animation, indicating whether the value changed
 #[derive(Debug, Clone, PartialEq)]
@@ -47,12 +68,11 @@ pub struct AnimationState<T: Animatable> {
     /// Pending enter value: consumed at first layout to start an enter
     /// animation instead of snapping to the target
     enter_from: Option<T>,
-    /// A sequence to play on demand. Unlike everything else here it has no
-    /// target: while it runs it *replaces* the declared value, and when it
-    /// ends the property goes back to whatever that value is now.
-    timeline: Option<Keyframes<T>>,
-    /// When the timeline started, if it is running.
-    playing: Option<Instant>,
+    /// A sequence to play on demand, and what plays it. Boxed and absent by
+    /// default: `ContainerAnims` holds nine of these states and only one
+    /// property can carry a sequence, so the rest pay a pointer rather than
+    /// the struct.
+    timeline: Option<Box<Timeline<T>>>,
 }
 
 impl<T: Animatable> AnimationState<T> {
@@ -80,7 +100,6 @@ impl<T: Animatable> AnimationState<T> {
             prev_value: None,
             enter_from: None,
             timeline: None,
-            playing: None,
         }
     }
 
@@ -116,8 +135,23 @@ impl<T: Animatable> AnimationState<T> {
             0.0
         };
 
-        self.start = self.current;
         self.target = new_target;
+        self.begin_segment(self.current, carried);
+    }
+
+    /// Start a fresh run toward the current target, from rest.
+    fn begin_segment_from(&mut self, from: T) {
+        self.begin_segment(from, 0.0);
+    }
+
+    /// The bookkeeping every new segment shares.
+    fn begin_segment(&mut self, from: T, carried: f32) {
+        let is_spring = matches!(
+            self.active_transition().timing,
+            crate::animation::TimingFunction::Spring(_)
+        );
+        self.start = from;
+        self.current = from;
         self.progress = 0.0;
         self.start_time = Instant::now();
         self.spring_state = if is_spring {
@@ -268,37 +302,114 @@ impl<T: Animatable> AnimationState<T> {
 
     /// Check if animation is still running
     pub fn is_animating(&self) -> bool {
-        self.playing.is_some()
+        self.timeline.as_ref().is_some_and(|t| t.playing.is_some())
             || self.progress < 1.0
             || (self.spring_state.is_some() && self.progress < 0.99)
     }
 
-    /// Give this property a sequence to play.
+    /// Give this property a sequence to play, keeping whatever already plays
+    /// it.
     pub(crate) fn set_timeline(&mut self, keyframes: Keyframes<T>) {
-        self.timeline = Some(keyframes);
+        match &mut self.timeline {
+            Some(timeline) => timeline.keyframes = keyframes,
+            None => {
+                self.timeline = Some(Box::new(Timeline {
+                    keyframes,
+                    playing: None,
+                    trigger: None,
+                    last_play: 0,
+                }))
+            }
+        }
+    }
+
+    /// Give it the signal that plays it. Ignored without a sequence, which
+    /// cannot happen through the builders.
+    pub(crate) fn set_play_trigger(&mut self, trigger: Signal<u32>) {
+        if let Some(timeline) = &mut self.timeline {
+            timeline.last_play = trigger.get_untracked();
+            timeline.trigger = Some(trigger);
+        }
+    }
+
+    /// Carry a sequence over from the state this one replaces.
+    ///
+    /// The builders each construct a fresh `AnimationState`, so without this
+    /// the order `keyframes_*` and `animate_*` were written in would decide
+    /// whether the sequence survived at all — silently, since the trigger
+    /// would go on firing against a state that had nothing to play.
+    pub(crate) fn adopt_timeline_of(&mut self, previous: Option<Self>) {
+        if let Some(previous) = previous
+            && let Some(timeline) = previous.timeline
+        {
+            self.timeline = Some(timeline);
+        }
+    }
+
+    /// Whether the trigger has moved since the sequence last played.
+    ///
+    /// Reading the signal is the subscription, so the pass that asks this is
+    /// the pass that gets woken.
+    pub(crate) fn wants_play(&self) -> bool {
+        self.timeline
+            .as_ref()
+            .and_then(|t| t.trigger.map(|signal| signal.get() != t.last_play))
+            .unwrap_or(false)
+    }
+
+    /// The same question, answered once: `true` hands over the play and marks
+    /// it taken, so nothing can ask twice for the same change.
+    pub(crate) fn take_play(&mut self) -> bool {
+        let Some(timeline) = &mut self.timeline else {
+            return false;
+        };
+        let Some(trigger) = timeline.trigger else {
+            return false;
+        };
+        let now = trigger.get();
+        if now == timeline.last_play {
+            return false;
+        }
+        timeline.last_play = now;
+        true
     }
 
     /// Start the sequence, from the top. Playing it again while it runs
     /// restarts it: the second refusal is not half a shake.
     pub(crate) fn play(&mut self) {
-        if self.timeline.as_ref().is_some_and(|t| !t.is_empty()) {
-            self.playing = Some(Instant::now());
+        if let Some(timeline) = &mut self.timeline
+            && !timeline.keyframes.is_empty()
+        {
+            timeline.playing = Some(Instant::now());
         }
     }
 
-    /// Advance the running timeline. `None` when there is none.
+    /// Advance the running timeline. `None` when there is none, or when the
+    /// one that was running has just handed the property back.
     fn advance_timeline(&mut self) -> Option<AdvanceResult<T>> {
-        let started = self.playing?;
+        // Both halves together, so a `playing` without a sequence to play
+        // cannot survive the question. On its own it would keep
+        // `is_animating` true for good: a surface asking for a frame every
+        // vsync with nothing to draw.
+        let Some(timeline) = &mut self.timeline else {
+            return None;
+        };
+        let started = timeline.playing?;
+
         let elapsed = started.elapsed().as_secs_f32() * 1000.0;
-        let value = match self.timeline.as_ref()?.value_at(elapsed) {
-            Some(value) => value,
-            None => {
-                // Over: the property goes back to whatever declared it, which
-                // `animate_to` has been keeping current all along.
-                self.playing = None;
-                self.progress = 1.0;
-                self.target
-            }
+        let Some(value) = timeline.keyframes.value_at(elapsed) else {
+            // Over. The property goes back to whatever declares it — by
+            // *animating* there from where the sequence left it, not by
+            // snapping to it. The declared transition was suspended for the
+            // duration, not cancelled, and ending it at the last frame is
+            // what made a card jump the moment a hover arrived mid-shake.
+            timeline.playing = None;
+            let landed = self.current;
+            self.begin_segment_from(landed);
+            // Returning `None` lets this frame run the ordinary path, so the
+            // hand-back is animated by the declared transition and reaches
+            // its completion edge — which is what fires `on_complete`.
+            return None;
         };
 
         let changed = self.prev_value.as_ref() != Some(&value);
@@ -516,6 +627,14 @@ mod tests {
     }
     use crate::animation::TimingFunction;
 
+    /// Step a running sequence to `ms` into its run.
+    fn play_at<T: Animatable>(anim: &mut AnimationState<T>, ms: u64) {
+        if let Some(timeline) = anim.timeline.as_mut() {
+            timeline.playing = Some(Instant::now() - std::time::Duration::from_millis(ms));
+        }
+        anim.advance();
+    }
+
     /// While a sequence runs it speaks for the property, and when it ends the
     /// property goes back to whatever is declared — including a value that
     /// changed while it was playing.
@@ -530,8 +649,7 @@ mod tests {
         anim.play();
         assert!(anim.is_animating(), "a playing timeline is an animation");
 
-        std::thread::sleep(std::time::Duration::from_millis(30));
-        anim.advance();
+        play_at(&mut anim, 30);
         assert!(
             *anim.current() > 4.0,
             "halfway through it should be near the peak, got {}",
@@ -540,8 +658,8 @@ mod tests {
 
         // The declared value moves while the sequence is running.
         anim.animate_to(3.0);
-        std::thread::sleep(std::time::Duration::from_millis(45));
-        anim.advance();
+        play_at(&mut anim, 70);
+        at(&mut anim, 10);
         assert_eq!(*anim.current(), 3.0, "over, and back to what is declared");
         assert!(!anim.is_animating());
     }
@@ -557,8 +675,7 @@ mod tests {
         anim.set_timeline(Keyframes::new(80.0).at(0.0, 0.0).at(1.0, 8.0));
 
         anim.play();
-        std::thread::sleep(std::time::Duration::from_millis(60));
-        anim.advance();
+        play_at(&mut anim, 60);
         let far = *anim.current();
 
         anim.play();
@@ -568,6 +685,101 @@ mod tests {
             "back near the top of the run, got {} after {far}",
             anim.current()
         );
+    }
+
+    /// The end of a sequence hands the property back to its declared
+    /// transition — it does not cancel it.
+    ///
+    /// Forcing the value to the target on the last frame made the case the
+    /// whole feature is sold on jump: a card shaking, a pointer arriving
+    /// mid-shake, and the hover landing instantly instead of on its spring.
+    #[test]
+    fn the_end_of_a_sequence_animates_back_rather_than_snapping() {
+        use crate::animation::Keyframes;
+
+        let mut anim = AnimationState::new(0.0_f32, Transition::new(200.0, TimingFunction::Linear));
+        anim.set_immediate(0.0);
+        anim.set_timeline(Keyframes::new(60.0).at(0.0, 0.0).at(1.0, 10.0));
+
+        anim.play();
+        play_at(&mut anim, 30);
+
+        // Something declares a new value while the sequence is running.
+        anim.animate_to(100.0);
+
+        // The sequence runs out.
+        play_at(&mut anim, 70);
+        let handed_back = *anim.current();
+        assert!(
+            handed_back < 100.0,
+            "the declared transition has to run, not be skipped: got \
+             {handed_back}"
+        );
+        assert!(anim.is_animating(), "and it is still going");
+
+        at(&mut anim, 400);
+        assert_eq!(*anim.current(), 100.0, "arriving under its own transition");
+    }
+
+    /// And the transition it hands back to reaches its completion edge, so a
+    /// callback gated on the property arriving still fires.
+    #[test]
+    fn a_sequence_does_not_swallow_the_completion_callback() {
+        use crate::animation::Keyframes;
+        use std::cell::Cell;
+        use std::rc::Rc;
+
+        let fired = Rc::new(Cell::new(0));
+        let seen = fired.clone();
+        let transition = Transition::new(50.0, TimingFunction::Linear)
+            .on_complete(move || seen.set(seen.get() + 1));
+
+        let mut anim = AnimationState::new(0.0_f32, transition);
+        anim.set_immediate(0.0);
+        anim.set_timeline(Keyframes::new(60.0).at(0.0, 0.0).at(1.0, 5.0));
+
+        anim.animate_to(1.0);
+        anim.play();
+        play_at(&mut anim, 30);
+        assert_eq!(fired.get(), 0, "nothing has arrived yet");
+
+        play_at(&mut anim, 70);
+        at(&mut anim, 100);
+        assert_eq!(fired.get(), 1, "the hand-back completes, and says so");
+    }
+
+    /// A `playing` with nothing to play cannot outlive the sequence: on its
+    /// own it would keep `is_animating` true for good, and the surface asking
+    /// for a frame every vsync with nothing to draw.
+    #[test]
+    fn a_play_without_a_sequence_does_not_pin_the_frame_loop() {
+        let mut anim = AnimationState::new(0.0_f32, Transition::new(10.0, TimingFunction::Linear));
+        anim.set_immediate(0.0);
+        anim.play();
+        anim.advance();
+        assert!(!anim.is_animating(), "nothing to play, nothing to animate");
+    }
+
+    /// The trigger is asked and committed in one place, so the pass that
+    /// subscribes and the pass that plays cannot disagree about what they
+    /// have seen.
+    #[test]
+    fn a_trigger_is_taken_once_per_change() {
+        use crate::animation::Keyframes;
+        use crate::reactive::create_signal;
+
+        let plays = create_signal(0_u32);
+        let mut anim = AnimationState::new(0.0_f32, Transition::new(0.0, TimingFunction::Linear));
+        anim.set_timeline(Keyframes::new(40.0).at(0.0, 0.0).at(1.0, 1.0));
+        anim.set_play_trigger(plays.into());
+
+        assert!(!anim.wants_play(), "nothing has happened yet");
+
+        plays.set(1);
+        assert!(anim.wants_play());
+        assert!(anim.take_play(), "the first ask takes it");
+        assert!(!anim.take_play(), "the second finds nothing left");
+        assert!(!anim.wants_play());
     }
 
     /// Step an animation to `ms` after its segment began.

--- a/src/widgets/container/animations.rs
+++ b/src/widgets/container/animations.rs
@@ -1,6 +1,6 @@
 use std::time::Instant;
 
-use crate::animation::{Animatable, SpringState, Transition, TransitionConfig};
+use crate::animation::{Animatable, Keyframes, SpringState, Transition, TransitionConfig};
 
 /// Result of advancing an animation, indicating whether the value changed
 #[derive(Debug, Clone, PartialEq)]
@@ -45,6 +45,12 @@ pub struct AnimationState<T: Animatable> {
     /// Pending enter value: consumed at first layout to start an enter
     /// animation instead of snapping to the target
     enter_from: Option<T>,
+    /// A sequence to play on demand. Unlike everything else here it has no
+    /// target: while it runs it *replaces* the declared value, and when it
+    /// ends the property goes back to whatever that value is now.
+    timeline: Option<Keyframes<T>>,
+    /// When the timeline started, if it is running.
+    playing: Option<Instant>,
 }
 
 impl<T: Animatable> AnimationState<T> {
@@ -71,6 +77,8 @@ impl<T: Animatable> AnimationState<T> {
             initialized: false, // Not yet initialized with real content-based value
             prev_value: None,
             enter_from: None,
+            timeline: None,
+            playing: None,
         }
     }
 
@@ -113,6 +121,12 @@ impl<T: Animatable> AnimationState<T> {
 
     /// Advance the animation and return whether the value changed
     pub fn advance(&mut self) -> AdvanceResult<T> {
+        // A sequence speaks for the property while it runs, and nothing else
+        // does — the same rule the cascade gives a CSS animation over a normal
+        // declaration.
+        if let Some(result) = self.advance_timeline() {
+            return result;
+        }
         if self.progress >= 1.0 && self.spring_state.is_none() {
             return AdvanceResult::NoChange;
         }
@@ -205,7 +219,47 @@ impl<T: Animatable> AnimationState<T> {
 
     /// Check if animation is still running
     pub fn is_animating(&self) -> bool {
-        self.progress < 1.0 || (self.spring_state.is_some() && self.progress < 0.99)
+        self.playing.is_some()
+            || self.progress < 1.0
+            || (self.spring_state.is_some() && self.progress < 0.99)
+    }
+
+    /// Give this property a sequence to play.
+    pub(crate) fn set_timeline(&mut self, keyframes: Keyframes<T>) {
+        self.timeline = Some(keyframes);
+    }
+
+    /// Start the sequence, from the top. Playing it again while it runs
+    /// restarts it: the second refusal is not half a shake.
+    pub(crate) fn play(&mut self) {
+        if self.timeline.as_ref().is_some_and(|t| !t.is_empty()) {
+            self.playing = Some(Instant::now());
+        }
+    }
+
+    /// Advance the running timeline. `None` when there is none.
+    fn advance_timeline(&mut self) -> Option<AdvanceResult<T>> {
+        let started = self.playing?;
+        let elapsed = started.elapsed().as_secs_f32() * 1000.0;
+        let value = match self.timeline.as_ref()?.value_at(elapsed) {
+            Some(value) => value,
+            None => {
+                // Over: the property goes back to whatever declared it, which
+                // `animate_to` has been keeping current all along.
+                self.playing = None;
+                self.progress = 1.0;
+                self.target
+            }
+        };
+
+        let changed = self.prev_value.as_ref() != Some(&value);
+        self.current = value;
+        self.prev_value = Some(value);
+        Some(if changed {
+            AdvanceResult::Changed(value)
+        } else {
+            AdvanceResult::NoChange
+        })
     }
 
     /// Get current value
@@ -412,6 +466,68 @@ mod tests {
         assert_eq!(fired.get(), 2, "a new completed run fires again");
     }
     use crate::animation::TimingFunction;
+
+    /// While a sequence runs it speaks for the property, and when it ends the
+    /// property goes back to whatever is declared — including a value that
+    /// changed while it was playing.
+    #[test]
+    fn a_timeline_plays_and_then_hands_the_property_back() {
+        use crate::animation::Keyframes;
+
+        let mut anim = AnimationState::new(0.0_f32, Transition::new(0.0, TimingFunction::Linear));
+        anim.set_immediate(0.0);
+        anim.set_timeline(Keyframes::new(60.0).at(0.0, 0.0).at(0.5, 10.0).at(1.0, 0.0));
+
+        anim.play();
+        assert!(anim.is_animating(), "a playing timeline is an animation");
+
+        std::thread::sleep(std::time::Duration::from_millis(30));
+        anim.advance();
+        assert!(
+            *anim.current() > 4.0,
+            "halfway through it should be near the peak, got {}",
+            anim.current()
+        );
+
+        // The declared value moves while the sequence is running.
+        anim.animate_to(3.0);
+        std::thread::sleep(std::time::Duration::from_millis(45));
+        anim.advance();
+        assert_eq!(*anim.current(), 3.0, "over, and back to what is declared");
+        assert!(!anim.is_animating());
+    }
+
+    /// Played again mid-run it restarts: the second refusal is not half a
+    /// shake.
+    #[test]
+    fn playing_again_starts_the_sequence_over() {
+        use crate::animation::Keyframes;
+
+        let mut anim = AnimationState::new(0.0_f32, Transition::new(0.0, TimingFunction::Linear));
+        anim.set_immediate(0.0);
+        anim.set_timeline(Keyframes::new(80.0).at(0.0, 0.0).at(1.0, 8.0));
+
+        anim.play();
+        std::thread::sleep(std::time::Duration::from_millis(60));
+        anim.advance();
+        let far = *anim.current();
+
+        anim.play();
+        anim.advance();
+        assert!(
+            *anim.current() < far,
+            "back near the top of the run, got {} after {far}",
+            anim.current()
+        );
+    }
+
+    #[test]
+    fn a_property_with_no_timeline_cannot_be_played() {
+        let mut anim = AnimationState::new(0.0_f32, Transition::new(10.0, TimingFunction::Linear));
+        anim.set_immediate(0.0);
+        anim.play();
+        assert!(!anim.is_animating(), "nothing to play");
+    }
 
     #[test]
     fn test_animation_state_new() {

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -1055,6 +1055,81 @@ fn a_container_wakes_when_its_timeline_is_asked_to_play() {
     );
 }
 
+/// The transform this container is painted with, once the queued jobs have
+/// run. A rotation shows up as a matrix that is no longer the identity.
+fn played_transform(h: &mut H) -> Transform {
+    pump(h);
+    h.fit(200.0, 200.0);
+    h.paint().children[0].local_transform
+}
+
+/// Waking is not playing. The test above passes whether or not the sequence
+/// survived, because the job comes from the trigger — so this one asks the
+/// only question that matters: did the property move?
+#[test]
+fn a_played_sequence_actually_moves_the_transform() {
+    use crate::animation::Keyframes;
+
+    let plays = create_signal(0u32);
+    let mut h = H::new(
+        container().layout(Flex::row()).child(
+            box_of(50.0, 50.0).keyframes_transform(
+                Keyframes::new(200.0)
+                    .at(0.0, Transform::IDENTITY)
+                    .at(0.5, Transform::rotate_degrees(20.0))
+                    .at(1.0, Transform::IDENTITY),
+                plays,
+            ),
+        ),
+    );
+    h.fit(200.0, 200.0);
+    h.paint();
+
+    plays.set(1);
+    let played = played_transform(&mut h);
+    assert_ne!(
+        played,
+        Transform::IDENTITY,
+        "the sequence has to reach the paint, not only the job queue"
+    );
+}
+
+/// And it survives the transition being declared after it.
+///
+/// `animate_transform` builds a fresh `AnimationState`, so the sequence used
+/// to be thrown away by whichever builder came second — with the trigger
+/// still firing, the job still queued and nothing at all to show for it.
+#[test]
+fn declaring_a_transition_after_a_sequence_does_not_lose_it() {
+    use crate::animation::Keyframes;
+
+    let plays = create_signal(0u32);
+    let mut h = H::new(
+        container().layout(Flex::row()).child(
+            box_of(50.0, 50.0)
+                .keyframes_transform(
+                    Keyframes::new(200.0)
+                        .at(0.0, Transform::IDENTITY)
+                        .at(0.5, Transform::rotate_degrees(20.0))
+                        .at(1.0, Transform::IDENTITY),
+                    plays,
+                )
+                // Written after, which used to decide the whole thing.
+                .animate_transform(Transition::new(100.0, TimingFunction::EaseOut)),
+        ),
+    );
+    h.fit(200.0, 200.0);
+    h.paint();
+
+    plays.set(1);
+    assert_ne!(
+        played_transform(&mut h),
+        Transform::IDENTITY,
+        "the order the two builders were written in must not decide whether \
+         the sequence exists"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Focus, now that it is stored state
 // ---------------------------------------------------------------------------

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -1024,6 +1024,38 @@ fn the_published_text_derived_is_freed_with_its_container() {
 }
 
 // ---------------------------------------------------------------------------
+// Keyframes
+// ---------------------------------------------------------------------------
+
+/// A timeline plays because a signal the caller owns changed, so the container
+/// has to be subscribed to it — reading the trigger where the targets are read
+/// is what does that, and without it a shake would wait for the next frame
+/// somebody else asked for.
+#[test]
+fn a_container_wakes_when_its_timeline_is_asked_to_play() {
+    use crate::animation::Keyframes;
+
+    let plays = create_signal(0u32);
+    let mut h = H::new(
+        box_of(50.0, 50.0).keyframes_transform(
+            Keyframes::new(200.0)
+                .at(0.0, Transform::IDENTITY)
+                .at(0.5, Transform::rotate_degrees(2.0))
+                .at(1.0, Transform::IDENTITY),
+            plays,
+        ),
+    );
+    h.fit(100.0, 100.0);
+    h.paint();
+
+    let queued = h.jobs_from(|| plays.set(1));
+    assert!(
+        queued.contains(&JobType::Animation),
+        "a play has to wake the container that would show it, got {queued:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Focus, now that it is stored state
 // ---------------------------------------------------------------------------
 

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -156,6 +156,19 @@ pub(super) struct ContainerAnims {
     pub(super) border_color: Option<AnimationState<Color>>,
     pub(super) transform: Option<AnimationState<Transform>>,
     pub(super) text_color: Option<AnimationState<Color>>,
+    /// What plays the transform's timeline, and the last count seen from it.
+    pub(super) transform_plays: Option<PlayTrigger>,
+}
+
+/// A signal whose every change plays a timeline once, and the value this
+/// container last saw from it.
+///
+/// A count rather than a flag, because two refusals in a row are two events
+/// and a signal that stays equal notifies nobody. It is the shape SwiftUI's
+/// keyframe animator takes too: play when a value the caller owns changes.
+pub(super) struct PlayTrigger {
+    pub(super) signal: Signal<u32>,
+    pub(super) last: u32,
 }
 
 bitflags::bitflags! {
@@ -1015,6 +1028,58 @@ impl Container {
         self
     }
 
+    /// Play a sequence of transforms whenever `plays` changes.
+    ///
+    /// The other animations here move *towards* a value; this one has none. It
+    /// plays, and while it plays it replaces whatever `transform` declares,
+    /// handing the property back when it ends — the rule CSS gives an
+    /// animation over a normal declaration.
+    ///
+    /// ```ignore
+    /// container()
+    ///     .keyframes_transform(
+    ///         Keyframes::new(320.0)
+    ///             .at(0.0, Transform::IDENTITY)
+    ///             .at(0.2, Transform::rotate_degrees(1.5))
+    ///             .at(0.5, Transform::rotate_degrees(-1.0))
+    ///             .at(1.0, Transform::IDENTITY),
+    ///         rejections,
+    ///     )
+    /// ```
+    ///
+    /// The trigger is a count and not a flag on purpose: a second refusal has
+    /// to shake as loudly as the first, and a signal that stays equal notifies
+    /// nobody. The count it starts at is whatever it holds when the container
+    /// is built, so nothing plays on the first frame.
+    pub fn keyframes_transform<M>(
+        mut self,
+        keyframes: crate::animation::Keyframes<Transform>,
+        plays: impl IntoSignal<u32, M>,
+    ) -> Self {
+        let initial = self.transform.get_or_untracked(Transform::IDENTITY);
+        let anim = self
+            .anims_mut()
+            .transform
+            // A transition of no duration: the timeline speaks for this
+            // property while it plays, and outside it the declared value
+            // applies at once, exactly as it would with no animation at all.
+            .get_or_insert_with(|| {
+                AnimationState::new(
+                    initial,
+                    crate::animation::Transition::new(
+                        0.0,
+                        crate::animation::TimingFunction::Linear,
+                    ),
+                )
+            });
+        anim.set_timeline(keyframes);
+
+        let signal = plays.into_signal();
+        let last = signal.get_untracked();
+        self.anims_mut().transform_plays = Some(PlayTrigger { signal, last });
+        self
+    }
+
     /// Enable transform animation with an ENTER transition: on first
     /// layout the transform animates from `enter_from` to its effective
     /// value, so the widget appears mid-animation — no signal flip, no
@@ -1224,6 +1289,18 @@ impl Widget for Container {
                 any_animating,
                 paint
             );
+            // A trigger that has moved starts the sequence, before the frame
+            // that will show its first value.
+            if let Some(trigger) = anims.transform_plays.as_mut() {
+                let plays =
+                    crate::reactive::diagnostics::snapshot_zone(|| trigger.signal.get_untracked());
+                if plays != trigger.last {
+                    trigger.last = plays;
+                    if let Some(anim) = anims.transform.as_mut() {
+                        anim.play();
+                    }
+                }
+            }
             advance_anim!(anims, transform, transform_target, id, any_animating, paint);
         }
 

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -156,19 +156,6 @@ pub(super) struct ContainerAnims {
     pub(super) border_color: Option<AnimationState<Color>>,
     pub(super) transform: Option<AnimationState<Transform>>,
     pub(super) text_color: Option<AnimationState<Color>>,
-    /// What plays the transform's timeline, and the last count seen from it.
-    pub(super) transform_plays: Option<PlayTrigger>,
-}
-
-/// A signal whose every change plays a timeline once, and the value this
-/// container last saw from it.
-///
-/// A count rather than a flag, because two refusals in a row are two events
-/// and a signal that stays equal notifies nobody. It is the shape SwiftUI's
-/// keyframe animator takes too: play when a value the caller owns changes.
-pub(super) struct PlayTrigger {
-    pub(super) signal: Signal<u32>,
-    pub(super) last: u32,
 }
 
 bitflags::bitflags! {
@@ -1024,7 +1011,13 @@ impl Container {
     /// Enable animation for transform changes
     pub fn animate_transform(mut self, transition: impl Into<TransitionConfig>) -> Self {
         let initial = self.transform.get_or_untracked(Transform::IDENTITY);
-        self.anims_mut().transform = Some(AnimationState::new(initial, transition));
+        // Whatever sequence is already here comes along: a fresh state would
+        // throw it away, and the order the two builders were written in would
+        // decide whether it exists — silently, with the trigger still firing.
+        let previous = self.anims_mut().transform.take();
+        let mut anim = AnimationState::new(initial, transition);
+        anim.adopt_timeline_of(previous);
+        self.anims_mut().transform = Some(anim);
         self
     }
 
@@ -1073,10 +1066,7 @@ impl Container {
                 )
             });
         anim.set_timeline(keyframes);
-
-        let signal = plays.into_signal();
-        let last = signal.get_untracked();
-        self.anims_mut().transform_plays = Some(PlayTrigger { signal, last });
+        anim.set_play_trigger(plays.into_signal());
         self
     }
 
@@ -1096,8 +1086,10 @@ impl Container {
         transition: impl Into<TransitionConfig>,
     ) -> Self {
         let initial = self.transform.get_or_untracked(Transform::IDENTITY);
-        self.anims_mut().transform =
-            Some(AnimationState::new(initial, transition).with_enter_from(enter_from));
+        let previous = self.anims_mut().transform.take();
+        let mut anim = AnimationState::new(initial, transition).with_enter_from(enter_from);
+        anim.adopt_timeline_of(previous);
+        self.anims_mut().transform = Some(anim);
         self
     }
 
@@ -1290,16 +1282,13 @@ impl Widget for Container {
                 paint
             );
             // A trigger that has moved starts the sequence, before the frame
-            // that will show its first value.
-            if let Some(trigger) = anims.transform_plays.as_mut() {
-                let plays =
-                    crate::reactive::diagnostics::snapshot_zone(|| trigger.signal.get_untracked());
-                if plays != trigger.last {
-                    trigger.last = plays;
-                    if let Some(anim) = anims.transform.as_mut() {
-                        anim.play();
-                    }
-                }
+            // that will show its first value. The read is a snapshot: the
+            // subscription belongs to `resync_animation_targets`, which asks
+            // the same question inside its tracking scope.
+            if let Some(anim) = anims.transform.as_mut()
+                && crate::reactive::diagnostics::snapshot_zone(|| anim.take_play())
+            {
+                anim.play();
             }
             advance_anim!(anims, transform, transform_target, id, any_animating, paint);
         }


### PR DESCRIPTION
Every animation in guido moves *towards* a value: a property changes and a
transition carries it there. That covers the whole of a state change and none of
a sequence — a shake, a flash, a bounce, anything whose point is the shape of
the motion rather than where it ends up.

```rust
container()
    .keyframes_transform(
        Keyframes::new(320.0)
            .at(0.0, Transform::IDENTITY)
            .at(0.15, Transform::rotate_degrees(2.0))
            .at(0.40, Transform::rotate_degrees(-1.6))
            .at(0.65, Transform::rotate_degrees(0.9))
            .at(1.0, Transform::IDENTITY),
        rejections,
    )
```

## The type

`Keyframes<T>` is stops on a run: a fraction, a value, and the easing of the
segment *leaving* it — CSS's rule for a timing function written inside a
keyframe. Stops written out of order are sorted, the ends hold rather than
extrapolate, `repeat(n)` plays the run again, and `value_at` returns `None` once
it is over, which is how the property gets handed back.

## What plays it

A signal, and every change to it plays the sequence once. A count and not a
flag, for the reason the app that prompted this had already discovered: two
refusals in a row are two events, and a signal that stays equal notifies nobody.
SwiftUI's keyframe animator takes its trigger the same way.

Nothing plays on the first frame — the container remembers what the signal held
when it was built — and playing again mid-run restarts it, because half a shake
is not what a second refusal means.

## Replace, not compose

While a timeline runs it **replaces** the declared value, and hands it back at
the end — to whatever is declared *then*, including a value that changed while
it was playing. That is the cascade rule CSS gives an animation over a normal
declaration, and `animation-composition`'s default. It is what lets a card
declare a hover transform it is simply not showing for those 320ms:

```rust
.when_hovered(|s| s.transform(Transform::scale(1.03)))
.animate_transform(Transition::spring(SpringConfig::SNAPPY))
.keyframes_transform(shake(), rejections)
```

Composition (CSS's `add`/`accumulate`) is deliberately not here. It is only
well-defined for some types — concatenation for transforms, addition for
scalars, nothing sensible for colours — and nothing has asked for it yet.

## Scope

Transform only for now. The machinery in `AnimationState` is generic, so each
further property is one builder — but a colour that flashes is usually a state
layer, and I would rather add them when something actually wants one.

## Verified

- Unit tests on the type: passing through the stops, sorting, the ends holding,
  repeats, per-segment easing, and an empty timeline playing nothing.
- On `AnimationState`: a timeline plays and then hands the property back to a
  declared value that changed meanwhile; playing again restarts it; a property
  with no timeline cannot be played.
- On the container: a change to the trigger queues an `Animation` job, i.e. the
  container is subscribed to the signal that plays it.
- `cargo run --example keyframes_example` — a shake and a nod from one trigger,
  over a hover that stays declared throughout.
- 405 lib tests green, clippy clean, book chapter added.

Depends on nothing else, but reads best after #195 (springs keeping their
momentum), which is the reason the "when not to use them" section can say that
out-and-back no longer needs a timeline.