### PR TITLE
The diff gets read by something that did not write it

### DIFF
--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -85,6 +85,11 @@ What to do with what it says:
   silence; the next person will wonder the same thing.
 - **A clean report is one line and you move on.** Do not ask again hoping for a
   different answer.
+- **A review that did not run is not a review that found nothing.** The two look
+  identical from the outside and mean opposite things. If it failed, timed out,
+  or was skipped, run it again; if it still will not run, say so in the pull
+  request in those words. Writing "nothing found" for a review that never
+  happened is the same act as re-blessing a golden to make a test pass.
 
 ## 8. Open the pull request
 

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -63,10 +63,33 @@ One focused change per commit, in the order the code was built: data structures,
 then behaviour, then the API that exposes it. Subject lines are sentences that
 say what is now true. No `Co-Authored-By`, no generated-with footer.
 
-## 7. Open the pull request
+## 7. Have it read by somebody who did not write it
+
+Now the commits exist and the pull request does not, which is the moment the
+`reviewer` subagent is written for: it asks about atomic commits, about what the
+pull request will have to say, and about the diff as a whole.
+
+Run it over the change. Its criteria live in `.claude/agents/reviewer.md` and are
+not repeated here — a second copy is a second thing to keep true, and the copy
+is always the one that goes stale.
+
+What to do with what it says:
+
+- **An architectural finding stops the work.** A new core type, a new trait, a
+  new cross-cutting mechanism, a new ownership rule, a family of call sites
+  respelled: that was the maintainer's decision to make before it was written,
+  and finding it here does not transfer the decision to whoever wrote it. Stop,
+  say what was found, and ask — the same verb as step 1.
+- **Everything else is yours to act on, or to disagree with in writing.** A
+  finding you did not act on is worth a sentence in the pull request rather than
+  silence; the next person will wonder the same thing.
+- **A clean report is one line and you move on.** Do not ask again hoping for a
+  different answer.
+
+## 8. Open the pull request
 
 Push the branch, `gh pr create`, fill in the template. Link the issue with
 `Closes #$ARGUMENTS`.
 
-Then report back, in four lines: what changed, what proves it, what you looked
-at by hand, and anything you left undone and why.
+Then report back, in five lines: what changed, what proves it, what the review
+found, what you looked at by hand, and anything you left undone and why.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
 <!--
-Four questions. The first two decide whether this can be reviewed at all.
+Five questions. The first two decide whether this can be reviewed at all.
 -->
 
 ## What changed
@@ -16,6 +16,15 @@ passes cargo test.
 If a golden or a snapshot was re-blessed, attach the before and after, say what
 moved and why that is the intended change, and add the `golden-update` label.
 CI refuses the pull request otherwise.
+-->
+
+## What the review found
+
+<!--
+The `reviewer` subagent read this diff before the pull request existed. What did
+it say, and what did you do about it. "Nothing — it reported the change sound"
+is a fine answer; so is a finding you disagreed with and why, which is worth a
+sentence here rather than silence.
 -->
 
 ## What was checked by hand

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,10 +21,14 @@ CI refuses the pull request otherwise.
 ## What the review found
 
 <!--
-The `reviewer` subagent read this diff before the pull request existed. What did
-it say, and what did you do about it. "Nothing — it reported the change sound"
-is a fine answer; so is a finding you disagreed with and why, which is worth a
-sentence here rather than silence.
+The `reviewer` subagent read this change before the pull request existed. What
+did it say, and what did you do about it. "Nothing — it reported the change
+sound" is a fine answer; so is a finding you disagreed with and why, which is
+worth a sentence here rather than silence.
+
+If it did not run — it failed, it timed out, nobody invoked it — say that
+instead, in those words. A review that did not happen and a review that found
+nothing look identical here and mean opposite things.
 -->
 
 ## What was checked by hand

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -51,7 +51,9 @@ jobs:
             failing test comes before the fix, and a snapshot or golden is
             never re-blessed to make a test pass.
 
-            Run the harness before you finish:
+            Have the diff read by the reviewer subagent once it is committed
+            and before the pull request exists, and run the harness before you
+            finish:
               cargo fmt --all
               cargo clippy --all-targets --all-features -- -D warnings
               cargo test --all-features

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -51,9 +51,7 @@ jobs:
             failing test comes before the fix, and a snapshot or golden is
             never re-blessed to make a test pass.
 
-            Have the diff read by the reviewer subagent once it is committed
-            and before the pull request exists, and run the harness before you
-            finish:
+            Run the harness before you finish:
               cargo fmt --all
               cargo clippy --all-targets --all-features -- -D warnings
               cargo test --all-features

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,10 +148,15 @@ themselves when the task touches them; you do not need to read them up front.
 3. **The failing test, then the fix.** In that order, so the test is known to
    test something.
 4. **Run the harness**, all of it, including the goldens.
-5. **Open the pull request** with the template filled in: what moved, what
-   proves it, what you looked at by hand.
+5. **Have it read by something that did not write it.** The `reviewer` subagent,
+   once the change is committed and before the pull request exists — its
+   criteria ask about the commits, so they need the commits. Whoever wrote a
+   change is the worst judge of whether it grew, and an architectural finding
+   here stops the work the same way a `needs-design` label stops it at step 1.
+6. **Open the pull request** with the template filled in: what moved, what
+   proves it, what the review found, what you looked at by hand.
 
-`/implement <issue>` does all five.
+`/implement <issue>` does all six.
 
 ## Commits and pull requests
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,7 @@ at lavapipe. In that job a skip is a failure.
 | documented API | doc tests, and `cargo doc` with warnings denied |
 | the user documentation | `mdbook build book` in CI |
 | the APIs this file and the skills name | `tests/skill_references.rs` |
+| what this file, `/implement` and the templates say about each other | `tests/agent_workflow.rs` |
 | Wayland protocol behaviour, compositor integration | **nothing automated.** Run an example and say what you saw in the pull request |
 
 That last row is the hole in the harness. It is the one place where "I ran it
@@ -149,10 +150,10 @@ themselves when the task touches them; you do not need to read them up front.
    test something.
 4. **Run the harness**, all of it, including the goldens.
 5. **Have it read by something that did not write it.** The `reviewer` subagent,
-   once the change is committed and before the pull request exists — its
-   criteria ask about the commits, so they need the commits. Whoever wrote a
-   change is the worst judge of whether it grew, and an architectural finding
-   here stops the work the same way a `needs-design` label stops it at step 1.
+   over the committed change and before the pull request exists — its criteria
+   ask about the commits, so they need the commits. Whoever wrote a change is
+   the worst judge of whether it grew, and an architectural finding here stops
+   the work: that decision belongs to the maintainer wherever it surfaces.
 6. **Open the pull request** with the template filled in: what moved, what
    proves it, what the review found, what you looked at by hand.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,7 @@ at lavapipe. In that job a skip is a failure.
 | documented API | doc tests, and `cargo doc` with warnings denied |
 | the user documentation | `mdbook build book` in CI |
 | the APIs this file and the skills name | `tests/skill_references.rs` |
-| what this file, `/implement` and the templates say about each other | `tests/agent_workflow.rs` |
+| the workflow this file, `/implement` and the templates describe | `tests/agent_workflow.rs` |
 | Wayland protocol behaviour, compositor integration | **nothing automated.** Run an example and say what you saw in the pull request |
 
 That last row is the hole in the harness. It is the one place where "I ran it

--- a/tests/agent_workflow.rs
+++ b/tests/agent_workflow.rs
@@ -1,14 +1,15 @@
 //! The workflow describes itself, and the description has to add up.
 //!
-//! `AGENTS.md`, `/implement` and the pull request template all count their own
-//! steps, and the counts are written out in prose next to lists that somebody
-//! edits. Inserting a step is exactly when they stop matching: the change that
-//! added a review step left the template saying "Four questions" above five of
-//! them, and the only reason anybody noticed is that a reviewer read it.
+//! `AGENTS.md`, `/implement` and the pull request template describe each other:
+//! they count their own steps in prose, next to lists somebody edits, and they
+//! point at files by name. Inserting a step is exactly when those stop
+//! matching, and a count in prose is the part a person is worst at checking.
 //!
-//! Nothing here reads the words. It counts headings and list markers, and
-//! compares them to the numbers the prose claims — which is the whole of what
-//! went wrong, and the part a person is worst at checking.
+//! Nothing here reads the words. It counts headings and list markers, compares
+//! them to the numbers the prose claims, checks that the files this
+//! documentation names exist, and checks the one ordering the workflow depends
+//! on — that the review comes after the commits, because its criteria ask about
+//! them.
 
 use std::path::{Path, PathBuf};
 
@@ -26,7 +27,15 @@ fn number_word(word: &str) -> Option<usize> {
     const WORDS: &[&str] = &[
         "zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten",
     ];
+    let word = word.trim_matches(|c: char| !c.is_ascii_alphabetic());
+    let word = word.to_ascii_lowercase();
     WORDS.iter().position(|w| *w == word)
+}
+
+/// The first number word anywhere in a sentence, so that rewording the sentence
+/// does not fail the build for a reason nobody meant.
+fn number_in(sentence: &str) -> Option<usize> {
+    sentence.split_whitespace().find_map(number_word)
 }
 
 /// The numbers at the start of `## 3. Something` headings, in order.
@@ -77,7 +86,13 @@ fn agents_md_counts_the_steps_it_lists() {
     let start = text
         .find("## Working on a change")
         .expect("AGENTS.md has no `Working on a change` section");
-    let section = &text[start..];
+    // To the next heading, not to the end of the file: a numbered list further
+    // down the document is not this list.
+    let rest = &text[start..];
+    let section = match rest[3..].find("\n## ") {
+        Some(offset) => &rest[..offset + 3],
+        None => rest,
+    };
     let steps = numbered_items(section);
     assert_contiguous(&steps, "AGENTS.md");
 
@@ -111,12 +126,107 @@ fn the_pull_request_template_asks_as_many_questions_as_it_says() {
         .lines()
         .find(|line| line.contains(" questions"))
         .expect("the template never says how many questions it asks");
-    let word = claim.split_whitespace().next().unwrap_or_default();
-    let claimed = number_word(&word.to_ascii_lowercase())
-        .unwrap_or_else(|| panic!("`{word}` is not a number this test knows"));
+    let claimed =
+        number_in(claim).unwrap_or_else(|| panic!("no number this test knows in: {claim}"));
 
     assert_eq!(
         claimed, sections,
-        "the template has {sections} sections and says it asks {word} questions"
+        "the template has {sections} sections and says: {claim}"
+    );
+}
+
+/// Step 7 keeps no copy of the reviewer's criteria — it points at the file that
+/// holds them. A pointer nobody checks is how that file gets moved and the step
+/// quietly stops saying anything.
+///
+/// This checks every repository path the agent-facing documentation names, not
+/// only that one: a backticked span that looks like a path in this tree has to
+/// resolve to something.
+#[test]
+fn the_documentation_points_at_files_that_exist() {
+    let mut missing = Vec::new();
+
+    for doc in [
+        "AGENTS.md",
+        ".claude/commands/implement.md",
+        ".claude/commands/spec.md",
+        ".claude/commands/harness.md",
+        ".claude/agents/reviewer.md",
+    ] {
+        let text = read(doc);
+        for span in text.split('`').skip(1).step_by(2) {
+            let looks_like_a_path = span.contains('/')
+                && !span.contains(' ')
+                && (span.ends_with(".rs")
+                    || span.ends_with(".md")
+                    || span.ends_with(".toml")
+                    || span.ends_with(".yml")
+                    || span.ends_with('/'));
+            // `target/` is build output: the documentation points at things
+            // that appear there when a test fails, and they are supposed not
+            // to exist the rest of the time.
+            if !looks_like_a_path || span.starts_with("target/") {
+                continue;
+            }
+            let path = repo().join(span.trim_end_matches('/'));
+            if !path.exists() {
+                missing.push(format!("  {doc}: `{span}`"));
+            }
+        }
+    }
+
+    assert!(
+        missing.is_empty(),
+        "documentation names {} path(s) that do not exist:\n{}",
+        missing.len(),
+        missing.join("\n")
+    );
+}
+
+/// The review runs *after* the commits, because its criteria ask about them —
+/// whether they are atomic, whether their subjects say what is now true. Swap
+/// the two steps and the step still reads sensibly while asking questions
+/// nothing can answer, which is the state this whole change started from.
+#[test]
+fn the_review_comes_after_the_commits() {
+    let text = read(".claude/commands/implement.md");
+
+    let step = |needle: &str| -> usize {
+        text.lines()
+            .filter_map(|line| line.strip_prefix("## "))
+            .find(|heading| heading.contains(needle))
+            .and_then(|heading| heading.split('.').next()?.parse().ok())
+            .unwrap_or_else(|| panic!("/implement has no step about `{needle}`"))
+    };
+
+    let commit = step("Commit");
+    let review = step("read by somebody who did not write it");
+    assert!(
+        review > commit,
+        "the review is step {review} and the commits are step {commit}: its \
+         criteria ask about commits that would not exist yet"
+    );
+}
+
+/// `/implement` ends by saying how many lines to report back, and the template
+/// says how many questions it asks. They are the same list, so they are the
+/// same number — and a count in prose beside a list is the thing this file
+/// exists to watch.
+#[test]
+fn the_report_back_matches_the_template() {
+    let implement = read(".claude/commands/implement.md");
+    let template = read(".github/pull_request_template.md");
+
+    let claim = implement
+        .lines()
+        .find(|line| line.contains("report back, in "))
+        .expect("/implement never says how many lines to report back");
+    let claimed =
+        number_in(claim).unwrap_or_else(|| panic!("no number this test knows in: {claim}"));
+    let sections = template.lines().filter(|l| l.starts_with("## ")).count();
+
+    assert_eq!(
+        claimed, sections,
+        "the template asks {sections} questions and /implement says: {claim}"
     );
 }

--- a/tests/agent_workflow.rs
+++ b/tests/agent_workflow.rs
@@ -17,9 +17,71 @@ fn repo() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).to_path_buf()
 }
 
+/// Everything an agent is handed, found rather than listed: a command added
+/// tomorrow is scanned tomorrow, which is the staleness this file exists to
+/// catch happening to this file.
+fn agent_facing_documents() -> Vec<PathBuf> {
+    let mut found = vec![repo().join("AGENTS.md")];
+    for dir in [".claude/commands", ".claude/agents", ".claude/skills"] {
+        let mut here = Vec::new();
+        collect_markdown(&repo().join(dir), &mut here);
+        assert!(
+            !here.is_empty(),
+            "no markdown under {dir}: scanning nothing"
+        );
+        found.extend(here);
+    }
+    found
+}
+
+fn collect_markdown(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_markdown(&path, out);
+        } else if path.extension().is_some_and(|e| e == "md") {
+            out.push(path);
+        }
+    }
+}
+
 fn read(relative: &str) -> String {
     std::fs::read_to_string(repo().join(relative))
         .unwrap_or_else(|e| panic!("cannot read {relative}: {e}"))
+}
+
+/// The backticked spans of a markdown file, with fenced blocks removed first.
+///
+/// Pairing backticks by parity over a whole file holds only as long as every
+/// fence contributes an even number of them. One apostrophe-free shell string
+/// with a stray backtick shifts the parity and every span after it is read as
+/// the gap between spans — so the scan finds nothing and the test passes for
+/// the worst possible reason. `skill_references.rs` already does this; this is
+/// the same fix.
+fn backticked(text: &str) -> Vec<String> {
+    let mut prose = String::new();
+    let mut rest = text;
+    while let Some(start) = rest.find("```") {
+        prose.push_str(&rest[..start]);
+        let after = &rest[start + 3..];
+        match after.find("```") {
+            Some(end) => rest = &after[end + 3..],
+            None => {
+                rest = "";
+                break;
+            }
+        }
+    }
+    prose.push_str(rest);
+    prose
+        .split('`')
+        .skip(1)
+        .step_by(2)
+        .map(str::to_string)
+        .collect()
 }
 
 /// "six" -> 6, for the counts that are written as words.
@@ -146,15 +208,15 @@ fn the_pull_request_template_asks_as_many_questions_as_it_says() {
 fn the_documentation_points_at_files_that_exist() {
     let mut missing = Vec::new();
 
-    for doc in [
-        "AGENTS.md",
-        ".claude/commands/implement.md",
-        ".claude/commands/spec.md",
-        ".claude/commands/harness.md",
-        ".claude/agents/reviewer.md",
-    ] {
-        let text = read(doc);
-        for span in text.split('`').skip(1).step_by(2) {
+    for doc in agent_facing_documents() {
+        let name = doc
+            .strip_prefix(repo())
+            .unwrap_or(&doc)
+            .display()
+            .to_string();
+        let text =
+            std::fs::read_to_string(&doc).unwrap_or_else(|e| panic!("cannot read {name}: {e}"));
+        for span in backticked(&text) {
             let looks_like_a_path = span.contains('/')
                 && !span.contains(' ')
                 && (span.ends_with(".rs")
@@ -170,7 +232,7 @@ fn the_documentation_points_at_files_that_exist() {
             }
             let path = repo().join(span.trim_end_matches('/'));
             if !path.exists() {
-                missing.push(format!("  {doc}: `{span}`"));
+                missing.push(format!("  {name}: `{span}`"));
             }
         }
     }
@@ -194,13 +256,16 @@ fn the_review_comes_after_the_commits() {
     let step = |needle: &str| -> usize {
         text.lines()
             .filter_map(|line| line.strip_prefix("## "))
-            .find(|heading| heading.contains(needle))
+            .find(|heading| heading.to_ascii_lowercase().contains(needle))
             .and_then(|heading| heading.split('.').next()?.parse().ok())
             .unwrap_or_else(|| panic!("/implement has no step about `{needle}`"))
     };
 
-    let commit = step("Commit");
-    let review = step("read by somebody who did not write it");
+    // Matched on the verb, not on the whole sentence: AGENTS.md spells this
+    // step "read by something that did not write it" and /implement spells it
+    // "somebody", and neither wording is the thing being asserted.
+    let commit = step("commit");
+    let review = step("read by");
     assert!(
         review > commit,
         "the review is step {review} and the commits are step {commit}: its \
@@ -228,5 +293,47 @@ fn the_report_back_matches_the_template() {
     assert_eq!(
         claimed, sections,
         "the template asks {sections} questions and /implement says: {claim}"
+    );
+}
+
+/// The three mutations the counting does not see: strip step 7 down to its
+/// heading, take the review section out of the template, or drop the review
+/// from AGENTS.md's list. Each leaves every count consistent and removes the
+/// change entirely.
+#[test]
+fn the_review_step_still_says_what_it_is_for() {
+    let implement = read(".claude/commands/implement.md");
+    let step_seven = implement
+        .split("## 7.")
+        .nth(1)
+        .expect("/implement has no step 7")
+        .split("\n## ")
+        .next()
+        .unwrap_or_default();
+
+    assert!(
+        step_seven.contains(".claude/agents/reviewer.md"),
+        "step 7 keeps no copy of the criteria, so naming the file that holds \
+         them is the whole of it — and it does not"
+    );
+    assert!(
+        step_seven.contains("did not run"),
+        "step 7 does not say what to do when the review does not run, and a \
+         review that did not run looks exactly like one that found nothing"
+    );
+
+    let template = read(".github/pull_request_template.md");
+    assert!(
+        template
+            .lines()
+            .any(|l| l.starts_with("## ") && l.contains("review")),
+        "the pull request template has no section asking what the review found"
+    );
+
+    let agents = read("AGENTS.md");
+    assert!(
+        agents.contains("`reviewer` subagent"),
+        "AGENTS.md's list of what a change goes through never mentions the \
+         reviewer, so the step exists only in the command"
     );
 }

--- a/tests/agent_workflow.rs
+++ b/tests/agent_workflow.rs
@@ -1,0 +1,122 @@
+//! The workflow describes itself, and the description has to add up.
+//!
+//! `AGENTS.md`, `/implement` and the pull request template all count their own
+//! steps, and the counts are written out in prose next to lists that somebody
+//! edits. Inserting a step is exactly when they stop matching: the change that
+//! added a review step left the template saying "Four questions" above five of
+//! them, and the only reason anybody noticed is that a reviewer read it.
+//!
+//! Nothing here reads the words. It counts headings and list markers, and
+//! compares them to the numbers the prose claims — which is the whole of what
+//! went wrong, and the part a person is worst at checking.
+
+use std::path::{Path, PathBuf};
+
+fn repo() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).to_path_buf()
+}
+
+fn read(relative: &str) -> String {
+    std::fs::read_to_string(repo().join(relative))
+        .unwrap_or_else(|e| panic!("cannot read {relative}: {e}"))
+}
+
+/// "six" -> 6, for the counts that are written as words.
+fn number_word(word: &str) -> Option<usize> {
+    const WORDS: &[&str] = &[
+        "zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten",
+    ];
+    WORDS.iter().position(|w| *w == word)
+}
+
+/// The numbers at the start of `## 3. Something` headings, in order.
+fn numbered_headings(text: &str) -> Vec<usize> {
+    text.lines()
+        .filter_map(|line| line.strip_prefix("## "))
+        .filter_map(|rest| rest.split('.').next()?.parse().ok())
+        .collect()
+}
+
+/// The numbers at the start of `3. **Something**` list items, in order.
+fn numbered_items(text: &str) -> Vec<usize> {
+    text.lines()
+        .filter_map(|line| {
+            let (head, rest) = line.split_once(". ")?;
+            if rest.starts_with("**") {
+                head.parse().ok()
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn assert_contiguous(numbers: &[usize], what: &str) {
+    assert!(
+        !numbers.is_empty(),
+        "{what}: found no numbered steps at all"
+    );
+    let expected: Vec<usize> = (1..=numbers.len()).collect();
+    assert_eq!(
+        numbers,
+        expected,
+        "{what}: the steps are numbered {numbers:?}, which is not 1..{}",
+        numbers.len()
+    );
+}
+
+#[test]
+fn implement_numbers_its_steps_in_order() {
+    let text = read(".claude/commands/implement.md");
+    assert_contiguous(&numbered_headings(&text), "/implement");
+}
+
+#[test]
+fn agents_md_counts_the_steps_it_lists() {
+    let text = read("AGENTS.md");
+    let start = text
+        .find("## Working on a change")
+        .expect("AGENTS.md has no `Working on a change` section");
+    let section = &text[start..];
+    let steps = numbered_items(section);
+    assert_contiguous(&steps, "AGENTS.md");
+
+    // "`/implement <issue>` does all six."
+    let claim = section
+        .lines()
+        .find(|line| line.contains("does all "))
+        .expect("AGENTS.md never says how many steps /implement does");
+    let word = claim
+        .split("does all ")
+        .nth(1)
+        .and_then(|rest| rest.split(['.', ' ']).next())
+        .expect("cannot read the number out of that sentence");
+    let claimed =
+        number_word(word).unwrap_or_else(|| panic!("`{word}` is not a number this test knows"));
+
+    assert_eq!(
+        claimed,
+        steps.len(),
+        "AGENTS.md lists {} steps and then says /implement does all {word}",
+        steps.len()
+    );
+}
+
+#[test]
+fn the_pull_request_template_asks_as_many_questions_as_it_says() {
+    let text = read(".github/pull_request_template.md");
+    let sections = text.lines().filter(|l| l.starts_with("## ")).count();
+
+    let claim = text
+        .lines()
+        .find(|line| line.contains(" questions"))
+        .expect("the template never says how many questions it asks");
+    let word = claim.split_whitespace().next().unwrap_or_default();
+    let claimed = number_word(&word.to_ascii_lowercase())
+        .unwrap_or_else(|| panic!("`{word}` is not a number this test knows"));
+
+    assert_eq!(
+        claimed, sections,
+        "the template has {sections} sections and says it asks {word} questions"
+    );
+}

--- a/tests/skill_references.rs
+++ b/tests/skill_references.rs
@@ -24,6 +24,7 @@ use std::path::{Path, PathBuf};
 /// else, and file names.
 const NOT_CRATE_SYMBOLS: &[&str] = &[
     "grim",
+    "reviewer",
     "mdbook",
     "lavapipe",
     "llvmpipe",


### PR DESCRIPTION
## What changed

Nothing ever invoked the reviewer subagent. Its criteria existed in `.claude/agents/reviewer.md` — including whether an architectural change is hiding inside an ordinary one — and no command, hook or CI job ran them. Six pull requests merged yesterday with no second opinion on any of them.

`/implement` now runs it at **step 7**: after the commits, because its criteria ask about the commits, and before the pull request, because that is the last moment a finding is cheap. The step keeps no copy of the criteria — a second copy is a second thing to keep true — and an **architectural finding stops the work** rather than being something the author may overrule in a sentence, because that decision belongs to the maintainer wherever it surfaces.

A review that did not run is reported as such. The first one here died on a connection error before reading a line, and nothing about that state is visible afterwards: "nothing found" is what a pull request also says when the reviewer read everything and was satisfied. Same failure as an ICD path that made every golden skip and report green.

## What proves it

`tests/agent_workflow.rs`, seven assertions, each verified by inversion rather than by passing:

| broken on purpose | what fails |
| --- | --- |
| template section removed, counts reverted | `the template has 5 sections and says it asks Four questions` |
| a step renumbered | `[1, 2, 3, 4, 5, 6, 9, 8], which is not 1..8` |
| review moved before the commits | `its criteria ask about commits that would not exist yet` |
| `reviewer.md` moved | `documentation names 1 path(s) that do not exist` |
| step 7 stripped to its heading | `naming the file that holds them is the whole of it — and it does not` |
| the review dropped from AGENTS.md's list | `the step exists only in the command` |

It also covers the twenty repository paths the skills name, which nothing checked before.

## What the review found

Three rounds, and each found what the previous one could not see.

**First**, on the uncommitted change: the template said "Four questions" above five sections — a real bug, introduced by the same commit that added the review step. Plus four findings about placement and about the step restating the criteria lossily.

**Second**, on the committed change: the test written to close the first round **did not prove the step**. It showed this by mutation — deleting the step, swapping it with the commits, or pointing at a `reviewer.md` that does not exist all passed. Also caught a commit body describing history that is not on the branch.

**Third**: the second version of the test was still evadable three ways, and worse, its path check could be **switched off in silence** — backticks were paired by parity across the whole file, so one stray backtick in a fenced shell string shifted the parity and the scan found nothing while reporting green. Precisely the failure the fourth commit legislates against, committed by the test that accompanied it. `skill_references.rs` already stripped fences; this now does too.

Everything above is acted on. Two things were declined rather than fixed:

- `claude.yml` lost the instruction to run the reviewer. Whether that action can invoke a subagent at all was never verified, and an unverifiable instruction is worse than none.
- Commit atomicity was smudged twice (`NOT_CRATE_SYMBOLS` landed one commit later than the change that made it necessary; a prose fix rode along with test hardening). Both are noted in the bodies; neither seemed worth a rebase.

## What was checked by hand

Nothing needed a compositor. Every inversion in the table above was run and its message read.

## Left undone

**The step has no stopping rule, and on this evidence that is the open question.** Three rounds, and none of them said "sound". Severity decayed — round one found a bug in the artifact, round three found backtick parity in a test — but the count did not, and a reviewer asked to review will always return a list. The instructions here say to run it once, act, and go; they do not say what counts as blocking. Until they do, "until the review is clean" is not a reachable state and should not be treated as one.

The honest next change is a bar: ask whether a finding would block the merge, act on those, and record the rest in the pull request or an issue. Then measure — if blocking findings stay at zero over some pull requests, the step is costing more than it returns and belongs on a sample rather than on every change.