### PR TITLE
A number for how much the suite is actually watching

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,0 +1,28 @@
+# cargo-mutants changes the code in one small way and asks whether anything
+# notices. A mutant that survives is a line the suite does not actually watch,
+# whatever the coverage says: coverage asks whether a line ran, this asks
+# whether it mattered.
+#
+#   cargo mutants -f 'src/reactive/**/*.rs' -C --lib -j 8
+#
+# The whole crate takes hours; a module at a time is how it is used by hand.
+# CI runs it only over the lines a pull request touched — see the workflow.
+
+# Mutants that cannot be killed by any test worth writing.
+#
+# A Display or Debug impl formats for a person reading a log. Asserting on that
+# text would pin wording nobody promised, and it is the one thing here that is
+# genuinely not behaviour.
+#
+# Nothing else is excluded. The teardown helpers, the diagnostics counters and
+# the platform-fed thread-local state all survive today, and that is a fact
+# about the suite rather than a fact about them.
+exclude_re = [
+    "impl .*fmt::Display",
+    "impl .*fmt::Debug",
+]
+
+# A mutant that hangs is a mutant that broke a loop's exit condition, which is
+# a kill and not a reason to wait. Five times the unmutated run is generous.
+timeout_multiplier = 5.0
+minimum_test_timeout = 30.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,39 @@ jobs:
       - name: Build the book
         run: mdbook build book
 
+  mutants:
+    name: Mutation testing
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-mutants
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libwayland-dev libxkbcommon-dev
+      # Only the lines this pull request touched. Mutating the whole crate takes
+      # hours and would say the same thing every time; mutating the diff asks
+      # the one question worth asking of a change — if this new code were
+      # wrong, would anything have noticed.
+      - name: The diff this pull request makes
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+        run: git diff "$BASE"...HEAD > /tmp/pull-request.diff
+      - name: Mutate what changed
+        run: cargo mutants --in-diff /tmp/pull-request.diff -j 4 --no-shuffle
+      - name: Upload what survived
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mutants-out
+          path: mutants.out/
+          if-no-files-found: ignore
+
   golden-guard:
     name: Golden re-bless needs a label
     if: github.event_name == 'pull_request'

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ book/book/
 
 # Personal, per-machine Claude Code settings
 .claude/settings.local.json
+
+# cargo-mutants working directories
+mutants.out/
+mutants.out.old/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,28 @@ That last row is the hole in the harness. It is the one place where "I ran it
 and it looked right" is still the standard, and the one place worth closing
 next.
 
+## What watches the harness
+
+Every row above is an opinion until something checks it. `cargo mutants` changes
+the code in one small way and asks whether any test notices: coverage asks
+whether a line ran, this asks whether it mattered.
+
+```bash
+cargo mutants -f 'src/reactive/**/*.rs' -C --lib -j 8
+```
+
+The reactive core stands at **168 caught, 84 survived — 67%** as of the run that
+introduced this. The survivors are not evenly spread and the number is less
+useful than the shape: the background-write queue, the whole of `clipboard`,
+`cursor` and most of `focus` are unwatched, and the numeric conversions in
+`into_signal` can return the wrong number without a test objecting.
+
+Whole-crate runs take hours; a module at a time is how it is used by hand. On a
+pull request CI mutates only the lines the diff touched, which asks the one
+question worth asking of new code — if this were wrong, would anything have
+noticed. That job reports; it does not block, until somebody decides the
+ratchet is worth the friction.
+
 ## Where the rest of it is
 
 `docs/` is the developer reference — read the relevant file before a


### PR DESCRIPTION
## What changed

Coverage says a line ran. It does not say anything noticed. `cargo mutants` changes the code in one small way and asks whether a test objects — which is the question this week kept answering by accident, and never by reading.

- `.cargo/mutants.toml` — configuration, and one exclusion: `Display` and `Debug` impls, because asserting on the text a log line formats would pin wording nobody promised. Nothing else is excluded; 484 of 486 mutants remain in the count.
- A CI job that mutates **only the lines a pull request touched**. The whole crate takes hours and would say the same thing every time; the diff asks the one question worth asking of new code — if this were wrong, would anything have noticed.
- The baseline, written into AGENTS.md so the number is somebody's to improve rather than a thing that was measured once.

**The job reports and does not block.** It is deliberately not in the ruleset's required checks: turning it into a ratchet is a decision about friction, and it should be taken on purpose.

## What proves it

The baseline run, 486 mutants over `src/reactive/`:

| | |
|---|---|
| caught | 168 |
| **survived** | **84** |
| unviable (do not compile) | 234 |
| **score** | **67%** |

And the CI mechanism itself, run against a real diff — the squash commit of #234:

```
6 mutants tested in 5m: 3 missed, 3 caught
MISSED  src/renderer/text.rs:151:47: replace && with ||
MISSED  src/renderer/text.rs:151:16: delete !
MISSED  src/renderer/text.rs:151:50: delete !
```

Line 151 is the guard around the very cull #218 fixed. All three survivors say the same thing, and it is about the code rather than the tests: `!is_identity() && !is_translation_only()` is not load-bearing. For an identity or translation-only transform the scale is 1, so the cull inside would not fire anyway — the guard saves two square roots and nothing else. Deleting it is a behaviour-preserving simplification, and it is a separate change.

## What was checked by hand

Nothing needed a compositor.

Local runs must build somewhere on disk: cargo-mutants copies the tree to `TMPDIR`, and with `/tmp` on tmpfs four parallel builds took the linker down with a bus error. `TMPDIR=…` on a real filesystem, and `-j 2`, is what the machine wants. Hosted runners have `/tmp` on disk, so CI is unaffected.

## Left undone

Every one of the 84 survivors. They are a ranked backlog, not a to-do list for this pull request:

1. **The background-write queue** (`runtime.rs`) — delete `flush_bg_writes`, invert its epoch check, or flip its guard, and nothing objects. It is the only path from a background thread to the screen.
2. **`compare_and_update_signal_value`** (`storage.rs:318`) — inverting the comparison that decides whether a value changed survives.
3. **`clipboard`, `cursor`, most of `focus`** — thread-local state machines the platform layer feeds, testable without a compositor, entirely unwatched.
4. **`into_signal`'s numeric conversions** — `u32`/`u16` to `f32` can return 0.0 and nothing fails.

Some survivors are honestly unkillable: the counters in `flush_bg_writes` only feed a log line, so no assertion can see them. They stay in the count rather than being excluded to flatter it.