### PR TITLE
Public API audit: predictable reactivity, one spelling per idea, two preludes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,8 @@ cargo test
 - `RwSignal<T>`: Read-write reactive signal (8 bytes). Created via `create_signal` (requires Clone+PartialEq+Send). Has `.get()`, `.set()`, `.update()`, `.writer()`. Converts to `Signal<T>` via `.read_only()` or `.into()`
 - `Signal<T>`: Read-only reactive signal (12 bytes). Created via `create_stored` (static, requires Clone) or `create_derived` (closure-backed). Has `.get()`, `.with()` — no mutation methods. Widget props accept `Signal<T>` via `IntoSignal<T, M>` (marker-type disambiguation — integers accepted where `f32`/`Length`/`Padding` expected)
 - `Memo<T>`: Eager computed values that recompute when dependencies change, only notify on actual changes (`PartialEq`)
-- `Effect`: Side effects that re-run when tracked signals change
+- `create_effect`: side effects that re-run when tracked signals change. Returns nothing — an effect's lifetime is its scope's
+- `create_task` / `create_service`: async background work, aborted with the scope. `create_task` for push-only, `create_service` when the UI sends commands
 - `Owner`: Ownership system for automatic resource cleanup (signals, effects, custom callbacks)
 - Runtime uses thread-local storage for automatic dependency tracking on the main thread
 - Container paint/layout auto-tracks signal reads via `with_signal_tracking()` — closures work as reactive properties
@@ -97,7 +98,8 @@ cargo test
 
 **`widgets/`** - Composable UI primitives implementing the `Widget` trait
 - `Container`: Handles padding, background colors, gradients, borders, corner radius, and event handlers (click, hover, scroll)
-- `Row` / `Column`: Flexbox-style layouts with alignment and spacing
+- **Reactivity rule**: everything that survives to paint takes `impl IntoSignal<T, M>` (background, gradient, backdrop_blur, overflow, corners, border, transform, …); structural declarations do not (`layout`, `scrollable`, `scrollbar`, `control`, `animate_*`)
+- `Flex` / `ZStack`: layouts plugged into a container via `.layout(Flex::row())`; the `Layout` trait is public, so an app can write its own
 - `Text`: Text rendering with reactive content and styling
 - `AnyWidget`: Type alias for `Box<dyn Widget>` with `Widget::into_any()` for type erasure
 - All widget properties can be static values or reactive (via `IntoSignal` trait)
@@ -130,7 +132,7 @@ cargo test
 **`layout/`** - Constraint-based layout system
 - `Constraints`: min/max width/height bounds for sizing
 - `Size`: layout results
-- Flexbox layout logic for Row/Column widgets
+- `Flex` (row/column) and `ZStack` layout implementations
 
 ### Reactive System Details
 
@@ -158,12 +160,15 @@ Both `Signal<T>` and `RwSignal<T>` are main-thread only (`!Send`). Background th
 
 ### Widget Trait
 
-All widgets implement:
-- `layout(constraints) -> Size`: Calculate size given constraints
-- `paint(ctx)`: Draw to the PaintContext
-- `event(event) -> EventResponse`: Handle input events
-- `set_origin(x, y)`: Position the widget
-- `bounds() -> Rect`: Get bounding box for hit testing
+Two methods are required, the rest have defaults:
+- `layout(&mut self, tree, id, constraints) -> Size`: measure, then `tree.cache_layout(..)`
+- `paint(&self, tree, id, ctx)`: draw into the PaintContext
+- `event(&mut self, tree, id, event) -> EventResponse`: handle input (defaults to `Ignored`)
+- `advance_animations`, `reconcile_children`, `layout_hints`, `register_children`: defaults
+
+Position and bounds live in the `Tree`, not on the widget. Writing one from
+outside the crate needs `guido::widget_prelude::*` alongside the ordinary
+prelude — see `tests/external_widget.rs`.
 
 ### Rendering Pipeline
 
@@ -194,7 +199,12 @@ Events flow from Wayland → platform layer → widgets:
 - `MouseDown`, `MouseUp`: Button clicks with coordinates
 - `Scroll`: Wheel or touchpad scrolling with delta values
 
-Containers provide callback builders (`.on_click()`, `.on_hover()`, `.on_scroll()`) that widgets can use to respond to events.
+Containers provide callback builders (`.on_click()`, `.on_hover()`, `.on_scroll()`) that widgets can use to respond to events. `on_click` accepts a closure, a `Callback`, or the `Option<Callback>` a `#[component]` prop holds.
+
+### Preludes
+
+- `guido::prelude` — applications
+- `guido::widget_prelude` — implementing `Widget` or `Layout` (`Tree`, `WidgetId`, `Constraints`, `PaintContext`, `RenderNode`, `LayoutHints`, `with_signal_tracking`, `JobType`). Import alongside the ordinary prelude; see `tests/external_widget.rs` and `book/src/advanced/custom-widgets.md`
 
 ## Important Patterns
 
@@ -206,8 +216,8 @@ Use the state layer API for hover and pressed visual feedback:
 container()
     .background(Color::rgb(0.2, 0.2, 0.3))
     .corner_radius(8.0)
-    .hover_state(|s| s.lighter(0.1))      // Lighten on hover
-    .pressed_state(|s| s.ripple())         // Ripple on press
+    .when_hovered(|s| s.lighter(0.1))      // Lighten on hover
+    .when_pressed(|s| s.ripple())         // Ripple on press
     .on_click(move || count.update(|c| *c += 1))
     .child(text("Click me"))
 ```
@@ -224,8 +234,8 @@ let view = container()
         text(move || format!("Count: {}", count.get())),
         container()
             .background(Color::rgb(0.3, 0.3, 0.4))
-            .hover_state(|s| s.lighter(0.1))
-            .pressed_state(|s| s.ripple())
+            .when_hovered(|s| s.lighter(0.1))
+            .when_pressed(|s| s.ripple())
             .on_click(move || count.update(|c| *c += 1))
             .child(text("Click me"))
     ]);
@@ -272,14 +282,14 @@ handle.set_keyboard_interactivity(KeyboardInteractivity::Exclusive);
 
 ### Integrating Background Tasks
 
-Use `create_service` for async background tasks that are automatically cleaned up. Use `.writer()` to get a `WriteSignal<T>` that is `Send` and can be moved into the async task:
+Use `create_task` for async background work that only pushes, `create_service` when the UI also sends commands. Both are cleaned up automatically. Use `.writer()` to get a `WriteSignal<T>` that is `Send` and can be moved into the async task:
 
 ```rust
 let data = create_signal(String::new());
 let data_w = data.writer();  // WriteSignal<T> — Send, for background tasks
 
-// Read-only service (ignore receiver)
-let _ = create_service::<(), _, _>(move |_rx, ctx| async move {
+// Push-only: no command type, no receiver
+create_task(move |ctx| async move {
     while ctx.is_running() {
         data_w.set(fetch_data());
         tokio::time::sleep(Duration::from_secs(1)).await;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,7 @@ cargo test
 
 **`widgets/`** - Composable UI primitives implementing the `Widget` trait
 - `Container`: Handles padding, background colors, gradients, borders, corner radius, and event handlers (click, hover, scroll)
-- **Reactivity rule**: everything that survives to paint takes `impl IntoSignal<T, M>` (background, gradient, backdrop_blur, overflow, corners, border, transform, …); structural declarations do not (`layout`, `scrollable`, `scrollbar`, `control`, `animate_*`)
+- **Reactivity rule**: everything that survives to paint takes `impl IntoSignal<T, M>` (background, gradient, backdrop_blur, overflow, corners, border, transform, …); structural declarations do not (`layout`, `scrollable`, `scrollbar`, `scrollbar_visibility`, `control`, `animate_*`)
 - `Flex` / `ZStack`: layouts plugged into a container via `.layout(Flex::row())`; the `Layout` trait is public, so an app can write its own
 - `Text`: Text rendering with reactive content and styling
 - `AnyWidget`: Type alias for `Box<dyn Widget>` with `Widget::into_any()` for type erasure

--- a/README.md
+++ b/README.md
@@ -42,37 +42,39 @@ Guido is a GPU-accelerated GUI library for building Wayland layer shell applicat
 use guido::prelude::*;
 
 fn main() {
-    let count = create_signal(0);
+    App::new().run(|app| {
+        let count = create_signal(0);
 
-    let (app, _) = App::new().add_surface(
-        SurfaceConfig::new()
-            .height(48)
-            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
-            .layer(Layer::Top)
-            .background_color(Color::rgb(0.1, 0.1, 0.15)),
-        move || {
-            container()
-                .height(fill())
-                .layout(
-                    Flex::row()
-                        .spacing(16.0)
-                        .cross_alignment(CrossAlignment::Center),
-                )
-                .padding([0.0, 16.0])
-                .child(text(move || format!("Count: {}", count.get())).color(Color::WHITE))
-                .child(
-                    container()
-                        .background(Color::rgb(0.3, 0.3, 0.4))
-                        .corner_radius(8.0)
-                        .padding(8.0)
-                        .hover_state(|s| s.lighter(0.1))
-                        .pressed_state(|s| s.ripple())
-                        .on_click(move || count.update(|c| *c += 1))
-                        .child(text("Click me").color(Color::WHITE)),
-                )
-        },
-    );
-    app.run();
+        app.add_surface(
+            SurfaceConfig::new()
+                .height(48)
+                .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+                .layer(Layer::Top)
+                .background_color(Color::rgb(0.1, 0.1, 0.15)),
+            move || {
+                container()
+                    .height(fill())
+                    .layout(
+                        Flex::row()
+                            .spacing(16.0)
+                            .cross_alignment(CrossAlignment::Center),
+                    )
+                    .padding([0.0, 16.0])
+                    .text_color(Color::WHITE)
+                    .child(text(move || format!("Count: {}", count.get())))
+                    .child(
+                        container()
+                            .background(Color::rgb(0.3, 0.3, 0.4))
+                            .corner_radius(8.0)
+                            .padding(8.0)
+                            .when_hovered(|s| s.lighter(0.1))
+                            .when_pressed(|s| s.ripple())
+                            .on_click(move || count.update(|c| *c += 1))
+                            .child(text("Click me")),
+                    )
+            },
+        );
+    });
 }
 ```
 

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -57,6 +57,7 @@
 
 - [Advanced Topics](advanced/README.md)
     - [Creating Components](advanced/components.md)
+    - [Custom Widgets and Layouts](advanced/custom-widgets.md)
     - [Dynamic Children](advanced/dynamic-children.md)
     - [Background Tasks](advanced/background-threads.md)
     - [Widget Ref](advanced/widget-ref.md)

--- a/book/src/advanced/README.md
+++ b/book/src/advanced/README.md
@@ -5,6 +5,7 @@ This section covers advanced patterns for building complex Guido applications.
 ## In This Section
 
 - [Creating Components](components.md) - Reusable widgets with the `#[component]` macro
+- [Custom Widgets and Layouts](custom-widgets.md) - Implementing `Widget` and `Layout` from outside the crate
 - [Dynamic Children](dynamic-children.md) - Reactive lists and conditional rendering
 - [Background Tasks](background-threads.md) - Integrating async operations
 - [Widget Ref](widget-ref.md) - Querying widget bounds at runtime
@@ -20,3 +21,4 @@ These topics become relevant when building:
 - **Data-driven UIs** - Lists that update from external sources
 - **Real-time applications** - System monitors, clocks, live data
 - **Desktop widgets** - Status bars, panels, overlays
+- **Something the primitives cannot draw or arrange** - a custom widget or layout

--- a/book/src/advanced/app-lifecycle.md
+++ b/book/src/advanced/app-lifecycle.md
@@ -65,7 +65,7 @@ This is useful for reloading configuration, switching themes, or resetting appli
 Both `quit_app()` and `restart_app()` are `Send` — they work from any thread, including background services:
 
 ```rust
-let _ = create_service::<(), _, _>(move |_rx, ctx| async move {
+create_task(move |ctx| async move {
     loop {
         tokio::select! {
             _ = watch_config_file() => {

--- a/book/src/advanced/background-threads.md
+++ b/book/src/advanced/background-threads.md
@@ -2,9 +2,9 @@
 
 Guido signals (`RwSignal<T>` and `Signal<T>`) live on the main thread and are `!Send` — they cannot be captured directly in background tasks. To update signals from a background task, call `.writer()` on an `RwSignal<T>` to obtain a `WriteSignal<T>`, which **is** `Send`. Writes through a `WriteSignal` are queued and applied on the main thread during the next frame.
 
-The `create_service` API provides a convenient way to spawn async background tasks that are automatically cleaned up when the component unmounts. Services run as tokio tasks: if your `main` already runs inside a tokio runtime (e.g. `#[tokio::main]`), that runtime is used; otherwise guido lazily starts a small background runtime of its own, so a plain `fn main()` works too.
+`create_task` and `create_service` spawn async background work that is automatically cleaned up when the component unmounts — `create_task` for work that only pushes into signals, `create_service` when the UI also sends it commands. Both run as tokio tasks: if your `main` already runs inside a tokio runtime (e.g. `#[tokio::main]`), that runtime is used; otherwise guido lazily starts a small background runtime of its own, so a plain `fn main()` works too.
 
-## Basic Pattern: Read-Only Service
+## Basic Pattern: A Task That Only Pushes
 
 For services that only push data to signals (no commands from UI):
 
@@ -14,15 +14,15 @@ use std::time::Duration;
 let time = create_signal(String::new());
 let time_w = time.writer(); // Get a Send-able write handle
 
-// Spawn a read-only service - use () as command type
-let _ = create_service::<(), _, _>(move |_rx, ctx| async move {
+// A task has no command channel, so no command type and no receiver
+create_task(move |ctx| async move {
     while ctx.is_running() {
         time_w.set(chrono::Local::now().format("%H:%M:%S").to_string());
         tokio::time::sleep(Duration::from_secs(1)).await;
     }
 });
 
-// The service automatically stops when the component unmounts
+// The task automatically stops when the component unmounts
 ```
 
 ## Bidirectional Service
@@ -86,7 +86,7 @@ fn main() {
         let time_w = time.writer();
 
         // Background monitoring service
-        let _ = create_service::<(), _, _>(move |_rx, ctx| async move {
+        create_task(move |ctx| async move {
             while ctx.is_running() {
                 // Simulate system monitoring
                 cpu_w.set(rand::random::<f32>() * 100.0);
@@ -130,7 +130,7 @@ let weather_w = weather.writer();
 let news_w = news.writer();
 
 // Weather service
-let _ = create_service::<(), _, _>(move |_rx, ctx| async move {
+create_task(move |ctx| async move {
     while ctx.is_running() {
         weather_w.set(fetch_weather());
         tokio::time::sleep(Duration::from_secs(300)).await; // Every 5 minutes
@@ -138,7 +138,7 @@ let _ = create_service::<(), _, _>(move |_rx, ctx| async move {
 });
 
 // News service
-let _ = create_service::<(), _, _>(move |_rx, ctx| async move {
+create_task(move |ctx| async move {
     while ctx.is_running() {
         news_w.set(fetch_news());
         tokio::time::sleep(Duration::from_secs(60)).await; // Every minute
@@ -160,7 +160,7 @@ enum DataState {
 let status = create_signal(DataState::Loading);
 let status_w = status.writer();
 
-let _ = create_service::<(), _, _>(move |_rx, ctx| async move {
+create_task(move |ctx| async move {
     while ctx.is_running() {
         match fetch_data() {
             Ok(data) => status_w.set(DataState::Success(data)),
@@ -186,7 +186,7 @@ Simple clock using a service:
 let time = create_signal(String::new());
 let time_w = time.writer();
 
-let _ = create_service::<(), _, _>(move |_rx, ctx| async move {
+create_task(move |ctx| async move {
     while ctx.is_running() {
         let now = chrono::Local::now();
         time_w.set(now.format("%H:%M:%S").to_string());
@@ -210,7 +210,7 @@ value, and awaitable.
 let menu_open = create_memo(move || active_menu.get() == Some(Menu::SystemInfo));
 let mut open_rx = menu_open.watch();
 
-let _ = create_service::<(), _, _>(move |_rx, ctx| async move {
+create_task(move |ctx| async move {
     while ctx.is_running() {
         // Current value, no polling
         let scope = if *open_rx.borrow_and_update() { Scope::All } else { Scope::Bar };
@@ -271,7 +271,7 @@ let cpu_w = cpu.writer();
 let memory_w = memory.writer();
 let disk_w = disk.writer();
 
-let _ = create_service::<(), _, _>(move |_rx, ctx| async move {
+create_task(move |ctx| async move {
     while ctx.is_running() {
         let data = fetch_all_data();
 

--- a/book/src/advanced/components.md
+++ b/book/src/advanced/components.md
@@ -54,9 +54,9 @@ button().label("Required")
 #[component]
 pub fn button(
     label: String,
-    #[prop(default = "Color::rgb(0.3, 0.3, 0.4)")]
+    #[prop(default = Color::rgb(0.3, 0.3, 0.4))]
     background: Color,
-    #[prop(default = "Padding::all(8.0)")]
+    #[prop(default = Padding::all(8.0))]
     padding: Padding,
 ) -> impl Widget {
     container()
@@ -82,7 +82,7 @@ pub fn button(
     #[prop(callback)] on_click: (),
 ) -> impl Widget {
     container()
-        .on_click_option(on_click)
+        .on_click(on_click)
         .child(text(label))
 }
 ```
@@ -123,14 +123,14 @@ In the function body, each prop is a read-only `Signal<T>` (which is `Copy`). Pa
 #[component]
 pub fn button(
     label: String,
-    #[prop(default = "Padding::all(8.0)")] padding: Padding,
-    #[prop(default = "Color::rgb(0.3, 0.3, 0.4)")] background: Color,
+    #[prop(default = Padding::all(8.0))] padding: Padding,
+    #[prop(default = Color::rgb(0.3, 0.3, 0.4))] background: Color,
     #[prop(callback)] on_click: (),
 ) -> impl Widget {
     container()
         .padding(padding)                  // Pass Signal<Padding> directly (Copy, keeps reactivity)
         .background(background)            // Pass Signal<Color> directly (Copy, keeps reactivity)
-        .on_click_option(on_click)         // Copy handle, no clone
+        .on_click(on_click)         // Copy handle, no clone
         .child(text(label))
 }
 ```
@@ -257,8 +257,8 @@ use guido::prelude::*;
 #[component]
 pub fn button(
     label: String,
-    #[prop(default = "Color::rgb(0.3, 0.3, 0.4)")] background: Color,
-    #[prop(default = "Padding::all(8.0)")] padding: Padding,
+    #[prop(default = Color::rgb(0.3, 0.3, 0.4))] background: Color,
+    #[prop(default = Padding::all(8.0))] padding: Padding,
     #[prop(callback)] on_click: (),
 ) -> impl Widget {
     container()
@@ -267,14 +267,14 @@ pub fn button(
         .corner_radius(6.0)
         .when_hovered(|s| s.lighter(0.1))
         .when_pressed(|s| s.ripple())
-        .on_click_option(on_click)
+        .on_click(on_click)
         .child(container().text_color(Color::WHITE).child(text(label)))
 }
 
 #[component]
 pub fn card(
     title: String,
-    #[prop(default = "Color::rgb(0.18, 0.18, 0.22)")] background: Color,
+    #[prop(default = Color::rgb(0.18, 0.18, 0.22))] background: Color,
     #[prop(children)] children: (),
 ) -> impl Widget {
     container()

--- a/book/src/advanced/custom-widgets.md
+++ b/book/src/advanced/custom-widgets.md
@@ -1,0 +1,138 @@
+# Custom Widgets and Layouts
+
+Guido ships few widgets on purpose. `Container` is the box — padding, colours,
+corners, borders, events — and `Text`, `Image` and `TextInput` are the things
+that draw content. A checkbox, a toggle, a slider are compositions of those,
+written as functions or as `#[component]`s in your own app.
+
+Occasionally that is not enough: you need to draw something the primitives
+cannot express, or arrange children in a way `Flex` and `ZStack` do not. Both
+are extension points, and both are reachable from outside the crate.
+
+## The two preludes
+
+`guido::prelude` is the application's vocabulary. Writing a widget or a layout
+needs a second one:
+
+```rust
+use guido::prelude::*;
+use guido::widget_prelude::*;
+```
+
+`widget_prelude` adds what the `Widget` and `Layout` signatures name — `Tree`,
+`WidgetId`, `Constraints`, `PaintContext`, `RenderNode`, `LayoutHints` — plus
+`with_signal_tracking` and `JobType`, which are explained below.
+
+## A widget
+
+`Widget` has two required methods. Everything else — `event`,
+`advance_animations`, `reconcile_children`, `layout_hints`,
+`register_children` — has a default.
+
+```rust
+struct Bar {
+    extent: Signal<f32>,
+    measured: f32,
+}
+
+impl Widget for Bar {
+    fn layout(&mut self, tree: &mut Tree, id: WidgetId, constraints: Constraints) -> Size {
+        let extent = with_signal_tracking(id, JobType::Layout, || self.extent.get());
+        self.measured = extent;
+
+        let size = Size::new(extent, extent);
+        tree.cache_layout(id, constraints, size);
+        tree.clear_needs_layout(id);
+        size
+    }
+
+    fn paint(&self, _tree: &Tree, _id: WidgetId, ctx: &mut PaintContext) {
+        // Local coordinates: the parent has already placed this node.
+        ctx.draw_rounded_rect(
+            Rect::new(0.0, 0.0, self.measured, self.measured),
+            Color::RED,
+            0.0,
+        );
+    }
+}
+```
+
+Three things are worth spelling out.
+
+**Position lives in the `Tree`, not on the widget.** `layout` measures and
+reports; the parent decides where the result goes. Paint therefore happens in
+local coordinates, with `(0, 0)` at the widget's own origin.
+
+**The layout protocol is `cache_layout` then `clear_needs_layout`.** Without
+them the widget re-lays-out every frame, because nothing recorded that it is
+clean.
+
+**`with_signal_tracking` is not optional.** It is the scope that makes a
+widget's signal reads belong to *it*. Without one, a read registers against the
+nearest ancestor that opened a scope — the parent container — so a change to
+this widget's own content re-lays-out every one of its siblings. Still reactive,
+but imprecise, and silently so. Pass `JobType::Layout` for reads that change
+the size and `JobType::Paint` for reads that only change the drawing.
+
+## A layout
+
+`Layout` has one method: given the children and the constraints, place them and
+report the size the parent should use.
+
+```rust
+struct Stagger {
+    step: f32,
+}
+
+impl Layout for Stagger {
+    fn layout(
+        &mut self,
+        tree: &mut Tree,
+        children: &[WidgetId],
+        constraints: Constraints,
+        origin: (f32, f32),
+    ) -> Size {
+        let mut size = Size::zero();
+        for (i, &child_id) in children.iter().enumerate() {
+            let child = tree
+                .with_widget_mut(child_id, |w, id, t| w.layout(t, id, constraints))
+                .unwrap_or_default();
+
+            let x = origin.0 + i as f32 * self.step;
+            let y = origin.1 + i as f32 * self.step;
+            tree.set_origin(child_id, x, y);
+
+            size.width = size.width.max(x + child.width - origin.0);
+            size.height = size.height.max(y + child.height - origin.1);
+        }
+        constraints.constrain(size)
+    }
+}
+```
+
+It plugs into any container:
+
+```rust
+container()
+    .layout(Stagger { step: 8.0 })
+    .child(card("one"))
+    .child(card("two"))
+```
+
+The absence of a built-in grid is not a gap — this is where a grid goes.
+
+If your layout reads signals of its own (a reactive spacing, an alignment that
+follows a setting), read them straight from `layout`: the container runs it
+inside its own tracking scope, so those reads are attributed correctly without
+you opening one.
+
+`tree.with_widget(child_id, |w| w.layout_hints())` reports whether a child
+wants to fill an axis, which is what lets a layout give the remaining space to
+the children that asked for it — `ZStack` in the guido source is the short
+example to read.
+
+## Checking your work
+
+`tests/external_widget.rs` in the guido repository is a widget written against
+the public API only, with a test that lays it out and paints it. It is the
+shortest complete example of everything on this page.

--- a/book/src/advanced/dynamic-children.md
+++ b/book/src/advanced/dynamic-children.md
@@ -94,11 +94,11 @@ Keys must be unique and stable — never use the index:
 
 ```rust
 keyed(data, |item| item.id, build)          // Good: stable identity
-keyed(data, |item| item.name.clone(), build) // Good: any Hash + Eq + Debug key
+keyed(data, |item| item.name.clone(), build) // Good: any Hash + Eq key
 keyed(data, |(index, _)| *index, build)      // Bad: reorder loses state
 ```
 
-The key is anything `Hash + Eq + Clone + Debug`, and rows are indexed by the key itself
+The key is anything `Hash + Eq + Clone`, and rows are indexed by the key itself
 rather than by a hash of it, so two distinct keys are never reconciled as one.
 
 The item type chooses the update granularity: fields included in the item
@@ -237,7 +237,7 @@ pub fn keyed<T, I, K, W>(
 where
     T: Clone + PartialEq + 'static,
     I: IntoIterator<Item = T>,
-    K: Hash + Eq + Clone + Debug + 'static,
+    K: Hash + Eq + Clone + 'static,
     W: Widget + 'static;
 
 // Cleanup registration (use inside reactive closures and builders)

--- a/book/src/advanced/dynamic-children.md
+++ b/book/src/advanced/dynamic-children.md
@@ -94,11 +94,11 @@ Keys must be unique and stable — never use the index:
 
 ```rust
 keyed(data, |item| item.id, build)          // Good: stable identity
-keyed(data, |item| item.name.clone(), build) // Good: any Hash + Eq key
+keyed(data, |item| item.name.clone(), build) // Good: any Hash + Eq + Debug key
 keyed(data, |(index, _)| *index, build)      // Bad: reorder loses state
 ```
 
-The key is anything `Hash + Eq + Clone`, and rows are indexed by the key itself
+The key is anything `Hash + Eq + Clone + Debug`, and rows are indexed by the key itself
 rather than by a hash of it, so two distinct keys are never reconciled as one.
 
 The item type chooses the update granularity: fields included in the item
@@ -237,7 +237,7 @@ pub fn keyed<T, I, K, W>(
 where
     T: Clone + PartialEq + 'static,
     I: IntoIterator<Item = T>,
-    K: Hash + Eq + Clone + 'static,
+    K: Hash + Eq + Clone + Debug + 'static,
     W: Widget + 'static;
 
 // Cleanup registration (use inside reactive closures and builders)

--- a/book/src/advanced/dynamic-children.md
+++ b/book/src/advanced/dynamic-children.md
@@ -93,9 +93,13 @@ Per item, identity (`key`) and content (`PartialEq`) are diffed separately:
 Keys must be unique and stable — never use the index:
 
 ```rust
-keyed(data, |item| item.id, build)              // Good: stable identity
-keyed(data, |(index, _)| *index as u64, build)  // Bad: reorder loses state
+keyed(data, |item| item.id, build)          // Good: stable identity
+keyed(data, |item| item.name.clone(), build) // Good: any Hash + Eq key
+keyed(data, |(index, _)| *index, build)      // Bad: reorder loses state
 ```
+
+The key is anything `Hash + Eq + Clone`, and rows are indexed by the key itself
+rather than by a hash of it, so two distinct keys are never reconciled as one.
 
 The item type chooses the update granularity: fields included in the item
 trigger a row rebuild when they change; fields left out can be read via
@@ -225,14 +229,15 @@ impl Container {
 
 // Reactive keyed children list: tracked data, key-based identity,
 // untracked per-item builder with content diffing.
-pub fn keyed<T, I, W>(
+pub fn keyed<T, I, K, W>(
     data: impl Fn() -> I + 'static,
-    key: impl Fn(&T) -> u64 + 'static,
+    key: impl Fn(&T) -> K + 'static,
     build: impl Fn(T) -> W + 'static,
-) -> KeyedChildren<T, I, W>
+) -> KeyedChildren<T, I, K, W>
 where
     T: Clone + PartialEq + 'static,
     I: IntoIterator<Item = T>,
+    K: Hash + Eq + Clone + 'static,
     W: Widget + 'static;
 
 // Cleanup registration (use inside reactive closures and builders)

--- a/book/src/advanced/wayland.md
+++ b/book/src/advanced/wayland.md
@@ -319,14 +319,15 @@ impl SurfaceHandle {
     /// Change anchor edges
     pub fn set_anchor(&self, anchor: Anchor);
 
-    /// Change surface size
-    pub fn set_size(&self, width: u32, height: u32);
+    /// Change surface size — same vocabulary as `SurfaceConfig::width`,
+    /// so an axis can be handed back to `content()`
+    pub fn set_size(&self, width: impl Into<SurfaceExtent>, height: impl Into<SurfaceExtent>);
 
-    /// Change exclusive zone
-    pub fn set_exclusive_zone(&self, zone: i32);
+    /// Change the screen-space reservation policy
+    pub fn set_exclusive_zone(&self, zone: impl Into<ExclusiveZone>);
 
-    /// Change margins
-    pub fn set_margin(&self, top: i32, right: i32, bottom: i32, left: i32);
+    /// Change margins — CSS shorthands, as `padding` takes
+    pub fn set_margin(&self, margin: impl Into<Margin>);
 }
 ```
 
@@ -602,8 +603,7 @@ create_effect(move || {
     if popup.dismissed() {
         menu_open.set(false);
     }
-})
-.detach();
+});
 ```
 
 `popup.close()` closes it programmatically. Popups render their own
@@ -676,7 +676,7 @@ fn main() {
                 .height(32)
                 .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
                 .layer(Layer::Top)
-                .exclusive_zone(Some(32))
+                .exclusive_zone(32u32)
                 .namespace("status-bar")
                 .background_color(Color::rgb(0.1, 0.1, 0.15)),
             || {
@@ -708,7 +708,7 @@ fn main() {
                 .height(64)
                 .anchor(Anchor::BOTTOM | Anchor::LEFT | Anchor::RIGHT)
                 .layer(Layer::Top)
-                .exclusive_zone(Some(64))
+                .exclusive_zone(64u32)
                 .namespace("dock")
                 .background_color(Color::rgba(0.1, 0.1, 0.15, 0.9)),
             || {
@@ -772,7 +772,7 @@ impl SurfaceConfig {
     pub fn exclusive_zone(self, zone: Option<i32>) -> Self;
     pub fn namespace(self, namespace: impl Into<String>) -> Self;
     pub fn background_color(self, color: Color) -> Self;
-    pub fn margin(self, top: i32, right: i32, bottom: i32, left: i32) -> Self;
+    pub fn margin(self, margin: impl Into<Margin>) -> Self;
     pub fn output(self, output: OutputId) -> Self;
     pub fn input_region(self, rects: impl Into<Vec<Rect>>) -> Self;
     pub fn click_through(self) -> Self;
@@ -835,9 +835,9 @@ impl SurfaceHandle {
     pub fn set_layer(&self, layer: Layer);
     pub fn set_keyboard_interactivity(&self, mode: KeyboardInteractivity);
     pub fn set_anchor(&self, anchor: Anchor);
-    pub fn set_size(&self, width: u32, height: u32);
-    pub fn set_exclusive_zone(&self, zone: i32);
-    pub fn set_margin(&self, top: i32, right: i32, bottom: i32, left: i32);
+    pub fn set_size(&self, width: impl Into<SurfaceExtent>, height: impl Into<SurfaceExtent>);
+    pub fn set_exclusive_zone(&self, zone: impl Into<ExclusiveZone>);
+    pub fn set_margin(&self, margin: impl Into<Margin>);
     pub fn set_input_region(&self, rects: Option<Vec<Rect>>);
 }
 ```

--- a/book/src/advanced/wayland.md
+++ b/book/src/advanced/wayland.md
@@ -764,12 +764,12 @@ fn main() {
 ```rust
 impl SurfaceConfig {
     pub fn new() -> Self;
-    pub fn width(self, width: u32) -> Self;
-    pub fn height(self, height: u32) -> Self;
+    pub fn width(self, width: impl Into<SurfaceExtent>) -> Self;
+    pub fn height(self, height: impl Into<SurfaceExtent>) -> Self;
     pub fn anchor(self, anchor: Anchor) -> Self;
     pub fn layer(self, layer: Layer) -> Self;
     pub fn keyboard_interactivity(self, mode: KeyboardInteractivity) -> Self;
-    pub fn exclusive_zone(self, zone: Option<i32>) -> Self;
+    pub fn exclusive_zone(self, zone: impl Into<ExclusiveZone>) -> Self;
     pub fn namespace(self, namespace: impl Into<String>) -> Self;
     pub fn background_color(self, color: Color) -> Self;
     pub fn margin(self, margin: impl Into<Margin>) -> Self;

--- a/book/src/animations/properties.md
+++ b/book/src/animations/properties.md
@@ -25,7 +25,9 @@ Animate border thickness:
 container()
     .border(1.0, Color::rgb(0.3, 0.3, 0.4))
     .animate_border_width(Transition::new(150.0, TimingFunction::EaseOut))
-    .when_hovered(|s| s.border(2.0, Color::rgb(0.5, 0.7, 1.0)))
+    // A border is declared as a pair, so the layer restates the colour it is
+    // not changing — otherwise the width eases while the colour jumps.
+    .when_hovered(|s| s.border(2.0, Color::rgb(0.3, 0.3, 0.4)))
 ```
 
 ## Border Color
@@ -36,7 +38,8 @@ Animate border color:
 container()
     .border(2.0, Color::rgb(0.3, 0.3, 0.4))
     .animate_border_color(Transition::new(150.0, TimingFunction::EaseOut))
-    .when_hovered(|s| s.border(1.0, Color::rgb(0.5, 0.7, 1.0)))
+    // The mirror image: the width is restated so only the colour moves.
+    .when_hovered(|s| s.border(2.0, Color::rgb(0.5, 0.7, 1.0)))
 ```
 
 ## Transform

--- a/book/src/animations/properties.md
+++ b/book/src/animations/properties.md
@@ -25,7 +25,7 @@ Animate border thickness:
 container()
     .border(1.0, Color::rgb(0.3, 0.3, 0.4))
     .animate_border_width(Transition::new(150.0, TimingFunction::EaseOut))
-    .when_hovered(|s| s.border_width(2.0))
+    .when_hovered(|s| s.border(2.0, Color::rgb(0.5, 0.7, 1.0)))
 ```
 
 ## Border Color
@@ -36,7 +36,7 @@ Animate border color:
 container()
     .border(2.0, Color::rgb(0.3, 0.3, 0.4))
     .animate_border_color(Transition::new(150.0, TimingFunction::EaseOut))
-    .when_hovered(|s| s.border_color(Color::rgb(0.5, 0.7, 1.0)))
+    .when_hovered(|s| s.border(1.0, Color::rgb(0.5, 0.7, 1.0)))
 ```
 
 ## Transform

--- a/book/src/animations/properties.md
+++ b/book/src/animations/properties.md
@@ -87,6 +87,26 @@ container()
     .when_hovered(|s| s.elevation(6.0))
 ```
 
+A shadow falls outside the box that casts it, so the container has to tell the
+layout how far its painting reaches — and the reach has to cover the deepest
+shadow it can ever cast, since a hover never re-runs layout.
+
+That makes the two ways of lifting a card cost different amounts:
+
+```rust
+// Constants: the deepest is 6 whatever happens, so hovering moves only the
+// paint and nothing is re-laid-out.
+.elevation(2.0).when_hovered(|s| s.elevation(6.0))
+
+// A signal: the deepest genuinely changes when it is written, so every write
+// re-runs the layout of this subtree.
+.elevation(move || if lifted.get() { 6.0 } else { 2.0 })
+```
+
+Both are correct, and the second is the one to reach for when the depth is
+driven by something other than pointer state. Prefer the state layer when it can
+say the same thing.
+
 ## Multiple Animations
 
 Combine animations on a single container:

--- a/book/src/architecture/events.md
+++ b/book/src/architecture/events.md
@@ -142,19 +142,24 @@ The state layer system uses events internally:
 4. **MouseUp** → Set pressed state false, trigger ripple contraction
 
 ```rust
-fn event(&mut self, event: &Event) -> EventResponse {
+fn event(&mut self, tree: &mut Tree, id: WidgetId, event: &Event) -> EventResponse {
     match event {
         Event::MouseEnter => {
-            self.hover_state = true;
+            self.flags.update(|f| f.insert(InteractionFlags::HOVERED));
         }
         Event::MouseDown { x, y, .. } => {
-            self.pressed_state = true;
-            self.press_point = Some((*x, *y));
+            self.flags.update(|f| f.insert(InteractionFlags::PRESSED));
+            self.ripple.start(*x, *y, Instant::now());
         }
         // ...
     }
+    EventResponse::Ignored
 }
 ```
+
+The flags live in a signal rather than a plain field, so that a *descendant*
+resolving a state layer subscribes to them — see
+[Interactivity](../interactivity/README.md).
 
 ## EventResponse
 

--- a/book/src/architecture/rendering.md
+++ b/book/src/architecture/rendering.md
@@ -57,16 +57,19 @@ Each widget:
 After layout, widgets paint to the `PaintContext`:
 
 ```rust
-fn paint(&self, ctx: &mut PaintContext) {
-    // Draw background
-    ctx.draw_rounded_rect(self.bounds, self.background, self.corner_radius);
+fn paint(&self, tree: &Tree, id: WidgetId, ctx: &mut PaintContext) {
+    // Bounds come from the Tree — the single source of truth — and paint
+    // happens in LOCAL coordinates, the parent having placed the node.
+    let bounds = tree.get_bounds(id).unwrap_or_default();
+    let local = Rect::new(0.0, 0.0, bounds.width, bounds.height);
 
-    // Draw border
-    ctx.draw_border(self.bounds, self.border_width, self.border_color);
+    // Background and border are one command: a rounded rect carries its own
+    // border, shadow and gradient.
+    ctx.draw_rounded_rect(local, self.background, self.corner_radius);
 
     // Paint children
-    for child in &self.children {
-        child.paint(ctx);
+    for &child_id in self.children.iter() {
+        tree.with_widget(child_id, |child| child.paint(tree, child_id, ctx));
     }
 }
 ```

--- a/book/src/building-ui/README.md
+++ b/book/src/building-ui/README.md
@@ -45,8 +45,7 @@ All styling is done in Rust code, not external CSS files. This provides type saf
 
 // Spacing
 .padding(16.0)
-.padding_horizontal(20.0)
-.padding_vertical(10.0)
+.padding([10.0, 20.0])   // [vertical, horizontal]
 
 // Size
 .width(100.0)

--- a/book/src/building-ui/borders.md
+++ b/book/src/building-ui/borders.md
@@ -11,23 +11,21 @@ container()
     .border(2.0, Color::WHITE)  // 2px white border
 ```
 
-A border is always both halves at once: a width with no colour and a colour
-with no width are the same thing, which is no border. Each half takes a signal
-of its own, so anything that has to change already can:
+A border is always both halves at once — everywhere. A width with no colour and
+a colour with no width are the same thing, which is no border, so there is
+nothing for a half-declaration to mean, and no way to write one. Each half takes
+a signal of its own, which covers anything that has to change:
 
 ```rust
 container().border(1.5, move || if failed.get() { theme.danger } else { theme.line })
 ```
 
-### One Half, in a State Layer
-
-A state layer overrides a base that already has both halves, so naming one there
-*is* meaningful — and saves restating the one you are not changing:
+A state layer says it the same way, and replaces the whole border:
 
 ```rust
 container()
     .border(1.5, theme.line)
-    .when_focused(|s| s.border_color(theme.accent))
+    .when_focused(|s| s.border(1.5, theme.accent))
 ```
 
 ## Corner Radius

--- a/book/src/building-ui/borders.md
+++ b/book/src/building-ui/borders.md
@@ -11,12 +11,23 @@ container()
     .border(2.0, Color::WHITE)  // 2px white border
 ```
 
-### Separate Width and Color
+A border is always both halves at once: a width with no colour and a colour
+with no width are the same thing, which is no border. Each half takes a signal
+of its own, so anything that has to change already can:
+
+```rust
+container().border(1.5, move || if failed.get() { theme.danger } else { theme.line })
+```
+
+### One Half, in a State Layer
+
+A state layer overrides a base that already has both halves, so naming one there
+*is* meaningful — and saves restating the one you are not changing:
 
 ```rust
 container()
-    .border_width(2.0)
-    .border_color(Color::rgb(0.5, 0.5, 0.6))
+    .border(1.5, theme.line)
+    .when_focused(|s| s.border_color(theme.accent))
 ```
 
 ## Corner Radius

--- a/book/src/building-ui/images.md
+++ b/book/src/building-ui/images.md
@@ -147,10 +147,15 @@ let svg_data = r##"
     </svg>
 "##;
 
-image(ImageSource::SvgBytes(svg_data.as_bytes().into()))
+container()
     .width(48.0)
     .height(48.0)
+    .child(image(ImageSource::SvgBytes(svg_data.as_bytes().into())))
 ```
+
+An `Image` carries no box of its own: the container it sits in is what gives it
+one, exactly as with a `text`. `content_fit` then decides how the picture uses
+that box.
 
 ## Reactive Images
 
@@ -211,9 +216,10 @@ fn main() {
             )
             .child(
                 // SVG from memory
-                image(ImageSource::SvgBytes(svg_icon.as_bytes().into()))
+                container()
                     .width(32.0)
                     .height(32.0)
+                    .child(image(ImageSource::SvgBytes(svg_icon.as_bytes().into())))
             )
             .child(
                 // Rotated image

--- a/book/src/building-ui/styling.md
+++ b/book/src/building-ui/styling.md
@@ -71,8 +71,7 @@ container().padding(16)                // Integers work too
 container().padding([8.0, 16.0])       // [vertical, horizontal]
 container().padding([8, 16])           // Integer arrays too
 container().padding([1.0, 2.0, 3.0, 4.0])  // [top, right, bottom, left]
-container().padding_horizontal(20.0)   // Left and right
-container().padding_vertical(10.0)     // Top and bottom
+container().padding(Padding::all(8.0).with_top(20.0))  // Builder for one edge
 ```
 
 ## Sizing
@@ -97,10 +96,8 @@ container()
 
 ```rust
 container()
-    .min_width(50.0)
-    .max_width(200.0)
-    .min_height(30.0)
-    .max_height(100.0)
+    .width(at_least(50.0).at_most(200.0))
+    .height(at_least(30.0).at_most(100.0))
 ```
 
 ### At Least / At Most
@@ -125,6 +122,31 @@ round-trip:
 let volume = create_signal(40);
 container().width(move || fraction(volume.get() as f32 / 100.0))
 ```
+
+## Static or Reactive
+
+Every property that survives to paint takes a signal, a closure, or a plain
+value — the same `IntoSignal` shape everywhere, so which spelling you use is
+never the API's decision:
+
+```rust
+container()
+    .background(theme.surface)                       // a constant
+    .background(surface_color)                       // a signal
+    .background(move || if hot.get() { HOT } else { COOL })   // a closure
+    .gradient(move || palette.get().header())
+    .backdrop_blur(move || if frosted.get() { 24.0 } else { 0.0 })
+    .overflow(move || if collapsed.get() { Overflow::Hidden } else { Overflow::Visible })
+```
+
+A blur radius of `0.0` is "no blur", on a container and on a text alike, which
+is what lets one signal switch the effect on and off rather than forcing the
+caller to rebuild the widget in a Rust branch.
+
+**What is not reactive** is structural: `.layout(..)`, `.scrollable(..)`,
+`.scrollbar(..)`, `.control()`, and the `.animate_*()` declarations. These say
+what kind of thing the container *is*; change one and you are describing a
+different widget, so declare it in the closure that builds the widget instead.
 
 ## Complete Example
 

--- a/book/src/building-ui/styling.md
+++ b/book/src/building-ui/styling.md
@@ -51,8 +51,7 @@ container()
 
 // Or separately
 container()
-    .border_width(2.0)
-    .border_color(Color::WHITE)
+    .border(2.0, Color::WHITE)
 ```
 
 ## Shadows (Elevation)

--- a/book/src/building-ui/styling.md
+++ b/book/src/building-ui/styling.md
@@ -144,7 +144,8 @@ is what lets one signal switch the effect on and off rather than forcing the
 caller to rebuild the widget in a Rust branch.
 
 **What is not reactive** is structural: `.layout(..)`, `.scrollable(..)`,
-`.scrollbar(..)`, `.control()`, and the `.animate_*()` declarations. These say
+`.scrollbar(..)`, `.scrollbar_visibility(..)`, `.control()`, and the
+`.animate_*()` declarations. These say
 what kind of thing the container *is*; change one and you are describing a
 different widget, so declare it in the closure that builds the widget instead.
 

--- a/book/src/building-ui/text-input.md
+++ b/book/src/building-ui/text-input.md
@@ -221,7 +221,7 @@ container()
     .background(Color::rgb(0.15, 0.15, 0.2))
     .border(1.0, Color::rgb(0.3, 0.3, 0.4))
     .corner_radius(4.0)
-    .when_focused(|s| s.border_color(Color::rgb(0.4, 0.6, 1.0)))
+    .when_focused(|s| s.border(1.0, Color::rgb(0.4, 0.6, 1.0)))
     .child(
         container().text_color(Color::WHITE).child(text_input(value))
     )
@@ -252,7 +252,7 @@ fn login_form() -> Container {
                         .background(Color::rgb(0.15, 0.15, 0.2))
                         .border(1.0, Color::rgb(0.3, 0.3, 0.4))
                         .corner_radius(4.0)
-                        .when_focused(|s| s.border_color(Color::rgb(0.4, 0.6, 1.0)))
+                        .when_focused(|s| s.border(1.0, Color::rgb(0.4, 0.6, 1.0)))
                         .child(
                             container().text_color(Color::WHITE).font_size(14.0).child(text_input(username))
                         ),
@@ -267,7 +267,7 @@ fn login_form() -> Container {
                         .background(Color::rgb(0.15, 0.15, 0.2))
                         .border(1.0, Color::rgb(0.3, 0.3, 0.4))
                         .corner_radius(4.0)
-                        .when_focused(|s| s.border_color(Color::rgb(0.4, 0.6, 1.0)))
+                        .when_focused(|s| s.border(1.0, Color::rgb(0.4, 0.6, 1.0)))
                         .child(
                             container().text_color(Color::WHITE).font_size(14.0).child(text_input(password).password(true))
                         ),

--- a/book/src/building-ui/text-input.md
+++ b/book/src/building-ui/text-input.md
@@ -202,7 +202,7 @@ TextInput handles text editing but not visual styling like backgrounds and borde
 
 ```rust
 container()
-    .padding(Padding::horizontal(12.0).vertical(8.0))
+    .padding([8.0, 12.0])
     .background(Color::rgb(0.15, 0.15, 0.2))
     .border(1.0, Color::rgb(0.3, 0.3, 0.4))
     .corner_radius(4.0)
@@ -217,7 +217,7 @@ Add visual feedback when the input is focused:
 
 ```rust
 container()
-    .padding(Padding::horizontal(12.0).vertical(8.0))
+    .padding([8.0, 12.0])
     .background(Color::rgb(0.15, 0.15, 0.2))
     .border(1.0, Color::rgb(0.3, 0.3, 0.4))
     .corner_radius(4.0)
@@ -248,7 +248,7 @@ fn login_form() -> Container {
                 .children([
                     container().font_size(12.0).text_color(Color::rgb(0.6, 0.6, 0.7)).child(text("Username")),
                     container()
-                        .padding(Padding::horizontal(12.0).vertical(8.0))
+                        .padding([8.0, 12.0])
                         .background(Color::rgb(0.15, 0.15, 0.2))
                         .border(1.0, Color::rgb(0.3, 0.3, 0.4))
                         .corner_radius(4.0)
@@ -263,7 +263,7 @@ fn login_form() -> Container {
                 .children([
                     container().font_size(12.0).text_color(Color::rgb(0.6, 0.6, 0.7)).child(text("Password")),
                     container()
-                        .padding(Padding::horizontal(12.0).vertical(8.0))
+                        .padding([8.0, 12.0])
                         .background(Color::rgb(0.15, 0.15, 0.2))
                         .border(1.0, Color::rgb(0.3, 0.3, 0.4))
                         .corner_radius(4.0)
@@ -274,7 +274,7 @@ fn login_form() -> Container {
                 ]),
             // Submit button
             container()
-                .padding(Padding::horizontal(16.0).vertical(10.0))
+                .padding([10.0, 16.0])
                 .background(Color::rgb(0.3, 0.5, 0.9))
                 .corner_radius(6.0)
                 .when_hovered(|s| s.lighter(0.1))

--- a/book/src/concepts/container.md
+++ b/book/src/concepts/container.md
@@ -244,13 +244,14 @@ fn create_button(label: &str, on_click: impl Fn() + 'static) -> Container {
 ### Children
 - `.child(widget)` - Add single child
 - `.children([...])` - Add multiple children
-- `.maybe_child(condition, factory)` - Conditional child
-- `.children_dyn(items, key_fn, view_fn)` - Dynamic list
+- `.maybe_child(Option<widget>)` - Conditional child
+- `.child(move || ..)` - Reactive child, rebuilt when a signal it read changes
+- `.children(keyed(items, key_fn, view_fn))` - Keyed reactive list
 
 ### Styling
 - `.background(color)` - Solid background
 - `.gradient_horizontal(start, end)` - Horizontal gradient
-- `.gradient_vertical(start, end)` - Vertical gradient
+- `.gradient_vertical(start, end)` / `.gradient_diagonal(start, end)`
 - `.corner_radius(radius)` - Rounded corners
 - `.squircle()` / `.bevel()` / `.scoop()` - Corner curvature
 - `.border(width, color)` - Border
@@ -258,13 +259,13 @@ fn create_button(label: &str, on_click: impl Fn() + 'static) -> Container {
 
 ### Spacing
 - `.padding(all)` - Uniform padding
-- `.padding_horizontal(h)` - Left/right padding
-- `.padding_vertical(v)` - Top/bottom padding
+- `.padding([v, h])` - CSS two-value shorthand
+- `.padding([t, r, b, l])` - CSS four-value shorthand
 
 ### Sizing
 - `.width(w)` / `.height(h)` - Fixed size
-- `.min_width(w)` / `.max_width(w)` - Width constraints
-- `.min_height(h)` / `.max_height(h)` - Height constraints
+- `.width(at_least(w))` / `.width(at_most(w))` - Bounded width
+- `.height(at_least(h).at_most(h2))` - Bounded height
 
 ### Layout
 - `.layout(Flex::row())` - Horizontal layout

--- a/book/src/concepts/layout.md
+++ b/book/src/concepts/layout.md
@@ -201,9 +201,7 @@ container()
 ### Minimum/Maximum
 
 ```rust
-container()
-    .min_width(100.0)
-    .max_width(300.0)
+container().width(at_least(100.0).at_most(300.0))
 ```
 
 ### At Least

--- a/book/src/concepts/reactive-model.md
+++ b/book/src/concepts/reactive-model.md
@@ -186,7 +186,7 @@ Use `.writers()` to get `Send` handles for background task updates:
 ```rust
 let writers = state.writers();
 
-let _ = create_service::<(), _, _>(move |_rx, ctx| async move {
+create_task(move |ctx| async move {
     while ctx.is_running() {
         // Each field is set individually with PartialEq change detection.
         // Effects that depend on multiple fields run only once (batched).

--- a/book/src/concepts/widgets.md
+++ b/book/src/concepts/widgets.md
@@ -150,10 +150,9 @@ Control widget sizing with builder methods:
 
 ```rust
 container()
-    .width(100.0)        // Fixed width
-    .height(50.0)        // Fixed height
-    .min_width(50.0)     // Minimum width
-    .max_width(200.0)    // Maximum width
+    .width(100.0)                          // Fixed width
+    .height(50.0)                          // Fixed height
+    .width(at_least(50.0).at_most(200.0))  // Bounded instead
 ```
 
 ## Event Flow

--- a/book/src/getting-started/examples.md
+++ b/book/src/getting-started/examples.md
@@ -195,7 +195,7 @@ cargo run --example children_example
 - `.child()` for single children
 - `.children([...])` for multiple children
 - `.maybe_child()` for conditional rendering
-- `.children_dyn()` for reactive lists
+- `.children(keyed(..))` for reactive lists
 
 ---
 

--- a/book/src/interactivity/state-layer.md
+++ b/book/src/interactivity/state-layer.md
@@ -39,7 +39,6 @@ State layers can override these properties:
 ### Border
 
 ```rust
-.when_hovered(|s| s.border(2.0, Color::WHITE))
 .when_hovered(|s| s.border(2.0, Color::WHITE))   // both halves, always
 ```
 

--- a/book/src/interactivity/state-layer.md
+++ b/book/src/interactivity/state-layer.md
@@ -40,8 +40,7 @@ State layers can override these properties:
 
 ```rust
 .when_hovered(|s| s.border(2.0, Color::WHITE))
-.when_hovered(|s| s.border_width(2.0))
-.when_hovered(|s| s.border_color(Color::WHITE))
+.when_hovered(|s| s.border(2.0, Color::WHITE))   // both halves, always
 ```
 
 ### Transform
@@ -137,11 +136,13 @@ Internally, `StateStyle` holds all possible overrides:
 ```rust
 pub struct StateStyle {
     pub background: Option<BackgroundOverride>,
-    pub border_width: Option<f32>,
-    pub border_color: Option<Color>,
-    pub corner_radius: Option<f32>,
-    pub transform: Option<Transform>,
-    pub elevation: Option<f32>,
+    // Both halves or neither: half a border is no border.
+    pub border: Option<BorderOverride>,
+    pub corner_radius: Option<Signal<f32>>,
+    pub transform: Option<Signal<Transform>>,
+    pub elevation: Option<Signal<f32>>,
+    pub text_color: Option<Signal<Color>>,
+    pub alpha: Option<Signal<f32>>,
     pub ripple: Option<RippleConfig>,
 }
 ```

--- a/book/src/interactivity/states.md
+++ b/book/src/interactivity/states.md
@@ -316,10 +316,8 @@ impl StateStyleBuilder {
     pub fn lighter(self, amount: f32) -> Self;
     pub fn darker(self, amount: f32) -> Self;
 
-    // Border
+    // Border — both halves, always; half a border is no border
     pub fn border(self, width: f32, color: Color) -> Self;
-    pub fn border_width(self, width: f32) -> Self;
-    pub fn border_color(self, color: Color) -> Self;
 
     // Other
     pub fn corner_radius(self, radius: f32) -> Self;

--- a/book/src/transforms/basics.md
+++ b/book/src/transforms/basics.md
@@ -161,11 +161,11 @@ All transform properties accept static values, signals, or closures. Integers al
 
 ```rust
 impl Container {
-    pub fn translate(self, x: f32, y: f32) -> Self;
+    pub fn translate<M1, M2>(self, x: impl IntoSignal<f32, M1>, y: impl IntoSignal<f32, M2>) -> Self;
     pub fn rotate<M>(self, degrees: impl IntoSignal<f32, M>) -> Self;
     pub fn scale<M>(self, factor: impl IntoSignal<f32, M>) -> Self;
-    pub fn scale_xy(self, sx: f32, sy: f32) -> Self;
-    pub fn transform(self, transform: Transform) -> Self;
+    pub fn scale_xy<M1, M2>(self, sx: impl IntoSignal<f32, M1>, sy: impl IntoSignal<f32, M2>) -> Self;
+    pub fn transform<M>(self, transform: impl IntoSignal<Transform, M>) -> Self;
 }
 ```
 
@@ -173,7 +173,7 @@ impl Container {
 
 ```rust
 impl Transform {
-    pub fn identity() -> Self;
+    pub const IDENTITY: Self;
     pub fn translate(x: f32, y: f32) -> Self;
     pub fn rotate(angle_radians: f32) -> Self;
     pub fn rotate_degrees(angle_degrees: f32) -> Self;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -207,6 +207,7 @@ handle.set_layer(Layer::Overlay);
 handle.set_keyboard_interactivity(KeyboardInteractivity::Exclusive);
 handle.set_anchor(Anchor::TOP | Anchor::RIGHT);
 handle.set_size(400, 300);
+handle.set_margin([8, 12]);
 ```
 
 ### `transform.rs` - 2D Transforms

--- a/docs/REACTIVE.md
+++ b/docs/REACTIVE.md
@@ -141,7 +141,7 @@ text(move || state.name.get())                          // ignores count/items c
 // Get writer handles (Send + Copy) for background services
 let writers = state.writers();
 
-let _ = create_service::<(), _, _>(move |_rx, ctx| async move {
+create_task(move |ctx| async move {
     while ctx.is_running() {
         let new_state = fetch_state().await;
         writers.set(new_state);  // Decomposes struct, sets each field individually
@@ -267,7 +267,7 @@ let data = create_signal(String::new());
 let data_w = data.writer();  // WriteSignal<T> — Send, for background tasks
 
 // Spawn a background service - automatically cleaned up on unmount
-let _ = create_service::<(), _, _>(move |_rx, ctx| async move {
+create_task(move |ctx| async move {
     while ctx.is_running() {
         let new_data = fetch_data();
         data_w.set(new_data);  // Queued, applied next frame

--- a/docs/REFACTORING.md
+++ b/docs/REFACTORING.md
@@ -68,6 +68,51 @@ Also: `create_task` for the very common push-only service, `keyed()` accepting
 any `Hash` key rather than insisting on a `u64`, and `#[prop(default = expr)]`
 unquoted, which is what makes a string literal spellable as a default.
 
+### What making a property reactive costs
+
+Review of the branch found seven real bugs, and six of them are the same bug:
+**a consumer written for a value that could not move.** Worth recording,
+because the next property to become reactive will meet it again.
+
+While `gradient`, `backdrop_blur`, `overflow` and `elevation` were constants,
+their interactions were settled in the builder chain and visible statically. A
+gradient that dropped the shadow was an authoring mistake you made once and saw.
+An elevation table read with `level as i32` was exact, because the only levels
+that ever arrived were the six integers. A `border_width` with no colour was a
+line you would not write. Once a signal can move any of these between frames,
+each becomes a case the paint gate has to handle *at every frame*, and the ones
+that only misbehave in the fractions or in one branch are invisible until
+something animates through them.
+
+The specific shapes, all fixed with tests:
+
+- **A gate on one half of a pair.** `backdrop_blur`'s surface path checked
+  `radius > 0.0`; its compositor path never did, and the region registry had no
+  withdrawal — so "0.0 means off" held for the half with a draw command and not
+  for the half with a side effect.
+- **A quantized consumer.** `elevation_to_shadow` truncated to an integer, which
+  is a staircase under animation and, where the table met the formula that
+  continues it, not even monotonic.
+- **A branch that forgets a sibling property.** The gradient path drew and
+  returned without consulting the elevation; reachable by signal, mid-animation.
+- **A default that is invisible rather than absent.** `border_color` defaults to
+  transparent, so gating the frame on the width alone emitted an invisible
+  command every frame once `border_width` became separately spellable.
+- **A read on the pointer path.** A closure-backed signal recomputes on every
+  read, and `overflow` was read during event dispatch — for every container
+  under the pointer, on every coalesced `MouseMove`. The tracked reads in layout
+  and paint publish what they resolved, and dispatch reads that; which is also
+  the more correct value, since events resolve against the frame on screen, as
+  `hit.bounds` already do.
+- **A request that outruns the round trip.** `set_surface_size` only sends a
+  protocol request; the size arrives back in `configure`. An `Auto` exclusive
+  zone resolved against the stale value reserved for the size the surface was
+  leaving.
+
+The seventh was independent: widening `keyed()` from `u64` to any `Hash` while
+the reconciler still indexed by a 64-bit hash of the key, so two colliding keys
+became one row.
+
 The documentation was audited against the code in the same pass. It described
 `.children_dyn()`, `.padding_horizontal()`, `.min_width()`, `.gradient_diagonal()`
 and `.animate_elevation()`, none of which existed; `Row` and `Column` widgets,

--- a/docs/REFACTORING.md
+++ b/docs/REFACTORING.md
@@ -112,6 +112,17 @@ The seventh was independent: widening `keyed()` from `u64` to any `Hash` while
 the reconciler still indexed by a 64-bit hash of the key, so two colliding keys
 became one row.
 
+A later round found the same shape once more, in the mechanism rather than in a
+consumer, and it is the one worth remembering: the compositor blur region was a
+**registry written during paint**, and every way a container can stop painting —
+hidden, culled, outside a scroller's window, served from the paint cache — was a
+way for that registry to disagree with the screen. Four rounds of review found
+four of them, one at a time. The region is now *derived* from the flattened
+command list instead: a container that did not paint has no command in it, one
+served from the cache carries its command along, and ordering stops mattering
+because the list only exists after the paint that built it. State that has to be
+told about every way it can go stale is the smell; deriving it is the fix.
+
 ### Settled: a border is one thing, everywhere
 
 The audit added `border_width` and `border_color` to `Container`, on the strength

--- a/docs/REFACTORING.md
+++ b/docs/REFACTORING.md
@@ -112,22 +112,40 @@ The seventh was independent: widening `keyed()` from `u64` to any `Hash` while
 the reconciler still indexed by a 64-bit hash of the key, so two colliding keys
 became one row.
 
-### Tried and withdrawn: half a border
+### Settled: a border is one thing, everywhere
 
-The audit added `border_width` and `border_color` to `Container`, on the
-strength of `docs/STYLING.md` documenting them — the same "the docs were right
-early" reasoning that kept `gradient_diagonal` and `animate_elevation`. That
-reasoning does not transfer, and applying it without judging the design was the
-mistake: a *base* declaration with only one half of a border is not an
-under-specified border, it is **no border**, so the split introduced two states
-that mean nothing and then needed defending in the paint gate — one of the bugs
-above.
+The audit added `border_width` and `border_color` to `Container`, on the strength
+of `docs/STYLING.md` documenting them — the same "the docs were right early"
+reasoning that kept `gradient_diagonal` and `animate_elevation`. That reasoning
+does not transfer: those two are whole features the docs promised, this is a
+*decomposition*, and a decomposition has to be judged on whether its parts mean
+anything alone. They do not. A declaration naming one half of a border is not an
+under-specified border, it is **no border** — so the split introduced two states
+that mean nothing, and then needed defending in the paint gate, which is where it
+turned up as one of the bugs above.
 
-The state layer is the opposite case and keeps both setters: it overrides a base
-that already has both halves, so naming one is meaningful, and not restating the
-width you are not changing was the whole point. `Container::border(w, c)` takes
-both, always; each half accepts its own signal, which covers everything the base
-needs to express.
+Withdrawn from `Container`, and then from `StateStyle` too, which had carried
+them since #183. Half a border does not become meaningful for being an override:
+it is the same nothing, and border was the only property in `StateStyle` with
+more than one setter — every other one has exactly one. Uniformity is the point.
+`border(w, c)` takes both, always, wherever it appears, and each half accepts its
+own signal, which is what covers anything that has to change over time.
+
+The pair is one field rather than two, `border: Option<BorderOverride>`, so half
+a border cannot be built even by hand. `BorderOverride` follows
+`BackgroundOverride`: a named override type, not exported in the prelude.
+
+For a width repeated across several layers — the complaint that started this —
+the answer is a constant in the application, which is the same answer this
+document already gives for "the same kind of label, many times".
+
+**`animate_border_width` and `animate_border_color` stay separate**, and that is
+not the same question. Those name an animatable *channel*, not a way to state a
+value: the two are different `Animatable` types with their own states and their
+own curves, and `examples/animation_example.rs` springs the width while easing
+the colour — which one call could not express. `animate_padding` is one call
+because `Padding` is one `Animatable` whose four edges lerp together; a border is
+not.
 
 The documentation was audited against the code in the same pass. It described
 `.children_dyn()`, `.padding_horizontal()`, `.min_width()`, `.gradient_diagonal()`

--- a/docs/REFACTORING.md
+++ b/docs/REFACTORING.md
@@ -19,6 +19,62 @@ and why, and the one design still open.
 | Three tracking scopes in one paint | **Closed** — see below |
 | Container as a style source | Open — direction settled, not scheduled |
 | Interaction groups | **Done** (#188), as `control()`; names unified in #189 |
+| Public API audit: reactivity, symmetry, preludes | **Done** — see below |
+
+---
+
+## The API audit
+
+An audit of the whole public surface, read against a real application written
+on top of it. What it found was not missing features but *inconsistency*: the
+same idea spelled two ways, or reactive in one place and constant in the
+neighbouring one, so nothing about the API could be predicted from the rest of
+it.
+
+**Reactivity had no rule.** `background` took a signal and `gradient` did not;
+`corner_radius` did and `backdrop_blur` did not; `visible` did and `overflow`
+did not. Worse, `backdrop_blur` was reactive on `Text` and constant on
+`Container` — one name, two contracts. All four are reactive now, and the rule
+is stated: **anything that survives to paint takes a signal; anything
+structural — the layout, whether a container scrolls — does not.**
+
+**Two spellings for one idea.** `Padding::symmetric(horizontal, vertical)`
+against the `[vertical, horizontal]` shorthand every call site uses; a border
+that could only be set as a pair while its state-layer counterpart had
+`border_width` and `border_color` apart; `on_click_option` beside `on_click`
+because a `#[component]` prop is an `Option<Callback>`; `Transform::identity()`
+beside `Transform::IDENTITY`. In each case one spelling survives, and it is the
+one already used everywhere else.
+
+**A handle that did not speak its config's language.** `SurfaceConfig` takes an
+`ExclusiveZone` and a `SurfaceExtent`; `SurfaceHandle` took an `i32` and a
+`u32`, so a policy could never be changed to another policy and an axis pinned
+once could never go back to `content()`. Margins get a `Margin` type with the
+conversions `Padding` has.
+
+**A guard whose Drop depended on ambient state.** `create_effect` returned an
+`Effect` that disposed itself unless an owner had claimed it — invisible at the
+call site either way. It returns nothing now; an effect's lifetime is its
+scope's.
+
+**One prelude for two audiences.** 133 names, mixing what an application needs
+with what a widget author does — and failing the widget author anyway, since
+`Tree`, `WidgetId`, `RenderNode` and `Layout` were not in it. Split into
+`prelude` and `widget_prelude`. `IntoSignal` and `IntoVal` moved the other way:
+they look internal and are not, being what makes a custom type usable as a
+`#[component]` prop.
+
+Also: `create_task` for the very common push-only service, `keyed()` accepting
+any `Hash` key rather than insisting on a `u64`, and `#[prop(default = expr)]`
+unquoted, which is what makes a string literal spellable as a default.
+
+The documentation was audited against the code in the same pass. It described
+`.children_dyn()`, `.padding_horizontal()`, `.min_width()`, `.gradient_diagonal()`
+and `.animate_elevation()`, none of which existed; `Row` and `Column` widgets,
+which have never existed; the pre-`Tree` `Widget` signatures; and
+`hover_state`/`pressed_state`, renamed in #189. Of that list `gradient_diagonal`
+and `animate_elevation` turned out to be worth having and were implemented
+rather than deleted from the docs.
 
 ---
 
@@ -202,9 +258,9 @@ The third row needed no mechanism, which is why it shipped ahead of the rest.
 
 ### Also settled
 
-- **`when_hovered` becomes `when_hovered`.** The old name reads as "*my* hover
-  state", which is false on a label. `when_hovered` promises nothing about
-  whose.
+- **`hover_state` becomes `when_hovered`** (shipped in #189). The old name
+  reads as "*my* hover state", which is false on a label. `when_hovered`
+  promises nothing about whose.
 - **Precedence is already last-declared-wins** (#183), which is what this
   design needs.
 
@@ -219,10 +275,6 @@ The third row needed no mechanism, which is why it shipped ahead of the rest.
 
 ### Still open
 
-- **`when_hovered`/`when_pressed`/`when_focused` on `Container`** should
-  become `when_hovered`/`when_pressed`/`when_focused` to match the leaves. A
-  mechanical rename across ~290 call sites, deliberately kept out of #188 so
-  the mechanism could be reviewed on its own.
 - **`focus_visible`.** Needed: where an input holds focus essentially always, a
   permanent focus ring is noise. Separate question — it is about how the focus
   arrived, not about who resolves it.

--- a/docs/REFACTORING.md
+++ b/docs/REFACTORING.md
@@ -39,9 +39,8 @@ is stated: **anything that survives to paint takes a signal; anything
 structural — the layout, whether a container scrolls — does not.**
 
 **Two spellings for one idea.** `Padding::symmetric(horizontal, vertical)`
-against the `[vertical, horizontal]` shorthand every call site uses; a border
-that could only be set as a pair while its state-layer counterpart had
-`border_width` and `border_color` apart; `on_click_option` beside `on_click`
+against the `[vertical, horizontal]` shorthand every call site uses;
+`on_click_option` beside `on_click`
 because a `#[component]` prop is an `Option<Callback>`; `Transform::identity()`
 beside `Transform::IDENTITY`. In each case one spelling survives, and it is the
 one already used everywhere else.
@@ -78,8 +77,8 @@ While `gradient`, `backdrop_blur`, `overflow` and `elevation` were constants,
 their interactions were settled in the builder chain and visible statically. A
 gradient that dropped the shadow was an authoring mistake you made once and saw.
 An elevation table read with `level as i32` was exact, because the only levels
-that ever arrived were the six integers. A `border_width` with no colour was a
-line you would not write. Once a signal can move any of these between frames,
+that ever arrived were the six integers. Once a signal can move any of these
+between frames,
 each becomes a case the paint gate has to handle *at every frame*, and the ones
 that only misbehave in the fractions or in one branch are invisible until
 something animates through them.
@@ -97,7 +96,7 @@ The specific shapes, all fixed with tests:
   returned without consulting the elevation; reachable by signal, mid-animation.
 - **A default that is invisible rather than absent.** `border_color` defaults to
   transparent, so gating the frame on the width alone emitted an invisible
-  command every frame once `border_width` became separately spellable.
+  command every frame whenever a border resolved to only one of its halves.
 - **A read on the pointer path.** A closure-backed signal recomputes on every
   read, and `overflow` was read during event dispatch — for every container
   under the pointer, on every coalesced `MouseMove`. The tracked reads in layout
@@ -112,6 +111,23 @@ The specific shapes, all fixed with tests:
 The seventh was independent: widening `keyed()` from `u64` to any `Hash` while
 the reconciler still indexed by a 64-bit hash of the key, so two colliding keys
 became one row.
+
+### Tried and withdrawn: half a border
+
+The audit added `border_width` and `border_color` to `Container`, on the
+strength of `docs/STYLING.md` documenting them — the same "the docs were right
+early" reasoning that kept `gradient_diagonal` and `animate_elevation`. That
+reasoning does not transfer, and applying it without judging the design was the
+mistake: a *base* declaration with only one half of a border is not an
+under-specified border, it is **no border**, so the split introduced two states
+that mean nothing and then needed defending in the paint gate — one of the bugs
+above.
+
+The state layer is the opposite case and keeps both setters: it overrides a base
+that already has both halves, so naming one is meaningful, and not restating the
+width you are not changing was the whole point. `Container::border(w, c)` takes
+both, always; each half accepts its own signal, which covers everything the base
+needs to express.
 
 The documentation was audited against the code in the same pass. It described
 `.children_dyn()`, `.padding_horizontal()`, `.min_width()`, `.gradient_diagonal()`

--- a/docs/RENDERER.md
+++ b/docs/RENDERER.md
@@ -117,10 +117,10 @@ ctx.draw_rounded_rect(rect, color, radius);
 ctx.draw_rounded_rect_with_curvature(rect, color, radius, curvature);
 
 // Gradient rectangle
-ctx.draw_gradient_rect(rect, gradient, radius, curvature);
+ctx.draw_rounded_rect_full(rect, color, radius, curvature, border, shadow, gradient);
 
 // Border frame (no fill)
-ctx.draw_border_frame(rect, border_color, radius, border_width);
+ctx.draw_border_frame_with_curvature(rect, border_color, radius, border_width, curvature);
 
 // With shadow
 ctx.draw_rounded_rect_with_shadow(rect, color, radius, curvature, shadow);

--- a/docs/STATE_LAYER.md
+++ b/docs/STATE_LAYER.md
@@ -138,8 +138,6 @@ Note that a layer *replaces* the base value rather than ranking against it. A pr
 .border(1.0, Color::rgb(0.3, 0.3, 0.4))
 .when_hovered(|s| s.border(2.0, Color::rgb(0.5, 0.5, 0.6)))
 .when_pressed(|s| s.border(3.0, Color::rgb(0.7, 0.7, 0.8)))
-
-// Or just width or color
 .when_hovered(|s| s.border(2.0, Color::WHITE))   // both halves, always
 ```
 

--- a/docs/STATE_LAYER.md
+++ b/docs/STATE_LAYER.md
@@ -140,8 +140,7 @@ Note that a layer *replaces* the base value rather than ranking against it. A pr
 .when_pressed(|s| s.border(3.0, Color::rgb(0.7, 0.7, 0.8)))
 
 // Or just width or color
-.when_hovered(|s| s.border_width(2.0))
-.when_hovered(|s| s.border_color(Color::WHITE))
+.when_hovered(|s| s.border(2.0, Color::WHITE))   // both halves, always
 ```
 
 ### Transform
@@ -261,8 +260,8 @@ The `StateStyle` struct holds all possible overrides:
 ```rust
 pub struct StateStyle {
     pub background: Option<BackgroundOverride>,
-    pub border_width: Option<Signal<f32>>,
-    pub border_color: Option<Signal<Color>>,
+    /// Both halves or neither — half a border is no border.
+    pub border: Option<BorderOverride>,
     pub corner_radius: Option<Signal<f32>>,
     pub transform: Option<Signal<Transform>>,
     pub elevation: Option<Signal<f32>>,

--- a/docs/STYLING.md
+++ b/docs/STYLING.md
@@ -198,11 +198,34 @@ container()
 
 ```rust
 container()
-    .min_width(50.0)
-    .max_width(200.0)
-    .min_height(30.0)
-    .max_height(100.0)
+    .width(at_least(50.0).at_most(200.0))
+    .height(at_least(30.0).at_most(100.0))
 ```
+
+## Static or Reactive
+
+Every property that survives to paint takes a signal, a closure, or a plain
+value — the same `IntoSignal` shape everywhere, so which spelling you use is
+never the API's decision:
+
+```rust
+container()
+    .background(theme.surface)                       // a constant
+    .background(surface_color)                       // a signal
+    .background(move || if hot.get() { HOT } else { COOL })   // a closure
+    .gradient(move || palette.get().header())
+    .backdrop_blur(move || if frosted.get() { 24.0 } else { 0.0 })
+    .overflow(move || if collapsed.get() { Overflow::Hidden } else { Overflow::Visible })
+```
+
+A blur radius of `0.0` is "no blur", on a container and on a text alike, which
+is what lets one signal switch the effect on and off rather than forcing the
+caller to rebuild the widget in a Rust branch.
+
+**What is not reactive** is structural: `.layout(..)`, `.scrollable(..)`,
+`.scrollbar(..)`, `.control()`, and the `.animate_*()` declarations. These say
+what kind of thing the container *is*; change one and you are describing a
+different widget, so declare it in the closure that builds the widget instead.
 
 ## Text Styling
 

--- a/docs/STYLING.md
+++ b/docs/STYLING.md
@@ -197,7 +197,7 @@ container().padding([8.0, 16.0])                   // [vertical, horizontal]
 container().padding([8, 16])                       // integer arrays work too
 container().padding([1.0, 2.0, 3.0, 4.0])         // [top, right, bottom, left]
 container().padding([1, 2, 3, 4])                  // integer 4-value shorthand
-container().padding(Padding::all(8.0).top(20.0))   // builder pattern
+container().padding(Padding::all(8.0).with_top(20.0))   // builder pattern
 ```
 
 ## Sizing

--- a/docs/STYLING.md
+++ b/docs/STYLING.md
@@ -62,12 +62,26 @@ container()
     .border(2.0, Color::WHITE)  // 2px white border
 ```
 
-### Separate Width and Color
+A border is always both halves at once. A width with no colour and a colour
+with no width are the same thing — no border — so there is nothing for a
+half-declaration to mean. Each half takes a signal of its own, which covers
+anything that has to change:
+
+```rust
+container().border(1.5, move || if failed.get() { theme.danger } else { theme.line })
+```
+
+### One Half, in a State Layer
+
+A state layer overrides a base that already has both, so naming one half there
+*is* meaningful — and it is the reason not to restate the width you are not
+changing:
 
 ```rust
 container()
-    .border_width(2.0)
-    .border_color(Color::rgb(0.5, 0.5, 0.6))
+    .border(1.5, theme.line)
+    .when_focused(|s| s.border_color(theme.accent))
+    .state(failed, |s| s.border_color(theme.danger))
 ```
 
 ### Animated Borders

--- a/docs/STYLING.md
+++ b/docs/STYLING.md
@@ -223,7 +223,8 @@ is what lets one signal switch the effect on and off rather than forcing the
 caller to rebuild the widget in a Rust branch.
 
 **What is not reactive** is structural: `.layout(..)`, `.scrollable(..)`,
-`.scrollbar(..)`, `.control()`, and the `.animate_*()` declarations. These say
+`.scrollbar(..)`, `.scrollbar_visibility(..)`, `.control()`, and the
+`.animate_*()` declarations. These say
 what kind of thing the container *is*; change one and you are describing a
 different widget, so declare it in the closure that builds the widget instead.
 

--- a/docs/STYLING.md
+++ b/docs/STYLING.md
@@ -62,26 +62,33 @@ container()
     .border(2.0, Color::WHITE)  // 2px white border
 ```
 
-A border is always both halves at once. A width with no colour and a colour
-with no width are the same thing — no border — so there is nothing for a
-half-declaration to mean. Each half takes a signal of its own, which covers
-anything that has to change:
+A border is always both halves at once — on the container and in a state layer
+alike. A width with no colour and a colour with no width are the same thing, no
+border, so there is nothing for a half-declaration to mean and no way to write
+one. Each half takes a signal of its own, which covers anything that has to
+change:
 
 ```rust
 container().border(1.5, move || if failed.get() { theme.danger } else { theme.line })
 ```
 
-### One Half, in a State Layer
+### In a State Layer
 
-A state layer overrides a base that already has both, so naming one half there
-*is* meaningful — and it is the reason not to restate the width you are not
-changing:
+Same call, and it replaces the whole border. Layers resolve last-declared-wins,
+so the border a caller wants to outrank the others goes last:
 
 ```rust
 container()
     .border(1.5, theme.line)
-    .when_focused(|s| s.border_color(theme.accent))
-    .state(failed, |s| s.border_color(theme.danger))
+    .when_focused(|s| s.border(1.5, theme.accent))
+    .state(failed, |s| s.border(1.5, theme.danger))
+```
+
+A width repeated across layers is a constant in your own code, not something the
+API should let you leave half-said:
+
+```rust
+const FIELD_BORDER: f32 = 1.5;
 ```
 
 ### Animated Borders

--- a/docs/TRANSFORMS.md
+++ b/docs/TRANSFORMS.md
@@ -152,7 +152,7 @@ Transforms are properly accounted for in hit testing. A rotated button will corr
 ```rust
 impl Transform {
     // Creation
-    pub fn identity() -> Self;
+    pub const IDENTITY: Self;
     pub fn translate(x: f32, y: f32) -> Self;
     pub fn rotate(angle_radians: f32) -> Self;
     pub fn rotate_degrees(angle_degrees: f32) -> Self;
@@ -163,12 +163,14 @@ impl Transform {
     pub fn then(&self, other: &Transform) -> Transform;
     pub fn center_at(self, cx: f32, cy: f32) -> Self;
 
+    // The matrix itself, `[a, b, tx, c, d, ty]`
+    pub fn a(&self) -> f32;  // and b, c, d, tx, ty
+
     // Utilities
     pub fn inverse(&self) -> Transform;
     pub fn transform_point(&self, x: f32, y: f32) -> (f32, f32);
     pub fn is_identity(&self) -> bool;
-    pub fn has_rotation(&self) -> bool;
-    pub fn extract_scale(&self) -> f32;
+    pub fn is_translation_only(&self) -> bool;
 }
 ```
 
@@ -176,12 +178,12 @@ impl Transform {
 
 ```rust
 impl Container {
-    pub fn translate(self, x: f32, y: f32) -> Self;
+    pub fn translate<M1, M2>(self, x: impl IntoSignal<f32, M1>, y: impl IntoSignal<f32, M2>) -> Self;
     pub fn rotate<M>(self, degrees: impl IntoSignal<f32, M>) -> Self;
     pub fn scale<M>(self, factor: impl IntoSignal<f32, M>) -> Self;
-    pub fn scale_xy(self, sx: f32, sy: f32) -> Self;
-    pub fn transform(self, transform: Transform) -> Self;
+    pub fn scale_xy<M1, M2>(self, sx: impl IntoSignal<f32, M1>, sy: impl IntoSignal<f32, M2>) -> Self;
+    pub fn transform<M>(self, transform: impl IntoSignal<Transform, M>) -> Self;
     pub fn transform_origin<M>(self, origin: impl IntoSignal<TransformOrigin, M>) -> Self;
-    pub fn animate_transform(self, transition: Transition) -> Self;
+    pub fn animate_transform(self, transition: impl Into<TransitionConfig>) -> Self;
 }
 ```

--- a/examples/animation_example.rs
+++ b/examples/animation_example.rs
@@ -175,7 +175,7 @@ fn border_card() -> Container {
             )
             .animate_border_width(Transition::spring(SpringConfig::BOUNCY))
             .animate_border_color(Transition::new(300.0, TimingFunction::EaseOut))
-            .when_hovered(|s| s.border_color(Color::rgb(0.40, 0.80, 0.60)))
+            .when_hovered(|s| s.border(2.0, Color::rgb(0.40, 0.80, 0.60)))
             .on_click(move || thick.update(|t| *t = !*t)),
     )
 }

--- a/examples/animation_example.rs
+++ b/examples/animation_example.rs
@@ -175,7 +175,17 @@ fn border_card() -> Container {
             )
             .animate_border_width(Transition::spring(SpringConfig::BOUNCY))
             .animate_border_color(Transition::new(300.0, TimingFunction::EaseOut))
-            .when_hovered(|s| s.border(2.0, Color::rgb(0.40, 0.80, 0.60)))
+            // A border is declared as a pair, so the hover restates the width —
+            // and restates it as the same signal, or hovering would pin it and
+            // the click would have nothing left to spring. Each half of a state
+            // layer's border takes a signal of its own, which is what makes that
+            // possible.
+            .when_hovered(|s| {
+                s.border(
+                    move || if thick.get() { 14.0 } else { 2.0 },
+                    Color::rgb(0.40, 0.80, 0.60),
+                )
+            })
             .on_click(move || thick.update(|t| *t = !*t)),
     )
 }

--- a/examples/at_most_animation.rs
+++ b/examples/at_most_animation.rs
@@ -91,7 +91,7 @@ fn main() {
                 .width(content())
                 .height(content())
                 .anchor(Anchor::TOP | Anchor::LEFT)
-                .margin(40, 0, 0, 40)
+                .margin([40, 0, 0, 40])
                 .layer(Layer::Overlay)
                 .keyboard_interactivity(KeyboardInteractivity::OnDemand)
                 .namespace("guido-at-most")

--- a/examples/blur_example.rs
+++ b/examples/blur_example.rs
@@ -17,7 +17,7 @@ fn main() {
                 .width(420)
                 .height(260)
                 .anchor(Anchor::TOP)
-                .margin(120, 0, 0, 0)
+                .margin([120, 0, 0, 0])
                 .layer(Layer::Overlay)
                 .exclusive_zone(ExclusiveZone::None)
                 .background_color(Color::TRANSPARENT),

--- a/examples/blur_regions.rs
+++ b/examples/blur_regions.rs
@@ -1,0 +1,214 @@
+//! The *shape* of a compositor blur region.
+//!
+//! `ext-background-effect-v1` carries no radius — the compositor picks how
+//! strong its blur is — so all a client controls is **where** it applies. That
+//! region is a `wl_region`, a union of rectangles, and guido derives it from the
+//! same draw command the renderer filters its own backdrop from, tessellating
+//! the rounded corners into slabs.
+//!
+//! Everything below is a case where the published region and the shape on
+//! screen can disagree. Each card is translucent, so the desktop shows through
+//! it; wherever the compositor blurs *outside* the card, or leaves a corner of
+//! it sharp, the two have come apart.
+//!
+//! Requires a compositor implementing `ext-background-effect-v1` with its blur
+//! capability, and with blur actually enabled — the log says
+//! "Compositor blur capability available" when the protocol is there. Without
+//! it these are plain translucent cards.
+
+use guido::prelude::*;
+
+const GLASS: Color = Color::rgba(0.10, 0.10, 0.16, 0.45);
+const FRAME: Color = Color::rgba(1.0, 1.0, 1.0, 0.25);
+
+/// A translucent card that asks the compositor to blur behind it.
+///
+/// No border: where one of these is clipped, the shape on screen is the
+/// clip's and a border drawn on the child would be cut away at every curve —
+/// which looks like a rendering fault and is only the child being square. The
+/// border goes on whatever supplies the visible outline.
+fn glass() -> Container {
+    container()
+        .backdrop_blur(BackdropBlur::new(24.0).sources(BackdropSources::COMPOSITOR))
+        .background(GLASS)
+}
+
+fn label(s: &'static str) -> impl Widget {
+    container()
+        .font_size(11.0)
+        .text_color(Color::rgba(1.0, 1.0, 1.0, 0.75))
+        .child(text(s))
+}
+
+fn case(caption: &'static str, body: impl Widget + 'static) -> impl Widget {
+    container()
+        .layout(
+            Flex::column()
+                .spacing(6.0)
+                .cross_alignment(CrossAlignment::Center),
+        )
+        .children([body.into_any(), label(caption).into_any()])
+}
+
+fn main() {
+    env_logger::init();
+
+    App::new().run(|app| {
+        // The on/off that took the longest to get right: a radius reaching zero
+        // has to withdraw the region, not keep blurring for the life of the
+        // surface.
+        let frosted = create_signal(true);
+
+        app.add_surface(
+            SurfaceConfig::new()
+                .width(900)
+                .height(420)
+                .anchor(Anchor::TOP)
+                .margin([80, 0, 0, 0])
+                .namespace("guido-blur")
+                .layer(Layer::Overlay)
+                .exclusive_zone(ExclusiveZone::None)
+                .background_color(Color::TRANSPARENT),
+            move || {
+                container()
+                    .width(fill())
+                    .height(fill())
+                    .padding(24.0)
+                    .layout(
+                        Flex::column()
+                            .spacing(20.0)
+                            .main_alignment(MainAlignment::Center)
+                            .cross_alignment(CrossAlignment::Center),
+                    )
+                    .children([
+                        container()
+                            .layout(Flex::row().spacing(20.0))
+                            .children([
+                                // Four different corners. The region used to be
+                                // tessellated from `radii.max()`, so the sharp
+                                // corners here were cut as though they were the
+                                // round ones — a wedge of blur outside the card
+                                // at every corner that is not the largest.
+                                case(
+                                    "per-corner radii",
+                                    glass()
+                                        .width(200.0)
+                                        .height(120.0)
+                                        .corner_radii([36.0, 0.0, 36.0, 0.0])
+                                        .border(1.0, FRAME),
+                                )
+                                .into_any(),
+                                // A blurred child filling a rounded clip
+                                // exactly. Both rectangles supply all four
+                                // edges, and the corners on screen are the
+                                // parent's — reading them as the child's leaves
+                                // four sharp wedges of blurred desktop outside
+                                // the panel.
+                                case(
+                                    "child fills a rounded clip",
+                                    container()
+                                        .width(200.0)
+                                        .height(120.0)
+                                        .corner_radius(28.0)
+                                        .border(1.0, FRAME)
+                                        .overflow(Overflow::Hidden)
+                                        .child(glass().width(fill()).height(fill())),
+                                )
+                                .into_any(),
+                                // Half out of the same clip. The cut edge is
+                                // straight, so the two corners along it are
+                                // square — published as round, the region gives
+                                // back a wedge the size of the radius at each.
+                                case(
+                                    "child half out of a clip",
+                                    container()
+                                        .width(200.0)
+                                        .height(120.0)
+                                        .corner_radius(28.0)
+                                        .border(1.0, FRAME)
+                                        .overflow(Overflow::Hidden)
+                                        .layout(Flex::row())
+                                        .child(
+                                            glass().width(320.0).height(fill()).corner_radius(20.0),
+                                        ),
+                                )
+                                .into_any(),
+                            ])
+                            .into_any(),
+                        container()
+                            .layout(Flex::row().spacing(20.0))
+                            .children([
+                                // An unevenly scaled corner is an ellipse. One
+                                // radius for both axes — the geometric mean —
+                                // is neither of them, so the region cut a curve
+                                // this card does not have.
+                                case(
+                                    "scaled 1.6x / 1.0x",
+                                    container().width(200.0).height(120.0).child(
+                                        glass()
+                                            .width(120.0)
+                                            .height(120.0)
+                                            .corner_radius(28.0)
+                                            .border(1.0, FRAME)
+                                            .scale_xy(1.6, 1.0),
+                                    ),
+                                )
+                                .into_any(),
+                                // A rotation moves the extremes onto the other
+                                // diagonal; the region is the bounding box of
+                                // the turned card, which is wider than the card.
+                                case(
+                                    "rotated 20°",
+                                    container().width(200.0).height(120.0).child(
+                                        glass()
+                                            .width(150.0)
+                                            .height(90.0)
+                                            .corner_radius(16.0)
+                                            .border(1.0, FRAME)
+                                            .rotate(20.0),
+                                    ),
+                                )
+                                .into_any(),
+                                // Click: the radius goes to zero and the region
+                                // has to be withdrawn. Turning it back on has to
+                                // work too — the fix for the first bug inverted
+                                // it, so it switched off and never came back.
+                                case(
+                                    "click to switch off and on",
+                                    container()
+                                        .width(200.0)
+                                        .height(120.0)
+                                        .corner_radius(24.0)
+                                        .background(GLASS)
+                                        .border(1.0, FRAME)
+                                        .backdrop_blur(move || {
+                                            BackdropBlur::new(if frosted.get() {
+                                                24.0
+                                            } else {
+                                                0.0
+                                            })
+                                            .sources(BackdropSources::COMPOSITOR)
+                                        })
+                                        .when_hovered(|s| s.lighter(0.06))
+                                        .on_click(move || frosted.update(|f| *f = !*f))
+                                        .layout(
+                                            Flex::column()
+                                                .main_alignment(MainAlignment::Center)
+                                                .cross_alignment(CrossAlignment::Center),
+                                        )
+                                        .child(text(move || {
+                                            if frosted.get() {
+                                                "blur on".to_owned()
+                                            } else {
+                                                "blur off".to_owned()
+                                            }
+                                        })),
+                                )
+                                .into_any(),
+                            ])
+                            .into_any(),
+                    ])
+            },
+        );
+    });
+}

--- a/examples/blur_transforms.rs
+++ b/examples/blur_transforms.rs
@@ -1,0 +1,142 @@
+//! Does a transform move the blur with the shape, or only the shape?
+//!
+//! A backdrop blur is resolved to a region twice from the same draw command:
+//! the renderer filters the surface's own content inside it, and the compositor
+//! is handed a `wl_region` for the desktop behind it. Both are computed as the
+//! **axis-aligned bounding box** of the container's world shape.
+//!
+//! A bounding box equals the shape for any transform that keeps the axes, and
+//! is larger than it for one that does not. This lays the four cases side by
+//! side over a striped backdrop this surface draws itself, so the blur is
+//! visible without a compositor implementing `ext-background-effect-v1`:
+//!
+//! - each card's **border marks the shape** — it is transformed with the card;
+//! - the **blurred area is the region**.
+//!
+//! Wherever the two come apart, they have come apart. Expect them to agree for
+//! the first three and not for the fourth.
+
+use guido::prelude::*;
+
+const CARD: Color = Color::rgba(0.10, 0.10, 0.16, 0.35);
+const FRAME: Color = Color::rgba(1.0, 1.0, 1.0, 0.55);
+
+/// A high-contrast backdrop, drawn by this surface so the *surface* half of the
+/// blur has something to filter. `SURFACE` blurs what has already been drawn —
+/// over a transparent background there is nothing to see.
+fn stripes() -> impl Widget {
+    let bars: Vec<AnyWidget> = (0..26)
+        .map(|i| {
+            let warm = i % 2 == 0;
+            container()
+                .width(fill())
+                .height(20.0)
+                .background(if warm {
+                    Color::rgb(0.85, 0.35, 0.30)
+                } else {
+                    Color::rgb(0.15, 0.45, 0.85)
+                })
+                .into_any()
+        })
+        .collect();
+
+    container()
+        .width(fill())
+        .height(fill())
+        .layout(Flex::column())
+        .children(bars)
+}
+
+/// A card whose blur comes from this surface's own content, so the case is
+/// visible whatever the compositor does.
+fn card() -> Container {
+    container()
+        .width(150.0)
+        .height(90.0)
+        .corner_radius(18.0)
+        .background(CARD)
+        .border(2.0, FRAME)
+        .backdrop_blur(BackdropBlur::new(14.0).sources(BackdropSources::SURFACE))
+}
+
+fn case(caption: &'static str, body: impl Widget + 'static) -> AnyWidget {
+    container()
+        .width(210.0)
+        .layout(
+            Flex::column()
+                .spacing(10.0)
+                .main_alignment(MainAlignment::Center)
+                .cross_alignment(CrossAlignment::Center),
+        )
+        .children([
+            container()
+                .width(210.0)
+                .height(190.0)
+                .layout(
+                    Flex::row()
+                        .main_alignment(MainAlignment::Center)
+                        .cross_alignment(CrossAlignment::Center),
+                )
+                .child(body)
+                .into_any(),
+            container()
+                .font_size(12.0)
+                .text_color(Color::WHITE)
+                .child(text(caption))
+                .into_any(),
+        ])
+        .into_any()
+}
+
+fn main() {
+    env_logger::init();
+
+    App::new().run(|app| {
+        app.add_surface(
+            SurfaceConfig::new()
+                .width(900)
+                .height(240)
+                .anchor(Anchor::TOP)
+                .margin([100, 0, 0, 0])
+                .namespace("guido-blur-transforms")
+                .layer(Layer::Overlay)
+                .exclusive_zone(ExclusiveZone::None)
+                .background_color(Color::TRANSPARENT),
+            move || {
+                container()
+                    .width(fill())
+                    .height(fill())
+                    .layout(ZStack::new())
+                    .children([
+                        stripes().into_any(),
+                        container()
+                            .width(fill())
+                            .height(fill())
+                            .layout(
+                                Flex::row()
+                                    .main_alignment(MainAlignment::Center)
+                                    .cross_alignment(CrossAlignment::Center),
+                            )
+                            .children([
+                                // A translated box is the same box somewhere
+                                // else, so its bounding box is itself.
+                                case("translated 30, 12", card().translate(30.0, 12.0)),
+                                // A uniformly scaled one likewise — and its
+                                // corners grow with it, or the region cuts a
+                                // curve the card does not have.
+                                case("scaled 1.4x", card().scale(1.4)),
+                                // Unevenly scaled: still axis-aligned, so still
+                                // exact, but the corner is now an ellipse.
+                                case("scaled 1.6x / 0.8x", card().scale_xy(1.6, 0.8)),
+                                // A rotation is the one that does not keep the
+                                // axes: the bounding box gains the four corner
+                                // triangles, and the mask has no transform to
+                                // cut them back out with.
+                                case("rotated 20°", card().rotate(20.0)),
+                            ])
+                            .into_any(),
+                    ])
+            },
+        );
+    });
+}

--- a/examples/children_example.rs
+++ b/examples/children_example.rs
@@ -345,7 +345,7 @@ fn main() {
                                 })
                                 .child(container().text_color(Color::WHITE).child(text("Static 2")))
                                 .child(move || {
-                                    show_optional.get().then(|| container()
+                                    show_optional2.get().then(|| container()
                                         .padding(6.0)
                                         .background(Color::rgb(0.3, 0.2, 0.5))
                                         .corner_radius(4.0)

--- a/examples/component_example.rs
+++ b/examples/component_example.rs
@@ -14,7 +14,7 @@ pub fn button(
         .corner_radius(6.0)
         .when_hovered(|s| s.lighter(0.1))
         .when_pressed(|s| s.ripple())
-        .on_click_option(on_click)
+        .on_click(on_click)
         .text_color(Color::WHITE)
         .child(text(label))
 }

--- a/examples/component_example.rs
+++ b/examples/component_example.rs
@@ -4,8 +4,8 @@ use guido::prelude::*;
 #[component]
 pub fn button(
     label: String,
-    #[prop(default = "Color::rgb(0.3, 0.3, 0.4)")] background: Color,
-    #[prop(default = "Padding::all(8.0)")] padding: Padding,
+    #[prop(default = Color::rgb(0.3, 0.3, 0.4))] background: Color,
+    #[prop(default = Padding::all(8.0))] padding: Padding,
     #[prop(callback)] on_click: (),
 ) -> impl Widget {
     container()
@@ -23,7 +23,7 @@ pub fn button(
 #[component]
 pub fn card(
     title: String,
-    #[prop(default = "Color::rgb(0.18, 0.18, 0.22)")] background: Color,
+    #[prop(default = Color::rgb(0.18, 0.18, 0.22))] background: Color,
     #[prop(children)] children: (),
 ) -> impl Widget {
     container()

--- a/examples/elevation_example.rs
+++ b/examples/elevation_example.rs
@@ -13,23 +13,24 @@ fn main() {
     App::new().run(|app| {
         app.add_surface(
             SurfaceConfig::new()
-                .width(600)
-                .height(280)
+                .width(1200)
+                .height(700)
                 .anchor(Anchor::TOP | Anchor::LEFT)
                 .background_color(Color::rgb(0.85, 0.85, 0.9)),
             || {
                 container()
-                    .layout(Flex::column().spacing(16.0))
+                    .padding(48.0)
+                    .layout(Flex::column().spacing(48.0))
                     // Declared once: the cards below inherit it through the
                     // rows, and row 3 overrides it per card.
                     .text_color(Color::rgb(0.2, 0.2, 0.2))
                     .child(
                         // Row 1: Basic elevation levels
                         container()
-                            .layout(Flex::row().spacing(16.0))
+                            .layout(Flex::row().spacing(48.0))
                             .child(
                                 container()
-                                    .padding(16.0)
+                                    .padding(28.0)
                                     .background(Color::WHITE)
                                     .corner_radius(8.0)
                                     .elevation(0.0)
@@ -37,7 +38,7 @@ fn main() {
                             )
                             .child(
                                 container()
-                                    .padding(16.0)
+                                    .padding(28.0)
                                     .background(Color::WHITE)
                                     .corner_radius(8.0)
                                     .elevation(1.0)
@@ -45,7 +46,7 @@ fn main() {
                             )
                             .child(
                                 container()
-                                    .padding(16.0)
+                                    .padding(28.0)
                                     .background(Color::WHITE)
                                     .corner_radius(8.0)
                                     .elevation(2.0)
@@ -53,7 +54,7 @@ fn main() {
                             )
                             .child(
                                 container()
-                                    .padding(16.0)
+                                    .padding(28.0)
                                     .background(Color::WHITE)
                                     .corner_radius(8.0)
                                     .elevation(3.0)
@@ -63,10 +64,10 @@ fn main() {
                     .child(
                         // Row 2: Higher elevation levels
                         container()
-                            .layout(Flex::row().spacing(16.0))
+                            .layout(Flex::row().spacing(48.0))
                             .child(
                                 container()
-                                    .padding(16.0)
+                                    .padding(28.0)
                                     .background(Color::WHITE)
                                     .corner_radius(8.0)
                                     .elevation(4.0)
@@ -74,7 +75,7 @@ fn main() {
                             )
                             .child(
                                 container()
-                                    .padding(16.0)
+                                    .padding(28.0)
                                     .background(Color::WHITE)
                                     .corner_radius(8.0)
                                     .elevation(5.0)
@@ -82,7 +83,7 @@ fn main() {
                             )
                             .child(
                                 container()
-                                    .padding(16.0)
+                                    .padding(28.0)
                                     .background(Color::WHITE)
                                     .corner_radius(8.0)
                                     .elevation(7.0)
@@ -90,7 +91,7 @@ fn main() {
                             )
                             .child(
                                 container()
-                                    .padding(16.0)
+                                    .padding(28.0)
                                     .background(Color::WHITE)
                                     .corner_radius(8.0)
                                     .elevation(10.0)
@@ -100,10 +101,10 @@ fn main() {
                     .child(
                         // Row 3: Colored cards with elevation
                         container()
-                            .layout(Flex::row().spacing(16.0))
+                            .layout(Flex::row().spacing(48.0))
                             .child(
                                 container()
-                                    .padding(16.0)
+                                    .padding(28.0)
                                     .background(Color::rgb(0.9, 0.7, 0.7))
                                     .corner_radius(12.0)
                                     .elevation(2.0)
@@ -112,7 +113,7 @@ fn main() {
                             )
                             .child(
                                 container()
-                                    .padding(16.0)
+                                    .padding(28.0)
                                     .background(Color::rgb(0.7, 0.9, 0.7))
                                     .corner_radius(12.0)
                                     .elevation(3.0)
@@ -121,7 +122,7 @@ fn main() {
                             )
                             .child(
                                 container()
-                                    .padding(16.0)
+                                    .padding(28.0)
                                     .background(Color::rgb(0.7, 0.7, 0.9))
                                     .corner_radius(12.0)
                                     .elevation(4.0)
@@ -132,10 +133,10 @@ fn main() {
                     .child(
                         // Row 4: Squircle with elevation
                         container()
-                            .layout(Flex::row().spacing(16.0))
+                            .layout(Flex::row().spacing(48.0))
                             .child(
                                 container()
-                                    .padding(16.0)
+                                    .padding(28.0)
                                     .background(Color::rgb(0.95, 0.95, 0.95))
                                     .corner_radius(16.0)
                                     .squircle()
@@ -144,7 +145,7 @@ fn main() {
                             )
                             .child(
                                 container()
-                                    .padding(16.0)
+                                    .padding(28.0)
                                     .background(Color::rgb(0.95, 0.95, 0.95))
                                     .corner_radius(16.0)
                                     .squircle()
@@ -153,7 +154,7 @@ fn main() {
                             )
                             .child(
                                 container()
-                                    .padding(16.0)
+                                    .padding(28.0)
                                     .background(Color::rgb(0.95, 0.95, 0.95))
                                     .corner_radius(16.0)
                                     .squircle()

--- a/examples/incremental_layout_test.rs
+++ b/examples/incremental_layout_test.rs
@@ -22,7 +22,7 @@ async fn main() {
         // A label that changes text — and therefore size — 10 times a second
         let ticks = create_signal(0u32);
         let ticks_w = ticks.writer();
-        let _ = create_service::<(), _, _>(move |_rx, ctx| async move {
+        create_task(move |ctx| async move {
             while ctx.is_running() {
                 ticks_w.update(|t| *t += 1);
                 tokio::time::sleep(std::time::Duration::from_millis(100)).await;

--- a/examples/popup_example.rs
+++ b/examples/popup_example.rs
@@ -98,8 +98,7 @@ fn main() {
                                     if popup.dismissed() {
                                         menu_open.set(false);
                                     }
-                                })
-                                .detach();
+                                });
 
                                 *popup_slot.borrow_mut() = Some(popup);
                             })

--- a/examples/popup_example.rs
+++ b/examples/popup_example.rs
@@ -3,6 +3,13 @@
 //! Clicking the button opens a grabbed popup under it — the compositor
 //! positions it (flipping/sliding at screen edges) and dismisses it when
 //! you click anywhere outside. No fullscreen overlay involved.
+//!
+//! "Settings ▸" opens a **nested** popup, parented to the first one rather than
+//! to the bar. That is the case with the sharpest failure: a popup must be
+//! destroyed before its parent or the compositor raises `not_the_topmost_popup`
+//! and closes the connection, so getting the teardown order wrong does not draw
+//! something odd, it kills the application. Worth reaching by hand — dismiss the
+//! pair with one outside click, and close the parent while the child is open.
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -18,12 +25,81 @@ fn menu_entry(label: &str) -> Container {
         .child(text(label))
 }
 
+/// The entry that opens a popup parented to the popup it lives in.
+///
+/// The parent arrives through a slot rather than by value: the factory that
+/// builds a popup's content runs *before* `spawn_popup` hands back its handle,
+/// so at the time this entry is built its own parent does not exist yet.
+fn submenu_entry(parent: Rc<RefCell<Option<PopupHandle>>>, open: RwSignal<bool>) -> Container {
+    let entry_ref = create_widget_ref();
+    let child_slot: Rc<RefCell<Option<PopupHandle>>> = Rc::new(RefCell::new(None));
+
+    container()
+        .widget_ref(entry_ref)
+        .padding([8.0, 12.0])
+        .corner_radius(6.0)
+        .when_hovered(|s| s.lighter(0.12))
+        .font_size(13)
+        .on_click(move || {
+            if open.get() {
+                if let Some(child) = child_slot.borrow_mut().take() {
+                    child.close();
+                }
+                return;
+            }
+
+            let Some(parent_id) = parent.borrow().as_ref().map(|p| p.id()) else {
+                return;
+            };
+
+            // Parented to the popup, not to the bar: that is what makes it a
+            // nested one, and what puts it above its parent in the grab chain.
+            let child = spawn_popup(
+                parent_id,
+                PopupConfig::new(180)
+                    .anchor_rect(entry_ref.rect().get())
+                    .anchor(PopupAnchor::Right)
+                    .gravity(PopupGravity::Right)
+                    .grab()
+                    .background_color(Color::TRANSPARENT),
+                || {
+                    container()
+                        .width(fill())
+                        .background(Color::rgb(0.16, 0.16, 0.24))
+                        .corner_radius(10.0)
+                        .padding(8.0)
+                        .layout(Flex::column().spacing(2.0))
+                        .child(menu_entry("Appearance"))
+                        .child(menu_entry("Keyboard"))
+                        .child(menu_entry("Network"))
+                },
+            );
+            open.set(true);
+
+            create_effect(move || {
+                if child.dismissed() {
+                    open.set(false);
+                }
+            });
+
+            *child_slot.borrow_mut() = Some(child);
+        })
+        .child(text(move || {
+            if open.get() {
+                "Settings ◂".to_string()
+            } else {
+                "Settings ▸".to_string()
+            }
+        }))
+}
+
 fn main() {
     env_logger::init();
 
     App::new().run(|app| {
         let button_ref = create_widget_ref();
         let menu_open = create_signal(false);
+        let submenu_open = create_signal(false);
         let popup_slot: Rc<RefCell<Option<PopupHandle>>> = Rc::new(RefCell::new(None));
         // The bar id is only known after add_surface returns; the click
         // handler runs later, so a slot is enough.
@@ -37,6 +113,9 @@ fn main() {
                 .background_color(Color::rgb(0.1, 0.1, 0.15)),
             move || {
                 let popup_slot = popup_slot.clone();
+                // The same slot the parent handle lands in: the submenu reads
+                // it at click time, by which point it holds its parent.
+                let popup_slot_for_child = popup_slot.clone();
                 container()
                     .width(fill())
                     .layout(
@@ -75,19 +154,22 @@ fn main() {
                                         .gravity(PopupGravity::Top)
                                         .grab()
                                         .background_color(Color::TRANSPARENT),
-                                    || {
-                                        // Auto-height popup: the content
-                                        // wraps, no fill-height here
-                                        container()
-                                            .width(fill())
-                                            .background(Color::rgb(0.13, 0.13, 0.2))
-                                            .corner_radius(10.0)
-                                            .padding(8.0)
-                                            .layout(Flex::column().spacing(2.0))
-                                            .child(menu_entry("Profile"))
-                                            .child(menu_entry("Settings"))
-                                            .child(menu_entry("About"))
-                                            .child(menu_entry("Quit"))
+                                    {
+                                        let submenu_parent = popup_slot_for_child.clone();
+                                        move || {
+                                            // Auto-height popup: the content
+                                            // wraps, no fill-height here
+                                            container()
+                                                .width(fill())
+                                                .background(Color::rgb(0.13, 0.13, 0.2))
+                                                .corner_radius(10.0)
+                                                .padding(8.0)
+                                                .layout(Flex::column().spacing(2.0))
+                                                .child(menu_entry("Profile"))
+                                                .child(submenu_entry(submenu_parent, submenu_open))
+                                                .child(menu_entry("About"))
+                                                .child(menu_entry("Quit"))
+                                        }
                                     },
                                 );
                                 menu_open.set(true);

--- a/examples/render_stats_test.rs
+++ b/examples/render_stats_test.rs
@@ -19,7 +19,7 @@ async fn main() {
 
         // Continuously update rotation to force frame rendering
         let rotation_w = rotation.writer();
-        let _ = create_service::<(), _, _>(move |_rx, ctx| async move {
+        create_task(move |ctx| async move {
             while ctx.is_running() {
                 rotation_w.update(|r| *r += 1.0);
                 tokio::time::sleep(std::time::Duration::from_millis(16)).await; // ~60fps

--- a/examples/service_example.rs
+++ b/examples/service_example.rs
@@ -24,7 +24,7 @@ async fn main() {
         let time_w = time.writer(); // WriteSignal is Send — can be captured by service
 
         // Clock service - read-only (ignore the receiver)
-        let _ = create_service::<(), _, _>(move |_rx, ctx| async move {
+        create_task(move |ctx| async move {
             log::info!("Clock service started");
 
             while ctx.is_running() {

--- a/examples/simple_lock.rs
+++ b/examples/simple_lock.rs
@@ -21,7 +21,7 @@ fn lock_screen(output: OutputInfo) -> Container {
     // Safety net for an example: never leave the user locked out.
     let auto_unlock = create_signal(false);
     let auto_unlock_w = auto_unlock.writer();
-    let _ = create_service::<(), _, _>(move |_rx, ctx| async move {
+    create_task(move |ctx| async move {
         tokio::time::sleep(Duration::from_secs(30)).await;
         if ctx.is_running() {
             auto_unlock_w.set(true);

--- a/examples/surface_runtime.rs
+++ b/examples/surface_runtime.rs
@@ -1,0 +1,293 @@
+//! Changing a surface's anchor, size, margin and reservation at runtime.
+//!
+//! These four are the ones an `ExclusiveZone::Auto` reservation follows: it
+//! resolves to the extent of the anchored axis plus that edge's margin, so
+//! moving any of them moves it, and the anchor also decides *which* axis it
+//! follows and which axes the compositor owns.
+//!
+//! They are also the ones with the sharp edges. `zwlr_layer_surface_v1` makes a
+//! size of zero on an axis not anchored to opposite edges a protocol error, and
+//! a non-zero one on an axis that *is* hands back a dimension the compositor
+//! owns — so the anchor and the size have to be sent together or the connection
+//! is closed at the next commit. A `content()` axis has no size until it has
+//! been measured, so a reservation that follows one has to wait for the measure
+//! rather than resolve against whatever the compositor last confirmed.
+//!
+//! Watch the strip of desktop this bar reserves: it should always match the
+//! edge the bar is on and the size it is drawn at. **Sweep margin** drives the
+//! same command every frame, which is where a missing commit or a missing
+//! re-measure shows up as a reservation drifting away from the bar.
+
+use std::time::Duration;
+
+use guido::prelude::*;
+
+#[derive(Clone, Copy, PartialEq)]
+enum Zone {
+    Auto,
+    Fixed,
+    None,
+    Ignore,
+}
+
+impl Zone {
+    fn next(self) -> Self {
+        match self {
+            Zone::Auto => Zone::Fixed,
+            Zone::Fixed => Zone::None,
+            Zone::None => Zone::Ignore,
+            Zone::Ignore => Zone::Auto,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Zone::Auto => "Auto",
+            Zone::Fixed => "Fixed(60)",
+            Zone::None => "None",
+            Zone::Ignore => "Ignore",
+        }
+    }
+
+    fn value(self) -> ExclusiveZone {
+        match self {
+            Zone::Auto => ExclusiveZone::Auto,
+            Zone::Fixed => ExclusiveZone::Fixed(60),
+            Zone::None => ExclusiveZone::None,
+            Zone::Ignore => ExclusiveZone::Ignore,
+        }
+    }
+}
+
+/// The handle for a surface whose id arrives after its widgets are built.
+fn handle(surface: RwSignal<Option<SurfaceId>>) -> SurfaceHandle {
+    surface_handle(
+        surface
+            .get_untracked()
+            .expect("the surface id is set once `add_surface` returns"),
+    )
+}
+
+fn button<M>(label: impl IntoSignal<String, M>, on_click: impl Fn() + 'static) -> AnyWidget {
+    container()
+        .padding([6.0, 12.0])
+        .background(Color::rgb(0.22, 0.24, 0.34))
+        .corner_radius(6.0)
+        .text_color(Color::WHITE)
+        .font_size(13.0)
+        .when_hovered(|s| s.lighter(0.10))
+        .when_pressed(|s| s.ripple())
+        .on_click(on_click)
+        .child(text(label))
+        .into_any()
+}
+
+fn main() {
+    env_logger::init();
+
+    App::new().run(|app| {
+        // What the bar currently is, so the captions can say it and the buttons
+        // can toggle it. The surface itself is the source of truth; these mirror
+        // what was last asked for.
+        let top_bar = create_signal(true);
+        let fixed_size = create_signal(true);
+        let zone = create_signal(Zone::Auto);
+        let margin = create_signal(0i32);
+        let sweeping = create_signal(false);
+        let tall = create_signal(false);
+        // `add_surface` hands the id back, and the widget closure runs later —
+        // so the closures reach it through a signal rather than by capture.
+        let surface = create_signal(None::<SurfaceId>);
+
+        let id = app.add_surface(
+            SurfaceConfig::new()
+                // Both axes named, because the anchor decides which one is ours
+                // and the other's number is what gets sent when it stops being
+                // the compositor's. Leaving one to `SurfaceConfig`'s default
+                // means a re-anchoring reserves a width nobody chose.
+                .width(220)
+                .height(56)
+                .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+                .exclusive_zone(ExclusiveZone::Auto)
+                .namespace("guido-surface-runtime")
+                .layer(Layer::Top)
+                .keyboard_interactivity(KeyboardInteractivity::OnDemand)
+                .background_color(Color::rgb(0.10, 0.11, 0.16)),
+            move || {
+                let controls = move || {
+                    [
+                        // The anchor decides which axis the reservation follows
+                        // and which axes are the compositor's, so the size has
+                        // to travel with it.
+                        button(
+                            move || {
+                                if top_bar.get() {
+                                    "anchor: top bar".to_owned()
+                                } else {
+                                    "anchor: left dock".to_owned()
+                                }
+                            },
+                            move || {
+                                top_bar.update(|t| *t = !*t);
+                                handle(surface).set_anchor(if top_bar.get() {
+                                    Anchor::TOP | Anchor::LEFT | Anchor::RIGHT
+                                } else {
+                                    Anchor::LEFT | Anchor::TOP | Anchor::BOTTOM
+                                });
+                            },
+                        ),
+                        // `content()` has no size until it has been measured,
+                        // and asking for its 1px placeholder collapses the
+                        // surface with nothing to bring it back.
+                        button(
+                            move || {
+                                if fixed_size.get() {
+                                    "size: fixed".to_owned()
+                                } else {
+                                    "size: content()".to_owned()
+                                }
+                            },
+                            move || {
+                                fixed_size.update(|f| *f = !*f);
+                                let h = handle(surface);
+                                if fixed_size.get() {
+                                    h.set_size(220, 56);
+                                } else {
+                                    h.set_size(content(), content());
+                                }
+                            },
+                        ),
+                        // An `Auto` reservation is the extent *plus* this, so
+                        // moving it has to move the reservation with it.
+                        button(
+                            move || format!("margin: {}", margin.get()),
+                            move || {
+                                margin.update(|m| *m = (*m + 8) % 40);
+                                handle(surface).set_margin(margin.get());
+                            },
+                        ),
+                        // Only `Auto` reads a size; the other three are numbers
+                        // that must reach the compositor whatever the size is
+                        // doing.
+                        button(
+                            move || format!("zone: {}", zone.get().label()),
+                            move || {
+                                zone.update(|z| *z = z.next());
+                                handle(surface).set_exclusive_zone(zone.get().value());
+                            },
+                        ),
+                        // The same command every frame: where a missing commit
+                        // or a missing re-measure shows as the reservation
+                        // drifting away from the bar.
+                        button(
+                            move || {
+                                if sweeping.get() {
+                                    "sweep margin: on".to_owned()
+                                } else {
+                                    "sweep margin: off".to_owned()
+                                }
+                            },
+                            move || sweeping.update(|s| *s = !*s),
+                        ),
+                        // With `size: content()` and `zone: Auto` this is the
+                        // question the two of them answer together: the bar's
+                        // own content grows over 400ms, so the measure has to
+                        // run on frame after frame and the reservation follow it
+                        // the whole way rather than jumping at the end.
+                        button(
+                            move || {
+                                if tall.get() {
+                                    "grow: 150".to_owned()
+                                } else {
+                                    "grow: 50".to_owned()
+                                }
+                            },
+                            move || tall.update(|t| *t = !*t),
+                        ),
+                    ]
+                };
+
+                container()
+                    // Reactive, because a `content()` surface has nothing for a
+                    // `fill()` to fill: it would expand into the whole incoming
+                    // constraint and take the surface with it. A default
+                    // `Length` is "as large as what is inside".
+                    .width(move || {
+                        if fixed_size.get() {
+                            fill()
+                        } else {
+                            Length::default()
+                        }
+                    })
+                    .height(move || {
+                        if fixed_size.get() {
+                            fill()
+                        } else {
+                            Length::default()
+                        }
+                    })
+                    .padding([6.0, 10.0])
+                    // `layout` is a structural declaration and takes no signal —
+                    // the rule this library settled on — so a bar that becomes a
+                    // dock swaps the container rather than the layout inside it.
+                    .child(move || {
+                        let row = Flex::row()
+                            .spacing(8.0)
+                            .cross_alignment(CrossAlignment::Center);
+                        let column = Flex::column()
+                            .spacing(8.0)
+                            .cross_alignment(CrossAlignment::Start);
+                        // The animated block sits beside the controls, so a
+                        // `content()` surface has something whose size moves.
+                        let grown = container()
+                            .width(120.0)
+                            .height(move || if tall.get() { 150.0 } else { 50.0 })
+                            .animate_height(Transition::new(400.0, TimingFunction::EaseOut))
+                            .background(Color::rgb(0.30, 0.45, 0.35))
+                            .corner_radius(6.0)
+                            .into_any();
+                        if top_bar.get() {
+                            container()
+                                .layout(row)
+                                .children(controls())
+                                .child(grown)
+                                .into_any()
+                        } else {
+                            container()
+                                .layout(column)
+                                .children(controls())
+                                .child(grown)
+                                .into_any()
+                        }
+                    })
+            },
+        );
+
+        surface.set(Some(id));
+
+        // A background task cannot touch a signal or a handle — its future has
+        // to be `Send` and neither is — so it only beats time through a
+        // `WriteSignal`, and an effect on the main thread does the driving.
+        let tick = create_signal(0u32);
+        let tick_w = tick.writer();
+        create_task(move |ctx| async move {
+            while ctx.is_running() {
+                tokio::time::sleep(Duration::from_millis(16)).await;
+                tick_w.update(|t| *t = t.wrapping_add(1));
+            }
+        });
+
+        create_effect(move || {
+            let t = tick.get();
+            if !sweeping.get() {
+                return;
+            }
+            // A triangle wave, so the margin is always moving and the same
+            // command is sent on frame after frame.
+            let step = t % 120;
+            let m = if step < 60 { step } else { 120 - step } as i32;
+            margin.set(m / 2);
+            handle(surface).set_margin(margin.get());
+        });
+    });
+}

--- a/examples/test_dynamic.rs
+++ b/examples/test_dynamic.rs
@@ -15,7 +15,7 @@ async fn main() {
 
         // Create a service that adds an item after 2 seconds
         let items_w = items.writer();
-        let _ = create_service::<(), _, _>(move |_rx, ctx| async move {
+        create_task(move |ctx| async move {
             tokio::time::sleep(Duration::from_secs(2)).await;
             if ctx.is_running() && !ADD_TRIGGERED.swap(true, Ordering::SeqCst) {
                 items_w.update(|list| {

--- a/examples/text_transform_example.rs
+++ b/examples/text_transform_example.rs
@@ -22,7 +22,7 @@ async fn main() {
         // Animation service - updates the angle signal continuously
         let start_time = std::time::Instant::now();
         let angle_w = angle.writer();
-        let _ = create_service::<(), _, _>(move |_rx, ctx| async move {
+        create_task(move |ctx| async move {
             while ctx.is_running() {
                 let elapsed = start_time.elapsed().as_secs_f32();
                 let new_angle = (elapsed * PI / 2.0).to_degrees() % 360.0;

--- a/examples/transform_origin_test.rs
+++ b/examples/transform_origin_test.rs
@@ -13,7 +13,7 @@ async fn main() {
         // Animation service - updates the angle signal continuously
         let start_time = std::time::Instant::now();
         let angle_w = angle.writer();
-        let _ = create_service::<(), _, _>(move |_rx, ctx| async move {
+        create_task(move |ctx| async move {
             while ctx.is_running() {
                 let elapsed = start_time.elapsed().as_secs_f32();
                 let new_angle = (elapsed * 45.0) % 360.0; // 45 degrees per second

--- a/guido-macros/src/lib.rs
+++ b/guido-macros/src/lib.rs
@@ -10,7 +10,7 @@ use syn::{DeriveInput, Expr, Fields, ItemFn, Meta, Type, TypeBareFn, parse_macro
 ///
 /// # Attributes on parameters
 /// - No attribute — standard prop, `Signal<T>`, default = `create_stored(Default::default())`
-/// - `#[prop(default = "expr")]` — standard prop with custom default
+/// - `#[prop(default = <expr>)]` — standard prop with custom default
 /// - `#[prop(callback)]` — callback prop. Use `()` for `Fn()`, or `fn(T1, T2)` for typed params
 /// - `#[prop(children)]` — children support via `ChildrenSource`
 /// - `#[prop(slot)]` — named widget slot
@@ -20,9 +20,9 @@ use syn::{DeriveInput, Expr, Fields, ItemFn, Meta, Type, TypeBareFn, parse_macro
 /// #[component]
 /// pub fn button(
 ///     label: String,
-///     #[prop(default = "Color::rgb(0.3, 0.3, 0.4)")]
+///     #[prop(default = Color::rgb(0.3, 0.3, 0.4))]
 ///     background: Color,
-///     #[prop(default = "8.0")]
+///     #[prop(default = 8.0)]
 ///     padding: f32,
 ///     #[prop(callback)]
 ///     on_click: (),
@@ -107,29 +107,12 @@ pub fn component(_attr: TokenStream, input: TokenStream) -> TokenStream {
                 } else if meta.path().is_ident("slot") {
                     is_slot = true;
                 } else if meta.path().is_ident("default") {
+                    // The value is an ordinary Rust expression. It used to be
+                    // accepted quoted as well, which made a string literal
+                    // unspellable: `default = "Guest"` parsed its own contents
+                    // and asked for a variable called Guest.
                     if let Meta::NameValue(nv) = meta {
-                        // If the value is a string literal, parse its contents as an expression.
-                        // This supports `#[prop(default = "Color::RED")]` syntax where the string
-                        // contains arbitrary Rust expressions.
-                        if let Expr::Lit(syn::ExprLit {
-                            lit: syn::Lit::Str(lit_str),
-                            ..
-                        }) = &nv.value
-                        {
-                            match lit_str.parse::<Expr>() {
-                                Ok(expr) => default_value = Some(expr),
-                                Err(e) => {
-                                    return syn::Error::new_spanned(
-                                        lit_str,
-                                        format!("failed to parse default value: {e}"),
-                                    )
-                                    .to_compile_error()
-                                    .into();
-                                }
-                            }
-                        } else {
-                            default_value = Some(nv.value.clone());
-                        }
+                        default_value = Some(nv.value.clone());
                     } else {
                         return syn::Error::new_spanned(meta, "expected `default = <expr>`")
                             .to_compile_error()

--- a/guido-macros/src/lib.rs
+++ b/guido-macros/src/lib.rs
@@ -30,7 +30,7 @@ use syn::{DeriveInput, Expr, Fields, ItemFn, Meta, Type, TypeBareFn, parse_macro
 ///     container()
 ///         .padding(padding) // Signal<f32> is Copy, no clone needed
 ///         .background(background) // Signal<Color> is Copy
-///         .on_click_option(on_click.clone())
+///         .on_click(on_click)
 ///         .child(text(label).color(Color::WHITE))
 /// }
 /// ```

--- a/guido-macros/src/lib.rs
+++ b/guido-macros/src/lib.rs
@@ -92,11 +92,19 @@ pub fn component(_attr: TokenStream, input: TokenStream) -> TokenStream {
         if let Some(prop_attr) = prop_attr
             && let Meta::List(meta_list) = &prop_attr.meta
         {
-            let nested = meta_list
-                .parse_args_with(
-                    syn::punctuated::Punctuated::<Meta, syn::Token![,]>::parse_terminated,
-                )
-                .unwrap_or_default();
+            // Reported, not swallowed. An unparseable list used to yield an
+            // empty one, so a `#[prop(...)]` with a typo in it compiled as a
+            // plain `Signal<T>` with `Default::default()` — taking `callback`,
+            // `children` and `slot` on the same attribute down with it, and
+            // leaving a component silently unwired instead of failing to build.
+            // `default` now takes a raw expression, which is a great deal easier
+            // to write wrong than the string it used to be.
+            let nested = match meta_list.parse_args_with(
+                syn::punctuated::Punctuated::<Meta, syn::Token![,]>::parse_terminated,
+            ) {
+                Ok(nested) => nested,
+                Err(err) => return err.to_compile_error().into(),
+            };
 
             for meta in &nested {
                 if meta.path().is_ident("callback") {

--- a/src/animation/animatable.rs
+++ b/src/animation/animatable.rs
@@ -26,7 +26,7 @@ pub trait Animatable: Copy + PartialEq + Send + Sync + 'static {
 
     /// The value as the vector of numbers the animation interpolates.
     ///
-    /// Only [`carry_velocity`] reads this, and only as a direction: a spring's
+    /// Only `carry_velocity` reads this, and only as a direction: a spring's
     /// momentum is a vector in this space, and what a new segment inherits is
     /// the part of it pointing along itself. The channels may be in different
     /// units — `Transform` mixes pixels with unitless coefficients — and that

--- a/src/animation/mod.rs
+++ b/src/animation/mod.rs
@@ -7,7 +7,7 @@ pub(crate) use animatable::carry_velocity;
 pub use animatable::{Animatable, Channels};
 pub use keyframes::Keyframes;
 pub use spring::{SpringConfig, SpringState};
-pub use timing::TimingFunction;
+pub use timing::{CustomCurve, TimingFunction};
 
 /// Configuration for how a property should animate when it changes
 #[derive(Clone)]

--- a/src/animation/spring.rs
+++ b/src/animation/spring.rs
@@ -89,7 +89,19 @@ impl SpringConfig {
             return 0.0;
         }
         let zeta = self.damping / denominator;
-        if zeta >= 1.0 || zeta <= 0.0 {
+        if zeta < 0.0 {
+            // Negative damping is not a spring, it is an explosion. Nothing
+            // bounds it, so it reports nothing rather than a number a caller
+            // would size a rect from.
+            return 0.0;
+        }
+        if zeta == 0.0 {
+            // Undamped: it swings the whole way past its target, forever. The
+            // formula below is the limit of exactly this, and reporting zero for
+            // the spring that overshoots *most* was the wrong way round.
+            return 1.0;
+        }
+        if zeta >= 1.0 {
             return 0.0;
         }
         (-std::f32::consts::PI * zeta / (1.0 - zeta * zeta).sqrt()).exp()
@@ -249,6 +261,26 @@ mod overshoot_tests {
                 "{config:?} documents {documented} and computes {computed}"
             );
         }
+    }
+
+    /// The spring that oscillates most reported the least. Undamped, it swings
+    /// the whole way past its target and keeps doing it, so anything sizing a
+    /// bound from the target has to be told that.
+    #[test]
+    fn an_undamped_spring_reports_a_full_overshoot() {
+        let undamped = SpringConfig {
+            mass: 1.0,
+            stiffness: 100.0,
+            damping: 0.0,
+        };
+        assert_eq!(undamped.peak_overshoot(), 1.0);
+
+        // And it is the limit the formula approaches, so nothing jumps at zero.
+        let nearly = SpringConfig {
+            damping: 0.02,
+            ..undamped
+        };
+        assert!(nearly.peak_overshoot() > 0.99);
     }
 
     /// A critically damped or overdamped spring never passes its target.

--- a/src/animation/spring.rs
+++ b/src/animation/spring.rs
@@ -283,6 +283,40 @@ mod overshoot_tests {
         assert!(nearly.peak_overshoot() > 0.99);
     }
 
+    /// A spring that starts already moving goes further than one released from
+    /// rest, so the step-response figure `peak_overshoot` reports is *not* a
+    /// bound for a retargeted animation — `retarget` restarts the spring with
+    /// the velocity it was carrying.
+    ///
+    /// This is why anything sizing a rect from that figure has to clamp what it
+    /// draws to it rather than assume the value stays inside: see
+    /// `Container::animated_elevation`.
+    #[test]
+    fn a_spring_given_velocity_overshoots_more_than_one_at_rest() {
+        let config = SpringConfig::BOUNCY;
+        let reported = 1.0 + config.peak_overshoot();
+
+        let peak_of = |initial_velocity: f32| {
+            let mut state = SpringState::moving_at(initial_velocity);
+            let mut elapsed = 0.0f32;
+            let mut peak = 0.0f32;
+            // Finely enough to catch the peak rather than a point beside it.
+            for _ in 0..4000 {
+                elapsed += 1.0 / 480.0;
+                peak = peak.max(state.step(elapsed, &config));
+            }
+            peak
+        };
+
+        assert!(peak_of(0.0) <= reported + 0.01, "from rest it holds");
+
+        let carried = peak_of(16.0);
+        assert!(
+            carried > reported + 0.05,
+            "and carrying velocity it does not: {carried} against {reported}"
+        );
+    }
+
     /// A critically damped or overdamped spring never passes its target.
     #[test]
     fn a_spring_that_cannot_bounce_reports_nothing() {

--- a/src/animation/spring.rs
+++ b/src/animation/spring.rs
@@ -89,6 +89,14 @@ impl SpringConfig {
             return 0.0;
         }
         let zeta = self.damping / denominator;
+        if !zeta.is_finite() {
+            // A negative mass or stiffness makes the ratio NaN, and NaN fails
+            // every comparison below on its way to `exp`. A NaN here is not a
+            // number that stays here: it multiplies a damage reach, which sizes
+            // a rect, and `f32::min` hands back the *other* operand — so the
+            // clamp that reads the reach would quietly stop clamping too.
+            return 0.0;
+        }
         if zeta < 0.0 {
             // Negative damping is not a spring, it is an explosion. Nothing
             // bounds it, so it reports nothing rather than a number a caller
@@ -197,6 +205,35 @@ impl Default for SpringState {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A spring built from a nonsense config must not seed NaN into anything
+    /// that sizes a rect from it.
+    #[test]
+    fn an_impossible_spring_reports_no_overshoot_rather_than_nan() {
+        for config in [
+            SpringConfig {
+                mass: -1.0,
+                stiffness: 400.0,
+                damping: 20.0,
+            },
+            SpringConfig {
+                mass: 1.0,
+                stiffness: -400.0,
+                damping: 20.0,
+            },
+            SpringConfig {
+                mass: f32::NAN,
+                stiffness: 400.0,
+                damping: 20.0,
+            },
+        ] {
+            let overshoot = config.peak_overshoot();
+            assert!(
+                overshoot.is_finite(),
+                "{config:?} reported {overshoot}, which would poison a damage rect"
+            );
+        }
+    }
 
     #[test]
     fn test_spring_reaches_target() {

--- a/src/animation/spring.rs
+++ b/src/animation/spring.rs
@@ -71,6 +71,29 @@ impl SpringConfig {
         stiffness: 250.0,
         damping: 24.7,
     };
+
+    /// How far past its target this spring goes at the peak, as a fraction of
+    /// the distance travelled.
+    ///
+    /// The standard result for a second-order system:
+    /// `exp(-πζ / sqrt(1 - ζ²))` for a damping ratio `ζ = c / (2·sqrt(m·k))`
+    /// below 1, and nothing at all at or above it.
+    ///
+    /// Anything sizing a bound from an animation's *target* needs this, because
+    /// a spring does not stop there — a damage rect being the case that found
+    /// it, since the shadow at the peak falls outside a rect measured for the
+    /// resting value.
+    pub fn peak_overshoot(&self) -> f32 {
+        let denominator = 2.0 * (self.mass * self.stiffness).sqrt();
+        if denominator <= 0.0 {
+            return 0.0;
+        }
+        let zeta = self.damping / denominator;
+        if zeta >= 1.0 || zeta <= 0.0 {
+            return 0.0;
+        }
+        (-std::f32::consts::PI * zeta / (1.0 - zeta * zeta).sqrt()).exp()
+    }
 }
 
 /// State for spring physics simulation
@@ -201,5 +224,69 @@ mod tests {
             "Bouncy spring should overshoot, max was {}",
             max_position
         );
+    }
+}
+
+#[cfg(test)]
+mod overshoot_tests {
+    use super::*;
+
+    /// Each preset overshoots by about what its doc comment claims, so the two
+    /// cannot drift apart. The tolerance is a point and a half because the
+    /// comments round, `GENTLE` being the one that rounds up.
+    #[test]
+    fn the_presets_overshoot_by_what_they_say() {
+        let pairs = [
+            (SpringConfig::DEFAULT, 0.06),
+            (SpringConfig::BOUNCY, 0.17),
+            (SpringConfig::SNAPPY, 0.04),
+            (SpringConfig::GENTLE, 0.03),
+        ];
+        for (config, documented) in pairs {
+            let computed = config.peak_overshoot();
+            assert!(
+                (computed - documented).abs() < 0.015,
+                "{config:?} documents {documented} and computes {computed}"
+            );
+        }
+    }
+
+    /// A critically damped or overdamped spring never passes its target.
+    #[test]
+    fn a_spring_that_cannot_bounce_reports_nothing() {
+        let critical = SpringConfig {
+            mass: 1.0,
+            stiffness: 100.0,
+            damping: 20.0,
+        };
+        assert_eq!(critical.peak_overshoot(), 0.0);
+
+        let overdamped = SpringConfig {
+            mass: 1.0,
+            stiffness: 100.0,
+            damping: 40.0,
+        };
+        assert_eq!(overdamped.peak_overshoot(), 0.0);
+    }
+
+    /// A spring really does go past its target by about what it reports — the
+    /// step simulation is the thing being bounded, so it is what is checked.
+    #[test]
+    fn the_simulation_stays_within_the_reported_peak() {
+        for config in [SpringConfig::DEFAULT, SpringConfig::BOUNCY] {
+            let mut state = SpringState::new();
+            let mut peak = 0.0f32;
+            // `step` takes the total elapsed time, not a delta.
+            let mut elapsed = 0.0f32;
+            for _ in 0..2000 {
+                elapsed += 1.0 / 240.0;
+                peak = peak.max(state.step(elapsed, &config));
+            }
+            let bound = 1.0 + config.peak_overshoot();
+            assert!(
+                peak <= bound + 0.01 && peak > 1.0,
+                "{config:?} peaked at {peak}, bound {bound}"
+            );
+        }
     }
 }

--- a/src/animation/timing.rs
+++ b/src/animation/timing.rs
@@ -44,7 +44,6 @@ pub enum TimingFunction {
     CubicBezier(f32, f32, f32, f32),
     /// Spring physics simulation (can overshoot)
     Spring(SpringConfig),
-    /// Custom timing function
     /// Custom timing function, with how far it was measured to leave `[0, 1]`.
     ///
     /// The excursion is sampled once by [`custom`](TimingFunction::custom) and

--- a/src/animation/timing.rs
+++ b/src/animation/timing.rs
@@ -62,21 +62,27 @@ impl TimingFunction {
             TimingFunction::EaseInOut => ease_in_out(t),
             TimingFunction::CubicBezier(x1, y1, x2, y2) => cubic_bezier(t, *x1, *y1, *x2, *y2),
             TimingFunction::Spring(_) => t, // Springs handled separately with real time
-            TimingFunction::Custom(f) => f(t),
+            // Clamped, so `peak_overshoot` is a bound rather than a hope:
+            // anything sized from it — a damage rect, most of all — would
+            // otherwise be measured for less than what gets drawn.
+            TimingFunction::Custom(f) => f(t).min(1.0 + Self::CUSTOM_MAX_OVERSHOOT),
         }
     }
 
-    /// Create a custom timing function from a closure
     /// How far past 1.0 this curve can go, as a fraction of the distance
     /// travelled. Zero for every curve that only eases.
     ///
     /// A bezier is bounded by its control polygon, so its control points give
-    /// the bound directly. A [`Custom`](TimingFunction::Custom) curve is
-    /// arbitrary and cannot be asked, so it gets an allowance — generous enough
-    /// for anything written to look like a spring, and documented as the one
-    /// case that is a bound rather than a fact.
+    /// the bound directly, and a spring's physics give it exactly.
+    ///
+    /// A [`Custom`](TimingFunction::Custom) curve is an arbitrary closure and
+    /// cannot be asked, so it is **clamped** to
+    /// [`CUSTOM_MAX_OVERSHOOT`](Self::CUSTOM_MAX_OVERSHOOT) by
+    /// [`evaluate`](Self::evaluate) rather than merely assumed to respect it. A
+    /// bound nothing enforces is not a bound: a hand-rolled bounce peaking at
+    /// 1.5 would have had its damage rect measured for 1.25, leaving the ring
+    /// between the two outside every one of them.
     pub fn peak_overshoot(&self) -> f32 {
-        const CUSTOM_ALLOWANCE: f32 = 0.25;
         match self {
             TimingFunction::Linear
             | TimingFunction::EaseIn
@@ -84,10 +90,16 @@ impl TimingFunction {
             | TimingFunction::EaseInOut => 0.0,
             TimingFunction::CubicBezier(_, y1, _, y2) => (y1.max(*y2) - 1.0).max(0.0),
             TimingFunction::Spring(config) => config.peak_overshoot(),
-            TimingFunction::Custom(_) => CUSTOM_ALLOWANCE,
+            TimingFunction::Custom(_) => Self::CUSTOM_MAX_OVERSHOOT,
         }
     }
 
+    /// How far past its target a [`Custom`](TimingFunction::Custom) curve is
+    /// allowed to go. Generous enough for anything written to look like a
+    /// spring, and enforced rather than trusted.
+    pub const CUSTOM_MAX_OVERSHOOT: f32 = 0.25;
+
+    /// Create a custom timing function from a closure.
     pub fn custom<F>(f: F) -> Self
     where
         F: Fn(f32) -> f32 + Send + Sync + 'static,
@@ -188,5 +200,45 @@ mod tests {
     fn test_ease_out() {
         let result = TimingFunction::EaseOut.evaluate(0.5);
         assert!(result > 0.5); // Should be faster at start
+    }
+}
+
+#[cfg(test)]
+mod overshoot_bound_tests {
+    use super::*;
+
+    /// A custom curve that goes further than the allowance is clamped to it, so
+    /// what `peak_overshoot` reports is a bound and not a hope. Anything sized
+    /// from that number — the damage rect an elevation shadow needs, above all —
+    /// would otherwise be measured for less than what is drawn.
+    #[test]
+    fn a_custom_curve_cannot_exceed_the_allowance_it_is_credited_with() {
+        let overzealous = TimingFunction::custom(|t| t * 1.5);
+        let bound = 1.0 + TimingFunction::CUSTOM_MAX_OVERSHOOT;
+
+        for step in 0..=100 {
+            let t = step as f32 / 100.0;
+            assert!(
+                overzealous.evaluate(t) <= bound + 1e-6,
+                "t = {t} evaluated past the bound"
+            );
+        }
+        assert_eq!(overzealous.evaluate(1.0), bound, "and reaches it");
+    }
+
+    /// The curves that only ease report nothing, and a bezier reports its own
+    /// control points.
+    #[test]
+    fn the_ordinary_curves_report_what_they_do() {
+        assert_eq!(TimingFunction::Linear.peak_overshoot(), 0.0);
+        assert_eq!(TimingFunction::EaseInOut.peak_overshoot(), 0.0);
+        assert!(
+            (TimingFunction::CubicBezier(0.34, 1.56, 0.64, 1.0).peak_overshoot() - 0.56).abs()
+                < 1e-5
+        );
+        assert_eq!(
+            TimingFunction::CubicBezier(0.4, 0.0, 0.6, 1.0).peak_overshoot(),
+            0.0
+        );
     }
 }

--- a/src/animation/timing.rs
+++ b/src/animation/timing.rs
@@ -79,13 +79,19 @@ impl TimingFunction {
     /// A bezier is bounded by its control polygon, so its control points give
     /// the bound directly, and a spring's physics give it exactly.
     ///
-    /// A [`Custom`](TimingFunction::Custom) curve is an arbitrary closure and
-    /// cannot be asked, so it is **clamped** to
-    /// [`custom`](TimingFunction::custom), which samples it once, rather than by
-    /// [`evaluate`](Self::evaluate) rather than merely assumed to respect it. A
-    /// bound nothing enforces is not a bound: a hand-rolled bounce peaking at
-    /// 1.5 would have had its damage rect measured for 1.25, leaving the ring
-    /// between the two outside every one of them.
+    /// A [`Custom`](TimingFunction::Custom) curve is an arbitrary closure, so it
+    /// cannot be asked — it is **measured**:
+    /// [`custom`](TimingFunction::custom) samples it once when it is built and
+    /// carries the excursion it found, which is what this reports. The curve
+    /// itself is untouched, and [`evaluate`](Self::evaluate) hands back exactly
+    /// what it returns.
+    ///
+    /// Clamping the curve to an assumed allowance would make the bound true by
+    /// shortening every hand-rolled bounce, silently, which is the wrong way
+    /// round: the bound describes the curve, not the reverse. Assuming one
+    /// without measuring is no better — a bounce peaking at 1.5 would have had
+    /// its damage rect measured for 1.25, leaving the ring between the two
+    /// outside every one of them.
     pub fn peak_overshoot(&self) -> f32 {
         match self {
             TimingFunction::Linear
@@ -232,13 +238,11 @@ mod tests {
 mod overshoot_bound_tests {
     use super::*;
 
-    /// A custom curve that goes further than the allowance is clamped to it, so
-    /// what `peak_overshoot` reports is a bound and not a hope. Anything sized
-    /// from that number — the damage rect an elevation shadow needs, above all —
-    /// would otherwise be measured for less than what is drawn.
     /// A custom curve keeps the shape it was written with, and reports what that
-    /// shape actually does. Clamping it to a constant instead would have made the
-    /// bound true by shortening every hand-rolled bounce, silently.
+    /// shape actually does. Anything sized from that number — the damage rect an
+    /// elevation shadow needs, above all — would otherwise be measured for less
+    /// than what is drawn; clamping the curve instead would have made the bound
+    /// true by shortening every hand-rolled bounce, silently.
     #[test]
     fn a_custom_curve_is_measured_rather_than_clamped() {
         // Overshoots at the end and anticipates at the start: a bound that holds

--- a/src/animation/timing.rs
+++ b/src/animation/timing.rs
@@ -67,6 +67,27 @@ impl TimingFunction {
     }
 
     /// Create a custom timing function from a closure
+    /// How far past 1.0 this curve can go, as a fraction of the distance
+    /// travelled. Zero for every curve that only eases.
+    ///
+    /// A bezier is bounded by its control polygon, so its control points give
+    /// the bound directly. A [`Custom`](TimingFunction::Custom) curve is
+    /// arbitrary and cannot be asked, so it gets an allowance — generous enough
+    /// for anything written to look like a spring, and documented as the one
+    /// case that is a bound rather than a fact.
+    pub fn peak_overshoot(&self) -> f32 {
+        const CUSTOM_ALLOWANCE: f32 = 0.25;
+        match self {
+            TimingFunction::Linear
+            | TimingFunction::EaseIn
+            | TimingFunction::EaseOut
+            | TimingFunction::EaseInOut => 0.0,
+            TimingFunction::CubicBezier(_, y1, _, y2) => (y1.max(*y2) - 1.0).max(0.0),
+            TimingFunction::Spring(config) => config.peak_overshoot(),
+            TimingFunction::Custom(_) => CUSTOM_ALLOWANCE,
+        }
+    }
+
     pub fn custom<F>(f: F) -> Self
     where
         F: Fn(f32) -> f32 + Send + Sync + 'static,

--- a/src/animation/timing.rs
+++ b/src/animation/timing.rs
@@ -65,7 +65,10 @@ impl TimingFunction {
             // Clamped, so `peak_overshoot` is a bound rather than a hope:
             // anything sized from it — a damage rect, most of all — would
             // otherwise be measured for less than what gets drawn.
-            TimingFunction::Custom(f) => f(t).min(1.0 + Self::CUSTOM_MAX_OVERSHOOT),
+            TimingFunction::Custom(f) => f(t).clamp(
+                -Self::CUSTOM_MAX_OVERSHOOT,
+                1.0 + Self::CUSTOM_MAX_OVERSHOOT,
+            ),
         }
     }
 
@@ -88,15 +91,26 @@ impl TimingFunction {
             | TimingFunction::EaseIn
             | TimingFunction::EaseOut
             | TimingFunction::EaseInOut => 0.0,
-            TimingFunction::CubicBezier(_, y1, _, y2) => (y1.max(*y2) - 1.0).max(0.0),
+            // Both ends. An anticipation curve dips *below* its start before it
+            // goes anywhere — `cubic_bezier(0.5, -0.6, 0.5, 1.2)` is the shape
+            // every "wind up first" easing has — and a caller sizing a bound from
+            // this would otherwise be told the value never leaves [0, 1] from
+            // below. The bezier is contained by its control polygon, so the
+            // control points bound both directions.
+            TimingFunction::CubicBezier(_, y1, _, y2) => {
+                let above = (y1.max(*y2) - 1.0).max(0.0);
+                let below = (-y1.min(*y2)).max(0.0);
+                above.max(below)
+            }
             TimingFunction::Spring(config) => config.peak_overshoot(),
             TimingFunction::Custom(_) => Self::CUSTOM_MAX_OVERSHOOT,
         }
     }
 
-    /// How far past its target a [`Custom`](TimingFunction::Custom) curve is
-    /// allowed to go. Generous enough for anything written to look like a
-    /// spring, and enforced rather than trusted.
+    /// How far past either end a [`Custom`](TimingFunction::Custom) curve is
+    /// allowed to go — past 1 at the finish, and below 0 at the start, since an
+    /// anticipation curve winds up before it moves. Generous enough for anything
+    /// written to look like a spring, and enforced rather than trusted.
     pub const CUSTOM_MAX_OVERSHOOT: f32 = 0.25;
 
     /// Create a custom timing function from a closure.
@@ -213,17 +227,22 @@ mod overshoot_bound_tests {
     /// would otherwise be measured for less than what is drawn.
     #[test]
     fn a_custom_curve_cannot_exceed_the_allowance_it_is_credited_with() {
-        let overzealous = TimingFunction::custom(|t| t * 1.5);
-        let bound = 1.0 + TimingFunction::CUSTOM_MAX_OVERSHOOT;
+        let allowance = TimingFunction::CUSTOM_MAX_OVERSHOOT;
+        // Overshooting at the end, and anticipating at the start: a bound that
+        // holds only above 1 is not a bound, and every "wind up first" easing
+        // dips below 0.
+        let overzealous = TimingFunction::custom(|t| t * 2.0 - 0.5);
 
         for step in 0..=100 {
             let t = step as f32 / 100.0;
+            let v = overzealous.evaluate(t);
             assert!(
-                overzealous.evaluate(t) <= bound + 1e-6,
-                "t = {t} evaluated past the bound"
+                v <= 1.0 + allowance + 1e-6 && v >= -allowance - 1e-6,
+                "t = {t} evaluated to {v}, outside the bound"
             );
         }
-        assert_eq!(overzealous.evaluate(1.0), bound, "and reaches it");
+        assert_eq!(overzealous.evaluate(1.0), 1.0 + allowance, "and reaches it");
+        assert_eq!(overzealous.evaluate(0.0), -allowance, "at both ends");
     }
 
     /// The curves that only ease report nothing, and a bezier reports its own
@@ -239,6 +258,11 @@ mod overshoot_bound_tests {
         assert_eq!(
             TimingFunction::CubicBezier(0.4, 0.0, 0.6, 1.0).peak_overshoot(),
             0.0
+        );
+        // Anticipation: it dips to -0.6 before it rises to 1.2, and the larger
+        // excursion is the one that bounds it.
+        assert!(
+            (TimingFunction::CubicBezier(0.5, -0.6, 0.5, 1.2).peak_overshoot() - 0.6).abs() < 1e-5
         );
     }
 }

--- a/src/animation/timing.rs
+++ b/src/animation/timing.rs
@@ -122,6 +122,13 @@ impl TimingFunction {
     const CUSTOM_SAMPLES: usize = 65;
 
     /// Create a custom timing function from a closure.
+    ///
+    /// The curve is sampled here, once, to find how far it leaves `[0, 1]` — so
+    /// building one costs a construction plus 65 evaluations of
+    /// the closure, around half a microsecond for a curve with a trig call in
+    /// it. Free where a curve is built once and shared, which is the usual
+    /// shape; inside a per-row builder rebuilt on every pass it is worth
+    /// hoisting, since `TimingFunction` is `Clone`.
     pub fn custom<F>(f: F) -> Self
     where
         F: Fn(f32) -> f32 + Send + Sync + 'static,

--- a/src/animation/timing.rs
+++ b/src/animation/timing.rs
@@ -45,7 +45,14 @@ pub enum TimingFunction {
     /// Spring physics simulation (can overshoot)
     Spring(SpringConfig),
     /// Custom timing function
-    Custom(Arc<dyn Fn(f32) -> f32 + Send + Sync>),
+    /// Custom timing function, with how far it was measured to leave `[0, 1]`.
+    ///
+    /// The excursion is sampled once by [`custom`](TimingFunction::custom) and
+    /// carried, rather than the curve being clamped to a constant: anything
+    /// sizing a bound from a curve — a damage rect is why this exists — needs a
+    /// number that is true of *that* curve, and a hand-rolled bounce should
+    /// bounce as far as it was written to.
+    Custom(Arc<dyn Fn(f32) -> f32 + Send + Sync>, f32),
 }
 
 impl TimingFunction {
@@ -62,13 +69,7 @@ impl TimingFunction {
             TimingFunction::EaseInOut => ease_in_out(t),
             TimingFunction::CubicBezier(x1, y1, x2, y2) => cubic_bezier(t, *x1, *y1, *x2, *y2),
             TimingFunction::Spring(_) => t, // Springs handled separately with real time
-            // Clamped, so `peak_overshoot` is a bound rather than a hope:
-            // anything sized from it — a damage rect, most of all — would
-            // otherwise be measured for less than what gets drawn.
-            TimingFunction::Custom(f) => f(t).clamp(
-                -Self::CUSTOM_MAX_OVERSHOOT,
-                1.0 + Self::CUSTOM_MAX_OVERSHOOT,
-            ),
+            TimingFunction::Custom(f, _) => f(t),
         }
     }
 
@@ -80,7 +81,7 @@ impl TimingFunction {
     ///
     /// A [`Custom`](TimingFunction::Custom) curve is an arbitrary closure and
     /// cannot be asked, so it is **clamped** to
-    /// [`CUSTOM_MAX_OVERSHOOT`](Self::CUSTOM_MAX_OVERSHOOT) by
+    /// [`custom`](TimingFunction::custom), which samples it once, rather than by
     /// [`evaluate`](Self::evaluate) rather than merely assumed to respect it. A
     /// bound nothing enforces is not a bound: a hand-rolled bounce peaking at
     /// 1.5 would have had its damage rect measured for 1.25, leaving the ring
@@ -103,22 +104,32 @@ impl TimingFunction {
                 above.max(below)
             }
             TimingFunction::Spring(config) => config.peak_overshoot(),
-            TimingFunction::Custom(_) => Self::CUSTOM_MAX_OVERSHOOT,
+            TimingFunction::Custom(_, excursion) => *excursion,
         }
     }
 
-    /// How far past either end a [`Custom`](TimingFunction::Custom) curve is
-    /// allowed to go — past 1 at the finish, and below 0 at the start, since an
-    /// anticipation curve winds up before it moves. Generous enough for anything
-    /// written to look like a spring, and enforced rather than trusted.
-    pub const CUSTOM_MAX_OVERSHOOT: f32 = 0.25;
+    /// How many points [`custom`](TimingFunction::custom) samples a curve at to
+    /// find how far it leaves `[0, 1]`.
+    ///
+    /// Enough that a bounce or an anticipation is caught at its extreme; a curve
+    /// with a spike narrower than a 64th of its duration is not a timing curve.
+    const CUSTOM_SAMPLES: usize = 65;
 
     /// Create a custom timing function from a closure.
     pub fn custom<F>(f: F) -> Self
     where
         F: Fn(f32) -> f32 + Send + Sync + 'static,
     {
-        TimingFunction::Custom(Arc::new(f))
+        // Measured once, here, rather than clamped at every evaluation: the
+        // curve keeps whatever shape it was written with, and `peak_overshoot`
+        // reports what that shape actually does instead of a constant everyone
+        // has to be held to.
+        let mut excursion = 0.0f32;
+        for i in 0..Self::CUSTOM_SAMPLES {
+            let v = f(i as f32 / (Self::CUSTOM_SAMPLES - 1) as f32);
+            excursion = excursion.max(v - 1.0).max(-v);
+        }
+        TimingFunction::Custom(Arc::new(f), excursion.max(0.0))
     }
 }
 
@@ -133,7 +144,7 @@ impl std::fmt::Debug for TimingFunction {
                 write!(f, "CubicBezier({}, {}, {}, {})", x1, y1, x2, y2)
             }
             TimingFunction::Spring(config) => write!(f, "Spring({:?})", config),
-            TimingFunction::Custom(_) => write!(f, "Custom"),
+            TimingFunction::Custom(_, excursion) => write!(f, "Custom(±{excursion})"),
         }
     }
 }
@@ -225,24 +236,38 @@ mod overshoot_bound_tests {
     /// what `peak_overshoot` reports is a bound and not a hope. Anything sized
     /// from that number — the damage rect an elevation shadow needs, above all —
     /// would otherwise be measured for less than what is drawn.
+    /// A custom curve keeps the shape it was written with, and reports what that
+    /// shape actually does. Clamping it to a constant instead would have made the
+    /// bound true by shortening every hand-rolled bounce, silently.
     #[test]
-    fn a_custom_curve_cannot_exceed_the_allowance_it_is_credited_with() {
-        let allowance = TimingFunction::CUSTOM_MAX_OVERSHOOT;
-        // Overshooting at the end, and anticipating at the start: a bound that
-        // holds only above 1 is not a bound, and every "wind up first" easing
-        // dips below 0.
-        let overzealous = TimingFunction::custom(|t| t * 2.0 - 0.5);
+    fn a_custom_curve_is_measured_rather_than_clamped() {
+        // Overshoots at the end and anticipates at the start: a bound that holds
+        // only above 1 is not a bound, and every "wind up first" easing dips
+        // below 0.
+        let curve = TimingFunction::custom(|t| t * 2.0 - 0.5);
+
+        assert_eq!(curve.evaluate(1.0), 1.5, "the curve is left alone");
+        assert_eq!(curve.evaluate(0.0), -0.5);
+
+        // …and its bound is the larger of the two excursions, measured.
+        assert!((curve.peak_overshoot() - 0.5).abs() < 1e-5);
 
         for step in 0..=100 {
             let t = step as f32 / 100.0;
-            let v = overzealous.evaluate(t);
+            let v = curve.evaluate(t);
+            let bound = curve.peak_overshoot();
             assert!(
-                v <= 1.0 + allowance + 1e-6 && v >= -allowance - 1e-6,
-                "t = {t} evaluated to {v}, outside the bound"
+                v <= 1.0 + bound + 1e-4 && v >= -bound - 1e-4,
+                "t = {t} evaluated to {v}, outside the bound it reports"
             );
         }
-        assert_eq!(overzealous.evaluate(1.0), 1.0 + allowance, "and reaches it");
-        assert_eq!(overzealous.evaluate(0.0), -allowance, "at both ends");
+    }
+
+    /// An ordinary custom ease reports nothing, so it costs nothing downstream.
+    #[test]
+    fn a_custom_curve_that_only_eases_reports_no_excursion() {
+        let eased = TimingFunction::custom(|t| t * t);
+        assert_eq!(eased.peak_overshoot(), 0.0);
     }
 
     /// The curves that only ease report nothing, and a bezier reports its own

--- a/src/animation/timing.rs
+++ b/src/animation/timing.rs
@@ -44,14 +44,33 @@ pub enum TimingFunction {
     CubicBezier(f32, f32, f32, f32),
     /// Spring physics simulation (can overshoot)
     Spring(SpringConfig),
-    /// Custom timing function, with how far it was measured to leave `[0, 1]`.
+    /// A curve of the caller's own, built by [`custom`](TimingFunction::custom).
     ///
-    /// The excursion is sampled once by [`custom`](TimingFunction::custom) and
-    /// carried, rather than the curve being clamped to a constant: anything
-    /// sizing a bound from a curve — a damage rect is why this exists — needs a
-    /// number that is true of *that* curve, and a hand-rolled bounce should
-    /// bounce as far as it was written to.
-    Custom(Arc<dyn Fn(f32) -> f32 + Send + Sync>, f32),
+    /// The excursion it carries is sampled once at construction rather than the
+    /// curve being clamped to a constant: anything sizing a bound from a curve —
+    /// a damage rect is why this exists — needs a number that is true of *that*
+    /// curve, and a hand-rolled bounce should bounce as far as it was written
+    /// to. Which is why [`CustomCurve`] cannot be assembled by hand: a
+    /// `Custom(f, 0.0)` written out where the enum is in scope type-checks, and
+    /// its excursion is then a claim nobody measured.
+    Custom(CustomCurve),
+}
+
+/// A caller-supplied easing curve and the excursion measured from it.
+///
+/// Opaque on purpose. The pair is only meaningful when the second half was
+/// measured from the first, so [`TimingFunction::custom`] is the only way to
+/// make one — see [`TimingFunction::Custom`].
+#[derive(Clone)]
+pub struct CustomCurve {
+    f: Arc<dyn Fn(f32) -> f32 + Send + Sync>,
+    excursion: f32,
+}
+
+impl CustomCurve {
+    fn evaluate(&self, t: f32) -> f32 {
+        (self.f)(t)
+    }
 }
 
 impl TimingFunction {
@@ -68,7 +87,7 @@ impl TimingFunction {
             TimingFunction::EaseInOut => ease_in_out(t),
             TimingFunction::CubicBezier(x1, y1, x2, y2) => cubic_bezier(t, *x1, *y1, *x2, *y2),
             TimingFunction::Spring(_) => t, // Springs handled separately with real time
-            TimingFunction::Custom(f, _) => f(t),
+            TimingFunction::Custom(curve) => curve.evaluate(t),
         }
     }
 
@@ -109,7 +128,7 @@ impl TimingFunction {
                 above.max(below)
             }
             TimingFunction::Spring(config) => config.peak_overshoot(),
-            TimingFunction::Custom(_, excursion) => *excursion,
+            TimingFunction::Custom(curve) => curve.excursion,
         }
     }
 
@@ -141,7 +160,10 @@ impl TimingFunction {
             let v = f(i as f32 / (Self::CUSTOM_SAMPLES - 1) as f32);
             excursion = excursion.max(v - 1.0).max(-v);
         }
-        TimingFunction::Custom(Arc::new(f), excursion.max(0.0))
+        TimingFunction::Custom(CustomCurve {
+            f: Arc::new(f),
+            excursion: excursion.max(0.0),
+        })
     }
 }
 
@@ -156,7 +178,7 @@ impl std::fmt::Debug for TimingFunction {
                 write!(f, "CubicBezier({}, {}, {}, {})", x1, y1, x2, y2)
             }
             TimingFunction::Spring(config) => write!(f, "Spring({:?})", config),
-            TimingFunction::Custom(_, excursion) => write!(f, "Custom(±{excursion})"),
+            TimingFunction::Custom(curve) => write!(f, "Custom(±{})", curve.excursion),
         }
     }
 }

--- a/src/backdrop.rs
+++ b/src/backdrop.rs
@@ -87,3 +87,31 @@ impl From<i32> for BackdropBlur {
         Self::new(radius as f32)
     }
 }
+
+/// Bare float literals default to f64.
+impl From<f64> for BackdropBlur {
+    fn from(radius: f64) -> Self {
+        Self::new(radius as f32)
+    }
+}
+
+// A closure may return a bare radius where a blur is expected, so the same
+// conversions have to exist for `IntoVal` — that is what makes
+// `.backdrop_blur(move || if glass { 16.0 } else { 0.0 })` compile.
+impl crate::reactive::IntoVal<BackdropBlur> for f32 {
+    fn into_val(self) -> BackdropBlur {
+        BackdropBlur::new(self)
+    }
+}
+
+impl crate::reactive::IntoVal<BackdropBlur> for f64 {
+    fn into_val(self) -> BackdropBlur {
+        BackdropBlur::new(self as f32)
+    }
+}
+
+impl crate::reactive::IntoVal<BackdropBlur> for i32 {
+    fn into_val(self) -> BackdropBlur {
+        BackdropBlur::new(self as f32)
+    }
+}

--- a/src/blur.rs
+++ b/src/blur.rs
@@ -36,6 +36,18 @@ pub(crate) fn register_blur(id: WidgetId, corner_radius: f32) {
     });
 }
 
+/// Withdraw a widget's blur request.
+///
+/// The registry cannot discover this on its own: `collect_for_surface` prunes
+/// widgets that left the *tree*, and a container that merely stopped asking for
+/// blur is still in it. So the paint that stops asking has to say so — which is
+/// exactly the frame on which a radius driven by a signal reaches zero.
+pub(crate) fn unregister_blur(id: WidgetId) {
+    BLUR_WIDGETS.with(|reg| {
+        reg.borrow_mut().remove(&id);
+    });
+}
+
 /// Collect tessellated blur rects for every blur widget under `root`,
 /// sorted for deterministic change detection. Prunes stale entries.
 pub(crate) fn collect_for_surface(tree: &Tree, root: WidgetId) -> Vec<BlurRect> {

--- a/src/blur.rs
+++ b/src/blur.rs
@@ -7,10 +7,8 @@
 //! to the platform layer. No-ops when the compositor doesn't support the
 //! protocol or its blur capability.
 
-use std::cell::RefCell;
-use std::collections::HashMap;
-
-use crate::tree::{Tree, WidgetId};
+use crate::backdrop::BackdropSources;
+use crate::renderer::{DrawCommand, FlattenedCommand};
 use crate::widgets::Rect;
 
 /// An axis-aligned rectangle of a blur region, in logical surface pixels.
@@ -22,107 +20,48 @@ pub(crate) struct BlurRect {
     pub height: i32,
 }
 
-thread_local! {
-    /// Widgets currently requesting background blur: id → corner radius.
-    /// Bounds are read fresh from the tree at collect time; entries whose
-    /// widget left the tree are pruned then too.
-    static BLUR_WIDGETS: RefCell<HashMap<WidgetId, f32>> = RefCell::new(HashMap::new());
-}
-
-/// Record a widget's blur request (called from `Container::paint`).
-pub(crate) fn register_blur(id: WidgetId, corner_radius: f32) {
-    BLUR_WIDGETS.with(|reg| {
-        reg.borrow_mut().insert(id, corner_radius);
-    });
-}
-
-/// Withdraw a widget's blur request.
+/// The region to hand `ext-background-effect-v1`, read off the frame that was
+/// just drawn.
 ///
-/// The registry cannot discover this on its own: `collect_for_surface` prunes
-/// widgets that left the *tree*, and a container that merely stopped asking for
-/// blur is still in it. So the paint that stops asking has to say so — which is
-/// exactly the frame on which a radius driven by a signal reaches zero.
-pub(crate) fn unregister_blur(id: WidgetId) {
-    BLUR_WIDGETS.with(|reg| {
-        reg.borrow_mut().remove(&id);
-    });
-}
-
-/// Whether anything is registered at all, in O(1).
+/// **Derived, never remembered.** An earlier version kept a registry that
+/// containers wrote to during paint, and every way a container can *stop*
+/// painting — hidden, culled, outside a scroller's window, satisfied from the
+/// paint cache — was a way for that registry to disagree with the screen. Each
+/// one had to be found and told, and one of them was always missing.
 ///
-/// The cull path asks before doing any work: a surface with no compositor blur —
-/// which is most of them — must not pay for a sweep it cannot need.
-pub(crate) fn is_empty() -> bool {
-    BLUR_WIDGETS.with(|reg| reg.borrow().is_empty())
-}
-
-/// Withdraw every request from inside one of these subtrees, because none of
-/// them was painted this frame.
-///
-/// The rule this enforces: **a subtree that did not paint keeps no region.** A
-/// widget withdraws its own request during its own paint, so a subtree whose
-/// paint never ran cannot — and there are three ways that happens, all of them a
-/// parent's decision rather than the widget's: the parent returned at its
-/// visibility gate, a scroller's window did not offer the child, or
-/// `paint_children` culled it.
-///
-/// It cannot be a blanket sweep before painting, tempting as that is: the
-/// registry has to stay sticky across *skipped* paints, because a clean container
-/// satisfied from the paint cache still wants its region and will not re-register
-/// it. So the parent names what it did not paint.
-///
-/// Walks the registry rather than the subtrees: the registry holds a handful of
-/// entries however many thousand rows were skipped.
-pub(crate) fn unregister_unpainted(tree: &Tree, subtrees: &[WidgetId]) {
-    if subtrees.is_empty() || is_empty() {
-        return;
-    }
-    BLUR_WIDGETS.with(|reg| {
-        reg.borrow_mut()
-            .retain(|&id, _| !subtrees.iter().any(|&root| is_under(tree, id, root)));
-    });
-}
-
-/// Collect tessellated blur rects for every blur widget under `root`,
-/// sorted for deterministic change detection. Prunes stale entries.
-pub(crate) fn collect_for_surface(tree: &Tree, root: WidgetId) -> Vec<BlurRect> {
-    BLUR_WIDGETS.with(|reg| {
-        let mut reg = reg.borrow_mut();
-        let mut out = Vec::new();
-        reg.retain(|&id, &mut radius| {
-            if !tree.contains(id) {
-                return false;
-            }
-            // Only widgets belonging to this surface's subtree
-            if is_under(tree, id, root)
-                && let Some(bounds) = tree.get_surface_relative_bounds(id)
-            {
-                out.extend(rounded_rect_to_blur_rects(bounds, radius));
-            }
-            true
-        });
-        out.sort_unstable_by_key(|r| (r.y, r.x, r.width, r.height));
-        out
-    })
-}
-
-fn is_under(tree: &Tree, mut id: WidgetId, root: WidgetId) -> bool {
-    loop {
-        if id == root {
-            return true;
+/// The flattened command list is the frame. A container that did not paint has
+/// no command in it; one served from the paint cache carries its command along
+/// unchanged; a culled one is absent. Ordering stops mattering too, since the
+/// list only exists after the paint that built it.
+pub(crate) fn regions_from_commands(commands: &[FlattenedCommand]) -> Vec<BlurRect> {
+    let mut out = Vec::new();
+    for cmd in commands {
+        let DrawCommand::BackdropBlur {
+            rect,
+            sources,
+            corner_radii,
+            ..
+        } = &*cmd.command
+        else {
+            continue;
+        };
+        if !sources.contains(BackdropSources::COMPOSITOR) {
+            continue;
         }
-        match tree.get_parent(id) {
-            Some(parent) => id = parent,
-            None => return false,
-        }
-    }
-}
 
-/// Reset blur state.
-///
-/// Called during `App::drop()`.
-pub(crate) fn reset_blur() {
-    BLUR_WIDGETS.with(|reg| reg.borrow_mut().clear());
+        // World coordinates, so a scrolled or transformed container reports
+        // where it actually is. The protocol takes rectangles, so a rotated one
+        // contributes its bounding box.
+        let (x, y) = cmd.world_transform.transform_point(rect.x, rect.y);
+        let (x2, y2) = cmd
+            .world_transform
+            .transform_point(rect.x + rect.width, rect.y + rect.height);
+        let world = Rect::new(x.min(x2), y.min(y2), (x2 - x).abs(), (y2 - y).abs());
+
+        out.extend(rounded_rect_to_blur_rects(world, corner_radii.max()));
+    }
+    out.sort_unstable_by_key(|r| (r.y, r.x, r.width, r.height));
+    out
 }
 
 /// Approximate a uniformly rounded rectangle as a union of axis-aligned

--- a/src/blur.rs
+++ b/src/blur.rs
@@ -12,7 +12,7 @@
 //! protocol or its blur capability.
 
 use crate::backdrop::BackdropSources;
-use crate::renderer::{DrawCommand, FlattenedCommand};
+use crate::renderer::{CornerRadii, DrawCommand, EllipticalRadii, FlattenedCommand};
 use crate::widgets::Rect;
 
 /// An axis-aligned rectangle of a blur region, in logical surface pixels.
@@ -62,59 +62,86 @@ pub(crate) fn regions_from_commands(commands: &[FlattenedCommand]) -> Vec<BlurRe
         else {
             continue;
         };
-        out.extend(rounded_rect_to_blur_rects(world, world_radii.max()));
+        out.extend(rounded_rect_to_blur_rects(world, world_radii));
     }
     out.sort_unstable_by_key(|r| (r.y, r.x, r.width, r.height));
     out
 }
 
-/// Approximate a uniformly rounded rectangle as a union of axis-aligned
-/// rects that **inscribe** the shape. A zero radius or degenerate rectangle
-/// yields the bounding box.
+/// Approximate a rounded rectangle as a union of axis-aligned rects that
+/// **inscribe** the shape. Zero radii or a degenerate rectangle yield the
+/// bounding box.
+///
+/// Every corner separately, and every corner an ellipse. One radius for the
+/// whole shape was the seam this used to be reached through: the caller
+/// computed four and collapsed them with `.max()` on the way in, so a card cut
+/// square on one side by a clip was still tessellated as though that side were
+/// round, and the region lost a wedge the size of the radius along the cut —
+/// which is the artefact the clipping exists to prevent.
 ///
 /// `bounds` is in logical surface pixels, matching what `wl_region` expects.
-fn rounded_rect_to_blur_rects(bounds: Rect, radius: f32) -> Vec<BlurRect> {
+fn rounded_rect_to_blur_rects(bounds: Rect, radii: EllipticalRadii) -> Vec<BlurRect> {
     if bounds.width <= 0.0 || bounds.height <= 0.0 {
         return Vec::new();
     }
 
-    let w = bounds.width;
-    let h = bounds.height;
+    let (w, h) = (bounds.width, bounds.height);
+    let (rx, ry) = clamp_radii(radii, w, h);
 
-    // Clamp so two corners sharing an edge can never overlap.
-    let r = radius.clamp(0.0, w.min(h) / 2.0);
+    // How far each side is eaten into at height `y`, by whichever corner on that
+    // side reaches it. Zero between the bands, and correct where a shape short
+    // enough for its corners to meet has both reaching the same height.
+    let left = |y: f32| {
+        corner_inset(y, rx.top_left, ry.top_left).max(corner_inset(
+            h - y,
+            rx.bottom_left,
+            ry.bottom_left,
+        ))
+    };
+    let right = |y: f32| {
+        corner_inset(y, rx.top_right, ry.top_right).max(corner_inset(
+            h - y,
+            rx.bottom_right,
+            ry.bottom_right,
+        ))
+    };
 
-    if r <= 0.5 {
+    let band_top = ry.top_left.max(ry.top_right);
+    let band_bottom = ry.bottom_left.max(ry.bottom_right);
+    if band_top <= 0.5 && band_bottom <= 0.5 {
         return Vec::from_iter(to_blur_rect(bounds));
     }
 
     let mut out = Vec::new();
 
-    // Middle band spans the full width between the corner bands.
-    if h - r > r {
+    // The straight middle is one rect rather than a stack of slabs.
+    if h - band_bottom > band_top {
         out.extend(to_blur_rect(Rect::new(
             bounds.x,
-            bounds.y + r,
+            bounds.y + band_top,
             w,
-            h - 2.0 * r,
+            h - band_top - band_bottom,
         )));
     }
 
-    let mut emit_band = |y_start: f32, y_end: f32| {
+    let emit_band = |y_start: f32, y_end: f32, out: &mut Vec<BlurRect>| {
         let band_h = y_end - y_start;
+        if band_h <= 0.0 {
+            return;
+        }
         let steps = (band_h.ceil() as u32).clamp(4, 32);
         let slab_h = band_h / steps as f32;
         for i in 0..steps {
             let y0 = y_start + i as f32 * slab_h;
             let y1 = y0 + slab_h;
             // Widest inset within the slab keeps it inside the curve.
-            let inset = corner_inset(y0, r, h).max(corner_inset(y1, r, h));
-            let slab_w = w - 2.0 * inset;
+            let (l, r) = (left(y0).max(left(y1)), right(y0).max(right(y1)));
+            let slab_w = w - l - r;
             if slab_w <= 0.0 {
                 continue;
             }
             out.extend(to_blur_rect(Rect::new(
-                bounds.x + inset,
+                bounds.x + l,
                 bounds.y + y0,
                 slab_w,
                 slab_h,
@@ -122,23 +149,42 @@ fn rounded_rect_to_blur_rects(bounds: Rect, radius: f32) -> Vec<BlurRect> {
         }
     };
 
-    emit_band(0.0, r);
-    emit_band(h - r, h);
+    emit_band(0.0, band_top, &mut out);
+    // Starting where the top band ended, so corners tall enough to meet in a
+    // short shape are tessellated once rather than twice.
+    emit_band((h - band_bottom).max(band_top), h, &mut out);
 
     out
 }
 
-/// Horizontal inset of a uniformly rounded edge at height `y`.
-fn corner_inset(y: f32, r: f32, h: f32) -> f32 {
-    if y < r {
-        let dy = r - y;
-        r - (r * r - dy * dy).max(0.0).sqrt()
-    } else if y > h - r {
-        let dy = y - (h - r);
-        r - (r * r - dy * dy).max(0.0).sqrt()
-    } else {
-        0.0
+/// Shrink radii until no two sharing an edge can overlap, all by one factor so
+/// the shape keeps its proportions — the rule CSS `border-radius` uses.
+fn clamp_radii(radii: EllipticalRadii, w: f32, h: f32) -> (CornerRadii, CornerRadii) {
+    let non_negative = |r: CornerRadii| CornerRadii {
+        top_left: r.top_left.max(0.0),
+        top_right: r.top_right.max(0.0),
+        bottom_right: r.bottom_right.max(0.0),
+        bottom_left: r.bottom_left.max(0.0),
+    };
+    let (rx, ry) = (non_negative(radii.x), non_negative(radii.y));
+
+    let ratio = |extent: f32, sum: f32| if sum > extent { extent / sum } else { 1.0 };
+    let f = ratio(w, rx.top_left + rx.top_right)
+        .min(ratio(w, rx.bottom_left + rx.bottom_right))
+        .min(ratio(h, ry.top_left + ry.bottom_left))
+        .min(ratio(h, ry.top_right + ry.bottom_right));
+
+    (rx.scaled(f), ry.scaled(f))
+}
+
+/// How far a corner eats into its side at distance `d` from the edge it sits
+/// on, for an ellipse `rx` wide and `ry` tall. Zero once past the corner.
+fn corner_inset(d: f32, rx: f32, ry: f32) -> f32 {
+    if rx <= 0.0 || ry <= 0.0 || d >= ry {
+        return 0.0;
     }
+    let dy = (ry - d) / ry;
+    rx - rx * (1.0 - dy * dy).max(0.0).sqrt()
 }
 
 /// Round-to-nearest on all four edges so adjacent slabs tile without gaps
@@ -167,9 +213,14 @@ mod tests {
             .any(|r| x >= r.x && x < r.x + r.width && y >= r.y && y < r.y + r.height)
     }
 
+    /// The same radius on every corner and both axes.
+    fn round(radius: f32) -> EllipticalRadii {
+        EllipticalRadii::circular(CornerRadii::uniform(radius))
+    }
+
     #[test]
     fn zero_radius_is_bounding_box() {
-        let rects = rounded_rect_to_blur_rects(Rect::new(10.0, 20.0, 100.0, 50.0), 0.0);
+        let rects = rounded_rect_to_blur_rects(Rect::new(10.0, 20.0, 100.0, 50.0), round(0.0));
         assert_eq!(
             rects,
             vec![BlurRect {
@@ -183,13 +234,13 @@ mod tests {
 
     #[test]
     fn degenerate_rect_is_empty() {
-        assert!(rounded_rect_to_blur_rects(Rect::new(0.0, 0.0, 0.0, 40.0), 8.0).is_empty());
-        assert!(rounded_rect_to_blur_rects(Rect::new(0.0, 0.0, 40.0, -1.0), 8.0).is_empty());
+        assert!(rounded_rect_to_blur_rects(Rect::new(0.0, 0.0, 0.0, 40.0), round(8.0)).is_empty());
+        assert!(rounded_rect_to_blur_rects(Rect::new(0.0, 0.0, 40.0, -1.0), round(8.0)).is_empty());
     }
 
     #[test]
     fn rounded_corners_are_cut() {
-        let rects = rounded_rect_to_blur_rects(Rect::new(0.0, 0.0, 100.0, 60.0), 20.0);
+        let rects = rounded_rect_to_blur_rects(Rect::new(0.0, 0.0, 100.0, 60.0), round(20.0));
         // Corner pixels outside the curve are not covered…
         assert!(!covers(&rects, 0, 0));
         assert!(!covers(&rects, 99, 0));
@@ -206,7 +257,7 @@ mod tests {
     #[test]
     fn slabs_stay_inside_the_curve() {
         let r = 16.0f32;
-        let rects = rounded_rect_to_blur_rects(Rect::new(0.0, 0.0, 80.0, 80.0), r);
+        let rects = rounded_rect_to_blur_rects(Rect::new(0.0, 0.0, 80.0, 80.0), round(r));
         for rect in &rects {
             // Every rect corner must be inside (or on) the rounded shape,
             // with half-pixel tolerance for edge rounding.
@@ -231,9 +282,125 @@ mod tests {
     #[test]
     fn radius_clamped_to_half_size() {
         // Radius larger than half the shape: a circle-ish region, still non-empty
-        let rects = rounded_rect_to_blur_rects(Rect::new(0.0, 0.0, 40.0, 40.0), 100.0);
+        let rects = rounded_rect_to_blur_rects(Rect::new(0.0, 0.0, 40.0, 40.0), round(100.0));
         assert!(!rects.is_empty());
         assert!(covers(&rects, 20, 20));
         assert!(!covers(&rects, 0, 0));
+    }
+
+    /// A square corner is square. This is the seam the region used to be lost
+    /// at: a clip squared off two corners, the caller collapsed the four radii
+    /// with `.max()`, and the shape arrived here as though all four were round —
+    /// so the region gave back a wedge the size of the radius along the cut,
+    /// which is the artefact the clipping exists to prevent.
+    #[test]
+    fn a_square_corner_is_not_rounded_because_another_one_is() {
+        let square_right = EllipticalRadii::circular(CornerRadii {
+            top_left: 16.0,
+            top_right: 0.0,
+            bottom_right: 0.0,
+            bottom_left: 16.0,
+        });
+        let rects = rounded_rect_to_blur_rects(Rect::new(0.0, 0.0, 40.0, 100.0), square_right);
+
+        assert!(
+            covers(&rects, 39, 0) && covers(&rects, 39, 99),
+            "the cut edge is straight, so its corners reach the edge"
+        );
+        assert!(
+            !covers(&rects, 0, 0) && !covers(&rects, 0, 99),
+            "and the round ones are still cut"
+        );
+    }
+
+    /// Only the corner that has a radius is cut. A list row rounding its top
+    /// corners and butting against the next one keeps its full bottom edge.
+    #[test]
+    fn corners_are_cut_one_by_one() {
+        let rects = rounded_rect_to_blur_rects(
+            Rect::new(0.0, 0.0, 100.0, 60.0),
+            EllipticalRadii::circular(CornerRadii::top(20.0)),
+        );
+
+        assert!(!covers(&rects, 0, 0) && !covers(&rects, 99, 0), "top cut");
+        assert!(
+            covers(&rects, 0, 59) && covers(&rects, 99, 59),
+            "bottom square"
+        );
+    }
+
+    /// An unevenly scaled corner is an ellipse: 32 wide and 16 tall reaches the
+    /// left edge 16 down, where a circle of either radius would not.
+    #[test]
+    fn an_elliptical_corner_is_cut_on_both_of_its_axes() {
+        let radii = EllipticalRadii {
+            x: CornerRadii::uniform(32.0),
+            y: CornerRadii::uniform(16.0),
+        };
+        let rects = rounded_rect_to_blur_rects(Rect::new(0.0, 0.0, 200.0, 100.0), radii);
+
+        assert!(!covers(&rects, 0, 0), "the corner itself is outside");
+        assert!(
+            covers(&rects, 0, 20),
+            "the curve is 16 tall, so the left edge is reached by 20 down"
+        );
+        assert!(
+            !covers(&rects, 5, 1),
+            "and 32 wide, so it is still outside 5 in at the top"
+        );
+    }
+
+    /// Every emitted rect stays inside the ellipse it approximates, for radii
+    /// that differ per corner and per axis — the property the whole tessellation
+    /// exists to have, checked where the shape is least uniform.
+    #[test]
+    fn slabs_stay_inside_a_shape_with_four_different_corners() {
+        let radii = EllipticalRadii {
+            x: CornerRadii {
+                top_left: 30.0,
+                top_right: 10.0,
+                bottom_right: 0.0,
+                bottom_left: 20.0,
+            },
+            y: CornerRadii {
+                top_left: 15.0,
+                top_right: 10.0,
+                bottom_right: 0.0,
+                bottom_left: 40.0,
+            },
+        };
+        let (w, h) = (120.0f32, 100.0f32);
+        let rects = rounded_rect_to_blur_rects(Rect::new(0.0, 0.0, w, h), radii);
+        assert!(!rects.is_empty());
+
+        // The centre of each corner's ellipse, and its two semi-axes.
+        let corners = [
+            (30.0f32, 15.0f32, 30.0f32, 15.0f32, true, true),
+            (w - 10.0, 10.0, 10.0, 10.0, false, true),
+            (20.0, h - 40.0, 20.0, 40.0, true, false),
+        ];
+        for rect in &rects {
+            for (px, py) in [
+                (rect.x, rect.y),
+                (rect.x + rect.width, rect.y),
+                (rect.x, rect.y + rect.height),
+                (rect.x + rect.width, rect.y + rect.height),
+            ] {
+                let (px, py) = (px as f32, py as f32);
+                for (cx, cy, rx, ry, left, top) in corners {
+                    // Only points in this corner's quadrant are governed by it.
+                    let in_x = if left { px < cx } else { px > cx };
+                    let in_y = if top { py < cy } else { py > cy };
+                    if !in_x || !in_y {
+                        continue;
+                    }
+                    let d = ((px - cx) / rx).powi(2) + ((py - cy) / ry).powi(2);
+                    assert!(
+                        d <= 1.0 + 0.1,
+                        "({px}, {py}) is outside the {rx}x{ry} corner at ({cx}, {cy}): {d}"
+                    );
+                }
+            }
+        }
     }
 }

--- a/src/blur.rs
+++ b/src/blur.rs
@@ -53,11 +53,15 @@ pub(crate) fn regions_from_commands(commands: &[FlattenedCommand]) -> Vec<BlurRe
             continue;
         }
 
-        // World coordinates, so a scrolled or transformed container reports where
-        // it actually is — and by the same computation the renderer uses for the
-        // surface half of this very command, so the two cannot describe
-        // different shapes.
-        let (world, world_radii) = cmd.world_rounded_rect(*rect, *corner_radii);
+        // World coordinates *and* the clip, by the same computation the renderer
+        // uses for the surface half of this very command — so the two cannot
+        // describe different shapes. A card half out of a viewport is filtered
+        // only where it is on show, and a region published for the whole card
+        // blurs the desktop beside a panel that is not there.
+        let Some((world, world_radii)) = cmd.clipped_world_rounded_rect(*rect, *corner_radii)
+        else {
+            continue;
+        };
         out.extend(rounded_rect_to_blur_rects(world, world_radii.max()));
     }
     out.sort_unstable_by_key(|r| (r.y, r.x, r.width, r.height));

--- a/src/blur.rs
+++ b/src/blur.rs
@@ -48,6 +48,33 @@ pub(crate) fn unregister_blur(id: WidgetId) {
     });
 }
 
+/// Whether anything is registered at all, in O(1).
+///
+/// The cull path asks before doing any work: a surface with no compositor blur —
+/// which is most of them — must not pay for a sweep it cannot need.
+pub(crate) fn is_empty() -> bool {
+    BLUR_WIDGETS.with(|reg| reg.borrow().is_empty())
+}
+
+/// Withdraw every request from widgets inside one of `culled`.
+///
+/// A culled child's `paint` is never called, so it cannot withdraw its own
+/// request — and the registry has to be sticky across skipped paints, because a
+/// *clean* container whose paint was satisfied from cache still wants its region.
+/// So the parent that culled says so on its behalf.
+///
+/// Walks the registry rather than the culled subtrees: the registry holds a
+/// handful of entries however long the list being culled is.
+pub(crate) fn unregister_culled(tree: &Tree, culled: &[WidgetId]) {
+    if culled.is_empty() || is_empty() {
+        return;
+    }
+    BLUR_WIDGETS.with(|reg| {
+        reg.borrow_mut()
+            .retain(|&id, _| !culled.iter().any(|&c| is_under(tree, id, c)));
+    });
+}
+
 /// Collect tessellated blur rects for every blur widget under `root`,
 /// sorted for deterministic change detection. Prunes stale entries.
 pub(crate) fn collect_for_surface(tree: &Tree, root: WidgetId) -> Vec<BlurRect> {

--- a/src/blur.rs
+++ b/src/blur.rs
@@ -56,22 +56,30 @@ pub(crate) fn is_empty() -> bool {
     BLUR_WIDGETS.with(|reg| reg.borrow().is_empty())
 }
 
-/// Withdraw every request from widgets inside one of `culled`.
+/// Withdraw every request from inside one of these subtrees, because none of
+/// them was painted this frame.
 ///
-/// A culled child's `paint` is never called, so it cannot withdraw its own
-/// request — and the registry has to be sticky across skipped paints, because a
-/// *clean* container whose paint was satisfied from cache still wants its region.
-/// So the parent that culled says so on its behalf.
+/// The rule this enforces: **a subtree that did not paint keeps no region.** A
+/// widget withdraws its own request during its own paint, so a subtree whose
+/// paint never ran cannot — and there are three ways that happens, all of them a
+/// parent's decision rather than the widget's: the parent returned at its
+/// visibility gate, a scroller's window did not offer the child, or
+/// `paint_children` culled it.
 ///
-/// Walks the registry rather than the culled subtrees: the registry holds a
-/// handful of entries however long the list being culled is.
-pub(crate) fn unregister_culled(tree: &Tree, culled: &[WidgetId]) {
-    if culled.is_empty() || is_empty() {
+/// It cannot be a blanket sweep before painting, tempting as that is: the
+/// registry has to stay sticky across *skipped* paints, because a clean container
+/// satisfied from the paint cache still wants its region and will not re-register
+/// it. So the parent names what it did not paint.
+///
+/// Walks the registry rather than the subtrees: the registry holds a handful of
+/// entries however many thousand rows were skipped.
+pub(crate) fn unregister_unpainted(tree: &Tree, subtrees: &[WidgetId]) {
+    if subtrees.is_empty() || is_empty() {
         return;
     }
     BLUR_WIDGETS.with(|reg| {
         reg.borrow_mut()
-            .retain(|&id, _| !culled.iter().any(|&c| is_under(tree, id, c)));
+            .retain(|&id, _| !subtrees.iter().any(|&root| is_under(tree, id, root)));
     });
 }
 

--- a/src/blur.rs
+++ b/src/blur.rs
@@ -1,10 +1,14 @@
 //! Compositor-side background blur (`ext-background-effect-v1`).
 //!
-//! Containers opt in via `.background_blur()`. During paint they register
-//! their id and corner radius here; each frame the surface sync reads the
-//! current bounds from the tree, tessellates rounded corners into
-//! axis-aligned rects (`wl_region` has no notion of curves), and hands them
-//! to the platform layer. No-ops when the compositor doesn't support the
+//! Containers opt in via [`backdrop_blur`](crate::widgets::Container::backdrop_blur),
+//! which emits one `DrawCommand::BackdropBlur` carrying the sources it asked
+//! for. The renderer filters the surface's own backdrop from that command; this
+//! module reads the compositor's region off the same one, after the frame has
+//! been flattened, and tessellates its rounded corners into axis-aligned rects
+//! — `wl_region` has no notion of curves.
+//!
+//! Nothing is remembered between frames: see [`regions_from_commands`] for why
+//! that is the whole point. No-ops when the compositor does not support the
 //! protocol or its blur capability.
 
 use crate::backdrop::BackdropSources;
@@ -49,16 +53,12 @@ pub(crate) fn regions_from_commands(commands: &[FlattenedCommand]) -> Vec<BlurRe
             continue;
         }
 
-        // World coordinates, so a scrolled or transformed container reports
-        // where it actually is. The protocol takes rectangles, so a rotated one
-        // contributes its bounding box.
-        let (x, y) = cmd.world_transform.transform_point(rect.x, rect.y);
-        let (x2, y2) = cmd
-            .world_transform
-            .transform_point(rect.x + rect.width, rect.y + rect.height);
-        let world = Rect::new(x.min(x2), y.min(y2), (x2 - x).abs(), (y2 - y).abs());
-
-        out.extend(rounded_rect_to_blur_rects(world, corner_radii.max()));
+        // World coordinates, so a scrolled or transformed container reports where
+        // it actually is — and by the same computation the renderer uses for the
+        // surface half of this very command, so the two cannot describe
+        // different shapes.
+        let (world, world_radii) = cmd.world_rounded_rect(*rect, *corner_radii);
+        out.extend(rounded_rect_to_blur_rects(world, world_radii.max()));
     }
     out.sort_unstable_by_key(|r| (r.y, r.x, r.width, r.height));
     out

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ use platform::create_wayland_app;
 use reactive::owner::with_owner;
 use reactive::{OwnerId, take_clipboard_change, take_cursor_change};
 use renderer::{GpuContext, PaintContext, Renderer, flatten_root_into};
-use surface::{SurfaceCommand, SurfaceConfig, SurfaceExtent, SurfaceId, drain_surface_commands};
+use surface::{SurfaceCommand, SurfaceConfig, SurfaceId, drain_surface_commands};
 use surface_manager::{ManagedSurface, SurfaceManager};
 use widgets::Widget;
 use widgets::font::FontFamily;
@@ -257,35 +257,6 @@ fn close_surface_now(
     wayland_state.destroy_surface(id);
 }
 
-/// The size an axis is currently asking for: its own, if it has one, and the
-/// live surface size while a content axis waits to be measured.
-fn requested_extent(extent: SurfaceExtent, live: Option<u32>) -> u32 {
-    match extent {
-        SurfaceExtent::Fixed(v) => v,
-        SurfaceExtent::Content => live.unwrap_or_else(|| extent.initial()),
-    }
-}
-
-/// What a runtime resize asks the compositor for, and whether the surface has
-/// to be re-measured before that answer is right.
-///
-/// A content axis has no size of its own yet — `SurfaceExtent::initial()` is
-/// 1px — so asking for it directly collapses the surface, and nothing brings it
-/// back: the content-measure pass runs only for a surface that had layout
-/// activity, and a bare `set_size` produces none. So a content axis holds the
-/// live size and asks for a layout, which is what brings the measure round.
-fn resize_request(
-    width: SurfaceExtent,
-    height: SurfaceExtent,
-    live: Option<(u32, u32)>,
-) -> (u32, u32, bool) {
-    (
-        requested_extent(width, live.map(|(w, _)| w)),
-        requested_extent(height, live.map(|(_, h)| h)),
-        width.is_content() || height.is_content(),
-    )
-}
-
 /// Re-publish the reservation after something it *follows* has moved — the
 /// size, the margin, the anchor.
 ///
@@ -327,8 +298,8 @@ fn publish_exclusive_zone(
     measured: Option<(u32, u32)>,
 ) {
     let known = measured.or_else(|| wayland_state.get_surface(id).map(|s| (s.width, s.height)));
-    let width = requested_extent(config.width, known.map(|(w, _)| w));
-    let height = requested_extent(config.height, known.map(|(_, h)| h));
+    let width = surface::requested_extent(config.width, known.map(|(w, _)| w));
+    let height = surface::requested_extent(config.height, known.map(|(_, h)| h));
     let zone = config
         .exclusive_zone
         .resolve(config.anchor, config.margin, width, height);
@@ -384,47 +355,37 @@ fn process_surface_commands(
                 wayland_state.set_surface_keyboard_interactivity(id, mode);
             }
             SurfaceCommand::SetAnchor { id, anchor } => {
-                reconfigure(id, surface_manager, wayland_state, |surface, wayland| {
+                let asked = reconfigure(id, surface_manager, wayland_state, |surface, wayland| {
                     surface.config.anchor = anchor;
                     wayland.set_surface_anchor(id, anchor);
-                    // A content axis the new anchor stretches can never take
-                    // effect, exactly as at creation.
-                    surface::warn_content_on_stretched_axis(id, &surface.config);
+                    // The size goes with it: which axes are the compositor's
+                    // follows from the anchor, so a bar re-anchored to one edge
+                    // has to stop asking for zero on the axis it now owns.
+                    send_size(id, surface, wayland)
                 });
+                if let Some((true, root)) = asked {
+                    jobs::request_job(root, jobs::JobRequest::Layout);
+                }
             }
             SurfaceCommand::SetSize { id, width, height } => {
                 let asked = reconfigure(id, surface_manager, wayland_state, |surface, wayland| {
                     surface.config.width = width;
                     surface.config.height = height;
-                    // The creation path refuses a content axis the compositor
-                    // owns with a warning; a runtime resize has to say the same,
-                    // or a full-width bar shrinks to its content in silence.
-                    surface::warn_content_on_stretched_axis(id, &surface.config);
-
-                    let live = wayland.get_surface(id).map(|s| (s.width, s.height));
-                    let (ask_w, ask_h, needs_measure) = resize_request(width, height, live);
-                    let (stretch_w, stretch_h) =
-                        surface::compositor_owned_axes(surface.config.anchor);
-                    wayland.set_surface_size(
-                        id,
-                        if stretch_w { 0 } else { ask_w },
-                        if stretch_h { 0 } else { ask_h },
-                    );
-                    (needs_measure, surface.widget_id)
+                    send_size(id, surface, wayland)
                 });
                 if let Some((true, root)) = asked {
                     jobs::request_job(root, jobs::JobRequest::Layout);
                 }
             }
             SurfaceCommand::SetExclusiveZone { id, zone } => {
-                if let Some(surface) = surface_manager.get_mut(id) {
+                // Through `reconfigure` like the rest, but this one publishes
+                // unconditionally: the policy *itself* changed, where the other
+                // triggers only matter to `Auto`. The resync `reconfigure` then
+                // does is a no-op for anything else.
+                reconfigure(id, surface_manager, wayland_state, |surface, wayland| {
                     surface.config.exclusive_zone = zone;
-                }
-                // The policy itself changed, so this publishes whatever it now
-                // is — unlike the follow triggers, which only matter to `Auto`.
-                if let Some(surface) = surface_manager.get(id) {
-                    publish_exclusive_zone(id, &surface.config, wayland_state, None);
-                }
+                    publish_exclusive_zone(id, &surface.config, wayland, None);
+                });
             }
             SurfaceCommand::SetMargin { id, margin } => {
                 reconfigure(id, surface_manager, wayland_state, |surface, wayland| {
@@ -559,7 +520,10 @@ fn measure_natural_size(
 ///
 /// Also clears needs_paint flags and the per-frame `repainted` marker for
 /// freshly painted widgets (skipping already-clean subtrees entirely).
-fn cache_paint_results(tree: &mut Tree, node: &std::rc::Rc<renderer::RenderNode>) -> bool {
+pub(crate) fn cache_paint_results(
+    tree: &mut Tree,
+    node: &std::rc::Rc<renderer::RenderNode>,
+) -> bool {
     if !node.repainted.get() {
         // Reused from cache: its subtree is by construction complete and its
         // cache entries are already valid — nothing to do below it.
@@ -913,6 +877,28 @@ fn layout_pass(
     reactive::focus::apply_pending_focus(tree);
 }
 
+/// Send the size the surface is currently asking for, and report whether the
+/// content-measure pass has to run before that answer is right.
+///
+/// Shared by the two commands that can change it — a resize, and a re-anchoring
+/// that changes which axes are ours — so the anchor and the size cannot end up
+/// describing different surfaces.
+fn send_size(
+    id: SurfaceId,
+    surface: &ManagedSurface,
+    wayland_state: &mut platform::WaylandState,
+) -> (bool, WidgetId) {
+    // The creation path refuses a content axis the compositor owns with a
+    // warning; the runtime paths say the same, or a full-width bar shrinks to
+    // its content in silence.
+    surface::warn_content_on_stretched_axis(id, &surface.config);
+
+    let live = wayland_state.get_surface(id).map(|s| (s.width, s.height));
+    let (ask_w, ask_h, needs_measure) = surface::resize_request(&surface.config, live);
+    wayland_state.set_surface_size(id, ask_w, ask_h);
+    (needs_measure, surface.widget_id)
+}
+
 /// Apply a change to a surface, then re-publish what follows from it.
 ///
 /// Every property an [`ExclusiveZone::Auto`] reservation follows — the anchor,
@@ -933,30 +919,6 @@ fn reconfigure<R>(
     let result = change(surface, wayland_state);
     resync_exclusive_zone(id, &surface.config, wayland_state, None);
     Some(result)
-}
-
-/// Paint the tree, and collect the compositor blur region the paint left behind.
-///
-/// **The order is the contract, which is why these two are one function.** A
-/// paint is what registers a blur region and what withdraws one, so collecting
-/// first publishes what the *previous* frame asked for — and a withdrawal made
-/// during this paint would then wait for a next frame that a settled surface
-/// never renders, leaving the desktop blurred behind a panel that has stopped
-/// asking. Splitting them is how that shipped once already, so the tests drive
-/// this function rather than calling the two halves in an order of their own.
-///
-/// The one caller that legitimately collects without painting is the skip-frame
-/// path, where no registration can have changed.
-pub(crate) fn paint_surface(
-    tree: &mut Tree,
-    root: WidgetId,
-    node: &mut renderer::RenderNode,
-) -> Vec<blur::BlurRect> {
-    tree.with_widget_mut(root, |widget, id, tree| {
-        let mut ctx = PaintContext::new(node);
-        widget.paint(tree, id, &mut ctx);
-    });
-    blur::collect_for_surface(tree, root)
 }
 
 /// Paint, flatten, hand the frame to the GPU, and re-arm the pacing gate.
@@ -980,11 +942,11 @@ fn paint_and_present(ctx: &mut FrameContext, frame: &Frame, geometry: &Geometry)
 
     // Skip frame if nothing needs paint
     if !tree.needs_paint(surface.widget_id) {
-        // No paint means no registration can have changed, so the region is
-        // whatever the last paint left. Still synced: a blur-region change
-        // without a repaint (the compositor's blur capability arriving) needs
-        // its own commit.
-        let blur_rects = blur::collect_for_surface(tree, surface.widget_id);
+        // The retained command buffer still holds the last frame, which is what
+        // is on screen — so it is also the right region. Still synced: a
+        // blur-region change without a repaint (the compositor's blur capability
+        // arriving) needs its own commit.
+        let blur_rects = blur::regions_from_commands(&surface.flattened_commands);
         wayland_state.sync_blur_region(id, blur_rects, qh, true);
         render_stats::record_frame_skipped();
         render_stats::end_frame(&DamageRegion::None);
@@ -996,13 +958,12 @@ fn paint_and_present(ctx: &mut FrameContext, frame: &Frame, geometry: &Geometry)
     surface.root_node.bounds =
         widgets::Rect::new(0.0, 0.0, frame.width as f32, frame.height as f32);
 
-    let blur_rects = time_phase!(render_stats::Phase::Paint, {
-        paint_surface(tree, surface.widget_id, &mut surface.root_node)
+    time_phase!(render_stats::Phase::Paint, {
+        tree.with_widget_mut(surface.widget_id, |widget, id, tree| {
+            let mut ctx = PaintContext::new(&mut surface.root_node);
+            widget.paint(tree, id, &mut ctx);
+        });
     });
-
-    // Set the blur region now so it rides the buffer commit performed inside
-    // present() — region and content change in the same frame.
-    wayland_state.sync_blur_region(id, blur_rects, qh, false);
 
     // Flatten tree into reused buffers
     time_phase!(render_stats::Phase::Flatten, {
@@ -1012,6 +973,13 @@ fn paint_and_present(ctx: &mut FrameContext, frame: &Frame, geometry: &Geometry)
             &mut surface.command_layers,
         );
     });
+
+    // The compositor blur region is read off the frame that was just built, so
+    // it cannot disagree with what is on screen — see `blur`. Set before
+    // present() so it rides the buffer commit: region and content change
+    // together.
+    let blur_rects = blur::regions_from_commands(&surface.flattened_commands);
+    wayland_state.sync_blur_region(id, blur_rects, qh, false);
 
     // Re-arm the frame callback BEFORE presenting so the request rides
     // the same commit as the buffer (present() commits internally). The
@@ -1601,7 +1569,6 @@ impl Drop for App {
         compositor::reset_compositor_effects();
         keyboard::reset_keyboard_modifiers();
         reactive::focus::reset_pending_focus();
-        blur::reset_blur();
         session_lock::reset_session_lock();
         FONTS_CONSUMED.with(|f| f.set(false));
     }
@@ -1617,7 +1584,7 @@ impl Default for App {
 mod exclusive_zone_resync_tests {
     use super::*;
     use crate::platform::Anchor;
-    use crate::surface::{ExclusiveZone, Margin};
+    use crate::surface::{ExclusiveZone, Margin, SurfaceExtent};
 
     /// The reservation has to follow the size that was just *requested*. The
     /// compositor only tells us the new size a round trip later, so resolving
@@ -1626,7 +1593,7 @@ mod exclusive_zone_resync_tests {
     fn a_fixed_axis_resolves_against_the_requested_size() {
         // A bar that was 32 tall and has just asked for 48.
         let live_height = Some(32);
-        let height = requested_extent(SurfaceExtent::Fixed(48), live_height);
+        let height = surface::requested_extent(SurfaceExtent::Fixed(48), live_height);
         assert_eq!(height, 48, "the request wins over the stale configure");
 
         let zone =
@@ -1638,10 +1605,13 @@ mod exclusive_zone_resync_tests {
     /// must never be what a running surface asks for.
     #[test]
     fn a_content_axis_holds_the_live_size_until_it_is_measured() {
-        assert_eq!(requested_extent(SurfaceExtent::Content, Some(240)), 240);
+        assert_eq!(
+            surface::requested_extent(SurfaceExtent::Content, Some(240)),
+            240
+        );
         // Only before the first configure is there nothing better to say.
         assert_eq!(
-            requested_extent(SurfaceExtent::Content, None),
+            surface::requested_extent(SurfaceExtent::Content, None),
             SurfaceExtent::Content.initial()
         );
     }
@@ -1671,14 +1641,59 @@ mod exclusive_zone_resync_tests {
     #[test]
     fn handing_an_axis_to_content_keeps_the_size_and_asks_for_a_measure() {
         let live = Some((300u32, 40u32));
+        let anchored = |w: SurfaceExtent, h: SurfaceExtent| SurfaceConfig {
+            anchor: Anchor::TOP,
+            width: w,
+            height: h,
+            ..SurfaceConfig::new()
+        };
 
-        let (w, h, measure) = resize_request(SurfaceExtent::Content, 40.into(), live);
+        let (w, h, measure) =
+            surface::resize_request(&anchored(SurfaceExtent::Content, 40.into()), live);
         assert_eq!((w, h), (300, 40), "no 1px collapse");
         assert!(measure, "the measure pass has to be woken");
 
-        let (w, h, measure) = resize_request(200.into(), 60.into(), live);
+        let (w, h, measure) = surface::resize_request(&anchored(200.into(), 60.into()), live);
         assert_eq!((w, h), (200, 60));
         assert!(!measure, "two fixed axes need no measure");
+    }
+
+    /// Which axes are the compositor's follows from the anchor, and layer-shell
+    /// is strict about it: omitting a dimension *without* opposite-edge
+    /// anchoring is a protocol error, so a bar re-anchored to one edge has to
+    /// stop asking for zero on the axis it now owns — at the next commit, which
+    /// is every frame, the compositor would close the connection.
+    #[test]
+    fn the_size_asked_for_follows_the_anchor() {
+        let bar = |anchor: Anchor| SurfaceConfig {
+            anchor,
+            width: 800.into(),
+            height: 32.into(),
+            ..SurfaceConfig::new()
+        };
+        let live = Some((1920u32, 32u32));
+
+        let stretched =
+            surface::resize_request(&bar(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT), live);
+        assert_eq!(
+            (stretched.0, stretched.1),
+            (0, 32),
+            "anchored to both horizontal edges, the width is the compositor's"
+        );
+
+        let pinned = surface::resize_request(&bar(Anchor::TOP | Anchor::LEFT), live);
+        assert_eq!(
+            (pinned.0, pinned.1),
+            (800, 32),
+            "anchored to one, it is ours again and must be sent"
+        );
+
+        let dock = surface::resize_request(&bar(Anchor::LEFT | Anchor::TOP | Anchor::BOTTOM), live);
+        assert_eq!(
+            (dock.0, dock.1),
+            (800, 0),
+            "and the other axis, the other way"
+        );
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -848,7 +848,7 @@ fn layout_pass(
         });
         wayland_state.reposition_popup_if_changed(id, natural, qh);
     } else if (has_pending_layouts || frame.force_render_surface)
-        && (surface.config.width.is_content() || surface.config.height.is_content())
+        && surface::needs_content_measure(&surface.config)
     {
         // Initialization included: a freshly spawned surface reaches
         // its first frames through the full-layout path, not
@@ -868,7 +868,13 @@ fn layout_pass(
         tree.with_widget_mut(surface.widget_id, |widget, wid, tree| {
             widget.layout(tree, wid, constraints);
         });
-        if (nw, nh) != (frame.width, frame.height) {
+        // Compared as they will be *asked for*, not as they were measured. On an
+        // axis the compositor owns both sides are zero, so a `content()` width
+        // under `LEFT | RIGHT` cannot make this true for ever by measuring 300
+        // against a screen's 1920 — which it did, resizing, resyncing,
+        // committing and logging once a frame for the whole life of the surface.
+        let asking = surface::honour_owned_axes(surface.config.anchor, nw, nh);
+        if asking != surface::honour_owned_axes(surface.config.anchor, frame.width, frame.height) {
             // One commit, like every other pair of these. A content surface whose
             // content animates resizes on frame after frame, and two commits a
             // frame show the compositor the new size against the old reservation
@@ -879,7 +885,7 @@ fn layout_pass(
                 // on an axis the compositor owns hands back an axis that is not
                 // ours, and a full-width bar would then stay at whatever the
                 // screen was when it was measured.
-                let (ask_w, ask_h) = surface::honour_owned_axes(config.anchor, nw, nh);
+                let (ask_w, ask_h) = asking;
                 wayland.set_surface_size(id, ask_w, ask_h);
                 // An `Auto` reservation follows an automatic resize too, and this
                 // is the one caller that knows the measured size before the
@@ -1024,8 +1030,9 @@ fn paint_and_present(ctx: &mut FrameContext, frame: &Frame, geometry: &Geometry)
     });
 
     // Flatten tree into reused buffers
+    let compositor_blur;
     time_phase!(render_stats::Phase::Flatten, {
-        flatten_root_into(
+        compositor_blur = flatten_root_into(
             &surface.root_node,
             &mut surface.flattened_commands,
             &mut surface.command_layers,
@@ -1039,7 +1046,15 @@ fn paint_and_present(ctx: &mut FrameContext, frame: &Frame, geometry: &Geometry)
     // Asked before the scan, not after: without the protocol there is nothing
     // to publish, and walking the frame's commands to find out would be a
     // per-frame cost on the compositors that can do the least with it.
-    if wayland_state.supports_blur_region() {
+    //
+    // And on the compositors that *can*, only for a frame that asks. The flatten
+    // counted them on its way past, so the scan is skipped for the surfaces —
+    // almost all of them — with no compositor blur in the frame at all. The one
+    // frame that has to be walked without carrying one is the frame that stops:
+    // it owes the compositor the empty region that withdraws the last one.
+    if wayland_state.supports_blur_region()
+        && (compositor_blur || wayland_state.has_published_blur(id))
+    {
         let blur_rects = blur::regions_from_commands(&surface.flattened_commands);
         wayland_state.sync_blur_region(id, blur_rects, qh, false);
     }
@@ -1744,15 +1759,22 @@ mod exclusive_zone_resync_tests {
             ..SurfaceConfig::new()
         };
 
-        let (_, _, measure) =
-            surface::resize_request(&bar(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT), live);
+        let stretched = bar(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT);
+        let (_, _, measure) = surface::resize_request(&stretched, live);
         assert!(!measure, "the width is the compositor's either way");
+        assert!(
+            !surface::needs_content_measure(&stretched),
+            "and the frame loop's measure pass asks the same question, or it \
+             re-measures a discarded axis on every frame that lays anything out"
+        );
 
-        let (_, _, measure) = surface::resize_request(&bar(Anchor::TOP | Anchor::LEFT), live);
+        let ours = bar(Anchor::TOP | Anchor::LEFT);
+        let (_, _, measure) = surface::resize_request(&ours, live);
         assert!(
             measure,
             "anchored to one edge it is ours, and has to be measured"
         );
+        assert!(surface::needs_content_measure(&ours));
     }
 
     /// Which axes are the compositor's follows from the anchor, and layer-shell

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,7 +173,7 @@ pub mod prelude {
         LockState, lock_session, lock_state, session_locked, unlock_session,
     };
     pub use crate::surface::{
-        ExclusiveZone, PopupAnchor, PopupConfig, PopupGravity, PopupHandle, SurfaceConfig,
+        ExclusiveZone, Margin, PopupAnchor, PopupConfig, PopupGravity, PopupHandle, SurfaceConfig,
         SurfaceExtent, SurfaceHandle, SurfaceId, content, spawn_popup, spawn_surface,
         surface_handle,
     };
@@ -230,6 +230,36 @@ fn close_surface_now(
     wayland_state.destroy_surface(id);
 }
 
+/// Push the surface's reservation policy to the compositor, resolved against
+/// what it is anchored to and how big it currently is.
+///
+/// [`ExclusiveZone::Auto`] is a policy, not a number, so it has to be
+/// re-resolved after anything it follows — the size, the margin, the policy
+/// itself — has moved.
+fn resync_exclusive_zone(
+    id: SurfaceId,
+    surface_manager: &SurfaceManager,
+    wayland_state: &mut platform::WaylandState,
+) {
+    let Some(surface) = surface_manager.get(id) else {
+        return;
+    };
+    let (width, height) = match wayland_state.get_surface(id) {
+        Some(s) => (s.width, s.height),
+        None => (
+            surface.config.width.initial(),
+            surface.config.height.initial(),
+        ),
+    };
+    let zone = surface.config.exclusive_zone.resolve(
+        surface.config.anchor,
+        surface.config.margin,
+        width,
+        height,
+    );
+    wayland_state.set_surface_exclusive_zone(id, zone);
+}
+
 /// Process dynamic surface commands (create, close, property changes).
 /// Returns false if all surfaces have been closed and the app should exit.
 fn process_surface_commands(
@@ -282,19 +312,29 @@ fn process_surface_commands(
                 wayland_state.set_surface_anchor(id, anchor);
             }
             SurfaceCommand::SetSize { id, width, height } => {
-                wayland_state.set_surface_size(id, width, height);
+                // Recorded on the config as well as sent: the content-sizing
+                // pass reads it every frame to decide which axes it owns, so
+                // an axis handed back to `content()` has to be visible there.
+                if let Some(surface) = surface_manager.get_mut(id) {
+                    surface.config.width = width;
+                    surface.config.height = height;
+                }
+                wayland_state.set_surface_size(id, width.initial(), height.initial());
+                resync_exclusive_zone(id, surface_manager, wayland_state);
             }
             SurfaceCommand::SetExclusiveZone { id, zone } => {
-                wayland_state.set_surface_exclusive_zone(id, zone);
+                if let Some(surface) = surface_manager.get_mut(id) {
+                    surface.config.exclusive_zone = zone;
+                }
+                resync_exclusive_zone(id, surface_manager, wayland_state);
             }
-            SurfaceCommand::SetMargin {
-                id,
-                top,
-                right,
-                bottom,
-                left,
-            } => {
-                wayland_state.set_surface_margin(id, top, right, bottom, left);
+            SurfaceCommand::SetMargin { id, margin } => {
+                if let Some(surface) = surface_manager.get_mut(id) {
+                    surface.config.margin = margin;
+                }
+                wayland_state.set_surface_margin(id, margin);
+                // An `Auto` reservation counts the anchored edge's margin.
+                resync_exclusive_zone(id, surface_manager, wayland_state);
             }
             SurfaceCommand::SetInputRegion { id, rects } => {
                 wayland_state.set_surface_input_region(id, rects.as_deref());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ use platform::create_wayland_app;
 use reactive::owner::with_owner;
 use reactive::{OwnerId, take_clipboard_change, take_cursor_change};
 use renderer::{GpuContext, PaintContext, Renderer, flatten_root_into};
-use surface::{SurfaceCommand, SurfaceConfig, SurfaceId, drain_surface_commands};
+use surface::{SurfaceCommand, SurfaceConfig, SurfaceExtent, SurfaceId, drain_surface_commands};
 use surface_manager::{ManagedSurface, SurfaceManager};
 use widgets::Widget;
 use widgets::font::FontFamily;
@@ -263,6 +263,35 @@ fn close_surface_now(
 /// [`ExclusiveZone::Auto`] is a policy, not a number, so it has to be
 /// re-resolved after anything it follows — the size, the margin, the policy
 /// itself — has moved.
+/// The size an axis is currently asking for: its own, if it has one, and the
+/// live surface size while a content axis waits to be measured.
+fn requested_extent(extent: SurfaceExtent, live: Option<u32>) -> u32 {
+    match extent {
+        SurfaceExtent::Fixed(v) => v,
+        SurfaceExtent::Content => live.unwrap_or_else(|| extent.initial()),
+    }
+}
+
+/// What a runtime resize asks the compositor for, and whether the surface has
+/// to be re-measured before that answer is right.
+///
+/// A content axis has no size of its own yet — `SurfaceExtent::initial()` is
+/// 1px — so asking for it directly collapses the surface, and nothing brings it
+/// back: the content-measure pass runs only for a surface that had layout
+/// activity, and a bare `set_size` produces none. So a content axis holds the
+/// live size and asks for a layout, which is what brings the measure round.
+fn resize_request(
+    width: SurfaceExtent,
+    height: SurfaceExtent,
+    live: Option<(u32, u32)>,
+) -> (u32, u32, bool) {
+    (
+        requested_extent(width, live.map(|(w, _)| w)),
+        requested_extent(height, live.map(|(_, h)| h)),
+        width.is_content() || height.is_content(),
+    )
+}
+
 fn resync_exclusive_zone(
     id: SurfaceId,
     surface_manager: &SurfaceManager,
@@ -271,13 +300,21 @@ fn resync_exclusive_zone(
     let Some(surface) = surface_manager.get(id) else {
         return;
     };
-    let (width, height) = match wayland_state.get_surface(id) {
-        Some(s) => (s.width, s.height),
-        None => (
-            surface.config.width.initial(),
-            surface.config.height.initial(),
-        ),
-    };
+    // The size we just *asked* for, not the one the compositor last told us
+    // about: `set_surface_size` only sends the protocol request, and
+    // `WaylandSurfaceState` learns the new size a round trip later, in
+    // `configure`. Resolving against that reserves for the size the surface is
+    // leaving — a bar going from 32 to 48 keeps reserving 32.
+    //
+    // A `Fixed` axis is therefore authoritative here. A `Content` one has no
+    // number yet, so it falls back to the live size and the content-measure
+    // pass re-resolves once it has measured. And the axis an `Auto` reservation
+    // follows is always one we own — `follow_axis` gives up on an axis anchored
+    // to both edges, the only kind the compositor sizes — so the value we
+    // asked for is the value that will take effect.
+    let live = wayland_state.get_surface(id).map(|s| (s.width, s.height));
+    let width = requested_extent(surface.config.width, live.map(|(w, _)| w));
+    let height = requested_extent(surface.config.height, live.map(|(_, h)| h));
     let zone = surface.config.exclusive_zone.resolve(
         surface.config.anchor,
         surface.config.margin,
@@ -342,11 +379,18 @@ fn process_surface_commands(
                 // Recorded on the config as well as sent: the content-sizing
                 // pass reads it every frame to decide which axes it owns, so
                 // an axis handed back to `content()` has to be visible there.
-                if let Some(surface) = surface_manager.get_mut(id) {
+                let root = surface_manager.get_mut(id).map(|surface| {
                     surface.config.width = width;
                     surface.config.height = height;
+                    surface.widget_id
+                });
+
+                let live = wayland_state.get_surface(id).map(|s| (s.width, s.height));
+                let (ask_w, ask_h, needs_measure) = resize_request(width, height, live);
+                wayland_state.set_surface_size(id, ask_w, ask_h);
+                if needs_measure && let Some(root) = root {
+                    jobs::request_job(root, jobs::JobRequest::Layout);
                 }
-                wayland_state.set_surface_size(id, width.initial(), height.initial());
                 resync_exclusive_zone(id, surface_manager, wayland_state);
             }
             SurfaceCommand::SetExclusiveZone { id, zone } => {
@@ -1506,6 +1550,56 @@ impl Drop for App {
 impl Default for App {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod exclusive_zone_resync_tests {
+    use super::*;
+    use crate::platform::Anchor;
+    use crate::surface::{ExclusiveZone, Margin};
+
+    /// The reservation has to follow the size that was just *requested*. The
+    /// compositor only tells us the new size a round trip later, so resolving
+    /// against what it last said reserves for the size the surface is leaving.
+    #[test]
+    fn a_fixed_axis_resolves_against_the_requested_size() {
+        // A bar that was 32 tall and has just asked for 48.
+        let live_height = Some(32);
+        let height = requested_extent(SurfaceExtent::Fixed(48), live_height);
+        assert_eq!(height, 48, "the request wins over the stale configure");
+
+        let zone =
+            ExclusiveZone::Auto.resolve(Anchor::TOP, Margin::from([6, 0, 0, 0]), 800, height);
+        assert_eq!(zone, 48 + 6);
+    }
+
+    /// A content axis has no number of its own yet — `initial()` is 1px, which
+    /// must never be what a running surface asks for.
+    #[test]
+    fn a_content_axis_holds_the_live_size_until_it_is_measured() {
+        assert_eq!(requested_extent(SurfaceExtent::Content, Some(240)), 240);
+        // Only before the first configure is there nothing better to say.
+        assert_eq!(
+            requested_extent(SurfaceExtent::Content, None),
+            SurfaceExtent::Content.initial()
+        );
+    }
+
+    /// Handing an axis back to `content()` at runtime must not ask for 1px, and
+    /// must ask for a layout — nothing else brings the content-measure pass
+    /// round for a surface whose widgets did not change.
+    #[test]
+    fn handing_an_axis_to_content_keeps_the_size_and_asks_for_a_measure() {
+        let live = Some((300u32, 40u32));
+
+        let (w, h, measure) = resize_request(SurfaceExtent::Content, 40.into(), live);
+        assert_eq!((w, h), (300, 40), "no 1px collapse");
+        assert!(measure, "the measure pass has to be woken");
+
+        let (w, h, measure) = resize_request(200.into(), 60.into(), live);
+        assert_eq!((w, h), (200, 60));
+        assert!(!measure, "two fixed axes need no measure");
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,7 +150,7 @@ pub fn quit_app() {
 ///
 /// Writing a *widget* or a *layout* rather than an application is a different
 /// job with a different vocabulary — the tree, the paint context, the tracking
-/// scope. That lives in [`widget_prelude`](crate::widget_prelude), and is not
+/// scope. That lives in [`widget_prelude`], and is not
 /// re-exported here.
 pub mod prelude {
     pub use crate::animation::{
@@ -207,7 +207,7 @@ pub mod prelude {
 /// use guido::widget_prelude::*;
 /// ```
 ///
-/// [`Widget`](crate::widgets::Widget) has two required methods, `layout` and
+/// [`Widget`] has two required methods — `layout` and
 /// `paint`; [`Layout`](crate::layout::Layout) has one. Everything else here is
 /// what those signatures name, plus
 /// [`with_signal_tracking`](crate::reactive::with_signal_tracking) — the scope
@@ -866,7 +866,12 @@ fn layout_pass(
             widget.layout(tree, wid, constraints);
         });
         if (nw, nh) != (frame.width, frame.height) {
-            wayland_state.set_surface_size(id, nw, nh);
+            // Through the same rule as every other resize: a measured number on
+            // an axis the compositor owns hands back an axis that is not ours,
+            // and a full-width bar would then stay at whatever the screen was
+            // when it was measured.
+            let (ask_w, ask_h) = surface::honour_owned_axes(surface.config.anchor, nw, nh);
+            wayland_state.set_surface_size(id, ask_w, ask_h);
             // An `Auto` reservation follows an automatic resize too, and this is
             // the one caller that knows the measured size before the compositor
             // does — so it passes it rather than letting the helper look it up.
@@ -907,10 +912,10 @@ fn send_size(
     surface: &ManagedSurface,
     wayland_state: &mut platform::WaylandState,
 ) -> (bool, WidgetId) {
-    // The creation path refuses a content axis the compositor owns with a
-    // warning; the runtime paths say the same, or a full-width bar shrinks to
-    // its content in silence.
-    surface::warn_content_on_stretched_axis(id, &surface.config);
+    // Every size that reaches here was asked for by name, so anything the
+    // anchor discards is worth saying — a `content()` axis that will never be
+    // measured, and a `Fixed` one whose number is simply dropped.
+    surface::warn_size_request_on_stretched_axis(id, &surface.config);
 
     let live = configured_size(wayland_state, id);
     let (ask_w, ask_h, needs_measure) = surface::resize_request(&surface.config, live);
@@ -935,9 +940,15 @@ fn reconfigure<R>(
     change: impl FnOnce(&mut ManagedSurface, &mut platform::WaylandState) -> R,
 ) -> Option<R> {
     let surface = surface_manager.get_mut(id)?;
-    let result = change(surface, wayland_state);
-    resync_exclusive_zone(id, &surface.config, wayland_state, None);
-    Some(result)
+    let mut result = None;
+    // One commit for the group. A re-anchoring sends the anchor, the size and
+    // the reservation, and each request committing on its own would show the
+    // compositor two intermediate surfaces on the way.
+    wayland_state.batch_layer_requests(id, |wayland| {
+        result = Some(change(surface, wayland));
+        resync_exclusive_zone(id, &surface.config, wayland, None);
+    });
+    result
 }
 
 /// Paint, flatten, hand the frame to the GPU, and re-arm the pacing gate.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,6 +146,12 @@ pub fn quit_app() {
     jobs::set_exit_request(jobs::ExitRequest::Quit);
 }
 
+/// Everything an application needs, and nothing it does not.
+///
+/// Writing a *widget* or a *layout* rather than an application is a different
+/// job with a different vocabulary — the tree, the paint context, the tracking
+/// scope. That lives in [`widget_prelude`](crate::widget_prelude), and is not
+/// re-exported here.
 pub mod prelude {
     pub use crate::animation::{
         Keyframes, SpringConfig, TimingFunction, Transition, TransitionConfig,
@@ -154,21 +160,18 @@ pub mod prelude {
     pub use crate::compositor::{CompositorEffects, compositor_effects};
     pub use crate::keyboard::keyboard_modifiers;
     pub use crate::layout::{
-        Axis, Constraints, CrossAlignment, Flex, IntoF32, Length, MainAlignment, Size, ZStack,
-        at_least, at_most, fill, fraction,
+        Axis, CrossAlignment, Flex, Length, MainAlignment, Size, ZStack, at_least, at_most, fill,
+        fraction,
     };
     pub use crate::outputs::{OutputId, OutputInfo, outputs, surface_output};
     pub use crate::platform::{Anchor, KeyboardInteractivity, Layer};
     pub use crate::reactive::{
-        Callback, CursorIcon, Memo, OptionSignalExt, RwSignal, Service, Signal, Trigger,
+        Callback, CursorIcon, IntoSignal, IntoVal, Memo, RwSignal, Service, Signal, Trigger,
         WriteSignal, create_derived, create_effect, create_memo, create_service, create_signal,
-        create_stored, create_trigger, expect_context, has_context, on_cleanup, provide_context,
-        provide_signal_context, set_cursor, use_context, with_context,
+        create_stored, create_task, create_trigger, expect_context, has_context, on_cleanup,
+        provide_context, provide_signal_context, set_cursor, use_context, with_context,
     };
-    // For widgets written outside the crate: the scope that makes a widget's
-    // own signal reads its own.
-    pub use crate::reactive::{JobType, with_signal_tracking};
-    pub use crate::renderer::{PaintContext, Shadow, measure_text};
+    pub use crate::renderer::{Shadow, measure_text};
     pub use crate::session_lock::{
         LockState, lock_session, lock_state, session_locked, unlock_session,
     };
@@ -192,6 +195,30 @@ pub mod prelude {
         App, ExitReason, SignalFields, component, default_font_family, load_font, quit_app,
         restart_app, set_default_font_family,
     };
+}
+
+/// What a widget or a layout written outside the crate needs, on top of
+/// [`prelude`].
+///
+/// The two are meant to be imported together:
+///
+/// ```ignore
+/// use guido::prelude::*;
+/// use guido::widget_prelude::*;
+/// ```
+///
+/// [`Widget`](crate::widgets::Widget) has two required methods, `layout` and
+/// `paint`; [`Layout`](crate::layout::Layout) has one. Everything else here is
+/// what those signatures name, plus
+/// [`with_signal_tracking`](crate::reactive::with_signal_tracking) — the scope
+/// that makes a widget's signal reads *its own*, so a change to its content
+/// re-runs it rather than the nearest ancestor that happened to open a scope.
+pub mod widget_prelude {
+    pub use crate::layout::{Constraints, IntoF32, Layout};
+    pub use crate::reactive::{JobType, OptionSignalExt, with_signal_tracking};
+    pub use crate::renderer::{PaintContext, RenderNode};
+    pub use crate::tree::{Tree, WidgetId};
+    pub use crate::widgets::{LayoutHints, Widget};
 }
 
 use smithay_client_toolkit::reexports::client::QueueHandle;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -384,36 +384,36 @@ fn process_surface_commands(
                 wayland_state.set_surface_keyboard_interactivity(id, mode);
             }
             SurfaceCommand::SetAnchor { id, anchor } => {
-                // Recorded, like the size and the margin: the anchor is what
-                // `ExclusiveZone::Auto` reads to decide which axis it follows
-                // and which edge's margin counts, so a stale one keeps a dock
-                // reserving a bar's height at the top of the screen.
-                if let Some(surface) = surface_manager.get_mut(id) {
+                reconfigure(id, surface_manager, wayland_state, |surface, wayland| {
                     surface.config.anchor = anchor;
-                }
-                wayland_state.set_surface_anchor(id, anchor);
-                if let Some(surface) = surface_manager.get(id) {
-                    resync_exclusive_zone(id, &surface.config, wayland_state, None);
-                }
+                    wayland.set_surface_anchor(id, anchor);
+                    // A content axis the new anchor stretches can never take
+                    // effect, exactly as at creation.
+                    surface::warn_content_on_stretched_axis(id, &surface.config);
+                });
             }
             SurfaceCommand::SetSize { id, width, height } => {
-                // Recorded on the config as well as sent: the content-sizing
-                // pass reads it every frame to decide which axes it owns, so
-                // an axis handed back to `content()` has to be visible there.
-                let root = surface_manager.get_mut(id).map(|surface| {
+                let asked = reconfigure(id, surface_manager, wayland_state, |surface, wayland| {
                     surface.config.width = width;
                     surface.config.height = height;
-                    surface.widget_id
-                });
+                    // The creation path refuses a content axis the compositor
+                    // owns with a warning; a runtime resize has to say the same,
+                    // or a full-width bar shrinks to its content in silence.
+                    surface::warn_content_on_stretched_axis(id, &surface.config);
 
-                let live = wayland_state.get_surface(id).map(|s| (s.width, s.height));
-                let (ask_w, ask_h, needs_measure) = resize_request(width, height, live);
-                wayland_state.set_surface_size(id, ask_w, ask_h);
-                if needs_measure && let Some(root) = root {
+                    let live = wayland.get_surface(id).map(|s| (s.width, s.height));
+                    let (ask_w, ask_h, needs_measure) = resize_request(width, height, live);
+                    let (stretch_w, stretch_h) =
+                        surface::compositor_owned_axes(surface.config.anchor);
+                    wayland.set_surface_size(
+                        id,
+                        if stretch_w { 0 } else { ask_w },
+                        if stretch_h { 0 } else { ask_h },
+                    );
+                    (needs_measure, surface.widget_id)
+                });
+                if let Some((true, root)) = asked {
                     jobs::request_job(root, jobs::JobRequest::Layout);
-                }
-                if let Some(surface) = surface_manager.get(id) {
-                    resync_exclusive_zone(id, &surface.config, wayland_state, None);
                 }
             }
             SurfaceCommand::SetExclusiveZone { id, zone } => {
@@ -427,14 +427,10 @@ fn process_surface_commands(
                 }
             }
             SurfaceCommand::SetMargin { id, margin } => {
-                if let Some(surface) = surface_manager.get_mut(id) {
+                reconfigure(id, surface_manager, wayland_state, |surface, wayland| {
                     surface.config.margin = margin;
-                }
-                wayland_state.set_surface_margin(id, margin);
-                // An `Auto` reservation counts the anchored edge's margin.
-                if let Some(surface) = surface_manager.get(id) {
-                    resync_exclusive_zone(id, &surface.config, wayland_state, None);
-                }
+                    wayland.set_surface_margin(id, margin);
+                });
             }
             SurfaceCommand::SetInputRegion { id, rects } => {
                 wayland_state.set_surface_input_region(id, rects.as_deref());
@@ -915,6 +911,28 @@ fn layout_pass(
     // A `WidgetRef::focus()` from application code lands here: after layout, so a
     // handle attached this very frame has resolved to a widget.
     reactive::focus::apply_pending_focus(tree);
+}
+
+/// Apply a change to a surface, then re-publish what follows from it.
+///
+/// Every property an [`ExclusiveZone::Auto`] reservation follows — the anchor,
+/// the size, the margin — goes through here, so the resync happens in one place
+/// and a fifth trigger cannot be added to three of the four. Forgetting exactly
+/// that is how a re-anchored dock went on reserving a bar's height at the top of
+/// the screen.
+///
+/// The change records on the config *and* sends the protocol request, because
+/// the two must not drift: the content-sizing pass reads the config every frame.
+fn reconfigure<R>(
+    id: SurfaceId,
+    surface_manager: &mut SurfaceManager,
+    wayland_state: &mut platform::WaylandState,
+    change: impl FnOnce(&mut ManagedSurface, &mut platform::WaylandState) -> R,
+) -> Option<R> {
+    let surface = surface_manager.get_mut(id)?;
+    let result = change(surface, wayland_state);
+    resync_exclusive_zone(id, &surface.config, wayland_state, None);
+    Some(result)
 }
 
 /// Paint the tree, and collect the compositor blur region the paint left behind.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -301,11 +301,18 @@ fn publish_exclusive_zone(
     // confirmed one is the wrong answer rather than an old one: a surface
     // declared `width(content()).anchor(TOP | LEFT | RIGHT)` is stretched, so
     // 1920 is what the compositor imposed on an axis that was not ours. Re-anchor
-    // it to `LEFT` and that number becomes a reservation — a dock asking for the
-    // whole screen, pushing every other window off it, until the measure lands.
+    // it into a side dock and that number becomes a reservation for the whole
+    // screen, pushing every other window off it, until the measure lands.
     //
-    // So it waits for the measure, which resyncs whenever it runs.
-    if measured.is_none() && surface::needs_content_measure(config) {
+    // So it waits for the measure, which resyncs whenever it runs — but only
+    // `Auto` waits, because only `Auto` reads a size. `Fixed`, `None` and
+    // `Ignore` are constants, and deferring one defers it for ever: nothing
+    // republishes a policy that is not `Auto`, so a `set_exclusive_zone(Fixed(40))`
+    // on a `content()` surface would simply never reach the compositor.
+    if config.exclusive_zone == surface::ExclusiveZone::Auto
+        && measured.is_none()
+        && surface::needs_content_measure(config)
+    {
         return;
     }
 
@@ -408,10 +415,23 @@ fn process_surface_commands(
                 });
             }
             SurfaceCommand::SetMargin { id, margin } => {
-                reconfigure(id, surface_manager, wayland_state, |surface, wayland| {
+                let asked = reconfigure(id, surface_manager, wayland_state, |surface, wayland| {
                     surface.config.margin = margin;
                     wayland.set_surface_margin(id, margin);
+                    // Like its three sisters. An `Auto` reservation is the margin
+                    // *plus* the extent, so moving the margin moves it — and on a
+                    // content axis the resync declines to guess and waits for a
+                    // measure. Without asking for one, nothing lays anything out,
+                    // the measure pass never runs, and the reservation keeps the
+                    // old margin for as long as the surface lives.
+                    (
+                        surface::needs_content_measure(&surface.config),
+                        surface.widget_id,
+                    )
                 });
+                if let Some((true, root)) = asked {
+                    jobs::request_job(root, jobs::JobRequest::Layout);
+                }
             }
             SurfaceCommand::SetInputRegion { id, rects } => {
                 wayland_state.set_surface_input_region(id, rects.as_deref());
@@ -1838,6 +1858,42 @@ mod exclusive_zone_resync_tests {
             "and the confirmed size is the whole screen, which is why publishing \
              from it has to wait"
         );
+    }
+
+    /// Only `Auto` waits, because only `Auto` reads a size. The other three are
+    /// constants, and nothing republishes a policy that is not `Auto` — so a
+    /// deferred one is a lost one: `set_exclusive_zone(Fixed(40))` on a surface
+    /// with a `content()` axis would never reach the compositor at all.
+    #[test]
+    fn only_a_reservation_that_reads_a_size_waits_for_one() {
+        let toast = |zone| SurfaceConfig {
+            anchor: Anchor::LEFT | Anchor::TOP | Anchor::BOTTOM,
+            width: SurfaceExtent::Content,
+            height: SurfaceExtent::Content,
+            exclusive_zone: zone,
+            ..SurfaceConfig::new()
+        };
+
+        assert!(
+            surface::needs_content_measure(&toast(surface::ExclusiveZone::Auto)),
+            "the premise: this is the surface whose measure is pending"
+        );
+
+        // Whatever size these are handed, they answer the same thing — so there
+        // is nothing for them to wait for.
+        for zone in [
+            surface::ExclusiveZone::Fixed(40),
+            surface::ExclusiveZone::None,
+            surface::ExclusiveZone::Ignore,
+        ] {
+            let config = toast(zone);
+            let unmeasured = zone.resolve(config.anchor, config.margin, 1, 1);
+            let measured = zone.resolve(config.anchor, config.margin, 240, 60);
+            assert_eq!(
+                unmeasured, measured,
+                "{zone:?} does not depend on the size, so deferring it only loses it"
+            );
+        }
     }
 
     /// Which axes are the compositor's follows from the anchor, and layer-shell

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -257,12 +257,6 @@ fn close_surface_now(
     wayland_state.destroy_surface(id);
 }
 
-/// Push the surface's reservation policy to the compositor, resolved against
-/// what it is anchored to and how big it currently is.
-///
-/// [`ExclusiveZone::Auto`] is a policy, not a number, so it has to be
-/// re-resolved after anything it follows — the size, the margin, the policy
-/// itself — has moved.
 /// The size an axis is currently asking for: its own, if it has one, and the
 /// live surface size while a content axis waits to be measured.
 fn requested_extent(extent: SurfaceExtent, live: Option<u32>) -> u32 {
@@ -292,35 +286,52 @@ fn resize_request(
     )
 }
 
+/// Re-publish the reservation after something it *follows* has moved — the
+/// size, the margin, the anchor.
+///
+/// Only [`ExclusiveZone::Auto`] follows anything: every other policy is a
+/// number, and republishing it would send the compositor a value it already has
+/// and log a line saying so, on every resize and every margin change.
+/// `measured` is for the one caller that knows a size the compositor has not
+/// been told about yet: the content-measure pass, which has just computed it.
 fn resync_exclusive_zone(
     id: SurfaceId,
-    surface_manager: &SurfaceManager,
+    config: &SurfaceConfig,
     wayland_state: &mut platform::WaylandState,
+    measured: Option<(u32, u32)>,
 ) {
-    let Some(surface) = surface_manager.get(id) else {
-        return;
-    };
-    // The size we just *asked* for, not the one the compositor last told us
-    // about: `set_surface_size` only sends the protocol request, and
-    // `WaylandSurfaceState` learns the new size a round trip later, in
-    // `configure`. Resolving against that reserves for the size the surface is
-    // leaving — a bar going from 32 to 48 keeps reserving 32.
-    //
-    // A `Fixed` axis is therefore authoritative here. A `Content` one has no
-    // number yet, so it falls back to the live size and the content-measure
-    // pass re-resolves once it has measured. And the axis an `Auto` reservation
-    // follows is always one we own — `follow_axis` gives up on an axis anchored
-    // to both edges, the only kind the compositor sizes — so the value we
-    // asked for is the value that will take effect.
-    let live = wayland_state.get_surface(id).map(|s| (s.width, s.height));
-    let width = requested_extent(surface.config.width, live.map(|(w, _)| w));
-    let height = requested_extent(surface.config.height, live.map(|(_, h)| h));
-    let zone = surface.config.exclusive_zone.resolve(
-        surface.config.anchor,
-        surface.config.margin,
-        width,
-        height,
-    );
+    if config.exclusive_zone == surface::ExclusiveZone::Auto {
+        publish_exclusive_zone(id, config, wayland_state, measured);
+    }
+}
+
+/// Resolve the reservation policy against what the surface is anchored to and
+/// how big it is, and send the protocol value.
+///
+/// The size is the one just *asked* for, not the one the compositor last told us
+/// about: `set_surface_size` only sends a request, and `WaylandSurfaceState`
+/// learns the new size a round trip later, in `configure`. Resolving against
+/// that reserves for the size the surface is leaving — a bar going from 32 to 48
+/// keeps reserving 32.
+///
+/// A `Fixed` axis is therefore authoritative here. A `Content` one has no number
+/// yet, so it falls back to `measured` if the caller has one and to the live
+/// size otherwise, the measure pass re-resolving once it does. And the axis an
+/// `Auto` reservation follows is always one we own — `follow_axis` gives up on
+/// an axis anchored to both edges, the only kind the compositor sizes — so the
+/// value we asked for is the value that will take effect.
+fn publish_exclusive_zone(
+    id: SurfaceId,
+    config: &SurfaceConfig,
+    wayland_state: &mut platform::WaylandState,
+    measured: Option<(u32, u32)>,
+) {
+    let known = measured.or_else(|| wayland_state.get_surface(id).map(|s| (s.width, s.height)));
+    let width = requested_extent(config.width, known.map(|(w, _)| w));
+    let height = requested_extent(config.height, known.map(|(_, h)| h));
+    let zone = config
+        .exclusive_zone
+        .resolve(config.anchor, config.margin, width, height);
     wayland_state.set_surface_exclusive_zone(id, zone);
 }
 
@@ -373,7 +384,17 @@ fn process_surface_commands(
                 wayland_state.set_surface_keyboard_interactivity(id, mode);
             }
             SurfaceCommand::SetAnchor { id, anchor } => {
+                // Recorded, like the size and the margin: the anchor is what
+                // `ExclusiveZone::Auto` reads to decide which axis it follows
+                // and which edge's margin counts, so a stale one keeps a dock
+                // reserving a bar's height at the top of the screen.
+                if let Some(surface) = surface_manager.get_mut(id) {
+                    surface.config.anchor = anchor;
+                }
                 wayland_state.set_surface_anchor(id, anchor);
+                if let Some(surface) = surface_manager.get(id) {
+                    resync_exclusive_zone(id, &surface.config, wayland_state, None);
+                }
             }
             SurfaceCommand::SetSize { id, width, height } => {
                 // Recorded on the config as well as sent: the content-sizing
@@ -391,13 +412,19 @@ fn process_surface_commands(
                 if needs_measure && let Some(root) = root {
                     jobs::request_job(root, jobs::JobRequest::Layout);
                 }
-                resync_exclusive_zone(id, surface_manager, wayland_state);
+                if let Some(surface) = surface_manager.get(id) {
+                    resync_exclusive_zone(id, &surface.config, wayland_state, None);
+                }
             }
             SurfaceCommand::SetExclusiveZone { id, zone } => {
                 if let Some(surface) = surface_manager.get_mut(id) {
                     surface.config.exclusive_zone = zone;
                 }
-                resync_exclusive_zone(id, surface_manager, wayland_state);
+                // The policy itself changed, so this publishes whatever it now
+                // is — unlike the follow triggers, which only matter to `Auto`.
+                if let Some(surface) = surface_manager.get(id) {
+                    publish_exclusive_zone(id, &surface.config, wayland_state, None);
+                }
             }
             SurfaceCommand::SetMargin { id, margin } => {
                 if let Some(surface) = surface_manager.get_mut(id) {
@@ -405,7 +432,9 @@ fn process_surface_commands(
                 }
                 wayland_state.set_surface_margin(id, margin);
                 // An `Auto` reservation counts the anchored edge's margin.
-                resync_exclusive_zone(id, surface_manager, wayland_state);
+                if let Some(surface) = surface_manager.get(id) {
+                    resync_exclusive_zone(id, &surface.config, wayland_state, None);
+                }
             }
             SurfaceCommand::SetInputRegion { id, rects } => {
                 wayland_state.set_surface_input_region(id, rects.as_deref());
@@ -873,17 +902,10 @@ fn layout_pass(
         });
         if (nw, nh) != (frame.width, frame.height) {
             wayland_state.set_surface_size(id, nw, nh);
-            // Auto reservations follow automatic resizes too; every
-            // other policy never moves
-            if surface.config.exclusive_zone == surface::ExclusiveZone::Auto {
-                let zone = surface.config.exclusive_zone.resolve(
-                    surface.config.anchor,
-                    surface.config.margin,
-                    nw,
-                    nh,
-                );
-                wayland_state.set_surface_exclusive_zone(id, zone);
-            }
+            // An `Auto` reservation follows an automatic resize too, and this is
+            // the one caller that knows the measured size before the compositor
+            // does — so it passes it rather than letting the helper look it up.
+            resync_exclusive_zone(id, &surface.config, wayland_state, Some((nw, nh)));
         }
     }
 
@@ -1584,6 +1606,25 @@ mod exclusive_zone_resync_tests {
             requested_extent(SurfaceExtent::Content, None),
             SurfaceExtent::Content.initial()
         );
+    }
+
+    /// The anchor is what an `Auto` reservation reads to decide which axis it
+    /// follows and which edge's margin counts, so a bar becoming a side dock has
+    /// to reserve on the other axis. It used to keep reserving its old one:
+    /// `SetAnchor` was the one command that recorded nothing on the config.
+    #[test]
+    fn a_reservation_follows_the_anchor_it_was_given() {
+        let margin = Margin::from([6, 20, 9, 20]);
+
+        // A 800x32 bar at the top reserves its height plus the top margin.
+        let bar = ExclusiveZone::Auto.resolve(Anchor::TOP, margin, 800, 32);
+        assert_eq!(bar, 32 + 6);
+
+        // The same surface, re-anchored as a 48-wide dock on the left, has to
+        // reserve its width plus the left margin instead.
+        let dock = ExclusiveZone::Auto.resolve(Anchor::LEFT, margin, 48, 600);
+        assert_eq!(dock, 48 + 20);
+        assert_ne!(dock, bar, "the axis genuinely changes with the anchor");
     }
 
     /// Handing an axis back to `content()` at runtime must not ask for 1px, and

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -917,6 +917,30 @@ fn layout_pass(
     reactive::focus::apply_pending_focus(tree);
 }
 
+/// Paint the tree, and collect the compositor blur region the paint left behind.
+///
+/// **The order is the contract, which is why these two are one function.** A
+/// paint is what registers a blur region and what withdraws one, so collecting
+/// first publishes what the *previous* frame asked for — and a withdrawal made
+/// during this paint would then wait for a next frame that a settled surface
+/// never renders, leaving the desktop blurred behind a panel that has stopped
+/// asking. Splitting them is how that shipped once already, so the tests drive
+/// this function rather than calling the two halves in an order of their own.
+///
+/// The one caller that legitimately collects without painting is the skip-frame
+/// path, where no registration can have changed.
+pub(crate) fn paint_surface(
+    tree: &mut Tree,
+    root: WidgetId,
+    node: &mut renderer::RenderNode,
+) -> Vec<blur::BlurRect> {
+    tree.with_widget_mut(root, |widget, id, tree| {
+        let mut ctx = PaintContext::new(node);
+        widget.paint(tree, id, &mut ctx);
+    });
+    blur::collect_for_surface(tree, root)
+}
+
 /// Paint, flatten, hand the frame to the GPU, and re-arm the pacing gate.
 ///
 /// The order at the end is not free-form: the frame callback and the damage
@@ -936,35 +960,31 @@ fn paint_and_present(ctx: &mut FrameContext, frame: &Frame, geometry: &Geometry)
         tree.mark_subtree_needs_paint(surface.widget_id);
     }
 
-    // Collect this surface's blur region from registered widgets (post
-    // layout, so bounds are current).
-    let blur_rects = blur::collect_for_surface(tree, surface.widget_id);
-
     // Skip frame if nothing needs paint
     if !tree.needs_paint(surface.widget_id) {
-        // A blur-region change without a repaint (e.g. the compositor's
-        // blur capability arriving) still needs its own commit.
+        // No paint means no registration can have changed, so the region is
+        // whatever the last paint left. Still synced: a blur-region change
+        // without a repaint (the compositor's blur capability arriving) needs
+        // its own commit.
+        let blur_rects = blur::collect_for_surface(tree, surface.widget_id);
         wayland_state.sync_blur_region(id, blur_rects, qh, true);
         render_stats::record_frame_skipped();
         render_stats::end_frame(&DamageRegion::None);
         return;
     }
 
-    // Set the blur region now so it rides the buffer commit performed
-    // inside present() — region and content change in the same frame.
-    wayland_state.sync_blur_region(id, blur_rects, qh, false);
-
     // Clear and reuse the root node (preserves capacity)
     surface.root_node.clear();
     surface.root_node.bounds =
         widgets::Rect::new(0.0, 0.0, frame.width as f32, frame.height as f32);
 
-    time_phase!(render_stats::Phase::Paint, {
-        tree.with_widget_mut(surface.widget_id, |widget, id, tree| {
-            let mut ctx = PaintContext::new(&mut surface.root_node);
-            widget.paint(tree, id, &mut ctx);
-        });
+    let blur_rects = time_phase!(render_stats::Phase::Paint, {
+        paint_surface(tree, surface.widget_id, &mut surface.root_node)
     });
+
+    // Set the blur region now so it rides the buffer commit performed inside
+    // present() — region and content change in the same frame.
+    wayland_state.sync_blur_region(id, blur_rects, qh, false);
 
     // Flatten tree into reused buffers
     time_phase!(render_stats::Phase::Flatten, {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,10 +186,10 @@ pub mod prelude {
     pub use crate::widgets::{
         AnyWidget, Border, Color, Container, ContentFit, Control, CornerRadii, Event,
         EventResponse, FontFamily, FontWeight, GradientDirection, Image, ImageSource, InputStyle,
-        InputStyled, IntoChildren, Key, LinearGradient, Modifiers, MouseButton, Overflow, Padding,
-        Rect, ScrollAxis, ScrollSource, ScrollbarBuilder, ScrollbarVisibility, Selection,
-        StateStyle, Stateful, Text, TextInput, TextShadow, TextStroke, TextStyle, TextStyled,
-        Widget, container, image, keyed, text, text_input,
+        InputStyled, IntoChildren, IntoClickHandler, Key, LinearGradient, Modifiers, MouseButton,
+        Overflow, Padding, Rect, ScrollAxis, ScrollSource, ScrollbarBuilder, ScrollbarVisibility,
+        Selection, StateStyle, Stateful, Text, TextInput, TextShadow, TextStroke, TextStyle,
+        TextStyled, Widget, container, image, keyed, text, text_input,
     };
     pub use crate::{
         App, ExitReason, SignalFields, component, default_font_family, load_font, quit_app,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -297,6 +297,18 @@ fn publish_exclusive_zone(
     wayland_state: &mut platform::WaylandState,
     measured: Option<(u32, u32)>,
 ) {
+    // A content axis waiting to be measured has no size to reserve for, and the
+    // confirmed one is the wrong answer rather than an old one: a surface
+    // declared `width(content()).anchor(TOP | LEFT | RIGHT)` is stretched, so
+    // 1920 is what the compositor imposed on an axis that was not ours. Re-anchor
+    // it to `LEFT` and that number becomes a reservation — a dock asking for the
+    // whole screen, pushing every other window off it, until the measure lands.
+    //
+    // So it waits for the measure, which resyncs whenever it runs.
+    if measured.is_none() && surface::needs_content_measure(config) {
+        return;
+    }
+
     let known = measured.or_else(|| configured_size(wayland_state, id));
     let width = surface::requested_extent(config.width, known.map(|(w, _)| w));
     let height = surface::requested_extent(config.height, known.map(|(_, h)| h));
@@ -874,19 +886,29 @@ fn layout_pass(
         // against a screen's 1920 — which it did, resizing, resyncing,
         // committing and logging once a frame for the whole life of the surface.
         let asking = surface::honour_owned_axes(surface.config.anchor, nw, nh);
-        if asking != surface::honour_owned_axes(surface.config.anchor, frame.width, frame.height) {
+        let resizing =
+            asking != surface::honour_owned_axes(surface.config.anchor, frame.width, frame.height);
+        // The resize is conditional; the resync is not. This is the only place
+        // the measurement is known, and the reservation may be waiting on it even
+        // when the size did not move — `publish_exclusive_zone` declines to
+        // resolve `Auto` against an unmeasured content axis, so a re-anchoring
+        // that measures back to the number it already had would otherwise leave
+        // the reservation deferred for ever.
+        {
             // One commit, like every other pair of these. A content surface whose
             // content animates resizes on frame after frame, and two commits a
             // frame show the compositor the new size against the old reservation
             // in between.
             let config = &surface.config;
             wayland_state.batch_layer_requests(id, |wayland| {
-                // Through the same rule as every other resize: a measured number
-                // on an axis the compositor owns hands back an axis that is not
-                // ours, and a full-width bar would then stay at whatever the
-                // screen was when it was measured.
-                let (ask_w, ask_h) = asking;
-                wayland.set_surface_size(id, ask_w, ask_h);
+                if resizing {
+                    // Through the same rule as every other resize: a measured
+                    // number on an axis the compositor owns hands back an axis
+                    // that is not ours, and a full-width bar would then stay at
+                    // whatever the screen was when it was measured.
+                    let (ask_w, ask_h) = asking;
+                    wayland.set_surface_size(id, ask_w, ask_h);
+                }
                 // An `Auto` reservation follows an automatic resize too, and this
                 // is the one caller that knows the measured size before the
                 // compositor does — so it passes it rather than letting the
@@ -1775,6 +1797,47 @@ mod exclusive_zone_resync_tests {
             "anchored to one edge it is ours, and has to be measured"
         );
         assert!(surface::needs_content_measure(&ours));
+    }
+
+    /// And until it *is* measured there is nothing to reserve for. The confirmed
+    /// size of a stretched axis is the compositor's, not a measurement: a bar
+    /// declared `width(content()).anchor(TOP | LEFT | RIGHT)` is confirmed at the
+    /// screen's 1920, and re-anchoring it into a side dock turns that into a
+    /// reservation for the whole screen — every other window pushed off it — for
+    /// the frame between the command and the measure.
+    #[test]
+    fn a_reservation_waits_for_the_measure_rather_than_guessing() {
+        // A left dock: anchored to one horizontal edge and both vertical ones, so
+        // the height is the compositor's and the reservation follows the width.
+        let dock = SurfaceConfig {
+            anchor: Anchor::LEFT | Anchor::TOP | Anchor::BOTTOM,
+            width: SurfaceExtent::Content,
+            height: 32.into(),
+            exclusive_zone: surface::ExclusiveZone::Auto,
+            ..SurfaceConfig::new()
+        };
+
+        // What the stretched anchor left behind, and what the content is worth.
+        let stale = 1920;
+        let measured = 240;
+
+        assert!(
+            surface::needs_content_measure(&dock),
+            "the width is ours now, so it is waiting on a measure"
+        );
+        assert_eq!(
+            dock.exclusive_zone
+                .resolve(dock.anchor, dock.margin, measured, 32),
+            240,
+            "the measure is what it reserves for"
+        );
+        assert_eq!(
+            dock.exclusive_zone
+                .resolve(dock.anchor, dock.margin, stale, 32),
+            1920,
+            "and the confirmed size is the whole screen, which is why publishing \
+             from it has to wait"
+        );
     }
 
     /// Which axes are the compositor's follows from the anchor, and layer-shell

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -297,7 +297,7 @@ fn publish_exclusive_zone(
     wayland_state: &mut platform::WaylandState,
     measured: Option<(u32, u32)>,
 ) {
-    let known = measured.or_else(|| wayland_state.get_surface(id).map(|s| (s.width, s.height)));
+    let known = measured.or_else(|| configured_size(wayland_state, id));
     let width = surface::requested_extent(config.width, known.map(|(w, _)| w));
     let height = surface::requested_extent(config.height, known.map(|(_, h)| h));
     let zone = config
@@ -378,13 +378,18 @@ fn process_surface_commands(
                 }
             }
             SurfaceCommand::SetExclusiveZone { id, zone } => {
-                // Through `reconfigure` like the rest, but this one publishes
-                // unconditionally: the policy *itself* changed, where the other
-                // triggers only matter to `Auto`. The resync `reconfigure` then
-                // does is a no-op for anything else.
+                // Recorded through `reconfigure` like the rest; the publishing is
+                // left to the resync it already does, which for `Auto` is exactly
+                // this. Doing it inside the closure too sent the request twice —
+                // and logged it twice — for the one policy the resync is for.
+                //
+                // The other policies are numbers the resync skips, so they
+                // publish here.
                 reconfigure(id, surface_manager, wayland_state, |surface, wayland| {
                     surface.config.exclusive_zone = zone;
-                    publish_exclusive_zone(id, &surface.config, wayland, None);
+                    if zone != surface::ExclusiveZone::Auto {
+                        publish_exclusive_zone(id, &surface.config, wayland, None);
+                    }
                 });
             }
             SurfaceCommand::SetMargin { id, margin } => {
@@ -877,6 +882,20 @@ fn layout_pass(
     reactive::focus::apply_pending_focus(tree);
 }
 
+/// The size the compositor has confirmed, if it has confirmed one.
+///
+/// `WaylandSurfaceState` is created holding the size that was *requested*, which
+/// for a content axis is the 1px placeholder — so reading it unconditionally
+/// would report a number nobody agreed on as though it were live, and make
+/// `requested_extent`'s "no size yet" branch unreachable while the case it
+/// describes was still happening.
+fn configured_size(wayland_state: &platform::WaylandState, id: SurfaceId) -> Option<(u32, u32)> {
+    wayland_state
+        .get_surface(id)
+        .filter(|s| s.configured)
+        .map(|s| (s.width, s.height))
+}
+
 /// Send the size the surface is currently asking for, and report whether the
 /// content-measure pass has to run before that answer is right.
 ///
@@ -893,7 +912,7 @@ fn send_size(
     // its content in silence.
     surface::warn_content_on_stretched_axis(id, &surface.config);
 
-    let live = wayland_state.get_surface(id).map(|s| (s.width, s.height));
+    let live = configured_size(wayland_state, id);
     let (ask_w, ask_h, needs_measure) = surface::resize_request(&surface.config, live);
     wayland_state.set_surface_size(id, ask_w, ask_h);
     (needs_measure, surface.widget_id)
@@ -946,8 +965,10 @@ fn paint_and_present(ctx: &mut FrameContext, frame: &Frame, geometry: &Geometry)
         // is on screen — so it is also the right region. Still synced: a
         // blur-region change without a repaint (the compositor's blur capability
         // arriving) needs its own commit.
-        let blur_rects = blur::regions_from_commands(&surface.flattened_commands);
-        wayland_state.sync_blur_region(id, blur_rects, qh, true);
+        if wayland_state.supports_blur_region() {
+            let blur_rects = blur::regions_from_commands(&surface.flattened_commands);
+            wayland_state.sync_blur_region(id, blur_rects, qh, true);
+        }
         render_stats::record_frame_skipped();
         render_stats::end_frame(&DamageRegion::None);
         return;
@@ -978,8 +999,13 @@ fn paint_and_present(ctx: &mut FrameContext, frame: &Frame, geometry: &Geometry)
     // it cannot disagree with what is on screen — see `blur`. Set before
     // present() so it rides the buffer commit: region and content change
     // together.
-    let blur_rects = blur::regions_from_commands(&surface.flattened_commands);
-    wayland_state.sync_blur_region(id, blur_rects, qh, false);
+    // Asked before the scan, not after: without the protocol there is nothing
+    // to publish, and walking the frame's commands to find out would be a
+    // per-frame cost on the compositors that can do the least with it.
+    if wayland_state.supports_blur_region() {
+        let blur_rects = blur::regions_from_commands(&surface.flattened_commands);
+        wayland_state.sync_blur_region(id, blur_rects, qh, false);
+    }
 
     // Re-arm the frame callback BEFORE presenting so the request rides
     // the same commit as the buffer (present() commits internally). The
@@ -1609,10 +1635,20 @@ mod exclusive_zone_resync_tests {
             surface::requested_extent(SurfaceExtent::Content, Some(240)),
             240
         );
-        // Only before the first configure is there nothing better to say.
+        // Before the first configure there is nothing better to say, and the
+        // placeholder is what creation asks for too — the content-measure pass
+        // runs on a surface's first frames regardless, so this is a size it is
+        // on its way out of rather than one it can be stuck at. What must not
+        // happen is reporting the placeholder as though the compositor had
+        // agreed to it, which is why `live` is the *configured* size.
         assert_eq!(
             surface::requested_extent(SurfaceExtent::Content, None),
             SurfaceExtent::Content.initial()
+        );
+        assert_eq!(
+            surface::requested_extent(SurfaceExtent::Content, Some(1)),
+            1,
+            "and once configured at 1px, 1px is the honest answer"
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -407,12 +407,24 @@ fn process_surface_commands(
                 //
                 // The other policies are numbers the resync skips, so they
                 // publish here.
-                reconfigure(id, surface_manager, wayland_state, |surface, wayland| {
+                let asked = reconfigure(id, surface_manager, wayland_state, |surface, wayland| {
                     surface.config.exclusive_zone = zone;
                     if zone != surface::ExclusiveZone::Auto {
                         publish_exclusive_zone(id, &surface.config, wayland, None);
                     }
+                    // Like its three sisters. Declaring `Auto` on a content
+                    // surface leaves the resync waiting for a measure — this arm
+                    // publishes nothing itself for `Auto`, on purpose — so
+                    // without asking for a layout the measure pass never runs on
+                    // a settled UI and the reservation is never sent at all.
+                    (
+                        surface::needs_content_measure(&surface.config),
+                        surface.widget_id,
+                    )
                 });
+                if let Some((true, root)) = asked {
+                    jobs::request_job(root, jobs::JobRequest::Layout);
+                }
             }
             SurfaceCommand::SetMargin { id, margin } => {
                 let asked = reconfigure(id, surface_manager, wayland_state, |surface, wayland| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -371,6 +371,9 @@ fn process_surface_commands(
                 let asked = reconfigure(id, surface_manager, wayland_state, |surface, wayland| {
                     surface.config.width = width;
                     surface.config.height = height;
+                    // Here every value is one the caller just named, so anything
+                    // the anchor discards is worth saying.
+                    surface::warn_size_request_on_stretched_axis(id, &surface.config);
                     send_size(id, surface, wayland)
                 });
                 if let Some((true, root)) = asked {
@@ -866,16 +869,24 @@ fn layout_pass(
             widget.layout(tree, wid, constraints);
         });
         if (nw, nh) != (frame.width, frame.height) {
-            // Through the same rule as every other resize: a measured number on
-            // an axis the compositor owns hands back an axis that is not ours,
-            // and a full-width bar would then stay at whatever the screen was
-            // when it was measured.
-            let (ask_w, ask_h) = surface::honour_owned_axes(surface.config.anchor, nw, nh);
-            wayland_state.set_surface_size(id, ask_w, ask_h);
-            // An `Auto` reservation follows an automatic resize too, and this is
-            // the one caller that knows the measured size before the compositor
-            // does — so it passes it rather than letting the helper look it up.
-            resync_exclusive_zone(id, &surface.config, wayland_state, Some((nw, nh)));
+            // One commit, like every other pair of these. A content surface whose
+            // content animates resizes on frame after frame, and two commits a
+            // frame show the compositor the new size against the old reservation
+            // in between.
+            let config = &surface.config;
+            wayland_state.batch_layer_requests(id, |wayland| {
+                // Through the same rule as every other resize: a measured number
+                // on an axis the compositor owns hands back an axis that is not
+                // ours, and a full-width bar would then stay at whatever the
+                // screen was when it was measured.
+                let (ask_w, ask_h) = surface::honour_owned_axes(config.anchor, nw, nh);
+                wayland.set_surface_size(id, ask_w, ask_h);
+                // An `Auto` reservation follows an automatic resize too, and this
+                // is the one caller that knows the measured size before the
+                // compositor does — so it passes it rather than letting the
+                // helper look it up.
+                resync_exclusive_zone(id, config, wayland, Some((nw, nh)));
+            });
         }
     }
 
@@ -907,16 +918,28 @@ fn configured_size(wayland_state: &platform::WaylandState, id: SurfaceId) -> Opt
 /// Shared by the two commands that can change it — a resize, and a re-anchoring
 /// that changes which axes are ours — so the anchor and the size cannot end up
 /// describing different surfaces.
+///
+/// An axis crossing from the compositor's side to ours has to be given a number:
+/// layer-shell makes zero on an axis not anchored to opposite edges a protocol
+/// error, so a re-anchored bar that says nothing is disconnected at its next
+/// commit. The number is the config's, **default included** — a bar written
+/// `height(32).anchor(TOP | LEFT | RIGHT)` never names a width, so re-anchoring
+/// it to `TOP | LEFT` asks for [`SurfaceConfig::default`]'s 400 rather than the
+/// screen width it was stretched to. Handing back the size it happens to have
+/// instead would read better there and worse where it counts: it would also
+/// override a width the app *did* name and had ignored while stretched. An app
+/// re-anchoring to an axis it cares about sets the size for it.
+///
+/// It does not warn. A re-anchoring names no sizes, so warning from here fired
+/// on every anchor change for an axis that was stretched before and still is —
+/// the noise
+/// [`warn_content_on_stretched_axis`](surface::warn_content_on_stretched_axis)
+/// was split off to avoid. The caller that was handed a size says so.
 fn send_size(
     id: SurfaceId,
     surface: &ManagedSurface,
     wayland_state: &mut platform::WaylandState,
 ) -> (bool, WidgetId) {
-    // Every size that reaches here was asked for by name, so anything the
-    // anchor discards is worth saying — a `content()` axis that will never be
-    // measured, and a `Fixed` one whose number is simply dropped.
-    surface::warn_size_request_on_stretched_axis(id, &surface.config);
-
     let live = configured_size(wayland_state, id);
     let (ask_w, ask_h, needs_measure) = surface::resize_request(&surface.config, live);
     wayland_state.set_surface_size(id, ask_w, ask_h);
@@ -972,11 +995,14 @@ fn paint_and_present(ctx: &mut FrameContext, frame: &Frame, geometry: &Geometry)
 
     // Skip frame if nothing needs paint
     if !tree.needs_paint(surface.widget_id) {
-        // The retained command buffer still holds the last frame, which is what
-        // is on screen — so it is also the right region. Still synced: a
-        // blur-region change without a repaint (the compositor's blur capability
-        // arriving) needs its own commit.
-        if wayland_state.supports_blur_region() {
+        // Only when one is owed. The retained command buffer still holds the
+        // last frame, which is what is on screen — so it is also the right
+        // region, and rebuilding it from those commands is right but not free:
+        // an idle surface would walk a whole frame's worth of them, every frame,
+        // to arrive at the region it published already. The one thing that can
+        // change while nothing paints is the compositor's blur capability, which
+        // drops its regions, and that says so.
+        if wayland_state.take_blur_resync(id) {
             let blur_rects = blur::regions_from_commands(&surface.flattened_commands);
             wayland_state.sync_blur_region(id, blur_rects, qh, true);
         }
@@ -1703,6 +1729,30 @@ mod exclusive_zone_resync_tests {
         let (w, h, measure) = surface::resize_request(&anchored(200.into(), 60.into()), live);
         assert_eq!((w, h), (200, 60));
         assert!(!measure, "two fixed axes need no measure");
+    }
+
+    /// A `content()` axis the compositor owns is measured and then thrown away.
+    /// Asking for the measure anyway re-lays out the whole subtree on every
+    /// resize and every re-anchoring, to produce a number nothing can use.
+    #[test]
+    fn a_stretched_content_axis_asks_for_no_measure() {
+        let live = Some((1920u32, 32u32));
+        let bar = |anchor: Anchor| SurfaceConfig {
+            anchor,
+            width: SurfaceExtent::Content,
+            height: 32.into(),
+            ..SurfaceConfig::new()
+        };
+
+        let (_, _, measure) =
+            surface::resize_request(&bar(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT), live);
+        assert!(!measure, "the width is the compositor's either way");
+
+        let (_, _, measure) = surface::resize_request(&bar(Anchor::TOP | Anchor::LEFT), live);
+        assert!(
+            measure,
+            "anchored to one edge it is ours, and has to be measured"
+        );
     }
 
     /// Which axes are the compositor's follows from the anchor, and layer-shell

--- a/src/platform/backdrop.rs
+++ b/src/platform/backdrop.rs
@@ -48,6 +48,24 @@ impl WaylandState {
         self.backdrop.bg_effect_supports_blur && self.backdrop.bg_effect_manager.is_some()
     }
 
+    /// Whether a surface that is *not* repainting still owes the compositor a
+    /// region, taking the debt as it answers.
+    ///
+    /// A frame that paints publishes its region from the commands it just
+    /// flattened, so the only reason an idle one has to say anything is that the
+    /// compositor forgot: the blur capability going away drops its regions, and
+    /// they have to be pushed again when it returns. Asking the retained command
+    /// list every idle frame instead walked a whole frame's commands, on every
+    /// still frame, to rebuild the region that was already published.
+    pub(crate) fn take_blur_resync(&mut self, id: SurfaceId) -> bool {
+        if !self.supports_blur_region() {
+            return false;
+        }
+        self.surfaces
+            .get_mut(&id)
+            .is_some_and(|s| std::mem::take(&mut s.blur_resync_owed))
+    }
+
     /// Push a surface's blur region to the compositor if it changed.
     ///
     /// The `set_blur_region` request is double-buffered: with `commit: false`
@@ -77,6 +95,7 @@ impl WaylandState {
         let Some(surface_state) = self.surfaces.get_mut(&id) else {
             return;
         };
+        surface_state.blur_resync_owed = false;
 
         // Never used blur and still doesn't — don't claim the surface.
         if rects.is_empty()
@@ -145,6 +164,7 @@ impl Dispatch<ExtBackgroundEffectManagerV1, ()> for WaylandState {
             // forget ours and wake the loop to push them again if it's back.
             for surface_state in state.surfaces.values_mut() {
                 surface_state.blur_region = None;
+                surface_state.blur_resync_owed = true;
             }
             crate::jobs::wake_loop();
         }

--- a/src/platform/backdrop.rs
+++ b/src/platform/backdrop.rs
@@ -38,6 +38,16 @@ impl Backdrop {
 }
 
 impl WaylandState {
+    /// Whether publishing a blur region can do anything at all.
+    ///
+    /// Asked *before* building one: on a compositor without
+    /// `ext-background-effect-v1` — most of them — `sync_blur_region` would
+    /// return at its first line, after the caller had already walked the frame's
+    /// whole command list to hand it something to ignore.
+    pub(crate) fn supports_blur_region(&self) -> bool {
+        self.backdrop.bg_effect_supports_blur && self.backdrop.bg_effect_manager.is_some()
+    }
+
     /// Push a surface's blur region to the compositor if it changed.
     ///
     /// The `set_blur_region` request is double-buffered: with `commit: false`
@@ -51,16 +61,6 @@ impl WaylandState {
     /// an *empty* region, never NULL: NULL only withdraws our opinion and
     /// lets such a rule blur the whole surface, where an empty region says
     /// "blur exactly nothing".
-    /// Whether publishing a blur region can do anything at all.
-    ///
-    /// Asked *before* building one: on a compositor without
-    /// `ext-background-effect-v1` — most of them — `sync_blur_region` would
-    /// return at its first line, after the caller had already walked the frame's
-    /// whole command list to hand it something to ignore.
-    pub(crate) fn supports_blur_region(&self) -> bool {
-        self.backdrop.bg_effect_supports_blur && self.backdrop.bg_effect_manager.is_some()
-    }
-
     pub(crate) fn sync_blur_region(
         &mut self,
         id: SurfaceId,

--- a/src/platform/backdrop.rs
+++ b/src/platform/backdrop.rs
@@ -48,6 +48,18 @@ impl WaylandState {
         self.backdrop.bg_effect_supports_blur && self.backdrop.bg_effect_manager.is_some()
     }
 
+    /// Whether this surface has a non-empty region standing with the compositor.
+    ///
+    /// A frame carrying no compositor blur skips the scan — except this one,
+    /// where the scan produces the empty region that withdraws what is still
+    /// published. Once withdrawn the answer is `false`, so it happens once.
+    pub(crate) fn has_published_blur(&self, id: SurfaceId) -> bool {
+        self.surfaces
+            .get(&id)
+            .and_then(|s| s.blur_region.as_ref())
+            .is_some_and(|rects| !rects.is_empty())
+    }
+
     /// Whether a surface that is *not* repainting still owes the compositor a
     /// region, taking the debt as it answers.
     ///

--- a/src/platform/backdrop.rs
+++ b/src/platform/backdrop.rs
@@ -51,6 +51,16 @@ impl WaylandState {
     /// an *empty* region, never NULL: NULL only withdraws our opinion and
     /// lets such a rule blur the whole surface, where an empty region says
     /// "blur exactly nothing".
+    /// Whether publishing a blur region can do anything at all.
+    ///
+    /// Asked *before* building one: on a compositor without
+    /// `ext-background-effect-v1` — most of them — `sync_blur_region` would
+    /// return at its first line, after the caller had already walked the frame's
+    /// whole command list to hand it something to ignore.
+    pub(crate) fn supports_blur_region(&self) -> bool {
+        self.backdrop.bg_effect_supports_blur && self.backdrop.bg_effect_manager.is_some()
+    }
+
     pub(crate) fn sync_blur_region(
         &mut self,
         id: SurfaceId,

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -33,6 +33,7 @@ use wayland_protocols::ext::background_effect::v1::client::{
     ext_background_effect_surface_v1::ExtBackgroundEffectSurfaceV1,
 };
 
+use std::cell::Cell;
 use std::collections::HashMap;
 
 use super::backdrop::Backdrop;
@@ -105,6 +106,11 @@ pub struct WaylandSurfaceState {
     /// been pushed yet (also reset when the blur capability changes, so the
     /// region is re-sent if it comes back).
     pub(super) blur_region: Option<Vec<BlurRect>>,
+    /// Set when the compositor's blur capability changes, so a surface that is
+    /// not repainting knows it owes a region — and, the rest of the time, knows
+    /// it does not. See
+    /// [`take_blur_resync`](WaylandState::take_blur_resync).
+    pub(super) blur_resync_owed: bool,
     /// Height sent in an in-flight popup reposition (cleared by the popup
     /// configure), so repeated content measurements don't re-send it.
     pub(super) pending_popup_height: Option<u32>,
@@ -131,6 +137,7 @@ impl WaylandSurfaceState {
             pending_events: Vec::new(),
             bg_effect_surface: None,
             blur_region: None,
+            blur_resync_owed: false,
             pending_popup_height: None,
         }
     }
@@ -139,6 +146,36 @@ impl WaylandSurfaceState {
     pub fn take_events(&mut self) -> Vec<Event> {
         std::mem::take(&mut self.pending_events)
     }
+}
+
+thread_local! {
+    /// Whether a [`batch_layer_requests`](WaylandState::batch_layer_requests)
+    /// group is open: individual requests hold their commit so the group makes
+    /// one.
+    ///
+    /// A dynamic scope rather than a field, because the scope has to survive a
+    /// panic. The closure gets `&mut WaylandState`, so a guard restoring a field
+    /// could not hold on to it while the closure runs — and a flag left set by
+    /// an unwind would be permanent: every later `set_margin` or `set_layer`
+    /// would hold its commit for a group that had already ended, and the surface
+    /// would stop answering its handle in silence.
+    static BATCHING: Cell<bool> = const { Cell::new(false) };
+}
+
+/// Run `f` inside the batching scope, and report whether it opened it.
+///
+/// Restored on the way out however that happens, which is the whole point.
+fn batching<R>(f: impl FnOnce() -> R) -> (bool, R) {
+    struct Restore(bool);
+    impl Drop for Restore {
+        fn drop(&mut self) {
+            BATCHING.with(|b| b.set(self.0));
+        }
+    }
+
+    let outer = BATCHING.with(|b| b.replace(true));
+    let _restore = Restore(outer);
+    (!outer, f())
 }
 
 pub struct WaylandState {
@@ -150,10 +187,6 @@ pub struct WaylandState {
 
     /// Whether the application should exit
     pub exit: bool,
-    /// Inside [`batch_layer_requests`](Self::batch_layer_requests): individual
-    /// requests hold their commit so the group makes one.
-    batching_requests: bool,
-
     // Multi-surface tracking
     /// All surfaces indexed by SurfaceId
     pub surfaces: HashMap<SurfaceId, WaylandSurfaceState>,
@@ -293,7 +326,6 @@ pub fn create_wayland_app(
         seat_state,
         layer_shell,
         exit: false,
-        batching_requests: false,
         surfaces: HashMap::new(),
         surface_lookup: HashMap::new(),
         current_pointer_surface: None,
@@ -476,8 +508,6 @@ impl WaylandState {
         }
     }
 
-    /// Helper to modify a surface's layer shell properties and commit.
-    /// No-ops (with a warning) on session-lock surfaces, which have none.
     /// Apply several layer-shell requests as one change.
     ///
     /// `with_layer_surface` commits after each
@@ -486,20 +516,29 @@ impl WaylandState {
     /// commits is two of them showing the compositor a surface halfway between
     /// two configurations — before this, an app animating a dock's margin sent a
     /// redundant pair every frame.
+    ///
+    /// The commit is the group's, so it is subject to the same rule each request
+    /// is: only a layer surface has these properties, and a batch aimed at a
+    /// session-lock or popup surface applies nothing. Committing anyway would
+    /// send a bare commit to exactly the roles the per-request path refuses to
+    /// touch.
     pub fn batch_layer_requests(&mut self, id: SurfaceId, f: impl FnOnce(&mut Self)) {
-        let outer = std::mem::replace(&mut self.batching_requests, true);
-        f(self);
-        self.batching_requests = outer;
-        if !outer && let Some(state) = self.surfaces.get(&id) {
+        let (outermost, ()) = batching(|| f(self));
+        if outermost
+            && let Some(state) = self.surfaces.get(&id)
+            && matches!(state.role, SurfaceRole::Layer(_))
+        {
             state.wl_surface.commit();
         }
     }
 
+    /// Helper to modify a surface's layer shell properties and commit.
+    /// No-ops (with a warning) on session-lock surfaces, which have none.
     fn with_layer_surface<F>(&mut self, id: SurfaceId, f: F)
     where
         F: FnOnce(&LayerSurface),
     {
-        let batching = self.batching_requests;
+        let batching = BATCHING.with(|b| b.get());
         if let Some(surface_state) = self.surfaces.get_mut(&id) {
             match &surface_state.role {
                 SurfaceRole::Layer(layer_surface) => {
@@ -790,3 +829,33 @@ impl ProvidesRegistryState for WaylandState {
 delegate_compositor!(WaylandState);
 delegate_layer!(WaylandState);
 delegate_registry!(WaylandState);
+
+#[cfg(test)]
+mod batching_tests {
+    use super::{BATCHING, batching};
+
+    /// A batch is a scope, and a scope that a panic can leave open is not one.
+    /// Left open, every later layer-shell request holds its commit for a group
+    /// that ended, and the surface stops answering its handle in silence.
+    #[test]
+    fn a_panic_inside_a_batch_still_closes_it() {
+        let escaped = std::panic::catch_unwind(|| {
+            batching(|| panic!("a request went wrong"));
+        });
+        assert!(escaped.is_err(), "the panic still propagates");
+        assert!(
+            !BATCHING.with(|b| b.get()),
+            "and the scope closed on its way out"
+        );
+    }
+
+    /// Only the outermost group commits, or a nested batch would commit halfway
+    /// through the one containing it.
+    #[test]
+    fn only_the_outermost_batch_reports_itself() {
+        let (outermost, inner) = batching(|| batching(|| ()).0);
+        assert!(outermost, "the outer one opened the scope");
+        assert!(!inner, "the inner one found it already open");
+        assert!(!BATCHING.with(|b| b.get()));
+    }
+}

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -391,15 +391,8 @@ impl WaylandState {
         // When anchored to both edges on an axis, the compositor owns
         // that dimension: set it to 0 so it stretches. Content sizing on
         // such an axis can never take effect — warn loudly.
-        let stretch_w =
-            config.anchor.contains(Anchor::LEFT) && config.anchor.contains(Anchor::RIGHT);
-        let stretch_h =
-            config.anchor.contains(Anchor::TOP) && config.anchor.contains(Anchor::BOTTOM);
-        if (stretch_w && config.width.is_content()) || (stretch_h && config.height.is_content()) {
-            log::warn!(
-                "Surface {id:?}: content() sizing on an axis anchored to both                  screen edges is compositor-owned and will be ignored"
-            );
-        }
+        let (stretch_w, stretch_h) = crate::surface::compositor_owned_axes(config.anchor);
+        crate::surface::warn_content_on_stretched_axis(id, config);
         let initial_width = config.width.initial();
         let initial_height = config.height.initial();
         let use_width = if stretch_w { 0 } else { initial_width };

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -150,6 +150,9 @@ pub struct WaylandState {
 
     /// Whether the application should exit
     pub exit: bool,
+    /// Inside [`batch_layer_requests`](Self::batch_layer_requests): individual
+    /// requests hold their commit so the group makes one.
+    batching_requests: bool,
 
     // Multi-surface tracking
     /// All surfaces indexed by SurfaceId
@@ -290,6 +293,7 @@ pub fn create_wayland_app(
         seat_state,
         layer_shell,
         exit: false,
+        batching_requests: false,
         surfaces: HashMap::new(),
         surface_lookup: HashMap::new(),
         current_pointer_surface: None,
@@ -474,15 +478,35 @@ impl WaylandState {
 
     /// Helper to modify a surface's layer shell properties and commit.
     /// No-ops (with a warning) on session-lock surfaces, which have none.
+    /// Apply several layer-shell requests as one change.
+    ///
+    /// `with_layer_surface` commits after each
+    /// request, which is right for one on its own and wrong for a group:
+    /// re-anchoring sends the anchor, the size and the reservation, and three
+    /// commits is two of them showing the compositor a surface halfway between
+    /// two configurations — before this, an app animating a dock's margin sent a
+    /// redundant pair every frame.
+    pub fn batch_layer_requests(&mut self, id: SurfaceId, f: impl FnOnce(&mut Self)) {
+        let outer = std::mem::replace(&mut self.batching_requests, true);
+        f(self);
+        self.batching_requests = outer;
+        if !outer && let Some(state) = self.surfaces.get(&id) {
+            state.wl_surface.commit();
+        }
+    }
+
     fn with_layer_surface<F>(&mut self, id: SurfaceId, f: F)
     where
         F: FnOnce(&LayerSurface),
     {
+        let batching = self.batching_requests;
         if let Some(surface_state) = self.surfaces.get_mut(&id) {
             match &surface_state.role {
                 SurfaceRole::Layer(layer_surface) => {
                     f(layer_surface);
-                    surface_state.wl_surface.commit();
+                    if !batching {
+                        surface_state.wl_surface.commit();
+                    }
                 }
                 SurfaceRole::Lock(_) | SurfaceRole::Popup { .. } => {
                     log::warn!(

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -149,33 +149,40 @@ impl WaylandSurfaceState {
 }
 
 thread_local! {
-    /// Whether a [`batch_layer_requests`](WaylandState::batch_layer_requests)
-    /// group is open: individual requests hold their commit so the group makes
-    /// one.
+    /// Which surface a [`batch_layer_requests`](WaylandState::batch_layer_requests)
+    /// group is open on: its requests hold their commit so the group makes one.
+    ///
+    /// The *id*, not a flag. The closure is handed a whole `&mut WaylandState`,
+    /// so it can address any surface it likes, and a flag suppressed the commit
+    /// of every one of them while promising it for exactly one: a request aimed
+    /// at another surface stayed double-buffered until something unrelated
+    /// committed that surface, which for an idle one is never.
     ///
     /// A dynamic scope rather than a field, because the scope has to survive a
     /// panic. The closure gets `&mut WaylandState`, so a guard restoring a field
-    /// could not hold on to it while the closure runs — and a flag left set by
+    /// could not hold on to it while the closure runs — and a scope left open by
     /// an unwind would be permanent: every later `set_margin` or `set_layer`
     /// would hold its commit for a group that had already ended, and the surface
     /// would stop answering its handle in silence.
-    static BATCHING: Cell<bool> = const { Cell::new(false) };
+    static BATCHING: Cell<Option<SurfaceId>> = const { Cell::new(None) };
 }
 
-/// Run `f` inside the batching scope, and report whether it opened it.
+/// Run `f` inside a batching scope for `id`, and report whether it opened it.
 ///
-/// Restored on the way out however that happens, which is the whole point.
-fn batching<R>(f: impl FnOnce() -> R) -> (bool, R) {
-    struct Restore(bool);
+/// Restored on the way out however that happens, which is the whole point. A
+/// group nested inside one on *another* surface opens its own, because the
+/// commit it owes is not the one the outer group will make.
+fn batching<R>(id: SurfaceId, f: impl FnOnce() -> R) -> (bool, R) {
+    struct Restore(Option<SurfaceId>);
     impl Drop for Restore {
         fn drop(&mut self) {
             BATCHING.with(|b| b.set(self.0));
         }
     }
 
-    let outer = BATCHING.with(|b| b.replace(true));
+    let outer = BATCHING.with(|b| b.replace(Some(id)));
     let _restore = Restore(outer);
-    (!outer, f())
+    (outer != Some(id), f())
 }
 
 pub struct WaylandState {
@@ -527,7 +534,7 @@ impl WaylandState {
     /// send a bare commit to exactly the roles the per-request path refuses to
     /// touch.
     pub fn batch_layer_requests(&mut self, id: SurfaceId, f: impl FnOnce(&mut Self)) {
-        let (outermost, ()) = batching(|| f(self));
+        let (outermost, ()) = batching(id, || f(self));
         if outermost
             && let Some(state) = self.surfaces.get(&id)
             && matches!(state.role, SurfaceRole::Layer(_))
@@ -542,7 +549,9 @@ impl WaylandState {
     where
         F: FnOnce(&LayerSurface),
     {
-        let batching = BATCHING.with(|b| b.get());
+        // Only for the surface the open group will commit for. Another one's
+        // request has nobody to ride with, so it commits for itself.
+        let batching = BATCHING.with(|b| b.get()) == Some(id);
         if let Some(surface_state) = self.surfaces.get_mut(&id) {
             match &surface_state.role {
                 SurfaceRole::Layer(layer_surface) => {
@@ -836,7 +845,12 @@ delegate_registry!(WaylandState);
 
 #[cfg(test)]
 mod batching_tests {
-    use super::{BATCHING, batching};
+    use super::{BATCHING, SurfaceId, batching};
+
+    /// Distinct ids; the counter is global and the numbers do not matter.
+    fn surface() -> SurfaceId {
+        SurfaceId::next()
+    }
 
     /// A batch is a scope, and a scope that a panic can leave open is not one.
     /// Left open, every later layer-shell request holds its commit for a group
@@ -844,11 +858,11 @@ mod batching_tests {
     #[test]
     fn a_panic_inside_a_batch_still_closes_it() {
         let escaped = std::panic::catch_unwind(|| {
-            batching(|| panic!("a request went wrong"));
+            batching(surface(), || panic!("a request went wrong"));
         });
         assert!(escaped.is_err(), "the panic still propagates");
         assert!(
-            !BATCHING.with(|b| b.get()),
+            BATCHING.with(|b| b.get()).is_none(),
             "and the scope closed on its way out"
         );
     }
@@ -857,9 +871,28 @@ mod batching_tests {
     /// through the one containing it.
     #[test]
     fn only_the_outermost_batch_reports_itself() {
-        let (outermost, inner) = batching(|| batching(|| ()).0);
+        let a = surface();
+        let (outermost, inner) = batching(a, || batching(a, || ()).0);
         assert!(outermost, "the outer one opened the scope");
         assert!(!inner, "the inner one found it already open");
-        assert!(!BATCHING.with(|b| b.get()));
+        assert!(BATCHING.with(|b| b.get()).is_none());
+    }
+
+    /// The scope belongs to a surface, not to the thread. A request aimed at
+    /// another surface inside an open group has nobody to ride with: suppressing
+    /// its commit leaves it double-buffered until something unrelated commits
+    /// that surface, which for an idle one is never.
+    #[test]
+    fn a_batch_on_one_surface_does_not_hold_another_one_s_commit() {
+        let (a, b) = (surface(), surface());
+        let mut seen = None;
+        let (outer, inner) = batching(a, || {
+            seen = Some(BATCHING.with(|s| s.get()));
+            batching(b, || ()).0
+        });
+        assert!(outer, "the group on a commits for a");
+        assert!(inner, "and the one on b commits for b, rather than nothing");
+        assert_eq!(seen, Some(Some(a)), "inside, the open group is a's");
+        assert!(BATCHING.with(|s| s.get()).is_none());
     }
 }

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -416,9 +416,9 @@ impl WaylandState {
         );
         layer_surface.set_exclusive_zone(zone);
 
-        let (top, right, bottom, left) = config.margin;
-        if (top, right, bottom, left) != (0, 0, 0, 0) {
-            layer_surface.set_margin(top, right, bottom, left);
+        let margin = config.margin;
+        if !margin.is_zero() {
+            layer_surface.set_margin(margin.top, margin.right, margin.bottom, margin.left);
         }
 
         if let Some(rects) = &config.input_region {
@@ -536,23 +536,11 @@ impl WaylandState {
     }
 
     /// Set the margin for a surface.
-    pub fn set_surface_margin(
-        &mut self,
-        id: SurfaceId,
-        top: i32,
-        right: i32,
-        bottom: i32,
-        left: i32,
-    ) {
-        self.with_layer_surface(id, |ls| ls.set_margin(top, right, bottom, left));
-        log::info!(
-            "Surface {:?} margin set to top={}, right={}, bottom={}, left={}",
-            id,
-            top,
-            right,
-            bottom,
-            left
-        );
+    pub fn set_surface_margin(&mut self, id: SurfaceId, margin: crate::surface::Margin) {
+        self.with_layer_surface(id, |ls| {
+            ls.set_margin(margin.top, margin.right, margin.bottom, margin.left)
+        });
+        log::info!("Surface {:?} margin set to {:?}", id, margin);
     }
 
     /// Get a surface state by SurfaceId.

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -431,8 +431,12 @@ impl WaylandState {
         // The same rule the runtime resize uses, so creation and re-anchoring
         // cannot disagree about which axes are the compositor's.
         let (use_width, use_height, _) = crate::surface::resize_request(config, None);
-        let initial_width = config.width.initial();
-        let initial_height = config.height.initial();
+        // Before the honouring: the size the surface believes it has, and the
+        // one a reservation resolves against. Through the same helper as the
+        // request, not `SurfaceExtent::initial()`, which happens to agree today
+        // only because `requested_extent` with no configure falls back to it.
+        let initial_width = crate::surface::requested_extent(config.width, None);
+        let initial_height = crate::surface::requested_extent(config.height, None);
 
         layer_surface.set_size(use_width, use_height);
         layer_surface.set_keyboard_interactivity(config.keyboard_interactivity);

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -391,12 +391,12 @@ impl WaylandState {
         // When anchored to both edges on an axis, the compositor owns
         // that dimension: set it to 0 so it stretches. Content sizing on
         // such an axis can never take effect — warn loudly.
-        let (stretch_w, stretch_h) = crate::surface::compositor_owned_axes(config.anchor);
         crate::surface::warn_content_on_stretched_axis(id, config);
+        // The same rule the runtime resize uses, so creation and re-anchoring
+        // cannot disagree about which axes are the compositor's.
+        let (use_width, use_height, _) = crate::surface::resize_request(config, None);
         let initial_width = config.width.initial();
         let initial_height = config.height.initial();
-        let use_width = if stretch_w { 0 } else { initial_width };
-        let use_height = if stretch_h { 0 } else { initial_height };
 
         layer_surface.set_size(use_width, use_height);
         layer_surface.set_keyboard_interactivity(config.keyboard_interactivity);

--- a/src/reactive/callback.rs
+++ b/src/reactive/callback.rs
@@ -7,7 +7,7 @@
 //! back its id, so the handle is `Copy` and goes wherever it is needed.
 //!
 //! It is also what keeps a struct that groups handles `Copy` — the same
-//! reason [`Signal`](super::Signal) and [`Service`](super::Service) are.
+//! reason [`Signal`] and [`Service`](super::Service) are.
 //!
 //! The argument list is a tuple, and each arity gets its own `new`/`run` so
 //! both ends stay flat:

--- a/src/reactive/diagnostics.rs
+++ b/src/reactive/diagnostics.rs
@@ -205,8 +205,7 @@ mod tests {
         assert_eq!(
             reports_of(|| crate::reactive::create_effect(move || {
                 let _ = count.get();
-            })
-            .detach()),
+            })),
             0
         );
     }

--- a/src/reactive/effect.rs
+++ b/src/reactive/effect.rs
@@ -1,7 +1,5 @@
 use super::owner::register_effect;
-#[cfg(test)]
-use super::runtime::EffectId;
-use super::runtime::{run_effect_by_id, with_runtime};
+use super::runtime::{EffectId, run_effect_by_id, with_runtime};
 
 /// Run `f` now, and again whenever a signal it read changes.
 ///
@@ -19,6 +17,21 @@ pub fn create_effect<F>(f: F)
 where
     F: FnMut() + 'static,
 {
+    create_effect_id(f);
+}
+
+/// [`create_effect`], returning the id.
+///
+/// Only the ownership tests reach for this: nothing in the running library needs
+/// an effect's id, because nothing disposes an effect other than the scope that
+/// owns it. It exists so those tests can ask whether registration happened —
+/// which is only worth asking if it is the *same* three steps the real path
+/// takes, in the same order. So `create_effect` delegates here rather than the
+/// two keeping their own copies.
+pub(crate) fn create_effect_id<F>(f: F) -> EffectId
+where
+    F: FnMut() + 'static,
+{
     let id = with_runtime(|rt| rt.allocate_effect(Box::new(f)));
 
     // Initial run establishes dependencies. Runs outside the runtime borrow, so
@@ -26,26 +39,6 @@ where
     run_effect_by_id(id);
 
     // Register with the current owner for automatic cleanup
-    register_effect(id);
-}
-
-/// [`create_effect`], returning the id.
-///
-/// Only the ownership tests reach for this: nothing in the running library needs
-/// an effect's id, because nothing disposes an effect other than the scope that
-/// owns it. It exists so those tests can ask whether registration happened.
-#[cfg(test)]
-pub(crate) fn create_effect_id<F>(f: F) -> EffectId
-where
-    F: FnMut() + 'static,
-{
-    let id = with_runtime(|rt| rt.allocate_effect(Box::new(f)));
-
-    // Initial run establishes dependencies. Runs outside the runtime
-    // borrow, so the callback can freely write signals or create new ones.
-    run_effect_by_id(id);
-
-    // Register with current owner for automatic cleanup
     register_effect(id);
 
     id

--- a/src/reactive/effect.rs
+++ b/src/reactive/effect.rs
@@ -1,5 +1,7 @@
 use super::owner::register_effect;
-use super::runtime::{EffectId, run_effect_by_id, with_runtime};
+#[cfg(test)]
+use super::runtime::EffectId;
+use super::runtime::{run_effect_by_id, with_runtime};
 
 /// Run `f` now, and again whenever a signal it read changes.
 ///
@@ -17,11 +19,22 @@ pub fn create_effect<F>(f: F)
 where
     F: FnMut() + 'static,
 {
-    create_effect_id(f);
+    let id = with_runtime(|rt| rt.allocate_effect(Box::new(f)));
+
+    // Initial run establishes dependencies. Runs outside the runtime borrow, so
+    // the callback can freely write signals or create new ones.
+    run_effect_by_id(id);
+
+    // Register with the current owner for automatic cleanup
+    register_effect(id);
 }
 
-/// [`create_effect`], returning the id — for the reactive primitives built on
-/// top of it, which have to be able to dispose their own.
+/// [`create_effect`], returning the id.
+///
+/// Only the ownership tests reach for this: nothing in the running library needs
+/// an effect's id, because nothing disposes an effect other than the scope that
+/// owns it. It exists so those tests can ask whether registration happened.
+#[cfg(test)]
 pub(crate) fn create_effect_id<F>(f: F) -> EffectId
 where
     F: FnMut() + 'static,

--- a/src/reactive/effect.rs
+++ b/src/reactive/effect.rs
@@ -1,67 +1,41 @@
-use super::owner::{effect_has_owner, register_effect};
+use super::owner::register_effect;
 use super::runtime::{EffectId, run_effect_by_id, with_runtime};
 
-pub struct Effect {
-    id: EffectId,
-}
-
-impl Effect {
-    pub fn new<F>(f: F) -> Self
-    where
-        F: FnMut() + 'static,
-    {
-        let id = with_runtime(|rt| rt.allocate_effect(Box::new(f)));
-
-        // Initial run establishes dependencies. Runs outside the runtime
-        // borrow, so the callback can freely write signals or create new ones.
-        run_effect_by_id(id);
-
-        // Register with current owner for automatic cleanup
-        register_effect(id);
-
-        Self { id }
-    }
-
-    /// Detach this effect from automatic cleanup.
-    ///
-    /// The effect will run for the lifetime of the application.
-    /// Use this for effects created outside of widget/owner scopes
-    /// (e.g. in `main()`) that should persist indefinitely.
-    ///
-    /// # Example
-    ///
-    /// ```ignore
-    /// create_effect(move || {
-    ///     println!("Signal changed: {}", my_signal.get());
-    /// }).detach();
-    /// ```
-    pub fn detach(self) {
-        std::mem::forget(self);
-    }
-
-    /// Get the effect's ID.
-    /// Used internally for testing the ownership system.
-    #[cfg(test)]
-    pub(crate) fn id(&self) -> EffectId {
-        self.id
-    }
-}
-
-impl Drop for Effect {
-    fn drop(&mut self) {
-        // Only dispose if not owned - owned effects are disposed by their owner.
-        // This prevents double disposal and allows the owner to control cleanup order.
-        if !effect_has_owner(self.id) {
-            with_runtime(|rt| rt.dispose_effect(self.id));
-        }
-    }
-}
-
-pub fn create_effect<F>(f: F) -> Effect
+/// Run `f` now, and again whenever a signal it read changes.
+///
+/// The effect belongs to the enclosing scope — the surface's, a component's,
+/// or the root one `App::run` opens — and is disposed with it. Created outside
+/// any scope it runs for the lifetime of the application.
+///
+/// ```ignore
+/// create_effect(move || println!("count is {}", count.get()));
+/// ```
+///
+/// There is deliberately no handle to keep: an effect's lifetime is its
+/// scope's. To end one earlier, put it in a scope that ends earlier.
+pub fn create_effect<F>(f: F)
 where
     F: FnMut() + 'static,
 {
-    Effect::new(f)
+    create_effect_id(f);
+}
+
+/// [`create_effect`], returning the id — for the reactive primitives built on
+/// top of it, which have to be able to dispose their own.
+pub(crate) fn create_effect_id<F>(f: F) -> EffectId
+where
+    F: FnMut() + 'static,
+{
+    let id = with_runtime(|rt| rt.allocate_effect(Box::new(f)));
+
+    // Initial run establishes dependencies. Runs outside the runtime
+    // borrow, so the callback can freely write signals or create new ones.
+    run_effect_by_id(id);
+
+    // Register with current owner for automatic cleanup
+    register_effect(id);
+
+    id
 }
 
 #[cfg(test)]
@@ -71,21 +45,22 @@ mod tests {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
 
+    /// An effect created where nobody owns it survives the statement that
+    /// created it. It used to depend on a guard the caller had to remember to
+    /// `detach()`, so forgetting silently produced an effect that never ran
+    /// again.
     #[test]
-    fn test_effect_detach_prevents_disposal() {
+    fn an_unowned_effect_keeps_running() {
         let signal = create_signal(0);
         let ran = Arc::new(AtomicBool::new(false));
         let ran_clone = ran.clone();
 
-        // Create and immediately detach — effect should survive
         create_effect(move || {
             let _ = signal.get();
             ran_clone.store(true, Ordering::SeqCst);
-        })
-        .detach();
+        });
 
-        // Effect ran during creation and was not disposed
-        assert!(ran.load(Ordering::SeqCst));
+        assert!(ran.load(Ordering::SeqCst), "it runs once on creation");
 
         // Trigger re-run by changing signal
         ran.store(false, Ordering::SeqCst);
@@ -111,15 +86,13 @@ mod tests {
         // Effect A: writes `intermediate` whenever `source` changes
         create_effect(move || {
             intermediate.set(source.get() + 1);
-        })
-        .detach();
+        });
 
         // Effect B: observes `intermediate`
         let observed_b = observed.clone();
         create_effect(move || {
             observed_b.set(intermediate.get());
-        })
-        .detach();
+        });
 
         assert_eq!(observed.get(), 1, "initial chain should have run");
 
@@ -150,8 +123,7 @@ mod tests {
             if created_in_effect.borrow().is_none() {
                 *created_in_effect.borrow_mut() = Some(create_signal(t));
             }
-        })
-        .detach();
+        });
 
         // Re-run the effect a few times (previously panicked out-of-bounds)
         trigger.set(1);
@@ -162,8 +134,7 @@ mod tests {
         let observed_c = observed.clone();
         create_effect(move || {
             observed_c.set(inner.get());
-        })
-        .detach();
+        });
 
         inner.set(42);
         assert_eq!(

--- a/src/reactive/into_signal.rs
+++ b/src/reactive/into_signal.rs
@@ -44,6 +44,18 @@ impl<T> IntoVal<T> for T {
     }
 }
 
+// A closure returning a bare value where an optional one is expected. The
+// constant path already accepts it, through std's `From<T> for Option<T>`, so
+// without this the *same expression* compiles as a value and not as a closure —
+// exactly the asymmetry `IntoSignal` exists to remove. `container().gradient`
+// is where that showed: `Some(g)` and `move || Some(g)` both worked, `g` worked
+// and `move || g` did not.
+impl<T> IntoVal<Option<T>> for T {
+    fn into_val(self) -> Option<T> {
+        Some(self)
+    }
+}
+
 // Lossy f64 → f32: bare float literals in closures default to f64, and
 // accepting them avoids the deprecated f32 inference fallback
 // (rust-lang/rust#154024)

--- a/src/reactive/invalidation.rs
+++ b/src/reactive/invalidation.rs
@@ -452,6 +452,50 @@ mod tests {
         });
     }
 
+    /// `get_untracked` has to be untracked for a *derived* signal too. Its
+    /// closure runs somewhere, and where it ran was inside whatever scope the
+    /// caller happened to be in: the diagnostic snapshot zone around it is
+    /// compiled away in release and never suppressed the recording.
+    ///
+    /// The cost is not a stale value but the wrong granularity — a read inside a
+    /// dynamic-children closure subscribed the parent's *children list*, so
+    /// writing it rebuilt every row where a repaint was the whole job.
+    #[test]
+    fn an_untracked_read_of_a_derived_subscribes_nobody() {
+        use crate::reactive::{create_derived, create_signal};
+
+        let subscribed = |wid: WidgetId| {
+            REGISTRY.with(|reg| {
+                reg.borrow()
+                    .widget_to_signals
+                    .get(&wid)
+                    .is_some_and(|signals| !signals.is_empty())
+            })
+        };
+
+        let inner = create_signal(1i32);
+        let derived = create_derived(move || inner.get() + 1);
+
+        let untracked = widget_id(500);
+        with_signal_tracking(untracked, JobType::Paint, || {
+            assert_eq!(derived.get_untracked(), 2);
+        });
+        assert!(
+            !subscribed(untracked),
+            "an untracked read must leave the scope holding nothing"
+        );
+
+        // The control: the same read, asked for by its tracking name.
+        let tracked = widget_id(501);
+        with_signal_tracking(tracked, JobType::Paint, || {
+            assert_eq!(derived.get(), 2);
+        });
+        assert!(
+            subscribed(tracked),
+            "and a tracked one still has to subscribe, or the test proves nothing"
+        );
+    }
+
     #[test]
     fn test_with_signal_tracking_registers_subscriber() {
         let wid = widget_id(300);

--- a/src/reactive/invalidation.rs
+++ b/src/reactive/invalidation.rs
@@ -452,7 +452,8 @@ mod tests {
         });
     }
 
-    /// `get_untracked` has to be untracked for a *derived* signal too. Its
+    /// `get_untracked` and `with_untracked` have to be untracked for a
+    /// *derived* signal too. Its
     /// closure runs somewhere, and where it ran was inside whatever scope the
     /// caller happened to be in: the diagnostic snapshot zone around it is
     /// compiled away in release and never suppressed the recording.
@@ -483,6 +484,16 @@ mod tests {
         assert!(
             !subscribed(untracked),
             "an untracked read must leave the scope holding nothing"
+        );
+
+        // The borrowing half is the same promise, and was the same bug.
+        let borrowed = widget_id(502);
+        with_signal_tracking(borrowed, JobType::Paint, || {
+            assert_eq!(derived.with_untracked(|v| *v), 2);
+        });
+        assert!(
+            !subscribed(borrowed),
+            "`with_untracked` says untracked too, and has to mean it"
         );
 
         // The control: the same read, asked for by its tracking name.

--- a/src/reactive/memo.rs
+++ b/src/reactive/memo.rs
@@ -67,19 +67,12 @@ where
     // whenever any dependency changes. Signal::set() uses PartialEq to
     // skip notification when the value hasn't changed.
     //
-    // Lifetime: when a current owner exists, the effect is registered with
-    // it and Effect::drop skips disposal (the owner cleans up). Without an
-    // owner (memo created outside App::run or any with_owner scope), the
-    // effect must be detached — otherwise dropping the binding would
-    // dispose it immediately and the memo would silently stop updating.
-    let effect = create_effect(move || {
+    // Lifetime: the effect belongs to whatever scope created the memo, and
+    // outlives the binding either way — a memo created outside any scope
+    // keeps updating for as long as the application runs.
+    create_effect(move || {
         signal.set(f());
     });
-    if super::owner::current_owner().is_some() {
-        drop(effect); // owned: Drop skips disposal, owner controls cleanup
-    } else {
-        effect.detach();
-    }
     Memo { signal }
 }
 
@@ -169,8 +162,7 @@ mod tests {
         let observed_c = observed.clone();
         crate::reactive::create_effect(move || {
             observed_c.set(doubled.get());
-        })
-        .detach();
+        });
 
         assert_eq!(observed.get(), 2);
 
@@ -226,8 +218,7 @@ mod tests {
             trigger.get();
             runs_c.set(runs_c.get() + 1);
             let _memo = create_memo(move || hot.get() * 2);
-        })
-        .detach();
+        });
 
         assert_eq!(runs.get(), 1);
 

--- a/src/reactive/mod.rs
+++ b/src/reactive/mod.rs
@@ -62,7 +62,7 @@ pub mod __internal {
 }
 pub use callback::Callback;
 pub(crate) use runtime::{bg_writes_pending, flush_bg_writes};
-pub use service::{Service, ServiceContext, create_service};
+pub use service::{Service, ServiceContext, create_service, create_task};
 pub use signal::{
     OptionSignalExt, RwSignal, Signal, WriteSignal, create_derived, create_signal, create_stored,
 };

--- a/src/reactive/mod.rs
+++ b/src/reactive/mod.rs
@@ -29,7 +29,7 @@ pub use context::{
 };
 pub use cursor::{CursorIcon, set_cursor};
 pub(crate) use cursor::{cursor_change_pending, take_cursor_change};
-pub use effect::{Effect, create_effect};
+pub use effect::create_effect;
 pub(crate) use focus::{
     focus_path, has_focus, init_focus, release_focus, release_focus_if_within, request_focus,
 };

--- a/src/reactive/owner.rs
+++ b/src/reactive/owner.rs
@@ -17,7 +17,7 @@
 //! // Create a scope with automatic cleanup
 //! let (result, owner_id) = with_owner(|| {
 //!     let signal = create_signal(42);
-//!     let effect = create_effect(move || {
+//!     create_effect(move || {
 //!         println!("Signal: {}", signal.get());
 //!     });
 //!
@@ -394,12 +394,11 @@ pub(crate) fn register_effect(id: EffectId) {
     }
 }
 
-/// Check if an effect is owned by any owner.
+/// Check if an effect is owned by any owner, in O(1) via the reverse mapping.
 ///
-/// This is used by Effect's Drop impl to determine if it should dispose
-/// the effect or let the owner handle it.
-///
-/// Uses O(1) lookup via the reverse mapping instead of linear search.
+/// Only the ownership tests below ask this: nothing in the running library
+/// needs to, since an effect's lifetime is entirely its scope's.
+#[cfg(test)]
 pub(crate) fn effect_has_owner(id: EffectId) -> bool {
     OWNERS.with(|owners| owners.borrow().effect_owners.contains_key(&id))
 }
@@ -649,7 +648,7 @@ mod tests {
 
     #[test]
     fn test_effect_registration_and_reverse_mapping() {
-        use super::super::effect::create_effect;
+        use super::super::effect::create_effect_id;
         use super::super::signal::create_signal;
 
         let effect_ran = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
@@ -657,11 +656,10 @@ mod tests {
 
         let (effect_id, owner_id) = with_owner(|| {
             let signal = create_signal(0);
-            let effect = create_effect(move || {
+            create_effect_id(move || {
                 let _ = signal.get();
                 effect_ran_clone.store(true, std::sync::atomic::Ordering::SeqCst);
-            });
-            effect.id()
+            })
         });
 
         // Effect should be owned via reverse mapping
@@ -699,21 +697,21 @@ mod tests {
 
     #[test]
     fn test_multiple_effects_registration() {
-        use super::super::effect::create_effect;
+        use super::super::effect::create_effect_id;
         use super::super::signal::create_signal;
 
         let (effect_ids, owner_id) = with_owner(|| {
             let signal = create_signal(0);
-            let e1 = create_effect(move || {
+            let e1 = create_effect_id(move || {
                 let _ = signal.get();
             });
-            let e2 = create_effect(move || {
+            let e2 = create_effect_id(move || {
                 let _ = signal.get();
             });
-            let e3 = create_effect(move || {
+            let e3 = create_effect_id(move || {
                 let _ = signal.get();
             });
-            (e1.id(), e2.id(), e3.id())
+            (e1, e2, e3)
         });
 
         // All effects should be owned
@@ -732,22 +730,22 @@ mod tests {
 
     #[test]
     fn test_nested_owners_effect_cleanup() {
-        use super::super::effect::create_effect;
+        use super::super::effect::create_effect_id;
         use super::super::signal::create_signal;
 
         let ((inner_effect, outer_effect), outer_id) = with_owner(|| {
             let signal = create_signal(0);
-            let outer = create_effect(move || {
+            let outer = create_effect_id(move || {
                 let _ = signal.get();
             });
 
             let (inner, _inner_id) = with_owner(|| {
-                create_effect(move || {
+                create_effect_id(move || {
                     let _ = signal.get();
                 })
             });
 
-            (inner.id(), outer.id())
+            (inner, outer)
         });
 
         // Both should be owned

--- a/src/reactive/runtime.rs
+++ b/src/reactive/runtime.rs
@@ -608,7 +608,7 @@ mod tests {
         let sig = create_signal(0);
         let observed = Rc::new(Cell::new(0));
         let o = observed.clone();
-        create_effect(move || o.set(sig.get())).detach();
+        create_effect(move || o.set(sig.get()));
 
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             batch(|| {
@@ -637,8 +637,7 @@ mod tests {
             if v == 1 {
                 panic!("effect panic");
             }
-        })
-        .detach();
+        });
 
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| sig.set(1)));
         assert!(result.is_err(), "panic must propagate out of set()");

--- a/src/reactive/service.rs
+++ b/src/reactive/service.rs
@@ -130,7 +130,7 @@ impl<Cmd: 'static> Service<Cmd> {
 pub fn create_service<Cmd, F, Fut>(f: F) -> Service<Cmd>
 where
     Cmd: Send + 'static,
-    F: FnOnce(mpsc::UnboundedReceiver<Cmd>, ServiceContext) -> Fut + Send + 'static,
+    F: FnOnce(mpsc::UnboundedReceiver<Cmd>, ServiceContext) -> Fut,
     Fut: Future<Output = ()> + Send + 'static,
 {
     let (tx, rx) = mpsc::unbounded_channel();
@@ -147,6 +147,13 @@ where
 /// graceful shutdown, while `abort()` cancels the task at its next `.await` for
 /// fast cleanup — which is what keeps a `WriteSignal` from writing after an App
 /// restart.
+/// Build the future on *this* thread and hand only the future to the runtime.
+///
+/// Which is why neither [`create_service`] nor [`create_task`] asks its factory
+/// to be `Send`: the factory runs here, so it may read whatever the caller has —
+/// a `Signal`, an `Rc` — as long as only owned data crosses into the `async`
+/// block. Both of them used to demand it anyway, which rejected exactly the
+/// idiom their own documentation shows.
 fn spawn_owned<F, Fut>(f: F)
 where
     F: FnOnce(ServiceContext) -> Fut,
@@ -182,7 +189,7 @@ where
 /// ```
 pub fn create_task<F, Fut>(f: F)
 where
-    F: FnOnce(ServiceContext) -> Fut + Send + 'static,
+    F: FnOnce(ServiceContext) -> Fut,
     Fut: Future<Output = ()> + Send + 'static,
 {
     // Not `create_service::<(), _, _>`: that would allocate a channel whose
@@ -391,5 +398,33 @@ mod tests {
         assert_eq!(received.load(Ordering::SeqCst), 12);
 
         dispose_owner_now(owner_id);
+    }
+}
+
+#[cfg(test)]
+mod factory_bounds {
+    use super::*;
+
+    /// Compile-time only: the factory runs on the calling thread, so it may
+    /// capture something that could never cross to the runtime. Nothing calls
+    /// this — spawning would want a scope and a runtime, and the claim is about
+    /// what type-checks.
+    #[allow(dead_code)]
+    fn a_factory_may_read_a_non_send_value() {
+        let local = std::rc::Rc::new(7u8);
+        create_task(move |_ctx| {
+            let owned = *local;
+            async move {
+                let _ = owned;
+            }
+        });
+
+        let local = std::rc::Rc::new(9u8);
+        let _service = create_service::<(), _, _>(move |_rx, _ctx| {
+            let owned = *local;
+            async move {
+                let _ = owned;
+            }
+        });
     }
 }

--- a/src/reactive/service.rs
+++ b/src/reactive/service.rs
@@ -47,7 +47,7 @@ impl ServiceContext {
 
 /// Handle to a background service for sending commands.
 ///
-/// `Copy`, like [`Signal`](super::Signal): the channel lives in the reactive
+/// `Copy`, like [`Signal`]: the channel lives in the reactive
 /// arena and the handle is just its id, so it can be dropped into as many
 /// closures as needed without a clone. Handles of services, signals and
 /// callbacks being `Copy` is what keeps a struct that groups them `Copy` too.

--- a/src/reactive/service.rs
+++ b/src/reactive/service.rs
@@ -125,22 +125,8 @@ impl<Cmd: 'static> Service<Cmd> {
 /// service.send(Cmd::SwitchWorkspace(2));
 /// ```
 ///
-/// # Example: Read-Only Service
-///
-/// For services that only push data to signals (no commands), use `()` as
-/// the command type and ignore the receiver:
-///
-/// ```ignore
-/// let time = create_signal(String::new());
-/// let time_w = time.writer();
-///
-/// let _ = create_service::<(), _, _>(move |_rx, ctx| async move {
-///     while ctx.is_running() {
-///         time_w.set(chrono::Local::now().format("%H:%M").to_string());
-///         tokio::time::sleep(Duration::from_secs(1)).await;
-///     }
-/// });
-/// ```
+/// A task with nothing to command is [`create_task`], which has no receiver
+/// and no turbofish.
 pub fn create_service<Cmd, F, Fut>(f: F) -> Service<Cmd>
 where
     Cmd: Send + 'static,
@@ -166,6 +152,31 @@ where
     });
 
     Service { sender }
+}
+
+/// Create a background task tied to the current Owner.
+///
+/// The half of [`create_service`] that only pushes: no commands, so no
+/// receiver, no command type to name, and no handle to keep. It is aborted
+/// when the scope that created it is disposed, exactly as a service is.
+///
+/// ```ignore
+/// let time = create_signal(String::new());
+/// let time_w = time.writer();
+///
+/// create_task(move |ctx| async move {
+///     while ctx.is_running() {
+///         time_w.set(chrono::Local::now().format("%H:%M").to_string());
+///         tokio::time::sleep(Duration::from_secs(1)).await;
+///     }
+/// });
+/// ```
+pub fn create_task<F, Fut>(f: F)
+where
+    F: FnOnce(ServiceContext) -> Fut + Send + 'static,
+    Fut: Future<Output = ()> + Send + 'static,
+{
+    create_service::<(), _, _>(move |_rx, ctx| f(ctx));
 }
 
 /// Get a runtime handle for spawning service tasks.
@@ -242,7 +253,7 @@ mod tests {
         let counter_clone = counter.clone();
 
         let (_, owner_id) = with_owner(|| {
-            let _ = create_service::<(), _, _>(move |_rx, ctx| async move {
+            create_task(move |ctx| async move {
                 while ctx.is_running() {
                     counter_clone.fetch_add(1, Ordering::SeqCst);
                     tokio::time::sleep(Duration::from_millis(10)).await;

--- a/src/reactive/service.rs
+++ b/src/reactive/service.rs
@@ -134,31 +134,40 @@ where
     Fut: Future<Output = ()> + Send + 'static,
 {
     let (tx, rx) = mpsc::unbounded_channel();
-    let running = Arc::new(AtomicBool::new(true));
-    let running_for_cleanup = running.clone();
-
-    let ctx = ServiceContext { running };
-    let handle = service_runtime().spawn(f(rx, ctx));
     // The channel lives in the arena so the handle can be Copy
     let sender = create_stored(tx);
+    spawn_owned(|ctx| f(rx, ctx));
+    Service { sender }
+}
 
-    // Register cleanup to stop the task when component unmounts.
-    // Setting is_running to false allows graceful shutdown, while abort()
-    // cancels the task at its next .await point for fast cleanup — this
-    // prevents stale WriteSignal writes after an App restart.
+/// Spawn a future on the service runtime, owned by the current scope.
+///
+/// The half both [`create_service`] and [`create_task`] need: the context, the
+/// spawn, and the cleanup that stops it. Setting `is_running` to false allows a
+/// graceful shutdown, while `abort()` cancels the task at its next `.await` for
+/// fast cleanup — which is what keeps a `WriteSignal` from writing after an App
+/// restart.
+fn spawn_owned<F, Fut>(f: F)
+where
+    F: FnOnce(ServiceContext) -> Fut,
+    Fut: Future<Output = ()> + Send + 'static,
+{
+    let running = Arc::new(AtomicBool::new(true));
+    let running_for_cleanup = running.clone();
+    let handle = service_runtime().spawn(f(ServiceContext { running }));
+
     on_cleanup(move || {
         running_for_cleanup.store(false, Ordering::SeqCst);
         handle.abort();
     });
-
-    Service { sender }
 }
 
 /// Create a background task tied to the current Owner.
 ///
 /// The half of [`create_service`] that only pushes: no commands, so no
-/// receiver, no command type to name, and no handle to keep. It is aborted
-/// when the scope that created it is disposed, exactly as a service is.
+/// receiver, no command type to name, no channel allocated and no handle to
+/// keep. It is aborted when the scope that created it is disposed, exactly as a
+/// service is.
 ///
 /// ```ignore
 /// let time = create_signal(String::new());
@@ -176,7 +185,11 @@ where
     F: FnOnce(ServiceContext) -> Fut + Send + 'static,
     Fut: Future<Output = ()> + Send + 'static,
 {
-    create_service::<(), _, _>(move |_rx, ctx| f(ctx));
+    // Not `create_service::<(), _, _>`: that would allocate a channel whose
+    // receiver is dropped at the first poll, and park its sender in an arena
+    // slot held until the scope is disposed. A status bar's dozen push-only
+    // tasks are a dozen dead channels.
+    spawn_owned(f);
 }
 
 /// Get a runtime handle for spawning service tasks.
@@ -244,6 +257,37 @@ mod tests {
         }
         assert_eq!(received.load(Ordering::SeqCst), 5);
 
+        dispose_owner_now(owner_id);
+    }
+
+    /// A task has nothing to receive, so it must not build the machinery for
+    /// receiving. Going through `create_service::<(), _, _>` allocated a channel
+    /// whose receiver died at the first poll and parked its sender in an arena
+    /// slot held until disposal — a dozen push-only tasks, a dozen dead
+    /// channels.
+    #[test]
+    fn a_task_allocates_no_channel() {
+        let before = crate::reactive::storage::slot_count();
+        let (_, owner_id) = with_owner(|| {
+            create_task(|ctx| async move {
+                let _ = ctx.is_running();
+            });
+        });
+        assert_eq!(
+            crate::reactive::storage::slot_count(),
+            before,
+            "a task must claim no arena slot"
+        );
+        dispose_owner_now(owner_id);
+
+        // The service, which does have something to receive, still claims one.
+        let before = crate::reactive::storage::slot_count();
+        let (_, owner_id) = with_owner(|| {
+            create_service::<i32, _, _>(|mut rx, _ctx| async move {
+                let _ = rx.recv().await;
+            })
+        });
+        assert!(crate::reactive::storage::slot_count() > before);
         dispose_owner_now(owner_id);
     }
 

--- a/src/reactive/signal.rs
+++ b/src/reactive/signal.rs
@@ -131,7 +131,8 @@ fn update_and_notify_always<T: Clone + 'static>(id: SignalId, f: impl FnOnce(&mu
 ///
 /// `Signal<T>` provides read access to reactive values. It is returned by
 /// [`create_stored`] (static values) and [`create_derived`] (closure-backed).
-/// Widget properties accept `Signal<T>` via the [`IntoSignal`] trait.
+/// Widget properties accept `Signal<T>` via the
+/// [`IntoSignal`](super::IntoSignal) trait.
 ///
 /// To create a read-write signal, use [`create_signal`] which returns [`RwSignal<T>`].
 ///
@@ -210,7 +211,8 @@ impl<T: Clone + Send + Sync + 'static> Signal<T> {
 ///
 /// Created by [`create_signal`]. Provides both read and write access.
 /// Can be converted to a read-only [`Signal<T>`] via [`read_only()`](RwSignal::read_only)
-/// or the [`From`] impl. Widget properties accept `RwSignal<T>` via [`IntoSignal`].
+/// or the [`From`] impl. Widget properties accept `RwSignal<T>` via
+/// [`IntoSignal`](super::IntoSignal).
 ///
 /// `RwSignal<T>` is `Copy` (8 bytes — just a signal ID).
 ///

--- a/src/reactive/signal.rs
+++ b/src/reactive/signal.rs
@@ -150,6 +150,19 @@ pub struct Signal<T> {
     _not_send: PhantomData<*const ()>,
 }
 
+/// Run a derived signal's closure with nothing listening.
+///
+/// One place, because there are two callers and they were not the same: the
+/// diagnostic zone alone is compiled away in release, so a `with_untracked` that
+/// had only that still recorded every signal the closure read against whatever
+/// happened to be tracking. Two sister functions with different contracts is
+/// worse than either contract.
+fn untracked_derived<T: Clone + 'static>(id: SignalId) -> T {
+    snapshot_zone(|| {
+        suspend_widget_tracking(|| suspend_effect_tracking(|| try_call_derived::<T>(id).unwrap()))
+    })
+}
+
 impl_signal_id_traits!(Signal);
 
 impl<T: Clone + 'static> Signal<T> {
@@ -174,11 +187,7 @@ impl<T: Clone + 'static> Signal<T> {
             SignalKind::Stored => get_stored_value(self.id),
             // The caller asked for a snapshot; the closure's own reads are
             // part of that snapshot and must not be reported either
-            SignalKind::Derived => snapshot_zone(|| {
-                suspend_widget_tracking(|| {
-                    suspend_effect_tracking(|| try_call_derived::<T>(self.id).unwrap())
-                })
-            }),
+            SignalKind::Derived => untracked_derived::<T>(self.id),
             SignalKind::Mutable => get_signal_value(self.id),
         }
     }
@@ -198,12 +207,17 @@ impl<T: Clone + 'static> Signal<T> {
         matches!(self.kind, SignalKind::Stored).then(|| get_stored_value(self.id))
     }
 
-    /// Borrow the value without tracking
+    /// Borrow the value without tracking.
+    ///
+    /// The borrowing half of [`get_untracked`](Self::get_untracked), suspended
+    /// the same three ways for the same reason: a derived signal's closure runs
+    /// somewhere, and unsuspended it runs inside whatever scope the caller was
+    /// in.
     pub fn with_untracked<R>(&self, f: impl FnOnce(&T) -> R) -> R {
         match self.kind {
             SignalKind::Stored => with_stored_value(self.id, f),
             SignalKind::Derived => {
-                let val = snapshot_zone(|| try_call_derived::<T>(self.id).unwrap());
+                let val = untracked_derived::<T>(self.id);
                 f(&val)
             }
             SignalKind::Mutable => with_signal_value(self.id, f),

--- a/src/reactive/signal.rs
+++ b/src/reactive/signal.rs
@@ -573,16 +573,12 @@ fn watch_value<T: Clone + Send + Sync + 'static>(
     read: impl Fn() -> T + 'static,
 ) -> tokio::sync::watch::Receiver<T> {
     let (tx, rx) = tokio::sync::watch::channel(initial);
-    let effect = super::effect::create_effect(move || {
+    // Owned by the scope that asked for the channel: disposing it drops the
+    // sender, which is how the task on the other end learns the UI is gone
+    // (`changed()` returns Err).
+    super::effect::create_effect(move || {
         let _ = tx.send(read());
     });
-    if super::owner::current_owner().is_some() {
-        // Owned: the scope disposes it, and dropping the sender is how the
-        // task learns the UI is gone (`changed()` returns Err)
-        drop(effect);
-    } else {
-        effect.detach();
-    }
     rx
 }
 
@@ -860,8 +856,7 @@ mod tests {
         create_effect(move || {
             let _ = sig.get();
             counter.set(counter.get() + 1);
-        })
-        .detach();
+        });
         assert_eq!(runs.get(), 1);
 
         sig.set(7); // equal: state write deduplicates

--- a/src/reactive/signal.rs
+++ b/src/reactive/signal.rs
@@ -317,7 +317,7 @@ impl<T: Clone + Send + Sync + 'static> RwSignal<T> {
     /// let wide = create_memo(move || menu.get() == Some(Menu::SystemInfo));
     /// let mut wide_rx = wide.watch();
     ///
-    /// create_service::<(), _, _>(move |_rx, ctx| async move {
+    /// create_task(move |ctx| async move {
     ///     while ctx.is_running() {
     ///         let scope = if *wide_rx.borrow() { Scope::All } else { Scope::Bar };
     ///         sample(scope);
@@ -367,7 +367,7 @@ impl<T: Clone + 'static> From<RwSignal<T>> for Signal<T> {
 /// let time = create_signal(get_current_time());
 /// let time_w = time.writer();
 ///
-/// let _ = create_service::<(), _, _>(move |_rx, ctx| async move {
+/// create_task(move |ctx| async move {
 ///     while ctx.is_running() {
 ///         time_w.set(get_current_time()); // queued for main thread
 ///         tokio::time::sleep(Duration::from_secs(1)).await;

--- a/src/reactive/signal.rs
+++ b/src/reactive/signal.rs
@@ -174,6 +174,15 @@ impl<T: Clone + 'static> Signal<T> {
         tracked_with(self.id, self.kind, f)
     }
 
+    /// The value, if this signal is one that can never change.
+    ///
+    /// A `create_stored` signal is a constant behind a signal-shaped handle, so
+    /// a builder handed one can take the cheap path — build one constant rather
+    /// than a derived that recomputes a value that will always be the same.
+    pub(crate) fn constant(&self) -> Option<T> {
+        matches!(self.kind, SignalKind::Stored).then(|| get_stored_value(self.id))
+    }
+
     /// Borrow the value without tracking
     pub fn with_untracked<R>(&self, f: impl FnOnce(&T) -> R) -> R {
         match self.kind {

--- a/src/reactive/signal.rs
+++ b/src/reactive/signal.rs
@@ -1,10 +1,11 @@
 use std::marker::PhantomData;
 
 use super::diagnostics::{check_reactive_scope, snapshot_zone};
-use super::invalidation::{notify_signal_change, record_signal_read};
+use super::invalidation::{notify_signal_change, record_signal_read, suspend_widget_tracking};
 use super::owner::register_signal;
 use super::runtime::{
-    SignalId, current_write_epoch, notify_write, queue_bg_write, record_effect_read, with_runtime,
+    SignalId, current_write_epoch, notify_write, queue_bg_write, record_effect_read,
+    suspend_effect_tracking, with_runtime,
 };
 use super::storage::{
     allocate_signal_slot, compare_and_set_signal_value, compare_and_update_signal_value,
@@ -158,13 +159,26 @@ impl<T: Clone + 'static> Signal<T> {
         tracked_get(self.id, self.kind)
     }
 
-    /// Get the current value without tracking
+    /// Get the current value without tracking.
+    ///
+    /// Untracked all the way down for a derived one: its closure runs with the
+    /// widget and effect scopes suspended, the same three-part suspension
+    /// [`create_memo`](crate::reactive::create_memo) seeds itself with. The
+    /// diagnostic zone alone was not it — in release it compiles to nothing, so
+    /// every signal the closure read was still recorded against whatever
+    /// happened to be tracking. A `get_untracked` inside a dynamic-children
+    /// closure therefore subscribed the *parent's children list* to it, and
+    /// writing it rebuilt the whole list where a repaint was the work.
     pub fn get_untracked(&self) -> T {
         match self.kind {
             SignalKind::Stored => get_stored_value(self.id),
             // The caller asked for a snapshot; the closure's own reads are
             // part of that snapshot and must not be reported either
-            SignalKind::Derived => snapshot_zone(|| try_call_derived::<T>(self.id).unwrap()),
+            SignalKind::Derived => snapshot_zone(|| {
+                suspend_widget_tracking(|| {
+                    suspend_effect_tracking(|| try_call_derived::<T>(self.id).unwrap())
+                })
+            }),
             SignalKind::Mutable => get_signal_value(self.id),
         }
     }

--- a/src/reactive/storage.rs
+++ b/src/reactive/storage.rs
@@ -348,6 +348,13 @@ fn downcast_cell<T: 'static>(rc: &Rc<dyn Any>, id: SignalId) -> &RefCell<T> {
 /// Reset all signal storage.
 ///
 /// Called during `App::drop()` to wipe all stored signal values.
+/// How many signal slots storage currently holds. Test-only: the cost of a
+/// primitive is only assertable against a number.
+#[cfg(test)]
+pub(crate) fn slot_count() -> usize {
+    STORAGE.with(|storage| storage.borrow().slots.len())
+}
+
 pub(crate) fn reset_storage() {
     STORAGE.with(|s| *s.borrow_mut() = SignalStorage::new());
 }

--- a/src/reactive/storage.rs
+++ b/src/reactive/storage.rs
@@ -345,16 +345,19 @@ fn downcast_cell<T: 'static>(rc: &Rc<dyn Any>, id: SignalId) -> &RefCell<T> {
     })
 }
 
-/// Reset all signal storage.
+/// How many signal slots storage currently holds — every slot ever allocated,
+/// occupied or vacated, which is what makes it the right measure for "did this
+/// primitive claim one". [`live_signal_count`] counts only the occupied ones.
 ///
-/// Called during `App::drop()` to wipe all stored signal values.
-/// How many signal slots storage currently holds. Test-only: the cost of a
-/// primitive is only assertable against a number.
+/// Test-only: the cost of a primitive is only assertable against a number.
 #[cfg(test)]
 pub(crate) fn slot_count() -> usize {
     STORAGE.with(|storage| storage.borrow().slots.len())
 }
 
+/// Reset all signal storage.
+///
+/// Called during `App::drop()` to wipe all stored signal values.
 pub(crate) fn reset_storage() {
     STORAGE.with(|s| *s.borrow_mut() = SignalStorage::new());
 }

--- a/src/reactive/storage.rs
+++ b/src/reactive/storage.rs
@@ -311,7 +311,7 @@ pub fn compare_and_update_signal_value<T: Clone + PartialEq + 'static>(
 /// Set unconditionally: no comparison, no `PartialEq` bound. Returns
 /// `true` if the write landed (`false` only when the slot is disposed).
 ///
-/// Backs [`RwSignal::set_always`]: trigger-style writes where every
+/// Backs [`RwSignal::set_always`](super::RwSignal::set_always): trigger-style writes where every
 /// emission must notify (or where the type has no meaningful equality).
 pub fn set_signal_value_always<T: 'static>(id: SignalId, value: T) -> bool {
     let Some(rc) = try_clone_slot_rc(id) else {

--- a/src/reactive/trigger.rs
+++ b/src/reactive/trigger.rs
@@ -68,8 +68,7 @@ mod tests {
         create_effect(move || {
             trigger.track();
             counter.set(counter.get() + 1);
-        })
-        .detach();
+        });
         assert_eq!(runs.get(), 1, "initial run");
 
         trigger.notify();

--- a/src/renderer/commands.rs
+++ b/src/renderer/commands.rs
@@ -183,6 +183,11 @@ pub enum DrawCommand {
     BackdropBlur {
         /// Region to filter, in local coordinates.
         rect: Rect,
+        /// Which backdrops this asks for. The surface's own is filtered by the
+        /// renderer; the compositor's is published as a `wl_region` collected
+        /// off this very command after flattening — which is what keeps the two
+        /// halves from disagreeing about whether a container still wants it.
+        sources: crate::backdrop::BackdropSources,
         /// Blur radius in logical pixels.
         radius: f32,
         /// Corner radii of the region, so the result is masked to the

--- a/src/renderer/commands.rs
+++ b/src/renderer/commands.rs
@@ -95,6 +95,56 @@ impl CornerRadii {
     }
 }
 
+/// Corner radii that need not be circular.
+///
+/// A non-uniform scale turns a round corner into an ellipse, and one radius per
+/// corner cannot say so: `.scale_xy(2.0, 1.0)` on a `corner_radius(16)` box
+/// draws corners 32 wide and 16 tall. Collapsing that to one number — the
+/// geometric mean, 22.6 — matches neither axis.
+///
+/// Only the consumer that can express an ellipse keeps both. The others say
+/// [`to_circular`](Self::to_circular) out loud rather than losing an axis
+/// silently on the way in.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct EllipticalRadii {
+    /// Horizontal semi-axis of each corner.
+    pub x: CornerRadii,
+    /// Vertical semi-axis of each corner.
+    pub y: CornerRadii,
+}
+
+impl EllipticalRadii {
+    /// The same radius on both axes — every corner a circle.
+    pub fn circular(radii: CornerRadii) -> Self {
+        Self { x: radii, y: radii }
+    }
+
+    /// Scale each axis by its own factor, which is what a transform does to a
+    /// corner.
+    pub fn scaled_xy(radii: CornerRadii, sx: f32, sy: f32) -> Self {
+        Self {
+            x: radii.scaled(sx),
+            y: radii.scaled(sy),
+        }
+    }
+
+    /// The circular approximation, for a consumer that takes one radius per
+    /// corner.
+    ///
+    /// The larger axis, so the corner cuts at least as much as the ellipse does:
+    /// a shape that stays inside the one it approximates blurs slightly less
+    /// than it should, where the other way round it blurs where nothing is
+    /// drawn.
+    pub fn to_circular(self) -> CornerRadii {
+        CornerRadii {
+            top_left: self.x.top_left.max(self.y.top_left),
+            top_right: self.x.top_right.max(self.y.top_right),
+            bottom_right: self.x.bottom_right.max(self.y.bottom_right),
+            bottom_left: self.x.bottom_left.max(self.y.bottom_left),
+        }
+    }
+}
+
 impl From<f32> for CornerRadii {
     fn from(radius: f32) -> Self {
         Self::uniform(radius)

--- a/src/renderer/flatten.rs
+++ b/src/renderer/flatten.rs
@@ -170,20 +170,62 @@ impl FlattenedCommand {
             return None;
         }
 
-        let (cut_left, cut_top) = (x > world.x, y > world.y);
-        let cut_right = right < world.x + world.width;
-        let cut_bottom = bottom < world.y + world.height;
-        // Both edges from the clip, both from the shape, or one from each.
-        let pick = |shape: f32, clip: f32, a: bool, b: bool| match (a, b) {
-            (false, false) => shape,
-            (true, true) => clip,
-            _ => 0.0,
+        // Which rectangle supplies each edge — and *both*, where they coincide.
+        // Asked as "is this edge at or inside the other's" rather than as "was
+        // this edge moved": a child filling its clipping parent exactly shares
+        // all four, and read as movement that is no movement at all, so the
+        // corners came back as the child's — square, for a child that declares
+        // no radius of its own, while the shape on screen is rounded by the
+        // parent. Four wedges of blurred desktop outside the panel, which is the
+        // artefact this whole computation exists to avoid, in the one case where
+        // the two rectangles are equal.
+        let (wr, wb) = (world.x + world.width, world.y + world.height);
+        let (cr, cb) = (
+            clip_rect.x + clip_rect.width,
+            clip_rect.y + clip_rect.height,
+        );
+        let (clip_l, shape_l) = (clip_rect.x >= world.x, world.x >= clip_rect.x);
+        let (clip_t, shape_t) = (clip_rect.y >= world.y, world.y >= clip_rect.y);
+        let (clip_r, shape_r) = (cr <= wr, wr <= cr);
+        let (clip_b, shape_b) = (cb <= wb, wb <= cb);
+
+        // A corner belongs to a rectangle when that rectangle supplies both of
+        // the edges meeting there. Both rectangles, where they coincide: the two
+        // curves are drawn one on top of the other and the tighter one is what
+        // shows. Neither, when one edge comes from each — a cut edge is straight.
+        let pick = |shape: f32, clip: f32, from_shape: bool, from_clip: bool| match (
+            from_shape, from_clip,
+        ) {
+            (true, true) => shape.max(clip),
+            (true, false) => shape,
+            (false, true) => clip,
+            (false, false) => 0.0,
         };
         let corners = |shape: CornerRadii, clip: CornerRadii| CornerRadii {
-            top_left: pick(shape.top_left, clip.top_left, cut_left, cut_top),
-            top_right: pick(shape.top_right, clip.top_right, cut_right, cut_top),
-            bottom_right: pick(shape.bottom_right, clip.bottom_right, cut_right, cut_bottom),
-            bottom_left: pick(shape.bottom_left, clip.bottom_left, cut_left, cut_bottom),
+            top_left: pick(
+                shape.top_left,
+                clip.top_left,
+                shape_l && shape_t,
+                clip_l && clip_t,
+            ),
+            top_right: pick(
+                shape.top_right,
+                clip.top_right,
+                shape_r && shape_t,
+                clip_r && clip_t,
+            ),
+            bottom_right: pick(
+                shape.bottom_right,
+                clip.bottom_right,
+                shape_r && shape_b,
+                clip_r && clip_b,
+            ),
+            bottom_left: pick(
+                shape.bottom_left,
+                clip.bottom_left,
+                shape_l && shape_b,
+                clip_l && clip_b,
+            ),
         };
 
         Some((
@@ -1289,6 +1331,48 @@ mod world_geometry_tests {
             radii.x.to_array(),
             [16.0; 4],
             "every corner is the scroller's, not the card's and not square"
+        );
+    }
+
+    /// And when the two rectangles are *equal*, both corners are there. A child
+    /// declared `width(fill()).height(fill())` inside a clipping parent with no
+    /// padding shares all four edges, so reading the corner as "was this edge
+    /// moved" found no movement and handed back the child's own radius — square,
+    /// where the shape on screen is rounded by the parent, and the compositor
+    /// blurs four wedges of desktop outside the panel.
+    #[test]
+    fn coincident_edges_keep_the_tighter_curve() {
+        // Exactly the clip: a fill/fill child of a zero-padding parent.
+        let rect = Rect::new(0.0, 0.0, 100.0, 100.0);
+        let mut cmd = command(Transform::translate(0.0, 0.0));
+        cmd.clip = Some(WorldClip {
+            rect: Rect::new(0.0, 0.0, 100.0, 100.0),
+            corner_radius: 16.0,
+            curvature: 1.0,
+        });
+
+        let (world, radii) = cmd
+            .clipped_world_rounded_rect(rect, CornerRadii::from(0.0))
+            .expect("nothing is cut away");
+        assert_eq!(
+            (world.x, world.y, world.width, world.height),
+            (0.0, 0.0, 100.0, 100.0),
+            "the intersection is either of them"
+        );
+        assert_eq!(
+            radii.x.to_array(),
+            [16.0; 4],
+            "the child declares none, so what shows is the parent's"
+        );
+
+        // The other way round: the tighter of the two is the one that shows.
+        let (_, radii) = cmd
+            .clipped_world_rounded_rect(rect, CornerRadii::uniform(24.0))
+            .expect("nothing is cut away");
+        assert_eq!(
+            radii.x.to_array(),
+            [24.0; 4],
+            "a child rounded harder than its clip keeps its own curve"
         );
     }
 

--- a/src/renderer/flatten.rs
+++ b/src/renderer/flatten.rs
@@ -103,10 +103,32 @@ impl FlattenedCommand {
             .map(|c| c.1)
             .fold(f32::NEG_INFINITY, f32::max);
 
-        (
-            Rect::new(min_x, min_y, max_x - min_x, max_y - min_y),
-            radii.scaled(self.world_transform.extract_scale()),
-        )
+        let world = Rect::new(min_x, min_y, max_x - min_x, max_y - min_y);
+        (world, radii.scaled(self.world_transform.extract_scale()))
+    }
+
+    /// [`world_rounded_rect`](Self::world_rounded_rect), narrowed to what the
+    /// command is allowed to show.
+    ///
+    /// The clip is part of the shape, not a detail of one consumer: a card half
+    /// out of a viewport is filtered only where it is on show, and a compositor
+    /// region published for the whole card blurs the desktop beside a panel that
+    /// is not there. Returns `None` when the clip leaves nothing.
+    pub fn clipped_world_rounded_rect(
+        &self,
+        rect: Rect,
+        radii: CornerRadii,
+    ) -> Option<(Rect, CornerRadii)> {
+        let (world, world_radii) = self.world_rounded_rect(rect, radii);
+        let Some(clip) = self.clip.as_ref().map(|c| c.rect) else {
+            return Some((world, world_radii));
+        };
+
+        let x = world.x.max(clip.x);
+        let y = world.y.max(clip.y);
+        let right = (world.x + world.width).min(clip.x + clip.width);
+        let bottom = (world.y + world.height).min(clip.y + clip.height);
+        (right > x && bottom > y).then(|| (Rect::new(x, y, right - x, bottom - y), world_radii))
     }
 }
 
@@ -372,7 +394,7 @@ impl CommandLayer {
 /// Flatten results are cached on nodes (via interior mutability) for
 /// incremental reuse in subsequent frames.
 ///
-/// `layers` receives the groups to draw, in order; see [`LayeredCommands`].
+/// `layers` receives the groups to draw, in order; see [`CommandLayer`].
 pub fn flatten_root_into(
     root: &RenderNode,
     commands: &mut Vec<FlattenedCommand>,
@@ -1028,6 +1050,46 @@ mod world_geometry_tests {
 
         assert_eq!(world.width, 200.0);
         assert_eq!(radii.max(), 32.0, "twice the box, twice the corner");
+    }
+
+    /// The clip is part of the shape. A card half out of a viewport is filtered
+    /// only where it is on show, and the region published to the compositor has
+    /// to agree — otherwise it blurs the desktop beside a panel that is not
+    /// there, which is the last way the two halves of one command could
+    /// describe different things.
+    #[test]
+    fn a_clip_narrows_the_shape_for_both_halves() {
+        let rect = Rect::new(0.0, 0.0, 100.0, 100.0);
+        let mut cmd = command(Transform::translate(0.0, 0.0));
+        cmd.clip = Some(WorldClip {
+            rect: Rect::new(0.0, 0.0, 40.0, 100.0),
+            corner_radius: 0.0,
+            curvature: 1.0,
+        });
+
+        let (world, _) = cmd
+            .clipped_world_rounded_rect(rect, CornerRadii::from(0.0))
+            .expect("still on show");
+        assert_eq!((world.x, world.width), (0.0, 40.0), "cut to the clip");
+        assert_eq!(world.height, 100.0, "and untouched on the other axis");
+    }
+
+    /// Clipped away entirely is nothing to publish, not an empty rectangle
+    /// somewhere.
+    #[test]
+    fn a_shape_outside_its_clip_has_no_region() {
+        let rect = Rect::new(0.0, 0.0, 100.0, 100.0);
+        let mut cmd = command(Transform::translate(500.0, 0.0));
+        cmd.clip = Some(WorldClip {
+            rect: Rect::new(0.0, 0.0, 100.0, 100.0),
+            corner_radius: 0.0,
+            curvature: 1.0,
+        });
+
+        assert!(
+            cmd.clipped_world_rounded_rect(rect, CornerRadii::from(0.0))
+                .is_none()
+        );
     }
 
     /// A translation moves it and changes nothing else.

--- a/src/renderer/flatten.rs
+++ b/src/renderer/flatten.rs
@@ -171,6 +171,12 @@ impl FlattenedCommand {
 /// column of buttons stays one group; a tint over a photo gets two.
 struct LayeredCommands {
     groups: Vec<LayerBuckets>,
+    /// Whether any command asks the compositor to blur behind it.
+    ///
+    /// Counted while the commands go past, because the alternative is walking
+    /// them all again afterwards to find out — on every painted frame, for the
+    /// large majority of surfaces that never ask for it at all.
+    compositor_blur: bool,
 }
 
 #[derive(Default)]
@@ -274,10 +280,16 @@ impl LayeredCommands {
     fn new() -> Self {
         Self {
             groups: vec![LayerBuckets::default()],
+            compositor_blur: false,
         }
     }
 
     fn push(&mut self, cmd: FlattenedCommand) {
+        if let DrawCommand::BackdropBlur { sources, .. } = &*cmd.command
+            && sources.contains(crate::backdrop::BackdropSources::COMPOSITOR)
+        {
+            self.compositor_blur = true;
+        }
         let layer = cmd.layer;
         let rect = world_bounds(&cmd);
         // `expect`: `new` seeds one group and nothing ever removes one.
@@ -413,18 +425,24 @@ impl CommandLayer {
 /// incremental reuse in subsequent frames.
 ///
 /// `layers` receives the groups to draw, in order; see [`CommandLayer`].
+///
+/// Returns whether the frame carries a backdrop blur the *compositor* is asked
+/// to apply, which is the only reason to walk the result again and build a
+/// `wl_region` from it.
 pub fn flatten_root_into(
     root: &RenderNode,
     commands: &mut Vec<FlattenedCommand>,
     layers: &mut Vec<CommandLayer>,
-) {
+) -> bool {
     commands.clear();
     layers.clear();
 
     let mut layered = LayeredCommands::new();
     flatten_node(root, Transform::IDENTITY, None, None, &mut layered);
 
+    let compositor_blur = layered.compositor_blur;
     layered.drain_into(commands, layers);
+    compositor_blur
 }
 
 /// Recursively flatten a node and its children.
@@ -520,6 +538,20 @@ fn flatten_node(
         let layer = match &**cmd {
             DrawCommand::Text { .. } => RenderLayer::Text,
             DrawCommand::Image { .. } => RenderLayer::Images,
+            // Only the half the renderer draws opens a backdrop group. A blur
+            // restricted to `COMPOSITOR` is published as a `wl_region` and drawn
+            // by nobody here, and `Backdrop` is not a free label: it is the
+            // lowest layer, so it splits the draw group, and a non-empty
+            // backdrop bucket ends the render pass to store the target the
+            // effect would sample. That is a pass break and a group per
+            // container per frame, to filter nothing. It still travels with the
+            // frame — the region is read off this list — it just travels with
+            // the shapes, where it produces no instance.
+            DrawCommand::BackdropBlur { sources, .. }
+                if !sources.contains(crate::backdrop::BackdropSources::SURFACE) =>
+            {
+                RenderLayer::Shapes
+            }
             DrawCommand::BackdropBlur { .. } | DrawCommand::TextBackdropBlur { .. } => {
                 RenderLayer::Backdrop
             }
@@ -793,6 +825,46 @@ mod tests {
     }
 
     use RenderLayer::{Images, Overlay, Shapes, Text};
+
+    /// A blur restricted to the compositor is published as a `wl_region` and
+    /// drawn by nobody here, so it must not be filed as a backdrop effect: that
+    /// bucket ends the render pass to store the target the effect would sample,
+    /// and it is the lowest layer, so it splits the draw group as well. Both,
+    /// per container, per frame, to filter nothing.
+    #[test]
+    fn a_compositor_only_blur_neither_breaks_the_pass_nor_splits_the_group() {
+        let frame = |sources| {
+            let rect = Rect::new(0.0, 0.0, 100.0, 100.0);
+            let mut node = RenderNode::new(1);
+            node.bounds = rect;
+            // The background first, so a backdrop landing after it is one the
+            // group rules have to split for.
+            node.commands
+                .push(Rc::new(DrawCommand::rounded_rect(rect, Color::WHITE, 0.0)));
+            node.commands.push(Rc::new(DrawCommand::BackdropBlur {
+                rect,
+                sources,
+                radius: 24.0,
+                corner_radii: CornerRadii::from(0.0),
+                curvature: 1.0,
+            }));
+
+            let (mut commands, mut layers) = (Vec::new(), Vec::new());
+            let told = flatten_root_into(&node, &mut commands, &mut layers);
+            let drawn = layers.iter().any(|l| !l.backdrop.is_empty());
+            (told, drawn, layers.len())
+        };
+
+        let (told, drawn, groups) = frame(crate::backdrop::BackdropSources::COMPOSITOR);
+        assert!(told, "the compositor still has to be handed a region");
+        assert!(!drawn, "and this renderer has nothing to do for it");
+        assert_eq!(groups, 1, "so the frame is not split for it either");
+
+        let (told, drawn, groups) = frame(crate::backdrop::BackdropSources::SURFACE);
+        assert!(!told, "nothing for the compositor");
+        assert!(drawn, "and a pass of our own to run");
+        assert_eq!(groups, 2, "which is what the split is for");
+    }
 
     #[test]
     fn ascending_layers_stay_in_one_group() {

--- a/src/renderer/flatten.rs
+++ b/src/renderer/flatten.rs
@@ -83,6 +83,14 @@ impl FlattenedCommand {
     /// radii scale with the box, or a `.scale(2.0)` container reports a shape
     /// whose corners are cut half as deep as the one it draws.
     pub fn world_rounded_rect(&self, rect: Rect, radii: CornerRadii) -> (Rect, CornerRadii) {
+        (
+            self.world_aabb(rect),
+            radii.scaled(self.world_transform.extract_scale()),
+        )
+    }
+
+    /// The axis-aligned world box containing a rect of this command's own space.
+    fn world_aabb(&self, rect: Rect) -> Rect {
         let corners = [
             self.world_transform.transform_point(rect.x, rect.y),
             self.world_transform
@@ -102,9 +110,7 @@ impl FlattenedCommand {
             .iter()
             .map(|c| c.1)
             .fold(f32::NEG_INFINITY, f32::max);
-
-        let world = Rect::new(min_x, min_y, max_x - min_x, max_y - min_y);
-        (world, radii.scaled(self.world_transform.extract_scale()))
+        Rect::new(min_x, min_y, max_x - min_x, max_y - min_y)
     }
 
     /// [`world_rounded_rect`](Self::world_rounded_rect), narrowed to what the
@@ -114,13 +120,25 @@ impl FlattenedCommand {
     /// out of a viewport is filtered only where it is on show, and a compositor
     /// region published for the whole card blurs the desktop beside a panel that
     /// is not there. Returns `None` when the clip leaves nothing.
+    ///
+    /// An overlay's clip is stored in the command's *local* space so a ripple
+    /// follows the shape it belongs to instead of an axis-aligned box around it
+    /// — so it is carried into world space here before the two are compared.
+    /// Intersecting the two spaces directly reported a region offset by every
+    /// translation between the shape and the surface.
     pub fn clipped_world_rounded_rect(
         &self,
         rect: Rect,
         radii: CornerRadii,
     ) -> Option<(Rect, CornerRadii)> {
         let (world, world_radii) = self.world_rounded_rect(rect, radii);
-        let Some(clip) = self.clip.as_ref().map(|c| c.rect) else {
+        let Some(clip) = self.clip.as_ref().map(|c| {
+            if self.clip_is_local {
+                self.world_aabb(c.rect)
+            } else {
+                c.rect
+            }
+        }) else {
             return Some((world, world_radii));
         };
 
@@ -1089,6 +1107,30 @@ mod world_geometry_tests {
         assert!(
             cmd.clipped_world_rounded_rect(rect, CornerRadii::from(0.0))
                 .is_none()
+        );
+    }
+
+    /// An overlay keeps its clip in local space so a ripple follows the shape
+    /// through a rotation. Compared against a world rect without being carried
+    /// over first, a ripple inside a translated subtree reports a region
+    /// somewhere else entirely — or none at all, for a shape wholly on show.
+    #[test]
+    fn a_local_clip_is_carried_into_world_space_before_it_cuts() {
+        let rect = Rect::new(0.0, 0.0, 100.0, 100.0);
+        let mut cmd = command(Transform::translate(500.0, 300.0));
+        cmd.clip = Some(WorldClip {
+            rect: Rect::new(0.0, 0.0, 100.0, 100.0),
+            corner_radius: 0.0,
+            curvature: 1.0,
+        });
+        cmd.clip_is_local = true;
+
+        let (world, _) = cmd
+            .clipped_world_rounded_rect(rect, CornerRadii::from(0.0))
+            .expect("the clip covers the whole shape, so nothing is cut");
+        assert_eq!(
+            (world.x, world.y, world.width, world.height),
+            (500.0, 300.0, 100.0, 100.0)
         );
     }
 

--- a/src/renderer/flatten.rs
+++ b/src/renderer/flatten.rs
@@ -8,7 +8,7 @@ use smallvec::SmallVec;
 use crate::transform::Transform;
 use crate::widgets::Rect;
 
-use super::commands::DrawCommand;
+use super::commands::{CornerRadii, DrawCommand};
 use super::tree::{CachedFlatten, ClipRegion, RenderNode};
 
 /// Render layer for draw command ordering.
@@ -65,6 +65,49 @@ pub struct FlattenedCommand {
     /// Whether the clip is in local coordinates (use frag_pos in shader instead of world_pos).
     /// This is true for overlay clips on transformed containers.
     pub clip_is_local: bool,
+}
+
+impl FlattenedCommand {
+    /// Where a local rounded rect of this command lands in world space: the
+    /// axis-aligned box that contains it, and the corner radii grown with it.
+    ///
+    /// **One implementation, because there are two consumers.** A backdrop blur
+    /// is filtered by the renderer and, for the same command, published to the
+    /// compositor as a `wl_region` — and the two must describe the same shape.
+    /// They did not: one folded four corners and the other subtracted two, so a
+    /// container rotated 45° produced a correct region for the renderer and a
+    /// zero-width one for the compositor.
+    ///
+    /// Four corners, because two only bound the box for a transform that keeps
+    /// the axes: a rotation moves the extremes onto the other diagonal. And the
+    /// radii scale with the box, or a `.scale(2.0)` container reports a shape
+    /// whose corners are cut half as deep as the one it draws.
+    pub fn world_rounded_rect(&self, rect: Rect, radii: CornerRadii) -> (Rect, CornerRadii) {
+        let corners = [
+            self.world_transform.transform_point(rect.x, rect.y),
+            self.world_transform
+                .transform_point(rect.x + rect.width, rect.y),
+            self.world_transform
+                .transform_point(rect.x, rect.y + rect.height),
+            self.world_transform
+                .transform_point(rect.x + rect.width, rect.y + rect.height),
+        ];
+        let min_x = corners.iter().map(|c| c.0).fold(f32::INFINITY, f32::min);
+        let max_x = corners
+            .iter()
+            .map(|c| c.0)
+            .fold(f32::NEG_INFINITY, f32::max);
+        let min_y = corners.iter().map(|c| c.1).fold(f32::INFINITY, f32::min);
+        let max_y = corners
+            .iter()
+            .map(|c| c.1)
+            .fold(f32::NEG_INFINITY, f32::max);
+
+        (
+            Rect::new(min_x, min_y, max_x - min_x, max_y - min_y),
+            radii.scaled(self.world_transform.extract_scale()),
+        )
+    }
 }
 
 /// Draw commands grouped so that batching never reorders drawing.
@@ -930,5 +973,72 @@ mod tests {
         let mut layers = Vec::new();
         layered.drain_into(&mut commands, &mut layers);
         assert!(layers.iter().all(|layer| !layer.is_empty()));
+    }
+}
+
+#[cfg(test)]
+mod world_geometry_tests {
+    use super::*;
+    use crate::widgets::Color;
+
+    fn command(transform: Transform) -> FlattenedCommand {
+        FlattenedCommand {
+            command: Rc::new(DrawCommand::RoundedRect {
+                rect: Rect::new(0.0, 0.0, 100.0, 100.0),
+                color: Color::RED,
+                radius: CornerRadii::uniform(16.0),
+                curvature: 1.0,
+                border: None,
+                shadow: None,
+                gradient: None,
+            }),
+            world_transform: transform,
+            world_transform_origin: None,
+            layer: RenderLayer::Shapes,
+            clip: None,
+            clip_is_local: false,
+        }
+    }
+
+    /// Two opposite corners do not bound a rotated box: a 45° rotation puts the
+    /// extremes on the *other* diagonal, and subtracting the two you happen to
+    /// have gives a zero-width rect — which downstream reads as "nothing to do".
+    #[test]
+    fn a_rotated_box_reports_the_diagonal_it_actually_covers() {
+        let rect = Rect::new(0.0, 0.0, 100.0, 100.0);
+        let (world, _) = command(Transform::rotate_degrees(45.0))
+            .world_rounded_rect(rect, CornerRadii::from(0.0));
+
+        let diagonal = 100.0 * 2.0f32.sqrt();
+        assert!(
+            (world.width - diagonal).abs() < 0.1 && (world.height - diagonal).abs() < 0.1,
+            "a 100x100 turned 45° covers {diagonal:.1} square, got {:.1}x{:.1}",
+            world.width,
+            world.height
+        );
+    }
+
+    /// The radii travel with the box, or a scaled container reports a shape
+    /// whose corners are cut a different amount from the one it draws.
+    #[test]
+    fn the_corner_radii_scale_with_the_box() {
+        let rect = Rect::new(0.0, 0.0, 100.0, 100.0);
+        let (world, radii) =
+            command(Transform::scale(2.0)).world_rounded_rect(rect, CornerRadii::uniform(16.0));
+
+        assert_eq!(world.width, 200.0);
+        assert_eq!(radii.max(), 32.0, "twice the box, twice the corner");
+    }
+
+    /// A translation moves it and changes nothing else.
+    #[test]
+    fn a_translation_only_moves_it() {
+        let rect = Rect::new(0.0, 0.0, 100.0, 60.0);
+        let (world, radii) = command(Transform::translate(20.0, 30.0))
+            .world_rounded_rect(rect, CornerRadii::uniform(8.0));
+
+        assert_eq!((world.x, world.y), (20.0, 30.0));
+        assert_eq!((world.width, world.height), (100.0, 60.0));
+        assert_eq!(radii.max(), 8.0);
     }
 }

--- a/src/renderer/flatten.rs
+++ b/src/renderer/flatten.rs
@@ -119,7 +119,8 @@ impl FlattenedCommand {
     /// The clip is part of the shape, not a detail of one consumer: a card half
     /// out of a viewport is filtered only where it is on show, and a compositor
     /// region published for the whole card blurs the desktop beside a panel that
-    /// is not there. Returns `None` when the clip leaves nothing.
+    /// is not there. Returns `None` when the clip leaves nothing, and drops the
+    /// radius of every corner the clip cut off — a cut edge is straight.
     ///
     /// An overlay's clip is stored in the command's *local* space so a ripple
     /// follows the shape it belongs to instead of an axis-aligned box around it
@@ -146,7 +147,26 @@ impl FlattenedCommand {
         let y = world.y.max(clip.y);
         let right = (world.x + world.width).min(clip.x + clip.width);
         let bottom = (world.y + world.height).min(clip.y + clip.height);
-        (right > x && bottom > y).then(|| (Rect::new(x, y, right - x, bottom - y), world_radii))
+        if right <= x || bottom <= y {
+            return None;
+        }
+
+        // A cut edge is a straight one. A corner survives only where neither of
+        // the edges meeting there was moved: keeping the radius on a corner the
+        // clip removed describes a curve that is not on screen, and the region
+        // built from it loses a wedge the size of the radius along the cut.
+        let (cut_left, cut_top) = (x > world.x, y > world.y);
+        let cut_right = right < world.x + world.width;
+        let cut_bottom = bottom < world.y + world.height;
+        let keep = |radius: f32, a: bool, b: bool| if a || b { 0.0 } else { radius };
+        let radii = CornerRadii {
+            top_left: keep(world_radii.top_left, cut_left, cut_top),
+            top_right: keep(world_radii.top_right, cut_right, cut_top),
+            bottom_right: keep(world_radii.bottom_right, cut_right, cut_bottom),
+            bottom_left: keep(world_radii.bottom_left, cut_left, cut_bottom),
+        };
+
+        Some((Rect::new(x, y, right - x, bottom - y), radii))
     }
 }
 
@@ -1162,6 +1182,35 @@ mod world_geometry_tests {
             .expect("still on show");
         assert_eq!((world.x, world.width), (0.0, 40.0), "cut to the clip");
         assert_eq!(world.height, 100.0, "and untouched on the other axis");
+    }
+
+    /// And the corners go with it. A card cut in half by a viewport has a
+    /// straight edge where the cut is, so the two corners along it are square —
+    /// published as round, the region loses a wedge the size of the radius at
+    /// each of them, and the desktop shows through beside the panel.
+    #[test]
+    fn a_clip_squares_off_the_corners_it_cuts() {
+        let rect = Rect::new(0.0, 0.0, 100.0, 100.0);
+        let mut cmd = command(Transform::translate(0.0, 0.0));
+        cmd.clip = Some(WorldClip {
+            rect: Rect::new(0.0, 0.0, 40.0, 100.0),
+            corner_radius: 0.0,
+            curvature: 1.0,
+        });
+
+        let (_, radii) = cmd
+            .clipped_world_rounded_rect(rect, CornerRadii::uniform(16.0))
+            .expect("still on show");
+        assert_eq!(
+            (radii.top_left, radii.bottom_left),
+            (16.0, 16.0),
+            "the left edge was not moved, so its corners are as they were drawn"
+        );
+        assert_eq!(
+            (radii.top_right, radii.bottom_right),
+            (0.0, 0.0),
+            "and the ones along the cut are square"
+        );
     }
 
     /// Clipped away entirely is nothing to publish, not an empty rectangle

--- a/src/renderer/flatten.rs
+++ b/src/renderer/flatten.rs
@@ -8,7 +8,7 @@ use smallvec::SmallVec;
 use crate::transform::Transform;
 use crate::widgets::Rect;
 
-use super::commands::{CornerRadii, DrawCommand};
+use super::commands::{CornerRadii, DrawCommand, EllipticalRadii};
 use super::tree::{CachedFlatten, ClipRegion, RenderNode};
 
 /// Render layer for draw command ordering.
@@ -81,11 +81,14 @@ impl FlattenedCommand {
     /// Four corners, because two only bound the box for a transform that keeps
     /// the axes: a rotation moves the extremes onto the other diagonal. And the
     /// radii scale with the box, or a `.scale(2.0)` container reports a shape
-    /// whose corners are cut half as deep as the one it draws.
-    pub fn world_rounded_rect(&self, rect: Rect, radii: CornerRadii) -> (Rect, CornerRadii) {
+    /// whose corners are cut half as deep as the one it draws — each axis by its
+    /// own factor, since a corner scaled unevenly is an ellipse and the
+    /// geometric mean of the two is neither of them.
+    pub fn world_rounded_rect(&self, rect: Rect, radii: CornerRadii) -> (Rect, EllipticalRadii) {
+        let (sx, sy) = self.world_transform.extract_scale_components();
         (
             self.world_aabb(rect),
-            radii.scaled(self.world_transform.extract_scale()),
+            EllipticalRadii::scaled_xy(radii, sx, sy),
         )
     }
 
@@ -119,8 +122,15 @@ impl FlattenedCommand {
     /// The clip is part of the shape, not a detail of one consumer: a card half
     /// out of a viewport is filtered only where it is on show, and a compositor
     /// region published for the whole card blurs the desktop beside a panel that
-    /// is not there. Returns `None` when the clip leaves nothing, and drops the
-    /// radius of every corner the clip cut off — a cut edge is straight.
+    /// is not there. Returns `None` when the clip leaves nothing.
+    ///
+    /// A corner of the intersection belongs to whichever rectangle supplied both
+    /// edges meeting there: the shape's own radius where the clip reached
+    /// neither, the *clip's* where it supplied both — a card inside a rounded
+    /// scroller is cornered by the scroller, and publishing the scroller's
+    /// square bounding box blurs the desktop in the four corners where the panel
+    /// is not drawn — and nothing where it supplied one, because a cut edge is
+    /// straight.
     ///
     /// An overlay's clip is stored in the command's *local* space so a ripple
     /// follows the shape it belongs to instead of an axis-aligned box around it
@@ -131,42 +141,58 @@ impl FlattenedCommand {
         &self,
         rect: Rect,
         radii: CornerRadii,
-    ) -> Option<(Rect, CornerRadii)> {
+    ) -> Option<(Rect, EllipticalRadii)> {
         let (world, world_radii) = self.world_rounded_rect(rect, radii);
-        let Some(clip) = self.clip.as_ref().map(|c| {
-            if self.clip_is_local {
-                self.world_aabb(c.rect)
-            } else {
-                c.rect
-            }
-        }) else {
+        let Some(clip) = self.clip.as_ref() else {
             return Some((world, world_radii));
         };
 
-        let x = world.x.max(clip.x);
-        let y = world.y.max(clip.y);
-        let right = (world.x + world.width).min(clip.x + clip.width);
-        let bottom = (world.y + world.height).min(clip.y + clip.height);
+        // A local clip and the radius that shapes it are in the same space, so
+        // both come out through the same transform.
+        let (sx, sy) = self.world_transform.extract_scale_components();
+        let (clip_rect, clip_radii) = if self.clip_is_local {
+            (
+                self.world_aabb(clip.rect),
+                EllipticalRadii::scaled_xy(CornerRadii::uniform(clip.corner_radius), sx, sy),
+            )
+        } else {
+            (
+                clip.rect,
+                EllipticalRadii::circular(CornerRadii::uniform(clip.corner_radius)),
+            )
+        };
+
+        let x = world.x.max(clip_rect.x);
+        let y = world.y.max(clip_rect.y);
+        let right = (world.x + world.width).min(clip_rect.x + clip_rect.width);
+        let bottom = (world.y + world.height).min(clip_rect.y + clip_rect.height);
         if right <= x || bottom <= y {
             return None;
         }
 
-        // A cut edge is a straight one. A corner survives only where neither of
-        // the edges meeting there was moved: keeping the radius on a corner the
-        // clip removed describes a curve that is not on screen, and the region
-        // built from it loses a wedge the size of the radius along the cut.
         let (cut_left, cut_top) = (x > world.x, y > world.y);
         let cut_right = right < world.x + world.width;
         let cut_bottom = bottom < world.y + world.height;
-        let keep = |radius: f32, a: bool, b: bool| if a || b { 0.0 } else { radius };
-        let radii = CornerRadii {
-            top_left: keep(world_radii.top_left, cut_left, cut_top),
-            top_right: keep(world_radii.top_right, cut_right, cut_top),
-            bottom_right: keep(world_radii.bottom_right, cut_right, cut_bottom),
-            bottom_left: keep(world_radii.bottom_left, cut_left, cut_bottom),
+        // Both edges from the clip, both from the shape, or one from each.
+        let pick = |shape: f32, clip: f32, a: bool, b: bool| match (a, b) {
+            (false, false) => shape,
+            (true, true) => clip,
+            _ => 0.0,
+        };
+        let corners = |shape: CornerRadii, clip: CornerRadii| CornerRadii {
+            top_left: pick(shape.top_left, clip.top_left, cut_left, cut_top),
+            top_right: pick(shape.top_right, clip.top_right, cut_right, cut_top),
+            bottom_right: pick(shape.bottom_right, clip.bottom_right, cut_right, cut_bottom),
+            bottom_left: pick(shape.bottom_left, clip.bottom_left, cut_left, cut_bottom),
         };
 
-        Some((Rect::new(x, y, right - x, bottom - y), radii))
+        Some((
+            Rect::new(x, y, right - x, bottom - y),
+            EllipticalRadii {
+                x: corners(world_radii.x, clip_radii.x),
+                y: corners(world_radii.y, clip_radii.y),
+            },
+        ))
     }
 }
 
@@ -1159,7 +1185,30 @@ mod world_geometry_tests {
             command(Transform::scale(2.0)).world_rounded_rect(rect, CornerRadii::uniform(16.0));
 
         assert_eq!(world.width, 200.0);
-        assert_eq!(radii.max(), 32.0, "twice the box, twice the corner");
+        assert_eq!(
+            (radii.x.max(), radii.y.max()),
+            (32.0, 32.0),
+            "twice the box, twice the corner"
+        );
+    }
+
+    /// Each axis by its own factor. A corner scaled unevenly is an ellipse, and
+    /// the geometric mean the shared scale used to return — 22.6 for 2x/1x — is
+    /// neither of its axes, so the region cut a curve the shape does not have.
+    #[test]
+    fn an_uneven_scale_gives_the_corner_two_axes() {
+        let rect = Rect::new(0.0, 0.0, 100.0, 100.0);
+        let (_, radii) = command(Transform::scale_xy(2.0, 1.0))
+            .world_rounded_rect(rect, CornerRadii::uniform(16.0));
+
+        assert_eq!(radii.x.top_left, 32.0, "twice as wide");
+        assert_eq!(radii.y.top_left, 16.0, "and as tall as it was");
+        assert_eq!(
+            radii.to_circular().top_left,
+            32.0,
+            "a consumer taking one radius gets the larger, so it cuts at least \
+             as much as the ellipse and stays inside the shape"
+        );
     }
 
     /// The clip is part of the shape. A card half out of a viewport is filtered
@@ -1202,14 +1251,44 @@ mod world_geometry_tests {
             .clipped_world_rounded_rect(rect, CornerRadii::uniform(16.0))
             .expect("still on show");
         assert_eq!(
-            (radii.top_left, radii.bottom_left),
+            (radii.x.top_left, radii.x.bottom_left),
             (16.0, 16.0),
             "the left edge was not moved, so its corners are as they were drawn"
         );
         assert_eq!(
-            (radii.top_right, radii.bottom_right),
+            (radii.x.top_right, radii.x.bottom_right),
             (0.0, 0.0),
             "and the ones along the cut are square"
+        );
+    }
+
+    /// A corner where the clip supplied *both* edges is the clip's corner. A
+    /// frosted card filling a rounded scroller published the scroller's square
+    /// bounding box, so the compositor blurred the desktop in the four corners
+    /// where the panel is not drawn — the function's own doc, applied to itself.
+    #[test]
+    fn a_corner_the_clip_supplies_belongs_to_the_clip() {
+        // The card overhangs the scroller on every side, so all four corners of
+        // the intersection come from the clip.
+        let rect = Rect::new(-10.0, -10.0, 120.0, 120.0);
+        let mut cmd = command(Transform::translate(0.0, 0.0));
+        cmd.clip = Some(WorldClip {
+            rect: Rect::new(0.0, 0.0, 100.0, 100.0),
+            corner_radius: 16.0,
+            curvature: 1.0,
+        });
+
+        let (world, radii) = cmd
+            .clipped_world_rounded_rect(rect, CornerRadii::uniform(4.0))
+            .expect("still on show");
+        assert_eq!(
+            (world.x, world.y, world.width, world.height),
+            (0.0, 0.0, 100.0, 100.0)
+        );
+        assert_eq!(
+            radii.x.to_array(),
+            [16.0; 4],
+            "every corner is the scroller's, not the card's and not square"
         );
     }
 
@@ -1264,6 +1343,6 @@ mod world_geometry_tests {
 
         assert_eq!((world.x, world.y), (20.0, 30.0));
         assert_eq!((world.width, world.height), (100.0, 60.0));
-        assert_eq!(radii.max(), 8.0);
+        assert_eq!((radii.x.max(), radii.y.max()), (8.0, 8.0));
     }
 }

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -28,7 +28,7 @@ mod textured_vertex;
 mod tree;
 mod types;
 
-pub use commands::{Border, CornerRadii, DrawCommand};
+pub use commands::{Border, CornerRadii, DrawCommand, EllipticalRadii};
 pub use flatten::{CommandLayer, FlattenedCommand, flatten_root_into};
 pub use gpu_context::{GpuContext, SurfaceState};
 pub use paint_context::PaintContext;

--- a/src/renderer/paint_context.rs
+++ b/src/renderer/paint_context.rs
@@ -407,7 +407,12 @@ impl<'a> PaintContext<'a> {
             return;
         }
 
-        if let Some(shadow) = shadow {
+        // Filtered like the stroke below it, and for the same reason the
+        // container's shadow is: a fully transparent one still expands into a
+        // ring of text copies, every frame, drawing nothing. Spellable
+        // deliberately (`TextShadow::new(.., Color::TRANSPARENT)`) and in
+        // passing, while an animated shadow colour leaves transparent.
+        if let Some(shadow) = shadow.filter(|s| s.color.a > 0.0) {
             for (dx, dy, sample_color) in shadow.samples() {
                 self.draw_text_styled(
                     text,

--- a/src/renderer/paint_context.rs
+++ b/src/renderer/paint_context.rs
@@ -220,44 +220,6 @@ impl<'a> PaintContext<'a> {
         }));
     }
 
-    /// Draw a rounded rectangle with gradient.
-    pub fn draw_gradient_rect(
-        &mut self,
-        rect: Rect,
-        gradient: Gradient,
-        radius: impl Into<CornerRadii>,
-        curvature: f32,
-    ) {
-        self.node.commands.push(Rc::new(DrawCommand::RoundedRect {
-            rect,
-            color: gradient.start_color, // Fallback color
-            radius: radius.into(),
-            curvature,
-            border: None,
-            shadow: None,
-            gradient: Some(gradient),
-        }));
-    }
-
-    /// Draw a border frame (no fill).
-    pub fn draw_border_frame(
-        &mut self,
-        rect: Rect,
-        border_color: Color,
-        radius: impl Into<CornerRadii>,
-        border_width: f32,
-    ) {
-        self.node.commands.push(Rc::new(DrawCommand::RoundedRect {
-            rect,
-            color: Color::TRANSPARENT,
-            radius: radius.into(),
-            curvature: 1.0,
-            border: Some(Border::new(border_width, border_color)),
-            shadow: None,
-            gradient: None,
-        }));
-    }
-
     /// Draw a border frame with curvature.
     pub fn draw_border_frame_with_curvature(
         &mut self,

--- a/src/renderer/paint_context.rs
+++ b/src/renderer/paint_context.rs
@@ -290,12 +290,14 @@ impl<'a> PaintContext<'a> {
     pub fn draw_backdrop_blur(
         &mut self,
         rect: Rect,
+        sources: crate::backdrop::BackdropSources,
         radius: f32,
         corner_radii: impl Into<CornerRadii>,
         curvature: f32,
     ) {
         self.node.commands.push(Rc::new(DrawCommand::BackdropBlur {
             rect,
+            sources,
             radius,
             corner_radii: corner_radii.into(),
             curvature,

--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -599,6 +599,7 @@ fn clip_rect(cmd: &FlattenedCommand, scale: f32) -> Option<Rect> {
 fn command_to_backdrop_region(cmd: &FlattenedCommand, scale: f32) -> Option<BackdropRegion> {
     let DrawCommand::BackdropBlur {
         rect,
+        sources,
         radius,
         corner_radii,
         curvature,
@@ -606,6 +607,11 @@ fn command_to_backdrop_region(cmd: &FlattenedCommand, scale: f32) -> Option<Back
     else {
         return None;
     };
+    // The compositor half of the same command is published as a `wl_region`
+    // instead; this pass filters only what the surface has drawn itself.
+    if !sources.contains(crate::backdrop::BackdropSources::SURFACE) {
+        return None;
+    }
 
     // The effect works on axis-aligned pixels, so a rotated container gets the
     // bounding box of its rotated rect — the mask still cuts the right shape

--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -618,6 +618,10 @@ fn command_to_backdrop_region(cmd: &FlattenedCommand, scale: f32) -> Option<Back
     // out of it for the common translation-only case. Shared with the region
     // published to the compositor, which is the same shape by definition.
     let (world, world_radii) = cmd.world_rounded_rect(*rect, *corner_radii);
+    // The mask shader takes one radius per corner, so an unevenly scaled corner
+    // is approximated here rather than on the way in — the region published to
+    // the compositor keeps both axes, because a `wl_region` can hold the shape.
+    let world_radii = world_radii.to_circular();
 
     Some(BackdropRegion {
         rect: Rect::new(

--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -615,36 +615,19 @@ fn command_to_backdrop_region(cmd: &FlattenedCommand, scale: f32) -> Option<Back
 
     // The effect works on axis-aligned pixels, so a rotated container gets the
     // bounding box of its rotated rect — the mask still cuts the right shape
-    // out of it for the common translation-only case.
-    let corners = [
-        cmd.world_transform.transform_point(rect.x, rect.y),
-        cmd.world_transform
-            .transform_point(rect.x + rect.width, rect.y),
-        cmd.world_transform
-            .transform_point(rect.x, rect.y + rect.height),
-        cmd.world_transform
-            .transform_point(rect.x + rect.width, rect.y + rect.height),
-    ];
-    let min_x = corners.iter().map(|c| c.0).fold(f32::INFINITY, f32::min);
-    let max_x = corners
-        .iter()
-        .map(|c| c.0)
-        .fold(f32::NEG_INFINITY, f32::max);
-    let min_y = corners.iter().map(|c| c.1).fold(f32::INFINITY, f32::min);
-    let max_y = corners
-        .iter()
-        .map(|c| c.1)
-        .fold(f32::NEG_INFINITY, f32::max);
+    // out of it for the common translation-only case. Shared with the region
+    // published to the compositor, which is the same shape by definition.
+    let (world, world_radii) = cmd.world_rounded_rect(*rect, *corner_radii);
 
     Some(BackdropRegion {
         rect: Rect::new(
-            min_x * scale,
-            min_y * scale,
-            (max_x - min_x) * scale,
-            (max_y - min_y) * scale,
+            world.x * scale,
+            world.y * scale,
+            world.width * scale,
+            world.height * scale,
         ),
         radius: radius * scale,
-        radii: corner_radii.scaled(scale),
+        radii: world_radii.scaled(scale),
         curvature: *curvature,
         clip: clip_rect(cmd, scale),
     })

--- a/src/session_lock.rs
+++ b/src/session_lock.rs
@@ -82,7 +82,9 @@ pub fn lock_state() -> Signal<LockState> {
     state_signal().read_only()
 }
 
-/// Lock the session (tracked read convenience: `lock_state` == `Locked`).
+/// Whether the session is locked right now — a tracked read, the convenience
+/// form of `lock_state() == LockState::Locked`. It reports the state; to
+/// *take* the lock, see [`lock_session`].
 pub fn session_locked() -> bool {
     lock_state().get() == LockState::Locked
 }

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -196,7 +196,7 @@ impl From<[i32; 4]> for Margin {
 ///   final-size surface.
 /// - On an axis anchored to both screen edges the compositor owns the
 ///   size; `Content` there is ignored with a warning at creation.
-/// - An exclusive zone of [`ExclusiveZone::FollowHeight`] follows content
+/// - An exclusive zone of [`ExclusiveZone::Auto`] follows content
 ///   resizes; every other policy never moves.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SurfaceExtent {
@@ -219,8 +219,9 @@ pub(crate) fn compositor_owned_axes(anchor: Anchor) -> (bool, bool) {
 }
 
 /// Warn about a `content()` axis the compositor owns, which can never take
-/// effect. Shared so the creation path and `SurfaceHandle::set_size` cannot
-/// disagree about what is worth saying.
+/// effect. For the creation path, where the *other* axis is usually just the
+/// default nobody chose — a bar declares its height and leaves the width alone —
+/// so a warning about a `Fixed` one there would be noise.
 pub(crate) fn warn_content_on_stretched_axis(id: SurfaceId, config: &SurfaceConfig) {
     let (stretch_w, stretch_h) = compositor_owned_axes(config.anchor);
     if (stretch_w && config.width.is_content()) || (stretch_h && config.height.is_content()) {
@@ -228,6 +229,31 @@ pub(crate) fn warn_content_on_stretched_axis(id: SurfaceId, config: &SurfaceConf
             "Surface {id:?}: content() sizing on an axis anchored to both screen \
              edges is compositor-owned and will be ignored"
         );
+    }
+}
+
+/// The same for a size asked for at runtime, where every value is one the caller
+/// chose — so a `Fixed` one being discarded is worth saying too. Silently
+/// dropping a number somebody passed is the failure mode this exists for.
+pub(crate) fn warn_size_request_on_stretched_axis(id: SurfaceId, config: &SurfaceConfig) {
+    let (stretch_w, stretch_h) = compositor_owned_axes(config.anchor);
+    for (stretched, extent, axis) in [
+        (stretch_w, config.width, "width"),
+        (stretch_h, config.height, "height"),
+    ] {
+        if !stretched {
+            continue;
+        }
+        match extent {
+            SurfaceExtent::Content => log::warn!(
+                "Surface {id:?}: content() {axis} on an axis anchored to both \
+                 screen edges is compositor-owned and will be ignored"
+            ),
+            SurfaceExtent::Fixed(v) => log::warn!(
+                "Surface {id:?}: {axis} of {v} on an axis anchored to both screen \
+                 edges is compositor-owned and will be ignored"
+            ),
+        }
     }
 }
 
@@ -245,35 +271,40 @@ pub(crate) fn requested_extent(extent: SurfaceExtent, live: Option<u32>) -> u32 
     }
 }
 
-/// What a runtime resize asks the compositor for, and whether the surface has
-/// to be re-measured before that answer is right.
+/// What a resize asks the compositor for, and whether the surface has to be
+/// re-measured before that answer is right.
 ///
 /// A content axis has no size of its own yet — `SurfaceExtent::initial()` is
 /// 1px — so asking for it directly collapses the surface, and nothing brings it
 /// back: the content-measure pass runs only for a surface that had layout
 /// activity, and a bare `set_size` produces none. So a content axis holds the
-/// live size and asks for a layout, which is what brings the measure round.
+/// confirmed size and asks for a layout, which is what brings the measure round.
 pub(crate) fn resize_request(config: &SurfaceConfig, live: Option<(u32, u32)>) -> (u32, u32, bool) {
-    // Zero on an axis the compositor owns is how layer-shell says "you decide",
-    // and it is not optional: `zwlr_layer_surface_v1::set_size` makes omitting a
-    // dimension *without* opposite-edge anchoring a protocol error, and sending
-    // a number *with* it hands back an axis that is not ours. Either way the
-    // anchor decides, so anything that moves the anchor has to come back through
-    // here — the connection is closed at the next commit otherwise, and every
-    // frame commits.
-    let (stretch_w, stretch_h) = compositor_owned_axes(config.anchor);
+    let (width, height) = honour_owned_axes(
+        config.anchor,
+        requested_extent(config.width, live.map(|(w, _)| w)),
+        requested_extent(config.height, live.map(|(_, h)| h)),
+    );
     (
-        if stretch_w {
-            0
-        } else {
-            requested_extent(config.width, live.map(|(w, _)| w))
-        },
-        if stretch_h {
-            0
-        } else {
-            requested_extent(config.height, live.map(|(_, h)| h))
-        },
+        width,
+        height,
         config.width.is_content() || config.height.is_content(),
+    )
+}
+
+/// Zero the axes the compositor owns, whatever size was going to be asked for.
+///
+/// Zero on such an axis is how layer-shell says "you decide", and it is not
+/// optional: `zwlr_layer_surface_v1::set_size` makes omitting a dimension
+/// *without* opposite-edge anchoring a protocol error, and sending a number
+/// *with* it hands back an axis that is not ours. The anchor decides, so every
+/// path that sends a size comes through here — creation, a runtime resize, a
+/// re-anchoring, and the content-measure pass.
+pub(crate) fn honour_owned_axes(anchor: Anchor, width: u32, height: u32) -> (u32, u32) {
+    let (stretch_w, stretch_h) = compositor_owned_axes(anchor);
+    (
+        if stretch_w { 0 } else { width },
+        if stretch_h { 0 } else { height },
     )
 }
 

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -91,14 +91,88 @@ pub struct SurfaceConfig {
     pub background_color: Color,
     /// Screen-space reservation policy (see [`ExclusiveZone`]).
     pub exclusive_zone: ExclusiveZone,
-    /// Margins from the anchored screen edges (top, right, bottom, left).
-    pub margin: (i32, i32, i32, i32),
+    /// Margins from the anchored screen edges.
+    pub margin: Margin,
     /// Output (monitor) to show the surface on. None lets the compositor choose.
     pub output: Option<OutputId>,
     /// Input region in logical surface coordinates. `None` means the whole
     /// surface accepts input; `Some(rects)` limits input to those rectangles
     /// (an empty list makes the surface fully click-through).
     pub input_region: Option<Vec<Rect>>,
+}
+
+/// Margins from the anchored screen edges, in logical pixels.
+///
+/// The same shorthands a [`Padding`](crate::widgets::Padding) takes, in the
+/// same order — one value for every edge, `[vertical, horizontal]`, or the
+/// full `[top, right, bottom, left]`:
+///
+/// ```ignore
+/// SurfaceConfig::new().margin(8)                   // all four edges
+/// SurfaceConfig::new().margin([0, 12])             // none top/bottom, 12 aside
+/// SurfaceConfig::new().margin([8, 12, 0, 12])      // top, right, bottom, left
+/// ```
+///
+/// Negative values are allowed: layer-shell reads them as pushing the surface
+/// past its anchored edge.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Margin {
+    pub top: i32,
+    pub right: i32,
+    pub bottom: i32,
+    pub left: i32,
+}
+
+impl Margin {
+    /// The same margin on every edge.
+    pub fn all(value: i32) -> Self {
+        Self {
+            top: value,
+            right: value,
+            bottom: value,
+            left: value,
+        }
+    }
+
+    pub(crate) fn is_zero(self) -> bool {
+        self == Self::default()
+    }
+}
+
+impl From<i32> for Margin {
+    fn from(v: i32) -> Self {
+        Margin::all(v)
+    }
+}
+
+impl From<u32> for Margin {
+    fn from(v: u32) -> Self {
+        Margin::all(v as i32)
+    }
+}
+
+/// `[vertical, horizontal]` — CSS-style 2-value shorthand.
+impl From<[i32; 2]> for Margin {
+    fn from(v: [i32; 2]) -> Self {
+        Margin {
+            top: v[0],
+            right: v[1],
+            bottom: v[0],
+            left: v[1],
+        }
+    }
+}
+
+/// `[top, right, bottom, left]` — CSS-style 4-value shorthand.
+impl From<[i32; 4]> for Margin {
+    fn from(v: [i32; 4]) -> Self {
+        Margin {
+            top: v[0],
+            right: v[1],
+            bottom: v[2],
+            left: v[3],
+        }
+    }
 }
 
 /// Per-axis sizing for layer surfaces.
@@ -198,28 +272,22 @@ pub enum ExclusiveZone {
 impl ExclusiveZone {
     /// Protocol value. [`Auto`](ExclusiveZone::Auto) resolves against the
     /// surface extent on the anchored axis plus that edge's margin.
-    pub(crate) fn resolve(
-        self,
-        anchor: Anchor,
-        margin: (i32, i32, i32, i32),
-        width: u32,
-        height: u32,
-    ) -> i32 {
+    pub(crate) fn resolve(self, anchor: Anchor, margin: Margin, width: u32, height: u32) -> i32 {
         match self {
             ExclusiveZone::Auto => match Self::follow_axis(anchor) {
                 Some(FollowAxis::Height) => {
                     let edge_margin = if anchor.contains(Anchor::TOP) {
-                        margin.0
+                        margin.top
                     } else {
-                        margin.2
+                        margin.bottom
                     };
                     height as i32 + edge_margin
                 }
                 Some(FollowAxis::Width) => {
                     let edge_margin = if anchor.contains(Anchor::LEFT) {
-                        margin.3
+                        margin.left
                     } else {
-                        margin.1
+                        margin.right
                     };
                     width as i32 + edge_margin
                 }
@@ -276,7 +344,7 @@ impl Default for SurfaceConfig {
             namespace: "guido-surface".to_string(),
             background_color: Color::rgb(0.1, 0.1, 0.15),
             exclusive_zone: ExclusiveZone::None,
-            margin: (0, 0, 0, 0),
+            margin: Margin::default(),
             output: None,
             input_region: None,
         }
@@ -344,9 +412,9 @@ impl SurfaceConfig {
 
     /// Set the margins from the anchored screen edges, applied at creation.
     ///
-    /// Use `SurfaceHandle::set_margin` to change them at runtime.
-    pub fn margin(mut self, top: i32, right: i32, bottom: i32, left: i32) -> Self {
-        self.margin = (top, right, bottom, left);
+    /// Use [`SurfaceHandle::set_margin`] to change them at runtime.
+    pub fn margin(mut self, margin: impl Into<Margin>) -> Self {
+        self.margin = margin.into();
         self
     }
 
@@ -553,38 +621,38 @@ impl SurfaceHandle {
         });
     }
 
-    /// Set the size of this surface in logical pixels.
+    /// Set the size of this surface, in the same vocabulary
+    /// [`SurfaceConfig::width`] takes — so an axis can be handed back to
+    /// [`content()`] at runtime, not only pinned to a number.
     ///
-    /// Note: When anchored to both edges on an axis (e.g., LEFT and RIGHT),
+    /// Note: when anchored to both edges on an axis (e.g. LEFT and RIGHT),
     /// the compositor may override that dimension.
-    pub fn set_size(&self, width: u32, height: u32) {
+    pub fn set_size(&self, width: impl Into<SurfaceExtent>, height: impl Into<SurfaceExtent>) {
         push_surface_command(SurfaceCommand::SetSize {
             id: self.id,
-            width,
-            height,
+            width: width.into(),
+            height: height.into(),
         });
     }
 
-    /// Set the exclusive zone for this surface.
+    /// Set the screen-space reservation for this surface, in the same
+    /// vocabulary [`SurfaceConfig::exclusive_zone`] takes.
     ///
-    /// The exclusive zone reserves screen space so other windows don't
-    /// overlap. Pass 0 for no exclusive zone, or a positive value for
-    /// the number of pixels to reserve.
-    pub fn set_exclusive_zone(&self, zone: i32) {
-        push_surface_command(SurfaceCommand::SetExclusiveZone { id: self.id, zone });
+    /// [`ExclusiveZone::Auto`] keeps following the surface's extent from here
+    /// on, exactly as it would had it been declared at creation.
+    pub fn set_exclusive_zone(&self, zone: impl Into<ExclusiveZone>) {
+        push_surface_command(SurfaceCommand::SetExclusiveZone {
+            id: self.id,
+            zone: zone.into(),
+        });
     }
 
-    /// Set the margin for this surface.
-    ///
-    /// Margins add space between the surface and the screen edge it's
-    /// anchored to.
-    pub fn set_margin(&self, top: i32, right: i32, bottom: i32, left: i32) {
+    /// Set the margins from the anchored screen edges, in the same vocabulary
+    /// [`SurfaceConfig::margin`] takes.
+    pub fn set_margin(&self, margin: impl Into<Margin>) {
         push_surface_command(SurfaceCommand::SetMargin {
             id: self.id,
-            top,
-            right,
-            bottom,
-            left,
+            margin: margin.into(),
         });
     }
 
@@ -623,19 +691,14 @@ pub(crate) enum SurfaceCommand {
     /// Set the size of a surface.
     SetSize {
         id: SurfaceId,
-        width: u32,
-        height: u32,
+        width: SurfaceExtent,
+        height: SurfaceExtent,
     },
-    /// Set the exclusive zone for a surface.
-    SetExclusiveZone { id: SurfaceId, zone: i32 },
+    /// Set the screen-space reservation for a surface. Resolved to a protocol
+    /// value by the loop, which is where the anchor and the current extent are.
+    SetExclusiveZone { id: SurfaceId, zone: ExclusiveZone },
     /// Set the margin for a surface.
-    SetMargin {
-        id: SurfaceId,
-        top: i32,
-        right: i32,
-        bottom: i32,
-        left: i32,
-    },
+    SetMargin { id: SurfaceId, margin: Margin },
     /// Set the input region for a surface.
     SetInputRegion {
         id: SurfaceId,
@@ -860,4 +923,60 @@ pub fn surface_handle(id: SurfaceId) -> SurfaceHandle {
 /// Part of the loop's wakeup check — see `queued_but_unwoken` in `lib.rs`.
 pub(crate) fn surface_commands_pending() -> bool {
     SURFACE_COMMANDS.with(|cmds| !cmds.borrow().is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The shorthands are the ones `Padding` takes, in the same order.
+    #[test]
+    fn margin_shorthands_follow_css_order() {
+        assert_eq!(Margin::from(8), Margin::all(8));
+        assert_eq!(
+            Margin::from([4, 12]),
+            Margin {
+                top: 4,
+                right: 12,
+                bottom: 4,
+                left: 12
+            }
+        );
+        assert_eq!(
+            Margin::from([1, 2, 3, 4]),
+            Margin {
+                top: 1,
+                right: 2,
+                bottom: 3,
+                left: 4
+            }
+        );
+    }
+
+    /// An `Auto` reservation counts the margin on the edge it is anchored to,
+    /// and only that one.
+    #[test]
+    fn an_auto_zone_adds_the_anchored_edges_margin() {
+        let margin = Margin::from([6, 20, 9, 20]);
+        let top = ExclusiveZone::Auto.resolve(Anchor::TOP, margin, 800, 32);
+        assert_eq!(top, 32 + 6);
+
+        let bottom = ExclusiveZone::Auto.resolve(Anchor::BOTTOM, margin, 800, 32);
+        assert_eq!(bottom, 32 + 9);
+
+        let left = ExclusiveZone::Auto.resolve(Anchor::LEFT, margin, 48, 600);
+        assert_eq!(left, 48 + 20);
+    }
+
+    /// The other policies are numbers, and never consult anything.
+    #[test]
+    fn the_other_zone_policies_ignore_the_surface() {
+        let m = Margin::all(10);
+        assert_eq!(ExclusiveZone::None.resolve(Anchor::TOP, m, 800, 32), 0);
+        assert_eq!(ExclusiveZone::Ignore.resolve(Anchor::TOP, m, 800, 32), -1);
+        assert_eq!(
+            ExclusiveZone::from(34u32).resolve(Anchor::TOP, m, 800, 32),
+            34
+        );
+    }
 }

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -280,16 +280,19 @@ pub(crate) fn requested_extent(extent: SurfaceExtent, live: Option<u32>) -> u32 
 /// activity, and a bare `set_size` produces none. So a content axis holds the
 /// confirmed size and asks for a layout, which is what brings the measure round.
 pub(crate) fn resize_request(config: &SurfaceConfig, live: Option<(u32, u32)>) -> (u32, u32, bool) {
+    let (owns_w, owns_h) = compositor_owned_axes(config.anchor);
     let (width, height) = honour_owned_axes(
         config.anchor,
         requested_extent(config.width, live.map(|(w, _)| w)),
         requested_extent(config.height, live.map(|(_, h)| h)),
     );
-    (
-        width,
-        height,
-        config.width.is_content() || config.height.is_content(),
-    )
+    // Only for a content axis that is *ours*. Stretched, the measure runs and
+    // `honour_owned_axes` throws the answer away — a full re-layout of the
+    // subtree for an axis that was never going to be ours. A bar declared
+    // `width(content()).anchor(LEFT | RIGHT)` did exactly that on every resize
+    // and every re-anchoring.
+    let measure = (config.width.is_content() && !owns_w) || (config.height.is_content() && !owns_h);
+    (width, height, measure)
 }
 
 /// Zero the axes the compositor owns, whatever size was going to be asked for.

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -206,6 +206,31 @@ pub enum SurfaceExtent {
     Content,
 }
 
+/// Which axes the compositor owns, from the anchor: an axis pinned to both of
+/// its screen edges is stretched to fit and the surface's request for it is
+/// ignored.
+///
+/// Returns `(width, height)`.
+pub(crate) fn compositor_owned_axes(anchor: Anchor) -> (bool, bool) {
+    (
+        anchor.contains(Anchor::LEFT) && anchor.contains(Anchor::RIGHT),
+        anchor.contains(Anchor::TOP) && anchor.contains(Anchor::BOTTOM),
+    )
+}
+
+/// Warn about a `content()` axis the compositor owns, which can never take
+/// effect. Shared so the creation path and `SurfaceHandle::set_size` cannot
+/// disagree about what is worth saying.
+pub(crate) fn warn_content_on_stretched_axis(id: SurfaceId, config: &SurfaceConfig) {
+    let (stretch_w, stretch_h) = compositor_owned_axes(config.anchor);
+    if (stretch_w && config.width.is_content()) || (stretch_h && config.height.is_content()) {
+        log::warn!(
+            "Surface {id:?}: content() sizing on an axis anchored to both screen \
+             edges is compositor-owned and will be ignored"
+        );
+    }
+}
+
 impl SurfaceExtent {
     /// The initial protocol size (`Content` starts at 1px until the first
     /// measure lands).

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -929,19 +929,44 @@ pub(crate) fn surface_commands_pending() -> bool {
 mod tests {
     use super::*;
 
-    /// The shorthands are the ones `Padding` takes, in the same order.
+    /// The doc promises "the same shorthands a `Padding` takes, in the same
+    /// order". The two types are written out separately — one holds i32 for the
+    /// protocol, the other f32 for layout — so the promise is only worth
+    /// anything if something checks it. This does, edge by edge, over every
+    /// shorthand and a set of inputs where confusing two edges shows up:
+    /// asymmetric, and non-zero everywhere.
     #[test]
-    fn margin_shorthands_follow_css_order() {
-        assert_eq!(Margin::from(8), Margin::all(8));
-        assert_eq!(
-            Margin::from([4, 12]),
-            Margin {
-                top: 4,
-                right: 12,
-                bottom: 4,
-                left: 12
-            }
+    fn a_margin_converts_exactly_as_a_padding_does() {
+        let same = |m: Margin, p: crate::widgets::Padding, what: &str| {
+            assert_eq!(m.top as f32, p.top, "{what}: top");
+            assert_eq!(m.right as f32, p.right, "{what}: right");
+            assert_eq!(m.bottom as f32, p.bottom, "{what}: bottom");
+            assert_eq!(m.left as f32, p.left, "{what}: left");
+        };
+
+        same(
+            Margin::from(8),
+            crate::widgets::Padding::from(8),
+            "one value",
         );
+        same(
+            Margin::all(8),
+            crate::widgets::Padding::all(8.0),
+            "all(), the named form",
+        );
+        same(
+            Margin::from([4, 12]),
+            crate::widgets::Padding::from([4, 12]),
+            "[vertical, horizontal]",
+        );
+        same(
+            Margin::from([1, 2, 3, 4]),
+            crate::widgets::Padding::from([1, 2, 3, 4]),
+            "[top, right, bottom, left]",
+        );
+
+        // And spelled out once, so a shared mistake in both types would still
+        // be caught: CSS order, clockwise from the top.
         assert_eq!(
             Margin::from([1, 2, 3, 4]),
             Margin {
@@ -949,6 +974,15 @@ mod tests {
                 right: 2,
                 bottom: 3,
                 left: 4
+            }
+        );
+        assert_eq!(
+            Margin::from([4, 12]),
+            Margin {
+                top: 4,
+                right: 12,
+                bottom: 4,
+                left: 12
             }
         );
     }

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -178,6 +178,22 @@ impl From<[i32; 4]> for Margin {
     }
 }
 
+/// `[vertical, horizontal]`, unsigned. A bare `[0, 12]` infers as `[i32; 2]`
+/// and needs neither of these, which is why the pair was missing while the doc
+/// said "arrays of them" — it takes a `[u32; 2]` named somewhere else to notice.
+impl From<[u32; 2]> for Margin {
+    fn from(v: [u32; 2]) -> Self {
+        Margin::from([v[0] as i32, v[1] as i32])
+    }
+}
+
+/// `[top, right, bottom, left]`, unsigned.
+impl From<[u32; 4]> for Margin {
+    fn from(v: [u32; 4]) -> Self {
+        Margin::from([v[0] as i32, v[1] as i32, v[2] as i32, v[3] as i32])
+    }
+}
+
 /// Per-axis sizing for layer surfaces.
 ///
 /// `Fixed` is a size in logical pixels (plain integers convert into it).

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -231,6 +231,47 @@ pub(crate) fn warn_content_on_stretched_axis(id: SurfaceId, config: &SurfaceConf
     }
 }
 
+/// The size an axis is currently asking for: its own, if it has one, and the
+/// live surface size while a content axis waits to be measured.
+pub(crate) fn requested_extent(extent: SurfaceExtent, live: Option<u32>) -> u32 {
+    match extent {
+        SurfaceExtent::Fixed(v) => v,
+        SurfaceExtent::Content => live.unwrap_or_else(|| extent.initial()),
+    }
+}
+
+/// What a runtime resize asks the compositor for, and whether the surface has
+/// to be re-measured before that answer is right.
+///
+/// A content axis has no size of its own yet — `SurfaceExtent::initial()` is
+/// 1px — so asking for it directly collapses the surface, and nothing brings it
+/// back: the content-measure pass runs only for a surface that had layout
+/// activity, and a bare `set_size` produces none. So a content axis holds the
+/// live size and asks for a layout, which is what brings the measure round.
+pub(crate) fn resize_request(config: &SurfaceConfig, live: Option<(u32, u32)>) -> (u32, u32, bool) {
+    // Zero on an axis the compositor owns is how layer-shell says "you decide",
+    // and it is not optional: `zwlr_layer_surface_v1::set_size` makes omitting a
+    // dimension *without* opposite-edge anchoring a protocol error, and sending
+    // a number *with* it hands back an axis that is not ours. Either way the
+    // anchor decides, so anything that moves the anchor has to come back through
+    // here — the connection is closed at the next commit otherwise, and every
+    // frame commits.
+    let (stretch_w, stretch_h) = compositor_owned_axes(config.anchor);
+    (
+        if stretch_w {
+            0
+        } else {
+            requested_extent(config.width, live.map(|(w, _)| w))
+        },
+        if stretch_h {
+            0
+        } else {
+            requested_extent(config.height, live.map(|(_, h)| h))
+        },
+        config.width.is_content() || config.height.is_content(),
+    )
+}
+
 impl SurfaceExtent {
     /// The initial protocol size (`Content` starts at 1px until the first
     /// measure lands).

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -103,9 +103,12 @@ pub struct SurfaceConfig {
 
 /// Margins from the anchored screen edges, in logical pixels.
 ///
-/// The same shorthands a [`Padding`](crate::widgets::Padding) takes, in the
-/// same order — one value for every edge, `[vertical, horizontal]`, or the
-/// full `[top, right, bottom, left]`:
+/// The shorthands a [`Padding`](crate::widgets::Padding) takes, in the same
+/// order — one value for every edge, `[vertical, horizontal]`, or the full
+/// `[top, right, bottom, left]` — but **whole pixels only**: `i32`, `u32` and
+/// arrays of them. `margin(8.0)` does not compile where `padding(8.0)` does,
+/// because `zwlr_layer_surface_v1::set_margin` is defined in integers and a
+/// fractional margin has nothing to round to that the compositor would honour.
 ///
 /// ```ignore
 /// SurfaceConfig::new().margin(8)                   // all four edges
@@ -280,19 +283,26 @@ pub(crate) fn requested_extent(extent: SurfaceExtent, live: Option<u32>) -> u32 
 /// activity, and a bare `set_size` produces none. So a content axis holds the
 /// confirmed size and asks for a layout, which is what brings the measure round.
 pub(crate) fn resize_request(config: &SurfaceConfig, live: Option<(u32, u32)>) -> (u32, u32, bool) {
-    let (owns_w, owns_h) = compositor_owned_axes(config.anchor);
     let (width, height) = honour_owned_axes(
         config.anchor,
         requested_extent(config.width, live.map(|(w, _)| w)),
         requested_extent(config.height, live.map(|(_, h)| h)),
     );
-    // Only for a content axis that is *ours*. Stretched, the measure runs and
-    // `honour_owned_axes` throws the answer away — a full re-layout of the
-    // subtree for an axis that was never going to be ours. A bar declared
-    // `width(content()).anchor(LEFT | RIGHT)` did exactly that on every resize
-    // and every re-anchoring.
-    let measure = (config.width.is_content() && !owns_w) || (config.height.is_content() && !owns_h);
-    (width, height, measure)
+    (width, height, needs_content_measure(config))
+}
+
+/// Whether this surface has a `content()` axis worth measuring.
+///
+/// A content axis the compositor owns is not one: the measure runs, and
+/// [`honour_owned_axes`] throws the answer away. A bar declared
+/// `width(content()).anchor(TOP | LEFT | RIGHT)` measured its content and
+/// discarded it on every resize, every re-anchoring, and — until this was the
+/// gate on the frame loop's measure pass too — on **every frame with any layout
+/// activity at all**, since the width it measured could never equal the screen
+/// width it had been given.
+pub(crate) fn needs_content_measure(config: &SurfaceConfig) -> bool {
+    let (owns_w, owns_h) = compositor_owned_axes(config.anchor);
+    (config.width.is_content() && !owns_w) || (config.height.is_content() && !owns_h)
 }
 
 /// Zero the axes the compositor owns, whatever size was going to be asked for.

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -232,7 +232,12 @@ pub(crate) fn warn_content_on_stretched_axis(id: SurfaceId, config: &SurfaceConf
 }
 
 /// The size an axis is currently asking for: its own, if it has one, and the
-/// live surface size while a content axis waits to be measured.
+/// size the compositor has confirmed while a content axis waits to be measured.
+///
+/// Before the first configure there is no confirmed size, and the placeholder is
+/// what creation asks for too — the content-measure pass runs on the first
+/// frames of a surface either way, so 1px is a value it is leaving, not one it
+/// can be stuck at.
 pub(crate) fn requested_extent(extent: SurfaceExtent, live: Option<u32>) -> u32 {
     match extent {
         SurfaceExtent::Fixed(v) => v,

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -24,11 +24,6 @@ impl Transform {
         data: [1.0, 0.0, 0.0, 0.0, 1.0, 0.0],
     };
 
-    /// Create an identity transform
-    pub fn identity() -> Self {
-        Self::IDENTITY
-    }
-
     /// Create a translation transform
     pub fn translate(x: f32, y: f32) -> Self {
         Self {
@@ -165,12 +160,6 @@ impl Transform {
         *self == Self::IDENTITY
     }
 
-    /// Check if this transform contains rotation.
-    /// Rotation is present when the off-diagonal elements (b, c) are non-zero.
-    pub fn has_rotation(&self) -> bool {
-        self.b().abs() > 1e-6 || self.c().abs() > 1e-6
-    }
-
     /// Get the X translation component
     #[inline]
     pub fn tx(&self) -> f32 {
@@ -185,61 +174,28 @@ impl Transform {
 
     /// Set the X translation component
     #[inline]
-    pub fn set_tx(&mut self, val: f32) {
+    pub(crate) fn set_tx(&mut self, val: f32) {
         self.data[2] = val;
     }
 
     /// Set the Y translation component
     #[inline]
-    pub fn set_ty(&mut self, val: f32) {
+    pub(crate) fn set_ty(&mut self, val: f32) {
         self.data[5] = val;
     }
 
-    /// Scale the translation components by a factor (useful for HiDPI scaling)
-    pub fn scale_translation(&mut self, factor: f32) {
-        self.data[2] *= factor;
-        self.data[5] *= factor;
-    }
-
-    /// Extract the X and Y scale components from the transform.
-    ///
-    /// For transforms that contain rotation and/or scale:
-    /// - sx = sqrt(a² + b²)
-    /// - sy = sqrt(c² + d²)
-    ///
-    /// Returns `(scale_x, scale_y)` as a tuple.
-    pub fn extract_scale_components(&self) -> (f32, f32) {
+    /// The X and Y scale components — `sqrt(a² + b²)` and `sqrt(c² + d²)`,
+    /// so a rotated transform still reports the scale it carries.
+    pub(crate) fn extract_scale_components(&self) -> (f32, f32) {
         let (a, b, c, d) = (self.a(), self.b(), self.c(), self.d());
         ((a * a + b * b).sqrt(), (c * c + d * d).sqrt())
     }
 
-    /// Extract the uniform scale factor from this transform.
-    ///
-    /// For transforms that contain rotation and/or scale, this returns the
-    /// average scale factor. For pure scale transforms, returns the exact scale.
-    /// For transforms with non-uniform scaling, returns the geometric mean.
-    pub fn extract_scale(&self) -> f32 {
+    /// One scale factor for a transform that may not have exactly one: the
+    /// geometric mean of the two axes.
+    pub(crate) fn extract_scale(&self) -> f32 {
         let (sx, sy) = self.extract_scale_components();
-        // Return geometric mean for uniform scale approximation
         (sx * sy).sqrt()
-    }
-
-    /// Create a transform with the scale component removed.
-    ///
-    /// This preserves rotation and translation but normalizes scale to 1.0.
-    /// Useful for render-to-texture workflows where text is pre-scaled.
-    pub fn without_scale(&self) -> Transform {
-        let (sx, sy) = self.extract_scale_components();
-        let [a, b, tx, c, d, ty] = self.data;
-
-        // Avoid division by zero
-        if sx < 1e-10 || sy < 1e-10 {
-            return Transform::translate(tx, ty);
-        }
-
-        Transform {
-            data: [a / sx, b / sx, tx, c / sy, d / sy, ty],
-        }
     }
 
     /// Check if this transform contains only translation (no rotation or scale).
@@ -247,30 +203,6 @@ impl Transform {
         let (a, b, c, d) = (self.a(), self.b(), self.c(), self.d());
         // For pure translation: a=1, b=0, c=0, d=1
         (a - 1.0).abs() < 1e-6 && b.abs() < 1e-6 && c.abs() < 1e-6 && (d - 1.0).abs() < 1e-6
-    }
-
-    /// Check if this transform contains non-trivial transformation (rotation or non-unit scale).
-    pub fn has_rotation_or_scale(&self) -> bool {
-        !self.is_translation_only()
-    }
-
-    /// Extract just the rotation component, removing both scale and translation.
-    ///
-    /// This is useful when you need to apply the same rotation to a different
-    /// object at a different position (like text inside a transformed container).
-    pub fn rotation_only(&self) -> Transform {
-        let (sx, sy) = self.extract_scale_components();
-
-        // Avoid division by zero
-        if sx < 1e-10 || sy < 1e-10 {
-            return Transform::IDENTITY;
-        }
-
-        let [a, b, _tx, c, d, _ty] = self.data;
-
-        Transform {
-            data: [a / sx, b / sx, 0.0, c / sy, d / sy, 0.0],
-        }
     }
 }
 
@@ -290,7 +222,7 @@ mod tests {
 
     #[test]
     fn test_identity() {
-        let t = Transform::identity();
+        let t = Transform::IDENTITY;
         assert_eq!(t, Transform::IDENTITY);
         assert!(t.is_identity());
     }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -491,6 +491,14 @@ impl Tree {
         }
     }
 
+    /// How far this widget's paint reaches beyond its bounds.
+    #[cfg(test)]
+    pub(crate) fn paint_overflow(&self, id: WidgetId) -> f32 {
+        self.get_dense_index(id)
+            .map(|idx| self.dense[idx].paint_overflow)
+            .unwrap_or(0.0)
+    }
+
     /// Get the children of a widget (returns a slice to avoid heap allocation).
     pub fn get_children(&self, id: WidgetId) -> &[WidgetId] {
         self.get_dense_index(id)

--- a/src/widgets/container/anim_bridge.rs
+++ b/src/widgets/container/anim_bridge.rs
@@ -55,13 +55,13 @@ impl Container {
                 lengths.width.exact,
                 lengths.width.min,
                 lengths.width.max,
-                content.width + lengths.padding.horizontal(),
+                content.width + lengths.padding.horizontal_total(),
             ),
             (
                 lengths.height.exact,
                 lengths.height.min,
                 lengths.height.max,
-                content.height + lengths.padding.vertical(),
+                content.height + lengths.padding.vertical_total(),
             ),
         ];
         let Some(ref mut anims) = self.anims else {

--- a/src/widgets/container/anim_bridge.rs
+++ b/src/widgets/container/anim_bridge.rs
@@ -119,18 +119,19 @@ impl Container {
         let bg_init = anims.is_some_and(|a| a.background.as_ref().is_some_and(|a| a.is_initial()));
         let cr_init =
             anims.is_some_and(|a| a.corner_radius.as_ref().is_some_and(|a| a.is_initial()));
+        let el_init = anims.is_some_and(|a| a.elevation.as_ref().is_some_and(|a| a.is_initial()));
         let bc_init =
             anims.is_some_and(|a| a.border_color.as_ref().is_some_and(|a| a.is_initial()));
         let tf_init = anims.is_some_and(|a| a.transform.as_ref().is_some_and(|a| a.is_initial()));
         let tc_init = anims.is_some_and(|a| a.text_color.as_ref().is_some_and(|a| a.is_initial()));
 
-        if !(pd_init || bw_init || bg_init || cr_init || bc_init || tf_init || tc_init) {
+        if !(pd_init || bw_init || bg_init || cr_init || el_init || bc_init || tf_init || tc_init) {
             return;
         }
 
         // Targets are computed under `&self` first: the writes below need
         // `&mut self.anims`, and the effective_* readers need `&self`.
-        let (bg_target, cr_target, bc_target, tf_target, tc_target) =
+        let (bg_target, cr_target, el_target, bc_target, tf_target, tc_target) =
             with_signal_tracking(id, JobType::Animation, || {
                 // Read for the subscription even where the value is unused.
                 if pd_init {
@@ -142,6 +143,7 @@ impl Container {
                 (
                     bg_init.then(|| self.effective_background_target(id)),
                     cr_init.then(|| self.effective_corner_radius_target(id)),
+                    el_init.then(|| self.effective_elevation_target(id)),
                     bc_init.then(|| self.effective_border_color_target(id)),
                     tf_init.then(|| self.effective_transform_target(id)),
                     tc_init.then(|| self.effective_text_color_target(id)),
@@ -164,6 +166,9 @@ impl Container {
             anim.set_immediate(target);
         }
         if let (Some(anim), Some(target)) = (&mut anims.corner_radius, cr_target) {
+            anim.set_immediate(target);
+        }
+        if let (Some(anim), Some(target)) = (&mut anims.elevation, el_target) {
             anim.set_immediate(target);
         }
         if let (Some(anim), Some(target)) = (&mut anims.border_color, bc_target) {
@@ -221,6 +226,12 @@ impl Container {
                 drift |= moved(
                     a.is_initial(),
                     *a.target() == self.effective_corner_radius_target(id),
+                );
+            }
+            if let Some(a) = &anims.elevation {
+                drift |= moved(
+                    a.is_initial(),
+                    *a.target() == self.effective_elevation_target(id),
                 );
             }
             if let Some(a) = &anims.border_color {

--- a/src/widgets/container/animations.rs
+++ b/src/widgets/container/animations.rs
@@ -300,6 +300,16 @@ impl<T: Animatable> AnimationState<T> {
         }
     }
 
+    /// How far past its target this animation can travel, as a fraction of the
+    /// distance — the worse of the forward and reverse curves.
+    pub fn peak_overshoot(&self) -> f32 {
+        let forward = self.transition.timing.peak_overshoot();
+        match &self.reverse_transition {
+            Some(reverse) => forward.max(reverse.timing.peak_overshoot()),
+            None => forward,
+        }
+    }
+
     /// Check if animation is still running
     pub fn is_animating(&self) -> bool {
         self.timeline.as_ref().is_some_and(|t| t.playing.is_some())

--- a/src/widgets/container/box_model.rs
+++ b/src/widgets/container/box_model.rs
@@ -168,8 +168,8 @@ impl Container {
             constraints.max_height,
         );
 
-        let mut max_width = (layout_width - padding.horizontal()).max(0.0);
-        let mut max_height = (layout_height - padding.vertical()).max(0.0);
+        let mut max_width = (layout_width - padding.horizontal_total()).max(0.0);
+        let mut max_height = (layout_height - padding.vertical_total()).max(0.0);
 
         // A reserved gutter is space the content never gets, scrollbar shown
         // or not — that is the point of reserving it.
@@ -192,7 +192,9 @@ impl Container {
             max_width
         } else {
             let effective = lengths.width.min.unwrap_or(0.0).max(constraints.min_width);
-            (effective - padding.horizontal()).max(0.0).min(max_width)
+            (effective - padding.horizontal_total())
+                .max(0.0)
+                .min(max_width)
         };
         let min_height = if lengths.height.exact.is_some() || lengths.height.fill {
             max_height
@@ -202,7 +204,9 @@ impl Container {
                 .min
                 .unwrap_or(0.0)
                 .max(constraints.min_height);
-            (effective - padding.vertical()).max(0.0).min(max_height)
+            (effective - padding.vertical_total())
+                .max(0.0)
+                .min(max_height)
         };
 
         // The visible extent, captured before the scrolled axis is opened up.
@@ -257,7 +261,7 @@ impl Container {
                 Axis::Horizontal,
                 &lengths.width,
                 lengths.overflow,
-                content.width + lengths.padding.horizontal(),
+                content.width + lengths.padding.horizontal_total(),
                 constraints.min_width,
                 constraints.max_width,
             ),
@@ -265,7 +269,7 @@ impl Container {
                 Axis::Vertical,
                 &lengths.height,
                 lengths.overflow,
-                content.height + lengths.padding.vertical(),
+                content.height + lengths.padding.vertical_total(),
                 constraints.min_height,
                 constraints.max_height,
             ),

--- a/src/widgets/container/box_model.rs
+++ b/src/widgets/container/box_model.rs
@@ -34,6 +34,10 @@ pub(super) struct BoxLengths {
     pub padding: Padding,
     pub width: Length,
     pub height: Length,
+    /// Read here rather than at the point of use: `overflow` is reactive and
+    /// decides whether a box may shrink below its content, so the read has to
+    /// happen inside the layout tracking scope like every other length.
+    pub overflow: Overflow,
 }
 
 /// What the children of one layout pass are laid out into.
@@ -84,13 +88,15 @@ impl Container {
     /// Read the declared padding and lengths, tracked so a later write
     /// re-runs this layout, with fractions resolved against `constraints`.
     pub(super) fn read_box_lengths(&self, id: WidgetId, constraints: Constraints) -> BoxLengths {
-        let (padding, mut width, mut height) = with_signal_tracking(id, JobType::Layout, || {
-            (
-                self.animated_padding(),
-                self.width.as_ref().map(|w| w.get()).unwrap_or_default(),
-                self.height.as_ref().map(|h| h.get()).unwrap_or_default(),
-            )
-        });
+        let (padding, mut width, mut height, overflow) =
+            with_signal_tracking(id, JobType::Layout, || {
+                (
+                    self.animated_padding(),
+                    self.width.as_ref().map(|w| w.get()).unwrap_or_default(),
+                    self.height.as_ref().map(|h| h.get()).unwrap_or_default(),
+                    self.overflow.get_or(Overflow::Visible),
+                )
+            });
 
         if let Some(f) = width.fraction
             && constraints.max_width.is_finite()
@@ -107,6 +113,7 @@ impl Container {
             padding,
             width,
             height,
+            overflow,
         }
     }
 
@@ -249,6 +256,7 @@ impl Container {
             self.resolve_axis(
                 Axis::Horizontal,
                 &lengths.width,
+                lengths.overflow,
                 content.width + lengths.padding.horizontal(),
                 constraints.min_width,
                 constraints.max_width,
@@ -256,6 +264,7 @@ impl Container {
             self.resolve_axis(
                 Axis::Vertical,
                 &lengths.height,
+                lengths.overflow,
                 content.height + lengths.padding.vertical(),
                 constraints.min_height,
                 constraints.max_height,
@@ -267,6 +276,7 @@ impl Container {
         &self,
         axis: Axis,
         length: &Length,
+        overflow: Overflow,
         content: f32,
         parent_min: f32,
         parent_max: f32,
@@ -280,7 +290,7 @@ impl Container {
 
         // Growing back to fit the content is the default; these are the cases
         // where the author asked for a smaller box on purpose.
-        let allow_shrink = self.overflow == Overflow::Hidden
+        let allow_shrink = overflow == Overflow::Hidden
             || animating
             || has_exact
             || match axis {

--- a/src/widgets/container/box_model.rs
+++ b/src/widgets/container/box_model.rs
@@ -109,6 +109,10 @@ impl Container {
             height.exact = Some((constraints.max_height * f).max(0.0));
         }
 
+        // Event dispatch reads the resolved value from here rather than from
+        // the signal, so it costs nothing on the pointer path.
+        self.overflow_resolved.set(overflow);
+
         BoxLengths {
             padding,
             width,

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -1771,3 +1771,84 @@ fn a_surface_only_blur_publishes_no_compositor_region() {
 
     crate::blur::reset_blur();
 }
+
+/// A shadow belongs to the box, not to the fill, so a gradient must not lose
+/// it. Both are reactive, so a signal can move a container from one branch of
+/// the decoration to the other between frames — an elevation animation that
+/// crossed into the gradient branch stopped drawing while still asking for a
+/// frame at every step.
+#[test]
+fn a_gradient_keeps_its_shadow() {
+    let mut h = H::new(
+        container()
+            .width(40.0)
+            .height(20.0)
+            .elevation(3.0)
+            .gradient_horizontal(Color::RED, Color::BLUE),
+    );
+    h.fit(100.0, 100.0);
+    let node = h.paint();
+
+    assert_eq!(gradient_ends(&node), Some((Color::RED, Color::BLUE)));
+    assert_eq!(shadow_count(&node), 1, "the gradient is still elevated");
+}
+
+/// The two halves of a border can be declared apart, so either can be missing.
+/// A width with a transparent colour is an invisible frame, and it used to reach
+/// the instance buffer every frame.
+#[test]
+fn a_border_with_nothing_to_show_draws_nothing() {
+    let mut h = H::new(container().width(20.0).height(20.0).border_width(2.0));
+    h.fit(100.0, 100.0);
+    assert_eq!(
+        borders(&h.paint()),
+        Vec::new(),
+        "a width with no colour behind it"
+    );
+
+    // A colour with no width is not a border either — CSS says the same.
+    let mut h = H::new(
+        container()
+            .width(20.0)
+            .height(20.0)
+            .border_color(Color::RED),
+    );
+    h.fit(100.0, 100.0);
+    assert_eq!(borders(&h.paint()), Vec::new());
+
+    // Both, and it draws.
+    let mut h = H::new(
+        container()
+            .width(20.0)
+            .height(20.0)
+            .border_width(2.0)
+            .border_color(Color::RED),
+    );
+    h.fit(100.0, 100.0);
+    assert_eq!(borders(&h.paint()), vec![(2.0, Color::RED)]);
+}
+
+/// A colour fading in behind an already-declared width has to start drawing the
+/// moment it is visible, so the gate cannot be a build-time decision.
+#[test]
+fn a_border_appears_when_its_colour_does() {
+    let visible = create_signal(false);
+    let mut h = H::new(
+        container()
+            .width(20.0)
+            .height(20.0)
+            .border_width(2.0)
+            .border_color(move || {
+                if visible.get() {
+                    Color::RED
+                } else {
+                    Color::TRANSPARENT
+                }
+            }),
+    );
+    h.fit(100.0, 100.0);
+    assert_eq!(borders(&h.paint()), Vec::new());
+
+    visible.set(true);
+    assert_eq!(borders(&h.paint()), vec![(2.0, Color::RED)]);
+}

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -1626,29 +1626,46 @@ fn a_backdrop_blur_is_reactive_and_zero_means_off() {
     assert_eq!(blur_radii(&h.paint()), Vec::<f32>::new());
 }
 
-/// The border's two halves can be declared apart, so a state layer that only
-/// recolours it does not have to restate the width.
+/// A state layer overrides a base that already has both halves, so naming one
+/// half there is meaningful: a layer that only recolours the frame must not have
+/// to restate the width it is not changing.
 #[test]
-fn border_width_and_colour_are_separately_declarable() {
+fn a_state_layer_can_recolour_a_border_without_restating_its_width() {
     let danger = create_signal(false);
     let mut h = H::new(
         container()
             .width(20.0)
             .height(20.0)
-            .border_width(2.0)
-            .border_color(move || {
-                if danger.get() {
-                    Color::RED
-                } else {
-                    Color::GRAY
-                }
-            }),
+            .border(2.0, Color::GRAY)
+            .state(danger, |s| s.border_color(Color::RED)),
     );
     h.fit(100.0, 100.0);
     assert_eq!(borders(&h.paint()), vec![(2.0, Color::GRAY)]);
 
     danger.set(true);
-    assert_eq!(borders(&h.paint()), vec![(2.0, Color::RED)]);
+    assert_eq!(
+        borders(&h.paint()),
+        vec![(2.0, Color::RED)],
+        "the width the layer said nothing about is kept"
+    );
+}
+
+/// And the same for the width, over a colour the layer leaves alone.
+#[test]
+fn a_state_layer_can_thicken_a_border_without_restating_its_colour() {
+    let focused = create_signal(false);
+    let mut h = H::new(
+        container()
+            .width(20.0)
+            .height(20.0)
+            .border(1.0, Color::GRAY)
+            .state(focused, |s| s.border_width(3.0)),
+    );
+    h.fit(100.0, 100.0);
+    assert_eq!(borders(&h.paint()), vec![(1.0, Color::GRAY)]);
+
+    focused.set(true);
+    assert_eq!(borders(&h.paint()), vec![(3.0, Color::GRAY)]);
 }
 
 /// Elevation transitions like every other paint property now, instead of
@@ -1812,59 +1829,53 @@ fn a_gradient_keeps_its_shadow() {
     assert_eq!(shadow_count(&node), 1, "the gradient is still elevated");
 }
 
-/// The two halves of a border can be declared apart, so either can be missing.
-/// A width with a transparent colour is an invisible frame, and it used to reach
-/// the instance buffer every frame.
+/// A border resolving to nothing visible must draw nothing, rather than send an
+/// invisible frame to the instance buffer every frame.
+///
+/// The base declaration always names both halves, so it can only get here by
+/// asking for it — a deliberately transparent colour, or a zero width. A *state
+/// layer* can get here by naming one half over a base that has no border at all,
+/// which is the silent case the gate has to absorb.
 #[test]
 fn a_border_with_nothing_to_show_draws_nothing() {
-    let mut h = H::new(container().width(20.0).height(20.0).border_width(2.0));
-    h.fit(100.0, 100.0);
-    assert_eq!(
-        borders(&h.paint()),
-        Vec::new(),
-        "a width with no colour behind it"
-    );
-
-    // A colour with no width is not a border either — CSS says the same.
     let mut h = H::new(
         container()
             .width(20.0)
             .height(20.0)
-            .border_color(Color::RED),
+            .border(2.0, Color::TRANSPARENT),
+    );
+    h.fit(100.0, 100.0);
+    assert_eq!(borders(&h.paint()), Vec::new(), "an invisible colour");
+
+    let mut h = H::new(container().width(20.0).height(20.0).border(0.0, Color::RED));
+    h.fit(100.0, 100.0);
+    assert_eq!(borders(&h.paint()), Vec::new(), "a zero width");
+
+    // A layer naming one half over a base with no border resolves to half a
+    // border, which is no border.
+    let on = create_signal(true);
+    let mut h = H::new(
+        container()
+            .width(20.0)
+            .height(20.0)
+            .state(on, |s| s.border_width(2.0)),
     );
     h.fit(100.0, 100.0);
     assert_eq!(borders(&h.paint()), Vec::new());
-
-    // Both, and it draws.
-    let mut h = H::new(
-        container()
-            .width(20.0)
-            .height(20.0)
-            .border_width(2.0)
-            .border_color(Color::RED),
-    );
-    h.fit(100.0, 100.0);
-    assert_eq!(borders(&h.paint()), vec![(2.0, Color::RED)]);
 }
 
-/// A colour fading in behind an already-declared width has to start drawing the
-/// moment it is visible, so the gate cannot be a build-time decision.
+/// A colour fading in behind a declared width has to start drawing the moment it
+/// is visible, so the gate cannot be a build-time decision.
 #[test]
 fn a_border_appears_when_its_colour_does() {
     let visible = create_signal(false);
-    let mut h = H::new(
-        container()
-            .width(20.0)
-            .height(20.0)
-            .border_width(2.0)
-            .border_color(move || {
-                if visible.get() {
-                    Color::RED
-                } else {
-                    Color::TRANSPARENT
-                }
-            }),
-    );
+    let mut h = H::new(container().width(20.0).height(20.0).border(2.0, move || {
+        if visible.get() {
+            Color::RED
+        } else {
+            Color::TRANSPARENT
+        }
+    }));
     h.fit(100.0, 100.0);
     assert_eq!(borders(&h.paint()), Vec::new());
 

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -76,7 +76,8 @@ impl H {
     /// region read off the result, and `crate::cache_paint_results` to finish.
     ///
     /// Two of those are the loop's own code rather than a stand-in for it, and
-    /// both were learned the hard way. `cache_paint_results` written out by hand
+    /// both were learned the hard way — and it is called the way the loop calls
+    /// it, per child of the root, not on the root. `cache_paint_results` written out by hand
     /// left `cache_paint` undone, so `reuse_cached` never found a cache and every
     /// test repainted everything — making the whole class of bug about a widget
     /// that is *not* repainted structurally invisible here. And a `frame` that
@@ -111,7 +112,14 @@ impl H {
         crate::renderer::flatten_root_into(&node, &mut commands, &mut layers);
         let blur = crate::blur::regions_from_commands(&commands);
 
-        crate::cache_paint_results(&mut self.tree, &node);
+        // Per child of the root and then `clear_needs_paint(root)`, which is
+        // what the loop does: the surface root always repaints, so it is never
+        // cache-reused, and handing it to `cache_paint_results` would leave the
+        // harness with a cache entry the loop never has.
+        for child in &node.children {
+            crate::cache_paint_results(&mut self.tree, child);
+        }
+        self.tree.clear_needs_paint(root);
         self.last = Some((std::rc::Rc::clone(&node), commands));
 
         Frame { node, blur }
@@ -2416,6 +2424,43 @@ fn a_clipped_blur_publishes_only_what_is_on_show() {
     assert!(
         widest <= 40,
         "the row is 80 wide inside a 40-wide clip, so no region may reach {widest}"
+    );
+}
+
+/// The region is the shape *as drawn*, so a transform has to reach it: a scaled
+/// card covers more of the desktop and a rotated one covers a diagonal.
+///
+/// End to end through the real paint and flatten, because the geometry is
+/// derived there. The unit tests in `renderer::flatten` measure the arithmetic;
+/// this is the wiring — a region built from a command's local rect instead of
+/// its world one passes every one of those and still publishes a 40x40 upright
+/// box for a card the compositor is showing at 80x80 turned on its corner.
+#[test]
+fn a_transformed_blur_publishes_the_shape_it_is_drawn_as() {
+    let card = |c: Container| c.width(40.0).height(40.0).backdrop_blur(24.0);
+
+    let plain = H::new(card(container())).frame(200.0, 200.0).blur;
+    let scaled = H::new(card(container()).scale(2.0))
+        .frame(200.0, 200.0)
+        .blur;
+    let turned = H::new(card(container()).rotate(45.0))
+        .frame(200.0, 200.0)
+        .blur;
+
+    let span = |rects: &[crate::blur::BlurRect]| {
+        let left = rects.iter().map(|r| r.x).min().expect("a region");
+        let right = rects.iter().map(|r| r.x + r.width).max().expect("a region");
+        right - left
+    };
+
+    let (plain, scaled, turned) = (span(&plain), span(&scaled), span(&turned));
+    assert!(
+        scaled >= plain * 2 - 2,
+        "twice the card is twice the region: {scaled} against {plain}"
+    );
+    assert!(
+        turned > plain && turned < scaled,
+        "turned on its corner it covers its diagonal, {turned} against {plain}"
     );
 }
 

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -2275,3 +2275,80 @@ fn a_shadow_too_faint_to_see_is_not_drawn() {
     h.fit(100.0, 100.0);
     assert_eq!(shadow_count(&h.paint()), 1, "and drawn once it can be seen");
 }
+
+/// The clip is part of the shape, for the region as much as for the renderer. A
+/// blurred card cut off by its parent must publish only the part on show, or the
+/// desktop is blurred beside a panel that is not there.
+#[test]
+fn a_clipped_blur_publishes_only_what_is_on_show() {
+    // Content overflows by summing: each child answers to the parent's maximum,
+    // their row does not. So the second card sits entirely past the clip.
+    let card = || container().width(40.0).height(40.0).backdrop_blur(24.0);
+    let mut h = H::new(
+        container()
+            .width(40.0)
+            .height(40.0)
+            .overflow(Overflow::Hidden)
+            .layout(Flex::row())
+            .child(card())
+            .child(card()),
+    );
+    let frame = h.frame(200.0, 200.0);
+
+    let widest = frame
+        .blur
+        .iter()
+        .map(|r| r.x + r.width)
+        .max()
+        .expect("the visible card still blurs");
+    assert!(
+        widest <= 40,
+        "the row is 80 wide inside a 40-wide clip, so no region may reach {widest}"
+    );
+}
+
+/// A gradient between two fully transparent colours draws nothing, and must not
+/// push a rect per frame to do it — the same gate the fill, the border and the
+/// shadow have. With both endpoints reactive, one animating out through
+/// transparent reaches this every frame.
+#[test]
+fn a_fully_transparent_gradient_draws_nothing() {
+    let clear = Color::rgba(1.0, 0.0, 0.0, 0.0);
+
+    let mut h = H::new(
+        container()
+            .width(20.0)
+            .height(20.0)
+            .gradient(LinearGradient::horizontal(clear, clear)),
+    );
+    h.fit(100.0, 100.0);
+    assert_eq!(rects(&h.paint()), Vec::new(), "nothing to draw");
+
+    // One end still visible is still a gradient.
+    let mut half = H::new(
+        container()
+            .width(20.0)
+            .height(20.0)
+            .gradient(LinearGradient::horizontal(clear, Color::BLUE)),
+    );
+    half.fit(100.0, 100.0);
+    assert_eq!(
+        gradient_ends(&half.paint()),
+        Some((clear, Color::BLUE)),
+        "fading to transparent is a gradient"
+    );
+
+    // And an invisible gradient does not hide the background under it.
+    let mut over = H::new(
+        container()
+            .width(20.0)
+            .height(20.0)
+            .background(Color::GRAY)
+            .gradient(LinearGradient::horizontal(clear, clear)),
+    );
+    over.fit(100.0, 100.0);
+    assert_eq!(
+        rects(&over.paint()).first().map(|(_, c)| *c),
+        Some(Color::GRAY)
+    );
+}

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -1626,46 +1626,47 @@ fn a_backdrop_blur_is_reactive_and_zero_means_off() {
     assert_eq!(blur_radii(&h.paint()), Vec::<f32>::new());
 }
 
-/// A state layer overrides a base that already has both halves, so naming one
-/// half there is meaningful: a layer that only recolours the frame must not have
-/// to restate the width it is not changing.
+/// A state layer replaces the whole border, both halves at once, because that is
+/// the only way to say "border" anywhere in this API.
 #[test]
-fn a_state_layer_can_recolour_a_border_without_restating_its_width() {
+fn a_state_layer_replaces_the_whole_border() {
     let danger = create_signal(false);
     let mut h = H::new(
         container()
             .width(20.0)
             .height(20.0)
-            .border(2.0, Color::GRAY)
-            .state(danger, |s| s.border_color(Color::RED)),
+            .border(1.0, Color::GRAY)
+            .state(danger, |s| s.border(2.0, Color::RED)),
     );
     h.fit(100.0, 100.0);
-    assert_eq!(borders(&h.paint()), vec![(2.0, Color::GRAY)]);
+    assert_eq!(borders(&h.paint()), vec![(1.0, Color::GRAY)]);
 
     danger.set(true);
-    assert_eq!(
-        borders(&h.paint()),
-        vec![(2.0, Color::RED)],
-        "the width the layer said nothing about is kept"
-    );
+    assert_eq!(borders(&h.paint()), vec![(2.0, Color::RED)]);
+
+    danger.set(false);
+    assert_eq!(borders(&h.paint()), vec![(1.0, Color::GRAY)], "and back");
 }
 
-/// And the same for the width, over a colour the layer leaves alone.
+/// Two layers speaking about the border resolve last-declared-wins, as every
+/// other property does — and as a unit, since half of one cannot be declared.
 #[test]
-fn a_state_layer_can_thicken_a_border_without_restating_its_colour() {
-    let focused = create_signal(false);
+fn the_last_declared_border_layer_wins() {
+    let hovered = create_signal(true);
+    let failed = create_signal(true);
     let mut h = H::new(
         container()
             .width(20.0)
             .height(20.0)
             .border(1.0, Color::GRAY)
-            .state(focused, |s| s.border_width(3.0)),
+            .state(hovered, |s| s.border(2.0, Color::WHITE))
+            .state(failed, |s| s.border(3.0, Color::RED)),
     );
     h.fit(100.0, 100.0);
-    assert_eq!(borders(&h.paint()), vec![(1.0, Color::GRAY)]);
+    assert_eq!(borders(&h.paint()), vec![(3.0, Color::RED)]);
 
-    focused.set(true);
-    assert_eq!(borders(&h.paint()), vec![(3.0, Color::GRAY)]);
+    failed.set(false);
+    assert_eq!(borders(&h.paint()), vec![(2.0, Color::WHITE)]);
 }
 
 /// Elevation transitions like every other paint property now, instead of
@@ -1832,10 +1833,9 @@ fn a_gradient_keeps_its_shadow() {
 /// A border resolving to nothing visible must draw nothing, rather than send an
 /// invisible frame to the instance buffer every frame.
 ///
-/// The base declaration always names both halves, so it can only get here by
-/// asking for it — a deliberately transparent colour, or a zero width. A *state
-/// layer* can get here by naming one half over a base that has no border at all,
-/// which is the silent case the gate has to absorb.
+/// Every border names both halves, so this is only reachable deliberately — a
+/// transparent colour, a zero width — or in passing, while an animated colour
+/// crosses transparent.
 #[test]
 fn a_border_with_nothing_to_show_draws_nothing() {
     let mut h = H::new(
@@ -1850,18 +1850,6 @@ fn a_border_with_nothing_to_show_draws_nothing() {
     let mut h = H::new(container().width(20.0).height(20.0).border(0.0, Color::RED));
     h.fit(100.0, 100.0);
     assert_eq!(borders(&h.paint()), Vec::new(), "a zero width");
-
-    // A layer naming one half over a base with no border resolves to half a
-    // border, which is no border.
-    let on = create_signal(true);
-    let mut h = H::new(
-        container()
-            .width(20.0)
-            .height(20.0)
-            .state(on, |s| s.border_width(2.0)),
-    );
-    h.fit(100.0, 100.0);
-    assert_eq!(borders(&h.paint()), Vec::new());
 }
 
 /// A colour fading in behind a declared width has to start drawing the moment it

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -1511,3 +1511,195 @@ fn an_animated_colour_starts_from_the_inherited_base() {
         "and come back to it"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Reactivity — properties that used to accept only a constant
+// ---------------------------------------------------------------------------
+
+/// A gradient follows its signal, and does so as a repaint: nothing about the
+/// fill can move the box.
+#[test]
+fn a_gradient_is_reactive_and_paint_only() {
+    let warm = create_signal(true);
+    let mut h = H::new(container().width(20.0).height(20.0).gradient(move || {
+        if warm.get() {
+            LinearGradient::horizontal(Color::RED, Color::YELLOW)
+        } else {
+            LinearGradient::horizontal(Color::BLUE, Color::CYAN)
+        }
+    }));
+    h.fit(100.0, 100.0);
+    assert_eq!(gradient_ends(&h.paint()), Some((Color::RED, Color::YELLOW)));
+
+    let queued = h.jobs_from(|| warm.set(false));
+    assert_eq!(queued, vec![JobType::Paint], "got {queued:?}");
+    assert_eq!(gradient_ends(&h.paint()), Some((Color::BLUE, Color::CYAN)));
+}
+
+/// The endpoints are reactive on their own, so the common case needs no
+/// closure building a whole gradient.
+#[test]
+fn gradient_endpoints_are_reactive_one_by_one() {
+    let end = create_signal(Color::YELLOW);
+    let mut h = H::new(
+        container()
+            .width(20.0)
+            .height(20.0)
+            .gradient_vertical(Color::RED, end),
+    );
+    h.fit(100.0, 100.0);
+    assert_eq!(gradient_ends(&h.paint()), Some((Color::RED, Color::YELLOW)));
+
+    end.set(Color::GREEN);
+    assert_eq!(gradient_ends(&h.paint()), Some((Color::RED, Color::GREEN)));
+}
+
+/// `overflow` decides both whether children are clipped and whether the box may
+/// shrink below its content, so a write to it has to reach layout as well as
+/// paint.
+#[test]
+fn overflow_is_reactive_and_invalidates_layout() {
+    let clipped = create_signal(false);
+    let mut h = H::new(
+        container()
+            .width(50.0)
+            .height(20.0)
+            .overflow(move || {
+                if clipped.get() {
+                    Overflow::Hidden
+                } else {
+                    Overflow::Visible
+                }
+            })
+            .child(box_of(400.0, 10.0)),
+    );
+    h.fit(500.0, 500.0);
+    assert!(h.paint().clip.is_none());
+
+    let queued = h.jobs_from(|| clipped.set(true));
+    assert!(
+        queued.contains(&JobType::Layout) && queued.contains(&JobType::Paint),
+        "got {queued:?}"
+    );
+    h.fit(500.0, 500.0);
+    assert!(h.paint().clip.is_some());
+}
+
+/// A blur can be switched off by the same signal that switches it on: a radius
+/// of zero draws no blur command, which is the contract `Text` already had.
+#[test]
+fn a_backdrop_blur_is_reactive_and_zero_means_off() {
+    let radius = create_signal(0.0f32);
+    let mut h = H::new(
+        container()
+            .width(20.0)
+            .height(20.0)
+            .backdrop_blur(move || radius.get()),
+    );
+    h.fit(100.0, 100.0);
+    assert_eq!(blur_radii(&h.paint()), Vec::<f32>::new());
+
+    let queued = h.jobs_from(|| radius.set(12.0));
+    assert_eq!(queued, vec![JobType::Paint], "got {queued:?}");
+    assert_eq!(blur_radii(&h.paint()), vec![12.0]);
+
+    radius.set(0.0);
+    assert_eq!(blur_radii(&h.paint()), Vec::<f32>::new());
+}
+
+/// The border's two halves can be declared apart, so a state layer that only
+/// recolours it does not have to restate the width.
+#[test]
+fn border_width_and_colour_are_separately_declarable() {
+    let danger = create_signal(false);
+    let mut h = H::new(
+        container()
+            .width(20.0)
+            .height(20.0)
+            .border_width(2.0)
+            .border_color(move || {
+                if danger.get() {
+                    Color::RED
+                } else {
+                    Color::GRAY
+                }
+            }),
+    );
+    h.fit(100.0, 100.0);
+    assert_eq!(borders(&h.paint()), vec![(2.0, Color::GRAY)]);
+
+    danger.set(true);
+    assert_eq!(borders(&h.paint()), vec![(2.0, Color::RED)]);
+}
+
+/// Elevation transitions like every other paint property now, instead of
+/// jumping.
+#[test]
+fn elevation_animates_towards_its_state_layer() {
+    let mut h = H::new(
+        container()
+            .width(40.0)
+            .height(40.0)
+            .background(Color::RED)
+            .elevation(0.0)
+            .when_hovered(|s| s.elevation(8.0))
+            .animate_elevation(Transition::new(80.0, TimingFunction::Linear)),
+    );
+    h.fit(100.0, 100.0);
+    h.paint();
+
+    assert_eq!(shadow_count(&h.paint()), 0, "flat on the surface at rest");
+
+    set_hover(&mut h, true);
+    std::thread::sleep(std::time::Duration::from_millis(20));
+    pump(&mut h);
+    h.fit(100.0, 100.0);
+    assert_eq!(
+        shadow_count(&h.paint()),
+        1,
+        "it casts a shadow while it rises"
+    );
+
+    settle(&mut h, 80);
+    set_hover(&mut h, false);
+    settle(&mut h, 80);
+    assert_eq!(shadow_count(&h.paint()), 0, "and settles back down");
+}
+
+/// Every `BackdropBlur` radius drawn by a node.
+fn blur_radii(node: &RenderNode) -> Vec<f32> {
+    node.commands
+        .iter()
+        .filter_map(|c| match &**c {
+            DrawCommand::BackdropBlur { radius, .. } => Some(*radius),
+            _ => None,
+        })
+        .collect()
+}
+
+/// The endpoints of the first gradient drawn by a node.
+fn gradient_ends(node: &RenderNode) -> Option<(Color, Color)> {
+    node.commands.iter().find_map(|c| match &**c {
+        DrawCommand::RoundedRect {
+            gradient: Some(gradient),
+            ..
+        } => Some((gradient.start_color, gradient.end_color)),
+        _ => None,
+    })
+}
+
+/// How many of the node's rects carry a shadow.
+fn shadow_count(node: &RenderNode) -> usize {
+    node.commands
+        .iter()
+        .filter(|c| {
+            matches!(
+                &***c,
+                DrawCommand::RoundedRect {
+                    shadow: Some(_),
+                    ..
+                }
+            )
+        })
+        .count()
+}

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -60,6 +60,33 @@ impl H {
         node
     }
 
+    /// One frame in the order the loop runs it: queued jobs, layout, then
+    /// `crate::paint_surface` — the same function `paint_and_present` calls, so
+    /// a test cannot attest an order the loop does not have. Finishes by
+    /// clearing the paint flags, which is what `cache_paint_results` does and
+    /// what makes a clean child cullable on the frame after.
+    ///
+    /// Use this, not `paint()`, for anything whose correctness is about *when*
+    /// in the frame it happens.
+    fn frame(&mut self, w: f32, h: f32) -> Frame {
+        pump(self);
+        self.fit(w, h);
+
+        let root = self.root;
+        let mut node = RenderNode::new(root.as_u64());
+        let blur = crate::paint_surface(&mut self.tree, root, &mut node);
+
+        fn settle(tree: &mut Tree, node: &RenderNode) {
+            tree.clear_needs_paint(WidgetId::from_u64(node.id));
+            for child in &node.children {
+                settle(tree, child);
+            }
+        }
+        settle(&mut self.tree, &node);
+
+        Frame { node, blur }
+    }
+
     fn send(&mut self, event: Event) -> EventResponse {
         let root = self.root;
         // Event dispatch runs inside a snapshot zone in the real loop
@@ -107,6 +134,13 @@ impl H {
         jobs::recycle_job_buffer(drained);
         types
     }
+}
+
+/// What one frame produced: the render tree, and the compositor blur region the
+/// paint left registered.
+struct Frame {
+    node: RenderNode,
+    blur: Vec<crate::blur::BlurRect>,
 }
 
 /// A leaf of an exactly known size.
@@ -1741,74 +1775,6 @@ fn shadow_count(node: &RenderNode) -> usize {
         .count()
 }
 
-/// The compositor half of a backdrop blur is a region published to a registry,
-/// not a draw command — and the registry only prunes widgets that left the
-/// tree. So a container whose blur reached zero has to withdraw its own entry,
-/// or a blur switched on once blurs the desktop for the life of the surface.
-///
-/// This is the half the draw-command test cannot see: `DrawCommand::BackdropBlur`
-/// is the *surface* path, which was correctly gated all along.
-#[test]
-fn a_zero_radius_withdraws_the_compositor_blur_region() {
-    crate::blur::reset_blur();
-
-    let radius = create_signal(24.0f32);
-    let mut h = H::new(
-        container()
-            .width(40.0)
-            .height(20.0)
-            .backdrop_blur(move || BackdropBlur::new(radius.get())),
-    );
-    h.fit(100.0, 100.0);
-    h.paint();
-    assert!(
-        !crate::blur::collect_for_surface(&h.tree, h.root).is_empty(),
-        "a positive radius publishes a region"
-    );
-
-    radius.set(0.0);
-    pump(&mut h);
-    h.fit(100.0, 100.0);
-    h.paint();
-    assert_eq!(
-        crate::blur::collect_for_surface(&h.tree, h.root),
-        Vec::new(),
-        "and zero takes it back"
-    );
-
-    // Both ways, so the withdrawal is not a one-shot.
-    radius.set(12.0);
-    pump(&mut h);
-    h.fit(100.0, 100.0);
-    h.paint();
-    assert!(!crate::blur::collect_for_surface(&h.tree, h.root).is_empty());
-
-    crate::blur::reset_blur();
-}
-
-/// Restricting the sources to the surface must publish no compositor region at
-/// all, whatever the radius.
-#[test]
-fn a_surface_only_blur_publishes_no_compositor_region() {
-    crate::blur::reset_blur();
-
-    let mut h = H::new(
-        container()
-            .width(40.0)
-            .height(20.0)
-            .backdrop_blur(BackdropBlur::new(24.0).sources(BackdropSources::SURFACE)),
-    );
-    h.fit(100.0, 100.0);
-    h.paint();
-    assert_eq!(
-        crate::blur::collect_for_surface(&h.tree, h.root),
-        Vec::new()
-    );
-    assert_eq!(blur_radii(&h.paint()), vec![24.0], "but it still draws one");
-
-    crate::blur::reset_blur();
-}
-
 /// A shadow belongs to the box, not to the fill, so a gradient must not lose
 /// it. Both are reactive, so a signal can move a container from one branch of
 /// the decoration to the other between frames — an elevation animation that
@@ -2017,71 +1983,131 @@ fn a_declared_elevation_change_invalidates_the_reach() {
     assert!(h.tree.paint_overflow(h.root) > 0.0);
 }
 
-/// An invisible container blurs nothing.
-///
-/// It holds two mechanisms together: `paint` returns at the visibility gate,
-/// *before* the register/withdraw decision, so the withdrawal happens at the
-/// gate — and an invisible container also measures zero, so its region would
-/// tessellate to nothing even if the entry lingered. Belt and braces on purpose:
-/// the second is what makes this not a bug today, the first is what keeps the
-/// registry from growing one stale entry per hidden panel.
+// ---------------------------------------------------------------------------
+// Compositor blur regions — every one of these is about *when* in the frame
+// ---------------------------------------------------------------------------
+//
+// The surface half of a backdrop blur is a draw command and shows up in the
+// render tree. The compositor half is a region handed to `wl_region`, published
+// once per frame, and it is where the interesting failure lives: a region is
+// registered and withdrawn *during* paint, so anything that reads it must read
+// it after. These drive `H::frame`, which calls the same `crate::paint_surface`
+// the loop does, precisely so they cannot attest an order the loop lacks.
+
+/// Turning a blur off has to reach the compositor on the frame that turns it
+/// off. Collecting before the paint published the region the *previous* frame
+/// asked for, and then nothing was dirty any more — so the withdrawal waited for
+/// a frame that never came and the desktop stayed blurred for the life of the
+/// surface.
 #[test]
-fn an_invisible_container_withdraws_its_compositor_blur() {
+fn switching_a_compositor_blur_off_withdraws_it_on_that_frame() {
+    crate::blur::reset_blur();
+
+    let frosted = create_signal(true);
+    let mut h = H::new(
+        container()
+            .width(40.0)
+            .height(20.0)
+            .backdrop_blur(move || if frosted.get() { 24.0 } else { 0.0 }),
+    );
+    assert!(!h.frame(100.0, 100.0).blur.is_empty(), "frosted");
+
+    frosted.set(false);
+    assert_eq!(
+        h.frame(100.0, 100.0).blur,
+        Vec::new(),
+        "the frame that turns it off is the frame that stops publishing it"
+    );
+
+    // And a settled surface keeps it off: nothing is dirty, so this frame does
+    // not repaint, and the region must not come back.
+    assert_eq!(h.frame(100.0, 100.0).blur, Vec::new());
+
+    frosted.set(true);
+    assert!(!h.frame(100.0, 100.0).blur.is_empty(), "and back on");
+
+    crate::blur::reset_blur();
+}
+
+/// Restricting the sources to the surface publishes no compositor region at all,
+/// whatever the radius — while still drawing one.
+#[test]
+fn a_surface_only_blur_publishes_no_compositor_region() {
+    crate::blur::reset_blur();
+
+    let mut h = H::new(
+        container()
+            .width(40.0)
+            .height(20.0)
+            .backdrop_blur(BackdropBlur::new(24.0).sources(BackdropSources::SURFACE)),
+    );
+    let frame = h.frame(100.0, 100.0);
+    assert_eq!(frame.blur, Vec::new());
+    assert_eq!(blur_radii(&frame.node), vec![24.0], "but it draws one");
+
+    crate::blur::reset_blur();
+}
+
+/// A hidden panel blurs nothing, and neither does anything inside it. The
+/// parent's paint returns at the visibility gate before its children are
+/// painted, so a blurred *descendant* never gets to withdraw its own region —
+/// and layout returning zero for the parent leaves the child's own bounds
+/// exactly where they were.
+#[test]
+fn hiding_a_panel_withdraws_the_blur_of_everything_inside_it() {
     crate::blur::reset_blur();
 
     let open = create_signal(true);
     let mut h = H::new(
         container()
-            .width(40.0)
-            .height(20.0)
+            .width(60.0)
+            .height(40.0)
             .visible(move || open.get())
-            .backdrop_blur(24.0),
+            .child(container().width(40.0).height(20.0).backdrop_blur(24.0)),
     );
-    h.fit(100.0, 100.0);
-    h.paint();
-    assert!(!crate::blur::collect_for_surface(&h.tree, h.root).is_empty());
+    assert!(!h.frame(100.0, 100.0).blur.is_empty(), "open");
 
     open.set(false);
-    pump(&mut h);
-    h.fit(100.0, 100.0);
-    h.paint();
     assert_eq!(
-        crate::blur::collect_for_surface(&h.tree, h.root),
+        h.frame(100.0, 100.0).blur,
         Vec::new(),
-        "an invisible panel blurs nothing"
+        "a hidden panel blurs nothing, descendants included"
     );
+    assert_eq!(h.frame(100.0, 100.0).blur, Vec::new(), "and stays that way");
 
     open.set(true);
-    pump(&mut h);
-    h.fit(100.0, 100.0);
-    h.paint();
-    assert!(!crate::blur::collect_for_surface(&h.tree, h.root).is_empty());
+    assert!(!h.frame(100.0, 100.0).blur.is_empty(), "and back");
 
     crate::blur::reset_blur();
 }
 
-/// A child culled out of a scrolling viewport never paints, so it cannot withdraw
-/// its own region — the parent that culled it says so on its behalf.
-///
-/// Culling only skips a *clean* child, so the card's paint flag is cleared before
-/// the last frame, which is what the loop's `cache_paint_results` does once its
-/// content stops changing.
+/// A child scrolled out of a viewport blurs nothing. It never paints — culled,
+/// or outside the window the scroller even offers to `paint_children` — so it
+/// cannot withdraw its own region, and its bounds stay where they were.
 #[test]
-fn a_culled_child_withdraws_its_compositor_blur() {
+fn scrolling_a_frosted_card_away_withdraws_its_blur() {
     crate::blur::reset_blur();
+
+    // Enough rows that the scroller takes its windowing fast path, which is the
+    // case the sweep exists for and the one a two-child list never reaches.
+    let mut rows: Vec<crate::widgets::AnyWidget> = vec![
+        container()
+            .width(40.0)
+            .height(20.0)
+            .backdrop_blur(24.0)
+            .into_any(),
+    ];
+    rows.extend((0..60).map(|_| box_of(40.0, 20.0).into_any()));
 
     let mut h = H::new(
         container()
             .width(40.0)
             .height(30.0)
             .scrollable(ScrollAxis::Vertical)
-            .child(container().width(40.0).height(20.0).backdrop_blur(24.0))
-            .child(box_of(40.0, 400.0)),
+            .children(rows),
     );
-    h.fit(40.0, 30.0);
-    h.paint();
     assert!(
-        !crate::blur::collect_for_surface(&h.tree, h.root).is_empty(),
+        !h.frame(40.0, 30.0).blur.is_empty(),
         "visible at the top of the scroll"
     );
 
@@ -2089,18 +2115,14 @@ fn a_culled_child_withdraws_its_compositor_blur() {
         x: 20.0,
         y: 15.0,
         delta_x: 0.0,
-        delta_y: 300.0,
+        delta_y: 600.0,
         source: ScrollSource::Wheel,
     });
-    pump(&mut h);
-    h.fit(40.0, 30.0);
-
-    let card = h.children()[0];
-    h.tree.clear_needs_paint(card);
-    h.paint();
-
+    // Two frames: the first repaints the scroller and settles the flags, the
+    // second is where a clean card is culled — or never offered at all.
+    h.frame(40.0, 30.0);
     assert_eq!(
-        crate::blur::collect_for_surface(&h.tree, h.root),
+        h.frame(40.0, 30.0).blur,
         Vec::new(),
         "scrolled away, so it blurs nothing"
     );

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -2027,6 +2027,118 @@ fn the_damage_reach_allows_for_a_spring_overshooting() {
     );
 }
 
+/// The shadow's reach, as drawn — `None` where the box casts none.
+fn shadow_extent(node: &RenderNode) -> Option<f32> {
+    node.commands.iter().find_map(|c| match &**c {
+        DrawCommand::RoundedRect {
+            shadow: Some(shadow),
+            ..
+        } => Some(shadow.extent()),
+        _ => None,
+    })
+}
+
+/// A `.elevation(signal)` that falls has to *animate* down. It used to rise
+/// animated and drop in one frame.
+///
+/// The reach the layout records is also the ceiling paint clamps to, and the
+/// ceiling was recomputed at paint time from the declarations — which by then
+/// say 0, while the shadow on screen is still 8 deep. Every frame of the descent
+/// drew `min(interpolated, 0.0)`: no shadow at all, for an animation that went
+/// on running and asking for frames.
+#[test]
+fn a_falling_elevation_animates_down_instead_of_snapping() {
+    let level = create_signal(8.0f32);
+    let mut h = H::new(
+        container()
+            .width(40.0)
+            .height(40.0)
+            .background(Color::RED)
+            .elevation(move || level.get())
+            .animate_elevation(Transition::new(600.0, TimingFunction::Linear)),
+    );
+    h.fit(100.0, 100.0);
+    let lifted = shadow_extent(&h.paint()).expect("a lifted card casts a shadow");
+
+    level.set(0.0);
+    pump(&mut h);
+    h.fit(100.0, 100.0);
+    h.paint();
+
+    // A third of the way down a 600ms ramp: unmistakably moving, and nowhere
+    // near gone.
+    for _ in 0..5 {
+        std::thread::sleep(std::time::Duration::from_millis(40));
+        pump(&mut h);
+        h.fit(100.0, 100.0);
+        h.paint();
+    }
+    let falling = shadow_extent(&h.paint()).expect("it is still falling, not gone");
+    assert!(
+        falling < lifted,
+        "the descent has to move: {falling} vs {lifted}"
+    );
+}
+
+/// The clamp the descent above must not trip is still doing its job.
+///
+/// A spring keeps its momentum across a retarget, so hover flicker pumps it:
+/// driven near its damped natural frequency it settles at the resonant gain,
+/// which for a lightly damped spring is several times the step response the
+/// reach is measured from. Whatever it reaches, it is not allowed to draw
+/// outside the rect the layout reserved — that ring would be composited nowhere
+/// and left on screen.
+#[test]
+fn hover_flicker_cannot_push_a_shadow_outside_its_damage_rect() {
+    // Lightly damped (zeta = 0.1, resonant gain ~3.7x) and fast, so the pumping
+    // shows up within a test's worth of frames.
+    let pumpable = SpringConfig {
+        mass: 1.0,
+        stiffness: 3600.0,
+        damping: 12.0,
+    };
+    let mut h = H::new(
+        container()
+            .width(40.0)
+            .height(40.0)
+            .background(Color::RED)
+            // Small enough that the shadow is still growing with the number:
+            // past ~12 the blur and the offset are both capped, so a clamp
+            // there would have nothing to show for itself.
+            .elevation(0.0)
+            .when_hovered(|s| s.elevation(2.0))
+            .animate_elevation(Transition::spring(pumpable)),
+    );
+    h.fit(100.0, 100.0);
+    h.paint();
+
+    let reach = h.tree.paint_overflow(h.root);
+    let mut inside = false;
+    let mut worst: f32 = 0.0;
+    // Flipped by the clock, not by a frame count: pumping means reversing every
+    // half period (~53ms here), and a frame is only worth ~8ms of it.
+    let mut last_flip = std::time::Instant::now();
+    for step in 0..120 {
+        if last_flip.elapsed() >= std::time::Duration::from_millis(52) {
+            inside = !inside;
+            set_hover(&mut h, inside);
+            last_flip = std::time::Instant::now();
+        }
+        std::thread::sleep(std::time::Duration::from_millis(6));
+        pump(&mut h);
+        h.fit(100.0, 100.0);
+        let node = h.paint();
+        if let Some(extent) = shadow_extent(&node) {
+            worst = worst.max(extent);
+            assert!(
+                extent <= reach + 0.01,
+                "step {step} drew a shadow reaching {extent} outside a damage rect of {reach}"
+            );
+        }
+    }
+    assert!(worst > 0.0, "the flicker has to actually raise a shadow");
+}
+
 /// A declared elevation changing does need a new reach, so it must invalidate
 /// the layout that recorded the old one.
 #[test]

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -1536,6 +1536,25 @@ fn a_gradient_is_reactive_and_paint_only() {
     assert_eq!(gradient_ends(&h.paint()), Some((Color::BLUE, Color::CYAN)));
 }
 
+/// Two constant endpoints must not cost a derived that boxes a closure and
+/// recomputes, every read, a value that cannot change.
+#[test]
+fn a_constant_gradient_shorthand_stays_constant() {
+    let constant = container().gradient_vertical(Color::RED, Color::BLUE);
+    assert_eq!(
+        constant.gradient.and_then(|g| g.constant()),
+        Some(LinearGradient::vertical(Color::RED, Color::BLUE)),
+        "two constants make one constant"
+    );
+
+    let end = create_signal(Color::GREEN);
+    let reactive = container().gradient_vertical(Color::RED, end);
+    assert!(
+        reactive.gradient.expect("declared").constant().is_none(),
+        "a reactive endpoint has to stay reactive"
+    );
+}
+
 /// The endpoints are reactive on their own, so the common case needs no
 /// closure building a whole gradient.
 #[test]
@@ -1851,4 +1870,89 @@ fn a_border_appears_when_its_colour_does() {
 
     visible.set(true);
     assert_eq!(borders(&h.paint()), vec![(2.0, Color::RED)]);
+}
+
+/// A clipped child is invisible, and an invisible child must not answer for a
+/// click landing outside its parent's bounds.
+///
+/// Content overflows by *summing*: each child answers to the parent's maximum,
+/// their row does not. So the second pill sits beyond the parent's right edge.
+fn clip_host(clipped: Signal<bool>, clicked: RwSignal<i32>) -> Container {
+    container()
+        .width(40.0)
+        .height(20.0)
+        .layout(Flex::row())
+        .overflow(move || {
+            if clipped.get() {
+                Overflow::Hidden
+            } else {
+                Overflow::Visible
+            }
+        })
+        .child(box_of(40.0, 20.0))
+        .child(
+            container()
+                .width(40.0)
+                .height(20.0)
+                .on_click(move || clicked.update(|c| *c += 1)),
+        )
+}
+
+#[test]
+fn hidden_overflow_stops_events_reaching_a_clipped_child() {
+    let clicked = create_signal(0);
+    let clipped = create_signal(true);
+    let mut h = H::new(clip_host(clipped.into(), clicked));
+    h.fit(500.0, 500.0);
+    h.paint();
+
+    // x = 60 is inside the second pill and outside the clipping parent.
+    for event in click_at(60.0, 10.0) {
+        h.send(event);
+    }
+    assert_eq!(clicked.get_untracked(), 0, "clipped away, so not clickable");
+
+    clipped.set(false);
+    pump(&mut h);
+    h.fit(500.0, 500.0);
+    h.paint();
+
+    for event in click_at(60.0, 10.0) {
+        h.send(event);
+    }
+    assert_eq!(clicked.get_untracked(), 1, "unclipped, so clickable");
+}
+
+/// Events resolve against the frame on screen, not against the frame about to
+/// be drawn: the pointer is aimed at what the user can see. `hit.bounds` already
+/// come from the last layout, and the clip has to agree with them — which is
+/// also why the event path reads a cached value rather than running the
+/// container's own closure once per container per coalesced MouseMove.
+#[test]
+fn events_use_the_clip_of_the_frame_on_screen() {
+    let clicked = create_signal(0);
+    let clipped = create_signal(false);
+    let mut h = H::new(clip_host(clipped.into(), clicked));
+    h.fit(500.0, 500.0);
+    h.paint();
+
+    // The signal flips, but nothing has been laid out or drawn since.
+    clipped.set(true);
+    for event in click_at(60.0, 10.0) {
+        h.send(event);
+    }
+    assert_eq!(
+        clicked.get_untracked(),
+        1,
+        "the pill the user can see is still clickable"
+    );
+
+    // Once the clip is on screen, it applies.
+    pump(&mut h);
+    h.fit(500.0, 500.0);
+    h.paint();
+    for event in click_at(60.0, 10.0) {
+        h.send(event);
+    }
+    assert_eq!(clicked.get_untracked(), 1);
 }

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -109,7 +109,7 @@ impl H {
         let node = std::rc::Rc::new(node);
         let mut commands = Vec::new();
         let mut layers = Vec::new();
-        crate::renderer::flatten_root_into(&node, &mut commands, &mut layers);
+        let _ = crate::renderer::flatten_root_into(&node, &mut commands, &mut layers);
         let blur = crate::blur::regions_from_commands(&commands);
 
         // Per child of the root and then `clear_needs_paint(root)`, which is
@@ -796,6 +796,41 @@ fn advancing_animations_does_not_report_a_missing_scope() {
     assert!(
         queued.contains(&JobType::Animation),
         "and the properties must genuinely be subscribed, got {queued:?}"
+    );
+}
+
+/// A state layer's border moves the *width* as well as the colour, because a
+/// border is declared as a pair — so "can a state change move an animated
+/// property" has to answer yes for a container that animates only the width.
+///
+/// It answered no: the list named `border_color` and not `border_width`, from
+/// when the two were declared separately and a layer really could change one
+/// alone. This PR added `elevation` to that list and left the hole next to it
+/// that it had just made reachable.
+///
+/// Asked of the predicate rather than through a hover, because a hover reaches
+/// the animation by a second route as well: the interaction flags are a signal,
+/// and paint reads the animated width under `JobType::Animation` tracking, so
+/// setting the flag queues the job anyway. That route is why nothing was visibly
+/// broken — and it is not a reason to leave the direct answer wrong, since it
+/// holds only while some paint has already subscribed.
+#[test]
+fn a_border_width_animation_counts_as_movable_by_a_state_layer() {
+    let animated = container()
+        .border(2.0, Color::BLUE)
+        .animate_border_width(Transition::spring(SpringConfig::BOUNCY))
+        .when_hovered(|s| s.border(14.0, Color::BLUE));
+    assert!(
+        animated.has_animated_state_properties(),
+        "hovering moves the width, so it needs an Animation job"
+    );
+
+    let plain = container()
+        .border(2.0, Color::BLUE)
+        .when_hovered(|s| s.border(14.0, Color::BLUE));
+    assert!(
+        !plain.has_animated_state_properties(),
+        "with nothing animated, a plain repaint is the whole job"
     );
 }
 
@@ -2054,38 +2089,53 @@ fn shadow_extent(node: &RenderNode) -> Option<f32> {
 /// say 0, while the shadow on screen is still 8 deep. Every frame of the descent
 /// drew `min(interpolated, 0.0)`: no shadow at all, for an animation that went
 /// on running and asking for frames.
+///
+/// The descent runs on a ramp no loaded runner can reach the end of, because the
+/// claim is about what is drawn *while* it falls: with a short ramp, a slow
+/// machine would finish the fall between two sleeps and the test would read the
+/// correct absence of a shadow as the bug. Arrival is checked separately, by
+/// settling rather than by a clock.
 #[test]
 fn a_falling_elevation_animates_down_instead_of_snapping() {
-    let level = create_signal(8.0f32);
-    let mut h = H::new(
-        container()
-            .width(40.0)
-            .height(40.0)
-            .background(Color::RED)
-            .elevation(move || level.get())
-            .animate_elevation(Transition::new(600.0, TimingFunction::Linear)),
-    );
+    let falling = |ramp_ms: f32| {
+        let level = create_signal(8.0f32);
+        let h = H::new(
+            container()
+                .width(40.0)
+                .height(40.0)
+                .background(Color::RED)
+                .elevation(move || level.get())
+                .animate_elevation(Transition::new(ramp_ms, TimingFunction::Linear)),
+        );
+        (h, level)
+    };
+
+    let (mut h, level) = falling(60_000.0);
     h.fit(100.0, 100.0);
-    let lifted = shadow_extent(&h.paint()).expect("a lifted card casts a shadow");
+    assert!(
+        shadow_extent(&h.paint()).is_some(),
+        "a lifted card casts a shadow"
+    );
 
     level.set(0.0);
-    pump(&mut h);
-    h.fit(100.0, 100.0);
-    h.paint();
-
-    // A third of the way down a 600ms ramp: unmistakably moving, and nowhere
-    // near gone.
-    for _ in 0..5 {
-        std::thread::sleep(std::time::Duration::from_millis(40));
+    for step in 0..5 {
+        std::thread::sleep(std::time::Duration::from_millis(4));
         pump(&mut h);
         h.fit(100.0, 100.0);
-        h.paint();
+        assert!(
+            shadow_extent(&h.paint()).is_some(),
+            "frame {step} of the descent drew no shadow at all"
+        );
     }
-    let falling = shadow_extent(&h.paint()).expect("it is still falling, not gone");
-    assert!(
-        falling < lifted,
-        "the descent has to move: {falling} vs {lifted}"
-    );
+
+    // And it does arrive, on a ramp it can finish.
+    let (mut h, level) = falling(60.0);
+    h.fit(100.0, 100.0);
+    h.paint();
+    level.set(0.0);
+    pump(&mut h);
+    settle(&mut h, 200);
+    assert_eq!(shadow_count(&h.paint()), 0, "and settles flat");
 }
 
 /// The clamp the descent above must not trip is still doing its job.
@@ -2132,7 +2182,7 @@ fn hover_flicker_cannot_push_a_shadow_outside_its_damage_rect() {
             set_hover(&mut h, inside);
             last_flip = std::time::Instant::now();
         }
-        std::thread::sleep(std::time::Duration::from_millis(6));
+        std::thread::sleep(std::time::Duration::from_millis(4));
         pump(&mut h);
         h.fit(100.0, 100.0);
         let node = h.paint();

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -1703,3 +1703,71 @@ fn shadow_count(node: &RenderNode) -> usize {
         })
         .count()
 }
+
+/// The compositor half of a backdrop blur is a region published to a registry,
+/// not a draw command — and the registry only prunes widgets that left the
+/// tree. So a container whose blur reached zero has to withdraw its own entry,
+/// or a blur switched on once blurs the desktop for the life of the surface.
+///
+/// This is the half the draw-command test cannot see: `DrawCommand::BackdropBlur`
+/// is the *surface* path, which was correctly gated all along.
+#[test]
+fn a_zero_radius_withdraws_the_compositor_blur_region() {
+    crate::blur::reset_blur();
+
+    let radius = create_signal(24.0f32);
+    let mut h = H::new(
+        container()
+            .width(40.0)
+            .height(20.0)
+            .backdrop_blur(move || BackdropBlur::new(radius.get())),
+    );
+    h.fit(100.0, 100.0);
+    h.paint();
+    assert!(
+        !crate::blur::collect_for_surface(&h.tree, h.root).is_empty(),
+        "a positive radius publishes a region"
+    );
+
+    radius.set(0.0);
+    pump(&mut h);
+    h.fit(100.0, 100.0);
+    h.paint();
+    assert_eq!(
+        crate::blur::collect_for_surface(&h.tree, h.root),
+        Vec::new(),
+        "and zero takes it back"
+    );
+
+    // Both ways, so the withdrawal is not a one-shot.
+    radius.set(12.0);
+    pump(&mut h);
+    h.fit(100.0, 100.0);
+    h.paint();
+    assert!(!crate::blur::collect_for_surface(&h.tree, h.root).is_empty());
+
+    crate::blur::reset_blur();
+}
+
+/// Restricting the sources to the surface must publish no compositor region at
+/// all, whatever the radius.
+#[test]
+fn a_surface_only_blur_publishes_no_compositor_region() {
+    crate::blur::reset_blur();
+
+    let mut h = H::new(
+        container()
+            .width(40.0)
+            .height(20.0)
+            .backdrop_blur(BackdropBlur::new(24.0).sources(BackdropSources::SURFACE)),
+    );
+    h.fit(100.0, 100.0);
+    h.paint();
+    assert_eq!(
+        crate::blur::collect_for_surface(&h.tree, h.root),
+        Vec::new()
+    );
+    assert_eq!(blur_radii(&h.paint()), vec![24.0], "but it still draws one");
+
+    crate::blur::reset_blur();
+}

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -15,6 +15,7 @@ use rustc_hash::FxHashSet;
 
 use super::*;
 use crate::animation::{SpringConfig, TimingFunction, Transition};
+use crate::backdrop::BackdropSources;
 use crate::jobs::{self, JobType};
 use crate::layout::{Constraints, Flex, at_least, at_most, fill, fraction};
 use crate::reactive::create_signal;
@@ -60,29 +61,36 @@ impl H {
         node
     }
 
-    /// One frame in the order the loop runs it: queued jobs, layout, then
-    /// `crate::paint_surface` — the same function `paint_and_present` calls, so
-    /// a test cannot attest an order the loop does not have. Finishes by
-    /// clearing the paint flags, which is what `cache_paint_results` does and
-    /// what makes a clean child cullable on the frame after.
+    /// One frame, in the phases and the order the loop runs them: queued jobs,
+    /// layout, paint, flatten, the compositor blur region read off the result,
+    /// and `crate::cache_paint_results` to finish.
     ///
-    /// Use this, not `paint()`, for anything whose correctness is about *when*
-    /// in the frame it happens.
+    /// That last one is the real function, not a stand-in for the half of it a
+    /// test happened to need. Writing `clear_needs_paint` by hand instead left
+    /// `cache_paint` undone, so `reuse_cached` never found a cache and every
+    /// test repainted everything — which made a whole class of bug, the one
+    /// about a widget that is *not* repainted, structurally invisible here.
+    ///
+    /// Use this, not `paint()`, for anything whose correctness is about when in
+    /// the frame it happens, or about which widgets painted at all.
     fn frame(&mut self, w: f32, h: f32) -> Frame {
         pump(self);
         self.fit(w, h);
 
         let root = self.root;
         let mut node = RenderNode::new(root.as_u64());
-        let blur = crate::paint_surface(&mut self.tree, root, &mut node);
+        self.tree.with_widget_mut(root, |w, id, t| {
+            let mut ctx = PaintContext::new(&mut node);
+            w.paint(t, id, &mut ctx);
+        });
 
-        fn settle(tree: &mut Tree, node: &RenderNode) {
-            tree.clear_needs_paint(WidgetId::from_u64(node.id));
-            for child in &node.children {
-                settle(tree, child);
-            }
-        }
-        settle(&mut self.tree, &node);
+        let node = std::rc::Rc::new(node);
+        let mut commands = Vec::new();
+        let mut layers = Vec::new();
+        crate::renderer::flatten_root_into(&node, &mut commands, &mut layers);
+        let blur = crate::blur::regions_from_commands(&commands);
+
+        crate::cache_paint_results(&mut self.tree, &node);
 
         Frame { node, blur }
     }
@@ -139,7 +147,7 @@ impl H {
 /// What one frame produced: the render tree, and the compositor blur region the
 /// paint left registered.
 struct Frame {
-    node: RenderNode,
+    node: std::rc::Rc<RenderNode>,
     blur: Vec<crate::blur::BlurRect>,
 }
 
@@ -1556,11 +1564,11 @@ fn an_animated_colour_starts_from_the_inherited_base() {
 fn a_gradient_is_reactive_and_paint_only() {
     let warm = create_signal(true);
     let mut h = H::new(container().width(20.0).height(20.0).gradient(move || {
-        if warm.get() {
+        Some(if warm.get() {
             LinearGradient::horizontal(Color::RED, Color::YELLOW)
         } else {
             LinearGradient::horizontal(Color::BLUE, Color::CYAN)
-        }
+        })
     }));
     h.fit(100.0, 100.0);
     assert_eq!(gradient_ends(&h.paint()), Some((Color::RED, Color::YELLOW)));
@@ -1576,7 +1584,7 @@ fn a_gradient_is_reactive_and_paint_only() {
 fn a_constant_gradient_shorthand_stays_constant() {
     let constant = container().gradient_vertical(Color::RED, Color::BLUE);
     assert_eq!(
-        constant.gradient.and_then(|g| g.constant()),
+        constant.gradient.and_then(|g| g.constant()).flatten(),
         Some(LinearGradient::vertical(Color::RED, Color::BLUE)),
         "two constants make one constant"
     );
@@ -2035,8 +2043,6 @@ fn a_declared_elevation_change_invalidates_the_reach() {
 /// surface.
 #[test]
 fn switching_a_compositor_blur_off_withdraws_it_on_that_frame() {
-    crate::blur::reset_blur();
-
     let frosted = create_signal(true);
     let mut h = H::new(
         container()
@@ -2059,16 +2065,12 @@ fn switching_a_compositor_blur_off_withdraws_it_on_that_frame() {
 
     frosted.set(true);
     assert!(!h.frame(100.0, 100.0).blur.is_empty(), "and back on");
-
-    crate::blur::reset_blur();
 }
 
 /// Restricting the sources to the surface publishes no compositor region at all,
 /// whatever the radius — while still drawing one.
 #[test]
 fn a_surface_only_blur_publishes_no_compositor_region() {
-    crate::blur::reset_blur();
-
     let mut h = H::new(
         container()
             .width(40.0)
@@ -2078,8 +2080,6 @@ fn a_surface_only_blur_publishes_no_compositor_region() {
     let frame = h.frame(100.0, 100.0);
     assert_eq!(frame.blur, Vec::new());
     assert_eq!(blur_radii(&frame.node), vec![24.0], "but it draws one");
-
-    crate::blur::reset_blur();
 }
 
 /// A hidden panel blurs nothing, and neither does anything inside it. The
@@ -2089,8 +2089,6 @@ fn a_surface_only_blur_publishes_no_compositor_region() {
 /// exactly where they were.
 #[test]
 fn hiding_a_panel_withdraws_the_blur_of_everything_inside_it() {
-    crate::blur::reset_blur();
-
     let open = create_signal(true);
     let mut h = H::new(
         container()
@@ -2111,8 +2109,42 @@ fn hiding_a_panel_withdraws_the_blur_of_everything_inside_it() {
 
     open.set(true);
     assert!(!h.frame(100.0, 100.0).blur.is_empty(), "and back");
+}
 
-    crate::blur::reset_blur();
+/// Hiding and showing a panel has to work in *both* directions, and the return
+/// trip is the one that breaks: the panel repaints, but its child is clean and
+/// is served from the paint cache, so the child's own paint never runs.
+///
+/// While the region was a registry written during paint, that meant the blur
+/// went off and never came back — the withdrawal had a path and the
+/// re-registration did not. Reading the region off the frame instead makes the
+/// two directions one operation: a cached node carries its commands with it, so
+/// it carries its blur.
+#[test]
+fn a_blur_served_from_the_paint_cache_is_still_published() {
+    let open = create_signal(true);
+    let mut h = H::new(
+        container()
+            .width(60.0)
+            .height(40.0)
+            .visible(move || open.get())
+            .child(container().width(40.0).height(20.0).backdrop_blur(24.0)),
+    );
+    assert!(!h.frame(100.0, 100.0).blur.is_empty(), "open");
+
+    open.set(false);
+    assert_eq!(h.frame(100.0, 100.0).blur, Vec::new(), "hidden");
+
+    // The panel is dirty and repaints; the child is not, and comes from the
+    // cache without its paint running.
+    open.set(true);
+    assert!(
+        !h.frame(100.0, 100.0).blur.is_empty(),
+        "a blur that came back from the cache still has to be published"
+    );
+
+    // And it survives a frame in which nothing at all repaints.
+    assert!(!h.frame(100.0, 100.0).blur.is_empty(), "and stays");
 }
 
 /// A child scrolled out of a viewport blurs nothing. It never paints — culled,
@@ -2120,8 +2152,6 @@ fn hiding_a_panel_withdraws_the_blur_of_everything_inside_it() {
 /// cannot withdraw its own region, and its bounds stay where they were.
 #[test]
 fn scrolling_a_frosted_card_away_withdraws_its_blur() {
-    crate::blur::reset_blur();
-
     // Enough rows that the scroller takes its windowing fast path, which is the
     // case the sweep exists for and the one a two-child list never reaches.
     let mut rows: Vec<crate::widgets::AnyWidget> = vec![
@@ -2160,6 +2190,34 @@ fn scrolling_a_frosted_card_away_withdraws_its_blur() {
         Vec::new(),
         "scrolled away, so it blurs nothing"
     );
+}
 
-    crate::blur::reset_blur();
+/// A gradient needs a value that means "no gradient", or the rule the whole
+/// branch is about — a property you can turn off with the signal that turned it
+/// on — has a hole exactly where a header expands and collapses.
+#[test]
+fn a_gradient_can_be_switched_off_and_the_background_returns() {
+    let expanded = create_signal(true);
+    let mut h = H::new(
+        container()
+            .width(20.0)
+            .height(20.0)
+            .background(Color::GRAY)
+            .gradient(move || {
+                expanded
+                    .get()
+                    .then(|| LinearGradient::horizontal(Color::RED, Color::BLUE))
+            }),
+    );
+    h.fit(100.0, 100.0);
+    assert_eq!(gradient_ends(&h.paint()), Some((Color::RED, Color::BLUE)));
+
+    expanded.set(false);
+    let node = h.paint();
+    assert_eq!(gradient_ends(&node), None, "no gradient");
+    assert_eq!(
+        rects(&node).first().map(|(_, color)| *color),
+        Some(Color::GRAY),
+        "and the background it was covering is drawn again"
+    );
 }

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -14,7 +14,7 @@
 use rustc_hash::FxHashSet;
 
 use super::*;
-use crate::animation::{TimingFunction, Transition};
+use crate::animation::{SpringConfig, TimingFunction, Transition};
 use crate::jobs::{self, JobType};
 use crate::layout::{Constraints, Flex, at_least, at_most, fill, fraction};
 use crate::reactive::create_signal;
@@ -1954,6 +1954,40 @@ fn the_damage_reach_covers_the_elevation_a_hover_can_reach() {
     let mut flat = H::new(container().width(40.0).height(40.0).background(Color::RED));
     flat.fit(100.0, 100.0);
     assert_eq!(flat.tree.paint_overflow(flat.root), 0.0);
+}
+
+/// A spring goes past its target on purpose, so a reach measured from the target
+/// leaves the shadow ring outside the damage rect exactly at the peak — the same
+/// artefact the reach exists to prevent, moved to the moment it is most visible.
+#[test]
+fn the_damage_reach_allows_for_a_spring_overshooting() {
+    let bouncy = |c: Container| {
+        c.width(40.0)
+            .height(40.0)
+            .background(Color::RED)
+            .elevation(0.0)
+            .when_hovered(|s| s.elevation(8.0))
+    };
+
+    let mut eased = H::new(
+        bouncy(container()).animate_elevation(Transition::new(80.0, TimingFunction::Linear)),
+    );
+    eased.fit(100.0, 100.0);
+    let without_bounce = eased.tree.paint_overflow(eased.root);
+
+    let mut sprung =
+        H::new(bouncy(container()).animate_elevation(Transition::spring(SpringConfig::BOUNCY)));
+    sprung.fit(100.0, 100.0);
+    let with_bounce = sprung.tree.paint_overflow(sprung.root);
+
+    assert!(
+        with_bounce > without_bounce,
+        "a bouncy spring has to reach further than an ease: {with_bounce} vs {without_bounce}"
+    );
+    assert!(
+        with_bounce >= style::elevation_to_shadow(8.0 * 1.17).extent() - 0.01,
+        "and far enough for BOUNCY's ~17%, got {with_bounce}"
+    );
 }
 
 /// A declared elevation changing does need a new reach, so it must invalidate

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -29,6 +29,12 @@ use crate::widgets::widget::{Event, EventResponse, MouseButton};
 struct H {
     tree: Tree,
     root: WidgetId,
+    /// The last frame's render tree and flattened commands, retained as the
+    /// loop retains them — a frame that repaints nothing publishes from these.
+    last: Option<(
+        std::rc::Rc<RenderNode>,
+        Vec<crate::renderer::FlattenedCommand>,
+    )>,
 }
 
 impl H {
@@ -36,7 +42,11 @@ impl H {
         let mut tree = Tree::new();
         let root = tree.register(Box::new(widget));
         tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
-        Self { tree, root }
+        Self {
+            tree,
+            root,
+            last: None,
+        }
     }
 
     fn layout(&mut self, constraints: Constraints) -> Size {
@@ -61,15 +71,17 @@ impl H {
         node
     }
 
-    /// One frame, in the phases and the order the loop runs them: queued jobs,
-    /// layout, paint, flatten, the compositor blur region read off the result,
-    /// and `crate::cache_paint_results` to finish.
+    /// One frame, in the phases and the order `render_surface` runs them: queued
+    /// jobs, layout, the skip-frame gate, paint, flatten, the compositor blur
+    /// region read off the result, and `crate::cache_paint_results` to finish.
     ///
-    /// That last one is the real function, not a stand-in for the half of it a
-    /// test happened to need. Writing `clear_needs_paint` by hand instead left
-    /// `cache_paint` undone, so `reuse_cached` never found a cache and every
-    /// test repainted everything — which made a whole class of bug, the one
-    /// about a widget that is *not* repainted, structurally invisible here.
+    /// Two of those are the loop's own code rather than a stand-in for it, and
+    /// both were learned the hard way. `cache_paint_results` written out by hand
+    /// left `cache_paint` undone, so `reuse_cached` never found a cache and every
+    /// test repainted everything — making the whole class of bug about a widget
+    /// that is *not* repainted structurally invisible here. And a `frame` that
+    /// always painted could not reach the gate at all, where the loop publishes
+    /// the region from the buffer it retained.
     ///
     /// Use this, not `paint()`, for anything whose correctness is about when in
     /// the frame it happens, or about which widgets painted at all.
@@ -78,6 +90,15 @@ impl H {
         self.fit(w, h);
 
         let root = self.root;
+        if !self.tree.needs_paint(root)
+            && let Some((node, commands)) = self.last.clone()
+        {
+            // The gate: nothing is dirty, so nothing repaints and the region
+            // comes from the frame still on screen.
+            let blur = crate::blur::regions_from_commands(&commands);
+            return Frame { node, blur };
+        }
+
         let mut node = RenderNode::new(root.as_u64());
         self.tree.with_widget_mut(root, |w, id, t| {
             let mut ctx = PaintContext::new(&mut node);
@@ -91,6 +112,7 @@ impl H {
         let blur = crate::blur::regions_from_commands(&commands);
 
         crate::cache_paint_results(&mut self.tree, &node);
+        self.last = Some((std::rc::Rc::clone(&node), commands));
 
         Frame { node, blur }
     }
@@ -1730,9 +1752,16 @@ fn elevation_animates_towards_its_state_layer() {
     assert_eq!(shadow_count(&h.paint()), 0, "flat on the surface at rest");
 
     set_hover(&mut h, true);
-    std::thread::sleep(std::time::Duration::from_millis(20));
-    pump(&mut h);
-    h.fit(100.0, 100.0);
+    // Two frames: the first starts the animation, the second is far enough up
+    // the ramp for the shadow to be worth drawing — the very first values are
+    // below the alpha floor by design, since a shadow nobody can see is a rect
+    // drawn for nothing.
+    for _ in 0..2 {
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        pump(&mut h);
+        h.fit(100.0, 100.0);
+        h.paint();
+    }
     assert_eq!(
         shadow_count(&h.paint()),
         1,
@@ -2026,21 +2055,24 @@ fn a_declared_elevation_change_invalidates_the_reach() {
 }
 
 // ---------------------------------------------------------------------------
-// Compositor blur regions — every one of these is about *when* in the frame
+// Compositor blur regions — every one of these is about which widgets painted
 // ---------------------------------------------------------------------------
 //
-// The surface half of a backdrop blur is a draw command and shows up in the
-// render tree. The compositor half is a region handed to `wl_region`, published
-// once per frame, and it is where the interesting failure lives: a region is
-// registered and withdrawn *during* paint, so anything that reads it must read
-// it after. These drive `H::frame`, which calls the same `crate::paint_surface`
-// the loop does, precisely so they cannot attest an order the loop lacks.
+// The surface half of a backdrop blur is a draw command in the render tree. The
+// compositor half is a `wl_region` derived from the same command after
+// flattening, which is what makes these tests about *painting*: a container that
+// did not paint has no command, one served from the cache carries its along, and
+// a frame that repaints nothing publishes from the buffer it retained.
+//
+// They all go through `H::frame`, which runs those phases in the loop's order
+// and with the loop's own `cache_paint_results` — the two things a test of this
+// cannot model loosely and still be a test.
 
 /// Turning a blur off has to reach the compositor on the frame that turns it
-/// off. Collecting before the paint published the region the *previous* frame
-/// asked for, and then nothing was dirty any more — so the withdrawal waited for
-/// a frame that never came and the desktop stayed blurred for the life of the
-/// surface.
+/// off. While the region was collected before the paint, the frame that switched
+/// it off published the *previous* frame's answer, and nothing was dirty
+/// afterwards — so the withdrawal waited for a frame a settled surface never
+/// renders.
 #[test]
 fn switching_a_compositor_blur_off_withdraws_it_on_that_frame() {
     let frosted = create_signal(true);
@@ -2220,4 +2252,26 @@ fn a_gradient_can_be_switched_off_and_the_background_returns() {
         Some(Color::GRAY),
         "and the background it was covering is drawn again"
     );
+}
+
+/// The border is gated on resolving to something visible; the shadow has to be
+/// too. The opening frames of a lift are at ~0.001, where the shadow's alpha
+/// rounds to nothing — and without a floor each one still pushed a rect
+/// carrying it, every frame, for as long as the animation was leaving zero.
+#[test]
+fn a_shadow_too_faint_to_see_is_not_drawn() {
+    let level = create_signal(0.001f32);
+    let mut h = H::new(
+        container()
+            .width(40.0)
+            .height(40.0)
+            .background(Color::RED)
+            .elevation(move || level.get()),
+    );
+    h.fit(100.0, 100.0);
+    assert_eq!(shadow_count(&h.paint()), 0, "invisible, so not drawn");
+
+    level.set(1.0);
+    h.fit(100.0, 100.0);
+    assert_eq!(shadow_count(&h.paint()), 1, "and drawn once it can be seen");
 }

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -1955,3 +1955,155 @@ fn events_use_the_clip_of_the_frame_on_screen() {
     }
     assert_eq!(clicked.get_untracked(), 1);
 }
+
+/// A shadow falls outside the box that casts it, so the damage a container
+/// reports has to reach past its own bounds — and it has to reach far enough for
+/// the *largest* shadow it can cast, not the one showing.
+///
+/// Elevation animates paint-only, so a hover that lifts a card never re-runs the
+/// layout that records the reach. Sized to the resting value, the shadow ring
+/// falls outside every damage rect: absent on the way up, left on screen on the
+/// way down.
+#[test]
+fn the_damage_reach_covers_the_elevation_a_hover_can_reach() {
+    let mut h = H::new(
+        container()
+            .width(40.0)
+            .height(40.0)
+            .background(Color::RED)
+            .elevation(0.0)
+            .when_hovered(|s| s.elevation(8.0))
+            .animate_elevation(Transition::new(80.0, TimingFunction::Linear)),
+    );
+    h.fit(100.0, 100.0);
+
+    let reach = h.tree.paint_overflow(h.root);
+    let lifted = style::elevation_to_shadow(8.0).extent();
+    assert!(
+        reach >= lifted && lifted > 0.0,
+        "reach {reach} must cover the hovered shadow {lifted}"
+    );
+
+    // And a container that can never lift pays nothing for it.
+    let mut flat = H::new(container().width(40.0).height(40.0).background(Color::RED));
+    flat.fit(100.0, 100.0);
+    assert_eq!(flat.tree.paint_overflow(flat.root), 0.0);
+}
+
+/// A declared elevation changing does need a new reach, so it must invalidate
+/// the layout that recorded the old one.
+#[test]
+fn a_declared_elevation_change_invalidates_the_reach() {
+    let level = create_signal(0.0f32);
+    let mut h = H::new(
+        container()
+            .width(40.0)
+            .height(40.0)
+            .background(Color::RED)
+            .elevation(move || level.get()),
+    );
+    h.fit(100.0, 100.0);
+    h.paint();
+    assert_eq!(h.tree.paint_overflow(h.root), 0.0);
+
+    let queued = h.jobs_from(|| level.set(6.0));
+    assert!(queued.contains(&JobType::Layout), "got {queued:?}");
+
+    // `jobs_from` consumes the jobs without running them, so the reach is
+    // recomputed by a write that gets pumped.
+    level.set(9.0);
+    pump(&mut h);
+    h.fit(100.0, 100.0);
+    assert!(h.tree.paint_overflow(h.root) > 0.0);
+}
+
+/// An invisible container blurs nothing.
+///
+/// It holds two mechanisms together: `paint` returns at the visibility gate,
+/// *before* the register/withdraw decision, so the withdrawal happens at the
+/// gate — and an invisible container also measures zero, so its region would
+/// tessellate to nothing even if the entry lingered. Belt and braces on purpose:
+/// the second is what makes this not a bug today, the first is what keeps the
+/// registry from growing one stale entry per hidden panel.
+#[test]
+fn an_invisible_container_withdraws_its_compositor_blur() {
+    crate::blur::reset_blur();
+
+    let open = create_signal(true);
+    let mut h = H::new(
+        container()
+            .width(40.0)
+            .height(20.0)
+            .visible(move || open.get())
+            .backdrop_blur(24.0),
+    );
+    h.fit(100.0, 100.0);
+    h.paint();
+    assert!(!crate::blur::collect_for_surface(&h.tree, h.root).is_empty());
+
+    open.set(false);
+    pump(&mut h);
+    h.fit(100.0, 100.0);
+    h.paint();
+    assert_eq!(
+        crate::blur::collect_for_surface(&h.tree, h.root),
+        Vec::new(),
+        "an invisible panel blurs nothing"
+    );
+
+    open.set(true);
+    pump(&mut h);
+    h.fit(100.0, 100.0);
+    h.paint();
+    assert!(!crate::blur::collect_for_surface(&h.tree, h.root).is_empty());
+
+    crate::blur::reset_blur();
+}
+
+/// A child culled out of a scrolling viewport never paints, so it cannot withdraw
+/// its own region — the parent that culled it says so on its behalf.
+///
+/// Culling only skips a *clean* child, so the card's paint flag is cleared before
+/// the last frame, which is what the loop's `cache_paint_results` does once its
+/// content stops changing.
+#[test]
+fn a_culled_child_withdraws_its_compositor_blur() {
+    crate::blur::reset_blur();
+
+    let mut h = H::new(
+        container()
+            .width(40.0)
+            .height(30.0)
+            .scrollable(ScrollAxis::Vertical)
+            .child(container().width(40.0).height(20.0).backdrop_blur(24.0))
+            .child(box_of(40.0, 400.0)),
+    );
+    h.fit(40.0, 30.0);
+    h.paint();
+    assert!(
+        !crate::blur::collect_for_surface(&h.tree, h.root).is_empty(),
+        "visible at the top of the scroll"
+    );
+
+    h.send(Event::Scroll {
+        x: 20.0,
+        y: 15.0,
+        delta_x: 0.0,
+        delta_y: 300.0,
+        source: ScrollSource::Wheel,
+    });
+    pump(&mut h);
+    h.fit(40.0, 30.0);
+
+    let card = h.children()[0];
+    h.tree.clear_needs_paint(card);
+    h.paint();
+
+    assert_eq!(
+        crate::blur::collect_for_surface(&h.tree, h.root),
+        Vec::new(),
+        "scrolled away, so it blurs nothing"
+    );
+
+    crate::blur::reset_blur();
+}

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -1703,13 +1703,23 @@ impl Widget for Container {
             .unwrap_or_else(|| crate::renderer::CornerRadii::uniform(corner_radius));
         let corner_radius = corner_radius.max(corner_radii.max());
 
-        // Publish the compositor blur region: bounds are read fresh from the
-        // tree at frame sync, so only the (possibly animated) radius is
-        // recorded here.
-        if let Some(blur) = backdrop_blur
-            && blur.sources.contains(BackdropSources::COMPOSITOR)
-        {
+        // Publish (or withdraw) the compositor blur region: bounds are read
+        // fresh from the tree at frame sync, so only the (possibly animated)
+        // radius is recorded here.
+        //
+        // The zero-radius case has to withdraw rather than simply not register.
+        // `ext-background-effect-v1` carries no radius of its own, so nothing
+        // downstream can tell that this container asked for zero — and the
+        // registry only prunes widgets that left the tree, which a container
+        // whose blur signal reached zero has not. Without the withdrawal a
+        // blur switched on once stayed on for the life of the surface.
+        let wants_compositor_blur = backdrop_blur.is_some_and(|blur| {
+            blur.sources.contains(BackdropSources::COMPOSITOR) && blur.radius > 0.0
+        });
+        if wants_compositor_blur {
             crate::blur::register_blur(id, corner_radius);
+        } else {
+            crate::blur::unregister_blur(id);
         }
 
         // LOCAL bounds: the origin is this container, the parent already

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -54,6 +54,44 @@ use super::widget::{
 /// Callback for click events
 pub type ClickCallback = Rc<dyn Fn()>;
 
+#[doc(hidden)]
+pub struct FnHandler;
+#[doc(hidden)]
+pub struct CallbackHandler;
+#[doc(hidden)]
+pub struct OptionHandler;
+
+/// What a click handler can be written as.
+///
+/// A closure is the ordinary case. A [`Callback`](crate::reactive::Callback)
+/// and an `Option<Callback>` are the shapes a `#[component]` callback prop
+/// arrives in, so a component can forward its own prop straight through
+/// without a second method name for it.
+///
+/// The marker parameter is the same trick [`IntoSignal`] uses: it keeps the
+/// three impls from overlapping.
+pub trait IntoClickHandler<Marker = FnHandler> {
+    fn into_click_handler(self) -> Option<ClickCallback>;
+}
+
+impl<F: Fn() + 'static> IntoClickHandler<FnHandler> for F {
+    fn into_click_handler(self) -> Option<ClickCallback> {
+        Some(Rc::new(self))
+    }
+}
+
+impl IntoClickHandler<CallbackHandler> for crate::reactive::Callback {
+    fn into_click_handler(self) -> Option<ClickCallback> {
+        Some(Rc::new(move || self.run()))
+    }
+}
+
+impl IntoClickHandler<OptionHandler> for Option<crate::reactive::Callback> {
+    fn into_click_handler(self) -> Option<ClickCallback> {
+        self.map(|cb| Rc::new(move || cb.run()) as ClickCallback)
+    }
+}
+
 /// Callback for a key press: the key and the modifiers held with it.
 pub type KeyCallback = Rc<dyn Fn(Key, Modifiers)>;
 /// Callback for hover events (bool = is_hovered)
@@ -824,8 +862,26 @@ impl Container {
         self
     }
 
-    pub fn on_click<F: Fn() + 'static>(mut self, callback: F) -> Self {
-        self.interact_mut().on_click = Some(Rc::new(callback));
+    /// Called on a left-button press inside the bounds.
+    ///
+    /// Takes a closure, a [`Callback`](crate::reactive::Callback), or an
+    /// `Option<Callback>` — the last being what a `#[component]` callback prop
+    /// holds, so a component forwards its own prop with no ceremony:
+    ///
+    /// ```ignore
+    /// #[component]
+    /// fn button(#[prop(callback)] on_click: ()) -> impl Widget {
+    ///     container().on_click(on_click)
+    /// }
+    /// ```
+    ///
+    /// A `None` prop leaves the container without a click handler, but still a
+    /// pointer target if anything else made it one.
+    pub fn on_click<M>(mut self, callback: impl IntoClickHandler<M>) -> Self {
+        let handler = callback.into_click_handler();
+        if handler.is_some() || self.interaction.is_some() {
+            self.interact_mut().on_click = handler;
+        }
         self
     }
 
@@ -848,16 +904,6 @@ impl Container {
     /// or a popup holding a grab.
     pub fn on_key_down<F: Fn(Key, Modifiers) + 'static>(mut self, callback: F) -> Self {
         self.interact_mut().on_key_down = Some(Rc::new(callback));
-        self
-    }
-
-    /// Accept an optional click callback — the shape a `#[component]`
-    /// callback prop has, so it can be forwarded straight through.
-    pub fn on_click_option(mut self, callback: Option<crate::reactive::Callback>) -> Self {
-        if callback.is_some() || self.interaction.is_some() {
-            self.interact_mut().on_click =
-                callback.map(|cb| std::rc::Rc::new(move || cb.run()) as ClickCallback);
-        }
         self
     }
 

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -771,16 +771,16 @@ impl Container {
     /// container().border(1.5, move || if failed.get() { theme.danger } else { theme.line })
     /// ```
     ///
-    /// A *state layer* is the other story: it overrides a base that already has
-    /// both, so naming one half there is meaningful and
-    /// [`StateStyle`](crate::widgets::StateStyle) has `border_width` and
-    /// `border_color` for exactly that.
+    /// A state layer says it the same way, and replaces the whole border:
     ///
     /// ```ignore
     /// container()
     ///     .border(1.5, theme.line)
-    ///     .when_focused(|s| s.border_color(theme.accent))
+    ///     .when_focused(|s| s.border(1.5, theme.accent))
     /// ```
+    ///
+    /// A width repeated across layers is a constant in your own code — there is
+    /// deliberately no way to leave half a border unsaid.
     pub fn border<M1, M2>(
         mut self,
         width: impl IntoSignal<f32, M1>,
@@ -1104,7 +1104,15 @@ impl Container {
         self
     }
 
-    /// Enable animation for border color changes
+    /// Enable animation for border colour changes. See
+    /// [`animate_border_width`](Self::animate_border_width) for why the two
+    /// halves have their own declarations.
+    pub fn animate_border_color(mut self, transition: impl Into<TransitionConfig>) -> Self {
+        let initial = self.border_color.get_or_untracked(Color::TRANSPARENT);
+        self.anims_mut().border_color = Some(AnimationState::new(initial, transition));
+        self
+    }
+
     /// Animate the text colour of this container and its descendants.
     ///
     /// ```ignore
@@ -1120,12 +1128,6 @@ impl Container {
     /// with its own curve. CSS starts the inner one once, towards the outer's
     /// *final* value; that is the rule to adopt if it ever comes up. The chase
     /// converges either way.
-    pub fn animate_border_color(mut self, transition: impl Into<TransitionConfig>) -> Self {
-        let initial = self.border_color.get_or_untracked(Color::TRANSPARENT);
-        self.anims_mut().border_color = Some(AnimationState::new(initial, transition));
-        self
-    }
-
     pub fn animate_text_color(mut self, transition: impl Into<TransitionConfig>) -> Self {
         self.anims_mut().text_color = Some(AnimationState::new(Color::WHITE, transition.into()));
         self.animated_text = Some(create_signal(None));

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -1091,7 +1091,13 @@ impl Container {
         self
     }
 
-    /// Enable animation for border width changes
+    /// Enable animation for border width changes.
+    ///
+    /// Width and colour keep separate `animate_*` declarations even though the
+    /// border is *declared* as a pair: these name an animatable channel, not a
+    /// way to state a value, and the two channels are different types with
+    /// their own curves. `examples/animation_example.rs` springs the width while
+    /// easing the colour, which one call could not express.
     pub fn animate_border_width(mut self, transition: impl Into<TransitionConfig>) -> Self {
         let initial = self.border_width.get_or_untracked(0.0);
         self.anims_mut().border_width = Some(AnimationState::new(initial, transition));
@@ -1114,6 +1120,12 @@ impl Container {
     /// with its own curve. CSS starts the inner one once, towards the outer's
     /// *final* value; that is the rule to adopt if it ever comes up. The chase
     /// converges either way.
+    pub fn animate_border_color(mut self, transition: impl Into<TransitionConfig>) -> Self {
+        let initial = self.border_color.get_or_untracked(Color::TRANSPARENT);
+        self.anims_mut().border_color = Some(AnimationState::new(initial, transition));
+        self
+    }
+
     pub fn animate_text_color(mut self, transition: impl Into<TransitionConfig>) -> Self {
         self.anims_mut().text_color = Some(AnimationState::new(Color::WHITE, transition.into()));
         self.animated_text = Some(create_signal(None));
@@ -1125,12 +1137,6 @@ impl Container {
     pub fn animate_elevation(mut self, transition: impl Into<TransitionConfig>) -> Self {
         let initial = self.elevation.get_or_untracked(0.0);
         self.anims_mut().elevation = Some(AnimationState::new(initial, transition));
-        self
-    }
-
-    pub fn animate_border_color(mut self, transition: impl Into<TransitionConfig>) -> Self {
-        let initial = self.border_color.get_or_untracked(Color::TRANSPARENT);
-        self.anims_mut().border_color = Some(AnimationState::new(initial, transition));
         self
     }
 

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -23,7 +23,7 @@ use std::rc::Rc;
 
 use crate::advance_anim;
 use crate::animation::TransitionConfig;
-use crate::backdrop::{BackdropBlur, BackdropSources};
+use crate::backdrop::BackdropBlur;
 use crate::jobs::{JobRequest, JobType, RequiredJob, request_job};
 use crate::layout::{Constraints, Flex, Layout, Length, Size};
 use crate::reactive::{
@@ -361,7 +361,7 @@ pub struct Container {
     // Styling properties
     pub(super) padding: Option<Signal<Padding>>,
     pub(super) background: Option<Signal<Color>>,
-    pub(super) gradient: Option<Signal<LinearGradient>>,
+    pub(super) gradient: Option<Signal<Option<LinearGradient>>>,
     pub(super) corner_radius: Option<Signal<f32>>,
     pub(super) corner_radii: Option<Signal<crate::renderer::CornerRadii>>,
     pub(super) corner_curvature: Option<Signal<f32>>,
@@ -791,8 +791,21 @@ impl Container {
         self
     }
 
-    /// Set a linear gradient background. Replaces the solid fill.
-    pub fn gradient<M>(mut self, gradient: impl IntoSignal<LinearGradient, M>) -> Self {
+    /// Set a linear gradient background. Replaces the solid fill while it is
+    /// there.
+    ///
+    /// `None` is "no gradient", so the background shows through again — the same
+    /// contract a radius of `0.0` gives
+    /// [`backdrop_blur`](Self::backdrop_blur), and for the same reason: without
+    /// a value meaning *off*, a gradient that only applies sometimes forces the
+    /// caller back to branching in Rust and rebuilding the widget.
+    ///
+    /// ```ignore
+    /// container()
+    ///     .background(theme.surface)
+    ///     .gradient(move || expanded.get().then(|| palette.get().header()))
+    /// ```
+    pub fn gradient<M>(mut self, gradient: impl IntoSignal<Option<LinearGradient>, M>) -> Self {
         self.gradient = Some(gradient.into_signal());
         self
     }
@@ -843,10 +856,16 @@ impl Container {
         end: impl IntoSignal<Color, M2>,
         direction: GradientDirection,
     ) -> Self {
+        // The shorthands always mean "a gradient", so they wrap in Some for the
+        // caller; the general setter is where `None` is spellable.
         let (start, end) = (start.into_signal(), end.into_signal());
         match (start.constant(), end.constant()) {
-            (Some(start), Some(end)) => self.gradient(LinearGradient::new(start, end, direction)),
-            _ => self.gradient(move || LinearGradient::new(start.get(), end.get(), direction)),
+            (Some(start), Some(end)) => {
+                self.gradient(Some(LinearGradient::new(start, end, direction)))
+            }
+            _ => {
+                self.gradient(move || Some(LinearGradient::new(start.get(), end.get(), direction)))
+            }
         }
     }
 
@@ -1713,12 +1732,6 @@ impl Widget for Container {
     fn paint(&self, tree: &Tree, id: WidgetId, ctx: &mut PaintContext) {
         let is_visible = with_signal_tracking(id, JobType::Paint, || self.visible.get_or(true));
         if !is_visible {
-            // Nothing here draws, so nothing here may go on asking the compositor
-            // to blur the desktop behind it — and that includes the descendants,
-            // whose paint this return skips and whose own bounds layout left
-            // exactly where they were. Withdrawing only `self` would spare the
-            // container its own region and keep every one below it.
-            crate::blur::unregister_unpainted(tree, &[id]);
             return;
         }
 
@@ -1752,7 +1765,7 @@ impl Widget for Container {
                 self.animated_border_width(id),
                 self.animated_border_color(id),
                 self.corner_radii.as_ref().map(|s| s.get()),
-                self.gradient.as_ref().map(|g| g.get()),
+                self.gradient.as_ref().and_then(|g| g.get()),
                 self.backdrop_blur.as_ref().map(|b| b.get()),
                 self.overflow.get_or(Overflow::Visible),
             )
@@ -1768,28 +1781,6 @@ impl Widget for Container {
             .unwrap_or_else(|| crate::renderer::CornerRadii::uniform(corner_radius));
         let corner_radius = corner_radius.max(corner_radii.max());
 
-        // Publish (or withdraw) the compositor blur region: bounds are read
-        // fresh from the tree at frame sync, so only the (possibly animated)
-        // radius is recorded here.
-        //
-        // The zero-radius case has to withdraw rather than simply not register.
-        // `ext-background-effect-v1` carries no radius of its own, so nothing
-        // downstream can tell that this container asked for zero — and the
-        // registry only prunes widgets that left the tree, which a container
-        // whose blur signal reached zero has not. Without the withdrawal a
-        // blur switched on once stayed on for the life of the surface.
-        let wants_compositor_blur = backdrop_blur.is_some_and(|blur| {
-            blur.sources.contains(BackdropSources::COMPOSITOR) && blur.radius > 0.0
-        });
-        if wants_compositor_blur {
-            crate::blur::register_blur(id, corner_radius);
-        } else if self.backdrop_blur.is_some() {
-            // Only a container that could have registered needs to withdraw.
-            // Every other one would be a borrow and a miss on a mostly empty
-            // map, per container, per frame, on the paint path.
-            crate::blur::unregister_blur(id);
-        }
-
         // LOCAL bounds: the origin is this container, the parent already
         // positioned the node.
         let local_bounds = Rect::new(0.0, 0.0, bounds.width, bounds.height);
@@ -1801,13 +1792,25 @@ impl Widget for Container {
         }
 
         // Before the decoration: the container paints over its own blurred
-        // backdrop, and the effect must read a target that does not yet
-        // include this container.
+        // backdrop, and the effect must read a target that does not yet include
+        // this container.
+        //
+        // One command carries both halves. The renderer filters the surface's
+        // own; the compositor's region is read off this same command after
+        // flattening, so the two can never disagree about whether the container
+        // still wants it — and a blur cached, culled or hidden is carried or
+        // dropped by the render tree itself rather than by a registry that has
+        // to be told.
         if let Some(blur) = backdrop_blur
-            && blur.sources.contains(BackdropSources::SURFACE)
             && blur.radius > 0.0
         {
-            ctx.draw_backdrop_blur(local_bounds, blur.radius, corner_radii, corner_curvature);
+            ctx.draw_backdrop_blur(
+                local_bounds,
+                blur.sources,
+                blur.radius,
+                corner_radii,
+                corner_curvature,
+            );
         }
 
         self.paint_decoration(
@@ -1861,13 +1864,6 @@ impl Widget for Container {
         // to find the visible range (O(log n)) instead of iterating all children (O(n)).
         let all_children = self.children_source.get();
 
-        // Rows outside the scroller's window are not painted, so they are
-        // "unpainted" in exactly the sense the blur registry means — and this is
-        // the path a long list actually takes, the cull check inside
-        // `paint_children` never seeing them at all.
-        let mut unpainted_rows: Vec<WidgetId> = Vec::new();
-        let sweeping_blur = !crate::blur::is_empty();
-
         let visible_children: &[WidgetId] = if is_scrollable {
             let sd = self.scroll();
             match self.scroll_axis {
@@ -1887,10 +1883,6 @@ impl Widget for Container {
                         all_children.len() as u64,
                         (end - start) as u64,
                     );
-                    if sweeping_blur {
-                        unpainted_rows.extend_from_slice(&all_children[..start]);
-                        unpainted_rows.extend_from_slice(&all_children[end..]);
-                    }
                     &all_children[start..end]
                 }
                 ScrollAxis::Horizontal => {
@@ -1909,10 +1901,6 @@ impl Widget for Container {
                         all_children.len() as u64,
                         (end - start) as u64,
                     );
-                    if sweeping_blur {
-                        unpainted_rows.extend_from_slice(&all_children[..start]);
-                        unpainted_rows.extend_from_slice(&all_children[end..]);
-                    }
                     &all_children[start..end]
                 }
                 _ => all_children, // Both/None: fall back to full iteration
@@ -1940,7 +1928,6 @@ impl Widget for Container {
                 cache_requires_full_visibility: is_scrollable,
             },
         );
-        crate::blur::unregister_unpainted(tree, &unpainted_rows);
 
         // Draw scrollbar containers
         if is_scrollable {

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -1704,13 +1704,12 @@ impl Widget for Container {
     fn paint(&self, tree: &Tree, id: WidgetId, ctx: &mut PaintContext) {
         let is_visible = with_signal_tracking(id, JobType::Paint, || self.visible.get_or(true));
         if !is_visible {
-            // An invisible container draws nothing, and must not go on asking
-            // the compositor to blur the desktop behind where it would be. The
-            // withdrawal has to happen here rather than at the decision below,
-            // which this return never reaches.
-            if self.backdrop_blur.is_some() {
-                crate::blur::unregister_blur(id);
-            }
+            // Nothing here draws, so nothing here may go on asking the compositor
+            // to blur the desktop behind it — and that includes the descendants,
+            // whose paint this return skips and whose own bounds layout left
+            // exactly where they were. Withdrawing only `self` would spare the
+            // container its own region and keep every one below it.
+            crate::blur::unregister_unpainted(tree, &[id]);
             return;
         }
 
@@ -1852,6 +1851,14 @@ impl Widget for Container {
         // For scrollable containers with a single-axis layout, use binary search
         // to find the visible range (O(log n)) instead of iterating all children (O(n)).
         let all_children = self.children_source.get();
+
+        // Rows outside the scroller's window are not painted, so they are
+        // "unpainted" in exactly the sense the blur registry means — and this is
+        // the path a long list actually takes, the cull check inside
+        // `paint_children` never seeing them at all.
+        let mut unpainted_rows: Vec<WidgetId> = Vec::new();
+        let sweeping_blur = !crate::blur::is_empty();
+
         let visible_children: &[WidgetId] = if is_scrollable {
             let sd = self.scroll();
             match self.scroll_axis {
@@ -1871,6 +1878,10 @@ impl Widget for Container {
                         all_children.len() as u64,
                         (end - start) as u64,
                     );
+                    if sweeping_blur {
+                        unpainted_rows.extend_from_slice(&all_children[..start]);
+                        unpainted_rows.extend_from_slice(&all_children[end..]);
+                    }
                     &all_children[start..end]
                 }
                 ScrollAxis::Horizontal => {
@@ -1889,6 +1900,10 @@ impl Widget for Container {
                         all_children.len() as u64,
                         (end - start) as u64,
                     );
+                    if sweeping_blur {
+                        unpainted_rows.extend_from_slice(&all_children[..start]);
+                        unpainted_rows.extend_from_slice(&all_children[end..]);
+                    }
                     &all_children[start..end]
                 }
                 _ => all_children, // Both/None: fall back to full iteration
@@ -1916,6 +1931,7 @@ impl Widget for Container {
                 cache_requires_full_visibility: is_scrollable,
             },
         );
+        crate::blur::unregister_unpainted(tree, &unpainted_rows);
 
         // Draw scrollbar containers
         if is_scrollable {

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -760,25 +760,33 @@ impl Container {
         self
     }
 
-    /// Set a border with the given width and colour.
+    /// Set a border: a width and a colour, together.
+    ///
+    /// Both halves, always — a width with no colour and a colour with no width
+    /// are the same thing, which is no border, so there is nothing for a
+    /// half-declaration to mean. Each half takes a signal of its own, so
+    /// anything that has to change over time already can:
+    ///
+    /// ```ignore
+    /// container().border(1.5, move || if failed.get() { theme.danger } else { theme.line })
+    /// ```
+    ///
+    /// A *state layer* is the other story: it overrides a base that already has
+    /// both, so naming one half there is meaningful and
+    /// [`StateStyle`](crate::widgets::StateStyle) has `border_width` and
+    /// `border_color` for exactly that.
+    ///
+    /// ```ignore
+    /// container()
+    ///     .border(1.5, theme.line)
+    ///     .when_focused(|s| s.border_color(theme.accent))
+    /// ```
     pub fn border<M1, M2>(
         mut self,
         width: impl IntoSignal<f32, M1>,
         color: impl IntoSignal<Color, M2>,
     ) -> Self {
         self.border_width = Some(width.into_signal());
-        self.border_color = Some(color.into_signal());
-        self
-    }
-
-    /// Set only the border width, leaving the colour as declared.
-    pub fn border_width<M>(mut self, width: impl IntoSignal<f32, M>) -> Self {
-        self.border_width = Some(width.into_signal());
-        self
-    }
-
-    /// Set only the border colour, leaving the width as declared.
-    pub fn border_color<M>(mut self, color: impl IntoSignal<Color, M>) -> Self {
         self.border_color = Some(color.into_signal());
         self
     }

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -488,7 +488,7 @@ impl Container {
     /// - `padding(8.0)` or `padding(8)` — uniform on all sides
     /// - `padding([8.0, 16.0])` — `[vertical, horizontal]` (CSS 2-value shorthand)
     /// - `padding([1.0, 2.0, 3.0, 4.0])` — `[top, right, bottom, left]` (CSS 4-value)
-    /// - `padding(Padding::all(8.0).top(20.0))` — builder pattern
+    /// - `padding(Padding::all(8.0).with_top(20.0))` — builder pattern
     /// - `padding(signal)` or `padding(move || ...)` — reactive
     pub fn padding<M>(mut self, value: impl IntoSignal<Padding, M>) -> Self {
         self.padding = Some(value.into_signal());
@@ -1505,8 +1505,8 @@ impl Widget for Container {
 
         if self.scroll_axis != ScrollAxis::None {
             let sd = self.scroll_mut();
-            sd.scroll_state.content_width = content_size.width + padding.horizontal();
-            sd.scroll_state.content_height = content_size.height + padding.vertical();
+            sd.scroll_state.content_width = content_size.width + padding.horizontal_total();
+            sd.scroll_state.content_height = content_size.height + padding.vertical_total();
             sd.scroll_state.viewport_width = child.viewport.width;
             sd.scroll_state.viewport_height = child.viewport.height;
             sd.scroll_state.clamp_offsets();

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -373,12 +373,16 @@ pub struct Container {
     pub(super) overflow: Option<Signal<Overflow>>,
     /// What `overflow` resolved to in the last layout or paint.
     ///
-    /// Event dispatch needs it — a clipped child must not answer for a click
-    /// outside the bounds — but it needs the value the *drawn* frame used, and
-    /// it needs it without running application code: a closure-backed signal
-    /// recomputes on every read, and this one would be read for every container
-    /// on the pointer's path, on every coalesced MouseMove. The tracked reads
-    /// that do subscribe write here on their way past.
+    /// Event dispatch needs the value the *drawn* frame used, not the current
+    /// one: it tests against `hit.bounds`, which come from the last layout, and
+    /// a clip that disagreed with the box it is clipping would answer for a
+    /// point the geometry says nothing about. The tracked reads that do
+    /// subscribe write here on their way past.
+    ///
+    /// It is also cheaper than re-reading a closure-backed signal for every
+    /// container under the pointer on every coalesced `MouseMove` — but only
+    /// one such read of several on that path, so that is a bonus rather than
+    /// the reason.
     pub(super) overflow_resolved: Cell<Overflow>,
     pub(super) visible: Option<Signal<bool>>,
     pub(super) transform: Option<Signal<Transform>>,
@@ -504,8 +508,8 @@ impl Container {
         self
     }
 
-    /// Add a single child: a widget value, or [`dynamic(data, build)`](crate::widgets::dynamic)
-    /// for reactive content.
+    /// Add a single child: a widget value, or a closure returning one for
+    /// reactive content.
     pub fn child<M>(mut self, child: impl IntoChild<M>) -> Self {
         child.add_to_container(&mut self.children_source);
         self
@@ -727,7 +731,8 @@ impl Container {
     ///     .background(Color::rgba(0.1, 0.1, 0.15, 0.6))
     /// ```
     ///
-    /// Restrict it with [`BackdropSources`] when only one side should soften.
+    /// Restrict it with [`BackdropSources`](crate::backdrop::BackdropSources) when
+    /// only one side should soften.
     /// The compositor side needs `ext-background-effect-v1` — check
     /// [`compositor_effects()`](crate::compositor::compositor_effects) — and
     /// carries no radius of its own; the compositor picks one.

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -92,7 +92,7 @@ impl From<GradientDirection> for GradientDir {
 }
 
 /// Linear gradient definition
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct LinearGradient {
     pub start_color: Color,
     pub end_color: Color,
@@ -151,6 +151,7 @@ pub(super) struct ContainerAnims {
     pub(super) height: Option<AnimationState<f32>>,
     pub(super) background: Option<AnimationState<Color>>,
     pub(super) corner_radius: Option<AnimationState<f32>>,
+    pub(super) elevation: Option<AnimationState<f32>>,
     pub(super) padding: Option<AnimationState<Padding>>,
     pub(super) border_width: Option<AnimationState<f32>>,
     pub(super) border_color: Option<AnimationState<Color>>,
@@ -321,7 +322,7 @@ pub struct Container {
     // Styling properties
     pub(super) padding: Option<Signal<Padding>>,
     pub(super) background: Option<Signal<Color>>,
-    pub(super) gradient: Option<LinearGradient>,
+    pub(super) gradient: Option<Signal<LinearGradient>>,
     pub(super) corner_radius: Option<Signal<f32>>,
     pub(super) corner_radii: Option<Signal<crate::renderer::CornerRadii>>,
     pub(super) corner_curvature: Option<Signal<f32>>,
@@ -330,7 +331,7 @@ pub struct Container {
     pub(super) elevation: Option<Signal<f32>>,
     pub(super) width: Option<Signal<Length>>,
     pub(super) height: Option<Signal<Length>>,
-    pub(super) overflow: Overflow,
+    pub(super) overflow: Option<Signal<Overflow>>,
     pub(super) visible: Option<Signal<bool>>,
     pub(super) transform: Option<Signal<Transform>>,
     pub(super) transform_origin: Option<Signal<TransformOrigin>>,
@@ -343,7 +344,7 @@ pub struct Container {
     pub(super) widget_ref: Option<WidgetRef>,
 
     // Backdrop blur: this surface's own content, the compositor's, or both.
-    pub(super) backdrop_blur: Option<BackdropBlur>,
+    pub(super) backdrop_blur: Option<Signal<BackdropBlur>>,
 
     // How text inside this container looks. Boxed: most containers hold no
     // text and pay one pointer for the whole feature.
@@ -402,7 +403,7 @@ impl Container {
             elevation: None,
             width: None,
             height: None,
-            overflow: Overflow::Visible,
+            overflow: None,
             visible: None,
             transform: None,
             transform_origin: None,
@@ -684,8 +685,11 @@ impl Container {
     ///
     /// See [`crate::backdrop`] for why both are filtered rather than one
     /// being chosen.
-    pub fn backdrop_blur(mut self, blur: impl Into<BackdropBlur>) -> Self {
-        self.backdrop_blur = Some(blur.into());
+    /// A radius of `0.0` is "no blur", so a blur can be switched off by the
+    /// same signal that switches it on — the shape
+    /// [`Text::backdrop_blur`](crate::widgets::Text::backdrop_blur) already has.
+    pub fn backdrop_blur<M>(mut self, blur: impl IntoSignal<BackdropBlur, M>) -> Self {
+        self.backdrop_blur = Some(blur.into_signal());
         self
     }
 
@@ -707,7 +711,7 @@ impl Container {
         self
     }
 
-    /// Set a border with the given width and color
+    /// Set a border with the given width and colour.
     pub fn border<M1, M2>(
         mut self,
         width: impl IntoSignal<f32, M1>,
@@ -718,22 +722,54 @@ impl Container {
         self
     }
 
-    /// Set a linear gradient background
-    pub fn gradient(mut self, gradient: LinearGradient) -> Self {
-        self.gradient = Some(gradient);
+    /// Set only the border width, leaving the colour as declared.
+    pub fn border_width<M>(mut self, width: impl IntoSignal<f32, M>) -> Self {
+        self.border_width = Some(width.into_signal());
         self
     }
 
-    /// Convenience: horizontal gradient
-    pub fn gradient_horizontal(mut self, start: Color, end: Color) -> Self {
-        self.gradient = Some(LinearGradient::horizontal(start, end));
+    /// Set only the border colour, leaving the width as declared.
+    pub fn border_color<M>(mut self, color: impl IntoSignal<Color, M>) -> Self {
+        self.border_color = Some(color.into_signal());
         self
     }
 
-    /// Convenience: vertical gradient
-    pub fn gradient_vertical(mut self, start: Color, end: Color) -> Self {
-        self.gradient = Some(LinearGradient::vertical(start, end));
+    /// Set a linear gradient background. Replaces the solid fill.
+    pub fn gradient<M>(mut self, gradient: impl IntoSignal<LinearGradient, M>) -> Self {
+        self.gradient = Some(gradient.into_signal());
         self
+    }
+
+    /// Convenience: horizontal gradient.
+    pub fn gradient_horizontal<M1, M2>(
+        self,
+        start: impl IntoSignal<Color, M1>,
+        end: impl IntoSignal<Color, M2>,
+    ) -> Self {
+        let (start, end) = (start.into_signal(), end.into_signal());
+        self.gradient(move || LinearGradient::horizontal(start.get(), end.get()))
+    }
+
+    /// Convenience: vertical gradient.
+    pub fn gradient_vertical<M1, M2>(
+        self,
+        start: impl IntoSignal<Color, M1>,
+        end: impl IntoSignal<Color, M2>,
+    ) -> Self {
+        let (start, end) = (start.into_signal(), end.into_signal());
+        self.gradient(move || LinearGradient::vertical(start.get(), end.get()))
+    }
+
+    /// Convenience: diagonal gradient, top-left to bottom-right.
+    pub fn gradient_diagonal<M1, M2>(
+        self,
+        start: impl IntoSignal<Color, M1>,
+        end: impl IntoSignal<Color, M2>,
+    ) -> Self {
+        let (start, end) = (start.into_signal(), end.into_signal());
+        self.gradient(move || {
+            LinearGradient::new(start.get(), end.get(), GradientDirection::Diagonal)
+        })
     }
 
     /// Set the width of the container.
@@ -748,9 +784,9 @@ impl Container {
         self
     }
 
-    /// Set the overflow behavior for content that exceeds container bounds
-    pub fn overflow(mut self, overflow: Overflow) -> Self {
-        self.overflow = overflow;
+    /// Set the overflow behaviour for content that exceeds the container bounds.
+    pub fn overflow<M>(mut self, overflow: impl IntoSignal<Overflow, M>) -> Self {
+        self.overflow = Some(overflow.into_signal());
         self
     }
 
@@ -1002,6 +1038,14 @@ impl Container {
         self
     }
 
+    /// Animate elevation changes — the Material lift on hover, in motion
+    /// rather than as a jump.
+    pub fn animate_elevation(mut self, transition: impl Into<TransitionConfig>) -> Self {
+        let initial = self.elevation.get_or_untracked(0.0);
+        self.anims_mut().elevation = Some(AnimationState::new(initial, transition));
+        self
+    }
+
     pub fn animate_border_color(mut self, transition: impl Into<TransitionConfig>) -> Self {
         let initial = self.border_color.get_or_untracked(Color::TRANSPARENT);
         self.anims_mut().border_color = Some(AnimationState::new(initial, transition));
@@ -1204,6 +1248,7 @@ impl Widget for Container {
                 border_width_target,
                 bg_target,
                 corner_radius_target,
+                elevation_target,
                 border_color_target,
                 transform_target,
             ) = crate::reactive::diagnostics::snapshot_zone(|| {
@@ -1212,6 +1257,7 @@ impl Widget for Container {
                     self.effective_border_width_target(id),
                     self.effective_background_target(id),
                     self.effective_corner_radius_target(id),
+                    self.effective_elevation_target(id),
                     self.effective_border_color_target(id),
                     self.effective_transform_target(id),
                 )
@@ -1273,6 +1319,7 @@ impl Widget for Container {
                 any_animating,
                 paint
             );
+            advance_anim!(anims, elevation, elevation_target, id, any_animating, paint);
             advance_anim!(
                 anims,
                 border_color,
@@ -1538,8 +1585,8 @@ impl Widget for Container {
         // Children clipped away by hidden overflow or scrolling are invisible,
         // and an invisible child must not steal a click from a sibling drawn
         // below it (a collapsed submenu used to do exactly that).
-        let clips_children =
-            self.overflow == Overflow::Hidden || self.scroll_axis != ScrollAxis::None;
+        let clips_children = self.overflow.get_or(Overflow::Visible) == Overflow::Hidden
+            || self.scroll_axis != ScrollAxis::None;
         let skip_child_dispatch = clips_children
             && local_event
                 .coords()
@@ -1581,17 +1628,23 @@ impl Widget for Container {
             border_width,
             border_color,
             per_corner_radii,
+            gradient,
+            backdrop_blur,
+            overflow,
         ) = with_signal_tracking(id, JobType::Paint, || {
             (
                 self.animated_background(id),
                 self.animated_corner_radius(id),
                 self.corner_curvature.get_or(1.0),
-                self.effective_elevation(id),
+                self.animated_elevation(id),
                 self.animated_transform(id),
                 self.transform_origin.get_or(TransformOrigin::CENTER),
                 self.animated_border_width(id),
                 self.animated_border_color(id),
                 self.corner_radii.as_ref().map(|s| s.get()),
+                self.gradient.as_ref().map(|g| g.get()),
+                self.backdrop_blur.as_ref().map(|b| b.get()),
+                self.overflow.get_or(Overflow::Visible),
             )
         });
 
@@ -1607,7 +1660,7 @@ impl Widget for Container {
         // Publish the compositor blur region: bounds are read fresh from the
         // tree at frame sync, so only the (possibly animated) radius is
         // recorded here.
-        if let Some(blur) = self.backdrop_blur
+        if let Some(blur) = backdrop_blur
             && blur.sources.contains(BackdropSources::COMPOSITOR)
         {
             crate::blur::register_blur(id, corner_radius);
@@ -1626,7 +1679,7 @@ impl Widget for Container {
         // Before the decoration: the container paints over its own blurred
         // backdrop, and the effect must read a target that does not yet
         // include this container.
-        if let Some(blur) = self.backdrop_blur
+        if let Some(blur) = backdrop_blur
             && blur.sources.contains(BackdropSources::SURFACE)
             && blur.radius > 0.0
         {
@@ -1638,6 +1691,7 @@ impl Widget for Container {
             local_bounds,
             &Decoration {
                 background,
+                gradient,
                 corner_radii,
                 corner_curvature,
                 elevation: elevation_level,
@@ -1651,7 +1705,7 @@ impl Widget for Container {
 
         // Set clip region for scrollable or overflow:hidden containers
         // This clips all children to the container bounds
-        if is_scrollable || self.overflow == Overflow::Hidden {
+        if is_scrollable || overflow == Overflow::Hidden {
             ctx.set_clip(local_bounds, corner_radius, corner_curvature);
         }
 

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -1612,12 +1612,17 @@ impl Widget for Container {
         // Cache constraints and size for partial layout
         tree.cache_layout(id, constraints, size);
 
-        // An elevation shadow falls outside the box that casts it, so the
-        // damage this container reports has to reach past its own bounds.
-        // Snapshotted: a hover that only changes the elevation goes through
-        // paint, and this is here to size the damage, not to subscribe to it.
-        let elevation = self.elevation.get_or_untracked(0.0);
-        tree.set_paint_overflow(id, style::elevation_to_shadow(elevation).extent());
+        // An elevation shadow falls outside the box that casts it, so the damage
+        // this container reports has to reach past its own bounds.
+        //
+        // The *largest* elevation it can reach, not the one showing: elevation
+        // animates paint-only, so a hover that lifts a card never re-runs this
+        // layout, and a reach sized to the resting value would leave the shadow
+        // ring outside every damage rect — invisible on the way up, and left
+        // behind on the way down. Read under layout tracking, so a declared
+        // elevation changing does re-run it.
+        let reach = with_signal_tracking(id, JobType::Layout, || self.max_elevation());
+        tree.set_paint_overflow(id, style::elevation_to_shadow(reach).extent());
 
         // Register widget ref so update_widget_refs() can refresh bounds
         if let Some(ref wr) = self.widget_ref {
@@ -1697,6 +1702,13 @@ impl Widget for Container {
     fn paint(&self, tree: &Tree, id: WidgetId, ctx: &mut PaintContext) {
         let is_visible = with_signal_tracking(id, JobType::Paint, || self.visible.get_or(true));
         if !is_visible {
+            // An invisible container draws nothing, and must not go on asking
+            // the compositor to blur the desktop behind where it would be. The
+            // withdrawal has to happen here rather than at the decision below,
+            // which this return never reaches.
+            if self.backdrop_blur.is_some() {
+                crate::blur::unregister_blur(id);
+            }
             return;
         }
 
@@ -1761,7 +1773,10 @@ impl Widget for Container {
         });
         if wants_compositor_blur {
             crate::blur::register_blur(id, corner_radius);
-        } else {
+        } else if self.backdrop_blur.is_some() {
+            // Only a container that could have registered needs to withdraw.
+            // Every other one would be a borrow and a miss on a mostly empty
+            // map, per container, per frame, on the paint path.
             crate::blur::unregister_blur(id);
         }
 

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -828,6 +828,15 @@ impl Container {
     ///
     /// Two constant endpoints — much the commonest case — build one constant
     /// gradient rather than a derived recomputing a value that cannot change.
+    ///
+    /// The endpoints are converted before being asked, so the constant path
+    /// leaves two stored signals behind that nothing reads. Reading them first
+    /// would need an `as_constant` on `IntoSignal` itself, and its blanket
+    /// `Into<T>` impl consumes `self`, so that hook costs a `Clone` bound on
+    /// every value ever passed to any reactive property. Two arena slots per
+    /// gradient shorthand, freed with the scope, is the cheaper side of that
+    /// trade — the closure and the per-read recomputation were the parts worth
+    /// removing.
     fn gradient_between<M1, M2>(
         self,
         start: impl IntoSignal<Color, M1>,

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -18,6 +18,7 @@ pub use ripple::{MAX_LIVE_RIPPLES, Ripple, RippleState};
 use style::Decoration;
 
 use std::borrow::Cow;
+use std::cell::Cell;
 use std::rc::Rc;
 
 use crate::advance_anim;
@@ -370,6 +371,15 @@ pub struct Container {
     pub(super) width: Option<Signal<Length>>,
     pub(super) height: Option<Signal<Length>>,
     pub(super) overflow: Option<Signal<Overflow>>,
+    /// What `overflow` resolved to in the last layout or paint.
+    ///
+    /// Event dispatch needs it — a clipped child must not answer for a click
+    /// outside the bounds — but it needs the value the *drawn* frame used, and
+    /// it needs it without running application code: a closure-backed signal
+    /// recomputes on every read, and this one would be read for every container
+    /// on the pointer's path, on every coalesced MouseMove. The tracked reads
+    /// that do subscribe write here on their way past.
+    pub(super) overflow_resolved: Cell<Overflow>,
     pub(super) visible: Option<Signal<bool>>,
     pub(super) transform: Option<Signal<Transform>>,
     pub(super) transform_origin: Option<Signal<TransformOrigin>>,
@@ -442,6 +452,7 @@ impl Container {
             width: None,
             height: None,
             overflow: None,
+            overflow_resolved: Cell::new(Overflow::Visible),
             visible: None,
             transform: None,
             transform_origin: None,
@@ -784,8 +795,7 @@ impl Container {
         start: impl IntoSignal<Color, M1>,
         end: impl IntoSignal<Color, M2>,
     ) -> Self {
-        let (start, end) = (start.into_signal(), end.into_signal());
-        self.gradient(move || LinearGradient::horizontal(start.get(), end.get()))
+        self.gradient_between(start, end, GradientDirection::Horizontal)
     }
 
     /// Convenience: vertical gradient.
@@ -794,8 +804,7 @@ impl Container {
         start: impl IntoSignal<Color, M1>,
         end: impl IntoSignal<Color, M2>,
     ) -> Self {
-        let (start, end) = (start.into_signal(), end.into_signal());
-        self.gradient(move || LinearGradient::vertical(start.get(), end.get()))
+        self.gradient_between(start, end, GradientDirection::Vertical)
     }
 
     /// Convenience: diagonal gradient, top-left to bottom-right.
@@ -804,10 +813,24 @@ impl Container {
         start: impl IntoSignal<Color, M1>,
         end: impl IntoSignal<Color, M2>,
     ) -> Self {
+        self.gradient_between(start, end, GradientDirection::Diagonal)
+    }
+
+    /// The three shorthands above, which differ only in the direction.
+    ///
+    /// Two constant endpoints — much the commonest case — build one constant
+    /// gradient rather than a derived recomputing a value that cannot change.
+    fn gradient_between<M1, M2>(
+        self,
+        start: impl IntoSignal<Color, M1>,
+        end: impl IntoSignal<Color, M2>,
+        direction: GradientDirection,
+    ) -> Self {
         let (start, end) = (start.into_signal(), end.into_signal());
-        self.gradient(move || {
-            LinearGradient::new(start.get(), end.get(), GradientDirection::Diagonal)
-        })
+        match (start.constant(), end.constant()) {
+            (Some(start), Some(end)) => self.gradient(LinearGradient::new(start, end, direction)),
+            _ => self.gradient(move || LinearGradient::new(start.get(), end.get(), direction)),
+        }
     }
 
     /// Set the width of the container.
@@ -824,7 +847,12 @@ impl Container {
 
     /// Set the overflow behaviour for content that exceeds the container bounds.
     pub fn overflow<M>(mut self, overflow: impl IntoSignal<Overflow, M>) -> Self {
-        self.overflow = Some(overflow.into_signal());
+        let signal = overflow.into_signal();
+        // Seed the cache the event path reads, so a container declared clipped
+        // is clipped for the first event too, without depending on a layout
+        // having run first.
+        self.overflow_resolved.set(signal.get_untracked());
+        self.overflow = Some(signal);
         self
     }
 
@@ -1631,7 +1659,7 @@ impl Widget for Container {
         // Children clipped away by hidden overflow or scrolling are invisible,
         // and an invisible child must not steal a click from a sibling drawn
         // below it (a collapsed submenu used to do exactly that).
-        let clips_children = self.overflow.get_or(Overflow::Visible) == Overflow::Hidden
+        let clips_children = self.overflow_resolved.get() == Overflow::Hidden
             || self.scroll_axis != ScrollAxis::None;
         let skip_child_dispatch = clips_children
             && local_event
@@ -1693,6 +1721,7 @@ impl Widget for Container {
                 self.overflow.get_or(Overflow::Visible),
             )
         });
+        self.overflow_resolved.set(overflow);
 
         self.resync_animation_targets(id);
 

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -384,6 +384,16 @@ pub struct Container {
     /// one such read of several on that path, so that is a bonus rather than
     /// the reason.
     pub(super) overflow_resolved: Cell<Overflow>,
+    /// The elevation the last layout sized this container's damage rect for.
+    ///
+    /// Written by `layout` and read by `animated_elevation`, so the shadow that
+    /// is drawn and the rect that is repainted are the *same number* rather than
+    /// two computations of it. They were two, and they disagreed: paint asked
+    /// [`max_elevation`](style) again, which reads the elevation signal at its
+    /// current value, so a card animating from 8 down to 0 was clamped to the 0
+    /// it had not reached yet and the shadow vanished in one frame while the
+    /// animation went on running.
+    pub(super) elevation_reach: Cell<f32>,
     pub(super) visible: Option<Signal<bool>>,
     pub(super) transform: Option<Signal<Transform>>,
     pub(super) transform_origin: Option<Signal<TransformOrigin>>,
@@ -457,6 +467,7 @@ impl Container {
             height: None,
             overflow: None,
             overflow_resolved: Cell::new(Overflow::Visible),
+            elevation_reach: Cell::new(0.0),
             visible: None,
             transform: None,
             transform_origin: None,
@@ -1656,7 +1667,12 @@ impl Widget for Container {
         // ring outside every damage rect — invisible on the way up, and left
         // behind on the way down. Read under layout tracking, so a declared
         // elevation changing does re-run it.
+        //
+        // Kept as well as published, because paint clamps to it: the shadow that
+        // is drawn and the rect that is repainted have to be one number, not two
+        // computations of it made a frame apart.
         let reach = with_signal_tracking(id, JobType::Layout, || self.max_elevation());
+        self.elevation_reach.set(reach);
         tree.set_paint_overflow(id, style::elevation_to_shadow(reach).extent());
 
         // Register widget ref so update_widget_refs() can refresh bounds

--- a/src/widgets/container/style.rs
+++ b/src/widgets/container/style.rs
@@ -142,8 +142,15 @@ impl Container {
     /// what is possible rather than to what is showing keeps the damage rect
     /// correct without asking a colour change to re-run a layout.
     ///
-    /// Read tracked: a *declared* elevation changing is rare and does need a new
-    /// reach, so it should invalidate the layout that recorded the old one.
+    /// Read tracked, because a *declared* elevation changing genuinely needs a
+    /// new reach — which is also the cost to know about: `.elevation(move || if
+    /// hovered.get() { 8.0 } else { 0.0 })` re-lays-out the subtree on every
+    /// enter and leave, since the maximum really does change.
+    ///
+    /// `.elevation(0.0).when_hovered(|s| s.elevation(8.0))` says the same thing
+    /// and costs no layout at all: the maximum is 8 either way, so hovering
+    /// moves only the animation and the paint. That is the idiom to reach for,
+    /// and the reason this reads the maximum rather than the current value.
     ///
     /// An animated elevation is allowed past its target — a spring overshoots by
     /// design, `BOUNCY` by about 17% — so the largest *declared* value is not the
@@ -317,10 +324,25 @@ impl Container {
     }
 
     pub(super) fn animated_elevation(&self, id: WidgetId) -> f32 {
-        get_animated_value(
+        let level = get_animated_value(
             self.anims.as_ref().and_then(|a| a.elevation.as_ref()),
             || self.effective_elevation_target(id),
-        )
+        );
+
+        // Clamped to the reach the layout recorded, because a spring's step
+        // response is not its bound: `retarget` restarts it carrying the velocity
+        // it had, so a hover reversed mid-flight peaks past `peak_overshoot`,
+        // which is measured from rest — and the shadow ring at that peak would
+        // fall outside the damage rect, which is the artefact the reach exists to
+        // prevent. The cut is at the tip of an overshoot the reach already allows
+        // in full, and a bound nothing enforces is not a bound — see
+        // `a_spring_given_velocity_overshoots_more_than_one_at_rest`, which is
+        // where the premise is measured: at a carried velocity of 16 a BOUNCY
+        // spring peaks half again as far as its step response reports.
+        match self.anims.as_ref().and_then(|a| a.elevation.as_ref()) {
+            Some(_) => level.min(self.max_elevation()),
+            None => level,
+        }
     }
 
     pub(super) fn animated_transform(&self, id: WidgetId) -> Transform {
@@ -393,7 +415,14 @@ impl Container {
         let shadow = elevation_to_shadow(d.elevation);
         let shadow = (shadow.color.a > SHADOW_ALPHA_FLOOR).then_some(shadow);
 
-        if let Some(ref gradient) = d.gradient {
+        // Gated like the fill, the border and the shadow: a gradient between two
+        // fully transparent colours draws nothing, and with both endpoints
+        // reactive one animating out through transparent would push a rect per
+        // frame to do it. One end still visible is still a gradient.
+        let gradient = d
+            .gradient
+            .filter(|g| g.start_color.a > 0.0 || g.end_color.a > 0.0);
+        if let Some(ref gradient) = gradient {
             ctx.draw_rounded_rect_full(
                 bounds,
                 gradient.start_color,

--- a/src/widgets/container/style.rs
+++ b/src/widgets/container/style.rs
@@ -346,38 +346,51 @@ impl Container {
     /// `bounds` is local — the origin is the container itself, and the parent
     /// has already positioned the node.
     pub(super) fn paint_decoration(&self, ctx: &mut PaintContext, bounds: Rect, d: &Decoration) {
-        // A gradient replaces the solid fill rather than layering over it.
+        // A gradient replaces the solid fill rather than layering over it —
+        // but not the shadow, which belongs to the box rather than to the
+        // fill. Both are reactive, so which of the two branches a container
+        // takes can change between frames; a gradient that dropped the shadow
+        // meant an elevation animation stopped drawing halfway through while
+        // still asking for a frame at every step.
+        let shadow = (d.elevation > 0.0).then(|| elevation_to_shadow(d.elevation));
+
         if let Some(ref gradient) = d.gradient {
-            ctx.draw_gradient_rect(
+            ctx.draw_rounded_rect_full(
                 bounds,
-                crate::renderer::Gradient {
+                gradient.start_color,
+                d.corner_radii,
+                d.corner_curvature,
+                None,
+                shadow,
+                Some(crate::renderer::Gradient {
                     start_color: gradient.start_color,
                     end_color: gradient.end_color,
                     direction: gradient.direction.into(),
-                },
-                d.corner_radii,
-                d.corner_curvature,
+                }),
             );
         } else if d.background.a > 0.0 {
-            if d.elevation > 0.0 {
-                ctx.draw_rounded_rect_with_shadow(
+            match shadow {
+                Some(shadow) => ctx.draw_rounded_rect_with_shadow(
                     bounds,
                     d.background,
                     d.corner_radii,
                     d.corner_curvature,
-                    elevation_to_shadow(d.elevation),
-                );
-            } else {
-                ctx.draw_rounded_rect_with_curvature(
+                    shadow,
+                ),
+                None => ctx.draw_rounded_rect_with_curvature(
                     bounds,
                     d.background,
                     d.corner_radii,
                     d.corner_curvature,
-                );
+                ),
             }
         }
 
-        if d.border_width > 0.0 {
+        // A width with no colour behind it is an invisible frame, and one
+        // reaches the instance buffer every frame if it is not stopped here.
+        // `border_width(2.0)` on its own is newly spellable, and the default
+        // colour is transparent.
+        if d.border_width > 0.0 && d.border_color.a > 0.0 {
             ctx.draw_border_frame_with_curvature(
                 bounds,
                 d.border_color,
@@ -389,28 +402,52 @@ impl Container {
     }
 }
 
+/// The tabulated Material steps, `level => (offset_y, blur, alpha)`.
+///
+/// Level 0 is in the table so the interpolation below has somewhere to come
+/// from, and the last entry meets the formula that continues past it exactly:
+/// at 5, `level * 1.2`, `level * 2.0` and `0.12 + level * 0.02` are 6.0, 10.0
+/// and 0.22.
+const ELEVATION_STEPS: [(f32, f32, f32); 6] = [
+    (0.0, 0.0, 0.0),
+    (1.0, 3.0, 0.12),
+    (2.0, 4.0, 0.16),
+    (3.0, 6.0, 0.19),
+    (4.0, 8.0, 0.20),
+    (6.0, 10.0, 0.22),
+];
+
 /// Convert an elevation level to the shadow that expresses it.
 ///
 /// Material-style: the higher the surface sits, the further the shadow falls
-/// and the softer it gets. Levels 1–5 are tabulated; above that the numbers
+/// and the softer it gets. Levels 0–5 are tabulated; above that the numbers
 /// keep growing on the same curve, up to a ceiling.
+///
+/// A fractional level interpolates between the two steps around it. Reading the
+/// table with `level as i32` was fine while elevation could not be animated —
+/// it always arrived as one of the six integers. Now that it can, truncation
+/// made the shadow a staircase between 1 and 5, and worse, discontinuous where
+/// the table met the formula: 0.999 fell through to the formula for
+/// (1.199, 1.998, 0.140) while 1.0 read the table for (1.0, 3.0, 0.12), so
+/// crossing 1 dropped the offset and the alpha while jumping the blur.
 pub(super) fn elevation_to_shadow(level: f32) -> Shadow {
     if level <= 0.0 {
         return Shadow::none();
     }
 
-    let (offset_y, blur, alpha) = match level as i32 {
-        1 => (1.0, 3.0, 0.12),
-        2 => (2.0, 4.0, 0.16),
-        3 => (3.0, 6.0, 0.19),
-        4 => (4.0, 8.0, 0.20),
-        5 => (6.0, 10.0, 0.22),
-        _ => {
-            let offset = (level * 1.2).min(12.0);
-            let blur = (level * 2.0).min(24.0);
-            let alpha = (0.12 + level * 0.02).min(0.25);
-            (offset, blur, alpha)
-        }
+    let last = (ELEVATION_STEPS.len() - 1) as f32;
+    let (offset_y, blur, alpha) = if level >= last {
+        (
+            (level * 1.2).min(12.0),
+            (level * 2.0).min(24.0),
+            (0.12 + level * 0.02).min(0.25),
+        )
+    } else {
+        let lower = level.floor();
+        let t = level - lower;
+        let (o0, b0, a0) = ELEVATION_STEPS[lower as usize];
+        let (o1, b1, a1) = ELEVATION_STEPS[lower as usize + 1];
+        (o0 + (o1 - o0) * t, b0 + (b1 - b0) * t, a0 + (a1 - a0) * t)
     };
 
     Shadow::new(
@@ -419,4 +456,72 @@ pub(super) fn elevation_to_shadow(level: f32) -> Shadow {
         0.0,
         Color::rgba(0.0, 0.0, 0.0, alpha),
     )
+}
+
+#[cfg(test)]
+mod elevation_tests {
+    use super::*;
+
+    fn parts(level: f32) -> (f32, f32, f32) {
+        let s = elevation_to_shadow(level);
+        (s.offset.1, s.blur, s.color.a)
+    }
+
+    /// Whole levels keep the Material numbers they always had, so a static
+    /// elevation looks exactly as it did.
+    #[test]
+    fn the_tabulated_levels_are_unchanged() {
+        assert_eq!(parts(1.0), (1.0, 3.0, 0.12));
+        assert_eq!(parts(2.0), (2.0, 4.0, 0.16));
+        assert_eq!(parts(3.0), (3.0, 6.0, 0.19));
+        assert_eq!(parts(4.0), (4.0, 8.0, 0.20));
+        assert_eq!(parts(5.0), (6.0, 10.0, 0.22));
+    }
+
+    /// An animated elevation sweeps through the fractions, so every component
+    /// has to grow without ever going backwards. Reading the table with
+    /// `level as i32` failed this twice over: flat between whole levels, and
+    /// non-monotonic across 1, where the formula's (1.199, 1.998, 0.140) met
+    /// the table's (1.0, 3.0, 0.12).
+    #[test]
+    fn a_fractional_level_never_goes_backwards() {
+        let mut previous = parts(0.001);
+        let mut moved = 0;
+        for step in 2..=8000 {
+            let level = step as f32 * 0.001;
+            let current = parts(level);
+            assert!(
+                current.0 >= previous.0 - 1e-4
+                    && current.1 >= previous.1 - 1e-4
+                    && current.2 >= previous.2 - 1e-4,
+                "level {level} went backwards: {previous:?} -> {current:?}"
+            );
+            if current != previous {
+                moved += 1;
+            }
+            previous = current;
+        }
+        assert!(
+            moved > 7000,
+            "the shadow has to actually move with the level, moved on {moved} of 7999 steps"
+        );
+    }
+
+    /// The table hands over to the formula without a step.
+    #[test]
+    fn the_table_meets_the_formula_at_five() {
+        let below = parts(5.0 - 1e-4);
+        let above = parts(5.0 + 1e-4);
+        assert!((below.0 - above.0).abs() < 1e-2);
+        assert!((below.1 - above.1).abs() < 1e-2);
+        assert!((below.2 - above.2).abs() < 1e-3);
+    }
+
+    /// Zero is no shadow at all, not a shadow of size zero with a colour.
+    #[test]
+    fn zero_is_no_shadow() {
+        let s = elevation_to_shadow(0.0);
+        assert_eq!(s.color, Color::TRANSPARENT);
+        assert_eq!(s.blur, 0.0);
+    }
 }

--- a/src/widgets/container/style.rs
+++ b/src/widgets/container/style.rs
@@ -144,17 +144,27 @@ impl Container {
     ///
     /// Read tracked: a *declared* elevation changing is rare and does need a new
     /// reach, so it should invalidate the layout that recorded the old one.
+    ///
+    /// An animated elevation is allowed past its target — a spring overshoots by
+    /// design, `BOUNCY` by about 17% — so the largest *declared* value is not the
+    /// largest *drawn* one, and the peak is where the shadow ring would fall
+    /// outside the damage rect. The curve says how far it goes.
     pub(super) fn max_elevation(&self) -> f32 {
         let base = self.elevation.get_or(0.0);
-        let Some(ref ix) = self.interaction else {
-            return base;
+        let declared = match self.interaction {
+            Some(ref ix) => ix.states.iter().fold(base, |most, (_, state)| {
+                match state.elevation.map(|s| s.get()) {
+                    Some(level) => most.max(level),
+                    None => most,
+                }
+            }),
+            None => base,
         };
-        ix.states.iter().fold(base, |most, (_, state)| {
-            match state.elevation.map(|s| s.get()) {
-                Some(level) => most.max(level),
-                None => most,
-            }
-        })
+
+        match self.anims.as_ref().and_then(|a| a.elevation.as_ref()) {
+            Some(anim) => declared * (1.0 + anim.peak_overshoot()),
+            None => declared,
+        }
     }
 
     pub(super) fn effective_elevation_target(&self, id: WidgetId) -> f32 {
@@ -410,10 +420,11 @@ impl Container {
             }
         }
 
-        // A width with no colour behind it is an invisible frame, and one
-        // reaches the instance buffer every frame if it is not stopped here.
-        // `border_width(2.0)` on its own is newly spellable, and the default
-        // colour is transparent.
+        // A border that resolves to nothing visible must not reach the instance
+        // buffer every frame. Both halves are always declared together, so this
+        // is only reached deliberately — `border(2.0, TRANSPARENT)`,
+        // `border(0.0, RED)` — or in passing, while an animated colour crosses
+        // transparent.
         if d.border_width > 0.0 && d.border_color.a > 0.0 {
             ctx.draw_border_frame_with_curvature(
                 bounds,

--- a/src/widgets/container/style.rs
+++ b/src/widgets/container/style.rs
@@ -99,12 +99,12 @@ impl Container {
 
     pub(super) fn effective_border_width_target(&self, id: WidgetId) -> f32 {
         let base = self.border_width.get_or(0.0);
-        self.resolve_state_value(id, base, |state| state.border_width.map(|s| s.get()))
+        self.resolve_state_value(id, base, |state| state.border.map(|b| b.width.get()))
     }
 
     pub(super) fn effective_border_color_target(&self, id: WidgetId) -> Color {
         let base = self.border_color.get_or(Color::TRANSPARENT);
-        self.resolve_state_value(id, base, |state| state.border_color.map(|s| s.get()))
+        self.resolve_state_value(id, base, |state| state.border.map(|b| b.color.get()))
     }
 
     pub(super) fn effective_corner_radius_target(&self, id: WidgetId) -> f32 {

--- a/src/widgets/container/style.rs
+++ b/src/widgets/container/style.rs
@@ -133,8 +133,7 @@ impl Container {
         self.resolve_state_value(id, base, |state| state.text_color.map(|s| s.get()))
     }
 
-    /// Elevation is never animated, so the target *is* the drawn value.
-    pub(super) fn effective_elevation(&self, id: WidgetId) -> f32 {
+    pub(super) fn effective_elevation_target(&self, id: WidgetId) -> f32 {
         let base = self.elevation.get_or(0.0);
         self.resolve_state_value(id, base, |state| state.elevation.map(|s| s.get()))
     }
@@ -283,6 +282,13 @@ impl Container {
         )
     }
 
+    pub(super) fn animated_elevation(&self, id: WidgetId) -> f32 {
+        get_animated_value(
+            self.anims.as_ref().and_then(|a| a.elevation.as_ref()),
+            || self.effective_elevation_target(id),
+        )
+    }
+
     pub(super) fn animated_transform(&self, id: WidgetId) -> Transform {
         get_animated_value(
             self.anims.as_ref().and_then(|a| a.transform.as_ref()),
@@ -297,6 +303,7 @@ impl Container {
         self.anims.as_ref().is_some_and(|a| {
             a.background.is_some()
                 || a.corner_radius.is_some()
+                || a.elevation.is_some()
                 || a.border_color.is_some()
                 || a.transform.is_some()
                 || a.text_color.is_some()
@@ -313,6 +320,7 @@ impl Container {
                 || a.border_width.is_some()
                 || a.background.is_some()
                 || a.corner_radius.is_some()
+                || a.elevation.is_some()
                 || a.border_color.is_some()
                 || a.transform.is_some()
                 || a.text_color.is_some()
@@ -323,6 +331,7 @@ impl Container {
 /// The container's own surface, resolved for one frame.
 pub(super) struct Decoration {
     pub background: Color,
+    pub gradient: Option<LinearGradient>,
     pub corner_radii: crate::renderer::CornerRadii,
     pub corner_curvature: f32,
     pub elevation: f32,
@@ -338,7 +347,7 @@ impl Container {
     /// has already positioned the node.
     pub(super) fn paint_decoration(&self, ctx: &mut PaintContext, bounds: Rect, d: &Decoration) {
         // A gradient replaces the solid fill rather than layering over it.
-        if let Some(ref gradient) = self.gradient {
+        if let Some(ref gradient) = d.gradient {
             ctx.draw_gradient_rect(
                 bounds,
                 crate::renderer::Gradient {

--- a/src/widgets/container/style.rs
+++ b/src/widgets/container/style.rs
@@ -502,8 +502,15 @@ mod elevation_tests {
         (s.offset.1, s.blur, s.color.a)
     }
 
-    /// Whole levels keep the Material numbers they always had, so a static
-    /// elevation looks exactly as it did.
+    /// Whole levels keep the Material numbers they always had, which is every
+    /// elevation the examples and snapshots use.
+    ///
+    /// A *fractional* static elevation does move: `0.5` now interpolates from
+    /// nothing towards level 1 rather than falling through to the formula, so
+    /// its shadow is lighter and tighter than before. That is the point of
+    /// interpolating, and it is what makes an animation pass through the
+    /// fractions smoothly, but it is a change and this says so rather than
+    /// claiming nothing moved.
     #[test]
     fn the_tabulated_levels_are_unchanged() {
         assert_eq!(parts(1.0), (1.0, 3.0, 0.12));

--- a/src/widgets/container/style.rs
+++ b/src/widgets/container/style.rs
@@ -133,6 +133,30 @@ impl Container {
         self.resolve_state_value(id, base, |state| state.text_color.map(|s| s.get()))
     }
 
+    /// The largest elevation this container can reach: its own, or any a state
+    /// layer declares.
+    ///
+    /// Damage bounds want the worst case, not the current value. Elevation is a
+    /// paint-only animation, so a hover that lifts a card never re-runs layout —
+    /// and layout is where the shadow's reach is recorded. Sizing the reach to
+    /// what is possible rather than to what is showing keeps the damage rect
+    /// correct without asking a colour change to re-run a layout.
+    ///
+    /// Read tracked: a *declared* elevation changing is rare and does need a new
+    /// reach, so it should invalidate the layout that recorded the old one.
+    pub(super) fn max_elevation(&self) -> f32 {
+        let base = self.elevation.get_or(0.0);
+        let Some(ref ix) = self.interaction else {
+            return base;
+        };
+        ix.states.iter().fold(base, |most, (_, state)| {
+            match state.elevation.map(|s| s.get()) {
+                Some(level) => most.max(level),
+                None => most,
+            }
+        })
+    }
+
     pub(super) fn effective_elevation_target(&self, id: WidgetId) -> f32 {
         let base = self.elevation.get_or(0.0);
         self.resolve_state_value(id, base, |state| state.elevation.map(|s| s.get()))

--- a/src/widgets/container/style.rs
+++ b/src/widgets/container/style.rs
@@ -365,11 +365,18 @@ impl Container {
     /// Whether a state-layer change can move an animated property — i.e.
     /// whether hovering or pressing needs an Animation job rather than a plain
     /// repaint.
+    ///
+    /// `border_width` belongs here now that a state layer's border is declared
+    /// as a pair: `when_hovered(|s| s.border(14.0, GREEN))` moves the width as
+    /// well as the colour, and without it the enter queued no Animation job at
+    /// all. The spring then started a frame late, and only if something else had
+    /// forced that paint.
     pub(super) fn has_animated_state_properties(&self) -> bool {
         self.anims.as_ref().is_some_and(|a| {
             a.background.is_some()
                 || a.corner_radius.is_some()
                 || a.elevation.is_some()
+                || a.border_width.is_some()
                 || a.border_color.is_some()
                 || a.transform.is_some()
                 || a.text_color.is_some()

--- a/src/widgets/container/style.rs
+++ b/src/widgets/container/style.rs
@@ -386,7 +386,12 @@ impl Container {
         // takes can change between frames; a gradient that dropped the shadow
         // meant an elevation animation stopped drawing halfway through while
         // still asking for a frame at every step.
-        let shadow = (d.elevation > 0.0).then(|| elevation_to_shadow(d.elevation));
+        // Not `elevation > 0.0`: the first frames of a lift are at ~0.001, where
+        // the shadow's alpha rounds to nothing and every frame would still push a
+        // rect carrying it. The same gate the border gets, on the thing that is
+        // actually drawn rather than on the level that asked for it.
+        let shadow = elevation_to_shadow(d.elevation);
+        let shadow = (shadow.color.a > SHADOW_ALPHA_FLOOR).then_some(shadow);
 
         if let Some(ref gradient) = d.gradient {
             ctx.draw_rounded_rect_full(
@@ -436,6 +441,11 @@ impl Container {
         }
     }
 }
+
+/// Below this the shadow is not a faint shadow, it is nothing — and a rect
+/// carrying it is a rect drawn for no reason, once per frame for as long as an
+/// elevation animation is leaving zero.
+const SHADOW_ALPHA_FLOOR: f32 = 0.004;
 
 /// The tabulated Material steps, `level => (offset_y, blur, alpha)`.
 ///

--- a/src/widgets/container/style.rs
+++ b/src/widgets/container/style.rs
@@ -419,12 +419,19 @@ impl Container {
     /// `bounds` is local — the origin is the container itself, and the parent
     /// has already positioned the node.
     pub(super) fn paint_decoration(&self, ctx: &mut PaintContext, bounds: Rect, d: &Decoration) {
-        // A gradient replaces the solid fill rather than layering over it —
-        // but not the shadow, which belongs to the box rather than to the
-        // fill. Both are reactive, so which of the two branches a container
-        // takes can change between frames; a gradient that dropped the shadow
-        // meant an elevation animation stopped drawing halfway through while
-        // still asking for a frame at every step.
+        // A gradient replaces the solid fill rather than layering over it — but
+        // not the shadow, which belongs to the box rather than to either fill.
+        // Both are reactive, so which of the two branches a container takes can
+        // change between frames; a gradient that dropped the shadow meant an
+        // elevation animation stopped drawing halfway through while still asking
+        // for a frame at every step.
+        //
+        // To the box *it draws*, though: the shadow rides whichever fill runs,
+        // so a container with neither — no gradient, and a background that is
+        // transparent or has animated out — casts none, and `paint_overflow`
+        // goes on reserving the room. A shadow with nothing above it is a smear
+        // rather than a lift, so that is the behaviour; it is not a
+        // free-standing command waiting for a box to belong to.
         // Not `elevation > 0.0`: the first frames of a lift are at ~0.001, where
         // the shadow's alpha rounds to nothing and every frame would still push a
         // rect carrying it. The same gate the border gets, on the thing that is
@@ -521,8 +528,15 @@ const ELEVATION_STEPS: [(f32, f32, f32); 6] = [
 /// the table met the formula: 0.999 fell through to the formula for
 /// (1.199, 1.998, 0.140) while 1.0 read the table for (1.0, 3.0, 0.12), so
 /// crossing 1 dropped the offset and the alpha while jumping the blur.
+///
+/// A level that is not a number is no shadow. `.elevation(f32::NAN)` is
+/// writable, and NaN fails every comparison on the way in, so it reached the
+/// interpolating branch and came back out as a NaN extent — into
+/// `set_paint_overflow`, where it disables every `min` and `max` downstream
+/// without anything failing. The same guard `SpringConfig::peak_overshoot` has,
+/// for the same reason: a number that sizes a rect has to be one.
 pub(super) fn elevation_to_shadow(level: f32) -> Shadow {
-    if level <= 0.0 {
+    if level.is_nan() || level <= 0.0 {
         return Shadow::none();
     }
 
@@ -613,6 +627,17 @@ mod elevation_tests {
         assert!((below.0 - above.0).abs() < 1e-2);
         assert!((below.1 - above.1).abs() < 1e-2);
         assert!((below.2 - above.2).abs() < 1e-3);
+    }
+
+    /// A level that is not a number is no shadow either. NaN fails every
+    /// comparison on the way in, so it used to reach the interpolating branch and
+    /// come back out as a NaN extent — into `set_paint_overflow`, where it
+    /// disables every `min` and `max` downstream without anything failing.
+    #[test]
+    fn a_level_that_is_not_a_number_is_no_shadow() {
+        let s = elevation_to_shadow(f32::NAN);
+        assert_eq!(s.color, Color::TRANSPARENT);
+        assert!(!s.extent().is_nan(), "and nothing downstream is poisoned");
     }
 
     /// Zero is no shadow at all, not a shadow of size zero with a colour.

--- a/src/widgets/container/style.rs
+++ b/src/widgets/container/style.rs
@@ -133,8 +133,8 @@ impl Container {
         self.resolve_state_value(id, base, |state| state.text_color.map(|s| s.get()))
     }
 
-    /// The largest elevation this container can reach: its own, or any a state
-    /// layer declares.
+    /// The largest elevation this container can reach, and the number its damage
+    /// rect is sized from.
     ///
     /// Damage bounds want the worst case, not the current value. Elevation is a
     /// paint-only animation, so a hover that lifts a card never re-runs layout —
@@ -142,22 +142,26 @@ impl Container {
     /// what is possible rather than to what is showing keeps the damage rect
     /// correct without asking a colour change to re-run a layout.
     ///
-    /// Read tracked, because a *declared* elevation changing genuinely needs a
-    /// new reach — which is also the cost to know about: `.elevation(move || if
-    /// hovered.get() { 8.0 } else { 0.0 })` re-lays-out the subtree on every
-    /// enter and leave, since the maximum really does change.
+    /// Three things can be showing, so all three are folded:
     ///
-    /// `.elevation(0.0).when_hovered(|s| s.elevation(8.0))` says the same thing
-    /// and costs no layout at all: the maximum is 8 either way, so hovering
-    /// moves only the animation and the paint. That is the idiom to reach for,
-    /// and the reason this reads the maximum rather than the current value.
+    /// - the declared elevation, and every state layer's,
+    /// - the overshoot, because a spring does not stop at its target,
+    /// - **and whatever is in flight**, because a *falling* elevation is drawn
+    ///   from a value the declarations no longer mention. `.elevation(move ||
+    ///   if lifted.get() { 8.0 } else { 0.0 })` re-runs this layout on the write
+    ///   that starts the descent, and at that instant the declared maximum is
+    ///   already 0 while the shadow on screen is still 8 deep.
     ///
-    /// An animated elevation is allowed past its target — a spring overshoots by
-    /// design, `BOUNCY` by about 17% — so the largest *declared* value is not the
-    /// largest *drawn* one, and the peak is where the shadow ring would fall
-    /// outside the damage rect. The curve says how far it goes.
+    /// The whole fold is read under layout tracking, which is the cost to know
+    /// about: every elevation *any* state layer declares is a layout dependency,
+    /// active or not, because the maximum genuinely moves when one of them
+    /// changes. `.elevation(0.0).when_hovered(|s| s.elevation(8.0))` — both
+    /// constants — subscribes to nothing and hovering moves only the paint;
+    /// `when_hovered(|s| s.elevation(lift))` with `lift` a signal re-lays out the
+    /// subtree whenever `lift` is written, pressed or not.
     pub(super) fn max_elevation(&self) -> f32 {
         let base = self.elevation.get_or(0.0);
+        let anim = self.anims.as_ref().and_then(|a| a.elevation.as_ref());
         let declared = match self.interaction {
             Some(ref ix) => ix.states.iter().fold(base, |most, (_, state)| {
                 match state.elevation.map(|s| s.get()) {
@@ -168,8 +172,10 @@ impl Container {
             None => base,
         };
 
-        match self.anims.as_ref().and_then(|a| a.elevation.as_ref()) {
-            Some(anim) => declared * (1.0 + anim.peak_overshoot()),
+        match anim {
+            // The value in flight is already past its overshoot, so it is folded
+            // in flat; the declarations have theirs still to come.
+            Some(anim) => (declared * (1.0 + anim.peak_overshoot())).max(*anim.current()),
             None => declared,
         }
     }
@@ -323,24 +329,28 @@ impl Container {
         )
     }
 
+    /// The elevation to draw, never deeper than the rect the layout reserved.
+    ///
+    /// Clamped, and clamped to [`elevation_reach`](super::Container::elevation_reach)
+    /// — the number `layout` recorded — rather than to a fresh
+    /// [`max_elevation`](Self::max_elevation). Recomputing it here reads the
+    /// signals at *paint* time, which is a different frame's answer: on a falling
+    /// elevation the declared maximum has already reached 0 and the shadow was
+    /// cut to nothing while the animation was still playing.
+    ///
+    /// A clamp at all, rather than a wider reach, because the reach that would
+    /// make one unnecessary is not a small one. A spring keeps its momentum
+    /// across a retarget, so hover flicker *pumps* it: driven at its damped
+    /// natural frequency the steady-state excursion is the resonant gain,
+    /// `1 / (2ζ√(1-ζ²))` — 1.03x the step response for `BOUNCY`, but 3.7x at
+    /// ζ = 0.05, and sizing every damage rect for that is not a trade worth
+    /// making for the tip of a bounce nobody asked for. See
+    /// `hover_flicker_cannot_push_a_shadow_outside_its_damage_rect`.
     pub(super) fn animated_elevation(&self, id: WidgetId) -> f32 {
-        let level = get_animated_value(
-            self.anims.as_ref().and_then(|a| a.elevation.as_ref()),
-            || self.effective_elevation_target(id),
-        );
-
-        // Clamped to the reach the layout recorded, because a spring's step
-        // response is not its bound: `retarget` restarts it carrying the velocity
-        // it had, so a hover reversed mid-flight peaks past `peak_overshoot`,
-        // which is measured from rest — and the shadow ring at that peak would
-        // fall outside the damage rect, which is the artefact the reach exists to
-        // prevent. The cut is at the tip of an overshoot the reach already allows
-        // in full, and a bound nothing enforces is not a bound — see
-        // `a_spring_given_velocity_overshoots_more_than_one_at_rest`, which is
-        // where the premise is measured: at a carried velocity of 16 a BOUNCY
-        // spring peaks half again as far as its step response reports.
-        match self.anims.as_ref().and_then(|a| a.elevation.as_ref()) {
-            Some(_) => level.min(self.max_elevation()),
+        let anim = self.anims.as_ref().and_then(|a| a.elevation.as_ref());
+        let level = get_animated_value(anim, || self.effective_elevation_target(id));
+        match anim {
+            Some(_) => level.min(self.elevation_reach.get()),
             None => level,
         }
     }

--- a/src/widgets/diagnostic_audit.rs
+++ b/src/widgets/diagnostic_audit.rs
@@ -26,7 +26,7 @@ use crate::reactive::diagnostics::report_count;
 use crate::renderer::{PaintContext, RenderNode};
 use crate::tree::Tree;
 use crate::widgets::widget::{Event, Key, Modifiers, MouseButton, ScrollSource};
-use crate::widgets::{Color, ImageSource, ScrollAxis};
+use crate::widgets::{Color, ImageSource, LinearGradient, Overflow, ScrollAxis};
 use crate::widgets::{
     InputStyled, Stateful, TextStyled, Widget, container, image, text, text_input,
 };
@@ -137,10 +137,25 @@ fn a_fully_reactive_container_is_quiet() {
         .height(move || n.get() + 100.0)
         .visible(move || !flag.get())
         .rotate(move || n.get())
+        .gradient(move || {
+            LinearGradient::horizontal(
+                if flag.get() { Color::RED } else { Color::BLUE },
+                Color::WHITE,
+            )
+        })
+        .backdrop_blur(move || n.get() + 8.0)
+        .overflow(move || {
+            if flag.get() {
+                Overflow::Hidden
+            } else {
+                Overflow::Visible
+            }
+        })
         .animate_background(t())
         .animate_border_width(t())
         .animate_border_color(t())
         .animate_corner_radius(t())
+        .animate_elevation(t())
         .animate_padding(t())
         .animate_width(t())
         .animate_height(t())

--- a/src/widgets/diagnostic_audit.rs
+++ b/src/widgets/diagnostic_audit.rs
@@ -138,10 +138,10 @@ fn a_fully_reactive_container_is_quiet() {
         .visible(move || !flag.get())
         .rotate(move || n.get())
         .gradient(move || {
-            LinearGradient::horizontal(
+            Some(LinearGradient::horizontal(
                 if flag.get() { Color::RED } else { Color::BLUE },
                 Color::WHITE,
-            )
+            ))
         })
         .backdrop_blur(move || n.get() + 8.0)
         .overflow(move || {

--- a/src/widgets/into_child.rs
+++ b/src/widgets/into_child.rs
@@ -273,7 +273,7 @@ pub struct KeyedChildren<T, I, K, W> {
 /// read via signals inside the row for in-place updates, fields included
 /// trigger a row rebuild when they change.
 ///
-/// The key is any `Hash + Eq + Clone + Debug`, so an identity that is already a string
+/// The key is any `Hash + Eq + Clone`, so an identity that is already a string
 /// or a tuple can be used as it is rather than hashed by hand at the call site.
 /// Rows are indexed by the key itself, not by a hash of it, so two distinct keys
 /// are never reconciled as one:
@@ -299,7 +299,7 @@ pub fn keyed<T, I, K, W>(
 where
     T: Clone + PartialEq + 'static,
     I: IntoIterator<Item = T>,
-    K: Hash + Eq + Clone + std::fmt::Debug + 'static,
+    K: Hash + Eq + Clone + 'static,
     W: Widget + 'static,
 {
     KeyedChildren {
@@ -313,7 +313,7 @@ impl<T, I, K, W> IntoChildren<DynamicChildren> for KeyedChildren<T, I, K, W>
 where
     T: Clone + PartialEq + 'static,
     I: IntoIterator<Item = T> + 'static,
-    K: Hash + Eq + Clone + std::fmt::Debug + 'static,
+    K: Hash + Eq + Clone + 'static,
     W: Widget + 'static,
 {
     fn add_to_container(self, children_source: &mut ChildrenSource) {
@@ -332,7 +332,7 @@ fn add_keyed_children<T, I, K, W>(
 ) where
     T: Clone + PartialEq + 'static,
     I: IntoIterator<Item = T>,
-    K: Hash + Eq + Clone + std::fmt::Debug + 'static,
+    K: Hash + Eq + Clone + 'static,
     W: Widget + 'static,
 {
     struct Row<T> {
@@ -378,19 +378,21 @@ fn add_keyed_children<T, I, K, W>(
         let mut out = Vec::new();
         for (index, item) in items.into_iter().enumerate() {
             let key = key_fn(&item);
-            if seen.contains(&key) {
-                // The key, not just the position: for a list built from a
-                // filtered or sorted source the index is the index of nothing
-                // the caller can see, while the identity that collided — a
-                // workspace name, a tab title — is the whole content of the
-                // warning. `Debug` on the key costs nothing for the types this
-                // signature invites.
-                log::warn!("keyed children: duplicate key {key:?} at index {index}, skipping item");
+            // One lookup rather than a `contains` and then an `insert`: this runs
+            // per row per pass, and the clone a fresh row would have paid anyway
+            // is paid once here instead.
+            if !seen.insert(key.clone()) {
+                // Without the key's value: `Debug` would be a bound the mechanism
+                // does not need, and it would keep an opaque newtype out of
+                // `keyed` in order to format a log line. The type and the
+                // position are what can be said for nothing.
+                log::warn!(
+                    "keyed children: duplicate {} key at index {index}, skipping item",
+                    std::any::type_name::<K>()
+                );
                 continue;
             }
 
-            // The key is cloned only where a row is created — a reordered or
-            // unchanged list clones nothing.
             let generation = match st.rows.get(&key) {
                 Some(row) if row.item == item => row.generation,
                 _ => {
@@ -406,7 +408,6 @@ fn add_keyed_children<T, I, K, W>(
                     generation
                 }
             };
-            seen.insert(key);
 
             let adopt_state = Rc::clone(&state);
             out.push(DynItem::new(generation, move || {
@@ -459,7 +460,8 @@ mod tests {
     fn colliding_keys_are_still_distinct_rows() {
         /// A key whose hash is deliberately useless, standing in for the
         /// collision a real hash makes merely unlikely.
-        #[derive(Clone, Debug, PartialEq, Eq)]
+        // Deliberately not Debug: the key bound must not require it.
+        #[derive(Clone, PartialEq, Eq)]
         struct Collides(&'static str);
 
         impl std::hash::Hash for Collides {

--- a/src/widgets/into_child.rs
+++ b/src/widgets/into_child.rs
@@ -381,28 +381,28 @@ fn add_keyed_children<T, I, K, W>(
         let mut out = Vec::new();
         for (index, item) in items.into_iter().enumerate() {
             let key = key_fn(&item);
-            // Vacant-only, not `insert`: `insert` replaces, so with duplicates at
-            // 0, 2 and 5 the third would be reported against item 2 — which was
-            // itself skipped and is not in the list the reader is being sent to.
-            // The first sighting is the one still on screen.
-            match seen.entry(key.clone()) {
-                std::collections::hash_map::Entry::Occupied(first) => {
-                    // Without the key's value: `Debug` would be a bound the
-                    // mechanism does not need, and it would keep an opaque
-                    // newtype out of `keyed` in order to format a log line. Both
-                    // indices instead — the type alone names nothing, but the
-                    // pair of rows that collided is enough to go and look at
-                    // them.
-                    log::warn!(
-                        "keyed children: item {index} repeats the {} key of item {}, skipping it",
-                        std::any::type_name::<K>(),
-                        first.get()
-                    );
-                    continue;
-                }
-                std::collections::hash_map::Entry::Vacant(slot) => {
-                    slot.insert(index);
-                }
+            // Looked up now and recorded at the end of the row, rather than
+            // through `entry`: `entry` takes the key by value, so it would clone
+            // every key on every pass — a heap allocation per row for the string
+            // keys this signature invites, on a list that has settled and is
+            // building nothing. This way only a row that is actually created
+            // clones, and a second hash of a key already in cache is the cheaper
+            // half of that trade.
+            //
+            // The first sighting, not the previous one: reporting against the
+            // previous would, with duplicates at 0, 2 and 5, send the reader to
+            // item 2 — which was itself skipped and is not in the list.
+            if let Some(first) = seen.get(&key) {
+                // Without the key's value: `Debug` would be a bound the mechanism
+                // does not need, and it would keep an opaque newtype out of
+                // `keyed` in order to format a log line. Both indices instead —
+                // the type alone names nothing, but the pair of rows that
+                // collided is enough to go and look at them.
+                log::warn!(
+                    "keyed children: item {index} repeats the {} key of item {first}, skipping it",
+                    std::any::type_name::<K>(),
+                );
+                continue;
             }
 
             let generation = match st.rows.get(&key) {
@@ -420,6 +420,10 @@ fn add_keyed_children<T, I, K, W>(
                     generation
                 }
             };
+
+            // Recorded once the row is dealt with, moving the key rather than
+            // cloning it — nothing below needs it again.
+            seen.insert(key, index);
 
             let adopt_state = Rc::clone(&state);
             out.push(DynItem::new(generation, move || {

--- a/src/widgets/into_child.rs
+++ b/src/widgets/into_child.rs
@@ -26,6 +26,7 @@
 
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::hash::{BuildHasher, Hash};
 use std::rc::Rc;
 
 use crate::reactive::invalidation::suspend_widget_tracking;
@@ -254,6 +255,11 @@ pub struct KeyedChildren<T, I, W> {
     build: Box<dyn Fn(T) -> W>,
 }
 
+/// Reduce a key of any hashable type to the u64 the reconciler indexes by.
+fn key_hash<K: Hash>(key: &K) -> u64 {
+    rustc_hash::FxBuildHasher.hash_one(key)
+}
+
 /// Reactive keyed children list: tracked data, key-based identity,
 /// untracked per-item builder with content diffing.
 ///
@@ -272,26 +278,36 @@ pub struct KeyedChildren<T, I, W> {
 /// read via signals inside the row for in-place updates, fields included
 /// trigger a row rebuild when they change.
 ///
+/// The key is anything hashable, so an identity that is already a string or a
+/// tuple does not have to be hashed by hand at the call site:
+///
 /// ```ignore
 /// container().children(keyed(
 ///     move || workspaces.get(),
 ///     |ws| ws.id,
 ///     workspace_pill,
 /// ))
+///
+/// container().children(keyed(
+///     move || tabs.get(),
+///     |tab| tab.title.clone(),
+///     tab_button,
+/// ))
 /// ```
-pub fn keyed<T, I, W>(
+pub fn keyed<T, I, K, W>(
     data: impl Fn() -> I + 'static,
-    key: impl Fn(&T) -> u64 + 'static,
+    key: impl Fn(&T) -> K + 'static,
     build: impl Fn(T) -> W + 'static,
 ) -> KeyedChildren<T, I, W>
 where
     T: Clone + PartialEq + 'static,
     I: IntoIterator<Item = T>,
+    K: Hash,
     W: Widget + 'static,
 {
     KeyedChildren {
         data: Box::new(data),
-        key: Box::new(key),
+        key: Box::new(move |item| key_hash(&key(item))),
         build: Box::new(build),
     }
 }

--- a/src/widgets/into_child.rs
+++ b/src/widgets/into_child.rs
@@ -381,20 +381,28 @@ fn add_keyed_children<T, I, K, W>(
         let mut out = Vec::new();
         for (index, item) in items.into_iter().enumerate() {
             let key = key_fn(&item);
-            // One lookup rather than a `contains` and then an `insert`: this runs
-            // per row per pass, and the clone a fresh row would have paid anyway
-            // is paid once here instead.
-            if let Some(first) = seen.insert(key.clone(), index) {
-                // Without the key's value: `Debug` would be a bound the mechanism
-                // does not need, and it would keep an opaque newtype out of
-                // `keyed` in order to format a log line. Both indices instead —
-                // the type alone names nothing, but the pair of rows that
-                // collided is enough to go and look at them.
-                log::warn!(
-                    "keyed children: item {index} repeats the {} key of item {first}, skipping it",
-                    std::any::type_name::<K>()
-                );
-                continue;
+            // Vacant-only, not `insert`: `insert` replaces, so with duplicates at
+            // 0, 2 and 5 the third would be reported against item 2 — which was
+            // itself skipped and is not in the list the reader is being sent to.
+            // The first sighting is the one still on screen.
+            match seen.entry(key.clone()) {
+                std::collections::hash_map::Entry::Occupied(first) => {
+                    // Without the key's value: `Debug` would be a bound the
+                    // mechanism does not need, and it would keep an opaque
+                    // newtype out of `keyed` in order to format a log line. Both
+                    // indices instead — the type alone names nothing, but the
+                    // pair of rows that collided is enough to go and look at
+                    // them.
+                    log::warn!(
+                        "keyed children: item {index} repeats the {} key of item {}, skipping it",
+                        std::any::type_name::<K>(),
+                        first.get()
+                    );
+                    continue;
+                }
+                std::collections::hash_map::Entry::Vacant(slot) => {
+                    slot.insert(index);
+                }
             }
 
             let generation = match st.rows.get(&key) {
@@ -700,14 +708,17 @@ mod tests {
     fn keyed_children_skip_duplicate_keys() {
         let (mut tree, mut source) = children_host();
 
+        // Three of them, so the report has a choice to get wrong: the second and
+        // the third are both told about the *first*, which is the row still on
+        // screen — not about each other, one of which was itself skipped.
         keyed(
-            move || vec![(7u64, "x"), (7, "y")],
+            move || vec![(7u64, "x"), (1, "a"), (7, "y"), (7, "z")],
             |(id, _)| *id,
             |_| TestWidget,
         )
         .add_to_container(&mut source);
 
         // Only the first item with a given key is rendered
-        assert_eq!(source.reconcile_and_get(&mut tree).len(), 1);
+        assert_eq!(source.reconcile_and_get(&mut tree).len(), 2);
     }
 }

--- a/src/widgets/into_child.rs
+++ b/src/widgets/into_child.rs
@@ -26,7 +26,7 @@
 
 use std::cell::RefCell;
 use std::collections::HashMap;
-use std::hash::{BuildHasher, Hash};
+use std::hash::Hash;
 use std::rc::Rc;
 
 use crate::reactive::invalidation::suspend_widget_tracking;
@@ -249,15 +249,10 @@ where
 /// A reactive keyed children list: tracked data, key-based identity,
 /// untracked per-item builder. Built with [`keyed()`], consumed by
 /// `.children()`.
-pub struct KeyedChildren<T, I, W> {
+pub struct KeyedChildren<T, I, K, W> {
     data: Box<dyn Fn() -> I>,
-    key: Box<dyn Fn(&T) -> u64>,
+    key: Box<dyn Fn(&T) -> K>,
     build: Box<dyn Fn(T) -> W>,
-}
-
-/// Reduce a key of any hashable type to the u64 the reconciler indexes by.
-fn key_hash<K: Hash>(key: &K) -> u64 {
-    rustc_hash::FxBuildHasher.hash_one(key)
 }
 
 /// Reactive keyed children list: tracked data, key-based identity,
@@ -278,8 +273,10 @@ fn key_hash<K: Hash>(key: &K) -> u64 {
 /// read via signals inside the row for in-place updates, fields included
 /// trigger a row rebuild when they change.
 ///
-/// The key is anything hashable, so an identity that is already a string or a
-/// tuple does not have to be hashed by hand at the call site:
+/// The key is any `Hash + Eq + Clone`, so an identity that is already a string
+/// or a tuple can be used as it is rather than hashed by hand at the call site.
+/// Rows are indexed by the key itself, not by a hash of it, so two distinct keys
+/// are never reconciled as one:
 ///
 /// ```ignore
 /// container().children(keyed(
@@ -298,24 +295,25 @@ pub fn keyed<T, I, K, W>(
     data: impl Fn() -> I + 'static,
     key: impl Fn(&T) -> K + 'static,
     build: impl Fn(T) -> W + 'static,
-) -> KeyedChildren<T, I, W>
+) -> KeyedChildren<T, I, K, W>
 where
     T: Clone + PartialEq + 'static,
     I: IntoIterator<Item = T>,
-    K: Hash,
+    K: Hash + Eq + Clone + 'static,
     W: Widget + 'static,
 {
     KeyedChildren {
         data: Box::new(data),
-        key: Box::new(move |item| key_hash(&key(item))),
+        key: Box::new(key),
         build: Box::new(build),
     }
 }
 
-impl<T, I, W> IntoChildren<DynamicChildren> for KeyedChildren<T, I, W>
+impl<T, I, K, W> IntoChildren<DynamicChildren> for KeyedChildren<T, I, K, W>
 where
     T: Clone + PartialEq + 'static,
     I: IntoIterator<Item = T> + 'static,
+    K: Hash + Eq + Clone + 'static,
     W: Widget + 'static,
 {
     fn add_to_container(self, children_source: &mut ChildrenSource) {
@@ -326,14 +324,15 @@ where
 /// Wire a (tracked data, key, untracked builder) triple into a
 /// ChildrenSource as a keyed dynamic list. See [`keyed()`] for the
 /// semantics.
-fn add_keyed_children<T, I, W>(
+fn add_keyed_children<T, I, K, W>(
     source: &mut ChildrenSource,
     data_fn: impl Fn() -> I + 'static,
-    key_fn: impl Fn(&T) -> u64 + 'static,
+    key_fn: impl Fn(&T) -> K + 'static,
     build_fn: impl Fn(T) -> W + 'static,
 ) where
     T: Clone + PartialEq + 'static,
     I: IntoIterator<Item = T>,
+    K: Hash + Eq + Clone + 'static,
     W: Widget + 'static,
 {
     struct Row<T> {
@@ -342,15 +341,20 @@ fn add_keyed_children<T, I, W>(
         /// content version), stable while the item compares equal.
         generation: u64,
     }
-    struct KeyedState<T> {
-        rows: HashMap<u64, Row<T>>,
+    /// Rows are indexed by the key itself, not by a hash of it. Reducing the
+    /// key to a u64 first would make two colliding keys the same row — one
+    /// widget serving two items and the other silently dropped — and no
+    /// non-cryptographic hash can rule that out for keys like strings and
+    /// tuples, which is exactly what this signature invites.
+    struct KeyedState<T, K> {
+        rows: HashMap<K, Row<T>>,
         next_generation: u64,
         /// Widgets built eagerly this pass, awaiting adoption by the
         /// reconciler's factory calls (keyed by generation).
         pending: HashMap<u64, (Box<dyn Widget>, OwnerId)>,
     }
 
-    let state = Rc::new(RefCell::new(KeyedState::<T> {
+    let state = Rc::new(RefCell::new(KeyedState::<T, K> {
         rows: HashMap::new(),
         next_generation: 0,
         pending: HashMap::new(),
@@ -368,13 +372,15 @@ fn add_keyed_children<T, I, W>(
 
         let mut seen = std::collections::HashSet::new();
         let mut out = Vec::new();
-        for item in items {
+        for (index, item) in items.into_iter().enumerate() {
             let key = key_fn(&item);
-            if !seen.insert(key) {
-                log::warn!("keyed children: duplicate key {key}, skipping item");
+            if seen.contains(&key) {
+                log::warn!("keyed children: duplicate key at index {index}, skipping item");
                 continue;
             }
 
+            // The key is cloned only where a row is created — a reordered or
+            // unchanged list clones nothing.
             let generation = match st.rows.get(&key) {
                 Some(row) if row.item == item => row.generation,
                 _ => {
@@ -386,10 +392,11 @@ fn add_keyed_children<T, I, W>(
                         })
                     });
                     st.pending.insert(generation, (widget, owner_id));
-                    st.rows.insert(key, Row { item, generation });
+                    st.rows.insert(key.clone(), Row { item, generation });
                     generation
                 }
             };
+            seen.insert(key);
 
             let adopt_state = Rc::clone(&state);
             out.push(DynItem::new(generation, move || {
@@ -433,6 +440,44 @@ mod tests {
         let mut source = ChildrenSource::default();
         source.set_container_id(parent);
         (tree, source)
+    }
+
+    /// Two keys that a 64-bit hash cannot tell apart must still be two rows.
+    /// While the reconciler indexed by `FxHash` of the key this collapsed them:
+    /// one widget served both items and the other was silently dropped.
+    #[test]
+    fn colliding_keys_are_still_distinct_rows() {
+        /// A key whose hash is deliberately useless, standing in for the
+        /// collision a real hash makes merely unlikely.
+        #[derive(Clone, PartialEq, Eq)]
+        struct Collides(&'static str);
+
+        impl std::hash::Hash for Collides {
+            fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+                0u8.hash(state);
+            }
+        }
+
+        let (mut tree, mut source) = children_host();
+        let items = create_signal(vec![Collides("a"), Collides("b")]);
+
+        IntoChildren::<DynamicChildren>::add_to_container(
+            keyed(
+                move || items.get(),
+                |c: &Collides| c.clone(),
+                |_| TestWidget,
+            ),
+            &mut source,
+        );
+
+        let ids = source.reconcile_and_get(&mut tree).clone();
+        assert_eq!(ids.len(), 2, "two keys, two widgets");
+
+        // And the identity survives a reorder: same widgets, swapped.
+        items.set(vec![Collides("b"), Collides("a")]);
+        source.reconcile_with_tracking(&mut tree);
+        let reordered = source.reconcile_and_get(&mut tree).clone();
+        assert_eq!(reordered, vec![ids[1], ids[0]]);
     }
 
     #[test]

--- a/src/widgets/into_child.rs
+++ b/src/widgets/into_child.rs
@@ -24,7 +24,7 @@
 //! For lists, [`keyed()`] preserves per-row state through stable identity
 //! and rebuilds only rows whose item content changed.
 
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashMap;
 use std::cell::RefCell;
 use std::hash::Hash;
 use std::rc::Rc;
@@ -374,20 +374,24 @@ fn add_keyed_children<T, I, K, W>(
             dispose_owner_now(owner_id);
         }
 
-        let mut seen = FxHashSet::default();
+        // Keyed by first sighting rather than a plain set: a duplicate is worth
+        // reporting *with the row it collided with*, and that is the one thing a
+        // set cannot say.
+        let mut seen = FxHashMap::default();
         let mut out = Vec::new();
         for (index, item) in items.into_iter().enumerate() {
             let key = key_fn(&item);
             // One lookup rather than a `contains` and then an `insert`: this runs
             // per row per pass, and the clone a fresh row would have paid anyway
             // is paid once here instead.
-            if !seen.insert(key.clone()) {
+            if let Some(first) = seen.insert(key.clone(), index) {
                 // Without the key's value: `Debug` would be a bound the mechanism
                 // does not need, and it would keep an opaque newtype out of
-                // `keyed` in order to format a log line. The type and the
-                // position are what can be said for nothing.
+                // `keyed` in order to format a log line. Both indices instead —
+                // the type alone names nothing, but the pair of rows that
+                // collided is enough to go and look at them.
                 log::warn!(
-                    "keyed children: duplicate {} key at index {index}, skipping item",
+                    "keyed children: item {index} repeats the {} key of item {first}, skipping it",
                     std::any::type_name::<K>()
                 );
                 continue;
@@ -419,7 +423,7 @@ fn add_keyed_children<T, I, K, W>(
                 OwnedWidget::new(widget, owner_id)
             }));
         }
-        st.rows.retain(|key, _| seen.contains(key));
+        st.rows.retain(|key, _| seen.contains_key(key));
         out
     };
 

--- a/src/widgets/into_child.rs
+++ b/src/widgets/into_child.rs
@@ -24,8 +24,8 @@
 //! For lists, [`keyed()`] preserves per-row state through stable identity
 //! and rebuilds only rows whose item content changed.
 
+use rustc_hash::{FxHashMap, FxHashSet};
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::hash::Hash;
 use std::rc::Rc;
 
@@ -194,12 +194,12 @@ where
             next_generation: u64,
             /// Rows built by the latest run, adopted by the reconciler's
             /// factory calls in the same pass.
-            pending: HashMap<u64, Box<dyn Widget>>,
+            pending: FxHashMap<u64, Box<dyn Widget>>,
         }
 
         let state = Rc::new(RefCell::new(State {
             next_generation: 0,
-            pending: HashMap::new(),
+            pending: FxHashMap::default(),
         }));
         let list_fn = Rc::new(self);
 
@@ -347,17 +347,21 @@ fn add_keyed_children<T, I, K, W>(
     /// non-cryptographic hash can rule that out for keys like strings and
     /// tuples, which is exactly what this signature invites.
     struct KeyedState<T, K> {
-        rows: HashMap<K, Row<T>>,
+        rows: FxHashMap<K, Row<T>>,
         next_generation: u64,
         /// Widgets built eagerly this pass, awaiting adoption by the
         /// reconciler's factory calls (keyed by generation).
-        pending: HashMap<u64, (Box<dyn Widget>, OwnerId)>,
+        pending: FxHashMap<u64, (Box<dyn Widget>, OwnerId)>,
     }
 
+    // Fx rather than the std hasher: this runs once per row per pass, on every
+    // frame a list changes, and widening the key from u64 to any Hash made a
+    // string key ordinary. These are the app's own identities, not adversarial
+    // input, which is the condition SipHash is there for.
     let state = Rc::new(RefCell::new(KeyedState::<T, K> {
-        rows: HashMap::new(),
+        rows: FxHashMap::default(),
         next_generation: 0,
-        pending: HashMap::new(),
+        pending: FxHashMap::default(),
     }));
 
     let items_fn = move || {
@@ -370,7 +374,7 @@ fn add_keyed_children<T, I, K, W>(
             dispose_owner_now(owner_id);
         }
 
-        let mut seen = std::collections::HashSet::new();
+        let mut seen = FxHashSet::default();
         let mut out = Vec::new();
         for (index, item) in items.into_iter().enumerate() {
             let key = key_fn(&item);

--- a/src/widgets/into_child.rs
+++ b/src/widgets/into_child.rs
@@ -273,7 +273,7 @@ pub struct KeyedChildren<T, I, K, W> {
 /// read via signals inside the row for in-place updates, fields included
 /// trigger a row rebuild when they change.
 ///
-/// The key is any `Hash + Eq + Clone`, so an identity that is already a string
+/// The key is any `Hash + Eq + Clone + Debug`, so an identity that is already a string
 /// or a tuple can be used as it is rather than hashed by hand at the call site.
 /// Rows are indexed by the key itself, not by a hash of it, so two distinct keys
 /// are never reconciled as one:
@@ -299,7 +299,7 @@ pub fn keyed<T, I, K, W>(
 where
     T: Clone + PartialEq + 'static,
     I: IntoIterator<Item = T>,
-    K: Hash + Eq + Clone + 'static,
+    K: Hash + Eq + Clone + std::fmt::Debug + 'static,
     W: Widget + 'static,
 {
     KeyedChildren {
@@ -313,7 +313,7 @@ impl<T, I, K, W> IntoChildren<DynamicChildren> for KeyedChildren<T, I, K, W>
 where
     T: Clone + PartialEq + 'static,
     I: IntoIterator<Item = T> + 'static,
-    K: Hash + Eq + Clone + 'static,
+    K: Hash + Eq + Clone + std::fmt::Debug + 'static,
     W: Widget + 'static,
 {
     fn add_to_container(self, children_source: &mut ChildrenSource) {
@@ -332,7 +332,7 @@ fn add_keyed_children<T, I, K, W>(
 ) where
     T: Clone + PartialEq + 'static,
     I: IntoIterator<Item = T>,
-    K: Hash + Eq + Clone + 'static,
+    K: Hash + Eq + Clone + std::fmt::Debug + 'static,
     W: Widget + 'static,
 {
     struct Row<T> {
@@ -375,7 +375,13 @@ fn add_keyed_children<T, I, K, W>(
         for (index, item) in items.into_iter().enumerate() {
             let key = key_fn(&item);
             if seen.contains(&key) {
-                log::warn!("keyed children: duplicate key at index {index}, skipping item");
+                // The key, not just the position: for a list built from a
+                // filtered or sorted source the index is the index of nothing
+                // the caller can see, while the identity that collided — a
+                // workspace name, a tab title — is the whole content of the
+                // warning. `Debug` on the key costs nothing for the types this
+                // signature invites.
+                log::warn!("keyed children: duplicate key {key:?} at index {index}, skipping item");
                 continue;
             }
 
@@ -449,7 +455,7 @@ mod tests {
     fn colliding_keys_are_still_distinct_rows() {
         /// A key whose hash is deliberately useless, standing in for the
         /// collision a real hash makes merely unlikely.
-        #[derive(Clone, PartialEq, Eq)]
+        #[derive(Clone, Debug, PartialEq, Eq)]
         struct Collides(&'static str);
 
         impl std::hash::Hash for Collides {

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -18,7 +18,9 @@ pub mod widget;
 
 pub use crate::renderer::CornerRadii;
 pub use children::ChildrenSource;
-pub use container::{Border, Container, GradientDirection, LinearGradient, Overflow, container};
+pub use container::{
+    Border, Container, GradientDirection, IntoClickHandler, LinearGradient, Overflow, container,
+};
 pub use control::Control;
 pub use font::{FontFamily, FontWeight};
 pub use image::{ContentFit, Image, ImageSource, image};

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -29,7 +29,9 @@ pub use into_child::{
     DynamicChildren, IntoChild, IntoChildren, IntoDynChild, KeyedChildren, StaticChildren, keyed,
 };
 pub use scroll::{ScrollAxis, ScrollbarBuilder, ScrollbarConfig, ScrollbarVisibility};
-pub use state_layer::{BackgroundOverride, RippleConfig, StateStyle, StateWhen, Stateful};
+pub use state_layer::{
+    BackgroundOverride, BorderOverride, RippleConfig, StateStyle, StateWhen, Stateful,
+};
 pub use text::{Text, text};
 pub use text_input::{Selection, TextInput, text_input};
 pub use text_style::{TextShadow, TextStroke, TextStyle, TextStyled};

--- a/src/widgets/paint_children.rs
+++ b/src/widgets/paint_children.rs
@@ -57,6 +57,9 @@ pub(crate) fn paint_children(
     opts: &ChildPaintOptions,
 ) {
     let (offset_x, offset_y) = opts.scroll_offset;
+    // A culled child never paints, so it cannot withdraw a compositor blur
+    // region of its own. Collected here and swept once at the end.
+    let mut culled: Vec<WidgetId> = Vec::new();
 
     for &child_id in children {
         // Child bounds come from the tree in the parent's local coordinates
@@ -73,6 +76,9 @@ pub(crate) fn paint_children(
             if !cull.intersects(&child_rect) {
                 crate::render_stats::record_paint_child_culled();
                 ctx.mark_partial();
+                if !crate::blur::is_empty() {
+                    culled.push(child_id);
+                }
                 continue;
             }
         }
@@ -109,6 +115,8 @@ pub(crate) fn paint_children(
         });
         crate::render_stats::record_paint_child_painted();
     }
+
+    crate::blur::unregister_culled(tree, &culled);
 }
 
 /// Try to satisfy a child from its paint cache. Returns whether it worked.

--- a/src/widgets/paint_children.rs
+++ b/src/widgets/paint_children.rs
@@ -57,12 +57,6 @@ pub(crate) fn paint_children(
     opts: &ChildPaintOptions,
 ) {
     let (offset_x, offset_y) = opts.scroll_offset;
-    // A culled child never paints, so it cannot withdraw a compositor blur region
-    // of its own. Collected here and swept once at the end. The check is hoisted:
-    // the answer cannot change while the loop runs, and a long culled list would
-    // otherwise pay a thread-local borrow per row.
-    let mut culled: Vec<WidgetId> = Vec::new();
-    let sweeping_blur = !crate::blur::is_empty();
 
     for &child_id in children {
         // Child bounds come from the tree in the parent's local coordinates
@@ -79,9 +73,6 @@ pub(crate) fn paint_children(
             if !cull.intersects(&child_rect) {
                 crate::render_stats::record_paint_child_culled();
                 ctx.mark_partial();
-                if sweeping_blur {
-                    culled.push(child_id);
-                }
                 continue;
             }
         }
@@ -118,8 +109,6 @@ pub(crate) fn paint_children(
         });
         crate::render_stats::record_paint_child_painted();
     }
-
-    crate::blur::unregister_unpainted(tree, &culled);
 }
 
 /// Try to satisfy a child from its paint cache. Returns whether it worked.

--- a/src/widgets/paint_children.rs
+++ b/src/widgets/paint_children.rs
@@ -57,9 +57,12 @@ pub(crate) fn paint_children(
     opts: &ChildPaintOptions,
 ) {
     let (offset_x, offset_y) = opts.scroll_offset;
-    // A culled child never paints, so it cannot withdraw a compositor blur
-    // region of its own. Collected here and swept once at the end.
+    // A culled child never paints, so it cannot withdraw a compositor blur region
+    // of its own. Collected here and swept once at the end. The check is hoisted:
+    // the answer cannot change while the loop runs, and a long culled list would
+    // otherwise pay a thread-local borrow per row.
     let mut culled: Vec<WidgetId> = Vec::new();
+    let sweeping_blur = !crate::blur::is_empty();
 
     for &child_id in children {
         // Child bounds come from the tree in the parent's local coordinates
@@ -76,7 +79,7 @@ pub(crate) fn paint_children(
             if !cull.intersects(&child_rect) {
                 crate::render_stats::record_paint_child_culled();
                 ctx.mark_partial();
-                if !crate::blur::is_empty() {
+                if sweeping_blur {
                     culled.push(child_id);
                 }
                 continue;
@@ -116,7 +119,7 @@ pub(crate) fn paint_children(
         crate::render_stats::record_paint_child_painted();
     }
 
-    crate::blur::unregister_culled(tree, &culled);
+    crate::blur::unregister_unpainted(tree, &culled);
 }
 
 /// Try to satisfy a child from its paint cache. Returns whether it worked.

--- a/src/widgets/state_layer.rs
+++ b/src/widgets/state_layer.rs
@@ -179,7 +179,6 @@ impl StateStyle {
         self
     }
 
-    /// Set the border width and color for this state.
     /// Override the border while this state is active.
     ///
     /// Both halves, as on the container — see

--- a/src/widgets/state_layer.rs
+++ b/src/widgets/state_layer.rs
@@ -84,6 +84,16 @@ pub enum BackgroundOverride {
     Darker(Signal<f32>),
 }
 
+/// A border an active state draws instead of the declared one.
+///
+/// Named rather than a tuple, as [`BackgroundOverride`] is, and one value rather
+/// than two fields so that half a border cannot be built even by hand.
+#[derive(Clone, Copy)]
+pub struct BorderOverride {
+    pub width: Signal<f32>,
+    pub color: Signal<Color>,
+}
+
 /// Style overrides to apply during a specific interaction state.
 ///
 /// All fields are optional — `None` means use the base value from the
@@ -93,10 +103,10 @@ pub enum BackgroundOverride {
 pub struct StateStyle {
     /// Background color override
     pub background: Option<BackgroundOverride>,
-    /// Border width override
-    pub border_width: Option<Signal<f32>>,
-    /// Border color override
-    pub border_color: Option<Signal<Color>>,
+    /// Border override — both halves or neither. A width with no colour and a
+    /// colour with no width are the same thing, which is no border, so the pair
+    /// is one field rather than two that could disagree.
+    pub border: Option<BorderOverride>,
     /// Corner radius override
     pub corner_radius: Option<Signal<f32>>,
     /// Transform override (e.g., scale on press)
@@ -170,25 +180,20 @@ impl StateStyle {
     }
 
     /// Set the border width and color for this state.
+    /// Override the border while this state is active.
+    ///
+    /// Both halves, as on the container — see
+    /// [`Container::border`](crate::widgets::Container::border) for why there is
+    /// no way to say half of one.
     pub fn border<M1, M2>(
         mut self,
         width: impl IntoSignal<f32, M1>,
         color: impl IntoSignal<Color, M2>,
     ) -> Self {
-        self.border_width = Some(width.into_signal());
-        self.border_color = Some(color.into_signal());
-        self
-    }
-
-    /// Set just the border width for this state.
-    pub fn border_width<M>(mut self, width: impl IntoSignal<f32, M>) -> Self {
-        self.border_width = Some(width.into_signal());
-        self
-    }
-
-    /// Set just the border color for this state.
-    pub fn border_color<M>(mut self, color: impl IntoSignal<Color, M>) -> Self {
-        self.border_color = Some(color.into_signal());
+        self.border = Some(BorderOverride {
+            width: width.into_signal(),
+            color: color.into_signal(),
+        });
         self
     }
 

--- a/src/widgets/text.rs
+++ b/src/widgets/text.rs
@@ -626,4 +626,24 @@ mod tests {
         color.set(Color::BLUE);
         assert_eq!(frame(&mut tree, root).0, Color::BLUE);
     }
+
+    /// A shadow that resolves to nothing visible must not expand into a ring of
+    /// text copies. Same gate the stroke has, and the same one the container's
+    /// shadow got — a transparent shadow is spellable deliberately, and in
+    /// passing while an animated colour leaves transparent.
+    #[test]
+    fn a_fully_transparent_text_shadow_draws_nothing() {
+        let invisible = TextShadow::new(2.0, 2.0, 4.0, Color::TRANSPARENT);
+        assert_eq!(
+            commands(text("hi").text_shadow(invisible)),
+            vec!["text"],
+            "the glyphs, and no copies behind them"
+        );
+
+        let visible = TextShadow::new(2.0, 2.0, 4.0, Color::rgba(0.0, 0.0, 0.0, 0.5));
+        assert!(
+            commands(text("hi").text_shadow(visible)).len() > 1,
+            "and a shadow that can be seen still draws"
+        );
+    }
 }

--- a/src/widgets/text.rs
+++ b/src/widgets/text.rs
@@ -26,7 +26,7 @@ pub(crate) fn decoration_overflow(stroke: Option<TextStroke>, shadow: Option<Tex
 
 /// A run of text.
 ///
-/// Style may be declared here — [`TextStyled`](super::TextStyled) — or on an
+/// Style may be declared here — [`TextStyled`] — or on an
 /// enclosing container, in which case it is inherited from the nearest one
 /// that sets each property. A declaration on the text itself is the nearest
 /// there is, so it wins.

--- a/src/widgets/widget.rs
+++ b/src/widgets/widget.rs
@@ -291,43 +291,36 @@ impl Padding {
         }
     }
 
-    pub fn symmetric(horizontal: f32, vertical: f32) -> Self {
-        Self {
-            top: vertical,
-            right: horizontal,
-            bottom: vertical,
-            left: horizontal,
-        }
-    }
-
-    pub fn horizontal(&self) -> f32 {
+    /// How much width the padding takes: `left + right`.
+    pub fn horizontal_total(&self) -> f32 {
         self.left + self.right
     }
 
-    pub fn vertical(&self) -> f32 {
+    /// How much height the padding takes: `top + bottom`.
+    pub fn vertical_total(&self) -> f32 {
         self.top + self.bottom
     }
 
     /// Override the top padding value.
-    pub fn top(mut self, v: f32) -> Self {
+    pub fn with_top(mut self, v: f32) -> Self {
         self.top = v;
         self
     }
 
     /// Override the bottom padding value.
-    pub fn bottom(mut self, v: f32) -> Self {
+    pub fn with_bottom(mut self, v: f32) -> Self {
         self.bottom = v;
         self
     }
 
     /// Override the left padding value.
-    pub fn left(mut self, v: f32) -> Self {
+    pub fn with_left(mut self, v: f32) -> Self {
         self.left = v;
         self
     }
 
     /// Override the right padding value.
-    pub fn right(mut self, v: f32) -> Self {
+    pub fn with_right(mut self, v: f32) -> Self {
         self.right = v;
         self
     }
@@ -994,9 +987,10 @@ mod tests {
         assert_eq!(padding.left, 10.0);
     }
 
+    /// The two-value shorthand is CSS's: vertical first, then horizontal.
     #[test]
-    fn test_padding_symmetric() {
-        let padding = Padding::symmetric(20.0, 30.0);
+    fn test_padding_two_value_shorthand() {
+        let padding = Padding::from([30.0, 20.0]);
         assert_eq!(padding.top, 30.0);
         assert_eq!(padding.right, 20.0);
         assert_eq!(padding.bottom, 30.0);
@@ -1004,15 +998,10 @@ mod tests {
     }
 
     #[test]
-    fn test_padding_horizontal() {
-        let padding = Padding::symmetric(15.0, 10.0);
-        assert_eq!(padding.horizontal(), 30.0); // left + right = 15 + 15
-    }
-
-    #[test]
-    fn test_padding_vertical() {
-        let padding = Padding::symmetric(15.0, 10.0);
-        assert_eq!(padding.vertical(), 20.0); // top + bottom = 10 + 10
+    fn test_padding_totals_are_sums() {
+        let padding = Padding::from([10.0, 15.0]);
+        assert_eq!(padding.horizontal_total(), 30.0);
+        assert_eq!(padding.vertical_total(), 20.0);
     }
 
     #[test]
@@ -1026,7 +1015,7 @@ mod tests {
 
     #[test]
     fn test_padding_builder_methods() {
-        let padding = Padding::all(8.0).top(20.0).left(0.0);
+        let padding = Padding::all(8.0).with_top(20.0).with_left(0.0);
         assert_eq!(padding.top, 20.0);
         assert_eq!(padding.right, 8.0);
         assert_eq!(padding.bottom, 8.0);

--- a/tests/external_widget.rs
+++ b/tests/external_widget.rs
@@ -7,13 +7,12 @@
 //! register against the nearest ancestor that opened a scope, so a change to
 //! its own content re-lays-out every sibling it has.
 //!
-//! This file covers the first: everything below uses `guido::prelude` and the
-//! public `tree`, `layout` and `renderer` modules, nothing else.
+//! This file covers the first: the two preludes are the only imports, which is
+//! the point of `widget_prelude` existing — the tree, the paint context and the
+//! tracking scope used to have to be reached for one module at a time.
 
-use guido::layout::{Constraints, Size};
 use guido::prelude::*;
-use guido::renderer::RenderNode;
-use guido::tree::{Tree, WidgetId};
+use guido::widget_prelude::*;
 
 /// A box whose size follows a signal. Deliberately minimal: `layout` and
 /// `paint` are the only required methods, and the tracking scope is the only

--- a/tests/render_snapshots.rs
+++ b/tests/render_snapshots.rs
@@ -435,9 +435,12 @@ fn corners_borders_and_elevation() {
 /// which half of the effect runs, and until this scene existed no golden held a
 /// blur command at all.
 ///
-/// The transformed cases are here on purpose: the region's geometry is derived
-/// from the world transform, and a rotation moves its extremes onto the other
-/// diagonal while a scale grows the corner radii with the box.
+/// The transformed cases are here for what reaches the *renderer*: the command
+/// keeps its own rect and radii and carries the matrix, so the golden is where a
+/// transform silently baked into the geometry would show up. What the compositor
+/// is told is derived from that matrix later and is not in this file — the
+/// arithmetic is measured in `renderer::flatten`, and the wiring end to end in
+/// `a_transformed_blur_publishes_the_shape_it_is_drawn_as`.
 #[test]
 fn backdrop_blur_sources_and_geometry() {
     let frosted = |radius: f32| {

--- a/tests/render_snapshots.rs
+++ b/tests/render_snapshots.rs
@@ -137,6 +137,7 @@ fn dump_command(cmd: &DrawCommand, depth: usize, kind: &str, out: &mut String) {
             radius,
             corner_radii,
             curvature,
+            ..
         } => {
             out.push_str(&format!(
                 "{pad}{kind} backdrop-blur {} radius={} corners={}/{}/{}/{} k={}\n",

--- a/tests/render_snapshots.rs
+++ b/tests/render_snapshots.rs
@@ -134,14 +134,15 @@ fn dump_command(cmd: &DrawCommand, depth: usize, kind: &str, out: &mut String) {
     match cmd {
         DrawCommand::BackdropBlur {
             rect: r,
+            sources,
             radius,
             corner_radii,
             curvature,
-            ..
         } => {
             out.push_str(&format!(
-                "{pad}{kind} backdrop-blur {} radius={} corners={}/{}/{}/{} k={}\n",
+                "{pad}{kind} backdrop-blur {} sources={:?} radius={} corners={}/{}/{}/{} k={}\n",
                 rect(r),
+                sources,
                 n(*radius),
                 n(corner_radii.top_left),
                 n(corner_radii.top_right),
@@ -427,6 +428,42 @@ fn corners_borders_and_elevation() {
         );
 
     assert_snapshot("corners_borders_and_elevation", render(view, 500.0, 400.0));
+}
+
+/// After `examples/blur_example.rs`: the backdrop blur, which is the one command
+/// carrying a property the golden is the only reader of — `sources` decides
+/// which half of the effect runs, and until this scene existed no golden held a
+/// blur command at all.
+///
+/// The transformed cases are here on purpose: the region's geometry is derived
+/// from the world transform, and a rotation moves its extremes onto the other
+/// diagonal while a scale grows the corner radii with the box.
+#[test]
+fn backdrop_blur_sources_and_geometry() {
+    let frosted = |radius: f32| {
+        box_of(80.0, 60.0)
+            .background(Color::rgba(1.0, 1.0, 1.0, 0.15))
+            .corner_radius(16.0)
+            .backdrop_blur(radius)
+    };
+
+    let view = container()
+        .layout(Flex::row().spacing(20.0))
+        .padding(20.0)
+        .child(frosted(24.0))
+        .child(
+            frosted(24.0).backdrop_blur(BackdropBlur::new(24.0).sources(BackdropSources::SURFACE)),
+        )
+        .child(
+            frosted(24.0)
+                .backdrop_blur(BackdropBlur::new(24.0).sources(BackdropSources::COMPOSITOR)),
+        )
+        // A radius of zero is "no blur", so this one emits no command at all.
+        .child(frosted(0.0))
+        .child(frosted(24.0).rotate(45.0))
+        .child(frosted(24.0).scale(2.0));
+
+    assert_snapshot("backdrop_blur", render(view, 700.0, 200.0));
 }
 
 /// After `examples/clip_test.rs`: hidden overflow clips its children, and a

--- a/tests/signal_fields.rs
+++ b/tests/signal_fields.rs
@@ -129,7 +129,6 @@ fn test_writers_set_batches_effects() {
     let run_count_ptr = &run_count as *const Cell<u32>;
 
     // Effect reads both fields — should run once on creation.
-    // Hold the effect so it doesn't get disposed on drop.
     create_effect(move || {
         let _ = signals.count.get();
         let _ = signals.name.get();

--- a/tests/signal_fields.rs
+++ b/tests/signal_fields.rs
@@ -237,3 +237,17 @@ fn test_where_clause_generic() {
     });
     assert_eq!(signals.data.get(), vec![1, 2, 3]);
 }
+
+/// A string literal is a default like any other. It used to be impossible:
+/// the quoted form was parsed as Rust source, so `default = "Guest"` compiled
+/// to a reference to a variable named `Guest`.
+#[test]
+fn a_component_prop_can_default_to_a_string_literal() {
+    #[guido::component]
+    fn greeting(#[prop(default = "Guest".to_owned())] who: String) -> impl Widget {
+        text(move || format!("hello {}", who.get()))
+    }
+
+    let w = greeting();
+    assert_eq!(w.who.get(), "Guest");
+}

--- a/tests/signal_fields.rs
+++ b/tests/signal_fields.rs
@@ -130,7 +130,7 @@ fn test_writers_set_batches_effects() {
 
     // Effect reads both fields — should run once on creation.
     // Hold the effect so it doesn't get disposed on drop.
-    let _effect = create_effect(move || {
+    create_effect(move || {
         let _ = signals.count.get();
         let _ = signals.name.get();
         unsafe { &*run_count_ptr }.set(unsafe { &*run_count_ptr }.get() + 1);

--- a/tests/snapshots/backdrop_blur.snap
+++ b/tests/snapshots/backdrop_blur.snap
@@ -1,0 +1,18 @@
+node 0,0 620x100
+  node 0,0 80x60 at 20,20
+    draw backdrop-blur 0,0 80x60 sources=BackdropSources(SURFACE | COMPOSITOR) radius=24 corners=16/16/16/16 k=1
+    draw rect 0,0 80x60 fill=#ffffff26 radius=16/16/16/16
+  node 0,0 80x60 at 120,20
+    draw backdrop-blur 0,0 80x60 sources=BackdropSources(SURFACE) radius=24 corners=16/16/16/16 k=1
+    draw rect 0,0 80x60 fill=#ffffff26 radius=16/16/16/16
+  node 0,0 80x60 at 220,20
+    draw backdrop-blur 0,0 80x60 sources=BackdropSources(COMPOSITOR) radius=24 corners=16/16/16/16 k=1
+    draw rect 0,0 80x60 fill=#ffffff26 radius=16/16/16/16
+  node 0,0 80x60 at 320,20
+    draw rect 0,0 80x60 fill=#ffffff26 radius=16/16/16/16
+  node 0,0 80x60 matrix[0.71 -0.71 0.71 0.71 420 20] origin=Center/Center
+    draw backdrop-blur 0,0 80x60 sources=BackdropSources(SURFACE | COMPOSITOR) radius=24 corners=16/16/16/16 k=1
+    draw rect 0,0 80x60 fill=#ffffff26 radius=16/16/16/16
+  node 0,0 80x60 matrix[2 0 0 2 520 20] origin=Center/Center
+    draw backdrop-blur 0,0 80x60 sources=BackdropSources(SURFACE | COMPOSITOR) radius=24 corners=16/16/16/16 k=1
+    draw rect 0,0 80x60 fill=#ffffff26 radius=16/16/16/16


### PR DESCRIPTION
An audit of the whole public surface, read against a real application built on
top of it (allock). What it turned up was not missing features but
**inconsistency**: the same idea spelled two ways, or reactive in one place and
constant in the one next to it, so nothing about the API could be predicted
from the rest of it.

Ten atomic commits, each reviewable on its own.

## Reactivity now has a rule

Which container properties took a signal was arbitrary: `background` did and
`gradient` did not, `corner_radius` did and `backdrop_blur` did not, `visible`
did and `overflow` did not. Every gap forced the caller to branch in Rust and
rebuild the widget where the neighbouring property would simply have followed a
signal.

The sharpest case is `backdrop_blur`, which carried **two different contracts
under one name**: on `Text` a reactive radius where `0.0` means off, on
`Container` a constant.

```rust
container()
    .gradient(move || palette.get().header())
    .backdrop_blur(move || if frosted.get() { 24.0 } else { 0.0 })   // 0.0 = off
    .overflow(move || if collapsed.get() { Overflow::Hidden } else { Overflow::Visible })
```

The rule is now stated in `docs/STYLING.md` and the book: **anything that
survives to paint takes a signal; anything structural does not** (`layout`,
`scrollable`, `scrollbar`, `scrollbar_visibility`, `control`, `animate_*`).

`overflow` decides whether a box may shrink below its content, so it reaches
layout as well as paint: read inside the layout tracking scope alongside the
lengths it belongs with, and threaded through `BoxLengths` to the axis
resolver.

Also here, from the same audit: `border_width` and `border_color` as separate
setters (the state layer has had them all along, so a layer that only recolours
the frame no longer restates its width), and `gradient_diagonal` /
`animate_elevation`, both of which the book already documented.

## One spelling per idea

| | before | after |
|---|---|---|
| two-value padding | `Padding::symmetric(h, v)` **vs** `[v, h]` — opposite orders, both `f32`, no warning | only `[v, h]`; `horizontal_total()` says it is a sum; `with_top()` no longer collides with the field |
| effects | `create_effect(..)` returned a guard that disposed itself *unless* an owner had claimed it | returns `()`; an effect's lifetime is its scope's |
| surface handle | `set_exclusive_zone(i32)`, `set_size(u32, u32)`, `margin(t, r, b, l)` | the config's own vocabulary: `ExclusiveZone`, `SurfaceExtent`, `Margin` with the CSS shorthands |
| click | `on_click` **and** `on_click_option` | `on_click` takes a closure, a `Callback`, or an `Option<Callback>` |
| keys | `keyed(.., \|t\| -> u64, ..)` | any `Hash` key |
| services | `create_service::<(), _, _>(\|_rx, ctx\| ..)` | `create_task(\|ctx\| ..)` for the push-only half |
| prop defaults | `#[prop(default = "14.0")]`, parsed as source | `#[prop(default = 14.0)]` — and a string literal is finally spellable |
| identity | `Transform::identity()` and `Transform::IDENTITY` | `IDENTITY` |

`Effect` deserves a note: whether you needed to keep the guard alive depended on
ambient state the call site cannot see, and the answer was invisible either way
— forget it in the wrong place and the effect silently never runs again. Nobody
can tell which case they are in, so everybody guesses: allock writes `.detach()`
seven times inside `App::run`, where the root owner has already claimed every
effect and the call does nothing at all. This library's own tests did the same.

`Transform` also loses nine methods that only the renderer ever used; six had no
caller anywhere. The rest are `pub(crate)`.

## Two preludes, because there are two jobs

`guido::prelude` carried 133 names for two audiences and served neither. An
application got the tracking scope, the job types and the `Option<Signal<T>>`
helper. A widget written outside the crate could not be written from it at all:
`Tree`, `WidgetId`, `RenderNode` and `Layout` were not there.

`tests/external_widget.rs` is the proof — its four hand-picked imports collapse
into two:

```rust
use guido::prelude::*;
use guido::widget_prelude::*;
```

`IntoSignal` and `IntoVal` move the other way, into the application prelude.
They look like internals and are not: `IntoVal` is what makes a custom type
usable as a `#[component]` prop, and it was the single non-prelude `guido`
import in a whole application written against this library.

## Documentation that describes the library that exists

README's Quick Start **did not compile** — `App::new().add_surface(..)`
returning a tuple has not been the API for a long time. CLAUDE.md described
`Row` and `Column` widgets, which have never existed, and a `Widget` trait from
before the `Tree`. The book documented `.children_dyn()`,
`.padding_horizontal()`, `.min_width()`, `.gradient_diagonal()` and
`.animate_elevation()`, none of which were real, plus
`hover_state`/`pressed_state`, renamed in #189.

Two of those turned out to be worth having rather than worth deleting, so
`gradient_diagonal` and `animate_elevation` now exist and the docs were right
early.

Every complete program in the book and the README was extracted and compiled.
That found two more: an `exclusive_zone(Some(32))` no conversion accepts, and an
`image().width()` — an `Image` has no box of its own, the container gives it one.

New chapter: `book/src/advanced/custom-widgets.md`. The `Layout` trait being
public is the answer to "where is the grid", and nothing said so.

`docs/REFACTORING.md` gets the audit as a section, loses a bullet #189 had
already closed, and regains the subject of a sentence a sed had eaten
("`when_hovered` becomes `when_hovered`").

## Checks

`cargo fmt --check`, `clippy --all-targets --all-features -D warnings`, **543
tests**, `--no-default-features`, `--features gif,render-stats`, `mdbook build`
— all green. The render-tree snapshots were **not** re-blessed: no geometry
changed.

## Downstream

allock builds and lints clean against this branch after a **10-line** diff, in
exactly and only the two places this PR calls footguns: seven no-op `.detach()`
calls and three quoted prop defaults. That diff is not in this PR.

## Considered and dropped

- **`Container::alpha()`**, listed in the audit as an asymmetry with
  `StateStyle::alpha()`. It is not one: that `alpha` overrides the *background's*
  channel precisely so an override need not restate the colour, and a base
  already writes `background(Color::rgba(..))`.
- **Reactive `scrollbar_visibility`**: seven read sites across layout, event and
  paint, for a property that is configuration. Left static and named in the rule.
