### PR TITLE
State that belongs to the application says so where it is declared

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -332,6 +332,22 @@ See [docs/STYLING.md](docs/STYLING.md) for full styling reference.
 
 ## Development Workflow
 
+### Architectural changes are agreed before they are written
+
+**Before introducing a new architectural structure, explain why it is needed
+and get the design validated. Do not implement first and present after.**
+
+This covers anything other code will then be written against: a new core type
+or trait, a new cross-cutting mechanism, a new ownership or lifetime rule, a
+new registry, or a change to how a whole family of call sites is spelled.
+Ordinary work does not — fixing a bug at its definition, adding a widget
+method, following a pattern that already exists.
+
+"Explain why" means: the problem as it stands in the code, the sites that have
+it, why the existing pieces cannot answer it, the alternatives weighed, and a
+measurement wherever performance is claimed. The decision is the user's; the
+implementation starts after they have made it.
+
 ### Git Workflow
 
 **IMPORTANT: Never commit directly to the main branch.**

--- a/book/src/advanced/widget-ref.md
+++ b/book/src/advanced/widget-ref.md
@@ -94,16 +94,23 @@ you to request from a post-frame callback because during `initState` the widget 
 not mounted.
 
 Because of that, **asking early is allowed**: a request that names a widget which
-has not been laid out yet waits for it rather than being dropped, so `focus()` in a
-startup effect does what it looks like. Two requests in one frame are two answers
+has not been laid out *yet* waits for it rather than being dropped, so `focus()` in
+a startup effect does what it looks like. Two requests in one frame are two answers
 to the same question, and the later one wins.
+
+A request does not wait forever, though, and the difference matters: one whose
+widget has since **left** the tree is dropped, and so is one whose ref belonged to
+a scope that is gone — `.focus()` from inside a popup that closed before the frame
+came round. Both are waiting for something that already happened, and a request
+left parked would fire at whatever took that ref next.
 
 The rest of the verb:
 
 ```rust
 field.blur();          // give the keyboard back, if this widget has it
 field.is_focused();    // reactive when read in a tracked scope
-field.widget();        // Some(WidgetId) once laid out, None before
+field.widget();        // Some(WidgetId) once laid out; None before, and None
+                       // again once the widget leaves or the ref's scope dies
 ```
 
 For a field that should simply be ready when the screen appears, there is no need

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -36,6 +36,7 @@ Single-threaded reactive primitives inspired by SolidJS and Floem.
 - `Memo<T>` - Eager derived values that recompute when dependencies change, only notify on actual changes (`PartialEq`)
 - `Effect` - Side effects that re-run when tracked signals change
 - `WriteSignal<T>` - `Send` handle for background thread updates, obtained via `RwSignal::writer()`
+- `GlobalSignal<T>` (internal) - a signal whose owner is the *application*, declared as a `static`. See "Owners" below.
 
 **How it works:**
 ```rust
@@ -47,6 +48,26 @@ count.set(5);                           // doubled automatically becomes 10
 ```
 
 The runtime uses thread-local storage for automatic dependency tracking. When a signal is read inside a `Memo`, `Effect`, or during widget `paint()`/`layout()`, it registers itself as a dependency.
+
+**Owners:** a signal belongs to whatever scope is current when it is created,
+and that scope is ambient and time-dependent — inside a widget factory it is
+that surface's, inside a click handler the root, on an effect's first run
+whoever created the effect. For state with one instance per process — the
+keyboard modifiers, the output list, the compositor's capabilities, the session
+lock, the focus path — none of those is the answer: the owner is the
+application, and drawing it by lot from whichever scope read it first is how
+"signal was disposed" panics get made (#175).
+
+`GlobalSignal` says so at the declaration:
+
+```rust
+static MODIFIERS: GlobalSignal<Modifiers> = GlobalSignal::new(Modifiers::default);
+```
+
+Created under the root owner on first use, and rebuilt if its signal is gone —
+so a teardown that reads one cannot panic, and forgetting to clear the registry
+costs a stale entry rather than a crash. The identity is the `static` taken by
+address, so two globals of the same type are two globals.
 
 **Identity safety:** signal, effect, owner, and widget ids are all generational
 (`index + generation`). Slots are recycled, but a stale `Copy` handle held after
@@ -523,6 +544,7 @@ The feature has zero overhead when disabled (code is completely compiled out).
 | `src/renderer/flatten.rs` | Tree flattening with transform inheritance |
 | `src/renderer/shader.wgsl` | GPU shaders for instanced SDF rendering |
 | `src/reactive/signal.rs` | Signal implementation |
+| `src/reactive/global.rs` | `GlobalSignal`: state whose owner is the application |
 | `src/transform.rs` | Transform matrix operations |
 | `src/platform/wayland.rs` | Wayland connection, surfaces and layer shell |
 | `src/platform/input.rs` | Seat input: pointer, touch, keyboard |

--- a/docs/REACTIVE.md
+++ b/docs/REACTIVE.md
@@ -183,6 +183,30 @@ create_effect(move || {
 name.set("Guido".to_string()); // Effect re-runs, prints: Hello, Guido!
 ```
 
+### State the whole application shares
+
+A signal belongs to the scope that was current when it was created, and that
+scope is ambient: inside a widget factory it is that surface's, inside a click
+handler the root, on an effect's first run whoever created the effect. For the
+handful of things with one instance per process — what the compositor reports,
+where the keyboard focus is — the owner is none of those. It is the
+application.
+
+The library declares those as `GlobalSignal` (internal to the crate), which
+creates the signal under the root owner on first use and rebuilds it if the
+last one is gone:
+
+```rust
+static MODIFIERS: GlobalSignal<Modifiers> = GlobalSignal::new(Modifiers::default);
+
+pub fn keyboard_modifiers() -> Signal<Modifiers> {
+    MODIFIERS.get().read_only()
+}
+```
+
+Applications do not need it: a signal created in `App::run`'s setup already
+belongs to the root owner, which lives as long as the app.
+
 ## Using Signals in Widgets
 
 ### Static vs Reactive Properties

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -6,10 +6,8 @@
 //! where a blurred one is not on offer — needs to read that as a signal
 //! rather than ask once at startup.
 
-use std::cell::RefCell;
-
-use crate::reactive::owner::with_root_owner;
-use crate::reactive::{RwSignal, Signal, create_signal};
+use crate::reactive::global::GlobalSignal;
+use crate::reactive::{RwSignal, Signal};
 
 /// Compositor-side effects currently on offer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -22,18 +20,10 @@ pub struct CompositorEffects {
     pub blur: bool,
 }
 
-thread_local! {
-    /// Lazily created so it works both before and after platform init;
-    /// wiped by `reset_compositor_effects()`.
-    static EFFECTS: RefCell<Option<RwSignal<CompositorEffects>>> = const { RefCell::new(None) };
-}
+static EFFECTS: GlobalSignal<CompositorEffects> = GlobalSignal::new(CompositorEffects::default);
 
 fn effects_signal() -> RwSignal<CompositorEffects> {
-    EFFECTS.with(|cell| {
-        *cell
-            .borrow_mut()
-            .get_or_insert_with(|| with_root_owner(|| create_signal(CompositorEffects::default())))
-    })
+    EFFECTS.get()
 }
 
 /// Reactive view of the compositor's effect capabilities.
@@ -47,9 +37,4 @@ pub fn compositor_effects() -> Signal<CompositorEffects> {
 /// Record the compositor's blur capability. Called by the platform layer.
 pub(crate) fn set_blur_capability(blur: bool) {
     effects_signal().update(|effects| effects.blur = blur);
-}
-
-/// Reset capabilities. Called during `App::drop()`.
-pub(crate) fn reset_compositor_effects() {
-    EFFECTS.with(|cell| *cell.borrow_mut() = None);
 }

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -52,11 +52,10 @@ pub(crate) fn set_keyboard_modifiers(modifiers: Modifiers) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::reactive::global::reset_globals;
 
     #[test]
     fn the_state_starts_empty_and_follows_the_platform() {
-        reset_globals();
+        modifiers_signal().set(Modifiers::default());
         assert_eq!(keyboard_modifiers().get_untracked(), Modifiers::default());
 
         let latched = Modifiers {
@@ -78,7 +77,7 @@ mod tests {
         use crate::reactive::owner::{create_root_owner, dispose_owner_now, with_owner};
 
         create_root_owner();
-        reset_globals();
+        modifiers_signal().set(Modifiers::default());
 
         let (_, scope) = with_owner(|| keyboard_modifiers().get_untracked());
         dispose_owner_now(scope);
@@ -95,15 +94,19 @@ mod tests {
         assert!(keyboard_modifiers().get_untracked().caps_lock);
     }
 
+    /// A second `App` on this thread starts from the declaration, not from
+    /// whatever the last one latched. What ends the first one is the storage
+    /// being wiped, which is what `App::drop` does — and the global answers by
+    /// building another signal rather than reading into the hole.
     #[test]
     fn a_new_app_does_not_inherit_the_last_one_s_state() {
-        reset_globals();
         set_keyboard_modifiers(Modifiers {
             caps_lock: true,
             ..Default::default()
         });
+        assert!(keyboard_modifiers().get_untracked().caps_lock);
 
-        reset_globals();
+        crate::reactive::storage::reset_storage();
 
         assert_eq!(keyboard_modifiers().get_untracked(), Modifiers::default());
     }

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -19,24 +19,14 @@
 //! })
 //! ```
 
-use std::cell::RefCell;
-
-use crate::reactive::owner::with_root_owner;
-use crate::reactive::{RwSignal, Signal, create_signal};
+use crate::reactive::global::GlobalSignal;
+use crate::reactive::{RwSignal, Signal};
 use crate::widgets::Modifiers;
 
-thread_local! {
-    /// Lazily created so it works both before and after platform init;
-    /// wiped by `reset_keyboard_modifiers()`.
-    static MODIFIERS: RefCell<Option<RwSignal<Modifiers>>> = const { RefCell::new(None) };
-}
+static MODIFIERS: GlobalSignal<Modifiers> = GlobalSignal::new(Modifiers::default);
 
 fn modifiers_signal() -> RwSignal<Modifiers> {
-    MODIFIERS.with(|cell| {
-        *cell
-            .borrow_mut()
-            .get_or_insert_with(|| with_root_owner(|| create_signal(Modifiers::default())))
-    })
+    MODIFIERS.get()
 }
 
 /// Reactive view of the modifiers the keyboard currently reports.
@@ -59,18 +49,14 @@ pub(crate) fn set_keyboard_modifiers(modifiers: Modifiers) {
     }
 }
 
-/// Forget the modifier state. Called during `App::drop()`.
-pub(crate) fn reset_keyboard_modifiers() {
-    MODIFIERS.with(|cell| *cell.borrow_mut() = None);
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::reactive::global::reset_globals;
 
     #[test]
     fn the_state_starts_empty_and_follows_the_platform() {
-        reset_keyboard_modifiers();
+        reset_globals();
         assert_eq!(keyboard_modifiers().get_untracked(), Modifiers::default());
 
         let latched = Modifiers {
@@ -92,7 +78,7 @@ mod tests {
         use crate::reactive::owner::{create_root_owner, dispose_owner_now, with_owner};
 
         create_root_owner();
-        reset_keyboard_modifiers();
+        reset_globals();
 
         let (_, scope) = with_owner(|| keyboard_modifiers().get_untracked());
         dispose_owner_now(scope);
@@ -111,13 +97,13 @@ mod tests {
 
     #[test]
     fn a_new_app_does_not_inherit_the_last_one_s_state() {
-        reset_keyboard_modifiers();
+        reset_globals();
         set_keyboard_modifiers(Modifiers {
             caps_lock: true,
             ..Default::default()
         });
 
-        reset_keyboard_modifiers();
+        reset_globals();
 
         assert_eq!(keyboard_modifiers().get_untracked(), Modifiers::default());
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1369,8 +1369,6 @@ impl App {
     pub fn run(mut self, setup: impl FnOnce(&mut Self)) -> ExitReason {
         // Create root owner scope — all signals/effects created in setup are owned
         self.root_owner_id = Some(reactive::create_root_owner());
-        // Under the root owner, so it outlives every component scope.
-        reactive::init_focus();
         setup(&mut self);
 
         if self.surface_definitions.is_empty() {
@@ -1697,9 +1695,6 @@ impl Drop for App {
         surface::reset_surface_commands();
         surface::reset_popups();
         widget_ref::reset_widget_refs();
-        outputs::reset_outputs();
-        compositor::reset_compositor_effects();
-        keyboard::reset_keyboard_modifiers();
         reactive::focus::reset_pending_focus();
         session_lock::reset_session_lock();
         FONTS_CONSUMED.with(|f| f.set(false));

--- a/src/outputs.rs
+++ b/src/outputs.rs
@@ -19,11 +19,10 @@
 //! `surface_output(id)` reports which output a surface is currently shown on
 //! (tracked read — reactive when called inside a tracked closure).
 
-use std::cell::RefCell;
 use std::collections::HashMap;
 
-use crate::reactive::owner::with_root_owner;
-use crate::reactive::{RwSignal, Signal, create_signal};
+use crate::reactive::global::GlobalSignal;
+use crate::reactive::{RwSignal, Signal};
 use crate::surface::SurfaceId;
 
 /// Stable identifier for a connected output (monitor).
@@ -66,30 +65,18 @@ pub struct OutputInfo {
     pub logical_position: Option<(i32, i32)>,
 }
 
-thread_local! {
-    /// Reactive list of connected outputs. Lazily created so it works both
-    /// before and after platform init; wiped by `reset_outputs()`.
-    static OUTPUTS: RefCell<Option<RwSignal<Vec<OutputInfo>>>> = const { RefCell::new(None) };
-
-    /// Which output each surface is currently shown on (latest entered).
-    static SURFACE_OUTPUTS: RefCell<Option<RwSignal<HashMap<SurfaceId, OutputId>>>> =
-        const { RefCell::new(None) };
-}
+/// Reactive list of connected outputs.
+static OUTPUTS: GlobalSignal<Vec<OutputInfo>> = GlobalSignal::new(Vec::new);
+/// Which output each surface is currently shown on (latest entered).
+static SURFACE_OUTPUTS: GlobalSignal<HashMap<SurfaceId, OutputId>> =
+    GlobalSignal::new(HashMap::new);
 
 fn outputs_signal() -> RwSignal<Vec<OutputInfo>> {
-    OUTPUTS.with(|cell| {
-        *cell
-            .borrow_mut()
-            .get_or_insert_with(|| with_root_owner(|| create_signal(Vec::new())))
-    })
+    OUTPUTS.get()
 }
 
 fn surface_outputs_signal() -> RwSignal<HashMap<SurfaceId, OutputId>> {
-    SURFACE_OUTPUTS.with(|cell| {
-        *cell
-            .borrow_mut()
-            .get_or_insert_with(|| with_root_owner(|| create_signal(HashMap::new())))
-    })
+    SURFACE_OUTPUTS.get()
 }
 
 /// Reactive list of connected outputs (monitors), sorted by [`OutputId`].
@@ -152,13 +139,4 @@ pub(crate) fn output_removed(output: OutputId) {
     surface_outputs_signal().update(|m| {
         m.retain(|_, o| *o != output);
     });
-}
-
-/// Reset output state.
-///
-/// Called during `App::drop()`; the signals themselves die with the reactive
-/// storage reset, this just drops the stale handles.
-pub(crate) fn reset_outputs() {
-    OUTPUTS.with(|cell| *cell.borrow_mut() = None);
-    SURFACE_OUTPUTS.with(|cell| *cell.borrow_mut() = None);
 }

--- a/src/reactive/focus.rs
+++ b/src/reactive/focus.rs
@@ -27,7 +27,8 @@ use std::cell::RefCell;
 use smallvec::SmallVec;
 
 use crate::jobs::{JobRequest, request_job};
-use crate::reactive::signal::{RwSignal, create_signal};
+use crate::reactive::global::GlobalSignal;
+use crate::reactive::signal::RwSignal;
 use crate::tree::{Tree, WidgetId};
 
 /// The focused widget and every ancestor of it, innermost first.
@@ -62,31 +63,12 @@ impl FocusPath {
     }
 }
 
-thread_local! {
-    /// The focused widget and its ancestors. A signal, so that resolving a
-    /// `when_focused` subscribes to it.
-    ///
-    /// Held as an `Option` rather than eagerly, because the handle has to be
-    /// *droppable*: `reset_reactive` wipes the signal storage at `App::drop`,
-    /// and a thread-local holding an id into the old arena would leave a
-    /// second `App` on the same thread with a focus that silently never
-    /// updates. As a plain `RefCell<Option<WidgetId>>` this was immune by
-    /// construction; as a signal it has to be released explicitly.
-    static FOCUS: RefCell<Option<RwSignal<FocusPath>>> = const { RefCell::new(None) };
-}
+/// The focused widget and its ancestors. A signal, so that resolving a
+/// `when_focused` subscribes to it.
+static FOCUS: GlobalSignal<FocusPath> = GlobalSignal::new(FocusPath::default);
 
 fn focus() -> RwSignal<FocusPath> {
-    FOCUS.with(|cell| {
-        *cell
-            .borrow_mut()
-            .get_or_insert_with(|| create_signal(FocusPath::default()))
-    })
-}
-
-/// Create the focus signal under the root owner, before anything can create it
-/// under a narrower one that might be disposed mid-run.
-pub(crate) fn init_focus() {
-    let _ = focus();
+    FOCUS.get()
 }
 
 /// The current focus path. Reading this subscribes, like any other signal.
@@ -189,14 +171,6 @@ pub fn has_focus(id: WidgetId) -> bool {
 /// Get the ID of the currently focused widget, if any.
 pub fn focused_widget() -> Option<WidgetId> {
     focus().get_untracked().widget()
-}
-
-/// Release the focus signal (without paint jobs — used during App teardown).
-///
-/// Drops the handle rather than writing through it: the storage it points into
-/// is about to be replaced, and the next `App` has to get a fresh one.
-pub(crate) fn reset_focus() {
-    FOCUS.with(|cell| *cell.borrow_mut() = None);
 }
 
 /// Clear all focus (no widget will have focus).

--- a/src/reactive/focus.rs
+++ b/src/reactive/focus.rs
@@ -126,6 +126,13 @@ pub fn apply_pending_focus(tree: &Tree) {
     let Some(widget_ref) = PENDING.with(|pending| *pending.borrow()) else {
         return;
     };
+    // A request whose ref died with the scope that made it can never be
+    // honoured — `.focus()` from inside a popup that closed before the frame
+    // came round. Parked, it would be read again on every frame that follows.
+    if !widget_ref.is_alive() {
+        PENDING.with(|pending| *pending.borrow_mut() = None);
+        return;
+    }
     // A request naming a widget that is still not in the tree stays parked: the
     // app asked for a field that has not been built yet, which is the ordinary
     // shape of `focus()` called from a startup effect.
@@ -180,5 +187,33 @@ pub fn clear_focus() {
     if let Some(old_id) = old.widget() {
         request_job(old_id, JobRequest::Paint);
         focus().set(FocusPath::default());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::reactive::owner::{create_root_owner, dispose_owner_now, with_owner};
+
+    /// `.focus()` from inside a popup, on a ref composed in that popup, when the
+    /// popup closes before the loop comes round: the request is parked by
+    /// design — a widget not yet in the tree is the ordinary case — so a dead
+    /// one would be read again on every frame from then on.
+    #[test]
+    fn a_parked_request_whose_ref_died_is_dropped_rather_than_read_forever() {
+        create_root_owner();
+        let tree = Tree::new();
+        let ((), popup_scope) = with_owner(|| {
+            request_focus_deferred(crate::widget_ref::create_widget_ref());
+        });
+        dispose_owner_now(popup_scope);
+
+        apply_pending_focus(&tree);
+        apply_pending_focus(&tree);
+
+        assert!(
+            PENDING.with(|pending| pending.borrow().is_none()),
+            "a request that can never be honoured does not stay parked"
+        );
     }
 }

--- a/src/reactive/focus.rs
+++ b/src/reactive/focus.rs
@@ -30,6 +30,7 @@ use crate::jobs::{JobRequest, request_job};
 use crate::reactive::global::GlobalSignal;
 use crate::reactive::signal::RwSignal;
 use crate::tree::{Tree, WidgetId};
+use crate::widget_ref::Attachment;
 
 /// The focused widget and every ancestor of it, innermost first.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -126,20 +127,37 @@ pub fn apply_pending_focus(tree: &Tree) {
     let Some(widget_ref) = PENDING.with(|pending| *pending.borrow()) else {
         return;
     };
-    // A request whose ref died with the scope that made it can never be
-    // honoured — `.focus()` from inside a popup that closed before the frame
-    // came round. Parked, it would be read again on every frame that follows.
-    if !widget_ref.is_alive() {
-        PENDING.with(|pending| *pending.borrow_mut() = None);
-        return;
+    // One read of the handle, three outcomes. A request whose ref died with
+    // the scope that made it can never be honoured — `.focus()` from inside a
+    // popup that closed before the frame came round — and parked it would be
+    // read again on every frame after. One naming a widget that is not in the
+    // tree *yet* stays parked: that is the ordinary shape of `focus()` from a
+    // startup effect. One that names a widget applies.
+    match widget_ref.attachment() {
+        Attachment::Gone => PENDING.with(|pending| *pending.borrow_mut() = None),
+        Attachment::Unattached => {}
+        Attachment::To(id) => {
+            PENDING.with(|pending| *pending.borrow_mut() = None);
+            request_focus(tree, id);
+        }
     }
-    // A request naming a widget that is still not in the tree stays parked: the
-    // app asked for a field that has not been built yet, which is the ordinary
-    // shape of `focus()` called from a startup effect.
-    if let Some(id) = widget_ref.widget() {
-        PENDING.with(|pending| *pending.borrow_mut() = None);
-        request_focus(tree, id);
-    }
+}
+
+/// Drop a parked request that names `widget_ref`.
+///
+/// Called by the widget-ref registry when a ref's widget leaves the tree. A
+/// request waits for a widget that has not been laid out *yet* — that is the
+/// ordinary shape of `focus()` from a startup effect — but one whose widget
+/// has been and is gone is waiting for something that already happened, and
+/// left parked it would fire at whatever takes that ref next, stealing the
+/// keyboard from wherever the user had put it.
+pub(crate) fn drop_pending_focus_for(widget_ref: crate::widget_ref::WidgetRef) {
+    PENDING.with(|pending| {
+        let mut pending = pending.borrow_mut();
+        if *pending == Some(widget_ref) {
+            *pending = None;
+        }
+    });
 }
 
 /// Drop any parked request. Called during `App::drop()`.
@@ -194,6 +212,40 @@ pub fn clear_focus() {
 mod tests {
     use super::*;
     use crate::reactive::owner::{create_root_owner, dispose_owner_now, with_owner};
+
+    /// A request outlives a widget that comes and goes, and must not fire at
+    /// whatever takes its ref next: the field it named left the tree, so the
+    /// request is for something that already happened.
+    #[test]
+    fn a_request_dies_with_the_widget_it_named() {
+        use crate::layout::Constraints;
+        use crate::widgets::{container, text_input};
+
+        create_root_owner();
+        let field = crate::widget_ref::create_widget_ref();
+        let mut tree = Tree::new();
+        let root = tree.register(Box::new(container().child(
+            text_input(crate::reactive::create_signal(String::new())).widget_ref(field),
+        )));
+        tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
+        tree.with_widget_mut(root, |w, id, t| {
+            w.layout(t, id, Constraints::new(0.0, 0.0, 200.0, 40.0))
+        });
+        crate::widget_ref::update_widget_refs(&tree);
+        assert!(field.widget().is_some(), "laid out, so it names a widget");
+
+        request_focus_deferred(field);
+
+        // The field is taken out of the tree: the registry notices on its next
+        // pass, and the request goes with the widget it was waiting for.
+        crate::jobs::teardown_widget_subtree(&mut tree, root);
+        crate::widget_ref::update_widget_refs(&tree);
+
+        assert!(
+            PENDING.with(|pending| pending.borrow().is_none()),
+            "a request for a widget that has left does not wait for its ref to be reused"
+        );
+    }
 
     /// `.focus()` from inside a popup, on a ref composed in that popup, when the
     /// popup closes before the loop comes round: the request is parked by

--- a/src/reactive/global.rs
+++ b/src/reactive/global.rs
@@ -27,7 +27,9 @@
 //! same type are two globals. Nothing has to be registered, listed, or reset by
 //! hand.
 
+use std::any::TypeId;
 use std::cell::RefCell;
+use std::collections::hash_map::Entry;
 
 use rustc_hash::FxHashMap;
 
@@ -37,9 +39,9 @@ use super::signal::{RwSignal, create_signal};
 
 thread_local! {
     /// Which signal each declared global resolved to, keyed by the address of
-    /// its `static`. Cleared with the rest of the reactive state, which is the
-    /// whole of a global's teardown.
-    static GLOBALS: RefCell<FxHashMap<usize, SignalId>> = RefCell::new(FxHashMap::default());
+    /// its `static` and tagged with the type it was declared as.
+    static GLOBALS: RefCell<FxHashMap<usize, (SignalId, TypeId)>> =
+        RefCell::new(FxHashMap::default());
 }
 
 /// A signal that lives as long as the `App`.
@@ -59,25 +61,56 @@ impl<T: Clone + Send + 'static> GlobalSignal<T> {
         Self { init }
     }
 
-    /// The signal, creating it under the root owner if this is its first use.
+    /// The signal, creating it if this is its first use — or if the last one
+    /// is gone.
+    ///
+    /// The recreation is what keeps this from being one more thing to remember:
+    /// a global whose signal died with a previous `App` answers by making a new
+    /// one, so `reset_globals` is a tidying rather than a step the teardown has
+    /// to get in the right order. Reading a global while an `App` is being torn
+    /// down — a widget's cleanup, a drop — therefore cannot panic.
     pub(crate) fn get(&'static self) -> RwSignal<T> {
         let key = self as *const Self as usize;
-        if let Some(id) = GLOBALS.with(|globals| globals.borrow().get(&key).copied()) {
-            return RwSignal::from_id(id);
+        let cached = GLOBALS.with(|globals| globals.borrow().get(&key).copied());
+        if let Some((id, declared)) = cached {
+            // The address of the `static` is the identity, and nothing enforces
+            // that two of them cannot share one — a linker folding identical
+            // initialisers would. The type it was declared as is carried
+            // alongside so that would be caught here rather than surface as a
+            // downcast panic on somebody else's signal.
+            debug_assert_eq!(
+                declared,
+                TypeId::of::<T>(),
+                "two globals share an address: one of them is reading the other's signal"
+            );
+            if crate::reactive::storage::has_signal(id) {
+                return RwSignal::from_id(id);
+            }
         }
         // Outside the borrow: creating a signal touches the runtime, the owner
-        // arena and the storage, and any of them may create a global of its own.
+        // arena and the storage, and any of them may create a global of its own
+        // — including, re-entrantly, this one.
         let signal = with_root_owner(|| create_signal((self.init)()));
-        GLOBALS.with(|globals| globals.borrow_mut().insert(key, signal.id()));
-        signal
+        GLOBALS.with(|globals| {
+            match globals.borrow_mut().entry(key) {
+                // A re-entrant call got there first: it wins, and the signal
+                // built here is dropped with the scope that owns it. Two live
+                // signals under one name would be worse than one wasted slot.
+                Entry::Occupied(e) => RwSignal::from_id(e.get().0),
+                Entry::Vacant(e) => {
+                    e.insert((signal.id(), TypeId::of::<T>()));
+                    signal
+                }
+            }
+        })
     }
 }
 
 /// Forget every global's signal.
 ///
-/// Called from `reset_reactive` at `App::drop`. The signals die with the
-/// storage; this drops the ids that pointed at them, so the next `App` on this
-/// thread declares them afresh instead of reading into a wiped arena.
+/// Called from `reset_reactive` at `App::drop`. Not load-bearing: a global
+/// whose signal is gone builds another on the next read. This keeps the map
+/// from carrying one dead entry per global into the next `App`.
 pub(crate) fn reset_globals() {
     GLOBALS.with(|globals| globals.borrow_mut().clear());
 }
@@ -110,6 +143,27 @@ mod tests {
     fn every_read_of_one_global_is_the_same_signal() {
         create_root_owner();
         assert!(COUNT.get() == COUNT.get());
+    }
+
+    /// A global whose signal died with the last `App` builds another rather
+    /// than reading into a wiped arena. That is what keeps the teardown from
+    /// having an order to get right: `App::drop` disposes the root owner —
+    /// which owns every global — and only afterwards clears the tree, running
+    /// widget drops that may read one.
+    #[test]
+    fn a_global_whose_signal_is_gone_makes_another() {
+        create_root_owner();
+        COUNT.get().set(3);
+        assert_eq!(COUNT.get().get_untracked(), 3);
+
+        // What `App::drop` does before it gets to `reset_globals`.
+        crate::reactive::storage::reset_storage();
+
+        assert_eq!(
+            COUNT.get().get_untracked(),
+            7,
+            "back to what the declaration says, not a panic"
+        );
     }
 
     /// The identity is the declaration, not the type: two globals holding a

--- a/src/reactive/global.rs
+++ b/src/reactive/global.rs
@@ -1,0 +1,125 @@
+//! Signals whose owner is the application.
+//!
+//! A signal belongs to whatever scope is current when `create_signal` runs, and
+//! that scope is ambient and time-dependent: the same line inside a widget
+//! factory belongs to that surface, inside a click handler to the root, on an
+//! effect's first run to whoever created the effect. For state with one instance
+//! per process — what the compositor reports, where the keyboard focus is — the
+//! owner is none of those. It is the application, and drawing it by lot from
+//! whoever reads first is how "signal was disposed" panics get made.
+//!
+//! A `GlobalSignal` says so at the declaration:
+//!
+//! ```ignore
+//! static MODIFIERS: GlobalSignal<Modifiers> = GlobalSignal::new(Modifiers::default);
+//!
+//! pub fn keyboard_modifiers() -> Signal<Modifiers> {
+//!     MODIFIERS.get().read_only()
+//! }
+//! ```
+//!
+//! Created under the root owner on first use — so it outlives every scope that
+//! might read it — and forgotten when the `App` is dropped, which the next `App`
+//! on this thread needs: `reset_reactive` wipes the signal storage, and an id
+//! kept across that points into an arena that no longer exists.
+//!
+//! The identity is the `static` itself, taken by address, so two globals of the
+//! same type are two globals. Nothing has to be registered, listed, or reset by
+//! hand.
+
+use std::cell::RefCell;
+
+use rustc_hash::FxHashMap;
+
+use super::owner::with_root_owner;
+use super::runtime::SignalId;
+use super::signal::{RwSignal, create_signal};
+
+thread_local! {
+    /// Which signal each declared global resolved to, keyed by the address of
+    /// its `static`. Cleared with the rest of the reactive state, which is the
+    /// whole of a global's teardown.
+    static GLOBALS: RefCell<FxHashMap<usize, SignalId>> = RefCell::new(FxHashMap::default());
+}
+
+/// A signal that lives as long as the `App`.
+///
+/// Declare it as a `static` and read it through [`get`](GlobalSignal::get);
+/// the signal itself is created on first use. See the module docs.
+pub(crate) struct GlobalSignal<T: 'static> {
+    /// The value the signal starts from. A `fn` pointer rather than a `T` so
+    /// the `static` is `Sync` whatever `T` is, and so the value is built when
+    /// there is a runtime to build it in.
+    init: fn() -> T,
+}
+
+impl<T: Clone + Send + 'static> GlobalSignal<T> {
+    /// Declare a global signal starting from `init()`.
+    pub(crate) const fn new(init: fn() -> T) -> Self {
+        Self { init }
+    }
+
+    /// The signal, creating it under the root owner if this is its first use.
+    pub(crate) fn get(&'static self) -> RwSignal<T> {
+        let key = self as *const Self as usize;
+        if let Some(id) = GLOBALS.with(|globals| globals.borrow().get(&key).copied()) {
+            return RwSignal::from_id(id);
+        }
+        // Outside the borrow: creating a signal touches the runtime, the owner
+        // arena and the storage, and any of them may create a global of its own.
+        let signal = with_root_owner(|| create_signal((self.init)()));
+        GLOBALS.with(|globals| globals.borrow_mut().insert(key, signal.id()));
+        signal
+    }
+}
+
+/// Forget every global's signal.
+///
+/// Called from `reset_reactive` at `App::drop`. The signals die with the
+/// storage; this drops the ids that pointed at them, so the next `App` on this
+/// thread declares them afresh instead of reading into a wiped arena.
+pub(crate) fn reset_globals() {
+    GLOBALS.with(|globals| globals.borrow_mut().clear());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::reactive::owner::{create_root_owner, dispose_owner_now, with_owner};
+
+    static COUNT: GlobalSignal<u32> = GlobalSignal::new(|| 7);
+    static OTHER_COUNT: GlobalSignal<u32> = GlobalSignal::new(|| 100);
+
+    /// The whole point: the first reader does not become the owner.
+    #[test]
+    fn a_global_outlives_the_scope_that_read_it_first() {
+        create_root_owner();
+        let ((), first_reader) = with_owner(|| {
+            assert_eq!(COUNT.get().get_untracked(), 7);
+        });
+        dispose_owner_now(first_reader);
+
+        assert_eq!(COUNT.get().get_untracked(), 7, "still readable");
+        COUNT.get().set(9);
+        assert_eq!(COUNT.get().get_untracked(), 9, "and still writable");
+    }
+
+    /// Every read finds the same signal — otherwise a writer and a watcher
+    /// would be looking at two different values with the same name.
+    #[test]
+    fn every_read_of_one_global_is_the_same_signal() {
+        create_root_owner();
+        assert!(COUNT.get() == COUNT.get());
+    }
+
+    /// The identity is the declaration, not the type: two globals holding a
+    /// `u32` are two globals.
+    #[test]
+    fn two_globals_of_one_type_are_two_globals() {
+        create_root_owner();
+        COUNT.get().set(1);
+        OTHER_COUNT.get().set(2);
+        assert_eq!(COUNT.get().get_untracked(), 1);
+        assert_eq!(OTHER_COUNT.get().get_untracked(), 2);
+    }
+}

--- a/src/reactive/mod.rs
+++ b/src/reactive/mod.rs
@@ -5,6 +5,7 @@ pub mod cursor;
 pub mod diagnostics;
 pub mod effect;
 pub mod focus;
+pub(crate) mod global;
 pub(crate) mod guard;
 pub mod into_signal;
 pub mod invalidation;
@@ -31,7 +32,7 @@ pub use cursor::{CursorIcon, set_cursor};
 pub(crate) use cursor::{cursor_change_pending, take_cursor_change};
 pub use effect::create_effect;
 pub(crate) use focus::{
-    focus_path, has_focus, init_focus, release_focus, release_focus_if_within, request_focus,
+    focus_path, has_focus, release_focus, release_focus_if_within, request_focus,
 };
 #[doc(hidden)]
 pub use into_signal::{
@@ -73,12 +74,10 @@ pub use signal::{
 /// enabling clean restart of the application.
 pub(crate) fn reset_reactive() {
     owner::reset_owners();
+    // Before `reset_storage`, with the same reason the focus release below has:
+    // these hold ids into the arena that is about to be replaced.
+    global::reset_globals();
     runtime::reset_runtime();
-    // Before `reset_storage`: the focus path lives in a signal now, held by a
-    // thread-local that outlives the storage. It releases the handle rather
-    // than writing through it, so the next `App` on this thread gets a fresh
-    // one instead of a silently dead signal.
-    focus::reset_focus();
     storage::reset_storage();
     invalidation::reset_invalidation();
     clipboard::reset_clipboard();

--- a/src/reactive/signal.rs
+++ b/src/reactive/signal.rs
@@ -248,6 +248,26 @@ pub struct RwSignal<T> {
 
 impl_signal_id_traits!(RwSignal);
 
+impl<T> RwSignal<T> {
+    /// Rebuild a handle from an id kept elsewhere.
+    ///
+    /// For the global registry, which stores ids because it holds signals of
+    /// many types (`reactive/global.rs`). An id whose signal was disposed
+    /// fails the generation check on the next read, as any stale handle does.
+    pub(crate) const fn from_id(id: SignalId) -> Self {
+        Self {
+            id,
+            _marker: PhantomData,
+            _not_send: PhantomData,
+        }
+    }
+
+    /// This signal's id.
+    pub(crate) fn id(&self) -> SignalId {
+        self.id
+    }
+}
+
 impl<T: Clone + 'static> RwSignal<T> {
     /// Get the current value (tracks as dependency for effects)
     #[inline]

--- a/src/reactive/trigger.rs
+++ b/src/reactive/trigger.rs
@@ -41,6 +41,12 @@ pub fn create_trigger() -> Trigger {
 }
 
 impl Trigger {
+    /// Wrap a signal that is already owned by someone else — the global
+    /// registry, for a trigger that has to outlive every scope that reads it.
+    pub(crate) const fn from_signal(inner: RwSignal<()>) -> Self {
+        Self { inner }
+    }
+
     /// Notify every tracker, unconditionally.
     pub fn notify(&self) {
         self.inner.set_always(());

--- a/src/session_lock.rs
+++ b/src/session_lock.rs
@@ -104,7 +104,17 @@ where
 {
     LOCK.with(|lock| {
         let mut lock = lock.borrow_mut();
-        if lock.lock_requested || STATE.get().get_untracked() == LockState::Locked {
+        // `Locking` counts: a second request while the first is in flight is
+        // granted here, then refused by the platform on the next iteration —
+        // and the refusal path clears the factory. The compositor's `Locked`
+        // then arrives with nothing to build the lock screen from, which is a
+        // locked session with no way to type a password into it.
+        if lock.lock_requested
+            || matches!(
+                STATE.get().get_untracked(),
+                LockState::Locked | LockState::Locking
+            )
+        {
             log::warn!("lock_session() called while already locked or locking");
             return;
         }

--- a/src/session_lock.rs
+++ b/src/session_lock.rs
@@ -27,8 +27,9 @@ use smithay_client_toolkit::reexports::client::QueueHandle;
 
 use crate::outputs::{self, OutputId, OutputInfo};
 use crate::platform::{LockEvent, WaylandState};
-use crate::reactive::owner::{with_owner, with_root_owner};
-use crate::reactive::{RwSignal, Signal, create_signal};
+use crate::reactive::global::GlobalSignal;
+use crate::reactive::owner::with_owner;
+use crate::reactive::{RwSignal, Signal};
 use crate::surface::{SurfaceConfig, SurfaceId};
 use crate::surface_manager::{ManagedSurface, SurfaceManager};
 use crate::tree::Tree;
@@ -55,7 +56,6 @@ struct LockData {
     factory: Option<LockWidgetFn>,
     /// Lock surface per output.
     surfaces: HashMap<OutputId, SurfaceId>,
-    state: Option<RwSignal<LockState>>,
     lock_requested: bool,
     unlock_requested: bool,
 }
@@ -64,13 +64,13 @@ thread_local! {
     static LOCK: RefCell<LockData> = RefCell::new(LockData::default());
 }
 
+/// The lifecycle the application watches. Its own global rather than a field
+/// of `LockData`: the rest of that struct is the platform's bookkeeping, which
+/// dies with the `App`, while this is read from widget scopes that come and go.
+static STATE: GlobalSignal<LockState> = GlobalSignal::new(LockState::default);
+
 fn state_signal() -> RwSignal<LockState> {
-    LOCK.with(|lock| {
-        *lock
-            .borrow_mut()
-            .state
-            .get_or_insert_with(|| with_root_owner(|| create_signal(LockState::default())))
-    })
+    STATE.get()
 }
 
 fn set_state(state: LockState) {
@@ -104,7 +104,7 @@ where
 {
     LOCK.with(|lock| {
         let mut lock = lock.borrow_mut();
-        if lock.lock_requested || lock.state.map(|s| s.get_untracked()) == Some(LockState::Locked) {
+        if lock.lock_requested || STATE.get().get_untracked() == LockState::Locked {
             log::warn!("lock_session() called while already locked or locking");
             return;
         }

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -40,8 +40,8 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::outputs::OutputId;
 use crate::platform::{Anchor, KeyboardInteractivity, Layer};
-use crate::reactive::owner::with_root_owner;
-use crate::reactive::{Trigger, create_trigger};
+use crate::reactive::Trigger;
+use crate::reactive::global::GlobalSignal;
 use crate::widgets::{Color, Rect, Widget};
 
 /// Unique identifier for each surface in the application.
@@ -979,18 +979,14 @@ impl PopupHandle {
 thread_local! {
     static LIVE_POPUPS: RefCell<std::collections::HashSet<SurfaceId>> =
         RefCell::new(std::collections::HashSet::new());
-    static POPUP_DISMISSAL: RefCell<Option<Trigger>> = const { RefCell::new(None) };
 }
 
-/// The notifier that makes reading the registry reactive, created on first
-/// use under the root owner — it belongs to the application, not to whichever
-/// popup happened to be opened first.
+/// The notifier that makes reading the registry reactive. It belongs to the
+/// application, not to whichever popup happened to be opened first.
+static POPUP_DISMISSAL: GlobalSignal<()> = GlobalSignal::new(|| ());
+
 fn popup_dismissal() -> Trigger {
-    POPUP_DISMISSAL.with(|cell| {
-        *cell
-            .borrow_mut()
-            .get_or_insert_with(|| with_root_owner(create_trigger))
-    })
+    Trigger::from_signal(POPUP_DISMISSAL.get())
 }
 
 /// Mark a popup dismissed (called by the platform layer on popup_done, and
@@ -1004,12 +1000,10 @@ pub(crate) fn mark_popup_dismissed(id: SurfaceId) {
 
 /// Reset popup registry state.
 ///
-/// Called during `App::drop()`. The notifier is released rather than
-/// notified: the storage behind it is wiped in the same teardown, so keeping
-/// the handle would hand the next `App` on this thread a dead one.
+/// Called during `App::drop()`. The notifier needs nothing here — a global
+/// signal is forgotten with the rest of the reactive state.
 pub(crate) fn reset_popups() {
     LIVE_POPUPS.with(|live| live.borrow_mut().clear());
-    POPUP_DISMISSAL.with(|cell| *cell.borrow_mut() = None);
 }
 
 /// Spawn an xdg popup anchored to a parent surface.

--- a/src/widget_ref.rs
+++ b/src/widget_ref.rs
@@ -26,10 +26,6 @@ use crate::reactive::{RwSignal, Signal, create_signal};
 use crate::tree::{Tree, WidgetId};
 use crate::widgets::Rect;
 
-/// A handle to one widget: its bounds, and its focus.
-///
-/// Created via [`create_widget_ref()`]. Attach to a container or a text input
-/// with `.widget_ref(r)`.
 /// What a [`WidgetRef`] points at.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Attachment {
@@ -41,8 +37,13 @@ pub(crate) enum Attachment {
     Gone,
 }
 
-/// Two refs are the same ref when they name the same pair of signals — which
-/// is what a `Copy` of one is.
+/// A handle to one widget: its bounds, and its focus.
+///
+/// Created via [`create_widget_ref()`]. Attach to a container or a text input
+/// with `.widget_ref(r)`.
+///
+/// Two of them are equal when they name the same pair of signals — which is
+/// what a `Copy` of one is.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct WidgetRef {
     signal: RwSignal<Rect>,

--- a/src/widget_ref.rs
+++ b/src/widget_ref.rs
@@ -30,7 +30,20 @@ use crate::widgets::Rect;
 ///
 /// Created via [`create_widget_ref()`]. Attach to a container or a text input
 /// with `.widget_ref(r)`.
-#[derive(Clone, Copy)]
+/// What a [`WidgetRef`] points at.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Attachment {
+    /// Laid out, and this is the widget.
+    To(WidgetId),
+    /// Alive, but not laid out yet — or no longer.
+    Unattached,
+    /// The scope that created the ref is gone.
+    Gone,
+}
+
+/// Two refs are the same ref when they name the same pair of signals — which
+/// is what a `Copy` of one is.
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub struct WidgetRef {
     signal: RwSignal<Rect>,
     /// Which widget this ref is attached to, filled in when that widget is laid
@@ -56,15 +69,25 @@ impl WidgetRef {
         self.widget.try_get_untracked().flatten()
     }
 
+    /// What this ref points at, with the two cases [`widget`](Self::widget)
+    /// folds together kept apart.
+    ///
+    /// One read of the handle, for the callers that must tell "waiting for a
+    /// widget that has not been laid out yet" from "the scope that made this
+    /// ref is gone" — a parked focus request waits for the first and can never
+    /// be honoured by the second.
+    pub(crate) fn attachment(&self) -> Attachment {
+        match self.widget.try_get_untracked() {
+            None => Attachment::Gone,
+            Some(None) => Attachment::Unattached,
+            Some(Some(id)) => Attachment::To(id),
+        }
+    }
+
     /// Whether this ref's own signals are still alive — that is, whether the
     /// scope that created it is.
-    ///
-    /// Distinguishes the two cases [`widget`](Self::widget) folds together, for
-    /// the one caller that has to: a parked focus request naming a dead ref can
-    /// never be honoured, while one naming a widget not yet laid out is waiting
-    /// for exactly that.
     pub(crate) fn is_alive(&self) -> bool {
-        self.widget.try_get_untracked().is_some()
+        !matches!(self.attachment(), Attachment::Gone)
     }
 
     /// Move the keyboard focus to this widget.
@@ -154,20 +177,30 @@ pub(crate) fn update_widget_refs(tree: &Tree) {
         reg.borrow_mut().retain(|&id, widget_ref| {
             // A ref's signals belong to the scope that created it — a popup's
             // widget tree, a dynamic child — and this registry outlives every
-            // one of them. A ref that no longer points at a live widget is an
-            // entry with nothing left to update.
-            let attached = widget_ref.widget();
-            if attached.is_none() {
+            // one of them, so the handle is asked whether it is still there
+            // before it is read.
+            //
+            // Dead is not the same as detached: a `WidgetRef` is `Copy`, so one
+            // can be registered under two ids — the same view function used for
+            // two surfaces does it — and the entry whose widget left the tree
+            // clears the handle for both. The other entry is still live and
+            // still laid out, and evicting it would freeze its `rect()` until
+            // its container next re-registers.
+            if !widget_ref.is_alive() {
                 return false;
             }
+            let attached = widget_ref.widget();
             if let Some(rect) = tree.get_surface_relative_bounds(id) {
                 widget_ref.signal.set(rect);
                 true
             } else {
                 // Widget removed from tree — drop registry entry, and stop
-                // claiming the handle points at something.
+                // claiming the handle points at something. A focus request
+                // parked on this ref was waiting for the widget that just
+                // left, so it goes with it.
                 if attached == Some(id) {
                     widget_ref.widget.set(None);
+                    crate::reactive::focus::drop_pending_focus_for(*widget_ref);
                 }
                 false
             }

--- a/src/widget_ref.rs
+++ b/src/widget_ref.rs
@@ -46,8 +46,25 @@ impl WidgetRef {
     }
 
     /// The widget this ref is attached to, once it has been laid out.
+    ///
+    /// `None` before that first layout — and `None` again once the scope that
+    /// created the ref is gone, which is the same answer to the same question:
+    /// this handle does not point at a live widget. A `WidgetRef` is `Copy` and
+    /// can outlive the tree it named, so asking has to be safe whenever anyone
+    /// still holds one.
     pub fn widget(&self) -> Option<WidgetId> {
-        self.widget.get_untracked()
+        self.widget.try_get_untracked().flatten()
+    }
+
+    /// Whether this ref's own signals are still alive — that is, whether the
+    /// scope that created it is.
+    ///
+    /// Distinguishes the two cases [`widget`](Self::widget) folds together, for
+    /// the one caller that has to: a parked focus request naming a dead ref can
+    /// never be honoured, while one naming a widget not yet laid out is waiting
+    /// for exactly that.
+    pub(crate) fn is_alive(&self) -> bool {
+        self.widget.try_get_untracked().is_some()
     }
 
     /// Move the keyboard focus to this widget.
@@ -137,12 +154,12 @@ pub(crate) fn update_widget_refs(tree: &Tree) {
         reg.borrow_mut().retain(|&id, widget_ref| {
             // A ref's signals belong to the scope that created it — a popup's
             // widget tree, a dynamic child — and this registry outlives every
-            // one of them. Asking whether the handle is still alive is how an
-            // entry learns to go; reading it outright is how the frame after a
-            // popup closed used to panic.
-            let Some(attached) = widget_ref.widget.try_get_untracked() else {
+            // one of them. A ref that no longer points at a live widget is an
+            // entry with nothing left to update.
+            let attached = widget_ref.widget();
+            if attached.is_none() {
                 return false;
-            };
+            }
             if let Some(rect) = tree.get_surface_relative_bounds(id) {
                 widget_ref.signal.set(rect);
                 true
@@ -163,6 +180,19 @@ mod tests {
     use super::*;
     use crate::reactive::owner::{create_root_owner, dispose_owner_now, with_owner};
     use crate::widgets::container;
+
+    /// Every question a handle answers about its own identity has to survive
+    /// the scope that made it: it is `Copy`, so anyone can still be holding one.
+    #[test]
+    fn a_dead_ref_answers_instead_of_panicking() {
+        create_root_owner();
+        let (widget_ref, scope) = with_owner(create_widget_ref);
+        dispose_owner_now(scope);
+
+        assert_eq!(widget_ref.widget(), None, "it points at no live widget");
+        assert!(!widget_ref.is_focused(), "and it does not hold the focus");
+        assert!(!widget_ref.is_alive());
+    }
 
     /// A widget ref is created wherever its widget is composed, and a popup's
     /// content is composed inside the popup's own scope. The registry is


### PR DESCRIPTION
Three commits: a rule, a mechanism, and the fourth crash of the family #214
opened.

### The rule

Today's work started from three panics that were all the same shape and were
each repaired where they were found. Agreeing on *which* repair was the work,
not writing it. So `CLAUDE.md` now says that a new core type, a new
cross-cutting mechanism, a new ownership rule, or a change to how a whole
family of call sites is spelled, is explained and agreed before it is
implemented — not implemented and then presented.

### The mechanism

`create_signal` gives a signal to whatever scope is current, and that scope is
ambient and time-dependent — measured, not assumed: inside a widget factory it
is that surface's, inside a click handler it is the root, on an effect's first
run it is whoever created the effect. For the six pieces of state with one
instance per process the answer is none of those. There is one keyboard, one
set of monitors, one session lock, one focused widget: the owner is the
application.

Six sites had worked that out separately. Five wrapped the creation in
`with_root_owner` (#175) — one of those five, the session lock, had been
missed and crashed for it; the focus instead created its signal eagerly in
`App::run` so nothing narrower could get there first. Each also carried a
`reset_*` releasing the handle at teardown and a line in `App::drop` calling
it, because `reset_reactive` wipes the arena the id points into. Three
obligations that must hold together, written in three places, remembered by
hand. Two had already been forgotten once.

    static MODIFIERS: GlobalSignal<Modifiers> = GlobalSignal::new(Modifiers::default);

Created under the root on first use, forgotten with the rest of the reactive
state — one line in `reset_reactive`, not one per global. The identity is the
`static` taken by address, so two globals of the same type are two globals,
and the value comes from a `fn` so the declaration is `Sync` whatever it holds.
`init_focus` goes with it, along with five `reset_*` functions and their five
lines in `App::drop`.

It is internal. `keyboard_modifiers()`, `outputs()`, `compositor_effects()`,
`lock_state()` keep their signatures.

### The fourth crash

`.focus()` from inside a popup, on a ref composed in that popup, kills the
application one frame later. The request is parked until the loop can apply it
— correct, since a ref naming a widget not yet laid out is the ordinary case —
but `apply_pending_focus` asks the ref which widget it names, and that ref died
with the popup. From that frame the loop reads a disposed signal, every frame.

The first three were each answered where they were found. This one is answered
at the handle: `WidgetRef::widget()` already returns `Option<WidgetId>` for
"not laid out yet", and a dead ref is the same question with the same useful
answer, so it returns `None` there too instead of panicking. `is_alive()` stays
crate-internal for the one caller that must tell the two apart — a parked
request naming a dead ref can never be honoured, so it is dropped rather than
retried forever.

### What is not here

The same branch carried `.provide()` and the deletion of the context API.
Both are now issues instead: #220 records the three measured defects of the
context API, #221 records why the drafted replacement is not being shipped as
drafted — its main justification disappeared when #219 removed container-side
text style, and its ambient read has an edge the draft gets wrong.

### Testing

Both new crashes have a test verified to fail without its fix — reverting each
one makes its test panic at `storage.rs:84` with the same message the
application gave. `cargo test --all-features` green, clippy clean, snapshots
unchanged.