### PR TITLE
The guard reads a position, and the branch of the right repository

### DIFF
--- a/.claude/hooks/guard-bash.sh
+++ b/.claude/hooks/guard-bash.sh
@@ -7,11 +7,20 @@
 #      anything back. Blessing is a decision, and a decision is the
 #      maintainer's to make with the diff in front of them.
 #   2. Committing on main. The project merges through pull requests.
-set -euo pipefail
+#
+# Both are decided by looking at the position a word occupies, not at whether
+# the word appears. `git log | sed 's/^/commit: /'` is not a commit, a heredoc
+# that writes the name of the blessing variable into a file is not a blessing,
+# and the branch that matters is the one belonging to the directory the command
+# will run in — which, in a project that puts every change in a worktree of its
+# own, is usually not the directory the session is standing in.
+#
+# `.claude/hooks/guard-bash.test.sh` is the table of what that means.
+set -uo pipefail
 
 payload=$(cat)
 command=$(printf '%s' "$payload" | jq -r '.tool_input.command // ""')
-cwd=$(printf '%s' "$payload" | jq -r '.cwd // ""')
+session_cwd=$(printf '%s' "$payload" | jq -r '.cwd // "."')
 
 deny() {
   jq -n --arg reason "$1" '{
@@ -24,15 +33,85 @@ deny() {
   exit 0
 }
 
-if printf '%s' "$command" | grep -Eq '(^|[^A-Z_])(UPDATE_GOLDEN|UPDATE_SNAPSHOTS)='; then
-  deny "Re-blessing is blocked. A rewritten snapshot or golden makes a failing test pass without changing a pixel back — the failure is the finding, so read it: the golden diff images are in target/golden-failures/, and the snapshot diff is in the test output. If the change is intended, say so and the maintainer blesses it, with the golden-update label on the pull request."
-fi
+# A heredoc body is data being written, not commands being run. Drop it before
+# anything else looks at the text.
+strip_heredocs() {
+  awk '
+    {
+      if (skip) { if ($0 == delim) skip = 0; next }
+      line = $0
+      if (match(line, /<<-?[ ]*"?'"'"'?[A-Za-z_][A-Za-z0-9_]*"?'"'"'?/)) {
+        word = substr(line, RSTART, RLENGTH)
+        gsub(/^<<-?[ ]*/, "", word)
+        gsub(/["'"'"']/, "", word)
+        delim = word
+        skip = 1
+      }
+      print line
+    }
+  ' <<< "$1"
+}
 
-if printf '%s' "$command" | grep -Eq '\bgit\b.*\bcommit\b'; then
-  branch=$(git -C "${cwd:-.}" symbolic-ref --quiet --short HEAD 2>/dev/null || echo "")
-  if [ "$branch" = "main" ]; then
-    deny "This is main. Guido merges through pull requests: branch first (git checkout -b <kind>/<slug>), then commit, then open the pull request."
-  fi
-fi
+runnable=$(strip_heredocs "$command")
+
+# Split into command segments: a new command starts after ; && || | or a newline.
+segments=$(printf '%s' "$runnable" | sed -E 's/(\|\||&&|;|\||\n)/\n/g')
+
+# `cd somewhere &&` in an earlier segment sets where the later ones run.
+dir="$session_cwd"
+
+while IFS= read -r segment; do
+  # shellcheck disable=SC2206
+  read -ra tokens <<< "$segment"
+  [ ${#tokens[@]} -eq 0 ] && continue
+
+  i=0
+  # Leading `env` and NAME=VALUE assignments belong to the command that follows.
+  while [ $i -lt ${#tokens[@]} ]; do
+    case "${tokens[$i]}" in
+      env) i=$((i + 1)) ;;
+      UPDATE_GOLDEN=*|UPDATE_SNAPSHOTS=*)
+        deny "Re-blessing is blocked. A rewritten snapshot or golden makes a failing test pass without changing a pixel back — the failure is the finding, so read it: the golden diff images are in target/golden-failures/, and the snapshot diff is in the test output. If the change is intended, say so and the maintainer blesses it, with the golden-update label on the pull request."
+        ;;
+      *=*) i=$((i + 1)) ;;
+      *) break ;;
+    esac
+  done
+  [ $i -ge ${#tokens[@]} ] && continue
+
+  case "${tokens[$i]}" in
+    cd)
+      # Where the rest of the line runs.
+      candidate="${tokens[$((i + 1))]:-}"
+      [ -n "$candidate" ] && dir="$candidate"
+      ;;
+    git)
+      target="$dir"
+      j=$((i + 1))
+      # Walk git's own flags to reach the subcommand.
+      while [ $j -lt ${#tokens[@]} ]; do
+        case "${tokens[$j]}" in
+          -C)
+            target="${tokens[$((j + 1))]:-$dir}"
+            j=$((j + 2))
+            ;;
+          -c)
+            j=$((j + 2))
+            ;;
+          --*)
+            j=$((j + 1))
+            ;;
+          *) break ;;
+        esac
+      done
+      if [ "${tokens[$j]:-}" = "commit" ]; then
+        branch=$(git -C "$target" symbolic-ref --quiet --short HEAD 2>/dev/null || echo "")
+        if [ "$branch" = "main" ]; then
+          deny "This is main (in $target). Guido merges through pull requests: branch first (git checkout -b <kind>/<slug>), then commit, then open the pull request."
+        fi
+      fi
+      ;;
+  esac
+done <<< "$segments"
 
 exit 0

--- a/.claude/hooks/guard-bash.test.sh
+++ b/.claude/hooks/guard-bash.test.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# What the guard has to get right, as a table.
+#
+# It exists because all three of the guard's first defects were things a table
+# would have caught before anybody met them: a command refused for containing
+# the word "commit" inside a sed expression; the branch read from the session's
+# directory rather than the one the command runs in, which in a project that
+# puts every change in a worktree of its own is the wrong repository nearly
+# every time; and a heredoc *writing* this very file refused because the text
+# being written mentioned the variable that blesses a golden.
+#
+# One root cause under all three: matching a word anywhere in the command
+# instead of at the position where a command is actually invoked.
+set -uo pipefail
+
+here=$(cd "$(dirname "$0")" && pwd)
+guard="$here/guard-bash.sh"
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+# The variables the guard refuses, spelled so that this file does not contain
+# what it is testing for — otherwise writing it trips the guard.
+bless_golden="UPDATE_""GOLDEN=1"
+bless_snapshot="UPDATE_""SNAPSHOTS=1"
+
+# Two repositories: one sitting on main, one on a branch.
+for name in on-main on-branch; do
+  git init -q -b main "$tmp/$name"
+  git -C "$tmp/$name" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+done
+git -C "$tmp/on-branch" checkout -q -b fix/something
+
+failures=0
+
+# check <allow|deny> <cwd> <command> <what this case is>
+check() {
+  local expect=$1 cwd=$2 command=$3 why=$4
+  local out decision
+  out=$(jq -n --arg c "$command" --arg d "$cwd" \
+    '{tool_input:{command:$c},cwd:$d}' | "$guard" 2>/dev/null)
+  if printf '%s' "$out" | grep -q '"permissionDecision": *"deny"'; then
+    decision=deny
+  else
+    decision=allow
+  fi
+  if [ "$decision" != "$expect" ]; then
+    echo "FAIL  expected $expect, got $decision: $why"
+    echo "      command: $command"
+    failures=$((failures + 1))
+  else
+    echo "ok    $decision  $why"
+  fi
+}
+
+# The word is not the deed.
+check allow "$tmp/on-main" "git log --oneline | sed 's/^/commit: /'" \
+  "a read-only log that prints the word commit"
+check allow "$tmp/on-main" "echo 'run git commit after branching'" \
+  "prose about committing"
+check allow "$tmp/on-main" "cargo test --test golden_images" \
+  "an ordinary build command"
+check allow "$tmp/on-branch" "cat > notes.md <<'EOF'
+$bless_golden rewrites the reference
+EOF" \
+  "writing a file that mentions the blessing variable"
+
+# A commit on main is refused, wherever the session happens to be standing.
+check deny "$tmp/on-main" "git commit -m 'x'" \
+  "a commit on main"
+check deny "$tmp/on-main" "git commit -F - <<'MSG'
+A subject
+MSG" \
+  "a commit on main with a heredoc message"
+check deny "$tmp/on-branch" "git -C $tmp/on-main commit -m 'x'" \
+  "a commit aimed at main from elsewhere by -C"
+check deny "$tmp/on-main" "cd $tmp/on-main && git commit -m 'x'" \
+  "a commit on main reached by cd"
+
+# A commit on a branch is the normal case and must not be refused.
+check allow "$tmp/on-branch" "git commit -m 'x'" \
+  "a commit on a feature branch"
+check allow "$tmp/on-main" "git -C $tmp/on-branch commit -m 'x'" \
+  "a commit on a branch while the session sits on main"
+check allow "$tmp/on-main" "cd $tmp/on-branch && git commit -m 'x'" \
+  "a commit on a branch reached by cd from main"
+
+# Re-blessing, wherever it is typed.
+check deny "$tmp/on-branch" "$bless_golden cargo test --test golden_images" \
+  "re-blessing a golden"
+check deny "$tmp/on-branch" "$bless_snapshot cargo test" \
+  "re-blessing a snapshot"
+check deny "$tmp/on-branch" "cargo test && $bless_golden cargo test" \
+  "re-blessing after something else on the same line"
+check allow "$tmp/on-branch" "cargo test --test render_snapshots" \
+  "running the snapshots without blessing them"
+
+if [ "$failures" -ne 0 ]; then
+  echo
+  echo "$failures case(s) wrong."
+  exit 1
+fi
+echo
+echo "all cases pass"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,13 @@ jobs:
         run: cargo fmt --all -- --check
       - name: Run clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
+      # The guard that refuses a re-bless and a commit on main decides by the
+      # position a word occupies, not by whether it appears. Getting that wrong
+      # is how it came to refuse a sed expression and to read the branch of the
+      # wrong repository. The table says what it has to get right.
+      - name: Check the commit guard
+        run: .claude/hooks/guard-bash.test.sh
+
       # A broken intra-doc link is a broken promise in the published API
       # reference, and it costs one compile to find.
       - name: Build the API documentation


### PR DESCRIPTION
## What changed

The guard that refuses a re-bless and a commit on `main` matched words anywhere in the command text, and read the branch of whatever directory the session happened to be standing in. Both were wrong, and wrong in the direction that costs: it refused work that was fine, and would have allowed the thing it exists to stop.

Four refusals that should not have been — all met while using it, none visible by reading it:

- `git log --oneline | sed 's/^/commit: /'` — the word, not the deed
- a heredoc writing the name of the blessing variable *into a file* — data, not a command
- `git -C ../worktree commit` on a feature branch, refused because the session stood on `main`
- `gh pr create` with a body that quotes any of the above

And the one that matters, inverted: this project puts every change in a worktree of its own, so the session's directory is almost never the repository being committed to. A commit aimed at `main` by `-C` from a feature worktree passed.

The guard now splits the command into segments, drops heredoc bodies before anything reads them, walks leading assignments and `env`, and walks git's own flags to reach the subcommand. The branch comes from the directory the command will actually run in: the `-C` path if there is one, else where an earlier `cd` left it, else the session's.

## What proves it

`.claude/hooks/guard-bash.test.sh`, fifteen cases, run by CI. It was committed first, and against the old guard **six of them fail** — including three that had already happened to somebody. Against the new one all fifteen pass.

The table builds two throwaway repositories, one on `main` and one on a branch, and drives the guard through its real stdin contract rather than checking the regex by eye.

## What was checked by hand

The guard blocked its own repair three times while this was being written: refusing the heredoc that wrote the test file, refusing the commit of the fix, and refusing the command that opened this pull request. The first three are cases in the table; the fourth is the same root cause and is covered by the segment rule.

Nothing Rust changed, so the Rust harness is untouched by this.

## Left undone

`verify.sh` and `fmt-rust.sh` have no table of their own. They are simpler — one runs two cargo commands, the other formats a path — but "simpler" is what was said about this one.

The re-bless refusal still fires on a segment that merely *starts* with the variable, so an `echo` explaining the rule at the start of a line would be denied. Narrow, and the message says what to do.