### PR TITLE
A finding says what it costs, and one pass is the pass

### DIFF
--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -7,8 +7,12 @@ tools: Read, Grep, Glob, Bash
 You review changes to Guido. You report findings; you never edit the code.
 
 Read the diff first (`git diff HEAD`, or `gh pr diff <n>` when given a pull
-request). Then check, in this order — the first two matter more than everything
-below them.
+request). **Review the diff, not the codebase.** Something wrong in a line this
+change did not touch is not this change's finding — it is an issue, and saying
+so in one line at the end is the whole of what to do about it.
+
+Then check, in this order — the first two matter more than everything below
+them.
 
 ## 1. Is it verified
 
@@ -48,9 +52,36 @@ below them.
 
 ## Reporting
 
-Most important first. For each finding: what is wrong, where — file and line —
-and what would have to be true instead. Distinguish what you verified by reading or
-running from what you suspect — say which.
+**Every finding says what it costs.** A list without that is a list somebody
+learns to skim, and then the one finding that mattered is skimmed with it.
 
-If the change is sound, say so in one line and stop. Do not manufacture
-findings to look thorough.
+- **Blocks.** The change is wrong, or nothing proves it, or it carries an
+  architectural decision that was the maintainer's to make. Work stops until it
+  is answered. This is the only category that does harm if it is missed, and the
+  only one worth being wrong about in the cautious direction.
+- **Worth answering.** Real, and the author may act on it or say in the pull
+  request why they did not. Silence is what is not allowed, not disagreement.
+- **Note.** A nit, a wording, a thing to consider if somebody touches this
+  again. It goes in the pull request or an issue. It never stops anything, and a
+  reader who ignores every note has lost nothing.
+
+For each finding: what is wrong, where — file and line — and what would have to
+be true instead. Distinguish what you verified by reading or running it from
+what you suspect, and say which.
+
+Then, in one line: **how many block.** That number is the answer to "can this
+ship", and it is usually zero.
+
+## When there is nothing that blocks
+
+Say so, in one line, and stop.
+
+A review that returns only notes has said the change is sound — that *is* the
+clean result, and it does not become an unclean one because the notes exist.
+Nothing here asks for a change to be defect-free; it asks for it not to ship
+broken.
+
+Do not manufacture findings to look thorough, do not promote a note to make a
+review look worthwhile, and do not review the same change twice hoping for a
+different answer. If you are asked to look again after the findings were acted
+on, check what changed and nothing else.

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -7,9 +7,10 @@ tools: Read, Grep, Glob, Bash
 You review changes to Guido. You report findings; you never edit the code.
 
 Read the diff first (`git diff HEAD`, or `gh pr diff <n>` when given a pull
-request). **Review the diff, not the codebase.** Something wrong in a line this
-change did not touch is not this change's finding — it is an issue, and saying
-so in one line at the end is the whole of what to do about it.
+request). **Review the diff, not the codebase.** Something wrong in a line this change did
+not touch is not this change's finding. Mention it once, among the notes, as
+something that would make an issue — you do not open one, and it does not
+belong in the levels below.
 
 Then check, in this order — the first two matter more than everything below
 them.
@@ -74,12 +75,17 @@ ship", and it is usually zero.
 
 ## When there is nothing that blocks
 
-Say so, in one line, and stop.
+The *verdict* is one line — "nothing blocks" — under whatever findings there
+are. It does not replace them: notes and things worth answering were asked for
+and are still worth writing down.
 
-A review that returns only notes has said the change is sound — that *is* the
-clean result, and it does not become an unclean one because the notes exist.
-Nothing here asks for a change to be defect-free; it asks for it not to ship
-broken.
+What it does replace is the search for something to escalate. A review that
+returns only notes has said the change is sound, that *is* the clean result, and
+it does not become an unclean one because the notes exist. Nothing here asks for
+a change to be defect-free; it asks for it not to ship broken.
+
+When there is nothing at all — nothing blocking, nothing worth answering, no
+note worth the reader's time — one line is the whole report.
 
 Do not manufacture findings to look thorough, do not promote a note to make a
 review look worthwhile, and do not review the same change twice hoping for a

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -75,19 +75,22 @@ is always the one that goes stale.
 
 **One pass.** Not until it comes back clean — that is not a state it reaches,
 because a reviewer asked to review returns a list and a list always has items.
-It sorts its findings by what they cost, and that is what decides:
 
-- **Blocks** — the change is wrong, nothing proves it, or it carries an
-  architectural decision that was the maintainer's. Stop. For the architectural
-  case, say what was found and ask: the same verb as step 1, because finding it
-  late does not move the decision to whoever wrote it.
+It sorts its findings into three levels and says how many block. What those
+levels mean is its business and is defined where it is defined; what you do with
+each is this:
+
+- **Blocks** — stop. If it is the architectural case, say what was found and
+  ask, which is the same verb as step 1: finding it late does not move the
+  decision to whoever wrote it.
 - **Worth answering** — act on it, or say in the pull request why you did not.
   Silence is what is not allowed; disagreement is fine.
-- **Note** — into the pull request or an issue. It stops nothing.
+- **Note** — into the pull request or an issue.
 
 **Zero blocking findings is the pass.** A review that comes back with only notes
 has said the change is sound; it does not become unsound because the notes
 exist, and clearing them is not what this step is for.
+
 A review that did not run is not a review that found nothing: the two look
 identical from the outside and mean opposite things. If it failed, timed out or
 was skipped, run it again; if it still will not run, say so in the pull request

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -73,23 +73,26 @@ Run it over the change. Its criteria live in `.claude/agents/reviewer.md` and ar
 not repeated here — a second copy is a second thing to keep true, and the copy
 is always the one that goes stale.
 
-What to do with what it says:
+**One pass.** Not until it comes back clean — that is not a state it reaches,
+because a reviewer asked to review returns a list and a list always has items.
+It sorts its findings by what they cost, and that is what decides:
 
-- **An architectural finding stops the work.** A new core type, a new trait, a
-  new cross-cutting mechanism, a new ownership rule, a family of call sites
-  respelled: that was the maintainer's decision to make before it was written,
-  and finding it here does not transfer the decision to whoever wrote it. Stop,
-  say what was found, and ask — the same verb as step 1.
-- **Everything else is yours to act on, or to disagree with in writing.** A
-  finding you did not act on is worth a sentence in the pull request rather than
-  silence; the next person will wonder the same thing.
-- **A clean report is one line and you move on.** Do not ask again hoping for a
-  different answer.
-- **A review that did not run is not a review that found nothing.** The two look
-  identical from the outside and mean opposite things. If it failed, timed out,
-  or was skipped, run it again; if it still will not run, say so in the pull
-  request in those words. Writing "nothing found" for a review that never
-  happened is the same act as re-blessing a golden to make a test pass.
+- **Blocks** — the change is wrong, nothing proves it, or it carries an
+  architectural decision that was the maintainer's. Stop. For the architectural
+  case, say what was found and ask: the same verb as step 1, because finding it
+  late does not move the decision to whoever wrote it.
+- **Worth answering** — act on it, or say in the pull request why you did not.
+  Silence is what is not allowed; disagreement is fine.
+- **Note** — into the pull request or an issue. It stops nothing.
+
+**Zero blocking findings is the pass.** A review that comes back with only notes
+has said the change is sound; it does not become unsound because the notes
+exist, and clearing them is not what this step is for.
+A review that did not run is not a review that found nothing: the two look
+identical from the outside and mean opposite things. If it failed, timed out or
+was skipped, run it again; if it still will not run, say so in the pull request
+in those words. Writing "nothing found" for a review that never happened is the
+same act as re-blessing a golden to make a test pass.
 
 ## 8. Open the pull request
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,10 +21,13 @@ CI refuses the pull request otherwise.
 ## What the review found
 
 <!--
-The `reviewer` subagent read this change before the pull request existed. What
-did it say, and what did you do about it. "Nothing — it reported the change
-sound" is a fine answer; so is a finding you disagreed with and why, which is
-worth a sentence here rather than silence.
+The `reviewer` subagent read this change before the pull request existed. How
+many findings blocked, and what happened to them — that number is usually zero,
+and zero is a pass, not a thing to apologise for.
+
+Findings worth answering that you did not act on belong here in a sentence
+each: silence is what is not allowed, disagreement is fine. Notes do not need
+repeating here unless somebody should pick them up later.
 
 If it did not run — it failed, it timed out, nobody invoked it — say that
 instead, in those words. A review that did not happen and a review that found

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,8 +152,10 @@ themselves when the task touches them; you do not need to read them up front.
 5. **Have it read by something that did not write it.** The `reviewer` subagent,
    over the committed change and before the pull request exists — its criteria
    ask about the commits, so they need the commits. Whoever wrote a change is
-   the worst judge of whether it grew, and an architectural finding here stops
-   the work: that decision belongs to the maintainer wherever it surfaces.
+   the worst judge of whether it grew. One pass, and its findings say what they
+   cost: **zero blocking findings is the pass**, notes are not something to
+   clear. An architectural finding stops the work — that decision belongs to the
+   maintainer wherever it surfaces.
 6. **Open the pull request** with the template filled in: what moved, what
    proves it, what the review found, what you looked at by hand.
 

--- a/tests/agent_workflow.rs
+++ b/tests/agent_workflow.rs
@@ -317,6 +317,16 @@ fn the_review_step_still_says_what_it_is_for() {
          them is the whole of it — and it does not"
     );
     assert!(
+        step_seven.contains("One pass"),
+        "step 7 does not say it is one pass, and a review with no stopping rule \
+         is a review that runs until somebody gets tired"
+    );
+    assert!(
+        step_seven.contains("Blocks") && step_seven.contains("Note"),
+        "step 7 does not sort findings by what they cost, so every finding \
+         reads as equally urgent and the list becomes something to skim"
+    );
+    assert!(
         step_seven.contains("did not run"),
         "step 7 does not say what to do when the review does not run, and a \
          review that did not run looks exactly like one that found nothing"

--- a/tests/agent_workflow.rs
+++ b/tests/agent_workflow.rs
@@ -323,8 +323,7 @@ fn the_review_step_still_says_what_it_is_for() {
     );
     assert!(
         step_seven.contains("Blocks") && step_seven.contains("Note"),
-        "step 7 does not sort findings by what they cost, so every finding \
-         reads as equally urgent and the list becomes something to skim"
+        "step 7 does not say what to do with each level of finding"
     );
     assert!(
         step_seven.contains("did not run"),
@@ -345,5 +344,38 @@ fn the_review_step_still_says_what_it_is_for() {
         agents.contains("`reviewer` subagent"),
         "AGENTS.md's list of what a change goes through never mentions the \
          reviewer, so the step exists only in the command"
+    );
+}
+
+/// The levels live in the reviewer's own file; the command only says what to do
+/// with each. So the command is the copy, and a test that reads only the copy
+/// defends the wrong document: delete the levels from `reviewer.md` and the
+/// command goes on sorting findings into categories nothing produces.
+///
+/// This asserts they agree, which is the only thing that keeps two files
+/// describing one mechanism honest.
+#[test]
+fn the_reviewer_and_the_command_use_the_same_levels() {
+    const LEVELS: [&str; 3] = ["Blocks", "Worth answering", "Note"];
+
+    let reviewer = read(".claude/agents/reviewer.md");
+    let implement = read(".claude/commands/implement.md");
+
+    for level in LEVELS {
+        assert!(
+            reviewer.contains(level),
+            "the reviewer never defines `{level}`, so nothing it reports can \
+             carry that level and the command sorts into an empty box"
+        );
+        assert!(
+            implement.contains(level),
+            "/implement never says what to do with `{level}`"
+        );
+    }
+
+    assert!(
+        reviewer.contains("how many block"),
+        "the reviewer gives no verdict, so `zero blocking findings is the pass` \
+         has nothing to read"
     );
 }


### PR DESCRIPTION
## What changed

The review step had no stopping rule and no severity. Run that way it never comes back clean: three passes over one prose change in #237 produced five, six and six findings, with severity falling through the floor while the count did not — round one found a real bug in what shipped, round three found backtick parity in a test written during round two. A reviewer asked to review returns a list, and a list always has items.

That is the documented way these tools fail. Without severity the critical findings sit in the same list as the cosmetic ones, everybody learns to skim, and the tool gets switched off. The recommended shape is three levels where only the top one blocks. Corro's `product-docs-audit` already had it — three categories, a disposition for each, and *"correggi il falso sempre, è l'unica categoria che fa danno"*.

So findings are sorted by what they cost:

| level | what it does |
| --- | --- |
| **Blocks** | wrong, unproved, or an architectural decision that was the maintainer's — work stops |
| **Worth answering** | act on it, or say in the pull request why you did not; silence is what is not allowed, disagreement is fine |
| **Note** | into the pull request or an issue, stops nothing |

**Zero blocking findings is the pass.** A review returning only notes has said the change is sound, and clearing the notes is not what the step is for. One pass, over the diff and not the codebase — at #237's third round the reviewer was reading a test the change under review had introduced, which is a fine thing to read and not that change's finding.

## What proves it

Three assertions in `tests/agent_workflow.rs`, each verified by inversion:

| broken on purpose | what fails |
| --- | --- |
| the one-pass paragraph deleted | `a review with no stopping rule runs until somebody gets tired` |
| the levels deleted from `reviewer.md` | `the reviewer never defines Blocks… the command sorts into an empty box` |
| step 7's dispositions deleted | `step 7 does not say what to do with each level of finding` |

## What the review found

One pass, as the rule now says. **One finding blocked**, two were worth answering, two were notes — and it ended with a verdict line, which is the difference from every review before it.

**Blocking**: the two assertions read `.claude/commands/implement.md` and nothing read `.claude/agents/reviewer.md`, where the levels actually live. Delete the reviewer's reporting rules and the harness stays green while the command goes on sorting findings into categories nothing produces. The harness defended the copy, not the original. Fixed by asserting the two files agree.

**Worth answering, both acted on**: step 7 said the criteria are not repeated there and then repeated them almost word for word — it carries the dispositions now, not the definitions. And *"when nothing blocks, say so in one line and stop"* fired on nearly every review, since nothing blocking is the usual case, and read literally it discarded the notes the section above had just asked for. The reviewer reported that one from the inside: it had to choose an interpretation before it could write anything. The one line is the verdict now, under whatever findings there are.

**Notes**: a lost blank line that ran the did-not-run rule into the paragraph above it, and two sentences both claiming the last line of the report. Both fixed.

It was not run a second time. The rule says one pass, and re-running it to see whether it comes back clean is exactly the behaviour this change exists to stop.

## What was checked by hand

Nothing needed a compositor. Every inversion above was run and its message read.

## Left undone

**The bar makes the step finite. It does not yet make it useful, and that needs numbers this branch cannot have.** One pull request is a sample of one: today's count is one blocking finding out of one review, which is not zero and proves nothing.

The measurement is already available — every pull request body now says how many blocked, so `gh pr list --json body` counts it. If blocking findings stay at zero across ten or twenty pull requests, the step is costing more than it returns and belongs on a sample rather than on every change. The honest answer then is to take it off the required path, not to defend it.