### PR TITLE
The handle is drawn where the offset puts it, not where a pass left it

### DIFF
--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -1381,8 +1381,9 @@ impl Widget for Container {
             }
         }
 
-        // Update scrollbar handle positions based on current scroll offset
-        // (scroll is paint-only, so layout may not run during scrolling)
+        // Keep the origin the Tree holds for the handle in step with the offset,
+        // for the events forwarded to the handle widget. What is *drawn* no
+        // longer depends on this pass having run — see `scrollbar_handle_origin`.
         if self.scroll_axis != ScrollAxis::None {
             self.update_scrollbar_handle_positions(tree, id);
         }

--- a/src/widgets/container/scrollable.rs
+++ b/src/widgets/container/scrollable.rs
@@ -298,9 +298,21 @@ impl Container {
         animating
     }
 
-    /// Update scrollbar handle positions based on current scroll offset.
-    /// Called from advance_animations to ensure handles are positioned correctly
-    /// even when layout doesn't run (scroll is paint-only).
+    /// Write the handle's origin into the `Tree` for the current scroll offset.
+    ///
+    /// Not for the paint, which derives the position itself
+    /// (`scrollbar_handle_origin`): this is for the handle *widget*, which is a
+    /// `Container` of its own and hit-tests the events forwarded to it —
+    /// `MouseDown` at the start of a drag, the synthetic `MouseEnter` — against
+    /// the bounds the `Tree` holds for it. Layout writes that origin too.
+    ///
+    /// It does not cover the paint-only paths, and does not claim to: the one
+    /// caller is `advance_animations`, which runs for a `JobType::Animation`
+    /// job alone, so after a wheel scroll or a click on the track this origin
+    /// is stale until something asks for an animation frame. Pressing the
+    /// handle still starts the drag — that is decided from the derived rect —
+    /// but the handle's own pressed and hover colours miss it until then.
+    /// One answer for both readers is #244.
     pub(super) fn update_scrollbar_handle_positions(&mut self, tree: &mut Tree, id: WidgetId) {
         if self.scroll_axis == ScrollAxis::None
             || self.scroll().scrollbar_visibility == ScrollbarVisibility::Hidden
@@ -349,6 +361,42 @@ impl Container {
         }
     }
 
+    /// Where the handle belongs for the offset the container holds right now.
+    ///
+    /// Layout gives the handle its size and writes an origin into the `Tree`;
+    /// the offset gives it its place, and the offset moves without layout —
+    /// scrolling is paint-only, so a wheel scroll and a click on the track ask
+    /// for a `Paint` and nothing repositions anything. Painting from that
+    /// stored origin drew the handle wherever the last layout or animation pass
+    /// happened to leave it. Every hit test already derives the rect instead —
+    /// `handle_scrollbar_click`, `handle_scrollbar_drag`,
+    /// `update_scrollbar_hover` — and deriving it here too is what stops the
+    /// paint and the hit test disagreeing about where the handle is.
+    fn scrollbar_handle_origin(
+        &self,
+        tree: &Tree,
+        id: WidgetId,
+        axis: ScrollbarAxis,
+    ) -> (f32, f32) {
+        let bounds = tree.get_bounds(id).unwrap_or_default();
+        // Local bounds, like every other scrollbar computation: the parent
+        // transform carries the container's own position.
+        let local_bounds = Rect::new(0.0, 0.0, bounds.width, bounds.height);
+
+        let sd = self.scroll();
+        let needs_other = match axis {
+            ScrollbarAxis::Vertical => sd.scroll_state.needs_horizontal_scrollbar(),
+            ScrollbarAxis::Horizontal => sd.scroll_state.needs_vertical_scrollbar(),
+        };
+        let rect = sd.scroll_state.scrollbar_handle_rect(
+            axis,
+            local_bounds,
+            &sd.scrollbar_config,
+            needs_other,
+        );
+        (rect.x, rect.y)
+    }
+
     /// Paint scrollbar container widgets.
     /// Scrollbar containers are registered in Tree with real WidgetIds.
     /// Scrollbar bounds are in local coordinates (relative to container origin 0,0).
@@ -356,7 +404,7 @@ impl Container {
     pub(super) fn paint_scrollbar_containers(
         &self,
         tree: &Tree,
-        _id: WidgetId,
+        id: WidgetId,
         ctx: &mut PaintContext,
     ) {
         use crate::transform::Transform;
@@ -414,7 +462,9 @@ impl Container {
 
                 let mut handle_ctx = ctx.add_child(handle_id.as_u64(), handle_local);
                 // Scale from right edge (transform origin at right center)
-                let position = Transform::translate(handle_bounds.x, handle_bounds.y);
+                let (handle_x, handle_y) =
+                    self.scrollbar_handle_origin(tree, id, ScrollbarAxis::Vertical);
+                let position = Transform::translate(handle_x, handle_y);
                 let scale_origin_x = handle_bounds.width;
                 let scale_origin_y = handle_bounds.height / 2.0;
                 let combined = position
@@ -459,7 +509,9 @@ impl Container {
 
                 let mut handle_ctx = ctx.add_child(handle_id.as_u64(), handle_local);
                 // Scale from bottom edge (transform origin at bottom center)
-                let position = Transform::translate(handle_bounds.x, handle_bounds.y);
+                let (handle_x, handle_y) =
+                    self.scrollbar_handle_origin(tree, id, ScrollbarAxis::Horizontal);
+                let position = Transform::translate(handle_x, handle_y);
                 let scale_origin_x = handle_bounds.width / 2.0;
                 let scale_origin_y = handle_bounds.height;
                 let combined = position

--- a/tests/scrollbar_handle_tracking.rs
+++ b/tests/scrollbar_handle_tracking.rs
@@ -1,0 +1,302 @@
+//! The scrollbar handle is drawn where the offset says it is.
+//!
+//! Scrolling is paint-only, and the loop runs `advance_animations` for a
+//! `JobType::Animation` job alone. A wheel scroll and a click on the track both
+//! request a plain `Paint`, so every case here dispatches an event and paints
+//! with no animation pass in between — which is what the loop actually does for
+//! them. Running one here would mask the defect: it repositions the handle, and
+//! the test would pass without the fix.
+//!
+//! Both axes, because both are drawn from the same derivation and either can
+//! lose it on its own.
+
+use guido::layout::{Constraints, Flex};
+use guido::prelude::*;
+use guido::renderer::{PaintContext, RenderNode};
+use guido::tree::{Tree, WidgetId};
+
+/// The scrollbar sits 2px in from the edges of the container along its axis,
+/// and is `width` across — 6 by default. So a 200-long viewport carries a
+/// 196-long track starting at 2.
+const VIEWPORT: f32 = 200.0;
+const TRACK_START: f32 = 2.0;
+const TRACK_LENGTH: f32 = 196.0;
+
+/// A vertical scroller: 200x200 over 648px of content — 20 rows of 24, spaced
+/// 8, padded 8. The handle is `viewport / content * track` long.
+const V_CONTENT: f32 = 648.0;
+const V_HANDLE: f32 = 60.4938;
+
+/// A horizontal scroller: 200x80 over 888px of content — 10 columns of 80,
+/// spaced 8, padded 8.
+const H_CONTENT: f32 = 888.0;
+const H_HANDLE: f32 = 44.1441;
+
+/// Where the handle belongs for a given offset: the same proportion
+/// `ScrollState::scrollbar_handle_rect` computes, written out so the test says
+/// what it expects rather than deferring to the code under test.
+fn expected(offset: f32, content: f32, handle: f32) -> f32 {
+    let max_scroll = content - VIEWPORT;
+    TRACK_START + (offset / max_scroll) * (TRACK_LENGTH - handle)
+}
+
+struct H {
+    tree: Tree,
+    root: WidgetId,
+    /// Whether the handle travels in x or in y — the same question as which
+    /// axis the container scrolls on.
+    horizontal: bool,
+}
+
+impl H {
+    fn vertical() -> Self {
+        Self::new(
+            container()
+                .width(VIEWPORT)
+                .height(VIEWPORT)
+                .scrollable(ScrollAxis::Vertical)
+                .child(
+                    container()
+                        .layout(Flex::column().spacing(8.0))
+                        .padding(8.0)
+                        .children((0..20).map(|_| container().width(120.0).height(24.0))),
+                ),
+            VIEWPORT,
+            false,
+        )
+    }
+
+    fn horizontal() -> Self {
+        Self::new(
+            container()
+                .width(VIEWPORT)
+                .height(80.0)
+                .scrollable(ScrollAxis::Horizontal)
+                .child(
+                    container()
+                        .layout(Flex::row().spacing(8.0))
+                        .padding(8.0)
+                        .children((0..10).map(|_| container().width(80.0).height(24.0))),
+                ),
+            80.0,
+            true,
+        )
+    }
+
+    fn new(view: impl Widget + 'static, height: f32, horizontal: bool) -> Self {
+        let mut tree = Tree::new();
+        let root = tree.register(Box::new(view));
+        tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
+        // Once, deliberately: layout does not run again for a paint-only scroll,
+        // so neither does this test.
+        tree.with_widget_mut(root, |w, id, t| {
+            w.layout(t, id, Constraints::new(0.0, 0.0, VIEWPORT, height))
+        });
+        Self {
+            tree,
+            root,
+            horizontal,
+        }
+    }
+
+    fn dispatch(&mut self, event: Event) {
+        let root = self.root;
+        self.tree
+            .with_widget_mut(root, |w, id, t| w.event(t, id, &event));
+    }
+
+    fn paint(&mut self) -> RenderNode {
+        let root = self.root;
+        let mut node = RenderNode::new(root.as_u64());
+        self.tree.with_widget_mut(root, |w, id, t| {
+            let mut ctx = PaintContext::new(&mut node);
+            w.paint(t, id, &mut ctx);
+        });
+        node
+    }
+
+    /// The painted position of the scrollbar handle, along the axis it travels.
+    ///
+    /// `paint_scrollbar_containers` draws the track and then the handle, after
+    /// the content, so the scroller's children are content, track, handle. The
+    /// handle's extent is asserted so that a change to that order fails here
+    /// loudly rather than by silently measuring the wrong node.
+    fn handle_pos(&mut self) -> f32 {
+        let horizontal = self.horizontal;
+        let expect_extent = if horizontal { H_HANDLE } else { V_HANDLE };
+
+        let node = self.paint();
+        assert_eq!(
+            node.children.len(),
+            3,
+            "expected content, track and handle under the scroller"
+        );
+        let handle = &node.children[2];
+        let extent = if horizontal {
+            handle.bounds.width
+        } else {
+            handle.bounds.height
+        };
+        assert!(
+            (extent - expect_extent).abs() < 0.01,
+            "third child is {}x{}, not the handle",
+            handle.bounds.width,
+            handle.bounds.height
+        );
+
+        if horizontal {
+            handle.local_transform.tx()
+        } else {
+            handle.local_transform.ty()
+        }
+    }
+
+    /// How far the content has been scrolled, read off its painted origin.
+    fn scrolled_by(&mut self) -> f32 {
+        let content = &self.paint().children[0];
+        if self.horizontal {
+            -content.local_transform.tx()
+        } else {
+            -content.local_transform.ty()
+        }
+    }
+
+    fn wheel(&mut self, delta: f32) {
+        let (delta_x, delta_y) = if self.horizontal {
+            (delta, 0.0)
+        } else {
+            (0.0, delta)
+        };
+        self.dispatch(Event::Scroll {
+            x: 100.0,
+            y: 40.0,
+            delta_x,
+            delta_y,
+            source: ScrollSource::Wheel,
+        });
+    }
+}
+
+fn near(actual: f32, expected: f32) -> bool {
+    (actual - expected).abs() < 0.01
+}
+
+/// A mouse wheel never sets a velocity — `apply_scroll` gates that on
+/// `ScrollSource::Finger` — so it always takes the plain `Paint` arm. It is the
+/// ordinary way to scroll, and the handle has to follow it.
+#[test]
+fn a_wheel_scroll_moves_the_handle() {
+    let mut h = H::vertical();
+    assert!(
+        near(h.handle_pos(), TRACK_START),
+        "handle starts at the top"
+    );
+
+    h.wheel(120.0);
+
+    assert!(near(h.scrolled_by(), 120.0), "the content scrolled");
+    let want = expected(120.0, V_CONTENT, V_HANDLE);
+    let got = h.handle_pos();
+    assert!(near(got, want), "handle at {got}, expected {want}");
+}
+
+/// Clicking the foot of the track jumps the content to the end, so the handle
+/// belongs hard against the bottom of the track.
+#[test]
+fn a_track_click_moves_the_handle() {
+    let mut h = H::vertical();
+
+    h.dispatch(Event::MouseDown {
+        x: 195.0,
+        y: 190.0,
+        button: MouseButton::Left,
+    });
+
+    let max_scroll = V_CONTENT - VIEWPORT;
+    assert!(near(h.scrolled_by(), max_scroll), "the content jumped");
+    let want = expected(max_scroll, V_CONTENT, V_HANDLE);
+    let got = h.handle_pos();
+    assert!(near(got, want), "handle at {got}, expected {want}");
+}
+
+/// The same, sideways. A horizontal scroller is drawn from its own branch of
+/// `paint_scrollbar_containers`, so it can lose the derivation on its own —
+/// and `examples/scroll_example.rs` has one.
+#[test]
+fn a_wheel_scroll_moves_the_horizontal_handle() {
+    let mut h = H::horizontal();
+    assert!(
+        near(h.handle_pos(), TRACK_START),
+        "handle starts at the left"
+    );
+
+    h.wheel(200.0);
+
+    assert!(near(h.scrolled_by(), 200.0), "the content scrolled");
+    let want = expected(200.0, H_CONTENT, H_HANDLE);
+    let got = h.handle_pos();
+    assert!(near(got, want), "handle at {got}, expected {want}");
+}
+
+/// Clicking the right end of a horizontal track puts the handle hard against
+/// it, the mirror of the vertical case.
+#[test]
+fn a_track_click_moves_the_horizontal_handle() {
+    let mut h = H::horizontal();
+
+    h.dispatch(Event::MouseDown {
+        x: 190.0,
+        y: 75.0,
+        button: MouseButton::Left,
+    });
+
+    let max_scroll = H_CONTENT - VIEWPORT;
+    assert!(near(h.scrolled_by(), max_scroll), "the content jumped");
+    let want = expected(max_scroll, H_CONTENT, H_HANDLE);
+    let got = h.handle_pos();
+    assert!(near(got, want), "handle at {got}, expected {want}");
+}
+
+/// The handle travels the track in proportion to the offset, at every offset
+/// rather than at the two the cases above happen to reach.
+#[test]
+fn the_handle_follows_the_offset_across_the_track() {
+    let max_scroll = V_CONTENT - VIEWPORT;
+    for step in 0..=8 {
+        let offset = max_scroll * step as f32 / 8.0;
+        let mut h = H::vertical();
+        if offset > 0.0 {
+            h.wheel(offset);
+        }
+        let want = expected(offset, V_CONTENT, V_HANDLE);
+        let got = h.handle_pos();
+        assert!(
+            near(got, want),
+            "at offset {offset}: handle at {got}, expected {want}"
+        );
+    }
+}
+
+/// The invariant behind the others: what is painted is what the hit test
+/// accepts a drag on. Pressing the middle of the *painted* handle must begin a
+/// drag — which leaves the offset alone — and not land on the track, which
+/// would jump the content somewhere else.
+#[test]
+fn pressing_the_painted_handle_starts_a_drag_rather_than_jumping_the_track() {
+    let mut h = H::vertical();
+    h.wheel(120.0);
+
+    let painted_centre = h.handle_pos() + V_HANDLE / 2.0;
+    h.dispatch(Event::MouseDown {
+        x: 195.0,
+        y: painted_centre,
+        button: MouseButton::Left,
+    });
+
+    let after = h.scrolled_by();
+    assert!(
+        near(after, 120.0),
+        "pressing the painted handle at y={painted_centre} moved the content to {after}: \
+         the paint and the hit test disagree about where the handle is"
+    );
+}


### PR DESCRIPTION
## What changed

The scrollbar handle is now drawn at the position the current scroll offset
implies, instead of at an origin cached in the `Tree` that only layout and
`advance_animations` ever wrote. Scrolling is paint-only, so every offset change
that asked for a plain `Paint` — an ordinary mouse wheel, a click on the track —
moved the content and left the handle behind. `paint_scrollbar_containers`
derives the position from `ScrollState::scrollbar_handle_rect`, which is what
every hit test already did, so the paint and the hit test can no longer disagree
about where the handle is. Both axes. Closes #201

## What proves it

`tests/scrollbar_handle_tracking.rs`, six cases, all failing on `main`:

- `a_wheel_scroll_moves_the_handle` — `handle at 2, expected 38.296303`
- `a_track_click_moves_the_handle` — `handle at 2, expected 137.5062`
- `a_wheel_scroll_moves_the_horizontal_handle` — `handle at 2, expected 46.144154`
- `a_track_click_moves_the_horizontal_handle` — `handle at 2, expected 153.8559`
- `the_handle_follows_the_offset_across_the_track` — nine offsets
- `pressing_the_painted_handle_starts_a_drag_rather_than_jumping_the_track` —
  the invariant behind the rest: the press lands on the track and jumps the
  content to 0 without the fix

The tests dispatch and paint with **no animation pass in between**, which is
what the loop does for a `Paint` job. Running one repositions the handle and
hides the defect, so a test that calls `advance_animations` passes on `main`.

Each axis was checked to be load-bearing separately: reverting only the
horizontal `Transform::translate` leaves the whole suite green except the two
horizontal cases.

Nothing re-blessed. `tests/snapshots/scrolling.snap` is untouched — it paints at
offset 0, where the derived and cached positions agree — and the nine goldens on
lavapipe all pass unmoved. Full suite green, clippy clean with `-D warnings`.

## What the review found

The `reviewer` subagent ran over the commit before this pull request existed.
**One blocking finding**, acted on:

- *The horizontal half of the fix was proved by nothing.* It verified this by
  reverting those three lines and watching all 20 test binaries stay green. Two
  horizontal cases added; the revert now fails them.

Two worth answering, both acted on:

- *The comment on `update_scrollbar_handle_positions` claimed a guarantee the
  code does not give* — it said that pass keeps the handle's own hover and
  pressed states landing on it, when its only caller is `advance_animations` and
  so it does not run for exactly the paint-only paths this change is about. The
  reviewer measured the consequence: after a wheel scroll, pressing the painted
  handle starts the drag correctly but the handle paints at the resting colour.
  The comment now says what is true, including the half it does not cover, and
  that half is #244.
- *Stranded doc comment* — the new helper had been inserted between
  `paint_scrollbar_containers` and its rustdoc. Moved back.

One note it raised is the same ground as #244 and is recorded there: two places
still answer "where is the handle", and only the forwarded events read the
cached one.

## What was checked by hand

Nothing. This is widget geometry, and the harness sees all of it — the paint
path runs without a compositor or a GPU, which is what the new test exercises.
The interactive feel of a scrollbar under a real pointer is worth a look before
merge, `cargo run --example scroll_example`, but nothing here depends on it.

## Left undone

The handle widget's own pressed and hover colours still read the cached origin,
so after a paint-only scroll they miss until something asks for an animation
frame. Deliberately out of scope — this issue was about what is drawn, and that
is a second idea with its own test — filed as #244 with the measurement and the
one-call fix it points to.
