### PR TITLE
Creating a reference is not rewriting one, and only one of them is a decision

### DIFF
--- a/.claude/hooks/guard-bash.sh
+++ b/.claude/hooks/guard-bash.sh
@@ -2,10 +2,12 @@
 # Two things that must not happen quietly, refused where they are typed rather
 # than asked for in prose.
 #
-#   1. Re-blessing a snapshot or a golden. Both rewrite the artifact that was
-#      supposed to fail, which turns a failing test green without changing
-#      anything back. Blessing is a decision, and a decision is the
-#      maintainer's to make with the diff in front of them.
+#   1. Rewriting a snapshot or a golden. It turns a failing test green without
+#      changing anything back, so it is a decision, and a decision is the
+#      maintainer's to make with the diff in front of them. Creating a
+#      reference that does not exist yet is not that: a new scenario needs a
+#      first picture, and the harness only lets UPDATE_GOLDEN and
+#      UPDATE_SNAPSHOTS make one — rewriting needs REBLESS_*, which is this.
 #   2. Committing on main. The project merges through pull requests.
 #
 # Both are decided by looking at the position a word occupies, not at whether
@@ -70,8 +72,8 @@ while IFS= read -r segment; do
   while [ $i -lt ${#tokens[@]} ]; do
     case "${tokens[$i]}" in
       env) i=$((i + 1)) ;;
-      UPDATE_GOLDEN=*|UPDATE_SNAPSHOTS=*)
-        deny "Re-blessing is blocked. A rewritten snapshot or golden makes a failing test pass without changing a pixel back — the failure is the finding, so read it: the golden diff images are in target/golden-failures/, and the snapshot diff is in the test output. If the change is intended, say so and the maintainer blesses it, with the golden-update label on the pull request."
+      REBLESS_GOLDEN=*|REBLESS_SNAPSHOTS=*)
+        deny "Rewriting a reference is blocked. It makes a failing test pass without changing a pixel back, so the failure is the finding: read it. The golden diff images are in target/golden-failures/, and the snapshot diff is in the test output. Creating a reference that does not exist yet is not this and is not blocked — UPDATE_GOLDEN and UPDATE_SNAPSHOTS do that. Rewriting one is the maintainer's decision, and the pull request carries the golden-update label to say they made it."
         ;;
       *=*) i=$((i + 1)) ;;
       *) break ;;

--- a/.claude/hooks/guard-bash.test.sh
+++ b/.claude/hooks/guard-bash.test.sh
@@ -20,8 +20,9 @@ trap 'rm -rf "$tmp"' EXIT
 
 # The variables the guard refuses, spelled so that this file does not contain
 # what it is testing for — otherwise writing it trips the guard.
-bless_golden="UPDATE_""GOLDEN=1"
-bless_snapshot="UPDATE_""SNAPSHOTS=1"
+create_golden="UPDATE_""GOLDEN=1"
+rewrite_golden="REBLESS_""GOLDEN=1"
+rewrite_snapshot="REBLESS_""SNAPSHOTS=1"
 
 # Two repositories: one sitting on main, one on a branch.
 for name in on-main on-branch; do
@@ -60,7 +61,7 @@ check allow "$tmp/on-main" "echo 'run git commit after branching'" \
 check allow "$tmp/on-main" "cargo test --test golden_images" \
   "an ordinary build command"
 check allow "$tmp/on-branch" "cat > notes.md <<'EOF'
-$bless_golden rewrites the reference
+$rewrite_golden rewrites the reference
 EOF" \
   "writing a file that mentions the blessing variable"
 
@@ -84,13 +85,18 @@ check allow "$tmp/on-main" "git -C $tmp/on-branch commit -m 'x'" \
 check allow "$tmp/on-main" "cd $tmp/on-branch && git commit -m 'x'" \
   "a commit on a branch reached by cd from main"
 
-# Re-blessing, wherever it is typed.
-check deny "$tmp/on-branch" "$bless_golden cargo test --test golden_images" \
-  "re-blessing a golden"
-check deny "$tmp/on-branch" "$bless_snapshot cargo test" \
-  "re-blessing a snapshot"
-check deny "$tmp/on-branch" "cargo test && $bless_golden cargo test" \
-  "re-blessing after something else on the same line"
+# Rewriting a reference, wherever it is typed.
+check deny "$tmp/on-branch" "$rewrite_golden cargo test --test golden_images" \
+  "rewriting a golden"
+check deny "$tmp/on-branch" "$rewrite_snapshot cargo test" \
+  "rewriting a snapshot"
+check deny "$tmp/on-branch" "cargo test && $rewrite_golden cargo test" \
+  "rewriting after something else on the same line"
+
+# Creating one is ordinary work: a new scenario has to get its first picture
+# somehow, and the harness refuses to overwrite an existing one anyway.
+check allow "$tmp/on-branch" "$create_golden cargo test --test golden_images" \
+  "creating a reference that does not exist yet"
 check allow "$tmp/on-branch" "cargo test --test render_snapshots" \
   "running the snapshots without blessing them"
 

--- a/.claude/skills/visual-verification/SKILL.md
+++ b/.claude/skills/visual-verification/SKILL.md
@@ -66,13 +66,22 @@ stopped it* tests a clip; a ladder of values tests a property across its range;
 scale 2 tests what scale 1 cannot see. Then bless once, on lavapipe, and look at
 the PNG that comes out before committing it.
 
-### Never re-bless to make a test pass
+### Creating a reference, and rewriting one
 
-`UPDATE_GOLDEN=1` and `UPDATE_SNAPSHOTS=1` rewrite the thing that was supposed
-to fail. A hook blocks both, and CI refuses a pull request that edits
-`tests/golden/` without the `golden-update` label. When a change is intended:
-bless on lavapipe, put the before and after images in the pull request, add the
-label. The diff is the review.
+They are different acts and they have different words.
+
+`UPDATE_GOLDEN=1` creates a picture for a scenario that has none — that is how
+a new scenario starts, it is ordinary work, and nothing blocks it. Point it at
+a reference that already exists and it declines: the comparison runs instead,
+and if the pixels disagree you get the three images and the count.
+
+`REBLESS_GOLDEN=1` rewrites one that exists. That turns a failing test green
+without changing anything back, so a hook refuses it and CI refuses a pull
+request that rewrites a reference without the `golden-update` label. When the
+change is intended: look at the diff first, rewrite on lavapipe, put the before
+and after in the pull request, add the label. The diff is the review.
+
+`UPDATE_SNAPSHOTS` and `REBLESS_SNAPSHOTS` split the same way.
 
 ## 3. The screenshot
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,12 +16,15 @@ purpose. What is not negotiable is that a change can be *verified*.
 **Never commit to `main`.** Branch, open a pull request, merge it when CI is
 green.
 
-**Never re-bless a snapshot or a golden to make a test pass.** `UPDATE_SNAPSHOTS=1`
-and `UPDATE_GOLDEN=1` rewrite the thing that was supposed to fail. They are for a
-change somebody decided to make and then looked at. A hook blocks them, and CI
-refuses a pull request that edits `tests/golden/` without the `golden-update`
-label. That is deliberate, and asking for the hook to be lifted is the wrong
-move — read the diff instead.
+**Never rewrite a snapshot or a golden to make a test pass.** Creating one is
+ordinary: a new scenario needs a first picture, and `UPDATE_GOLDEN=1` and
+`UPDATE_SNAPSHOTS=1` make one for a reference that does not exist yet. They
+refuse to touch a reference that does, because rewriting it turns a failing test
+green without changing anything back. That takes `REBLESS_GOLDEN=1` or
+`REBLESS_SNAPSHOTS=1`, a hook refuses those, and CI refuses a pull request that
+rewrites a reference without the `golden-update` label. Asking for the hook to be
+lifted is the wrong move — read the diff instead, it is in
+`target/golden-failures/`.
 
 **Every change names the thing that proves it.** Before writing the fix, write
 the test that fails without it. A change to the renderer that no golden notices

--- a/tests/golden_images.rs
+++ b/tests/golden_images.rs
@@ -52,17 +52,21 @@
 //! `GUIDO_GOLDEN_REQUIRED=1` in the one job that must not skip, where a skip is
 //! a failure — a skipped test that reports green is worth less than no test.
 //!
-//! **Re-blessing is not a way to make a test pass.** A changed golden is a
-//! changed pixel on someone's screen, and the diff is the review:
+//! **Creating a reference is not rewriting one.** A scenario with no picture
+//! needs one, and making it is ordinary work:
 //!
 //! ```sh
 //! UPDATE_GOLDEN=1 cargo test --test golden_images
 //! ```
 //!
-//! CI refuses a pull request that edits `tests/golden/` unless it carries the
-//! `golden-update` label, so the re-blessing is always somebody's decision.
-//! On failure the three images (expected, actual, and a map of what moved)
-//! are written to `target/golden-failures/` and uploaded as a CI artifact.
+//! Pointed at a reference that already exists, it declines and lets the
+//! comparison run instead — because rewriting a picture that disagrees with the
+//! code makes a failing test pass without changing anything back. That is
+//! `REBLESS_GOLDEN=1`; a hook refuses it, and CI refuses a pull request that
+//! rewrites a reference without the `golden-update` label. So it is always
+//! somebody's decision, taken with the diff in front of them. On failure the
+//! three images (expected, actual, and a map of what moved) are written to
+//! `target/golden-failures/` and uploaded as a CI artifact.
 
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;

--- a/tests/render_snapshots.rs
+++ b/tests/render_snapshots.rs
@@ -19,13 +19,16 @@
 //! container-level tests instead; the scenarios here stay on the geometry, which
 //! is where the layout logic lives anyway.
 //!
-//! To re-bless after an intended change:
+//! A scenario with no snapshot gets one with:
 //!
 //! ```sh
 //! UPDATE_SNAPSHOTS=1 cargo test --test render_snapshots
 //! ```
 //!
-//! Read the resulting diff before committing it — that diff *is* the review.
+//! It refuses to overwrite one that already exists. Rewriting after an intended
+//! change is `REBLESS_SNAPSHOTS=1`, which a hook refuses and which a pull
+//! request carries the `golden-update` label to authorise. Read the diff before
+//! rewriting it — that diff *is* the review.
 
 use std::fmt::Write as _;
 


### PR DESCRIPTION
## What changed

Creating a reference and rewriting one are different acts, and the rule treated them as one.

A scenario with no picture needs a first one — that is how a scenario starts, and it is ordinary work. The hook refused it anyway, because from a command line it cannot see whether the file already exists. In #234 that cost an explicit go-ahead from the maintainer to create one image, which is heavier than the rule ever meant. CI, meanwhile, had already been narrowed to rewrites and deletions: **the guard was stricter than the rule it was enforcing.**

The harness can tell them apart, because it holds the path.

- `UPDATE_GOLDEN=1` / `UPDATE_SNAPSHOTS=1` write only what is missing. Aimed at a reference that exists they decline and let the comparison run — which is the useful answer either way: if it matches there was nothing to do, and if it does not, the diff images are what decides whether it should be rewritten at all.
- `REBLESS_GOLDEN=1` / `REBLESS_SNAPSHOTS=1` rewrite. The hook refuses those two, and CI still refuses a pull request that rewrites a reference without the `golden-update` label.

## What proves it

The guard's table, now sixteen cases: creating a reference is allowed, rewriting is denied wherever on the line it is typed. CI runs it.

And the harness itself, driven through all four states against a real scenario that was perturbed and put back:

| | outcome | reference |
|---|---|---|
| `UPDATE_GOLDEN`, everything matching | 9 passed | untouched |
| `UPDATE_GOLDEN`, scenario perturbed | **failed**, 14.4% of pixels moved | **untouched** |
| `REBLESS_GOLDEN`, same perturbation | 9 passed | rewritten |
| `UPDATE_SNAPSHOTS`, snapshot perturbed | **failed** | **untouched** |

The second row is the point: with the old behaviour that command would have rewritten the reference and reported green.

## What was checked by hand

Nothing needed a compositor. The perturbation was a real scenario edit — one fewer card in the elevation ladder — and the working tree was verified clean afterwards.

## Left undone

`REBLESS_*` is refused by the hook and allowed by everything else, so the way to use it is still a shell script or a maintainer's own terminal. That is the intent — it is meant to be inconvenient — but it means the hook cannot distinguish a maintainer from an agent, only a command from a command.