### PR TITLE
A handle that outlives its subject has to answer after it is gone

### DIFF
--- a/book/src/advanced/wayland.md
+++ b/book/src/advanced/wayland.md
@@ -609,6 +609,8 @@ create_effect(move || {
 `popup.close()` closes it programmatically. Popups render their own
 widget tree and share the app's reactive state like any surface;
 anchoring a popup to another popup creates a nested popup (submenus).
+A handle outlives its popup: reading `dismissed()` is safe after the
+popup is gone, including from a submenu whose parent closed with it.
 
 Note: for a bottom bar use `anchor(Top)` + `gravity(Top)` so the menu
 opens upward — or just rely on the compositor's flip adjustment.

--- a/src/platform/popups.rs
+++ b/src/platform/popups.rs
@@ -359,8 +359,8 @@ impl PopupHandler for WaylandState {
 
     fn done(&mut self, _conn: &Connection, _qh: &QueueHandle<Self>, popup: &Popup) {
         // Compositor dismissed the popup (outside click on a grab, parent
-        // gone). Flip the reactive dismissal signal and route through the
-        // normal close command for full teardown.
+        // gone). Mark it dismissed for anything watching, and route through
+        // the normal close command for full teardown.
         if let Some(id) = self.surface_lookup.get(&popup.wl_surface().id()).copied() {
             log::info!("Popup {:?} dismissed by compositor", id);
             crate::surface::mark_popup_dismissed(id);

--- a/src/reactive/signal.rs
+++ b/src/reactive/signal.rs
@@ -10,7 +10,8 @@ use super::runtime::{
 use super::storage::{
     allocate_signal_slot, compare_and_set_signal_value, compare_and_update_signal_value,
     create_signal_value, create_stored_value, get_signal_value, get_stored_value, has_signal,
-    store_derived_closure, try_call_derived, with_signal_value, with_stored_value,
+    store_derived_closure, try_call_derived, try_get_signal_value, with_signal_value,
+    with_stored_value,
 };
 
 /// Implement Clone (via Copy), Copy, PartialEq (by SignalId), and Eq for a signal type.
@@ -271,6 +272,17 @@ impl<T: Clone + 'static> RwSignal<T> {
     #[inline]
     pub fn get_untracked(&self) -> T {
         get_signal_value(self.id)
+    }
+
+    /// Get the current value without tracking, or `None` if the owner that
+    /// created this signal has been disposed.
+    ///
+    /// For state that outlives the scopes it holds handles from and has to
+    /// ask rather than assume — the widget-ref registry. Ordinary reads
+    /// should keep panicking: a dead handle there is a bug, not a race.
+    #[inline]
+    pub(crate) fn try_get_untracked(&self) -> Option<T> {
+        try_get_signal_value(self.id)
     }
 
     /// Borrow the value for reading

--- a/src/reactive/storage.rs
+++ b/src/reactive/storage.rs
@@ -252,6 +252,16 @@ pub fn get_signal_value<T: Clone + 'static>(id: SignalId) -> T {
     with_signal_cell(id, "read", |cell: &RefCell<T>| cell.borrow().clone())
 }
 
+/// Read a mutable signal's value, or `None` if its slot is gone.
+///
+/// The read-side mirror of the `try_*` writes below, for the one reader that
+/// races disposal by design: the widget-ref registry outlives the scopes that
+/// created the handles it holds, and looking is how it finds out.
+pub fn try_get_signal_value<T: Clone + 'static>(id: SignalId) -> Option<T> {
+    let rc = try_clone_slot_rc(id)?;
+    Some(downcast_cell::<T>(&rc, id).borrow().clone())
+}
+
 /// Set a signal's value (in-place replace, no Box allocation)
 pub fn set_signal_value<T: 'static>(id: SignalId, value: T) {
     with_signal_cell(id, "write", |cell: &RefCell<T>| {

--- a/src/session_lock.rs
+++ b/src/session_lock.rs
@@ -27,7 +27,7 @@ use smithay_client_toolkit::reexports::client::QueueHandle;
 
 use crate::outputs::{self, OutputId, OutputInfo};
 use crate::platform::{LockEvent, WaylandState};
-use crate::reactive::owner::with_owner;
+use crate::reactive::owner::{with_owner, with_root_owner};
 use crate::reactive::{RwSignal, Signal, create_signal};
 use crate::surface::{SurfaceConfig, SurfaceId};
 use crate::surface_manager::{ManagedSurface, SurfaceManager};
@@ -69,7 +69,7 @@ fn state_signal() -> RwSignal<LockState> {
         *lock
             .borrow_mut()
             .state
-            .get_or_insert_with(|| create_signal(LockState::default()))
+            .get_or_insert_with(|| with_root_owner(|| create_signal(LockState::default())))
     })
 }
 
@@ -249,4 +249,26 @@ fn teardown_lock_surfaces(
 /// Called during `App::drop()`.
 pub(crate) fn reset_session_lock() {
     LOCK.with(|lock| *lock.borrow_mut() = LockData::default());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::reactive::owner::{create_root_owner, dispose_owner_now, with_owner};
+
+    /// The lock state is process-wide and lives behind a thread-local built on
+    /// first use, so *whoever reads it first* would otherwise decide its owner.
+    /// When that first reader is a widget closure or an event handler — the
+    /// natural place to ask whether the session is locked — the signal dies
+    /// with that scope while the thread-local goes on holding the handle.
+    #[test]
+    fn the_lock_state_outlives_whoever_reads_it_first() {
+        create_root_owner();
+        let ((), first_reader) = with_owner(|| {
+            let _ = lock_state().get_untracked();
+        });
+        dispose_owner_now(first_reader);
+
+        assert_eq!(lock_state().get_untracked(), LockState::default());
+    }
 }

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -40,6 +40,8 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::outputs::OutputId;
 use crate::platform::{Anchor, KeyboardInteractivity, Layer};
+use crate::reactive::owner::with_root_owner;
+use crate::reactive::{Trigger, create_trigger};
 use crate::widgets::{Color, Rect, Widget};
 
 /// Unique identifier for each surface in the application.
@@ -928,7 +930,6 @@ where
 #[derive(Clone, Copy)]
 pub struct PopupHandle {
     id: SurfaceId,
-    dismissed: crate::reactive::RwSignal<bool>,
 }
 
 impl PopupHandle {
@@ -939,39 +940,62 @@ impl PopupHandle {
 
     /// Close the popup programmatically.
     pub fn close(&self) {
-        self.dismissed.set(true);
+        mark_popup_dismissed(self.id);
         push_surface_command(SurfaceCommand::Close(self.id));
     }
 
     /// Whether the popup has been dismissed (tracked read — reactive inside
     /// tracked closures). True after `close()` or a compositor dismissal
     /// (click outside a grabbed popup, parent closed).
+    ///
+    /// Safe to read after the popup is gone — including from a submenu whose
+    /// parent was dismissed by the same click.
     pub fn dismissed(&self) -> bool {
-        self.dismissed.get()
+        popup_dismissal().track();
+        !LIVE_POPUPS.with(|live| live.borrow().contains(&self.id))
     }
 }
 
-// Registry of popup dismissal signals so the platform layer can flip them
-// when the compositor dismisses a popup (xdg_popup.popup_done).
+// The popups that are still open, and one notifier for every change to that
+// set. A `PopupHandle` is `Copy` and outlives its popup by design, so
+// dismissal cannot be announced through anything scoped to whoever called
+// `spawn_popup`: for a nested popup that scope is the *parent* popup, which
+// dies at the same moment the child does. Here the registry is the truth —
+// absent means gone — and nothing is scoped to dispose.
 thread_local! {
-    static POPUP_DISMISSED: RefCell<std::collections::HashMap<SurfaceId, crate::reactive::RwSignal<bool>>> =
-        RefCell::new(std::collections::HashMap::new());
+    static LIVE_POPUPS: RefCell<std::collections::HashSet<SurfaceId>> =
+        RefCell::new(std::collections::HashSet::new());
+    static POPUP_DISMISSAL: RefCell<Option<Trigger>> = const { RefCell::new(None) };
+}
+
+/// The notifier that makes reading the registry reactive, created on first
+/// use under the root owner — it belongs to the application, not to whichever
+/// popup happened to be opened first.
+fn popup_dismissal() -> Trigger {
+    POPUP_DISMISSAL.with(|cell| {
+        *cell
+            .borrow_mut()
+            .get_or_insert_with(|| with_root_owner(create_trigger))
+    })
 }
 
 /// Mark a popup dismissed (called by the platform layer on popup_done, and
-/// on close). Removes the registry entry.
+/// on close). Removes the registry entry and notifies every watcher.
 pub(crate) fn mark_popup_dismissed(id: SurfaceId) {
-    let signal = POPUP_DISMISSED.with(|reg| reg.borrow_mut().remove(&id));
-    if let Some(signal) = signal {
-        signal.set(true);
+    let was_open = LIVE_POPUPS.with(|live| live.borrow_mut().remove(&id));
+    if was_open {
+        popup_dismissal().notify();
     }
 }
 
 /// Reset popup registry state.
 ///
-/// Called during `App::drop()`.
+/// Called during `App::drop()`. The notifier is released rather than
+/// notified: the storage behind it is wiped in the same teardown, so keeping
+/// the handle would hand the next `App` on this thread a dead one.
 pub(crate) fn reset_popups() {
-    POPUP_DISMISSED.with(|reg| reg.borrow_mut().clear());
+    LIVE_POPUPS.with(|live| live.borrow_mut().clear());
+    POPUP_DISMISSAL.with(|cell| *cell.borrow_mut() = None);
 }
 
 /// Spawn an xdg popup anchored to a parent surface.
@@ -1008,9 +1032,8 @@ where
     F: FnOnce() -> W + 'static,
 {
     let id = SurfaceId::next();
-    let dismissed = crate::reactive::create_signal(false);
-    POPUP_DISMISSED.with(|reg| {
-        reg.borrow_mut().insert(id, dismissed);
+    LIVE_POPUPS.with(|live| {
+        live.borrow_mut().insert(id);
     });
 
     push_surface_command(SurfaceCommand::CreatePopup {
@@ -1020,7 +1043,7 @@ where
         widget_fn: Box::new(move || Box::new(widget_fn())),
     });
 
-    PopupHandle { id, dismissed }
+    PopupHandle { id }
 }
 
 /// Get a handle to control an existing surface.
@@ -1143,5 +1166,58 @@ mod tests {
             ExclusiveZone::from(34u32).resolve(Anchor::TOP, m, 800, 32),
             34
         );
+    }
+
+    /// A `PopupHandle` is `Copy` and outlives its popup by design, so every
+    /// read through it has to survive the scope that opened it. For a nested
+    /// popup that scope *is* the parent popup — the click that opens the child
+    /// is dispatched to a widget living inside the parent, and one outside
+    /// click dismisses both. A dismissal announced through something owned by
+    /// that scope is announced to nobody.
+    #[test]
+    fn a_popup_reports_its_dismissal_after_the_scope_that_opened_it_is_gone() {
+        crate::reactive::owner::create_root_owner();
+        let (child, parent_scope) = crate::reactive::owner::with_owner(|| {
+            let child = spawn_popup(SurfaceId::next(), PopupConfig::new(120), || {
+                crate::widgets::container()
+            });
+            // The parent popup is also the first thing to watch its child.
+            assert!(!child.dismissed());
+            child
+        });
+        crate::reactive::owner::dispose_owner_now(parent_scope);
+
+        assert!(!child.dismissed(), "a live popup is not dismissed");
+        mark_popup_dismissed(child.id());
+        assert!(child.dismissed(), "and its death is still readable");
+    }
+
+    /// Dismissal is the one thing an application watches a popup for, and it
+    /// watches it reactively — closing the menu means resetting the state that
+    /// opened it.
+    #[test]
+    fn watching_a_popup_reacts_to_its_dismissal() {
+        let popup = spawn_popup(SurfaceId::next(), PopupConfig::new(120), || {
+            crate::widgets::container()
+        });
+        let seen = std::rc::Rc::new(std::cell::Cell::new(false));
+        let observer = seen.clone();
+        crate::reactive::create_effect(move || observer.set(popup.dismissed()));
+        assert!(!seen.get(), "the effect ran once, on a live popup");
+
+        mark_popup_dismissed(popup.id());
+        assert!(seen.get(), "the effect re-ran when the popup was dismissed");
+    }
+
+    /// One popup's death says nothing about another's.
+    #[test]
+    fn a_dismissal_speaks_only_for_the_popup_it_names() {
+        let build = || crate::widgets::container();
+        let first = spawn_popup(SurfaceId::next(), PopupConfig::new(120), build);
+        let second = spawn_popup(SurfaceId::next(), PopupConfig::new(120), build);
+
+        mark_popup_dismissed(first.id());
+        assert!(first.dismissed());
+        assert!(!second.dismissed(), "the other popup is still open");
     }
 }

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -939,8 +939,11 @@ impl PopupHandle {
     }
 
     /// Close the popup programmatically.
+    ///
+    /// Dismissal is announced when the loop closes it, not here: closing walks
+    /// the popup's descendants first, so a submenu is reported gone before the
+    /// menu it hangs from — the order the compositor's own dismissal gives.
     pub fn close(&self) {
-        mark_popup_dismissed(self.id);
         push_surface_command(SurfaceCommand::Close(self.id));
     }
 
@@ -951,8 +954,19 @@ impl PopupHandle {
     /// Safe to read after the popup is gone — including from a submenu whose
     /// parent was dismissed by the same click.
     pub fn dismissed(&self) -> bool {
-        popup_dismissal().track();
-        !LIVE_POPUPS.with(|live| live.borrow().contains(&self.id))
+        let live = LIVE_POPUPS.with(|live| live.borrow().contains(&self.id));
+        if live {
+            // Tracked only while there is still something to wait for. One
+            // notifier serves every popup, so a watcher that stayed subscribed
+            // after its own popup was gone would be woken by every dismissal
+            // that followed — and applications create these watchers in the
+            // click that opens the popup, where the owner is the root, so they
+            // accumulate for the life of the `App`. Reading a popup that is
+            // already gone subscribes to nothing: the answer can never change
+            // again.
+            popup_dismissal().track();
+        }
+        !live
     }
 }
 
@@ -1168,6 +1182,21 @@ mod tests {
         );
     }
 
+    /// A clean slate: a root owner for the effects, no popups left over from
+    /// another test on this thread, and the command queue drained of the
+    /// `CreatePopup`s these tests push and nobody consumes.
+    fn fresh() {
+        crate::reactive::owner::create_root_owner();
+        reset_popups();
+        let _ = drain_surface_commands();
+    }
+
+    fn popup() -> PopupHandle {
+        spawn_popup(SurfaceId::next(), PopupConfig::new(120), || {
+            crate::widgets::container()
+        })
+    }
+
     /// A `PopupHandle` is `Copy` and outlives its popup by design, so every
     /// read through it has to survive the scope that opened it. For a nested
     /// popup that scope *is* the parent popup — the click that opens the child
@@ -1176,11 +1205,9 @@ mod tests {
     /// that scope is announced to nobody.
     #[test]
     fn a_popup_reports_its_dismissal_after_the_scope_that_opened_it_is_gone() {
-        crate::reactive::owner::create_root_owner();
+        fresh();
         let (child, parent_scope) = crate::reactive::owner::with_owner(|| {
-            let child = spawn_popup(SurfaceId::next(), PopupConfig::new(120), || {
-                crate::widgets::container()
-            });
+            let child = popup();
             // The parent popup is also the first thing to watch its child.
             assert!(!child.dismissed());
             child
@@ -1197,9 +1224,8 @@ mod tests {
     /// opened it.
     #[test]
     fn watching_a_popup_reacts_to_its_dismissal() {
-        let popup = spawn_popup(SurfaceId::next(), PopupConfig::new(120), || {
-            crate::widgets::container()
-        });
+        fresh();
+        let popup = popup();
         let seen = std::rc::Rc::new(std::cell::Cell::new(false));
         let observer = seen.clone();
         crate::reactive::create_effect(move || observer.set(popup.dismissed()));
@@ -1212,12 +1238,60 @@ mod tests {
     /// One popup's death says nothing about another's.
     #[test]
     fn a_dismissal_speaks_only_for_the_popup_it_names() {
-        let build = || crate::widgets::container();
-        let first = spawn_popup(SurfaceId::next(), PopupConfig::new(120), build);
-        let second = spawn_popup(SurfaceId::next(), PopupConfig::new(120), build);
+        fresh();
+        let (first, second) = (popup(), popup());
 
         mark_popup_dismissed(first.id());
         assert!(first.dismissed());
         assert!(!second.dismissed(), "the other popup is still open");
+    }
+
+    /// One notifier serves every popup, and applications create their watchers
+    /// in the click that opens one — where the owner is the root, so the
+    /// watcher lives as long as the `App`. If a watcher stayed subscribed after
+    /// its own popup was gone, opening and closing a menu five hundred times
+    /// would leave five hundred of them to re-run on the next dismissal.
+    #[test]
+    fn a_watcher_stops_being_woken_once_its_own_popup_is_gone() {
+        fresh();
+        let (watched, other) = (popup(), popup());
+        let runs = std::rc::Rc::new(std::cell::Cell::new(0));
+        let counter = runs.clone();
+        crate::reactive::create_effect(move || {
+            watched.dismissed();
+            counter.set(counter.get() + 1);
+        });
+        assert_eq!(runs.get(), 1, "the initial run");
+
+        mark_popup_dismissed(watched.id());
+        assert_eq!(runs.get(), 2, "woken for its own popup");
+
+        mark_popup_dismissed(other.id());
+        assert_eq!(
+            runs.get(),
+            2,
+            "and not for anybody else's, once its own answer can no longer change"
+        );
+    }
+
+    /// `close()` hands the popup to the loop rather than declaring it gone on
+    /// the spot: closing walks the descendants first, so a submenu is reported
+    /// gone before the menu it hangs from — the order the compositor's own
+    /// dismissal gives. Declaring it here would report them the other way
+    /// round, and only for this one path.
+    #[test]
+    fn closing_leaves_the_announcement_to_the_close_that_follows() {
+        fresh();
+        let popup = popup();
+        popup.close();
+
+        assert!(!popup.dismissed(), "still open until the loop closes it");
+        assert!(
+            SURFACE_COMMANDS.with(|cmds| cmds
+                .borrow()
+                .iter()
+                .any(|c| matches!(c, SurfaceCommand::Close(id) if *id == popup.id()))),
+            "and the close is queued"
+        );
     }
 }

--- a/src/widget_ref.rs
+++ b/src/widget_ref.rs
@@ -128,17 +128,58 @@ pub(crate) fn reset_widget_refs() {
 pub(crate) fn update_widget_refs(tree: &Tree) {
     WIDGET_REF_REGISTRY.with(|reg| {
         reg.borrow_mut().retain(|&id, widget_ref| {
+            // A ref's signals belong to the scope that created it — a popup's
+            // widget tree, a dynamic child — and this registry outlives every
+            // one of them. Asking whether the handle is still alive is how an
+            // entry learns to go; reading it outright is how the frame after a
+            // popup closed used to panic.
+            let Some(attached) = widget_ref.widget.try_get_untracked() else {
+                return false;
+            };
             if let Some(rect) = tree.get_surface_relative_bounds(id) {
                 widget_ref.signal.set(rect);
                 true
             } else {
                 // Widget removed from tree — drop registry entry, and stop
                 // claiming the handle points at something.
-                if widget_ref.widget.get_untracked() == Some(id) {
+                if attached == Some(id) {
                     widget_ref.widget.set(None);
                 }
                 false
             }
         });
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::reactive::owner::{create_root_owner, dispose_owner_now, with_owner};
+    use crate::widgets::container;
+
+    /// A widget ref is created wherever its widget is composed, and a popup's
+    /// content is composed inside the popup's own scope. The registry is
+    /// process-wide and holds a `Copy` of the handle, so it keeps looking at
+    /// refs whose owner is gone — and the frame right after a popup closes is
+    /// exactly when it looks.
+    #[test]
+    fn a_ref_whose_scope_died_leaves_the_registry_instead_of_panicking() {
+        create_root_owner();
+        let mut popup_tree = Tree::new();
+        let id = popup_tree.register(Box::new(container()));
+
+        let ((), popup_scope) = with_owner(|| {
+            register_widget_ref(id, create_widget_ref());
+        });
+        dispose_owner_now(popup_scope);
+
+        // The popup's tree is gone: what the loop lays out next knows nothing
+        // about that widget.
+        update_widget_refs(&Tree::new());
+
+        assert!(
+            WIDGET_REF_REGISTRY.with(|reg| reg.borrow().is_empty()),
+            "the dead ref is evicted, not carried into the next frame"
+        );
+    }
 }

--- a/src/widget_ref.rs
+++ b/src/widget_ref.rs
@@ -104,9 +104,16 @@ thread_local! {
 /// Called from the layout of every widget that carries a `WidgetRef`. Idempotent
 /// — HashMap insert overwrites.
 pub(crate) fn register_widget_ref(id: WidgetId, widget_ref: WidgetRef) {
+    // A ref whose scope is gone has nothing left to point at, and the registry
+    // nothing to keep for it: the read below would panic, and the write after
+    // it would be dropped anyway. The claim this handle makes — that it answers
+    // after its subject is gone — has to hold on the write path too.
+    let Some(attached) = widget_ref.widget.try_get_untracked() else {
+        return;
+    };
     // Cheap when unchanged, and the write is what lets `focus()` resolve: a ref
     // that has never been laid out has no widget to focus.
-    if widget_ref.widget.get_untracked() != Some(id) {
+    if attached != Some(id) {
         widget_ref.widget.set(Some(id));
     }
     WIDGET_REF_REGISTRY.with(|reg| {


### PR DESCRIPTION
Closes #208.

Opening a menu, then a submenu inside it, then clicking outside killed the
application. The issue named the cause as the popup's own dismissal signal;
walking the example showed a second one behind it, and the sweep the issue
asked for ("whether the same ownership question applies to anything else a
`spawn_*` returns") turned up a third. All three are one shape:

> a `Copy` handle outlives its subject by design, and something it points at
> was owned by a scope that died first.

### The three

**A popup's dismissal outlives the popup, and its parent.** `spawn_popup`
created the dismissal signal in the caller's scope. `PopupHandle` is `Copy`
and outlives its popup by design, so no read through it can depend on who
called. The registry of live popups is now the truth — absent means gone —
with one notifier, owned by the application, making the read reactive.
Nothing about a popup is scoped to whoever opened it.

**The lock state belongs to the application, not to its first reader.**
The one process-wide signal that #175 missed: it was created in whatever
scope read it first, exactly the crash that PR was written to close.

**The widget-ref registry asks whether a ref is still alive.** This is the
one that actually killed `popup_example`: a `WidgetRef` composed inside a
popup's tree dies with it, and the next layout pass read the handle to
garbage-collect the entry. The pass that exists to clean up after a dead
widget could not survive it. Reads still panic on a disposed signal, as
they should; this registry gets the read-side mirror of the exception the
write paths already carve out for themselves.

### Testing

Each fix has a test that reproduces its crash, and each was run against the
unfixed code first: all three fail with `Signal … was disposed` without the
change. `cargo test --all-features` green, clippy clean, render snapshots
unchanged (no geometry is touched).

The example was then run by hand through the full sequence — menu, submenu,
outside click, and the reverse order closing from the bar — which is how the
second and third bugs were found in the first place.