### PR TITLE
Queueing work for the loop is the same call as waking it

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -319,6 +319,12 @@ either carry their payload or act as doorbells for data queued elsewhere
 flush point). Never call `jobs::wake_loop()` directly from a background
 thread as the *only* wakeup for queued work.
 
+Messages are counted while in flight, because a wakeup living inside
+calloop's channel is invisible from the sending side and the loop's pre-block
+check has to be able to ask about it. `ingress::arm()` puts the count up and
+hands back the message to send; the loop's channel callback takes it back down
+when it reads one.
+
 **Main thread → `jobs::wake_loop()`.**
 The frame-request ping is coalesced per loop iteration through a dedicated
 `PING_SENT` flag cleared once per wakeup (`mark_loop_awake`, right after
@@ -350,17 +356,36 @@ A focused input is the resting state of a lock screen, so that ran all night.
 
 **The contract is checked, not just written down.** Debug builds assert it at
 the one moment where breaking it is fatal: `queued_but_unwoken()` in
-`src/lib.rs` names every queue the loop drains, and nothing may be
-outstanding when the loop is about to block indefinitely. The reasoning is
-that each queue is drained unconditionally once per iteration, so anything
-still queued was produced *after* its own drain — and the only thing that
-brings the loop back is a frame request, which would have kept it from
-blocking. A non-empty queue there means nobody asked to be woken.
+`src/lib.rs`, run just before the loop blocks with no timeout.
 
-So a new queue needs one line in `queued_but_unwoken()` alongside its drain.
-Forget the wakeup and the next idle moment panics with the queue's name,
-instead of the app going quietly deaf until an unrelated compositor event
-happens along. Two of the bugs documented above were exactly that.
+It asks two questions, and needs both. `queued_work()` names every queue the
+loop drains and answers *what* is waiting. `wakeup_armed()` answers whether
+anything is coming to drain it — a ping still readable (`jobs::ping_in_flight`,
+the coalescing flag, cleared right after the dispatch that consumed it), a wake
+request still set, or an ingress message sent and not yet read
+(`ingress::in_flight`). Only a queue with none of those is reported.
+
+The second question is not optional, because a non-empty queue at that point
+is the ordinary case rather than the bug: the drains sit in the middle of the
+iteration and effects, event handlers and background threads all run after
+them, so work riding the next pass is what a working application looks like.
+An earlier version of this check asked the first question alone and panicked
+on healthy states — a background write landing after `flush_bg_writes()`, a
+surface command pushed by an effect whose `WAKE_REQUESTED` was then cleared by
+`take_wake_request()` later in the same iteration.
+
+The order of the two is part of the contract: **a producer arms before it
+queues**, so a queue seen non-empty already has its wakeup armed, and reading
+the arming first can miss one that lands a moment later on another thread.
+That is why `queue_bg_write` calls `ingress::arm()` before pushing and sends
+after — between the push and the send there is an instant where the queue is
+observably non-empty, and the main thread reads it.
+
+So a new queue needs one line in `queued_work()` alongside its drain, and its
+producer needs a wakeup through one of the two mechanisms above. Forget the
+wakeup and the next idle moment panics with the queue's name, instead of the
+app going quietly deaf until an unrelated compositor event happens along. Two
+of the bugs documented above were exactly that.
 
 ## Widget Trait
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -320,11 +320,12 @@ flush point). Never call `jobs::wake_loop()` directly from a background
 thread as the *only* wakeup for queued work.
 
 There are two ways in, and `ingress::sender` is private so there is no third.
-`notify()` resolves the sender at send time, for a producer whose payload is
-ready now. `IngressSender` is taken *before* the work starts and binds the send
-to the loop that was running then — a selection read has three seconds to
-finish, and a result that arrives after a restart would otherwise land in a
-loop whose generation counters have started over.
+`notify()` sends in the same call that queued the work, for a producer whose
+payload is ready then and there. `IngressSender` is taken *before* the work
+starts and binds the send to the loop that was running at that moment — a
+selection read has three seconds to finish, and a result that arrives after a
+restart would otherwise land in a loop whose generation counters have started
+over. Both hand the wakeup to the ping if the receiver has gone.
 
 **Main thread → `jobs::wake_loop()`.**
 The frame-request ping is coalesced per loop iteration through a dedicated
@@ -372,7 +373,7 @@ a coalescing flag for the ping and a count for messages in flight in the
 calloop channel. That is a lot of apparatus to verify at runtime a rule the
 type can make unbreakable.
 
-Three producers stay outside `deferred`, each for a reason worth knowing:
+Four producers stay outside `deferred`, each for a reason worth knowing:
 
 - **background writes** wake through the ingress channel rather than the ping,
   and there is exactly one of them (`queue_bg_write`), so the pairing is one
@@ -381,8 +382,14 @@ Three producers stay outside `deferred`, each for a reason worth knowing:
   per-surface lanes — and wake from inside `request_job`;
 - **a parked focus request** is the opposite invariant: it waits for a widget
   that may not be laid out for many frames, so *still full* is its resting
-  state, not a failure. It is applied once per iteration after the render
-  pass, where the tree is laid out.
+  state, not a failure. It is applied at the end of `layout_pass`, after the
+  tree has resolved and before the paint that shows it;
+- **the session lock's request flags** (`lock_session` / `unlock_session`) are
+  still a flag and a `wake_loop()` written as two statements. They belong in
+  `deferred` by shape — `process_session_lock` drains them unconditionally
+  once per iteration — and are not there yet because the request carries a
+  widget factory into a state machine with its own guards, and the path cannot
+  be exercised without locking the screen (see #209).
 
 Everything in `deferred` is drained unconditionally, once per iteration, in
 the loop body. That is what makes "the loop will get to it on the next pass"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -321,9 +321,20 @@ thread as the *only* wakeup for queued work.
 
 Messages are counted while in flight, because a wakeup living inside
 calloop's channel is invisible from the sending side and the loop's pre-block
-check has to be able to ask about it. `ingress::arm()` puts the count up and
-hands back the message to send; the loop's channel callback takes it back down
-when it reads one.
+check has to be able to ask about it. There are two entry points, and the
+difference is what the message stands for:
+
+- `ingress::arm()` raises the count *before* the work is queued and hands back
+  the message to send after — for a doorbell like `BgWritesQueued`, whose
+  payload sits in a queue the loop can already see;
+- `IngressSender::send` raises it around the send — for a message that carries
+  its own payload, which leaves no queue behind and so has nothing to arm
+  before. Its sender is bound to the loop that was running when the read
+  started, so a slow result cannot land in a later session's loop.
+
+The loop's channel callback takes the count back down when it reads a message.
+Nothing else may send: `ingress::sender` is private precisely so that every
+message the callback decrements for was counted up by one of these two.
 
 **Main thread → `jobs::wake_loop()`.**
 The frame-request ping is coalesced per loop iteration through a dedicated

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -319,22 +319,12 @@ either carry their payload or act as doorbells for data queued elsewhere
 flush point). Never call `jobs::wake_loop()` directly from a background
 thread as the *only* wakeup for queued work.
 
-Messages are counted while in flight, because a wakeup living inside
-calloop's channel is invisible from the sending side and the loop's pre-block
-check has to be able to ask about it. There are two entry points, and the
-difference is what the message stands for:
-
-- `ingress::arm()` raises the count *before* the work is queued and hands back
-  the message to send after — for a doorbell like `BgWritesQueued`, whose
-  payload sits in a queue the loop can already see;
-- `IngressSender::send` raises it around the send — for a message that carries
-  its own payload, which leaves no queue behind and so has nothing to arm
-  before. Its sender is bound to the loop that was running when the read
-  started, so a slow result cannot land in a later session's loop.
-
-The loop's channel callback takes the count back down when it reads a message.
-Nothing else may send: `ingress::sender` is private precisely so that every
-message the callback decrements for was counted up by one of these two.
+There are two ways in, and `ingress::sender` is private so there is no third.
+`notify()` resolves the sender at send time, for a producer whose payload is
+ready now. `IngressSender` is taken *before* the work starts and binds the send
+to the loop that was running then — a selection read has three seconds to
+finish, and a result that arrives after a restart would otherwise land in a
+loop whose generation counters have started over.
 
 **Main thread → `jobs::wake_loop()`.**
 The frame-request ping is coalesced per loop iteration through a dedicated
@@ -358,61 +348,48 @@ Work owed to a *clock* rather than to a frame — the blinking caret — is held
 asks `jobs::next_deadline()`, blocks exactly that long, and `promote_due_jobs()`
 turns whatever is due into an ordinary job at the top of the next iteration.
 
-This is why a scheduled job is not named in `queued_but_unwoken()`: nobody owes it
-a ping, because the loop is not late — it is waiting on purpose, with a bounded
+This is why a scheduled job owes no ping: the loop is not late — it is waiting on purpose, with a bounded
 timeout. The alternative is what the caret used to do: ask for an animation frame,
 which means "advance me every frame", pinning the loop at 60 fps for a square wave
 that changes twice a second and repainting the same pixels 113 frames out of 114.
 A focused input is the resting state of a lock screen, so that ran all night.
 
-**The contract is checked, not just written down.** Debug builds assert it at
-the one moment where breaking it is fatal: `queued_but_unwoken()` in
-`src/lib.rs`, run just before the loop blocks with no timeout.
+**The contract is structural, not policed.** A deferred queue and its wakeup
+are one object (`src/deferred.rs`): `DeferredQueue::push` and
+`DeferredSlot::set` *are* the wakeup, the cell inside is private, and there is
+no way to reach it that does not ask for the pass that empties it. Disposals
+and surface commands are queues; the cursor, the clipboard and the primary
+selection are slots, where two values in one frame means the second is the
+answer.
 
-It asks two questions, and needs both. `queued_work()` names every queue the
-loop drains and answers *what* is waiting. `wakeup_armed()` answers whether
-anything is coming to drain it — a ping written and not yet dispatched
-(`jobs::ping_in_flight`, the coalescing flag, cleared right after the dispatch
-that consumed it), or an ingress message sent and not yet read
-(`ingress::in_flight`). Only a queue with neither is reported.
+That replaced a `debug_assert!` before the blocking dispatch which named every
+queue and panicked if one was non-empty. It was the wrong shape twice over. It
+fired on healthy states — the drains sit in the middle of the iteration and
+effects, event handlers and background threads all run after them, so work
+riding the next pass is what a working application looks like — and answering
+that properly meant tracking, from the outside, whether a wakeup existed:
+a coalescing flag for the ping and a count for messages in flight in the
+calloop channel. That is a lot of apparatus to verify at runtime a rule the
+type can make unbreakable.
 
-`ping_in_flight` means *written*, not *requested*: `wake_loop` lowers the flag
-again when there was no handle to write to, because a flag raised over a ping
-that does not exist would tell the loop it is safe to block when nothing is
-coming — hiding the exact bug this check is for. `WAKE_REQUESTED` is not a
-third answer: `needs_polling` refuses to block while it is set, so the check
-is never reached with one outstanding.
+Three producers stay outside `deferred`, each for a reason worth knowing:
 
-The second question is not optional, because a non-empty queue at that point
-is the ordinary case rather than the bug: the drains sit in the middle of the
-iteration and effects, event handlers and background threads all run after
-them, so work riding the next pass is what a working application looks like.
-An earlier version of this check asked the first question alone and panicked
-on healthy states — a background write landing after `flush_bg_writes()`, a
-surface command pushed by an effect whose `WAKE_REQUESTED` was then cleared by
-`take_wake_request()` later in the same iteration.
+- **background writes** wake through the ingress channel rather than the ping,
+  and there is exactly one of them (`queue_bg_write`), so the pairing is one
+  function rather than a pattern;
+- **widget jobs** carry their own machinery — dedup, ownership resolution,
+  per-surface lanes — and wake from inside `request_job`;
+- **a parked focus request** is the opposite invariant: it waits for a widget
+  that may not be laid out for many frames, so *still full* is its resting
+  state, not a failure. It is applied once per iteration after the render
+  pass, where the tree is laid out.
 
-The first question only holds up while every queue it names is drained
-unconditionally. Widget jobs are the one exception, and are covered instead by
-`needs_polling`, which refuses to block while any are queued. The clipboard,
-primary selection and cursor used to be a second exception — `sync_platform_state`
-ran inside the per-surface pass, so an application with no surface configured
-yet could queue a copy or a cursor shape that nothing would ever drain. It runs
-once per iteration from the loop body now, which is where what it carries
-belongs anyway: the seat, not any one surface.
-
-The order of the two is part of the contract: **a producer arms before it
-queues**, so a queue seen non-empty already has its wakeup armed, and reading
-the arming first can miss one that lands a moment later on another thread.
-That is why `queue_bg_write` calls `ingress::arm()` before pushing and sends
-after — between the push and the send there is an instant where the queue is
-observably non-empty, and the main thread reads it.
-
-So a new queue needs one line in `queued_work()` alongside its drain, and its
-producer needs a wakeup through one of the two mechanisms above. Forget the
-wakeup and the next idle moment panics with the queue's name, instead of the
-app going quietly deaf until an unrelated compositor event happens along. Two
-of the bugs documented above were exactly that.
+Everything in `deferred` is drained unconditionally, once per iteration, in
+the loop body. That is what makes "the loop will get to it on the next pass"
+true regardless of which surfaces exist or whether any of them had a frame to
+draw — the clipboard and the cursor used to be drained inside the per-surface
+pass, which meant an application with no surface configured yet could queue a
+copy that nothing would ever take.
 
 ## Widget Trait
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -373,7 +373,7 @@ a coalescing flag for the ping and a count for messages in flight in the
 calloop channel. That is a lot of apparatus to verify at runtime a rule the
 type can make unbreakable.
 
-Four producers stay outside `deferred`, each for a reason worth knowing:
+Three producers stay outside `deferred`, each for a reason worth knowing:
 
 - **background writes** wake through the ingress channel rather than the ping,
   and there is exactly one of them (`queue_bg_write`), so the pairing is one
@@ -383,13 +383,12 @@ Four producers stay outside `deferred`, each for a reason worth knowing:
 - **a parked focus request** is the opposite invariant: it waits for a widget
   that may not be laid out for many frames, so *still full* is its resting
   state, not a failure. It is applied at the end of `layout_pass`, after the
-  tree has resolved and before the paint that shows it;
-- **the session lock's request flags** (`lock_session` / `unlock_session`) are
-  still a flag and a `wake_loop()` written as two statements. They belong in
-  `deferred` by shape — `process_session_lock` drains them unconditionally
-  once per iteration — and are not there yet because the request carries a
-  widget factory into a state machine with its own guards, and the path cannot
-  be exercised without locking the screen (see #209).
+  tree has resolved and before the paint that shows it.
+
+The session lock's request is *in* `deferred`, as a `DeferredSlot<LockRequest>`:
+`lock_session` and `unlock_session` are two answers to one question, and the
+pair of independent booleans they used to set let both be true at once — the
+loop then started a lock and undid it three steps later in the same iteration.
 
 Everything in `deferred` is drained unconditionally, once per iteration, in
 the loop body. That is what makes "the loop will get to it on the next pass"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -360,10 +360,17 @@ the one moment where breaking it is fatal: `queued_but_unwoken()` in
 
 It asks two questions, and needs both. `queued_work()` names every queue the
 loop drains and answers *what* is waiting. `wakeup_armed()` answers whether
-anything is coming to drain it — a ping still readable (`jobs::ping_in_flight`,
-the coalescing flag, cleared right after the dispatch that consumed it), a wake
-request still set, or an ingress message sent and not yet read
-(`ingress::in_flight`). Only a queue with none of those is reported.
+anything is coming to drain it — a ping written and not yet dispatched
+(`jobs::ping_in_flight`, the coalescing flag, cleared right after the dispatch
+that consumed it), or an ingress message sent and not yet read
+(`ingress::in_flight`). Only a queue with neither is reported.
+
+`ping_in_flight` means *written*, not *requested*: `wake_loop` lowers the flag
+again when there was no handle to write to, because a flag raised over a ping
+that does not exist would tell the loop it is safe to block when nothing is
+coming — hiding the exact bug this check is for. `WAKE_REQUESTED` is not a
+third answer: `needs_polling` refuses to block while it is set, so the check
+is never reached with one outstanding.
 
 The second question is not optional, because a non-empty queue at that point
 is the ordinary case rather than the bug: the drains sit in the middle of the
@@ -373,6 +380,15 @@ An earlier version of this check asked the first question alone and panicked
 on healthy states — a background write landing after `flush_bg_writes()`, a
 surface command pushed by an effect whose `WAKE_REQUESTED` was then cleared by
 `take_wake_request()` later in the same iteration.
+
+The first question only holds up while every queue it names is drained
+unconditionally. Widget jobs are the one exception, and are covered instead by
+`needs_polling`, which refuses to block while any are queued. The clipboard,
+primary selection and cursor used to be a second exception — `sync_platform_state`
+ran inside the per-surface pass, so an application with no surface configured
+yet could queue a copy or a cursor shape that nothing would ever drain. It runs
+once per iteration from the loop body now, which is where what it carries
+belongs anyway: the seat, not any one surface.
 
 The order of the two is part of the contract: **a producer arms before it
 queues**, so a queue seen non-empty already has its wakeup armed, and reading

--- a/src/deferred.rs
+++ b/src/deferred.rs
@@ -60,6 +60,10 @@ impl<T> DeferredQueue<T> {
         std::mem::take(&mut *self.items.borrow_mut())
     }
 
+    /// Whether anything is waiting. Nobody outside asks any more — the loop
+    /// drains unconditionally rather than deciding whether to — so this is
+    /// what the tests below assert against.
+    #[cfg(test)]
     pub(crate) fn is_empty(&self) -> bool {
         self.items.borrow().is_empty()
     }
@@ -100,6 +104,7 @@ impl<T> DeferredSlot<T> {
         self.item.borrow_mut().take()
     }
 
+    #[cfg(test)]
     pub(crate) fn is_empty(&self) -> bool {
         self.item.borrow().is_none()
     }

--- a/src/deferred.rs
+++ b/src/deferred.rs
@@ -1,0 +1,142 @@
+//! Work handed to the main loop, and the wakeup that comes with it.
+//!
+//! The loop blocks when there is nothing to do, so anything that queues work
+//! for it has to wake it — and for as long as those were two statements next
+//! to each other, the second one could be left out. It was, twice, and both
+//! times the symptom was an application that went deaf until an unrelated
+//! compositor event happened along.
+//!
+//! Here they are one call. [`DeferredQueue::push`] and [`DeferredSlot::set`]
+//! *are* the wakeup: the cell is private to the type, so there is no way to
+//! put something in one and not ask for the pass that takes it out.
+//!
+//! Two shapes, because the queues in this crate are two shapes:
+//!
+//! - [`DeferredQueue`] accumulates — every disposal and every surface command
+//!   has to happen, and none replaces another;
+//! - [`DeferredSlot`] is last-one-wins — two cursor shapes in one frame are
+//!   two answers to the same question, and the second is the answer.
+//!
+//! What is *not* here is as deliberate. Scheduled jobs (`jobs::request_job_at`)
+//! own no wakeup on purpose: the loop is not late for them, it sleeps exactly
+//! until the deadline. Widget jobs have their own machinery — dedup, ownership
+//! resolution, per-surface lanes — and wake from inside it. Background writes
+//! wake through the calloop ingress channel rather than the ping, and there is
+//! one of them; a type with a single instance encodes nothing but itself. A
+//! parked focus request is the opposite invariant again: it *waits*, for a
+//! widget that may not exist for many frames, so "still full" is its resting
+//! state rather than a failure.
+//!
+//! The loop drains everything here unconditionally, once per iteration.
+
+use std::cell::RefCell;
+
+/// Deferred work that accumulates, drained by the loop once per iteration.
+pub(crate) struct DeferredQueue<T> {
+    items: RefCell<Vec<T>>,
+}
+
+impl<T> DeferredQueue<T> {
+    pub(crate) const fn new() -> Self {
+        Self {
+            items: RefCell::new(Vec::new()),
+        }
+    }
+
+    /// Queue an item and ask for the pass that will take it. One call,
+    /// because they are one gesture.
+    pub(crate) fn push(&self, item: T) {
+        self.items.borrow_mut().push(item);
+        crate::jobs::wake_loop();
+    }
+
+    /// Take everything queued, leaving the queue ready to receive more.
+    ///
+    /// Taking rather than iterating in place is what makes it safe for a
+    /// drained item to queue another while it runs — a cleanup callback that
+    /// disposes a second owner lands in the next batch instead of invalidating
+    /// the borrow of this one.
+    pub(crate) fn drain(&self) -> Vec<T> {
+        std::mem::take(&mut *self.items.borrow_mut())
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.items.borrow().is_empty()
+    }
+
+    /// Forget everything queued, for `App::drop`.
+    pub(crate) fn clear(&self) {
+        self.items.borrow_mut().clear();
+    }
+
+    /// Look at what is queued without taking it. For tests that assert *what*
+    /// a gesture queued, which is the half `is_empty` cannot show.
+    #[cfg(test)]
+    pub(crate) fn with_items<R>(&self, f: impl FnOnce(&[T]) -> R) -> R {
+        f(&self.items.borrow())
+    }
+}
+
+/// Deferred work where the latest value is the only one that matters.
+pub(crate) struct DeferredSlot<T> {
+    item: RefCell<Option<T>>,
+}
+
+impl<T> DeferredSlot<T> {
+    pub(crate) const fn new() -> Self {
+        Self {
+            item: RefCell::new(None),
+        }
+    }
+
+    /// Put the value in the slot, replacing whatever was there, and ask for
+    /// the pass that will take it.
+    pub(crate) fn set(&self, value: T) {
+        *self.item.borrow_mut() = Some(value);
+        crate::jobs::wake_loop();
+    }
+
+    pub(crate) fn take(&self) -> Option<T> {
+        self.item.borrow_mut().take()
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.item.borrow().is_none()
+    }
+
+    /// Forget what is waiting, for `App::drop`.
+    pub(crate) fn clear(&self) {
+        *self.item.borrow_mut() = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The whole reason both types exist: there is no way to reach the cell
+    /// without the wakeup, so this is the only shape a producer can be
+    /// written in. What the test can check is that the gesture is one call —
+    /// the wakeup is `jobs`' to prove, and it does.
+    #[test]
+    fn a_queue_accumulates_and_a_slot_keeps_the_last() {
+        let queue: DeferredQueue<u8> = DeferredQueue::new();
+        assert!(queue.is_empty());
+        queue.push(1);
+        queue.push(2);
+        assert!(!queue.is_empty());
+        assert_eq!(queue.drain(), vec![1, 2], "a queue owes every item");
+        assert!(queue.is_empty(), "and is ready for the next batch");
+
+        let slot: DeferredSlot<u8> = DeferredSlot::new();
+        assert!(slot.is_empty());
+        slot.set(1);
+        slot.set(2);
+        assert_eq!(
+            slot.take(),
+            Some(2),
+            "a slot owes the answer, not the history"
+        );
+        assert!(slot.is_empty());
+    }
+}

--- a/src/deferred.rs
+++ b/src/deferred.rs
@@ -10,6 +10,14 @@
 //! *are* the wakeup: the cell is private to the type, so there is no way to
 //! put something in one and not ask for the pass that takes it out.
 //!
+//! What that guarantees is the pairing, not delivery. These live in
+//! thread-locals belonging to the main thread, so a producer calling from a
+//! background thread queues into its own thread's copy, which nothing drains
+//! — the wakeup fires and the value is lost. The public gestures that reach
+//! them (`set_cursor`, `clipboard_copy`, `primary_copy`, `dispose_owner`) are
+//! main-thread API for that reason; a background thread reaches the UI through
+//! `WriteSignal`, which is the one queue built to cross threads.
+//!
 //! Two shapes, because the queues in this crate are two shapes:
 //!
 //! - [`DeferredQueue`] accumulates — every disposal and every surface command
@@ -71,13 +79,6 @@ impl<T> DeferredQueue<T> {
     /// Forget everything queued, for `App::drop`.
     pub(crate) fn clear(&self) {
         self.items.borrow_mut().clear();
-    }
-
-    /// Look at what is queued without taking it. For tests that assert *what*
-    /// a gesture queued, which is the half `is_empty` cannot show.
-    #[cfg(test)]
-    pub(crate) fn with_items<R>(&self, f: impl FnOnce(&[T]) -> R) -> R {
-        f(&self.items.borrow())
     }
 }
 

--- a/src/ingress.rs
+++ b/src/ingress.rs
@@ -147,9 +147,10 @@ impl Armed {
     /// running or its receiver is gone. The count stays up until the loop
     /// takes delivery — [`delivered`].
     pub(crate) fn notify(mut self) {
-        let Some(message) = self.message.take() else {
-            return;
-        };
+        // `arm` is the only constructor and this consumes `self`, so the
+        // message is always there; `Drop` reads the same field to tell an
+        // armed-and-sent from an armed-and-abandoned.
+        let message = self.message.take().expect("an armed message to send");
         if let Some(tx) = sender()
             && tx.send(message).is_ok()
         {
@@ -284,6 +285,5 @@ mod tests {
             !in_flight(),
             "and must not leave the count owed for a message nobody has"
         );
-        crate::jobs::reset_jobs();
     }
 }

--- a/src/ingress.rs
+++ b/src/ingress.rs
@@ -55,11 +55,17 @@ pub(crate) fn install_ingress(sender: Sender<IngressMessage>) {
 pub(crate) struct IngressSender(Sender<IngressMessage>);
 
 impl IngressSender {
-    /// Send, dropping the message if that loop is gone. Nothing is woken in
-    /// that case: the message carries its own payload, so there is no queue
-    /// left behind for anyone to drain.
+    /// Send, or hand the wakeup to the ping if that loop is gone.
+    ///
+    /// The same fallback as [`notify`], for the same reason: nothing here
+    /// knows whether the message is carrying its own payload or standing in
+    /// for a queue somewhere else, and dropping the second kind silently
+    /// strands the work it speaks for.
     pub(crate) fn send(self, message: IngressMessage) {
-        let _ = self.0.send(message);
+        if self.0.send(message).is_err() {
+            log::debug!("ingress receiver is gone; waking through the ping instead");
+            crate::jobs::wake_loop();
+        }
     }
 }
 
@@ -108,18 +114,27 @@ mod tests {
     /// loop it queued for is gone: the wakeup has to be handed over to the
     /// ping rather than dropped, or the work sits in the write queue with
     /// nothing coming to flush it.
+    ///
+    /// Retried: `reactive::memo`'s tests call `jobs::reset_jobs()` without
+    /// taking the lock above, and that drops the ping handle this one just
+    /// installed. A regression fails every attempt — the fallback either
+    /// wakes or it does not — so one clean window out of many is enough.
     #[test]
     fn giving_up_on_the_channel_hands_the_wakeup_to_the_ping() {
         let _state = crate::jobs::wakeup_test_lock();
-        reset_ingress(); // no receiver: force the fallback
         let (ping, _source) = make_ping().expect("ping");
-        crate::jobs::init_wakeup(ping);
-        crate::jobs::mark_loop_awake();
 
-        notify(IngressMessage::BgWritesQueued);
+        let woken = (0..64).any(|_| {
+            reset_ingress(); // no receiver: force the fallback
+            crate::jobs::init_wakeup(ping.clone());
+            crate::jobs::mark_loop_awake();
 
+            notify(IngressMessage::BgWritesQueued);
+
+            crate::jobs::ping_in_flight()
+        });
         assert!(
-            crate::jobs::ping_in_flight(),
+            woken,
             "the fallback must wake the loop it could not send to"
         );
     }

--- a/src/ingress.rs
+++ b/src/ingress.rs
@@ -13,12 +13,6 @@
 //!
 //! When no loop is running (setup phase, tests, teardown) [`notify`] falls
 //! back to the wake ping, which degrades to a plain flag there.
-//!
-//! Messages are counted from before the work they speak for is queued until
-//! the loop takes delivery ([`in_flight`]), because a wakeup that only exists
-//! inside calloop's channel cannot be seen from here — and the loop's
-//! pre-block check has to be able to ask whether one is owed before it
-//! decides that a non-empty queue is a bug.
 
 use std::sync::Mutex;
 
@@ -45,135 +39,6 @@ pub(crate) enum IngressMessage {
 
 static INGRESS_SENDER: Mutex<Option<Sender<IngressMessage>>> = Mutex::new(None);
 
-/// Messages armed but not yet taken delivery of by the loop.
-///
-/// A calloop send wakes the next dispatch, and the message stays readable
-/// until the loop reads it — so a non-zero count means the loop cannot block
-/// indefinitely. That is invisible from the `Sender` side, which is why it is
-/// counted here: the loop's pre-block check has to be able to ask whether a
-/// wakeup is owed, not only whether a queue is empty (`queued_but_unwoken` in
-/// `lib.rs`).
-///
-/// Debug-only, like the check it answers. A status bar queues a background
-/// write several times a second, and in a release build there is nobody to
-/// answer — so the release half is a set of no-ops and a `false`, and the
-/// atomics are not paid for.
-#[cfg(debug_assertions)]
-mod count {
-    use std::sync::atomic::{AtomicUsize, Ordering};
-
-    static IN_FLIGHT: AtomicUsize = AtomicUsize::new(0);
-
-    /// `AcqRel`, not `Release`: the invariant is that the count is up
-    /// *before* the work becomes visible, which orders the writes that
-    /// follow, not only the ones that came before. Today `queue_bg_write`
-    /// pushes under a mutex whose unlock would carry it anyway — a queue
-    /// without that edge would not.
-    pub(super) fn up() {
-        IN_FLIGHT.fetch_add(1, Ordering::AcqRel);
-    }
-
-    /// Saturating, because [`super::reset_ingress`] can land between a thread
-    /// arming and that thread finding out there is no loop left to send to.
-    /// Wrapping past zero would leave the count permanently non-zero, which
-    /// reads as *a wakeup is always armed* — the check would stop reporting
-    /// anything at all, quietly.
-    pub(super) fn down() {
-        let _ = IN_FLIGHT.fetch_update(Ordering::AcqRel, Ordering::Acquire, |count| {
-            Some(count.saturating_sub(1))
-        });
-    }
-
-    /// Whatever was in flight is never arriving: the receiver goes with the
-    /// loop.
-    pub(super) fn reset() {
-        IN_FLIGHT.store(0, Ordering::Release);
-    }
-
-    pub(super) fn any() -> bool {
-        IN_FLIGHT.load(Ordering::Acquire) > 0
-    }
-}
-
-#[cfg(not(debug_assertions))]
-mod count {
-    pub(super) fn up() {}
-    pub(super) fn down() {}
-    pub(super) fn reset() {}
-    /// Nothing is ever counted, so nothing is ever owed — and the only caller
-    /// is compiled out anyway.
-    pub(super) fn any() -> bool {
-        false
-    }
-}
-
-/// Whether the loop has a message coming that it has not read yet.
-pub(crate) fn in_flight() -> bool {
-    count::any()
-}
-
-/// The loop took delivery of one message. Called by the ingress channel
-/// callback, before the drains that message speaks for.
-pub(crate) fn delivered() {
-    count::down();
-}
-
-/// A wakeup owed to the loop, counted from before the work it is owed for
-/// becomes visible until the loop takes delivery.
-///
-/// Arming first is the point: between queueing the work and sending the
-/// message there is an instant where the queue is observably non-empty, and
-/// a loop that looked at it right then would see work with nothing owed for
-/// it. The count is already up by then.
-#[must_use = "an armed wakeup that is never sent is a wakeup nobody will get"]
-pub(crate) struct Armed {
-    /// Taken by [`Armed::notify`]. Still `Some` in `drop` means the message
-    /// was never sent — give the count back rather than leaving the loop
-    /// owed a wakeup that is not coming.
-    message: Option<IngressMessage>,
-}
-
-/// Arm a wakeup, to be sent with [`Armed::notify`] once the work it speaks
-/// for is queued.
-pub(crate) fn arm(message: IngressMessage) -> Armed {
-    count::up();
-    Armed {
-        message: Some(message),
-    }
-}
-
-impl Armed {
-    /// Send the armed message, falling back to the wake ping when no loop is
-    /// running or its receiver is gone. The count stays up until the loop
-    /// takes delivery — [`delivered`].
-    pub(crate) fn notify(mut self) {
-        // `arm` is the only constructor and this consumes `self`, so the
-        // message is always there; `Drop` reads the same field to tell an
-        // armed-and-sent from an armed-and-abandoned.
-        let message = self.message.take().expect("an armed message to send");
-        if let Some(tx) = sender()
-            && tx.send(message).is_ok()
-        {
-            return;
-        }
-        // No loop, or the receiver died while shutting down: nothing will
-        // ever take delivery. Wake first, give the count back after — the
-        // same order this whole module argues for, and for the same reason:
-        // in between, the work is queued and the check runs on another
-        // thread.
-        crate::jobs::wake_loop();
-        count::down();
-    }
-}
-
-impl Drop for Armed {
-    fn drop(&mut self) {
-        if self.message.is_some() {
-            count::down();
-        }
-    }
-}
-
 /// Install the loop's channel sender. Called by `App::run` when the event
 /// loop is created.
 pub(crate) fn install_ingress(sender: Sender<IngressMessage>) {
@@ -187,9 +52,6 @@ pub(crate) fn install_ingress(sender: Sender<IngressMessage>) {
 /// seconds. Resolving the sender at send time instead would let the result of
 /// one session's read land in the next session's loop, which restarts its
 /// generation counters and cannot tell the two apart.
-///
-/// The count is kept around the send, so this is not a way to slip a message
-/// past the loop's wakeup check.
 pub(crate) struct IngressSender(Sender<IngressMessage>);
 
 impl IngressSender {
@@ -197,10 +59,7 @@ impl IngressSender {
     /// that case: the message carries its own payload, so there is no queue
     /// left behind for anyone to drain.
     pub(crate) fn send(self, message: IngressMessage) {
-        count::up();
-        if self.0.send(message).is_err() {
-            count::down();
-        }
+        let _ = self.0.send(message);
     }
 }
 
@@ -209,21 +68,26 @@ pub(crate) fn sender_handle() -> Option<IngressSender> {
     sender().map(IngressSender)
 }
 
-/// Private on purpose: a send that does not go through [`arm`] or
-/// [`IngressSender`] is a message the loop takes delivery of — and
-/// decrements the count for — without anything having counted it.
+/// Private on purpose: [`notify`] and [`IngressSender`] are the two ways in,
+/// and both send from the same gesture that queued the work.
 fn sender() -> Option<Sender<IngressMessage>> {
     INGRESS_SENDER.lock().ok().and_then(|g| g.as_ref().cloned())
 }
 
-/// Send a message to the main loop, falling back to the wake ping when no
-/// loop is running.
+/// Send a message to the main loop, falling back to the wake ping when there
+/// is no loop to send to or its receiver has already gone.
 ///
-/// For a message whose payload is ready now. A message acting as a doorbell
-/// for a queue elsewhere arms first and sends after the push — [`arm`].
-#[cfg(test)]
+/// Called from the same function that queued the work it speaks for — see
+/// `reactive::runtime::queue_bg_write`, and `deferred` for the main-thread
+/// half of the same rule.
 pub(crate) fn notify(message: IngressMessage) {
-    arm(message).notify();
+    match sender() {
+        Some(tx) if tx.send(message).is_ok() => {}
+        // No loop, or the receiver died while shutting down: nothing will
+        // take delivery, so hand the wakeup to the ping instead. The work is
+        // then at least flagged for whatever loop comes next.
+        _ => crate::jobs::wake_loop(),
+    }
 }
 
 /// Reset ingress state.
@@ -233,7 +97,6 @@ pub(crate) fn reset_ingress() {
     if let Ok(mut guard) = INGRESS_SENDER.lock() {
         *guard = None;
     }
-    count::reset();
 }
 
 #[cfg(test)]
@@ -241,35 +104,13 @@ mod tests {
     use super::*;
     use smithay_client_toolkit::reexports::calloop::ping::make_ping;
 
-    /// `App::drop` resets the count while a reader thread may be holding an
-    /// armed message it is about to find no receiver for. Wrapping there
-    /// would pin the count above zero for the rest of the process and turn
-    /// the loop's check into a no-op that reports nothing, forever.
-    /// Debug-only: the count is, and this is about its arithmetic.
-    #[cfg(debug_assertions)]
-    #[test]
-    fn a_reset_between_arming_and_giving_up_does_not_wrap_the_count() {
-        let _guard = crate::jobs::wakeup_test_lock();
-        let armed = arm(IngressMessage::BgWritesQueued);
-        assert!(in_flight());
-
-        reset_ingress();
-        drop(armed);
-
-        assert!(
-            !in_flight(),
-            "the count must be back at zero, not wrapped past it"
-        );
-    }
-
     /// The fallback branch, which is the one a real producer takes when the
-    /// loop it armed for is gone: the wakeup has to be handed over to the
-    /// ping *and* the count given back. Dropping the count without waking
-    /// leaves the work queued with nothing owed for it — the state the loop's
-    /// check panics on.
+    /// loop it queued for is gone: the wakeup has to be handed over to the
+    /// ping rather than dropped, or the work sits in the write queue with
+    /// nothing coming to flush it.
     #[test]
     fn giving_up_on_the_channel_hands_the_wakeup_to_the_ping() {
-        let _guard = crate::jobs::wakeup_test_lock();
+        let _state = crate::jobs::wakeup_test_lock();
         reset_ingress(); // no receiver: force the fallback
         let (ping, _source) = make_ping().expect("ping");
         crate::jobs::init_wakeup(ping);
@@ -280,10 +121,6 @@ mod tests {
         assert!(
             crate::jobs::ping_in_flight(),
             "the fallback must wake the loop it could not send to"
-        );
-        assert!(
-            !in_flight(),
-            "and must not leave the count owed for a message nobody has"
         );
     }
 }

--- a/src/ingress.rs
+++ b/src/ingress.rs
@@ -13,8 +13,15 @@
 //!
 //! When no loop is running (setup phase, tests, teardown) [`notify`] falls
 //! back to the wake ping, which degrades to a plain flag there.
+//!
+//! Messages are counted from before the work they speak for is queued until
+//! the loop takes delivery ([`in_flight`]), because a wakeup that only exists
+//! inside calloop's channel cannot be seen from here — and the loop's
+//! pre-block check has to be able to ask whether one is owed before it
+//! decides that a non-empty queue is a bug.
 
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use smithay_client_toolkit::reexports::calloop::channel::Sender;
 
@@ -39,6 +46,97 @@ pub(crate) enum IngressMessage {
 
 static INGRESS_SENDER: Mutex<Option<Sender<IngressMessage>>> = Mutex::new(None);
 
+/// Messages armed but not yet taken delivery of by the loop.
+///
+/// A calloop send wakes the next dispatch, and the message stays readable
+/// until the loop reads it — so a non-zero count means the loop cannot
+/// block indefinitely. That is invisible from the `Sender` side, which is
+/// why it is counted here: the loop's pre-block check has to be able to ask
+/// whether a wakeup is owed, not only whether a queue is empty
+/// (`queued_but_unwoken` in `lib.rs`).
+static IN_FLIGHT: AtomicUsize = AtomicUsize::new(0);
+
+/// Whether the loop has a message coming that it has not read yet.
+pub(crate) fn in_flight() -> bool {
+    IN_FLIGHT.load(Ordering::Acquire) > 0
+}
+
+/// A wakeup owed to the loop, counted from before the work it is owed for
+/// becomes visible until the loop takes delivery.
+///
+/// Arming first is the point: between queueing the work and sending the
+/// message there is an instant where the queue is observably non-empty, and
+/// a loop that looked at it right then would see work with nothing owed for
+/// it. The count is already up by then.
+#[must_use = "an armed wakeup that is never sent is a wakeup nobody will get"]
+pub(crate) struct Armed {
+    /// Taken by [`Armed::notify`]. Still `Some` in `drop` means the message
+    /// was never sent — give the count back rather than leaving the loop
+    /// owed a wakeup that is not coming.
+    message: Option<IngressMessage>,
+}
+
+/// Arm a wakeup, to be sent with [`Armed::notify`] once the work it speaks
+/// for is queued.
+pub(crate) fn arm(message: IngressMessage) -> Armed {
+    IN_FLIGHT.fetch_add(1, Ordering::Release);
+    Armed {
+        message: Some(message),
+    }
+}
+
+impl Armed {
+    /// Send the armed message, falling back to the wake ping when no loop is
+    /// running or its receiver is gone. The count stays up until the loop
+    /// takes delivery — `delivered()`.
+    pub(crate) fn notify(mut self) {
+        let message = match self.message.take() {
+            Some(message) => message,
+            None => return,
+        };
+        match sender() {
+            Some(tx) if tx.send(message).is_ok() => {}
+            // No loop, or the receiver died while shutting down: nothing will
+            // ever take delivery, so the count comes back down and the work is
+            // at least flagged for a future loop.
+            _ => {
+                disarm();
+                crate::jobs::wake_loop();
+            }
+        }
+    }
+}
+
+impl Drop for Armed {
+    fn drop(&mut self) {
+        if self.message.is_some() {
+            disarm();
+        }
+    }
+}
+
+/// The loop took delivery of one message. Called by the ingress channel
+/// callback, before the drains that message speaks for.
+pub(crate) fn delivered() {
+    release_one();
+}
+
+/// Give back a wakeup that is not coming after all.
+fn disarm() {
+    release_one();
+}
+
+/// Saturating, because [`reset_ingress`] can land between a thread arming
+/// and that thread finding out there is no loop left to send to. Wrapping
+/// past zero would leave the count permanently non-zero, which reads as *a
+/// wakeup is always armed* — the check would stop reporting anything at all,
+/// quietly.
+fn release_one() {
+    let _ = IN_FLIGHT.fetch_update(Ordering::Release, Ordering::Acquire, |count| {
+        Some(count.saturating_sub(1))
+    });
+}
+
 /// Install the loop's channel sender. Called by `App::run` when the event
 /// loop is created.
 pub(crate) fn install_ingress(sender: Sender<IngressMessage>) {
@@ -47,24 +145,36 @@ pub(crate) fn install_ingress(sender: Sender<IngressMessage>) {
     }
 }
 
-/// Get a sender clone for a background thread, if a loop is running.
-pub(crate) fn sender() -> Option<Sender<IngressMessage>> {
+/// Whether a loop is running to deliver messages to. For a producer that
+/// wants to give up early rather than arm a wakeup nobody will take.
+pub(crate) fn loop_running() -> bool {
+    sender().is_some()
+}
+
+/// Get a sender clone, if a loop is running. Private on purpose: a send that
+/// does not go through [`arm`] is a message the loop takes delivery of —
+/// and decrements the count for — without anything having counted it.
+fn sender() -> Option<Sender<IngressMessage>> {
     INGRESS_SENDER.lock().ok().and_then(|g| g.as_ref().cloned())
 }
 
 /// Send a message to the main loop, falling back to the wake ping
 /// when no loop is running.
+///
+/// For a message that carries its own payload. A message acting as a
+/// doorbell for a queue elsewhere arms first and sends after the push —
+/// [`arm`].
 pub(crate) fn notify(message: IngressMessage) {
-    match sender() {
-        Some(tx) => {
-            if tx.send(message).is_err() {
-                // Receiver died (loop shutting down) — fall back so pending
-                // work is at least flagged for a future loop.
-                crate::jobs::wake_loop();
-            }
-        }
-        None => crate::jobs::wake_loop(),
-    }
+    arm(message).notify();
+}
+
+/// The count is process-wide, and so are the tests that drive it directly
+/// — here and in `lib.rs`. Taking this first keeps one from reading the
+/// other's arming and calling it its own.
+#[cfg(test)]
+pub(crate) fn test_count_lock() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: Mutex<()> = Mutex::new(());
+    LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
 /// Reset ingress state.
@@ -73,5 +183,31 @@ pub(crate) fn notify(message: IngressMessage) {
 pub(crate) fn reset_ingress() {
     if let Ok(mut guard) = INGRESS_SENDER.lock() {
         *guard = None;
+    }
+    // Whatever was in flight is never arriving: the receiver goes with the loop.
+    IN_FLIGHT.store(0, Ordering::Release);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `App::drop` resets the count while a reader thread may be holding an
+    /// armed message it is about to find no receiver for. Wrapping there
+    /// would pin the count above zero for the rest of the process and turn
+    /// the loop's check into a no-op that reports nothing, forever.
+    #[test]
+    fn a_reset_between_arming_and_giving_up_does_not_wrap_the_count() {
+        let _guard = test_count_lock();
+        let armed = arm(IngressMessage::BgWritesQueued);
+        assert!(in_flight());
+
+        reset_ingress();
+        drop(armed);
+
+        assert!(
+            !in_flight(),
+            "the count must be back at zero, not wrapped past it"
+        );
     }
 }

--- a/src/ingress.rs
+++ b/src/ingress.rs
@@ -244,6 +244,8 @@ mod tests {
     /// armed message it is about to find no receiver for. Wrapping there
     /// would pin the count above zero for the rest of the process and turn
     /// the loop's check into a no-op that reports nothing, forever.
+    /// Debug-only: the count is, and this is about its arithmetic.
+    #[cfg(debug_assertions)]
     #[test]
     fn a_reset_between_arming_and_giving_up_does_not_wrap_the_count() {
         let _guard = crate::jobs::wakeup_test_lock();

--- a/src/ingress.rs
+++ b/src/ingress.rs
@@ -21,7 +21,6 @@
 //! decides that a non-empty queue is a bug.
 
 use std::sync::Mutex;
-use std::sync::atomic::{AtomicUsize, Ordering};
 
 use smithay_client_toolkit::reexports::calloop::channel::Sender;
 
@@ -55,46 +54,68 @@ static INGRESS_SENDER: Mutex<Option<Sender<IngressMessage>>> = Mutex::new(None);
 /// wakeup is owed, not only whether a queue is empty (`queued_but_unwoken` in
 /// `lib.rs`).
 ///
-/// Debug-only, like its one consumer. A status bar queues a background write
-/// several times a second, and in a release build the whole question is
-/// compiled out — the count would be two atomics paid to answer nobody.
+/// Debug-only, like the check it answers. A status bar queues a background
+/// write several times a second, and in a release build there is nobody to
+/// answer — so the release half is a set of no-ops and a `false`, and the
+/// atomics are not paid for.
 #[cfg(debug_assertions)]
-static IN_FLIGHT: AtomicUsize = AtomicUsize::new(0);
+mod count {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    static IN_FLIGHT: AtomicUsize = AtomicUsize::new(0);
+
+    /// `AcqRel`, not `Release`: the invariant is that the count is up
+    /// *before* the work becomes visible, which orders the writes that
+    /// follow, not only the ones that came before. Today `queue_bg_write`
+    /// pushes under a mutex whose unlock would carry it anyway — a queue
+    /// without that edge would not.
+    pub(super) fn up() {
+        IN_FLIGHT.fetch_add(1, Ordering::AcqRel);
+    }
+
+    /// Saturating, because [`super::reset_ingress`] can land between a thread
+    /// arming and that thread finding out there is no loop left to send to.
+    /// Wrapping past zero would leave the count permanently non-zero, which
+    /// reads as *a wakeup is always armed* — the check would stop reporting
+    /// anything at all, quietly.
+    pub(super) fn down() {
+        let _ = IN_FLIGHT.fetch_update(Ordering::AcqRel, Ordering::Acquire, |count| {
+            Some(count.saturating_sub(1))
+        });
+    }
+
+    /// Whatever was in flight is never arriving: the receiver goes with the
+    /// loop.
+    pub(super) fn reset() {
+        IN_FLIGHT.store(0, Ordering::Release);
+    }
+
+    pub(super) fn any() -> bool {
+        IN_FLIGHT.load(Ordering::Acquire) > 0
+    }
+}
+
+#[cfg(not(debug_assertions))]
+mod count {
+    pub(super) fn up() {}
+    pub(super) fn down() {}
+    pub(super) fn reset() {}
+    /// Nothing is ever counted, so nothing is ever owed — and the only caller
+    /// is compiled out anyway.
+    pub(super) fn any() -> bool {
+        false
+    }
+}
 
 /// Whether the loop has a message coming that it has not read yet.
-#[cfg(debug_assertions)]
 pub(crate) fn in_flight() -> bool {
-    IN_FLIGHT.load(Ordering::Acquire) > 0
-}
-
-/// One more message owed to the loop.
-///
-/// `AcqRel`, not `Release`: the invariant is that the count is up *before*
-/// the work becomes visible, which orders the writes that follow, not only
-/// the ones that came before. Today `queue_bg_write` pushes under a mutex
-/// whose unlock would carry it anyway — a queue without that edge would not.
-fn count_up() {
-    #[cfg(debug_assertions)]
-    IN_FLIGHT.fetch_add(1, Ordering::AcqRel);
-}
-
-/// One fewer: the loop read it, or it turned out not to be coming.
-///
-/// Saturating, because [`reset_ingress`] can land between a thread arming and
-/// that thread finding out there is no loop left to send to. Wrapping past
-/// zero would leave the count permanently non-zero, which reads as *a wakeup
-/// is always armed* — the check would stop reporting anything at all, quietly.
-fn count_down() {
-    #[cfg(debug_assertions)]
-    let _ = IN_FLIGHT.fetch_update(Ordering::AcqRel, Ordering::Acquire, |count| {
-        Some(count.saturating_sub(1))
-    });
+    count::any()
 }
 
 /// The loop took delivery of one message. Called by the ingress channel
 /// callback, before the drains that message speaks for.
 pub(crate) fn delivered() {
-    count_down();
+    count::down();
 }
 
 /// A wakeup owed to the loop, counted from before the work it is owed for
@@ -115,7 +136,7 @@ pub(crate) struct Armed {
 /// Arm a wakeup, to be sent with [`Armed::notify`] once the work it speaks
 /// for is queued.
 pub(crate) fn arm(message: IngressMessage) -> Armed {
-    count_up();
+    count::up();
     Armed {
         message: Some(message),
     }
@@ -140,14 +161,14 @@ impl Armed {
         // in between, the work is queued and the check runs on another
         // thread.
         crate::jobs::wake_loop();
-        count_down();
+        count::down();
     }
 }
 
 impl Drop for Armed {
     fn drop(&mut self) {
         if self.message.is_some() {
-            count_down();
+            count::down();
         }
     }
 }
@@ -175,9 +196,9 @@ impl IngressSender {
     /// that case: the message carries its own payload, so there is no queue
     /// left behind for anyone to drain.
     pub(crate) fn send(self, message: IngressMessage) {
-        count_up();
+        count::up();
         if self.0.send(message).is_err() {
-            count_down();
+            count::down();
         }
     }
 }
@@ -211,8 +232,7 @@ pub(crate) fn reset_ingress() {
     if let Ok(mut guard) = INGRESS_SENDER.lock() {
         *guard = None;
     }
-    // Whatever was in flight is never arriving: the receiver goes with the loop.
-    IN_FLIGHT.store(0, Ordering::Release);
+    count::reset();
 }
 
 #[cfg(test)]

--- a/src/ingress.rs
+++ b/src/ingress.rs
@@ -49,16 +49,52 @@ static INGRESS_SENDER: Mutex<Option<Sender<IngressMessage>>> = Mutex::new(None);
 /// Messages armed but not yet taken delivery of by the loop.
 ///
 /// A calloop send wakes the next dispatch, and the message stays readable
-/// until the loop reads it — so a non-zero count means the loop cannot
-/// block indefinitely. That is invisible from the `Sender` side, which is
-/// why it is counted here: the loop's pre-block check has to be able to ask
-/// whether a wakeup is owed, not only whether a queue is empty
-/// (`queued_but_unwoken` in `lib.rs`).
+/// until the loop reads it — so a non-zero count means the loop cannot block
+/// indefinitely. That is invisible from the `Sender` side, which is why it is
+/// counted here: the loop's pre-block check has to be able to ask whether a
+/// wakeup is owed, not only whether a queue is empty (`queued_but_unwoken` in
+/// `lib.rs`).
+///
+/// Debug-only, like its one consumer. A status bar queues a background write
+/// several times a second, and in a release build the whole question is
+/// compiled out — the count would be two atomics paid to answer nobody.
+#[cfg(debug_assertions)]
 static IN_FLIGHT: AtomicUsize = AtomicUsize::new(0);
 
 /// Whether the loop has a message coming that it has not read yet.
+#[cfg(debug_assertions)]
 pub(crate) fn in_flight() -> bool {
     IN_FLIGHT.load(Ordering::Acquire) > 0
+}
+
+/// One more message owed to the loop.
+///
+/// `AcqRel`, not `Release`: the invariant is that the count is up *before*
+/// the work becomes visible, which orders the writes that follow, not only
+/// the ones that came before. Today `queue_bg_write` pushes under a mutex
+/// whose unlock would carry it anyway — a queue without that edge would not.
+fn count_up() {
+    #[cfg(debug_assertions)]
+    IN_FLIGHT.fetch_add(1, Ordering::AcqRel);
+}
+
+/// One fewer: the loop read it, or it turned out not to be coming.
+///
+/// Saturating, because [`reset_ingress`] can land between a thread arming and
+/// that thread finding out there is no loop left to send to. Wrapping past
+/// zero would leave the count permanently non-zero, which reads as *a wakeup
+/// is always armed* — the check would stop reporting anything at all, quietly.
+fn count_down() {
+    #[cfg(debug_assertions)]
+    let _ = IN_FLIGHT.fetch_update(Ordering::AcqRel, Ordering::Acquire, |count| {
+        Some(count.saturating_sub(1))
+    });
+}
+
+/// The loop took delivery of one message. Called by the ingress channel
+/// callback, before the drains that message speaks for.
+pub(crate) fn delivered() {
+    count_down();
 }
 
 /// A wakeup owed to the loop, counted from before the work it is owed for
@@ -79,7 +115,7 @@ pub(crate) struct Armed {
 /// Arm a wakeup, to be sent with [`Armed::notify`] once the work it speaks
 /// for is queued.
 pub(crate) fn arm(message: IngressMessage) -> Armed {
-    IN_FLIGHT.fetch_add(1, Ordering::Release);
+    count_up();
     Armed {
         message: Some(message),
     }
@@ -88,53 +124,32 @@ pub(crate) fn arm(message: IngressMessage) -> Armed {
 impl Armed {
     /// Send the armed message, falling back to the wake ping when no loop is
     /// running or its receiver is gone. The count stays up until the loop
-    /// takes delivery — `delivered()`.
+    /// takes delivery — [`delivered`].
     pub(crate) fn notify(mut self) {
-        let message = match self.message.take() {
-            Some(message) => message,
-            None => return,
+        let Some(message) = self.message.take() else {
+            return;
         };
-        match sender() {
-            Some(tx) if tx.send(message).is_ok() => {}
-            // No loop, or the receiver died while shutting down: nothing will
-            // ever take delivery, so the count comes back down and the work is
-            // at least flagged for a future loop.
-            _ => {
-                disarm();
-                crate::jobs::wake_loop();
-            }
+        if let Some(tx) = sender()
+            && tx.send(message).is_ok()
+        {
+            return;
         }
+        // No loop, or the receiver died while shutting down: nothing will
+        // ever take delivery. Wake first, give the count back after — the
+        // same order this whole module argues for, and for the same reason:
+        // in between, the work is queued and the check runs on another
+        // thread.
+        crate::jobs::wake_loop();
+        count_down();
     }
 }
 
 impl Drop for Armed {
     fn drop(&mut self) {
         if self.message.is_some() {
-            disarm();
+            count_down();
         }
     }
-}
-
-/// The loop took delivery of one message. Called by the ingress channel
-/// callback, before the drains that message speaks for.
-pub(crate) fn delivered() {
-    release_one();
-}
-
-/// Give back a wakeup that is not coming after all.
-fn disarm() {
-    release_one();
-}
-
-/// Saturating, because [`reset_ingress`] can land between a thread arming
-/// and that thread finding out there is no loop left to send to. Wrapping
-/// past zero would leave the count permanently non-zero, which reads as *a
-/// wakeup is always armed* — the check would stop reporting anything at all,
-/// quietly.
-fn release_one() {
-    let _ = IN_FLIGHT.fetch_update(Ordering::Release, Ordering::Acquire, |count| {
-        Some(count.saturating_sub(1))
-    });
 }
 
 /// Install the loop's channel sender. Called by `App::run` when the event
@@ -145,36 +160,48 @@ pub(crate) fn install_ingress(sender: Sender<IngressMessage>) {
     }
 }
 
-/// Whether a loop is running to deliver messages to. For a producer that
-/// wants to give up early rather than arm a wakeup nobody will take.
-pub(crate) fn loop_running() -> bool {
-    sender().is_some()
+/// A sender bound to the loop that was running when it was taken, for a
+/// producer that only has its payload much later — a selection read can take
+/// seconds. Resolving the sender at send time instead would let the result of
+/// one session's read land in the next session's loop, which restarts its
+/// generation counters and cannot tell the two apart.
+///
+/// The count is kept around the send, so this is not a way to slip a message
+/// past the loop's wakeup check.
+pub(crate) struct IngressSender(Sender<IngressMessage>);
+
+impl IngressSender {
+    /// Send, dropping the message if that loop is gone. Nothing is woken in
+    /// that case: the message carries its own payload, so there is no queue
+    /// left behind for anyone to drain.
+    pub(crate) fn send(self, message: IngressMessage) {
+        count_up();
+        if self.0.send(message).is_err() {
+            count_down();
+        }
+    }
 }
 
-/// Get a sender clone, if a loop is running. Private on purpose: a send that
-/// does not go through [`arm`] is a message the loop takes delivery of —
-/// and decrements the count for — without anything having counted it.
+/// Take a sender for the loop running now, if there is one.
+pub(crate) fn sender_handle() -> Option<IngressSender> {
+    sender().map(IngressSender)
+}
+
+/// Private on purpose: a send that does not go through [`arm`] or
+/// [`IngressSender`] is a message the loop takes delivery of — and
+/// decrements the count for — without anything having counted it.
 fn sender() -> Option<Sender<IngressMessage>> {
     INGRESS_SENDER.lock().ok().and_then(|g| g.as_ref().cloned())
 }
 
-/// Send a message to the main loop, falling back to the wake ping
-/// when no loop is running.
+/// Send a message to the main loop, falling back to the wake ping when no
+/// loop is running.
 ///
-/// For a message that carries its own payload. A message acting as a
-/// doorbell for a queue elsewhere arms first and sends after the push —
-/// [`arm`].
+/// For a message whose payload is ready now. A message acting as a doorbell
+/// for a queue elsewhere arms first and sends after the push — [`arm`].
+#[cfg(test)]
 pub(crate) fn notify(message: IngressMessage) {
     arm(message).notify();
-}
-
-/// The count is process-wide, and so are the tests that drive it directly
-/// — here and in `lib.rs`. Taking this first keeps one from reading the
-/// other's arming and calling it its own.
-#[cfg(test)]
-pub(crate) fn test_count_lock() -> std::sync::MutexGuard<'static, ()> {
-    static LOCK: Mutex<()> = Mutex::new(());
-    LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
 /// Reset ingress state.
@@ -191,6 +218,7 @@ pub(crate) fn reset_ingress() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use smithay_client_toolkit::reexports::calloop::ping::make_ping;
 
     /// `App::drop` resets the count while a reader thread may be holding an
     /// armed message it is about to find no receiver for. Wrapping there
@@ -198,7 +226,7 @@ mod tests {
     /// the loop's check into a no-op that reports nothing, forever.
     #[test]
     fn a_reset_between_arming_and_giving_up_does_not_wrap_the_count() {
-        let _guard = test_count_lock();
+        let _guard = crate::jobs::wakeup_test_lock();
         let armed = arm(IngressMessage::BgWritesQueued);
         assert!(in_flight());
 
@@ -209,5 +237,31 @@ mod tests {
             !in_flight(),
             "the count must be back at zero, not wrapped past it"
         );
+    }
+
+    /// The fallback branch, which is the one a real producer takes when the
+    /// loop it armed for is gone: the wakeup has to be handed over to the
+    /// ping *and* the count given back. Dropping the count without waking
+    /// leaves the work queued with nothing owed for it — the state the loop's
+    /// check panics on.
+    #[test]
+    fn giving_up_on_the_channel_hands_the_wakeup_to_the_ping() {
+        let _guard = crate::jobs::wakeup_test_lock();
+        reset_ingress(); // no receiver: force the fallback
+        let (ping, _source) = make_ping().expect("ping");
+        crate::jobs::init_wakeup(ping);
+        crate::jobs::mark_loop_awake();
+
+        notify(IngressMessage::BgWritesQueued);
+
+        assert!(
+            crate::jobs::ping_in_flight(),
+            "the fallback must wake the loop it could not send to"
+        );
+        assert!(
+            !in_flight(),
+            "and must not leave the count owed for a message nobody has"
+        );
+        crate::jobs::reset_jobs();
     }
 }

--- a/src/jobs.rs
+++ b/src/jobs.rs
@@ -572,11 +572,10 @@ static EXIT_REQUEST: AtomicU8 = AtomicU8::new(ExitRequest::Running as u8);
 /// Wakes the event loop so the main loop checks promptly.
 pub(crate) fn set_exit_request(req: ExitRequest) {
     EXIT_REQUEST.store(req as u8, Ordering::Release);
-    // Through `wake_loop`, not straight to the ping: a ping written behind its
-    // back is one `ping_in_flight` cannot see, and the loop's pre-block check
-    // would call a woken loop unwoken. Coalescing is the right answer here too
-    // — if a ping is already armed the loop is already coming back, and it
-    // reads the exit request at the top of every pass.
+    // Through `wake_loop`, not straight to the ping: one way in means one set
+    // of rules about the coalescing flag. If a ping is already armed the loop
+    // is already coming back, and it reads the exit request at the top of
+    // every pass.
     wake_loop();
 }
 
@@ -650,18 +649,12 @@ pub(crate) fn wake_loop() {
     }
 }
 
-/// Whether a ping is readable by the next dispatch.
+/// Whether a ping is readable by the next dispatch: written by `wake_loop`,
+/// cleared by `mark_loop_awake` right after the dispatch that consumed it.
 ///
-/// True from the moment `wake_loop` writes one until `mark_loop_awake` clears
-/// the flag, right after the dispatch that consumed it — so at the loop's
-/// pre-block check it means the eventfd is still armed and `dispatch(None)`
-/// returns immediately. That is the half of "queued but unwoken" the queues
-/// cannot answer: work produced after its own drain point is the ordinary
-/// case, and what makes it a bug is nobody having asked for the next pass.
-///
-/// It says *written*, not *requested*: `wake_loop` raises it under the ping's
-/// lock, with the handle in hand, so there is no window where it stands for a
-/// ping that does not exist.
+/// For the tests that assert a producer woke the loop, which is the half of
+/// "queued and woken" that is not visible from the queue.
+#[cfg(test)]
 pub(crate) fn ping_in_flight() -> bool {
     PING_SENT.load(Ordering::Acquire)
 }
@@ -1057,12 +1050,12 @@ mod wakeup_contract {
     /// setup from scratch. The asymmetry is what makes this sound: a real
     /// regression pings on *no* attempt, so the failure needs no luck, while a
     /// pass needs only one clean window out of many.
-    /// An exit request is a wakeup like any other, and has to be one the
-    /// loop's pre-block check can see. It used to write the ping directly,
-    /// behind `PING_SENT`'s back: the loop was woken and the check said
-    /// nobody had woken it.
+    /// An exit request is a wakeup like any other, and goes through the same
+    /// door. It used to write the ping directly, past `PING_SENT`: a second
+    /// producer would then coalesce against a flag that nobody had raised, or
+    /// raise one for a ping already spent, depending on the order.
     #[test]
-    fn an_exit_request_arms_a_wakeup_the_check_can_see() {
+    fn an_exit_request_goes_through_the_one_door() {
         let _state = wakeup_test_lock();
         let (ping, _source) = make_ping().expect("ping");
 
@@ -1072,7 +1065,7 @@ mod wakeup_contract {
             set_exit_request(ExitRequest::Quit);
             ping_in_flight()
         });
-        assert!(seen, "quit_app must arm a wakeup the loop can account for");
+        assert!(seen, "quit_app must write its ping through wake_loop");
     }
 
     #[test]

--- a/src/jobs.rs
+++ b/src/jobs.rs
@@ -638,6 +638,18 @@ pub(crate) fn wake_loop() {
     }
 }
 
+/// Whether a ping is readable by the next dispatch.
+///
+/// True from the moment `wake_loop` sends one until `mark_loop_awake` clears
+/// the flag, right after the dispatch that consumed it — so at the loop's
+/// pre-block check it means the eventfd is still armed and `dispatch(None)`
+/// returns immediately. That is the half of "queued but unwoken" the queues
+/// cannot answer: work produced after its own drain point is the ordinary
+/// case, and what makes it a bug is nobody having asked for the next pass.
+pub(crate) fn ping_in_flight() -> bool {
+    PING_SENT.load(Ordering::Relaxed)
+}
+
 /// Reset ping coalescing after the event loop woke up. Any `wake_loop`
 /// from here until the next dispatch sends (at most) one fresh ping, which
 /// keeps the eventfd readable so that dispatch returns immediately.

--- a/src/jobs.rs
+++ b/src/jobs.rs
@@ -572,11 +572,18 @@ static EXIT_REQUEST: AtomicU8 = AtomicU8::new(ExitRequest::Running as u8);
 /// Wakes the event loop so the main loop checks promptly.
 pub(crate) fn set_exit_request(req: ExitRequest) {
     EXIT_REQUEST.store(req as u8, Ordering::Release);
-    // Through `wake_loop`, not straight to the ping: one way in means one set
-    // of rules about the coalescing flag. If a ping is already armed the loop
-    // is already coming back, and it reads the exit request at the top of
-    // every pass.
-    wake_loop();
+    // Its own ping, written unconditionally — the one producer that does not
+    // coalesce. `wake_loop` would decline to write one while a ping is already
+    // armed, which is right for work the loop will find on its next pass and
+    // wrong here: the loop reads the exit flag once per pass, and a request
+    // that lands after that read has no second chance. The store is `Release`
+    // and this write is what the loop's next dispatch returns from, so the
+    // pass that follows it sees the flag.
+    if let Ok(guard) = WAKEUP_PING.lock()
+        && let Some(ref ping) = *guard
+    {
+        ping.ping();
+    }
 }
 
 /// Read the current exit request (non-destructive — persists until `reset_jobs()`).
@@ -1050,22 +1057,38 @@ mod wakeup_contract {
     /// setup from scratch. The asymmetry is what makes this sound: a real
     /// regression pings on *no* attempt, so the failure needs no luck, while a
     /// pass needs only one clean window out of many.
-    /// An exit request is a wakeup like any other, and goes through the same
-    /// door. It used to write the ping directly, past `PING_SENT`: a second
-    /// producer would then coalesce against a flag that nobody had raised, or
-    /// raise one for a ping already spent, depending on the order.
+    /// An exit request has to reach the eventfd, not just the flag: the loop
+    /// reads the exit flag once per pass, so a request that arrives while a
+    /// ping is already armed cannot be left to that ping — the pass it belongs
+    /// to may already have read the flag.
     #[test]
-    fn an_exit_request_goes_through_the_one_door() {
+    fn an_exit_request_writes_its_own_ping() {
         let _state = wakeup_test_lock();
-        let (ping, _source) = make_ping().expect("ping");
+        let mut event_loop: EventLoop<bool> = EventLoop::try_new().expect("event loop");
+        let (ping, source) = make_ping().expect("ping");
+        event_loop
+            .handle()
+            .insert_source(source, |_, _, woken: &mut bool| *woken = true)
+            .expect("insert ping source");
 
-        let seen = (0..64).any(|_| {
+        let woke = (0..64).any(|_| {
             init_wakeup(ping.clone());
-            mark_loop_awake();
+            let mut drained = false;
+            let _ = event_loop.dispatch(Some(Duration::ZERO), &mut drained);
+
+            // The state that would tempt a coalescing producer to write
+            // nothing at all.
+            PING_SENT.store(true, Ordering::Relaxed);
             set_exit_request(ExitRequest::Quit);
-            ping_in_flight()
+
+            let mut woken = false;
+            let _ = event_loop.dispatch(Some(Duration::from_millis(20)), &mut woken);
+            woken
         });
-        assert!(seen, "quit_app must write its ping through wake_loop");
+        assert!(
+            woke,
+            "an exit request must wake a loop that already had a ping armed"
+        );
     }
 
     #[test]
@@ -1108,7 +1131,6 @@ mod wakeup_contract {
             }
         }
 
-        reset_jobs();
         panic!(
             "wake_loop must ping while WAKE_REQUESTED is set — gating on \
              that flag is what lost wakeups"

--- a/src/jobs.rs
+++ b/src/jobs.rs
@@ -572,12 +572,12 @@ static EXIT_REQUEST: AtomicU8 = AtomicU8::new(ExitRequest::Running as u8);
 /// Wakes the event loop so the main loop checks promptly.
 pub(crate) fn set_exit_request(req: ExitRequest) {
     EXIT_REQUEST.store(req as u8, Ordering::Release);
-    // Wake the event loop so it notices the exit request
-    if let Ok(guard) = WAKEUP_PING.lock()
-        && let Some(ref ping) = *guard
-    {
-        ping.ping();
-    }
+    // Through `wake_loop`, not straight to the ping: a ping written behind its
+    // back is one `ping_in_flight` cannot see, and the loop's pre-block check
+    // would call a woken loop unwoken. Coalescing is the right answer here too
+    // — if a ping is already armed the loop is already coming back, and it
+    // reads the exit request at the top of every pass.
+    wake_loop();
 }
 
 /// Read the current exit request (non-destructive — persists until `reset_jobs()`).
@@ -629,21 +629,24 @@ pub(crate) fn wake_loop() {
     // would revive it). PING_SENT is instead cleared exactly once per
     // wakeup (mark_loop_awake), so during any blocked period the first
     // request always pings.
-    let already_pinged = PING_SENT.swap(true, Ordering::Relaxed);
-    if already_pinged {
-        return;
+    //
+    // The flag is raised under the ping's own lock and only with a handle in
+    // hand, so it is never up over a ping that was not written: it is read as
+    // *the eventfd is armed*, and a raise-then-lower around a failed attempt
+    // would let a second caller coalesce against a flag that is about to come
+    // back down — no ping written, nobody pinged, both callers believing
+    // otherwise.
+    if PING_SENT.load(Ordering::Acquire) {
+        return; // already armed; the lock is the slow path, not this one
     }
-    let pinged = WAKEUP_PING
-        .lock()
-        .ok()
-        .and_then(|guard| guard.as_ref().map(|ping| ping.ping()))
-        .is_some();
-    if !pinged {
-        // No loop to ping (setup, tests, teardown). The flag has to come back
-        // down: `ping_in_flight` is read as *the eventfd is armed*, and a flag
-        // raised over a ping that was never written would tell the loop it is
-        // safe to block when nothing is coming.
-        PING_SENT.store(false, Ordering::Relaxed);
+    let Ok(guard) = WAKEUP_PING.lock() else {
+        return;
+    };
+    let Some(ping) = guard.as_ref() else {
+        return; // no loop to ping (setup, tests, teardown)
+    };
+    if !PING_SENT.swap(true, Ordering::Release) {
+        ping.ping();
     }
 }
 
@@ -656,22 +659,36 @@ pub(crate) fn wake_loop() {
 /// cannot answer: work produced after its own drain point is the ordinary
 /// case, and what makes it a bug is nobody having asked for the next pass.
 ///
-/// It says *written*, not *requested*, which is why `wake_loop` lowers the
-/// flag again when there was no ping to write.
+/// It says *written*, not *requested*: `wake_loop` raises it under the ping's
+/// lock, with the handle in hand, so there is no window where it stands for a
+/// ping that does not exist.
 pub(crate) fn ping_in_flight() -> bool {
-    PING_SENT.load(Ordering::Relaxed)
+    PING_SENT.load(Ordering::Acquire)
 }
 
-/// Serialises the tests that drive the process-wide wakeup state directly —
-/// here, in `ingress`, and in `lib.rs`. They set and clear the very flags
-/// each other reads, and `cargo test` runs them on different threads.
+/// Exclusive use of the process-wide wakeup state for one test, given back on
+/// the way out — including out of a panic, which a trailing `reset_jobs()`
+/// does not cover: a failing assertion would otherwise leave a ping handle and
+/// a raised flag behind and turn one real failure into a run of unrelated ones.
 ///
-/// Not a substitute for the retries in this file: tests elsewhere (memo,
-/// anything requesting a job) touch the same flags without taking this.
+/// Taken by every test that writes this state — here, in `ingress`, in
+/// `lib.rs`. Not a substitute for the retries in this file: tests elsewhere
+/// (memo, anything requesting a job) touch the same flags without taking it.
 #[cfg(test)]
-pub(crate) fn wakeup_test_lock() -> std::sync::MutexGuard<'static, ()> {
+pub(crate) fn wakeup_test_lock() -> WakeupTestState {
     static LOCK: Mutex<()> = Mutex::new(());
-    LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+    WakeupTestState(LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner()))
+}
+
+#[cfg(test)]
+pub(crate) struct WakeupTestState(#[allow(dead_code)] std::sync::MutexGuard<'static, ()>);
+
+#[cfg(test)]
+impl Drop for WakeupTestState {
+    fn drop(&mut self) {
+        reset_jobs();
+        crate::ingress::reset_ingress();
+    }
 }
 
 /// Reset ping coalescing after the event loop woke up. Any `wake_loop`
@@ -1040,8 +1057,29 @@ mod wakeup_contract {
     /// setup from scratch. The asymmetry is what makes this sound: a real
     /// regression pings on *no* attempt, so the failure needs no luck, while a
     /// pass needs only one clean window out of many.
+    /// An exit request is a wakeup like any other, and has to be one the
+    /// loop's pre-block check can see. It used to write the ping directly,
+    /// behind `PING_SENT`'s back: the loop was woken and the check said
+    /// nobody had woken it.
+    #[test]
+    fn an_exit_request_arms_a_wakeup_the_check_can_see() {
+        let _state = wakeup_test_lock();
+        let (ping, _source) = make_ping().expect("ping");
+
+        let seen = (0..64).any(|_| {
+            init_wakeup(ping.clone());
+            mark_loop_awake();
+            set_exit_request(ExitRequest::Quit);
+            ping_in_flight()
+        });
+        assert!(seen, "quit_app must arm a wakeup the loop can account for");
+    }
+
     #[test]
     fn a_request_pings_even_when_the_frame_flag_is_already_set() {
+        // This test writes PING_SENT and WAKEUP_PING directly, which is what
+        // the guard exists to keep one test from doing under another's feet.
+        let _state = wakeup_test_lock();
         let mut event_loop: EventLoop<bool> = EventLoop::try_new().expect("event loop");
         let (ping, source) = make_ping().expect("ping");
         event_loop
@@ -1073,7 +1111,6 @@ mod wakeup_contract {
                     PING_SENT.load(Ordering::Relaxed),
                     "a sent ping must leave the coalescing flag armed"
                 );
-                reset_jobs();
                 return;
             }
         }

--- a/src/jobs.rs
+++ b/src/jobs.rs
@@ -630,24 +630,48 @@ pub(crate) fn wake_loop() {
     // wakeup (mark_loop_awake), so during any blocked period the first
     // request always pings.
     let already_pinged = PING_SENT.swap(true, Ordering::Relaxed);
-    if !already_pinged
-        && let Ok(guard) = WAKEUP_PING.lock()
-        && let Some(ref ping) = *guard
-    {
-        ping.ping();
+    if already_pinged {
+        return;
+    }
+    let pinged = WAKEUP_PING
+        .lock()
+        .ok()
+        .and_then(|guard| guard.as_ref().map(|ping| ping.ping()))
+        .is_some();
+    if !pinged {
+        // No loop to ping (setup, tests, teardown). The flag has to come back
+        // down: `ping_in_flight` is read as *the eventfd is armed*, and a flag
+        // raised over a ping that was never written would tell the loop it is
+        // safe to block when nothing is coming.
+        PING_SENT.store(false, Ordering::Relaxed);
     }
 }
 
 /// Whether a ping is readable by the next dispatch.
 ///
-/// True from the moment `wake_loop` sends one until `mark_loop_awake` clears
+/// True from the moment `wake_loop` writes one until `mark_loop_awake` clears
 /// the flag, right after the dispatch that consumed it — so at the loop's
 /// pre-block check it means the eventfd is still armed and `dispatch(None)`
 /// returns immediately. That is the half of "queued but unwoken" the queues
 /// cannot answer: work produced after its own drain point is the ordinary
 /// case, and what makes it a bug is nobody having asked for the next pass.
+///
+/// It says *written*, not *requested*, which is why `wake_loop` lowers the
+/// flag again when there was no ping to write.
 pub(crate) fn ping_in_flight() -> bool {
     PING_SENT.load(Ordering::Relaxed)
+}
+
+/// Serialises the tests that drive the process-wide wakeup state directly —
+/// here, in `ingress`, and in `lib.rs`. They set and clear the very flags
+/// each other reads, and `cargo test` runs them on different threads.
+///
+/// Not a substitute for the retries in this file: tests elsewhere (memo,
+/// anything requesting a job) touch the same flags without taking this.
+#[cfg(test)]
+pub(crate) fn wakeup_test_lock() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: Mutex<()> = Mutex::new(());
+    LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
 /// Reset ping coalescing after the event loop woke up. Any `wake_loop`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -635,6 +635,16 @@ fn dispatch_events(
 /// Push anything the widgets changed back out to the compositor: the
 /// clipboard after a copy, the primary selection after a select-to-copy, the
 /// cursor shape after a hover.
+///
+/// Called once per iteration from the loop, not per surface. What it carries
+/// belongs to the seat rather than to any one surface, and running it inside
+/// the per-surface pass meant it only ran when a surface had a frame to give
+/// it: an application with no surface yet — one that spawns its bars from an
+/// event, a lock screen before its lock is granted — could copy or set a
+/// cursor and have it sit in the queue with no pass coming to drain it. The
+/// loop's pre-block check reads that queue and would have called it a lost
+/// wakeup, which it is not: the producer woke the loop, and the loop had
+/// nowhere to put the work.
 fn sync_platform_state(
     wayland_state: &mut platform::WaylandState,
     qh: &QueueHandle<platform::WaylandState>,
@@ -714,13 +724,14 @@ fn queued_but_unwoken() -> Option<&'static str> {
 }
 
 /// What the loop still owes a pass, named. Every queue it drains, in the
-/// order it drains them.
+/// order the iteration drains them — so a new queue goes next to its own
+/// drain here too, and the list keeps reading as the loop body does.
 fn queued_work() -> Option<&'static str> {
     [
-        ("widget jobs", has_pending_jobs()),
-        ("background signal writes", reactive::bg_writes_pending()),
         ("owner disposals", reactive::owner::disposals_pending()),
         ("surface commands", surface::surface_commands_pending()),
+        ("background signal writes", reactive::bg_writes_pending()),
+        ("widget jobs", has_pending_jobs()),
         ("a selection change", reactive::selection_change_pending()),
         ("a cursor change", reactive::cursor_change_pending()),
     ]
@@ -731,19 +742,24 @@ fn queued_work() -> Option<&'static str> {
 /// Whether something already owes the loop the pass that drains what is
 /// queued.
 ///
-/// Three ways to owe one, one per mechanism in the contract:
+/// Two ways to owe one, one per mechanism in the contract:
 ///
-/// - a ping is readable, so the next `dispatch` returns immediately;
-/// - a wake request is still set, so the loop refuses to block at all;
+/// - a ping has been written and not yet dispatched, so the next `dispatch`
+///   returns immediately;
 /// - an ingress message has been sent and not yet read, and calloop
 ///   guarantees it is delivered before the loop can block again.
 ///
-/// Any of them and the loop is not going deaf — it takes another pass, and
-/// every queue above is drained unconditionally on it. The state this leaves
-/// the assertion looking for is the one that was meant: work queued by a
-/// producer that woke nobody at all.
+/// Either one and the loop is not going deaf: it takes another pass, and
+/// every queue in [`queued_work`] is drained unconditionally on it — widget
+/// jobs by `needs_polling`, which refuses to block while any are queued. So
+/// the state this leaves the assertion looking for is the one that was meant:
+/// work queued by a producer that woke nobody at all.
+///
+/// `WAKE_REQUESTED` is deliberately not a third: `needs_polling` already
+/// refuses to block while it is set, so the check is never reached with one
+/// outstanding, and naming it here would be a guarantee that never applies.
 fn wakeup_armed() -> bool {
-    jobs::ping_in_flight() || jobs::wake_request_pending() || ingress::in_flight()
+    jobs::ping_in_flight() || ingress::in_flight()
 }
 
 /// What this surface tells us about itself, read once at the top of a frame.
@@ -1254,7 +1270,6 @@ fn render_surface(
 
     let root = ctx.surface.widget_id;
     dispatch_events(&frame.events, root, ctx.tree, active_roots);
-    sync_platform_state(ctx.wayland_state, ctx.qh);
 
     let geometry = resolve_geometry(ctx, &frame);
 
@@ -1563,14 +1578,20 @@ impl App {
             } else {
                 // About to block with nothing left to wake us but the
                 // compositor. Anything still queued must have a wakeup armed
-                // for it by now — see `queued_but_unwoken`.
-                debug_assert!(
-                    queued_but_unwoken().is_none(),
-                    "the loop is about to block indefinitely with {} still queued and \
-                     no wakeup armed for it — whatever produced it woke nobody. See \
-                     the Event Loop Wakeup Contract in docs/ARCHITECTURE.md.",
-                    queued_but_unwoken().unwrap_or_default()
-                );
+                // for it by now — see `queued_but_unwoken`. Read once: asking
+                // twice can catch a wakeup landing in between and print a
+                // panic with no name in it, which is the only thing the panic
+                // is for.
+                if cfg!(debug_assertions)
+                    && let Some(queue) = queued_but_unwoken()
+                {
+                    panic!(
+                        "the loop is about to block indefinitely with {queue} still \
+                         queued and no wakeup armed for it — whatever produced it woke \
+                         nobody. See the Event Loop Wakeup Contract in \
+                         docs/ARCHITECTURE.md."
+                    );
+                }
                 None // Block indefinitely until event
             };
 
@@ -1694,6 +1715,12 @@ impl App {
                     render_surface(&mut ctx, layout_roots, woken, &active_roots);
                 }
             }
+
+            // Hand the seat what the widgets changed — after the render
+            // pass, so a copy or a cursor set by this iteration's event
+            // handling still goes out in this iteration, and outside it, so
+            // it goes out whether or not any surface had a frame to draw.
+            sync_platform_state(&mut wayland_state, &qh);
 
             // Flush the connection once for all surfaces
             if let Err(e) = connection.flush() {
@@ -1999,6 +2026,8 @@ mod font_registry_tests {
 #[cfg(test)]
 mod wakeup_contract_coverage {
     use super::*;
+    use smithay_client_toolkit::reexports::calloop;
+    use smithay_client_toolkit::reexports::calloop::ping::make_ping;
 
     /// A probe that never reports anything would make the check in
     /// `queued_but_unwoken` silently useless, so each one is pinned to the
@@ -2044,6 +2073,13 @@ mod wakeup_contract_coverage {
     /// as a lost wakeup and panicked a debug build.
     #[test]
     fn work_queued_with_a_wakeup_armed_is_not_a_lost_wakeup() {
+        let _guard = jobs::wakeup_test_lock();
+        // A ping handle, because there is no loop in a test binary and
+        // `wake_loop` arms nothing without one — correctly: with nothing to
+        // write to, the work really would be unwoken.
+        let (ping, _source) = make_ping().expect("ping");
+        jobs::init_wakeup(ping);
+
         let _ = reactive::take_cursor_change();
         reactive::set_cursor(reactive::CursorIcon::Text);
         assert_eq!(
@@ -2056,13 +2092,19 @@ mod wakeup_contract_coverage {
         // difference between work riding the next pass and work nobody is
         // coming back for.
         //
-        // Retried because the arming flags are process-wide and other tests
-        // in this binary clear them (`reset_jobs`). The asymmetry is what
-        // makes it sound: the queue is this thread's own, so a regression —
-        // the check reading the queues alone — reports it on every attempt,
-        // while a pass needs one quiet window out of many.
-        let quiet = (0..64).any(|_| {
-            reactive::set_cursor(reactive::CursorIcon::Text);
+        // Retried because the arming flag is process-wide and tests that do
+        // not take the lock above clear it (`reset_jobs`, in the memo tests).
+        // Each attempt re-arms with a *different* shape: `set_cursor` returns
+        // early on the one already set, and would arm nothing after the first.
+        // The asymmetry is what makes it sound — the queue is this thread's
+        // own, so a regression reports it on every attempt, while a pass needs
+        // one quiet window out of many.
+        let quiet = (0..64).any(|attempt| {
+            reactive::set_cursor(if attempt % 2 == 0 {
+                reactive::CursorIcon::Default
+            } else {
+                reactive::CursorIcon::Text
+            });
             queued_but_unwoken().is_none()
         });
         assert!(
@@ -2071,6 +2113,7 @@ mod wakeup_contract_coverage {
         );
 
         let _ = reactive::take_cursor_change();
+        jobs::reset_jobs();
     }
 
     /// The reported window, in the loop's own order: an effect running at the
@@ -2081,11 +2124,13 @@ mod wakeup_contract_coverage {
     /// its own debug build.
     #[test]
     fn a_command_queued_after_its_drain_rides_the_next_pass() {
-        surface::reset_surface_commands();
+        // This one *writes* the process-wide flags (`mark_loop_awake`,
+        // `take_wake_request`), so it holds the lock for the whole run rather
+        // than racing the tests that read them.
+        let _guard = jobs::wakeup_test_lock();
+        let (ping, _source) = make_ping().expect("ping");
+        jobs::init_wakeup(ping);
 
-        // Retried for the arming flags other tests clear; see above. The
-        // command queue is this thread's own, so a regression reports it on
-        // every attempt.
         let quiet = (0..64).any(|_| {
             surface::reset_surface_commands();
             jobs::mark_loop_awake(); // the dispatch that woke us returned
@@ -2103,24 +2148,56 @@ mod wakeup_contract_coverage {
         );
 
         surface::reset_surface_commands();
+        jobs::reset_jobs();
     }
 
     /// Each arming mechanism has to be visible to `wakeup_armed`, or the
-    /// check is back to guessing from the queues alone.
+    /// check is back to guessing from the queues alone — and it has to mean
+    /// what it says, or the check hides the very bug it exists to report.
     #[test]
     fn every_way_of_owing_a_wakeup_reports_itself() {
-        // A ping stays readable until the dispatch that consumes it, which is
-        // exactly the window the pre-block check runs in. Retried for the
-        // same reason as above: `reset_jobs` in other tests clears the flag.
-        let ping_seen = (0..64).any(|_| {
-            jobs::wake_loop();
-            jobs::ping_in_flight()
-        });
-        assert!(ping_seen, "a sent ping must be visible to the check");
+        let _guard = jobs::wakeup_test_lock();
 
-        // An ingress message is armed before the work it speaks for is
-        // queued, and stays counted until the loop takes delivery.
-        let _guard = ingress::test_count_lock();
+        // A written ping, still readable: exactly the window the pre-block
+        // check runs in. Retried for the flags other tests clear.
+        let mut event_loop: calloop::EventLoop<bool> = calloop::EventLoop::try_new().expect("loop");
+        let (ping, source) = make_ping().expect("ping");
+        event_loop
+            .handle()
+            .insert_source(source, |_, _, woken: &mut bool| *woken = true)
+            .expect("insert ping source");
+
+        let readable = (0..64).any(|_| {
+            jobs::init_wakeup(ping.clone());
+            let mut drained = false;
+            let _ = event_loop.dispatch(Some(std::time::Duration::ZERO), &mut drained);
+            jobs::mark_loop_awake();
+
+            jobs::wake_loop();
+            let mut woken = false;
+            let _ = event_loop.dispatch(Some(std::time::Duration::ZERO), &mut woken);
+            woken && jobs::ping_in_flight()
+        });
+        assert!(
+            readable,
+            "the flag must be up for a ping the loop can actually read"
+        );
+
+        // And down when there was no ping to write. `ping_in_flight` is read
+        // as *the loop cannot block*; raising it over a ping that was never
+        // written would let the check bless the state it exists to catch.
+        let honest = (0..64).any(|_| {
+            jobs::reset_jobs(); // drops the wakeup handle
+            jobs::wake_loop();
+            !jobs::ping_in_flight()
+        });
+        assert!(
+            honest,
+            "a request with no ping handle to write to must not read as armed"
+        );
+
+        // An ingress message, armed before the work it speaks for is queued
+        // and counted until the loop takes delivery.
         let armed = ingress::arm(ingress::IngressMessage::BgWritesQueued);
         assert!(
             ingress::in_flight(),
@@ -2131,5 +2208,7 @@ mod wakeup_contract_coverage {
             !ingress::in_flight(),
             "and must stop being visible if it is never sent"
         );
+
+        jobs::reset_jobs();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -699,81 +699,6 @@ fn run_jobs(
     jobs::recycle_job_buffer(followup);
 }
 
-/// Deferred work that is queued with nothing owed to wake the loop for it.
-///
-/// The wakeup contract says a producer that queues work must also guarantee a
-/// wakeup that survives until its consumer runs. This is that contract as a
-/// check instead of as prose — prose does not fail a test run.
-///
-/// Both halves have to be asked. A queue left non-empty at the blocking point
-/// is the ordinary case, not the bug: the drains sit in the middle of the
-/// iteration and effects, event handlers and background threads all run after
-/// them, so work riding the next pass is what a working application looks
-/// like. What makes it a lost wakeup is nobody having asked for that pass —
-/// so the queues answer *what* is waiting, and [`wakeup_armed`] answers
-/// whether anything is coming to drain it.
-///
-/// Read in that order, never the other way round: a producer arms before it
-/// queues, so a queue seen non-empty already has its wakeup armed, while an
-/// arming read first can miss one that lands a moment later — the producer
-/// is on another thread.
-///
-/// Returns the name of the offender, because the point is the message.
-fn queued_but_unwoken() -> Option<&'static str> {
-    let queued = queued_work()?;
-    (!wakeup_armed()).then_some(queued)
-}
-
-/// What the loop still owes a pass, named. Every queue the *loop body* drains,
-/// in the order it drains them — so a new queue goes next to its own drain
-/// here too, and the list keeps reading as the loop body does.
-///
-/// Deliberately not every deferred queue in the library: a parked
-/// `WidgetRef::focus` is drained by `run_jobs`, inside the surface's own pass,
-/// because a focus request means nothing until there is a tree to resolve it
-/// against. Work that only a surface can drain cannot be judged by a check
-/// that runs whether or not one exists — which is the same reason the
-/// clipboard and the cursor had to move *out* of that pass to be listed here.
-fn queued_work() -> Option<&'static str> {
-    [
-        ("owner disposals", reactive::owner::disposals_pending()),
-        ("surface commands", surface::surface_commands_pending()),
-        ("background signal writes", reactive::bg_writes_pending()),
-        // Unreachable from `queued_but_unwoken`: `needs_polling` refuses to
-        // block while any job is queued, so the check is never reached with
-        // one. Listed because this is the inventory of what the loop drains,
-        // and leaving a queue out of it is how the next one gets forgotten.
-        ("widget jobs", has_pending_jobs()),
-        ("a selection change", reactive::selection_change_pending()),
-        ("a cursor change", reactive::cursor_change_pending()),
-    ]
-    .into_iter()
-    .find_map(|(name, pending)| pending.then_some(name))
-}
-
-/// Whether something already owes the loop the pass that drains what is
-/// queued.
-///
-/// Two ways to owe one, one per mechanism in the contract:
-///
-/// - a ping has been written and not yet dispatched, so the next `dispatch`
-///   returns immediately;
-/// - an ingress message has been sent and not yet read, and calloop
-///   guarantees it is delivered before the loop can block again.
-///
-/// Either one and the loop is not going deaf: it takes another pass, and
-/// every queue in [`queued_work`] is drained unconditionally on it — widget
-/// jobs by `needs_polling`, which refuses to block while any are queued. So
-/// the state this leaves the assertion looking for is the one that was meant:
-/// work queued by a producer that woke nobody at all.
-///
-/// `WAKE_REQUESTED` is deliberately not a third: `needs_polling` already
-/// refuses to block while it is set, so the check is never reached with one
-/// outstanding, and naming it here would be a guarantee that never applies.
-fn wakeup_armed() -> bool {
-    jobs::ping_in_flight() || ingress::in_flight()
-}
-
 /// What this surface tells us about itself, read once at the top of a frame.
 ///
 /// Copying it frees the borrow on `wayland_state`, which the phases below
@@ -1465,10 +1390,6 @@ impl App {
         loop_handle
             .insert_source(ingress_channel, |event, _, wayland_state| {
                 if let calloop_channel::Event::Msg(message) = event {
-                    // This message was itself the wakeup, and it is spent
-                    // now — the drains it speaks for run later this same
-                    // iteration.
-                    ingress::delivered();
                     match message {
                         // Doorbell only: the write payloads live in the
                         // reactive write queue, drained at the flush point
@@ -1583,30 +1504,17 @@ impl App {
             // - Otherwise block until event (Wayland or ping wakeup)
             let timeout = if needs_polling {
                 Some(std::time::Duration::from_millis(16)) // ~60fps for animations
-            } else if let Some(deadline) = jobs::next_deadline() {
-                // Not polling — waiting. A caret blinks twice a second, so this
-                // sleeps ~530 ms and wakes once, where treating the schedule as
-                // pending work would spin at 60 fps to repaint nothing 113 times
-                // out of 114.
-                Some(deadline.saturating_duration_since(std::time::Instant::now()))
             } else {
-                // About to block with nothing left to wake us but the
-                // compositor. Anything still queued must have a wakeup armed
-                // for it by now — see `queued_but_unwoken`. Read once: asking
-                // twice can catch a wakeup landing in between and print a
-                // panic with no name in it, which is the only thing the panic
-                // is for.
-                if cfg!(debug_assertions)
-                    && let Some(queue) = queued_but_unwoken()
-                {
-                    panic!(
-                        "the loop is about to block indefinitely with {queue} still \
-                         queued and no wakeup armed for it — whatever produced it woke \
-                         nobody. See the Event Loop Wakeup Contract in \
-                         docs/ARCHITECTURE.md."
-                    );
-                }
-                None // Block indefinitely until event
+                // Not polling — waiting. A deadline sleeps exactly that long: a
+                // caret blinks twice a second, so this wakes once where treating
+                // the schedule as pending work would spin at 60 fps to repaint
+                // nothing 113 frames out of 114.
+                //
+                // No deadline means blocking until the compositor or a ping.
+                // Nothing queued can be stranded by that: work and its wakeup
+                // are one gesture — see `deferred` and the ingress channel.
+                jobs::next_deadline()
+                    .map(|deadline| deadline.saturating_duration_since(std::time::Instant::now()))
             };
 
             if let Err(e) = event_loop.dispatch(timeout, &mut wayland_state) {
@@ -2045,197 +1953,6 @@ mod font_registry_tests {
             super::CUSTOM_FONTS.with(|f| f.borrow().len()),
             after_second + 1,
             "a different font must still register"
-        );
-    }
-}
-
-#[cfg(test)]
-mod wakeup_contract_coverage {
-    use super::*;
-    use smithay_client_toolkit::reexports::calloop;
-    use smithay_client_toolkit::reexports::calloop::ping::make_ping;
-
-    /// A probe that never reports anything would make the check in
-    /// `queued_but_unwoken` silently useless, so each one is pinned to the
-    /// drain it speaks for: queue, see it, drain, see it gone.
-    #[test]
-    fn each_probe_tracks_its_own_queue() {
-        // Clipboard and primary share one probe.
-        let _ = reactive::take_clipboard_change();
-        let _ = reactive::take_primary_change();
-        assert!(!reactive::selection_change_pending());
-
-        reactive::clipboard_copy("queued");
-        assert!(
-            reactive::selection_change_pending(),
-            "a copy must be visible to the wakeup check"
-        );
-        let _ = reactive::take_clipboard_change();
-        assert!(!reactive::selection_change_pending());
-
-        reactive::primary_copy("queued");
-        assert!(
-            reactive::selection_change_pending(),
-            "a primary-selection copy must be visible too"
-        );
-        let _ = reactive::take_primary_change();
-        assert!(!reactive::selection_change_pending());
-
-        // Cursor.
-        let _ = reactive::take_cursor_change();
-        assert!(!reactive::cursor_change_pending());
-        reactive::set_cursor(reactive::CursorIcon::Text);
-        assert!(
-            reactive::cursor_change_pending(),
-            "a cursor change must be visible to the wakeup check"
-        );
-        let _ = reactive::take_cursor_change();
-        assert!(!reactive::cursor_change_pending());
-    }
-
-    /// The bug this check had for as long as it existed: it asked what was
-    /// queued and never what was owed, so ordinary work — a background write
-    /// landing after the flush, a surface command pushed by an effect — read
-    /// as a lost wakeup and panicked a debug build.
-    #[test]
-    fn work_queued_with_a_wakeup_armed_is_not_a_lost_wakeup() {
-        let _guard = jobs::wakeup_test_lock();
-        // A ping handle, because there is no loop in a test binary and
-        // `wake_loop` arms nothing without one — correctly: with nothing to
-        // write to, the work really would be unwoken.
-        let (ping, _source) = make_ping().expect("ping");
-        jobs::init_wakeup(ping);
-
-        let _ = reactive::take_cursor_change();
-        reactive::set_cursor(reactive::CursorIcon::Text);
-        assert_eq!(
-            queued_work(),
-            Some("a cursor change"),
-            "the queue itself is still what names the offender"
-        );
-
-        // `set_cursor` woke the loop on its way past, which is the whole
-        // difference between work riding the next pass and work nobody is
-        // coming back for.
-        //
-        // Retried because the arming flag is process-wide and tests that do
-        // not take the lock above clear it (`reset_jobs`, in the memo tests).
-        // Each attempt re-arms with a *different* shape: `set_cursor` returns
-        // early on the one already set, and would arm nothing after the first.
-        // The asymmetry is what makes it sound — the queue is this thread's
-        // own, so a regression reports it on every attempt, while a pass needs
-        // one quiet window out of many.
-        let quiet = (0..64).any(|attempt| {
-            reactive::set_cursor(if attempt % 2 == 0 {
-                reactive::CursorIcon::Default
-            } else {
-                reactive::CursorIcon::Text
-            });
-            queued_but_unwoken().is_none()
-        });
-        assert!(
-            quiet,
-            "a queue whose producer woke the loop must not be reported as unwoken"
-        );
-
-        let _ = reactive::take_cursor_change();
-    }
-
-    /// The reported window, in the loop's own order: an effect running at the
-    /// flush point pushes a surface command *after* that queue's drain, and
-    /// `take_wake_request()` then clears the flag it set. The ping it sent is
-    /// the only thing left saying the loop is coming back — and reading the
-    /// queues alone cannot see it, which is how a healthy application panicked
-    /// its own debug build.
-    #[test]
-    fn a_command_queued_after_its_drain_rides_the_next_pass() {
-        // This one *writes* the process-wide flags (`mark_loop_awake`,
-        // `take_wake_request`), so it holds the lock for the whole run rather
-        // than racing the tests that read them.
-        let _guard = jobs::wakeup_test_lock();
-        let (ping, _source) = make_ping().expect("ping");
-        jobs::init_wakeup(ping);
-
-        let handle = surface::surface_handle(SurfaceId::next());
-        let quiet = (0..64).any(|_| {
-            surface::reset_surface_commands();
-            jobs::mark_loop_awake(); // the dispatch that woke us returned
-
-            // …the loop drains surface commands here, and only then flushes
-            // background writes, whose effects run before the take below.
-            handle.set_margin(8);
-            let _ = jobs::take_wake_request();
-
-            queued_but_unwoken().is_none()
-        });
-        assert!(
-            quiet,
-            "a surface command pushed after its drain has a ping armed for it"
-        );
-
-        surface::reset_surface_commands();
-    }
-
-    /// Each arming mechanism has to be visible to `wakeup_armed`, or the
-    /// check is back to guessing from the queues alone — and it has to mean
-    /// what it says, or the check hides the very bug it exists to report.
-    #[test]
-    fn every_way_of_owing_a_wakeup_reports_itself() {
-        let _guard = jobs::wakeup_test_lock();
-
-        // A written ping, still readable: exactly the window the pre-block
-        // check runs in. Retried for the flags other tests clear.
-        let mut event_loop: calloop::EventLoop<bool> = calloop::EventLoop::try_new().expect("loop");
-        let (ping, source) = make_ping().expect("ping");
-        event_loop
-            .handle()
-            .insert_source(source, |_, _, woken: &mut bool| *woken = true)
-            .expect("insert ping source");
-
-        let readable = (0..64).any(|_| {
-            jobs::init_wakeup(ping.clone());
-            let mut drained = false;
-            let _ = event_loop.dispatch(Some(std::time::Duration::ZERO), &mut drained);
-            jobs::mark_loop_awake();
-
-            jobs::wake_loop();
-            let mut woken = false;
-            let _ = event_loop.dispatch(Some(std::time::Duration::ZERO), &mut woken);
-            woken && jobs::ping_in_flight()
-        });
-        assert!(
-            readable,
-            "the flag must be up for a ping the loop can actually read"
-        );
-
-        // And down when there was no ping to write. `ping_in_flight` is read
-        // as *the loop cannot block*; raising it over a ping that was never
-        // written would let the check bless the state it exists to catch.
-        let honest = (0..64).any(|_| {
-            jobs::reset_jobs(); // drops the wakeup handle
-            jobs::wake_loop();
-            !jobs::ping_in_flight()
-        });
-        assert!(
-            honest,
-            "a request with no ping handle to write to must not read as armed"
-        );
-
-        // An ingress message, armed before the work it speaks for is queued
-        // and counted until the loop takes delivery. The count is debug-only,
-        // like the check it answers — in a release build there is nothing
-        // owed to anybody, and `in_flight` says so.
-        let armed = ingress::arm(ingress::IngressMessage::BgWritesQueued);
-        if cfg!(debug_assertions) {
-            assert!(
-                ingress::in_flight(),
-                "an armed message must be visible before it is even sent"
-            );
-        }
-        drop(armed);
-        assert!(
-            !ingress::in_flight(),
-            "and must stop being visible if it is never sent"
         );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -688,26 +688,36 @@ fn run_jobs(
     jobs::recycle_job_buffer(followup);
 }
 
-/// Deferred work that is queued and still waiting for the loop to drain it.
+/// Deferred work that is queued with nothing owed to wake the loop for it.
 ///
 /// The wakeup contract says a producer that queues work must also guarantee a
 /// wakeup that survives until its consumer runs. This is that contract as a
 /// check instead of as prose — prose does not fail a test run.
 ///
-/// Why an empty result is the only correct answer at the blocking point: each
-/// of these is drained unconditionally, once per iteration. Anything still
-/// queued was therefore produced *after* its own drain, and the only thing
-/// that can bring the loop back to drain it is a wake request — which would
-/// have kept it from blocking in the first place. So a non-empty queue here
-/// means nobody asked to be woken, and the app is about to go deaf until an
-/// unrelated compositor event happens along. That is precisely the shape of
-/// the lost-wakeup bug this contract exists to prevent.
+/// Both halves have to be asked. A queue left non-empty at the blocking point
+/// is the ordinary case, not the bug: the drains sit in the middle of the
+/// iteration and effects, event handlers and background threads all run after
+/// them, so work riding the next pass is what a working application looks
+/// like. What makes it a lost wakeup is nobody having asked for that pass —
+/// so the queues answer *what* is waiting, and [`wakeup_armed`] answers
+/// whether anything is coming to drain it.
+///
+/// Read in that order, never the other way round: a producer arms before it
+/// queues, so a queue seen non-empty already has its wakeup armed, while an
+/// arming read first can miss one that lands a moment later — the producer
+/// is on another thread.
 ///
 /// Returns the name of the offender, because the point is the message.
 fn queued_but_unwoken() -> Option<&'static str> {
+    let queued = queued_work()?;
+    (!wakeup_armed()).then_some(queued)
+}
+
+/// What the loop still owes a pass, named. Every queue it drains, in the
+/// order it drains them.
+fn queued_work() -> Option<&'static str> {
     [
         ("widget jobs", has_pending_jobs()),
-        ("a wake request", jobs::wake_request_pending()),
         ("background signal writes", reactive::bg_writes_pending()),
         ("owner disposals", reactive::owner::disposals_pending()),
         ("surface commands", surface::surface_commands_pending()),
@@ -716,6 +726,24 @@ fn queued_but_unwoken() -> Option<&'static str> {
     ]
     .into_iter()
     .find_map(|(name, pending)| pending.then_some(name))
+}
+
+/// Whether something already owes the loop the pass that drains what is
+/// queued.
+///
+/// Three ways to owe one, one per mechanism in the contract:
+///
+/// - a ping is readable, so the next `dispatch` returns immediately;
+/// - a wake request is still set, so the loop refuses to block at all;
+/// - an ingress message has been sent and not yet read, and calloop
+///   guarantees it is delivered before the loop can block again.
+///
+/// Any of them and the loop is not going deaf — it takes another pass, and
+/// every queue above is drained unconditionally on it. The state this leaves
+/// the assertion looking for is the one that was meant: work queued by a
+/// producer that woke nobody at all.
+fn wakeup_armed() -> bool {
+    jobs::ping_in_flight() || jobs::wake_request_pending() || ingress::in_flight()
 }
 
 /// What this surface tells us about itself, read once at the top of a frame.
@@ -1479,6 +1507,10 @@ impl App {
         loop_handle
             .insert_source(ingress_channel, |event, _, wayland_state| {
                 if let calloop_channel::Event::Msg(message) = event {
+                    // This message was itself the wakeup, and it is spent
+                    // now — the drains it speaks for run later this same
+                    // iteration.
+                    ingress::delivered();
                     match message {
                         // Doorbell only: the write payloads live in the
                         // reactive write queue, drained at the flush point
@@ -1530,13 +1562,13 @@ impl App {
                 Some(deadline.saturating_duration_since(std::time::Instant::now()))
             } else {
                 // About to block with nothing left to wake us but the
-                // compositor. Every queue must be empty by now — see
-                // `queued_but_unwoken`.
+                // compositor. Anything still queued must have a wakeup armed
+                // for it by now — see `queued_but_unwoken`.
                 debug_assert!(
                     queued_but_unwoken().is_none(),
-                    "the loop is about to block indefinitely with {} still queued — \
-                     whatever produced it owes a wakeup. See the Event Loop Wakeup \
-                     Contract in docs/ARCHITECTURE.md.",
+                    "the loop is about to block indefinitely with {} still queued and \
+                     no wakeup armed for it — whatever produced it woke nobody. See \
+                     the Event Loop Wakeup Contract in docs/ARCHITECTURE.md.",
                     queued_but_unwoken().unwrap_or_default()
                 );
                 None // Block indefinitely until event
@@ -2004,5 +2036,100 @@ mod wakeup_contract_coverage {
         );
         let _ = reactive::take_cursor_change();
         assert!(!reactive::cursor_change_pending());
+    }
+
+    /// The bug this check had for as long as it existed: it asked what was
+    /// queued and never what was owed, so ordinary work — a background write
+    /// landing after the flush, a surface command pushed by an effect — read
+    /// as a lost wakeup and panicked a debug build.
+    #[test]
+    fn work_queued_with_a_wakeup_armed_is_not_a_lost_wakeup() {
+        let _ = reactive::take_cursor_change();
+        reactive::set_cursor(reactive::CursorIcon::Text);
+        assert_eq!(
+            queued_work(),
+            Some("a cursor change"),
+            "the queue itself is still what names the offender"
+        );
+
+        // `set_cursor` woke the loop on its way past, which is the whole
+        // difference between work riding the next pass and work nobody is
+        // coming back for.
+        //
+        // Retried because the arming flags are process-wide and other tests
+        // in this binary clear them (`reset_jobs`). The asymmetry is what
+        // makes it sound: the queue is this thread's own, so a regression —
+        // the check reading the queues alone — reports it on every attempt,
+        // while a pass needs one quiet window out of many.
+        let quiet = (0..64).any(|_| {
+            reactive::set_cursor(reactive::CursorIcon::Text);
+            queued_but_unwoken().is_none()
+        });
+        assert!(
+            quiet,
+            "a queue whose producer woke the loop must not be reported as unwoken"
+        );
+
+        let _ = reactive::take_cursor_change();
+    }
+
+    /// The reported window, in the loop's own order: an effect running at the
+    /// flush point pushes a surface command *after* that queue's drain, and
+    /// `take_wake_request()` then clears the flag it set. The ping it sent is
+    /// the only thing left saying the loop is coming back — and reading the
+    /// queues alone cannot see it, which is how a healthy application panicked
+    /// its own debug build.
+    #[test]
+    fn a_command_queued_after_its_drain_rides_the_next_pass() {
+        surface::reset_surface_commands();
+
+        // Retried for the arming flags other tests clear; see above. The
+        // command queue is this thread's own, so a regression reports it on
+        // every attempt.
+        let quiet = (0..64).any(|_| {
+            surface::reset_surface_commands();
+            jobs::mark_loop_awake(); // the dispatch that woke us returned
+
+            // …the loop drains surface commands here, and only then flushes
+            // background writes, whose effects run before the take below.
+            surface::surface_handle(SurfaceId::next()).set_margin(8);
+            let _ = jobs::take_wake_request();
+
+            queued_but_unwoken().is_none()
+        });
+        assert!(
+            quiet,
+            "a surface command pushed after its drain has a ping armed for it"
+        );
+
+        surface::reset_surface_commands();
+    }
+
+    /// Each arming mechanism has to be visible to `wakeup_armed`, or the
+    /// check is back to guessing from the queues alone.
+    #[test]
+    fn every_way_of_owing_a_wakeup_reports_itself() {
+        // A ping stays readable until the dispatch that consumes it, which is
+        // exactly the window the pre-block check runs in. Retried for the
+        // same reason as above: `reset_jobs` in other tests clears the flag.
+        let ping_seen = (0..64).any(|_| {
+            jobs::wake_loop();
+            jobs::ping_in_flight()
+        });
+        assert!(ping_seen, "a sent ping must be visible to the check");
+
+        // An ingress message is armed before the work it speaks for is
+        // queued, and stays counted until the loop takes delivery.
+        let _guard = ingress::test_count_lock();
+        let armed = ingress::arm(ingress::IngressMessage::BgWritesQueued);
+        assert!(
+            ingress::in_flight(),
+            "an armed message must be visible before it is even sent"
+        );
+        drop(armed);
+        assert!(
+            !ingress::in_flight(),
+            "and must stop being visible if it is never sent"
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -933,6 +933,21 @@ fn layout_pass(
 
     // Update widget ref signals with current bounds after layout
     widget_ref::update_widget_refs(tree);
+
+    // A `WidgetRef::focus()` from application code lands here: after layout, so
+    // a handle attached this very frame has resolved to a widget, and before
+    // `paint_and_present`, so the frame that resolves it is the frame that
+    // draws the caret. Applying it after the render pass instead reads
+    // tidier — one call per iteration rather than one per surface — and costs
+    // an autofocused field a frame of looking unfocused.
+    //
+    // Staying parked is this one's resting state, unlike the queues in
+    // `deferred`: a request for a widget that does not exist yet is the
+    // ordinary shape of `focus()` from a startup effect, and it waits as many
+    // frames as it takes. Which is also why it does not matter that a surface
+    // must exist for this to run — without one there is no tree to resolve
+    // against.
+    reactive::focus::apply_pending_focus(tree);
 }
 
 /// The size the compositor has confirmed, if it has confirmed one.
@@ -1343,21 +1358,6 @@ impl App {
     /// });
     /// ```
     pub fn run(mut self, setup: impl FnOnce(&mut Self)) -> ExitReason {
-        // Create root owner scope — all signals/effects created in setup are owned
-        self.root_owner_id = Some(reactive::create_root_owner());
-        setup(&mut self);
-
-        if self.surface_definitions.is_empty() {
-            // Not an error: outputs-driven apps start with zero surfaces and
-            // spawn one per monitor from an effect once the compositor
-            // reports its outputs. An app that never spawns anything will
-            // just idle in the event loop.
-            log::info!(
-                "No static surfaces defined; waiting for dynamic surfaces \
-                 (spawn_surface, e.g. from an outputs() effect)"
-            );
-        }
-
         // The loop is created before the connection because the keyboard is
         // built during the first dispatch, and it needs the loop handle to arm
         // its key-repeat timer.
@@ -1365,12 +1365,12 @@ impl App {
             EventLoop::try_new().expect("Failed to create event loop");
         let loop_handle = event_loop.handle();
 
-        // Both wakeup mechanisms are installed before anything can use them.
-        // The compositor talks during `create_wayland_app`'s roundtrips and
-        // during the configure loop below — a clipboard offer arriving there
-        // starts a reader thread, and an app's own `create_task` can queue a
-        // background write — and a producer that finds neither a channel nor a
-        // ping handle has nowhere to put its wakeup.
+        // Both wakeup mechanisms are installed before anything can reach
+        // them, which means before `setup` runs: an app's very first act is
+        // often a `create_task` that writes a signal, and the compositor
+        // starts talking during `create_wayland_app`'s roundtrips and the
+        // configure loop. A producer that finds neither a channel nor a ping
+        // handle has nowhere to put its wakeup.
         // Create ping mechanism for wakeup on signal changes
         let (ping, ping_source) = make_ping().expect("Failed to create ping");
         init_wakeup(ping);
@@ -1405,6 +1405,21 @@ impl App {
                 }
             })
             .expect("Failed to insert ingress channel");
+
+        // Create root owner scope — all signals/effects created in setup are owned
+        self.root_owner_id = Some(reactive::create_root_owner());
+        setup(&mut self);
+
+        if self.surface_definitions.is_empty() {
+            // Not an error: outputs-driven apps start with zero surfaces and
+            // spawn one per monitor from an effect once the compositor
+            // reports its outputs. An app that never spawns anything will
+            // just idle in the event loop.
+            log::info!(
+                "No static surfaces defined; waiting for dynamic surfaces \
+                 (spawn_surface, e.g. from an outputs() effect)"
+            );
+        }
 
         let (connection, mut event_queue, mut wayland_state, qh) =
             match create_wayland_app(loop_handle.clone()) {
@@ -1637,18 +1652,6 @@ impl App {
                     render_surface(&mut ctx, layout_roots, woken, &active_roots);
                 }
             }
-
-            // A `WidgetRef::focus()` from application code lands here: after
-            // the render pass, so a handle attached during this iteration's
-            // layout has resolved to a widget, and once per iteration rather
-            // than once per surface — the tree is one, and the first surface
-            // to run this used to resolve for all of them.
-            //
-            // Unlike the queues below it, staying parked is this one's resting
-            // state: a request for a widget that does not exist yet is the
-            // ordinary shape of `focus()` from a startup effect, and it waits
-            // as many frames as it takes.
-            reactive::focus::apply_pending_focus(&self.tree);
 
             // Hand the seat what the widgets changed — after the render
             // pass, so a copy or a cursor set by this iteration's event

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -723,14 +723,25 @@ fn queued_but_unwoken() -> Option<&'static str> {
     (!wakeup_armed()).then_some(queued)
 }
 
-/// What the loop still owes a pass, named. Every queue it drains, in the
-/// order the iteration drains them — so a new queue goes next to its own
-/// drain here too, and the list keeps reading as the loop body does.
+/// What the loop still owes a pass, named. Every queue the *loop body* drains,
+/// in the order it drains them — so a new queue goes next to its own drain
+/// here too, and the list keeps reading as the loop body does.
+///
+/// Deliberately not every deferred queue in the library: a parked
+/// `WidgetRef::focus` is drained by `run_jobs`, inside the surface's own pass,
+/// because a focus request means nothing until there is a tree to resolve it
+/// against. Work that only a surface can drain cannot be judged by a check
+/// that runs whether or not one exists — which is the same reason the
+/// clipboard and the cursor had to move *out* of that pass to be listed here.
 fn queued_work() -> Option<&'static str> {
     [
         ("owner disposals", reactive::owner::disposals_pending()),
         ("surface commands", surface::surface_commands_pending()),
         ("background signal writes", reactive::bg_writes_pending()),
+        // Unreachable from `queued_but_unwoken`: `needs_polling` refuses to
+        // block while any job is queued, so the check is never reached with
+        // one. Listed because this is the inventory of what the loop drains,
+        // and leaving a queue out of it is how the next one gets forgotten.
         ("widget jobs", has_pending_jobs()),
         ("a selection change", reactive::selection_change_pending()),
         ("a cursor change", reactive::cursor_change_pending()),
@@ -1432,6 +1443,51 @@ impl App {
             EventLoop::try_new().expect("Failed to create event loop");
         let loop_handle = event_loop.handle();
 
+        // Both wakeup mechanisms are installed before anything can use them.
+        // The compositor talks during `create_wayland_app`'s roundtrips and
+        // during the configure loop below — a clipboard offer arriving there
+        // starts a reader thread, and an app's own `create_task` can queue a
+        // background write — and a producer that finds neither a channel nor a
+        // ping handle has nowhere to put its wakeup.
+        // Create ping mechanism for wakeup on signal changes
+        let (ping, ping_source) = make_ping().expect("Failed to create ping");
+        init_wakeup(ping);
+
+        // Insert ping source - this wakes the loop when signals change
+        loop_handle
+            .insert_source(ping_source, |_, _, _| {
+                // Ping received - a signal was updated, frame will be rendered
+            })
+            .expect("Failed to insert ping source");
+
+        // Cross-thread ingress channel: background threads send messages
+        // here instead of hand-rolling wakeups. calloop guarantees a send
+        // wakes the next dispatch — see the ingress module.
+        let (ingress_tx, ingress_channel) = calloop_channel::channel();
+        ingress::install_ingress(ingress_tx);
+        loop_handle
+            .insert_source(ingress_channel, |event, _, wayland_state| {
+                if let calloop_channel::Event::Msg(message) = event {
+                    // This message was itself the wakeup, and it is spent
+                    // now — the drains it speaks for run later this same
+                    // iteration.
+                    ingress::delivered();
+                    match message {
+                        // Doorbell only: the write payloads live in the
+                        // reactive write queue, drained at the flush point
+                        // later this same iteration.
+                        ingress::IngressMessage::BgWritesQueued => {}
+                        // Prefetched selection content from a reader thread
+                        ingress::IngressMessage::ClipboardUpdate {
+                            kind,
+                            generation,
+                            content,
+                        } => wayland_state.apply_clipboard_update(kind, generation, content),
+                    }
+                }
+            })
+            .expect("Failed to insert ingress channel");
+
         let (connection, mut event_queue, mut wayland_state, qh) =
             match create_wayland_app(loop_handle.clone()) {
                 Ok(app) => app,
@@ -1502,45 +1558,6 @@ impl App {
 
             surface_manager.add(managed);
         }
-
-        // Create ping mechanism for wakeup on signal changes
-        let (ping, ping_source) = make_ping().expect("Failed to create ping");
-        init_wakeup(ping);
-
-        // Insert ping source - this wakes the loop when signals change
-        loop_handle
-            .insert_source(ping_source, |_, _, _| {
-                // Ping received - a signal was updated, frame will be rendered
-            })
-            .expect("Failed to insert ping source");
-
-        // Cross-thread ingress channel: background threads send messages
-        // here instead of hand-rolling wakeups. calloop guarantees a send
-        // wakes the next dispatch — see the ingress module.
-        let (ingress_tx, ingress_channel) = calloop_channel::channel();
-        ingress::install_ingress(ingress_tx);
-        loop_handle
-            .insert_source(ingress_channel, |event, _, wayland_state| {
-                if let calloop_channel::Event::Msg(message) = event {
-                    // This message was itself the wakeup, and it is spent
-                    // now — the drains it speaks for run later this same
-                    // iteration.
-                    ingress::delivered();
-                    match message {
-                        // Doorbell only: the write payloads live in the
-                        // reactive write queue, drained at the flush point
-                        // later this same iteration.
-                        ingress::IngressMessage::BgWritesQueued => {}
-                        // Prefetched selection content from a reader thread
-                        ingress::IngressMessage::ClipboardUpdate {
-                            kind,
-                            generation,
-                            content,
-                        } => wayland_state.apply_clipboard_update(kind, generation, content),
-                    }
-                }
-            })
-            .expect("Failed to insert ingress channel");
 
         // Insert Wayland source - this handles all Wayland protocol events
         WaylandSource::new(connection.clone(), event_queue)
@@ -2113,7 +2130,6 @@ mod wakeup_contract_coverage {
         );
 
         let _ = reactive::take_cursor_change();
-        jobs::reset_jobs();
     }
 
     /// The reported window, in the loop's own order: an effect running at the
@@ -2131,13 +2147,14 @@ mod wakeup_contract_coverage {
         let (ping, _source) = make_ping().expect("ping");
         jobs::init_wakeup(ping);
 
+        let handle = surface::surface_handle(SurfaceId::next());
         let quiet = (0..64).any(|_| {
             surface::reset_surface_commands();
             jobs::mark_loop_awake(); // the dispatch that woke us returned
 
             // …the loop drains surface commands here, and only then flushes
             // background writes, whose effects run before the take below.
-            surface::surface_handle(SurfaceId::next()).set_margin(8);
+            handle.set_margin(8);
             let _ = jobs::take_wake_request();
 
             queued_but_unwoken().is_none()
@@ -2148,7 +2165,6 @@ mod wakeup_contract_coverage {
         );
 
         surface::reset_surface_commands();
-        jobs::reset_jobs();
     }
 
     /// Each arming mechanism has to be visible to `wakeup_armed`, or the
@@ -2212,7 +2228,5 @@ mod wakeup_contract_coverage {
             !ingress::in_flight(),
             "and must stop being visible if it is never sent"
         );
-
-        jobs::reset_jobs();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod animation;
 pub mod backdrop;
 mod blur;
 pub mod compositor;
+mod deferred;
 pub mod image_metadata;
 mod ingress;
 mod jobs;
@@ -1007,10 +1008,6 @@ fn layout_pass(
 
     // Update widget ref signals with current bounds after layout
     widget_ref::update_widget_refs(tree);
-
-    // A `WidgetRef::focus()` from application code lands here: after layout, so a
-    // handle attached this very frame has resolved to a widget.
-    reactive::focus::apply_pending_focus(tree);
 }
 
 /// The size the compositor has confirmed, if it has confirmed one.
@@ -1732,6 +1729,18 @@ impl App {
                     render_surface(&mut ctx, layout_roots, woken, &active_roots);
                 }
             }
+
+            // A `WidgetRef::focus()` from application code lands here: after
+            // the render pass, so a handle attached during this iteration's
+            // layout has resolved to a widget, and once per iteration rather
+            // than once per surface — the tree is one, and the first surface
+            // to run this used to resolve for all of them.
+            //
+            // Unlike the queues below it, staying parked is this one's resting
+            // state: a request for a widget that does not exist yet is the
+            // ordinary shape of `focus()` from a startup effect, and it waits
+            // as many frames as it takes.
+            reactive::focus::apply_pending_focus(&self.tree);
 
             // Hand the seat what the widgets changed — after the render
             // pass, so a copy or a cursor set by this iteration's event

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2197,12 +2197,16 @@ mod wakeup_contract_coverage {
         );
 
         // An ingress message, armed before the work it speaks for is queued
-        // and counted until the loop takes delivery.
+        // and counted until the loop takes delivery. The count is debug-only,
+        // like the check it answers — in a release build there is nothing
+        // owed to anybody, and `in_flight` says so.
         let armed = ingress::arm(ingress::IngressMessage::BgWritesQueued);
-        assert!(
-            ingress::in_flight(),
-            "an armed message must be visible before it is even sent"
-        );
+        if cfg!(debug_assertions) {
+            assert!(
+                ingress::in_flight(),
+                "an armed message must be visible before it is even sent"
+            );
+        }
         drop(armed);
         assert!(
             !ingress::in_flight(),

--- a/src/platform/selections.rs
+++ b/src/platform/selections.rs
@@ -224,11 +224,11 @@ impl WaylandState {
             return;
         };
 
-        // Taken now, not at send time: the read below has three seconds to
-        // finish, and a loop that restarts in the meantime starts its
-        // generation counters over — a stale content would pass the check in
-        // `apply_clipboard_update` against a matching generation from a
-        // different session.
+        // Bound to the loop that is running now, because the read below has
+        // three seconds to finish and a loop that restarts in the meantime
+        // starts its generation counters over: a result delivered into the
+        // next session would pass the check in `apply_clipboard_update`
+        // against a matching generation that means something else.
         let Some(sender) = crate::ingress::sender_handle() else {
             // No running event loop to deliver the result to.
             log::warn!("Selection prefetch skipped: no event loop running");

--- a/src/platform/selections.rs
+++ b/src/platform/selections.rs
@@ -224,17 +224,22 @@ impl WaylandState {
             return;
         };
 
-        if !crate::ingress::loop_running() {
+        // Taken now, not at send time: the read below has three seconds to
+        // finish, and a loop that restarts in the meantime starts its
+        // generation counters over — a stale content would pass the check in
+        // `apply_clipboard_update` against a matching generation from a
+        // different session.
+        let Some(sender) = crate::ingress::sender_handle() else {
             // No running event loop to deliver the result to.
             log::warn!("Selection prefetch skipped: no event loop running");
             return;
-        }
+        };
 
         if let Err(e) = std::thread::Builder::new()
             .name("guido-clipboard-read".into())
             .spawn(move || {
                 let content = read_pipe_with_deadline(pipe, Duration::from_secs(3));
-                crate::ingress::notify(crate::ingress::IngressMessage::ClipboardUpdate {
+                sender.send(crate::ingress::IngressMessage::ClipboardUpdate {
                     kind,
                     generation,
                     content,

--- a/src/platform/selections.rs
+++ b/src/platform/selections.rs
@@ -224,17 +224,17 @@ impl WaylandState {
             return;
         };
 
-        let Some(sender) = crate::ingress::sender() else {
+        if !crate::ingress::loop_running() {
             // No running event loop to deliver the result to.
             log::warn!("Selection prefetch skipped: no event loop running");
             return;
-        };
+        }
 
         if let Err(e) = std::thread::Builder::new()
             .name("guido-clipboard-read".into())
             .spawn(move || {
                 let content = read_pipe_with_deadline(pipe, Duration::from_secs(3));
-                let _ = sender.send(crate::ingress::IngressMessage::ClipboardUpdate {
+                crate::ingress::notify(crate::ingress::IngressMessage::ClipboardUpdate {
                     kind,
                     generation,
                     content,

--- a/src/reactive/clipboard.rs
+++ b/src/reactive/clipboard.rs
@@ -120,10 +120,3 @@ pub(crate) fn reset_clipboard() {
     OUTGOING_PRIMARY.with(|o| o.clear());
     SYSTEM_PRIMARY.with(|c| *c.borrow_mut() = None);
 }
-
-/// Whether a copy is queued for the compositor and not yet handed over.
-///
-/// Part of the loop's wakeup check — see `queued_but_unwoken` in `lib.rs`.
-pub(crate) fn selection_change_pending() -> bool {
-    OUTGOING_CLIPBOARD.with(|o| !o.is_empty()) || OUTGOING_PRIMARY.with(|o| !o.is_empty())
-}

--- a/src/reactive/clipboard.rs
+++ b/src/reactive/clipboard.rs
@@ -12,7 +12,8 @@ thread_local! {
     /// A copy waiting to be handed to the compositor. Being empty *is* the
     /// "nothing to sync" state — there is no separate dirty flag to keep in
     /// step with the value.
-    static OUTGOING_CLIPBOARD: RefCell<Option<String>> = const { RefCell::new(None) };
+    static OUTGOING_CLIPBOARD: crate::deferred::DeferredSlot<String> =
+        const { crate::deferred::DeferredSlot::new() };
 
     /// System clipboard contents (prefetched from the Wayland selection offer)
     static SYSTEM_CLIPBOARD: RefCell<Option<String>> = const { RefCell::new(None) };
@@ -21,7 +22,8 @@ thread_local! {
     static PRIMARY: RefCell<Option<String>> = const { RefCell::new(None) };
 
     /// A select-to-copy waiting to be handed to the compositor.
-    static OUTGOING_PRIMARY: RefCell<Option<String>> = const { RefCell::new(None) };
+    static OUTGOING_PRIMARY: crate::deferred::DeferredSlot<String> =
+        const { crate::deferred::DeferredSlot::new() };
 
     /// System primary-selection contents (prefetched from other apps)
     static SYSTEM_PRIMARY: RefCell<Option<String>> = const { RefCell::new(None) };
@@ -32,16 +34,13 @@ pub fn clipboard_copy(text: &str) {
     CLIPBOARD.with(|c| {
         *c.borrow_mut() = Some(text.to_string());
     });
-    OUTGOING_CLIPBOARD.with(|out| {
-        *out.borrow_mut() = Some(text.to_string());
-    });
-    // Queueing and waking are one gesture — see `jobs::wake_loop`.
-    crate::jobs::wake_loop();
+    // Setting the slot is what wakes the loop that hands the copy over.
+    OUTGOING_CLIPBOARD.with(|out| out.set(text.to_string()));
 }
 
 /// Take the copy waiting to go out to the compositor, if any.
 pub fn take_clipboard_change() -> Option<String> {
-    OUTGOING_CLIPBOARD.with(|out| out.borrow_mut().take())
+    OUTGOING_CLIPBOARD.with(|out| out.take())
 }
 
 /// Paste text from the clipboard
@@ -85,15 +84,12 @@ pub fn primary_copy(text: &str) {
     PRIMARY.with(|c| {
         *c.borrow_mut() = Some(text.to_string());
     });
-    OUTGOING_PRIMARY.with(|out| {
-        *out.borrow_mut() = Some(text.to_string());
-    });
-    crate::jobs::wake_loop();
+    OUTGOING_PRIMARY.with(|out| out.set(text.to_string()));
 }
 
 /// Take the select-to-copy waiting to go out to the compositor, if any.
 pub(crate) fn take_primary_change() -> Option<String> {
-    OUTGOING_PRIMARY.with(|out| out.borrow_mut().take())
+    OUTGOING_PRIMARY.with(|out| out.take())
 }
 
 /// Paste text from the primary selection (middle-click paste).
@@ -118,10 +114,10 @@ pub(crate) fn set_system_primary(text: Option<String>) {
 /// Called during `App::drop()` to wipe clipboard buffers.
 pub(crate) fn reset_clipboard() {
     CLIPBOARD.with(|c| *c.borrow_mut() = None);
-    OUTGOING_CLIPBOARD.with(|o| *o.borrow_mut() = None);
+    OUTGOING_CLIPBOARD.with(|o| o.clear());
     SYSTEM_CLIPBOARD.with(|c| *c.borrow_mut() = None);
     PRIMARY.with(|c| *c.borrow_mut() = None);
-    OUTGOING_PRIMARY.with(|o| *o.borrow_mut() = None);
+    OUTGOING_PRIMARY.with(|o| o.clear());
     SYSTEM_PRIMARY.with(|c| *c.borrow_mut() = None);
 }
 
@@ -129,6 +125,5 @@ pub(crate) fn reset_clipboard() {
 ///
 /// Part of the loop's wakeup check — see `queued_but_unwoken` in `lib.rs`.
 pub(crate) fn selection_change_pending() -> bool {
-    OUTGOING_CLIPBOARD.with(|o| o.borrow().is_some())
-        || OUTGOING_PRIMARY.with(|o| o.borrow().is_some())
+    OUTGOING_CLIPBOARD.with(|o| !o.is_empty()) || OUTGOING_PRIMARY.with(|o| !o.is_empty())
 }

--- a/src/reactive/cursor.rs
+++ b/src/reactive/cursor.rs
@@ -90,10 +90,3 @@ pub(crate) fn reset_cursor() {
 pub fn get_current_cursor() -> CursorIcon {
     CURRENT_CURSOR.with(|c| *c.borrow())
 }
-
-/// Whether a cursor shape change is queued for the compositor.
-///
-/// Part of the loop's wakeup check — see `queued_but_unwoken` in `lib.rs`.
-pub(crate) fn cursor_change_pending() -> bool {
-    OUTGOING_CURSOR.with(|o| !o.is_empty())
-}

--- a/src/reactive/cursor.rs
+++ b/src/reactive/cursor.rs
@@ -50,7 +50,8 @@ thread_local! {
 
     /// A shape waiting to be handed to the compositor. Being empty *is* the
     /// "nothing to sync" state — no separate dirty flag to keep in step.
-    static OUTGOING_CURSOR: RefCell<Option<CursorIcon>> = const { RefCell::new(None) };
+    static OUTGOING_CURSOR: crate::deferred::DeferredSlot<CursorIcon> =
+        const { crate::deferred::DeferredSlot::new() };
 }
 
 /// Set the cursor to display.
@@ -65,11 +66,8 @@ pub fn set_cursor(cursor: CursorIcon) {
         true
     });
     if changed {
-        OUTGOING_CURSOR.with(|out| {
-            *out.borrow_mut() = Some(cursor);
-        });
-        // Queueing and waking are one gesture — see `jobs::wake_loop`.
-        crate::jobs::wake_loop();
+        // Setting the slot is what wakes the loop that hands the shape over.
+        OUTGOING_CURSOR.with(|out| out.set(cursor));
     }
 }
 
@@ -77,7 +75,7 @@ pub fn set_cursor(cursor: CursorIcon) {
 ///
 /// Called by the main event loop to sync the cursor to Wayland.
 pub fn take_cursor_change() -> Option<CursorIcon> {
-    OUTGOING_CURSOR.with(|out| out.borrow_mut().take())
+    OUTGOING_CURSOR.with(|out| out.take())
 }
 
 /// Reset cursor state to defaults.
@@ -85,7 +83,7 @@ pub fn take_cursor_change() -> Option<CursorIcon> {
 /// Called during `App::drop()` to clear cursor state.
 pub(crate) fn reset_cursor() {
     CURRENT_CURSOR.with(|c| *c.borrow_mut() = CursorIcon::Default);
-    OUTGOING_CURSOR.with(|o| *o.borrow_mut() = None);
+    OUTGOING_CURSOR.with(|o| o.clear());
 }
 
 /// Get the current cursor without clearing the change flag.
@@ -97,5 +95,5 @@ pub fn get_current_cursor() -> CursorIcon {
 ///
 /// Part of the loop's wakeup check — see `queued_but_unwoken` in `lib.rs`.
 pub(crate) fn cursor_change_pending() -> bool {
-    OUTGOING_CURSOR.with(|o| o.borrow().is_some())
+    OUTGOING_CURSOR.with(|o| !o.is_empty())
 }

--- a/src/reactive/diagnostics.rs
+++ b/src/reactive/diagnostics.rs
@@ -136,7 +136,12 @@ pub(crate) fn report_count() -> u64 {
     imp::REPORTS.with(|c| c.get())
 }
 
-#[cfg(test)]
+/// Debug-only, like the diagnostic they are about: with the assertions off
+/// there is no counter to read, so `report_count` — gated `all(debug_assertions,
+/// test)` since it was written — does not exist and these tests do not compile.
+/// The gate belongs on both or neither, and the two later callers already
+/// carry it (`widgets::diagnostic_audit`, the animation characterization).
+#[cfg(all(test, debug_assertions))]
 mod tests {
     use super::*;
     use crate::jobs::JobType;

--- a/src/reactive/mod.rs
+++ b/src/reactive/mod.rs
@@ -17,7 +17,6 @@ pub mod signal;
 pub mod storage;
 mod trigger;
 
-pub(crate) use clipboard::selection_change_pending;
 pub(crate) use clipboard::{
     clear_system_clipboard, set_system_clipboard, set_system_primary, take_clipboard_change,
     take_primary_change,
@@ -28,8 +27,8 @@ pub use clipboard::{
 pub use context::{
     expect_context, has_context, provide_context, provide_signal_context, use_context, with_context,
 };
+pub(crate) use cursor::take_cursor_change;
 pub use cursor::{CursorIcon, set_cursor};
-pub(crate) use cursor::{cursor_change_pending, take_cursor_change};
 pub use effect::create_effect;
 pub(crate) use focus::{
     focus_path, has_focus, release_focus, release_focus_if_within, request_focus,
@@ -62,7 +61,7 @@ pub mod __internal {
     pub use super::runtime::batch;
 }
 pub use callback::Callback;
-pub(crate) use runtime::{bg_writes_pending, flush_bg_writes};
+pub(crate) use runtime::flush_bg_writes;
 pub use service::{Service, ServiceContext, create_service, create_task};
 pub use signal::{
     OptionSignalExt, RwSignal, Signal, WriteSignal, create_derived, create_signal, create_stored,

--- a/src/reactive/owner.rs
+++ b/src/reactive/owner.rs
@@ -405,8 +405,8 @@ pub(crate) fn effect_has_owner(id: EffectId) -> bool {
 
 // Owners scheduled for deferred disposal (see `dispose_owner`).
 thread_local! {
-    static PENDING_DISPOSALS: std::cell::RefCell<Vec<OwnerId>> =
-        const { std::cell::RefCell::new(Vec::new()) };
+    static PENDING_DISPOSALS: crate::deferred::DeferredQueue<OwnerId> =
+        const { crate::deferred::DeferredQueue::new() };
 }
 
 /// Dispose an owner: all its signals, effects, and cleanup callbacks.
@@ -421,10 +421,10 @@ thread_local! {
 /// Disposing the same owner twice (or an already-disposed owner) is
 /// harmless.
 pub fn dispose_owner(id: OwnerId) {
-    PENDING_DISPOSALS.with(|v| v.borrow_mut().push(id));
-    // Wake the loop so a disposal requested in a quiet moment (compositor
-    // dismissal with no other activity) is not postponed indefinitely
-    crate::jobs::wake_loop();
+    // Pushing is what wakes the loop, so a disposal requested in a quiet
+    // moment — a compositor dismissal with nothing else going on — is not
+    // postponed indefinitely.
+    PENDING_DISPOSALS.with(|v| v.push(id));
 }
 
 /// Run every pending deferred disposal. Called by the main loop at a safe
@@ -433,7 +433,7 @@ pub(crate) fn flush_pending_disposals() {
     // split_off keeps draining safe even if a cleanup callback disposes
     // another owner while running (it lands in the next batch)
     loop {
-        let batch = PENDING_DISPOSALS.with(|v| v.borrow_mut().split_off(0));
+        let batch = PENDING_DISPOSALS.with(|v| v.drain());
         if batch.is_empty() {
             return;
         }
@@ -447,7 +447,7 @@ pub(crate) fn flush_pending_disposals() {
 ///
 /// Part of the loop's wakeup check — see `queued_but_unwoken` in `lib.rs`.
 pub(crate) fn disposals_pending() -> bool {
-    PENDING_DISPOSALS.with(|v| !v.borrow().is_empty())
+    PENDING_DISPOSALS.with(|v| !v.is_empty())
 }
 
 #[cfg(test)]

--- a/src/reactive/owner.rs
+++ b/src/reactive/owner.rs
@@ -173,6 +173,12 @@ pub(crate) fn reset_owners() {
     CURRENT_OWNER.with(|c| *c.borrow_mut() = None);
     ROOT_OWNER.with(|root| root.set(None));
     OWNERS.with(|o| *o.borrow_mut() = OwnerArena::new());
+    // With them, anything queued against them. Owner ids restart from zero
+    // with the arena, so a disposal left over from the App that is going away
+    // names a live owner in the App that comes next — the same hazard
+    // `App::drop` already clears the tree for, where a late Unregister job
+    // would destroy a new widget that reused the id.
+    PENDING_DISPOSALS.with(|v| v.clear());
 }
 
 /// Run `f` under the root owner instead of whatever scope is current.

--- a/src/reactive/owner.rs
+++ b/src/reactive/owner.rs
@@ -443,13 +443,6 @@ pub(crate) fn flush_pending_disposals() {
     }
 }
 
-/// Whether any owner is waiting to be disposed.
-///
-/// Part of the loop's wakeup check — see `queued_but_unwoken` in `lib.rs`.
-pub(crate) fn disposals_pending() -> bool {
-    PENDING_DISPOSALS.with(|v| !v.is_empty())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/reactive/runtime.rs
+++ b/src/reactive/runtime.rs
@@ -184,18 +184,14 @@ pub(crate) fn current_write_epoch() -> u64 {
 /// flushed (e.g. App restart), the epoch will be stale and the write is
 /// silently discarded.
 pub fn queue_bg_write(epoch: u64, f: impl FnOnce() + Send + 'static) {
-    // Armed before the push, sent after it. The wakeup is owed for a write
-    // the loop cannot see yet, which costs nothing — where the other order
-    // leaves an instant with the queue observably non-empty and nothing owed
-    // for it, and the loop's pre-block check runs on the other thread.
-    let wakeup = crate::ingress::arm(crate::ingress::IngressMessage::BgWritesQueued);
     if let Ok(mut q) = WRITE_QUEUE.lock() {
         q.push((epoch, Box::new(f)));
     }
-    // Wake the event loop so flush_bg_writes() runs on the next frame.
-    // Routed through the calloop ingress channel: its readiness guarantees
-    // the loop wakes no matter where in its iteration the write landed.
-    wakeup.notify();
+    // Queueing and waking are one gesture here too — this is the cross-thread
+    // one, so the wakeup goes through the calloop ingress channel rather than
+    // the ping: its readiness guarantees the loop wakes no matter where in its
+    // iteration the write landed.
+    crate::ingress::notify(crate::ingress::IngressMessage::BgWritesQueued);
 }
 
 /// Drain queued background writes and execute them on the main thread.
@@ -590,13 +586,6 @@ pub fn batch<R>(f: impl FnOnce() -> R) -> R {
         flush_pending_effects();
     }
     result
-}
-
-/// Whether a background thread has queued a signal write not yet flushed.
-///
-/// Part of the loop's wakeup check — see `queued_but_unwoken` in `lib.rs`.
-pub(crate) fn bg_writes_pending() -> bool {
-    WRITE_QUEUE.lock().map(|q| !q.is_empty()).unwrap_or(false)
 }
 
 #[cfg(test)]

--- a/src/reactive/runtime.rs
+++ b/src/reactive/runtime.rs
@@ -184,13 +184,18 @@ pub(crate) fn current_write_epoch() -> u64 {
 /// flushed (e.g. App restart), the epoch will be stale and the write is
 /// silently discarded.
 pub fn queue_bg_write(epoch: u64, f: impl FnOnce() + Send + 'static) {
+    // Armed before the push, sent after it. The wakeup is owed for a write
+    // the loop cannot see yet, which costs nothing — where the other order
+    // leaves an instant with the queue observably non-empty and nothing owed
+    // for it, and the loop's pre-block check runs on the other thread.
+    let wakeup = crate::ingress::arm(crate::ingress::IngressMessage::BgWritesQueued);
     if let Ok(mut q) = WRITE_QUEUE.lock() {
         q.push((epoch, Box::new(f)));
     }
     // Wake the event loop so flush_bg_writes() runs on the next frame.
     // Routed through the calloop ingress channel: its readiness guarantees
     // the loop wakes no matter where in its iteration the write landed.
-    crate::ingress::notify(crate::ingress::IngressMessage::BgWritesQueued);
+    wakeup.notify();
 }
 
 /// Drain queued background writes and execute them on the main thread.

--- a/src/session_lock.rs
+++ b/src/session_lock.rs
@@ -56,12 +56,31 @@ struct LockData {
     factory: Option<LockWidgetFn>,
     /// Lock surface per output.
     surfaces: HashMap<OutputId, SurfaceId>,
-    lock_requested: bool,
-    unlock_requested: bool,
+}
+
+/// What the application last asked for, waiting for the state machine.
+enum LockRequest {
+    /// Lock, building each output's screen with this factory. The factory
+    /// travels with the request rather than being installed by the caller:
+    /// a request that is replaced takes its factory with it, and the one the
+    /// state machine acts on is the one it was handed.
+    Lock(LockWidgetFn),
+    Unlock,
 }
 
 thread_local! {
     static LOCK: RefCell<LockData> = RefCell::new(LockData::default());
+
+    /// A slot, not two flags: "lock" and "unlock" are two answers to one
+    /// question, and asking twice in a frame means the second answer is the
+    /// one meant. Two independent booleans let both be true at once, which
+    /// the loop then acted on in order — a lock sent to the compositor and
+    /// undone in the same iteration.
+    ///
+    /// Setting it is what wakes the loop, so the state machine cannot be
+    /// asked for something and left asleep — see `crate::deferred`.
+    static REQUEST: crate::deferred::DeferredSlot<LockRequest> =
+        const { crate::deferred::DeferredSlot::new() };
 }
 
 /// The lifecycle the application watches. Its own global rather than a field
@@ -102,32 +121,32 @@ where
     W: Widget + 'static,
     F: Fn(OutputInfo) -> W + 'static,
 {
-    LOCK.with(|lock| {
-        let mut lock = lock.borrow_mut();
-        // `Locking` counts: a second request while the first is in flight is
-        // granted here, then refused by the platform on the next iteration —
-        // and the refusal path clears the factory. The compositor's `Locked`
-        // then arrives with nothing to build the lock screen from, which is a
-        // locked session with no way to type a password into it.
-        if lock.lock_requested
-            || matches!(
-                STATE.get().get_untracked(),
-                LockState::Locked | LockState::Locking
-            )
-        {
-            log::warn!("lock_session() called while already locked or locking");
-            return;
-        }
-        lock.factory = Some(Box::new(move |info| Box::new(widget_fn(info))));
-        lock.lock_requested = true;
+    // `Locking` counts: a second request while the first is in flight is
+    // granted here, then refused by the platform on the next iteration — and
+    // the refusal path clears the factory. The compositor's `Locked` then
+    // arrives with nothing to build the lock screen from, which is a locked
+    // session with no way to type a password into it.
+    //
+    // A second request made before the state machine has seen the first needs
+    // no guard: it replaces it in the slot, so one request goes out either
+    // way, built from the factory the caller asked for last.
+    if matches!(
+        STATE.get().get_untracked(),
+        LockState::Locked | LockState::Locking
+    ) {
+        log::warn!("lock_session() called while already locked or locking");
+        return;
+    }
+    REQUEST.with(|request| {
+        request.set(LockRequest::Lock(Box::new(move |info| {
+            Box::new(widget_fn(info))
+        })))
     });
-    crate::jobs::wake_loop();
 }
 
 /// Unlock the session and drop all lock surfaces.
 pub fn unlock_session() {
-    LOCK.with(|lock| lock.borrow_mut().unlock_requested = true);
-    crate::jobs::wake_loop();
+    REQUEST.with(|request| request.set(LockRequest::Unlock));
 }
 
 /// Drive the session-lock state machine. Called once per main-loop
@@ -138,15 +157,23 @@ pub(crate) fn process_session_lock(
     qh: &QueueHandle<WaylandState>,
     tree: &mut Tree,
 ) {
-    // 1. Pending lock request
-    let lock_requested = LOCK.with(|l| std::mem::take(&mut l.borrow_mut().lock_requested));
-    if lock_requested {
-        if wayland_state.start_session_lock(qh) {
-            set_state(LockState::Locking);
-        } else {
-            LOCK.with(|l| l.borrow_mut().factory = None);
-            set_state(LockState::Unlocked);
+    // 1. Pending request. A lock goes out now; an unlock waits for step 3,
+    // after the compositor's events — a `Locked` arriving in the same
+    // iteration must land before the teardown, or the state ends up `Locked`
+    // with no surfaces under it.
+    let mut unlock_requested = false;
+    match REQUEST.with(|request| request.take()) {
+        Some(LockRequest::Lock(factory)) => {
+            LOCK.with(|l| l.borrow_mut().factory = Some(factory));
+            if wayland_state.start_session_lock(qh) {
+                set_state(LockState::Locking);
+            } else {
+                LOCK.with(|l| l.borrow_mut().factory = None);
+                set_state(LockState::Unlocked);
+            }
         }
+        Some(LockRequest::Unlock) => unlock_requested = true,
+        None => {}
     }
 
     // 2. Lock lifecycle events from the compositor
@@ -162,8 +189,7 @@ pub(crate) fn process_session_lock(
         }
     }
 
-    // 3. Pending unlock request
-    let unlock_requested = LOCK.with(|l| std::mem::take(&mut l.borrow_mut().unlock_requested));
+    // 3. Pending unlock request, taken above
     if unlock_requested && state_signal().get_untracked() != LockState::Unlocked {
         wayland_state.unlock_session();
         teardown_lock_surfaces(surface_manager, wayland_state, tree);
@@ -259,12 +285,40 @@ fn teardown_lock_surfaces(
 /// Called during `App::drop()`.
 pub(crate) fn reset_session_lock() {
     LOCK.with(|lock| *lock.borrow_mut() = LockData::default());
+    REQUEST.with(|request| request.clear());
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::reactive::owner::{create_root_owner, dispose_owner_now, with_owner};
+
+    /// Two answers in one frame, and the state machine acts on the second.
+    ///
+    /// The pair used to be two independent booleans, so both could be true at
+    /// once: the loop started a lock, sent it to the compositor, and undid it
+    /// three steps later in the same iteration — a lock screen that flashes up
+    /// and vanishes for an application that changed its mind.
+    #[test]
+    fn the_last_request_of_a_frame_is_the_one_that_counts() {
+        create_root_owner();
+        reset_session_lock();
+        set_state(LockState::Unlocked);
+
+        lock_session(|_| crate::widgets::container());
+        unlock_session();
+
+        assert!(
+            matches!(REQUEST.with(|r| r.take()), Some(LockRequest::Unlock)),
+            "the later request replaces the earlier one rather than joining it"
+        );
+        assert!(
+            REQUEST.with(|r| r.take()).is_none(),
+            "and there is only ever the one"
+        );
+
+        reset_session_lock();
+    }
 
     /// The lock state is process-wide and lives behind a thread-local built on
     /// first use, so *whoever reads it first* would otherwise decide its owner.

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -1272,10 +1272,11 @@ mod tests {
         popup.close();
 
         assert!(!popup.dismissed(), "still open until the loop closes it");
+        let queued = SURFACE_COMMANDS.with(|cmds| cmds.drain());
         assert!(
-            SURFACE_COMMANDS.with(|cmds| cmds.with_items(|queued| queued
+            queued
                 .iter()
-                .any(|c| matches!(c, SurfaceCommand::Close(id) if *id == popup.id())))),
+                .any(|c| matches!(c, SurfaceCommand::Close(id) if *id == popup.id())),
             "and the close is queued"
         );
     }

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -1079,13 +1079,6 @@ pub fn surface_handle(id: SurfaceId) -> SurfaceHandle {
     SurfaceHandle { id }
 }
 
-/// Whether any surface command (spawn, close, property change) is queued.
-///
-/// Part of the loop's wakeup check — see `queued_but_unwoken` in `lib.rs`.
-pub(crate) fn surface_commands_pending() -> bool {
-    SURFACE_COMMANDS.with(|cmds| !cmds.is_empty())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -849,27 +849,26 @@ pub(crate) enum SurfaceCommand {
 // Thread-local storage for the surface command queue.
 // Both sender and receiver are on the main thread — this is just a deferred command queue.
 thread_local! {
-    static SURFACE_COMMANDS: RefCell<Vec<SurfaceCommand>> = const { RefCell::new(Vec::new()) };
+    static SURFACE_COMMANDS: crate::deferred::DeferredQueue<SurfaceCommand> =
+        const { crate::deferred::DeferredQueue::new() };
 }
 
-/// Push a surface command to the thread-local queue.
+/// Push a surface command to the thread-local queue, waking the loop that
+/// will carry it out.
 pub(crate) fn push_surface_command(cmd: SurfaceCommand) {
-    SURFACE_COMMANDS.with(|cmds| {
-        cmds.borrow_mut().push(cmd);
-    });
-    crate::jobs::wake_loop();
+    SURFACE_COMMANDS.with(|cmds| cmds.push(cmd));
 }
 
 /// Reset the surface command queue.
 ///
 /// Called during `App::drop()` to clear stale surface commands.
 pub(crate) fn reset_surface_commands() {
-    SURFACE_COMMANDS.with(|cmds| cmds.borrow_mut().clear());
+    SURFACE_COMMANDS.with(|cmds| cmds.clear());
 }
 
 /// Drain all pending surface commands. Called by the main event loop.
 pub(crate) fn drain_surface_commands() -> Vec<SurfaceCommand> {
-    SURFACE_COMMANDS.with(|cmds| cmds.borrow_mut().drain(..).collect())
+    SURFACE_COMMANDS.with(|cmds| cmds.drain())
 }
 
 /// Spawn a new surface at runtime.
@@ -1084,7 +1083,7 @@ pub fn surface_handle(id: SurfaceId) -> SurfaceHandle {
 ///
 /// Part of the loop's wakeup check — see `queued_but_unwoken` in `lib.rs`.
 pub(crate) fn surface_commands_pending() -> bool {
-    SURFACE_COMMANDS.with(|cmds| !cmds.borrow().is_empty())
+    SURFACE_COMMANDS.with(|cmds| !cmds.is_empty())
 }
 
 #[cfg(test)]
@@ -1281,10 +1280,9 @@ mod tests {
 
         assert!(!popup.dismissed(), "still open until the loop closes it");
         assert!(
-            SURFACE_COMMANDS.with(|cmds| cmds
-                .borrow()
+            SURFACE_COMMANDS.with(|cmds| cmds.with_items(|queued| queued
                 .iter()
-                .any(|c| matches!(c, SurfaceCommand::Close(id) if *id == popup.id()))),
+                .any(|c| matches!(c, SurfaceCommand::Close(id) if *id == popup.id())))),
             "and the close is queued"
         );
     }


### PR DESCRIPTION
Closes #202.

## The report

The loop's pre-block `debug_assert!` named seven queues and panicked if one was non-empty. It fired on healthy states: a background write landing after `flush_bg_writes()`, a surface command pushed by an effect whose `WAKE_REQUESTED` was cleared by `take_wake_request()` later in the same iteration, and the instant inside `queue_bg_write` between the push and the notify. Reproducible in seconds — a debug build with a `create_task` writing a signal, which is the documented way to do background work.

## Where it landed

The first answer was to make the check ask the other half of the question: *is a wakeup armed?* That needed a coalescing flag for the ping and a count for messages in flight inside calloop's channel — about 150 lines and a new rule (`arm` before you queue) that every future producer would have to learn.

That was policing a rule the type system can make unbreakable, so the check is gone and the rule is structural instead. `src/deferred.rs`: a deferred queue and its wakeup are one object. `DeferredQueue::push` and `DeferredSlot::set` **are** the wakeup, the cell is private, and there is no way to reach it that does not ask for the pass that empties it. Six producers moved onto them — owner disposals, surface commands, cursor, clipboard, primary selection, and the session lock's request.

Three stay outside, each for a reason the module records: background writes wake through the ingress channel and there is exactly one of them; widget jobs carry their own machinery and wake from inside `request_job`; a parked focus request has the opposite invariant, since waiting for a widget that does not exist yet is its resting state.

Net: **−350 lines** against the branch's own high-water mark, and the state the assertion existed to report is now unrepresentable rather than reported.

## Bugs found and fixed on the way

- **A drain that only ran when a surface had a frame.** `sync_platform_state` sat inside the per-surface pass, so an application with no configured surface could queue a copy or a cursor shape that nothing would ever take. It runs once per iteration from the loop body now — where what it carries belongs anyway, since it is the seat's, not any one surface's.
- **A flag that said "requested" and was read as "readable".** `wake_loop` raised `PING_SENT` before trying the handle, so a second caller could coalesce against a ping that was never written. It is raised under the ping's lock, with the handle in hand.
- **`quit_app` could be coalesced away.** The loop reads the exit flag once per pass, so an exit request cannot be left to somebody else's ping. It writes its own, unconditionally.
- **A clipboard read could land in the next session.** The reader thread now binds its sender to the loop that was running when the read started; generations restart with the `WaylandState`, so a late result would otherwise match a number that means something else.
- **Owner disposals survived `App::drop`.** Owner ids restart with the arena, so a disposal queued on the way out named a live owner in the next App.
- **The wakeup mechanisms were installed too late** — after `create_wayland_app` and the configure loop, and after `setup`, which is where an app's first `create_task` runs.
- **The session lock asked for two things at once.** `lock_session` and `unlock_session` set independent booleans read three steps apart, so a lock could go out to the compositor and be undone in the same iteration. One slot, last answer wins.
- **`cargo test --release` had never compiled** (`report_count` gated `all(debug_assertions, test)`, its callers `cfg(test)` — since #148). With the target building again it immediately caught two tests of this branch asserting on a debug-only count.

## Verification

- Full suite green in debug and release; `cargo clippy --all-targets --all-features -- -D warnings` clean in debug, `--lib` clean in release.
- The reported failure, live on niri: `main` panics within seconds of the surface coming up, this branch survives 15 s and 60 s runs, exit 0. A second repro with no surface at all — an effect calling `set_cursor` — panics on the pre-move code and is clean here.
- Session lock exercised on the compositor: two full cycles, both unlocked by the password path, lock surfaces created from the factory carried inside the request and torn down, no warnings.
- Performance against `main`, release, `/proc` sampling: idle is **0 ms of CPU over 45 s** on both, and a background task writing a signal once a second costs the same CPU (0.33–0.35%) with 3–4% fewer wakeups on this branch.