### PR TITLE
A translate is watched from its seed to the frame it reaches

### DIFF
--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -1234,6 +1234,185 @@ fn declaring_a_transition_after_a_sequence_does_not_lose_it() {
     );
 }
 
+/// A translate that animates has to arrive where its signal points.
+///
+/// The one component with no such test until now, and four separate lists name
+/// it on the way: the target is only computed where `advance_animations` says
+/// the component is animated, and resolved only where `animated_transform`
+/// says something could move it.
+#[test]
+fn an_animated_translate_reaches_the_paint() {
+    let offset = create_signal(Translate::NONE);
+    let mut h = H::new(
+        container().layout(Flex::row()).child(
+            box_of(50.0, 50.0)
+                .translate(offset)
+                .animate_translate(Transition::new(600.0, TimingFunction::Linear)),
+        ),
+    );
+    h.fit(200.0, 200.0);
+    h.paint();
+    assert_eq!(
+        h.paint().children[0].local_transform.tx(),
+        0.0,
+        "at rest it sits where it was laid out"
+    );
+
+    offset.set(Translate::new(40.0, 0.0));
+
+    // One frame in: moving, and not arrived. Without this the test passes with
+    // the animation deleted outright — `get_animated_value` falls back to the
+    // signal, and paint lands on 40 the first time it is asked.
+    pump(&mut h);
+    h.fit(200.0, 200.0);
+    let midway = h.paint().children[0].local_transform.tx();
+    assert!(
+        midway > 0.0 && midway < 39.0,
+        "it has to animate towards the target rather than snap to it, got {midway}"
+    );
+
+    settle(&mut h, 400);
+    let tx = h.paint().children[0].local_transform.tx();
+    assert!(
+        (tx - 40.0).abs() < 0.5,
+        "the animation has to arrive at what the signal named, got {tx}"
+    );
+}
+
+/// A target the widget could only have reached through a branch it was not
+/// subscribed to when it first laid out.
+///
+/// `seed_animations` subscribes once, to whatever the closure read at the first
+/// layout — here `armed` alone, because the other branch was not taken.
+/// `advance_animations` reads in a `snapshot_zone` and subscribes to nothing.
+/// So `resync_animation_targets` is the only pass that can ever pick up
+/// `offset`, and the write below is the one nothing else can see: flipping
+/// `armed` wakes the container by the subscription it already had, but the
+/// write *after* that has only the re-sync between it and a stale value.
+#[test]
+fn a_translate_target_behind_an_untaken_branch_is_picked_up_by_the_resync() {
+    let armed = create_signal(false);
+    let offset = create_signal(0.0f32);
+    let mut h = H::new(
+        container().layout(Flex::row()).child(
+            box_of(50.0, 50.0)
+                .translate(move || {
+                    if armed.get() {
+                        Translate::new(offset.get(), 0.0)
+                    } else {
+                        Translate::NONE
+                    }
+                })
+                .animate_translate(Transition::new(80.0, TimingFunction::Linear)),
+        ),
+    );
+    h.fit(200.0, 200.0);
+    h.paint();
+
+    // The branch flips. This much the first subscription can see, and the
+    // paint it causes is the only chance anything has to notice `offset`.
+    armed.set(true);
+    settle(&mut h, 120);
+
+    offset.set(40.0);
+    settle(&mut h, 120);
+
+    let tx = h.paint().children[0].local_transform.tx();
+    assert!(
+        (tx - 40.0).abs() < 0.5,
+        "a target behind a branch nobody tracked still has to converge, got {tx}"
+    );
+}
+
+/// An enter animates in from the value it was handed instead of snapping to
+/// the target — for a translate, which `seed_animations` reaches through a
+/// third list, after the one that decides it is initial and the one that
+/// computes its target.
+#[test]
+fn an_entering_translate_starts_from_where_it_was_told() {
+    let entering = box_of(50.0, 50.0)
+        .translate(Translate::NONE)
+        .animate_translate_from(
+            Translate::new(0.0, -20.0),
+            Transition::new(200.0, TimingFunction::EaseOut),
+        );
+
+    let mut h = H::new(container().layout(Flex::row()).child(entering));
+    h.fit(200.0, 200.0);
+    h.paint();
+    pump(&mut h);
+    h.fit(200.0, 200.0);
+    let painted = h.paint().children[0].local_transform;
+
+    assert_eq!(
+        painted.tx(),
+        0.0,
+        "the enter was declared on one axis and has to stay on it"
+    );
+    assert!(
+        painted.ty() < -1.0,
+        "it has to start up where it was told, not snap to the target, got {}",
+        painted.ty()
+    );
+}
+
+/// The other two timelines, which `advance_animations` starts and
+/// `resync_animation_targets` wakes from lists that name each component once.
+/// Only `keyframes_rotate` was played by anything before this.
+///
+/// Neither sequence passes through the value that composes to the identity —
+/// the displacement stays out at 10 and the pulse never comes back below 1.1 —
+/// so neither assertion depends on how far the clock moved between `play` and
+/// the advance that reads it. A scale is the one that needs this: it
+/// interpolates *around* 1.0, and the first ~30ns of a linear ramp round to
+/// exactly `Scale::NONE`. Where the timeline never ran at all, the animation
+/// still holds the value it was built with, which is neutral, and that is what
+/// each assertion is against.
+#[test]
+fn a_translate_sequence_and_a_scale_sequence_move_the_transform() {
+    use crate::animation::Keyframes;
+
+    let plays = create_signal(0u32);
+    let mut h = H::new(
+        container().layout(Flex::row()).child(
+            box_of(50.0, 50.0).keyframes_translate(
+                Keyframes::new(200.0)
+                    .at(0.0, Translate::new(10.0, 0.0))
+                    .at(0.5, Translate::new(30.0, 0.0))
+                    .at(1.0, Translate::new(10.0, 0.0)),
+                plays,
+            ),
+        ),
+    );
+    h.fit(200.0, 200.0);
+    h.paint();
+    plays.set(1);
+    let played = played_transform(&mut h).tx();
+    assert!(
+        played > 5.0,
+        "a displacement sequence has to reach the paint, not only the job \
+         queue, got {played}"
+    );
+
+    let plays = create_signal(0u32);
+    let mut h = H::new(
+        container().layout(Flex::row()).child(
+            box_of(50.0, 50.0).keyframes_scale(
+                Keyframes::new(200.0)
+                    .at(0.0, Scale::uniform(1.1))
+                    .at(0.5, Scale::uniform(1.4))
+                    .at(1.0, Scale::uniform(1.1)),
+                plays,
+            ),
+        ),
+    );
+    h.fit(200.0, 200.0);
+    h.paint();
+    plays.set(1);
+    let played = played_transform(&mut h).a();
+    assert!(played > 1.05, "and so does a pulse, got {played}");
+}
+
 // ---------------------------------------------------------------------------
 // Focus, now that it is stored state
 // ---------------------------------------------------------------------------

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -235,6 +235,32 @@ fn a_scaling_state_layer_declares_only_a_scale() {
     assert!(!declared.rotate, "or a rotate");
 }
 
+/// And the other two mirrors, because `moves_anything` answers for the three
+/// components in a list of its own: one that named the wrong field would put a
+/// container back on the slow path, or leave it on the fast one while a layer
+/// moved it.
+#[test]
+fn a_translating_or_rotating_layer_declares_only_its_own_component() {
+    let declares = |c: &Container| {
+        c.interaction
+            .as_ref()
+            .map(|ix| ix.declares_transform)
+            .unwrap_or_default()
+    };
+
+    let translating =
+        declares(&container().when_hovered(|s| s.translate(Translate::new(0.0, -2.0))));
+    assert!(translating.translate, "the hovered layer names a translate");
+    assert!(
+        !translating.rotate && !translating.scale,
+        "and nothing else"
+    );
+
+    let rotating = declares(&container().when_pressed(|s| s.rotate(2.0)));
+    assert!(rotating.rotate, "the pressed layer names a rotate");
+    assert!(!rotating.translate && !rotating.scale, "and nothing else");
+}
+
 #[test]
 fn content_sizing_is_child_plus_padding() {
     let mut h = H::new(container().padding(8.0).child(box_of(40.0, 20.0)));
@@ -851,6 +877,75 @@ fn a_border_width_animation_counts_as_movable_by_a_state_layer() {
     assert!(
         !plain.has_animated_state_properties(),
         "with nothing animated, a plain repaint is the whole job"
+    );
+}
+
+/// The same question for the three transform components, which answer it from
+/// a list of their own.
+#[test]
+fn a_state_layer_moving_an_animated_transform_counts_as_movable() {
+    let t = || Transition::new(80.0, TimingFunction::Linear);
+
+    assert!(
+        container()
+            .animate_translate(t())
+            .when_hovered(|s| s.translate(Translate::new(0.0, -2.0)))
+            .has_animated_state_properties(),
+        "hovering moves the translate, so it needs an Animation job"
+    );
+    assert!(
+        container()
+            .animate_rotate(t())
+            .when_hovered(|s| s.rotate(2.0))
+            .has_animated_state_properties(),
+        "and a rotate"
+    );
+    assert!(
+        container()
+            .animate_scale(t())
+            .when_pressed(|s| s.scale(0.98))
+            .has_animated_state_properties(),
+        "and a scale — the layer on every button there is"
+    );
+    assert!(
+        !container()
+            .when_pressed(|s| s.scale(0.98))
+            .has_animated_state_properties(),
+        "and with nothing animated, a plain repaint is the whole job"
+    );
+}
+
+/// Every animated transform component holds a copy of signal-derived state, so
+/// every one of them needs the paint-time target re-sync. Width does not: its
+/// target follows the measured content and is recomputed at each layout.
+///
+/// Asked of the predicate rather than through a moving container, for the
+/// reason the border-width test above gives and one more of its own.
+/// `seed_animations` subscribes to the *condition* of a branching closure at
+/// the first layout, so flipping that condition queues an Animation job by that
+/// route and the container converges even with the re-sync gone. The
+/// behavioural route cannot see this omission; the predicate can.
+#[test]
+fn each_animated_transform_component_is_a_signal_animated_prop() {
+    let t = || Transition::new(80.0, TimingFunction::Linear);
+
+    assert!(
+        container()
+            .animate_translate(t())
+            .has_signal_animated_props(),
+        "a translate animation mirrors a signal, so it re-syncs at paint"
+    );
+    assert!(
+        container().animate_rotate(t()).has_signal_animated_props(),
+        "and a rotate"
+    );
+    assert!(
+        container().animate_scale(t()).has_signal_animated_props(),
+        "and a scale"
+    );
+    assert!(
+        !container().animate_width(t()).has_signal_animated_props(),
+        "a width follows the content it measured, and is retargeted at layout"
     );
 }
 


### PR DESCRIPTION
## What changed

A translate was watched while it held still and by nothing at all once it
moved. `animate_translate`, `animate_translate_from` and `keyframes_translate`
were named by no test in the repository — only by prose and by two examples
`cargo test` builds and never runs — and `keyframes_scale` had no use outside a
doc comment. Seven tests now drive the three transform components through the
four passes that name them one at a time, so a component dropped from any of
those lists fails a test instead of a review. No production code changes: the
diff is 274 insertions and zero deletions, all in
`src/widgets/container/characterization.rs`.

Closes #229

## What proves it

The tests are the change, so the usual order is inverted: there is nothing that
fails before and passes after, because the code was already correct. What each
test is worth is what it catches, so each was run against the one-line deletion
it exists to stop — applied on its own, `cargo test --all-features --lib` run,
the tree restored:

| deletion | test that went red |
| --- | --- |
| `animates_translate` → `false` (`mod.rs:1262`) | `an_animated_translate_reaches_the_paint` |
| `translate` out of `has_signal_animated_props` (`style.rs:334`) | `each_animated_transform_component_is_a_signal_animated_prop` |
| `translate` out of `has_animated_state_properties` (`style.rs:317`) | `a_state_layer_moving_an_animated_transform_counts_as_movable` |
| the translate drift check out of `resync_animation_targets` (`anim_bridge.rs:202`) | `a_translate_target_behind_an_untaken_branch_is_picked_up_by_the_resync` |
| `tr_init` → `false` in `seed_animations` (`anim_bridge.rs:112`) | `an_entering_translate_starts_from_where_it_was_told` |
| `translate`'s `wants_play` out of the re-sync (`anim_bridge.rs:275`) | `a_translate_sequence_and_a_scale_sequence_move_the_transform` |
| `start_timeline!(translate)` (`mod.rs:1349`) | the same |
| `start_timeline!(scale)` (`mod.rs:1351`) | the same |
| `Moves::translate` → `false` (`state_layer.rs:156`) | `a_translating_or_rotating_layer_declares_only_its_own_component` |

All nine were green on `main` before this.

`cargo mutants` over the two files the issue names, on `main` and on this
branch — 170 viable mutants each:

```
cargo mutants -f 'src/widgets/container/style.rs' \
              -f 'src/widgets/container/anim_bridge.rs' -C --lib -j 8
```

| | caught | missed |
| --- | --- | --- |
| `main` | 121 | 49 |
| this branch | **129** | **41** |

Eight newly caught, none newly missed, and every one of the eight is a
transform-component line: the `tr_init \|\| ro_init \|\| sc_init` chain in
`seed_animations` (:134, :135), `effective_translate_target` returning a
default (`style.rs:116`), the component gates in `animated_transform` (:271),
all three of `translate`/`rotate`/`scale` in `has_animated_state_properties`
(:324-326), and `translate` in `has_signal_animated_props` (:342).

The survivors that remain in those two predicates are `border_width`,
`background`, `corners`, `elevation` and `border_color` — the non-transform
properties, which nothing asserts one at a time and which #229 was not about.

Harness: `cargo fmt --check` clean, `cargo clippy --all-targets --all-features
-- -D warnings` clean, `cargo test --all-features` green (547 lib plus the
integration suites), `cargo test --test golden_images` 9/9 on lavapipe with no
skips. No golden and no snapshot moved, which is right for a change that adds
no production code.

## What the review found

**Zero blocking.** Three findings worth answering, all acted on:

1. *The scale half of the sequence test asserted a difference about 30 ns
   wide.* A scale interpolates around 1.0, so the first nanoseconds of a linear
   ramp round to exactly `Scale::NONE` and compose to the identity; the
   assertion depended on the gap between `play()` and the advance that reads
   it. Both sequences now step off a floor their timeline never returns to —
   the displacement stays out at 10, the pulse never comes back below 1.1 — and
   assert a value rather than "not the identity". No clock in either assertion.
2. *Two names promised more than they asserted.*
   `an_entering_translate_starts_from_where_it_was_told` now pins the axis
   (`tx() == 0.0`) and the direction (`ty() < -1.0`) instead of "not the
   identity", which an enter from the wrong axis or sign would have passed.
   `an_animated_translate_reaches_the_paint` passed with the animation deleted
   outright — paint fell back to reading the signal and landed on 40 at once —
   so it now asserts one frame in that the value is moving and has not arrived.
   Verified: deleting the `.animate_translate(..)` from that test turns it red.
3. *The `cargo mutants` figure the issue asked for was missing.* Above.

One note also acted on: `a_state_layer_moving_an_animated_transform_counts_as_movable`
had no negative case, unlike the border-width test it mirrors. It has one now.

Two notes left for later, neither this change's:

- `has_animated_state_properties` reads only `self.anims` and never
  `self.interaction`, so the `when_hovered`/`when_pressed` clauses in that test
  are inert while its name says the layer participates. House style — the
  border-width test it mirrors is the same shape — but it means neither test
  would notice a state layer that stopped counting.
- Nothing covers the *spring* translate path, which is what the real callers
  use: `examples/spring_momentum.rs` calls
  `animate_translate(Transition::spring(..))` four times, and every test here
  uses a timed transition.

## What was checked by hand

Nothing on a compositor — this adds no production code, so there is no
behaviour to look at. What was done by hand instead is the deletion table
above, and running the four timing-sensitive tests 20 times in a row (20/20) to
check the wall-clock sleeps in `settle` do not make them flaky. The direction is
safe as well as measured: load lengthens those sleeps, which helps an animation
converge rather than hurting it.

## Left undone

Two deviations from the issue, both deliberate:

- It asked for `a_scaling_state_layer_declares_only_a_scale` to be *extended*
  with the translate and rotate mirrors. A sibling test carries them instead, so
  each name stays true to what it asserts.
- It named one test for `has_signal_animated_props` and the re-sync drift check
  together. That is not possible — deleting the drift check cannot turn a
  predicate test red — so it is two: the predicate, and a behavioural test that
  reaches a target through a branch the container was not subscribed to when it
  first laid out.

Everything else in #229 stays open there and is untouched: the mechanism that
would make the membership a compile error (which needs a design decision), the
duplicated `Animatable` impls for `Translate` and `Scale`, and the overlap
between `tests/signal_conversions.rs` and `tests/transform_api.rs`.
