### PR TITLE
A momentum belongs to the gesture that ended, and is a speed rather than a delta

### DIFF
--- a/book/src/architecture/events.md
+++ b/book/src/architecture/events.md
@@ -46,14 +46,20 @@ Event::ScrollEnd { x, y }
 - `delta_y` - Vertical scroll amount, in pixels
 - `source` - `Wheel`, `Finger` or `Continuous`
 
-`ScrollEnd` is the end of a continuous gesture — the finger lifting off a
-touchpad, which the compositor reports as `wl_pointer.axis_stop`. It carries no
-delta because nothing moved. A wheel never sends one: its steps are discrete,
-there is no finger to lift, and nothing carries on afterwards.
+`ScrollEnd` is the end of a scroll gesture — the finger lifting off a touchpad,
+which the compositor reports as `wl_pointer.axis_stop`. It carries no delta
+because nothing moved.
+
+Only `Finger` is guaranteed to produce one. The protocol says a `wl_pointer`
+sequence from a `Wheel` or `Continuous` source *may or may not* be terminated,
+and that clients "should treat scroll sequences from these scroll sources as
+unterminated by default" — so a `Continuous` gesture may simply never end, and a
+wheel may occasionally send a stop even though nothing was held down.
 
 It is what decides when momentum scrolling may begin. Without it the end of a
 gesture has to be guessed from a gap between samples, and a slow scroll is made
-of gaps.
+of gaps. A source that never terminates therefore never gets momentum, which is
+the honest answer rather than a guess.
 
 ## Event Propagation
 

--- a/book/src/architecture/events.md
+++ b/book/src/architecture/events.md
@@ -10,7 +10,7 @@ Wayland → Platform → App → Widget Tree
                               ├─ MouseMove
                               ├─ MouseEnter/MouseLeave
                               ├─ MouseDown/MouseUp
-                              └─ Scroll
+                              └─ Scroll/ScrollEnd
 ```
 
 ## Event Types
@@ -37,12 +37,23 @@ Used for click detection and pressed states.
 ### Scrolling
 
 ```rust
-Event::Scroll { dx, dy, source }
+Event::Scroll { x, y, delta_x, delta_y, source }
+Event::ScrollEnd { x, y }
 ```
 
-- `dx` - Horizontal scroll amount
-- `dy` - Vertical scroll amount
-- `source` - Wheel or touchpad
+- `x`, `y` - Pointer position
+- `delta_x` - Horizontal scroll amount, in pixels
+- `delta_y` - Vertical scroll amount, in pixels
+- `source` - `Wheel`, `Finger` or `Continuous`
+
+`ScrollEnd` is the end of a continuous gesture — the finger lifting off a
+touchpad, which the compositor reports as `wl_pointer.axis_stop`. It carries no
+delta because nothing moved. A wheel never sends one: its steps are discrete,
+there is no finger to lift, and nothing carries on afterwards.
+
+It is what decides when momentum scrolling may begin. Without it the end of a
+gesture has to be guessed from a gap between samples, and a slow scroll is made
+of gaps.
 
 ## Event Propagation
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -452,8 +452,12 @@ Wayland → Platform → App → Widget Tree
                               │
                               ├─ MouseMove/Enter/Leave
                               ├─ MouseDown/MouseUp
-                              └─ Scroll
+                              └─ Scroll/ScrollEnd
 ```
+
+`ScrollEnd` is the end of a gesture, from `wl_pointer.axis_stop`. It carries no
+delta, and it is what decides when momentum scrolling may begin — guaranteed
+only for `ScrollSource::Finger`.
 
 Events propagate down the widget tree. Each widget can:
 - Handle the event (`EventResponse::Handled`)

--- a/src/platform/input.rs
+++ b/src/platform/input.rs
@@ -509,17 +509,33 @@ impl PointerHandler for WaylandState {
                         vertical.absolute as f32
                     };
 
-                    // Only emit scroll event if there's actual scroll delta
-                    if (delta_x != 0.0 || delta_y != 0.0)
+                    // An axis event says two things, and a guard on the delta
+                    // alone dropped the second. `axis_stop` is how the hardware
+                    // ends a continuous scroll, and it carries no delta —
+                    // because nothing moved — so it was filtered out one line
+                    // before anything could use it. It is the only unguessed
+                    // answer to when a gesture is over.
+                    let gesture_ended = horizontal.stop || vertical.stop;
+                    let scrolled = delta_x != 0.0 || delta_y != 0.0;
+
+                    if (scrolled || gesture_ended)
                         && let Some(events) = target_events
                     {
-                        events.push(Event::Scroll {
-                            x: self.input.pointer_x,
-                            y: self.input.pointer_y,
-                            delta_x,
-                            delta_y,
-                            source: scroll_source,
-                        });
+                        if scrolled {
+                            events.push(Event::Scroll {
+                                x: self.input.pointer_x,
+                                y: self.input.pointer_y,
+                                delta_x,
+                                delta_y,
+                                source: scroll_source,
+                            });
+                        }
+                        if gesture_ended {
+                            events.push(Event::ScrollEnd {
+                                x: self.input.pointer_x,
+                                y: self.input.pointer_y,
+                            });
+                        }
                     }
                 }
             }

--- a/src/widgets/container/interaction.rs
+++ b/src/widgets/container/interaction.rs
@@ -338,14 +338,11 @@ impl Container {
                     if self.scroll_axis != ScrollAxis::None
                         && self.apply_scroll(*delta_x, *delta_y, *source)
                     {
-                        let sd = self.scroll();
-                        let has_velocity = sd.scroll_state.velocity_x.abs() > 0.5
-                            || sd.scroll_state.velocity_y.abs() > 0.5;
-                        if has_velocity {
-                            request_job(id, JobRequest::Animation(RequiredJob::Paint));
-                        } else {
-                            request_job(id, JobRequest::Paint);
-                        }
+                        // A paint, and only a paint. A sample means the finger
+                        // is still down, so there is no momentum for an
+                        // animation pass to advance — it begins on the
+                        // end-of-gesture, which asks for its own frames.
+                        request_job(id, JobRequest::Paint);
                         return EventResponse::Handled;
                     }
 

--- a/src/widgets/container/interaction.rs
+++ b/src/widgets/container/interaction.rs
@@ -367,7 +367,26 @@ impl Container {
                 }
             }
 
-            Event::ScrollEnd { .. } | Event::KeyUp { .. } | Event::FocusIn | Event::FocusOut => {}
+            // The finger lifted. Momentum starts here or not at all — and it
+            // starts now, on the event, rather than becoming due for whatever
+            // frame happens along next.
+            Event::ScrollEnd { x, y } => {
+                if self.scroll_axis != ScrollAxis::None && hit.contains(*x, *y) {
+                    let since_ms = self
+                        .scroll()
+                        .scroll_state
+                        .last_scroll_time
+                        .map(|t| t.elapsed().as_secs_f32() * 1000.0);
+                    let sd = self.scroll_mut();
+                    sd.scroll_state.end_gesture(since_ms);
+                    if sd.scroll_state.should_apply_momentum() {
+                        request_job(id, JobRequest::Animation(RequiredJob::Paint));
+                    }
+                    return EventResponse::Handled;
+                }
+            }
+
+            Event::KeyUp { .. } | Event::FocusIn | Event::FocusOut => {}
         }
 
         EventResponse::Ignored

--- a/src/widgets/container/interaction.rs
+++ b/src/widgets/container/interaction.rs
@@ -367,7 +367,7 @@ impl Container {
                 }
             }
 
-            Event::KeyUp { .. } | Event::FocusIn | Event::FocusOut => {}
+            Event::ScrollEnd { .. } | Event::KeyUp { .. } | Event::FocusIn | Event::FocusOut => {}
         }
 
         EventResponse::Ignored

--- a/src/widgets/container/scrollable.rs
+++ b/src/widgets/container/scrollable.rs
@@ -931,17 +931,23 @@ impl Container {
             ScrollAxis::None => return false,
         }
 
-        if source == ScrollSource::Finger {
-            match axis {
-                ScrollAxis::Vertical => sd.scroll_state.velocity_y = delta_y,
-                ScrollAxis::Horizontal => sd.scroll_state.velocity_x = delta_x,
-                ScrollAxis::Both => {
-                    sd.scroll_state.velocity_x = delta_x;
-                    sd.scroll_state.velocity_y = delta_y;
-                }
-                ScrollAxis::None => {}
-            }
-            sd.scroll_state.last_scroll_time = Some(std::time::Instant::now());
+        // Only a continuous source has a gesture to measure. Both of them do,
+        // and both end with an `axis_stop`; a wheel has neither.
+        if source.is_continuous() {
+            let now = std::time::Instant::now();
+            let dt_ms = sd
+                .scroll_state
+                .last_scroll_time
+                .map(|t| now.duration_since(t).as_secs_f32() * 1000.0);
+            let (sample_x, sample_y) = match axis {
+                ScrollAxis::Vertical => (0.0, delta_y),
+                ScrollAxis::Horizontal => (delta_x, 0.0),
+                ScrollAxis::Both => (delta_x, delta_y),
+                ScrollAxis::None => (0.0, 0.0),
+            };
+            sd.scroll_state
+                .record_gesture_sample(sample_x, sample_y, dt_ms);
+            sd.scroll_state.last_scroll_time = Some(now);
         }
 
         old_x != sd.scroll_state.offset_x || old_y != sd.scroll_state.offset_y

--- a/src/widgets/scroll.rs
+++ b/src/widgets/scroll.rs
@@ -260,6 +260,10 @@ pub(crate) struct ScrollState {
     /// The gesture that produced the velocity is over, so the momentum may run.
     /// Set by an end-of-gesture, cleared by the next sample.
     pub gesture_ended: bool,
+    /// When the momentum became due, refreshed by every step it takes. A
+    /// momentum that stops being advanced has been abandoned, and the field is
+    /// what says how long ago that was.
+    pub momentum_since: Option<std::time::Instant>,
     /// Samples in the current gesture, so the first timed one seeds the
     /// estimate instead of being smoothed against a velocity from before it.
     pub gesture_samples: u32,
@@ -320,6 +324,7 @@ impl ScrollState {
         // A new sample means the finger is still down, whatever a previous
         // end-of-gesture said.
         self.gesture_ended = false;
+        self.momentum_since = None;
 
         let Some(dt_ms) = dt_ms else {
             self.velocity_x = 0.0;
@@ -359,6 +364,40 @@ impl ScrollState {
         }
         self.gesture_ended = true;
         self.gesture_samples = 0;
+        self.momentum_since = Some(std::time::Instant::now());
+    }
+
+    /// Discard a momentum that stopped being advanced `idle_ms` ago.
+    ///
+    /// A momentum belongs to a moment as well as to a gesture. Gating it on the
+    /// gesture having ended stopped a velocity being flung while the finger was
+    /// still down, but a flag that is set and stays set has the same fault the
+    /// timeout had: one that was left half-run — the loop went idle, nothing
+    /// asked for a frame — was still due, and the next animation frame from any
+    /// source picked it up where it stopped. Measured at 148px, then 304px
+    /// after a wait of 400ms.
+    ///
+    /// This is not a guess about the user, which is what the timeout was. It is
+    /// a statement about this loop: nothing has advanced this motion for long
+    /// enough that it is not the same motion any more.
+    pub fn expire_stale_momentum(&mut self, idle_ms: f32) {
+        /// Six dropped frames at 60fps. Long enough that an ordinary hitch does
+        /// not cut a fling short, short enough that nobody reads the resumption
+        /// as a continuation.
+        const MOMENTUM_STALE_MS: f32 = 200.0;
+
+        if idle_ms > MOMENTUM_STALE_MS {
+            self.velocity_x = 0.0;
+            self.velocity_y = 0.0;
+            self.gesture_ended = false;
+            self.momentum_since = None;
+        }
+    }
+
+    /// How long since the momentum was last advanced, if one is due.
+    pub fn momentum_idle_ms(&self) -> Option<f32> {
+        self.momentum_since
+            .map(|t| t.elapsed().as_secs_f32() * 1000.0)
     }
 
     /// Whether the momentum may run: the gesture is over and it left a speed.
@@ -382,12 +421,20 @@ impl ScrollState {
         const FRICTION: f32 = 0.92;
         const VELOCITY_THRESHOLD: f32 = 0.5;
 
+        // A motion nobody has advanced for long enough is not this motion any
+        // more, whatever velocity is left of it.
+        if let Some(idle_ms) = self.momentum_idle_ms() {
+            self.expire_stale_momentum(idle_ms);
+        }
+
         // Nothing to run, and nothing to keep the loop awake for: a velocity
         // whose gesture has not ended is not a momentum waiting its turn, it
         // belongs to a finger that is still down.
         if !self.should_apply_momentum() {
             return false;
         }
+
+        self.momentum_since = Some(std::time::Instant::now());
 
         let mut animating = false;
 
@@ -741,6 +788,38 @@ mod tests {
             "and nothing is animating, so the loop is not kept awake for it"
         );
         assert_eq!(coast(&mut state), 0.0);
+    }
+
+    /// The unit behind the integration case: a motion that has not been
+    /// advanced for long enough is over, whatever velocity is left of it.
+    #[test]
+    fn a_momentum_abandoned_mid_flight_expires() {
+        let mut state = scroller();
+        gesture(&mut state, 6, 10.0, 8.0);
+        assert!(state.should_apply_momentum(), "the flick is due");
+
+        // A few frames run, and then nothing does.
+        state.advance_momentum();
+        assert!(state.should_apply_momentum(), "still due between frames");
+
+        state.expire_stale_momentum(400.0);
+
+        assert!(!state.should_apply_momentum());
+        assert_eq!(state.velocity_y, 0.0);
+        assert_eq!(coast(&mut state), 0.0);
+    }
+
+    /// An ordinary hitch is not an abandonment: a dropped frame or two must not
+    /// cut a fling short.
+    #[test]
+    fn a_dropped_frame_does_not_expire_a_momentum() {
+        let mut state = scroller();
+        gesture(&mut state, 6, 10.0, 8.0);
+
+        state.expire_stale_momentum(50.0);
+
+        assert!(state.should_apply_momentum());
+        assert!(coast(&mut state) > 0.0);
     }
 
     /// A sample landing after the gesture ended is the next gesture starting,

--- a/src/widgets/scroll.rs
+++ b/src/widgets/scroll.rs
@@ -250,11 +250,19 @@ pub(crate) struct ScrollState {
     pub h_scrollbar_dragging: bool,
     pub h_scrollbar_drag_start_x: f32,
     pub h_scrollbar_drag_start_offset: f32,
-    /// Velocity for kinetic/momentum scrolling
+    /// Momentum velocity, in pixels per frame — the unit `advance_momentum`
+    /// adds. Built from a speed, not from the last delta.
     pub velocity_x: f32,
     pub velocity_y: f32,
-    /// Timestamp of last scroll event (for detecting when scrolling stops)
+    /// Timestamp of the last gesture sample, for the interval between samples
+    /// and for how old the gesture is when it ends.
     pub last_scroll_time: Option<std::time::Instant>,
+    /// The gesture that produced the velocity is over, so the momentum may run.
+    /// Set by an end-of-gesture, cleared by the next sample.
+    pub gesture_ended: bool,
+    /// Samples in the current gesture, so the first timed one seeds the
+    /// estimate instead of being smoothed against a velocity from before it.
+    pub gesture_samples: u32,
 }
 
 impl ScrollState {
@@ -284,21 +292,89 @@ impl ScrollState {
         self.offset_y = self.offset_y.clamp(0.0, self.max_scroll_y());
     }
 
-    /// Check if momentum scrolling should be active (user stopped scrolling but has velocity)
+    /// Record one sample of a continuous gesture: `delta` pixels moved,
+    /// `dt_ms` since the previous sample of the same gesture.
+    ///
+    /// The velocity is distance over time. Storing the raw delta made 3px in
+    /// 8ms and 3px in 60ms — speeds seven times apart — the same number, so
+    /// what the momentum continued with bore little relation to how fast the
+    /// finger was going.
+    ///
+    /// `dt_ms` is `None` for the first sample of a gesture: a distance with no
+    /// time is not a speed, and guessing one from a single sample is how the
+    /// old behaviour started. That sample moves the content and contributes no
+    /// momentum.
+    pub fn record_gesture_sample(&mut self, delta_x: f32, delta_y: f32, dt_ms: Option<f32>) {
+        /// Two events can arrive within the same millisecond; the speed that
+        /// implies is unbounded and meaningless.
+        const MIN_SAMPLE_MS: f32 = 1.0;
+        /// A momentum step is in pixels per frame, a gesture in pixels per
+        /// millisecond. This is what turns one into the other.
+        const NOMINAL_FRAME_MS: f32 = 1000.0 / 60.0;
+        /// Weight of the newest sample. Smoothed, because the last sample of a
+        /// gesture is the one most likely to be a stray.
+        const SMOOTHING: f32 = 0.6;
+        /// However fast the hardware claims the finger went.
+        const MAX_STEP: f32 = 120.0;
+
+        // A new sample means the finger is still down, whatever a previous
+        // end-of-gesture said.
+        self.gesture_ended = false;
+
+        let Some(dt_ms) = dt_ms else {
+            self.velocity_x = 0.0;
+            self.velocity_y = 0.0;
+            self.gesture_samples = 1;
+            return;
+        };
+
+        let dt_ms = dt_ms.max(MIN_SAMPLE_MS);
+        let step = |delta: f32| ((delta / dt_ms) * NOMINAL_FRAME_MS).clamp(-MAX_STEP, MAX_STEP);
+        let (step_x, step_y) = (step(delta_x), step(delta_y));
+
+        if self.gesture_samples <= 1 {
+            self.velocity_x = step_x;
+            self.velocity_y = step_y;
+        } else {
+            self.velocity_x = self.velocity_x * (1.0 - SMOOTHING) + step_x * SMOOTHING;
+            self.velocity_y = self.velocity_y * (1.0 - SMOOTHING) + step_y * SMOOTHING;
+        }
+        self.gesture_samples = self.gesture_samples.saturating_add(1);
+    }
+
+    /// The gesture ended — the finger lifted.
+    ///
+    /// `since_last_sample_ms` is how long ago the gesture last moved. A
+    /// momentum belongs to the gesture that produced it: a finger resting
+    /// before it lifts is not throwing anything, so a velocity that old is
+    /// spent rather than released.
+    pub fn end_gesture(&mut self, since_last_sample_ms: Option<f32>) {
+        /// Longer than this between the last movement and the lift, and the
+        /// gesture had already stopped.
+        const GESTURE_STALE_MS: f32 = 100.0;
+
+        if since_last_sample_ms.is_none_or(|ms| ms > GESTURE_STALE_MS) {
+            self.velocity_x = 0.0;
+            self.velocity_y = 0.0;
+        }
+        self.gesture_ended = true;
+        self.gesture_samples = 0;
+    }
+
+    /// Whether the momentum may run: the gesture is over and it left a speed.
+    ///
+    /// No clock. The end of a gesture used to be guessed from a 50ms gap since
+    /// the last sample, and a slow scroll is made of gaps longer than that — so
+    /// the guess fired *inside* the gesture and flung the list while the finger
+    /// was still down. It also meant a momentum could become due with nothing
+    /// scheduled to run it, and then be resumed by the next animation frame
+    /// from any source, however much later.
     pub fn should_apply_momentum(&self) -> bool {
         const VELOCITY_THRESHOLD: f32 = 0.5;
-        const SCROLL_TIMEOUT_MS: u128 = 50; // Wait 50ms after last scroll event
 
-        // Only apply momentum if we have velocity AND enough time has passed since last scroll
-        let has_velocity = self.velocity_x.abs() > VELOCITY_THRESHOLD
-            || self.velocity_y.abs() > VELOCITY_THRESHOLD;
-
-        let scroll_stopped = self
-            .last_scroll_time
-            .map(|t| t.elapsed().as_millis() > SCROLL_TIMEOUT_MS)
-            .unwrap_or(true);
-
-        has_velocity && scroll_stopped
+        self.gesture_ended
+            && (self.velocity_x.abs() > VELOCITY_THRESHOLD
+                || self.velocity_y.abs() > VELOCITY_THRESHOLD)
     }
 
     /// Advance kinetic scrolling animation, returns true if still animating
@@ -306,11 +382,11 @@ impl ScrollState {
         const FRICTION: f32 = 0.92;
         const VELOCITY_THRESHOLD: f32 = 0.5;
 
-        // Don't apply momentum while actively scrolling
+        // Nothing to run, and nothing to keep the loop awake for: a velocity
+        // whose gesture has not ended is not a momentum waiting its turn, it
+        // belongs to a finger that is still down.
         if !self.should_apply_momentum() {
-            // Still animating if we have velocity (waiting for timeout)
-            return self.velocity_x.abs() > VELOCITY_THRESHOLD
-                || self.velocity_y.abs() > VELOCITY_THRESHOLD;
+            return false;
         }
 
         let mut animating = false;
@@ -581,6 +657,115 @@ impl ScrollState {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A scroller with room to fling in.
+    fn scroller() -> ScrollState {
+        ScrollState {
+            content_height: 5000.0,
+            viewport_height: 400.0,
+            ..Default::default()
+        }
+    }
+
+    /// Play `samples` movements of `delta` pixels `dt_ms` apart, then lift.
+    fn gesture(state: &mut ScrollState, samples: u32, delta: f32, dt_ms: f32) {
+        for i in 0..samples {
+            let dt = (i > 0).then_some(dt_ms);
+            state.record_gesture_sample(0.0, delta, dt);
+        }
+        state.end_gesture(Some(dt_ms));
+    }
+
+    /// How far the momentum carries the content once the finger has lifted.
+    fn coast(state: &mut ScrollState) -> f32 {
+        let start = state.offset_y;
+        for _ in 0..600 {
+            if !state.advance_momentum() {
+                break;
+            }
+        }
+        state.offset_y - start
+    }
+
+    /// The point of measuring a speed instead of keeping the last delta: two
+    /// gestures covering the same distance in different times are different
+    /// speeds, and have to fling differently. Storing the raw delta made them
+    /// the same number.
+    #[test]
+    fn a_gesture_that_covered_its_distance_faster_flings_further() {
+        let mut quick = scroller();
+        gesture(&mut quick, 6, 10.0, 8.0);
+        let quick_coast = coast(&mut quick);
+
+        let mut slow = scroller();
+        gesture(&mut slow, 6, 10.0, 60.0);
+        let slow_coast = coast(&mut slow);
+
+        assert!(
+            quick_coast > slow_coast * 2.0,
+            "same 50px of gesture, {}x apart in time, coasted {quick_coast} and {slow_coast}",
+            60.0 / 8.0
+        );
+    }
+
+    /// A finger that has come to rest before it lifts is not throwing
+    /// anything. The velocity belongs to a gesture that had already stopped.
+    #[test]
+    fn a_finger_resting_before_it_lifts_does_not_fling() {
+        let mut state = scroller();
+        for i in 0..6 {
+            state.record_gesture_sample(0.0, 10.0, (i > 0).then_some(8.0));
+        }
+        assert!(state.velocity_y.abs() > 0.5, "the gesture built a speed");
+
+        // ... and then the finger sat still for a while before lifting.
+        state.end_gesture(Some(400.0));
+
+        assert!(!state.should_apply_momentum());
+        assert_eq!(coast(&mut state), 0.0);
+    }
+
+    /// While the finger is down there is no momentum to run, whatever speed
+    /// the samples have built up: the list goes where the finger puts it.
+    #[test]
+    fn a_gesture_in_progress_has_no_momentum_to_apply() {
+        let mut state = scroller();
+        for i in 0..6 {
+            state.record_gesture_sample(0.0, 10.0, (i > 0).then_some(8.0));
+        }
+
+        assert!(state.velocity_y.abs() > 0.5, "the gesture built a speed");
+        assert!(!state.should_apply_momentum(), "but it is not due");
+        assert!(
+            !state.advance_momentum(),
+            "and nothing is animating, so the loop is not kept awake for it"
+        );
+        assert_eq!(coast(&mut state), 0.0);
+    }
+
+    /// A sample landing after the gesture ended is the next gesture starting,
+    /// and it cancels the momentum rather than being flung along with it.
+    #[test]
+    fn a_new_sample_takes_the_gesture_back() {
+        let mut state = scroller();
+        gesture(&mut state, 6, 10.0, 8.0);
+        assert!(state.should_apply_momentum());
+
+        state.record_gesture_sample(0.0, 4.0, Some(8.0));
+        assert!(!state.should_apply_momentum());
+    }
+
+    /// One sample is a distance with no time. Guessing a speed from it is what
+    /// the old behaviour did, and it is what a slow gesture kept triggering.
+    #[test]
+    fn the_first_sample_of_a_gesture_is_not_a_speed() {
+        let mut state = scroller();
+        state.record_gesture_sample(0.0, 30.0, None);
+
+        assert_eq!(state.velocity_y, 0.0);
+        state.end_gesture(Some(8.0));
+        assert!(!state.should_apply_momentum());
+    }
 
     #[test]
     fn test_scroll_axis_allows_vertical() {

--- a/src/widgets/widget.rs
+++ b/src/widgets/widget.rs
@@ -437,9 +437,16 @@ pub enum ScrollSource {
 }
 
 impl ScrollSource {
-    /// Whether this source scrolls continuously, and so has a gesture with an
-    /// end the compositor reports. A wheel does not: its steps are discrete,
-    /// there is no finger to lift, and nothing to carry on afterwards.
+    /// Whether this source scrolls as a gesture that can be measured for a
+    /// speed, rather than in discrete steps. A wheel is not one: its steps have
+    /// no duration to divide by, and nothing to carry on afterwards.
+    ///
+    /// Being a gesture is not the same as having a reported end. The protocol
+    /// guarantees a `wl_pointer.axis_stop` only for
+    /// [`Finger`](ScrollSource::Finger); a sequence from
+    /// [`Continuous`](ScrollSource::Continuous) is to be treated as
+    /// unterminated by default. So a continuous source builds a velocity like a
+    /// touchpad and, on hardware that never terminates, simply never spends it.
     pub fn is_continuous(self) -> bool {
         matches!(self, ScrollSource::Finger | ScrollSource::Continuous)
     }

--- a/src/widgets/widget.rs
+++ b/src/widgets/widget.rs
@@ -436,6 +436,15 @@ pub enum ScrollSource {
     Continuous,
 }
 
+impl ScrollSource {
+    /// Whether this source scrolls continuously, and so has a gesture with an
+    /// end the compositor reports. A wheel does not: its steps are discrete,
+    /// there is no finger to lift, and nothing to carry on afterwards.
+    pub fn is_continuous(self) -> bool {
+        matches!(self, ScrollSource::Finger | ScrollSource::Continuous)
+    }
+}
+
 /// Keyboard modifier state
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct Modifiers {

--- a/src/widgets/widget.rs
+++ b/src/widgets/widget.rs
@@ -506,6 +506,18 @@ pub enum Event {
         /// Source of the scroll event
         source: ScrollSource,
     },
+    /// A continuous scroll gesture ended: the finger lifted.
+    ///
+    /// Sent for the sources that have an end — a touchpad or a touchscreen say
+    /// so with `wl_pointer.axis_stop`, a wheel has nothing to say. It carries
+    /// no delta, because nothing moved; what it carries is the one unguessed
+    /// answer to when a momentum may begin.
+    ScrollEnd {
+        /// X position of the pointer
+        x: f32,
+        /// Y position of the pointer
+        y: f32,
+    },
     /// Key pressed
     KeyDown {
         /// The key that was pressed
@@ -541,6 +553,7 @@ impl Event {
             Event::MouseUp { x, y, .. } => Some((*x, *y)),
             Event::MouseEnter { x, y } => Some((*x, *y)),
             Event::Scroll { x, y, .. } => Some((*x, *y)),
+            Event::ScrollEnd { x, y } => Some((*x, *y)),
             Event::MouseLeave
             | Event::KeyDown { .. }
             | Event::KeyUp { .. }
@@ -576,6 +589,7 @@ impl Event {
                 delta_y: *delta_y,
                 source: *source,
             },
+            Event::ScrollEnd { .. } => Event::ScrollEnd { x: new_x, y: new_y },
             Event::MouseLeave => Event::MouseLeave,
             // Keyboard/focus events don't have coordinates
             Event::KeyDown { key, modifiers } => Event::KeyDown {

--- a/tests/scroll_momentum.rs
+++ b/tests/scroll_momentum.rs
@@ -60,6 +60,14 @@ impl H {
         }
     }
 
+    /// The finger lifted, as the compositor's `axis_stop` reaches the tree.
+    fn scroll_end(&mut self) {
+        let root = self.root;
+        let event = Event::ScrollEnd { x: 100.0, y: 100.0 };
+        self.tree
+            .with_widget_mut(root, |w, id, t| w.event(t, id, &event));
+    }
+
     fn offset(&mut self) -> f32 {
         let root = self.root;
         let mut node = RenderNode::new(root.as_u64());
@@ -116,5 +124,32 @@ fn a_gesture_that_never_ended_is_not_resumed_by_a_later_frame() {
         (offset - after_gesture).abs() < 0.01,
         "content drifted from {after_gesture} to {offset} on a later frame: \
          a momentum nobody advanced was waiting instead of being over"
+    );
+}
+
+/// And the other half: a gesture that does end carries on. The whole path,
+/// from the samples through the end-of-gesture event to the frames that run
+/// the momentum — which is what `wl_pointer.axis_stop` reaches.
+#[test]
+fn a_gesture_that_ended_carries_on_past_the_last_sample() {
+    let mut h = H::new();
+
+    for _ in 0..6 {
+        h.finger_scroll(10.0);
+        std::thread::sleep(std::time::Duration::from_millis(8));
+    }
+    let at_lift = h.offset();
+    assert!(
+        (at_lift - 60.0).abs() < 0.01,
+        "the gesture itself moved {at_lift}px, not the 60px dispatched"
+    );
+
+    h.scroll_end();
+    h.frames(60);
+
+    let coasted = h.offset() - at_lift;
+    assert!(
+        coasted > 10.0,
+        "the finger lifted after a 60px flick and the content coasted {coasted}px"
     );
 }

--- a/tests/scroll_momentum.rs
+++ b/tests/scroll_momentum.rs
@@ -39,16 +39,30 @@ impl H {
 
     /// One touchpad scroll sample, as a finger moving by `delta` pixels.
     fn finger_scroll(&mut self, delta: f32) {
+        self.scroll(delta, ScrollSource::Finger);
+    }
+
+    /// One scroll sample from any source.
+    fn scroll(&mut self, delta: f32, source: ScrollSource) {
         let root = self.root;
         let event = Event::Scroll {
             x: 100.0,
             y: 100.0,
             delta_x: 0.0,
             delta_y: delta,
-            source: ScrollSource::Finger,
+            source,
         };
         self.tree
             .with_widget_mut(root, |w, id, t| w.event(t, id, &event));
+    }
+
+    /// Play a flick of `samples` movements and lift, from `source`.
+    fn flick(&mut self, source: ScrollSource) {
+        for _ in 0..6 {
+            self.scroll(10.0, source);
+            std::thread::sleep(std::time::Duration::from_millis(8));
+        }
+        self.scroll_end();
     }
 
     /// Run `n` animation frames, as the loop does while anything is animating.
@@ -151,5 +165,34 @@ fn a_gesture_that_ended_carries_on_past_the_last_sample() {
     assert!(
         coasted > 10.0,
         "the finger lifted after a 60px flick and the content coasted {coasted}px"
+    );
+}
+
+/// A continuous source is a gesture: it is measured for a speed and it coasts.
+/// A wheel is not — its steps have no duration to divide by, and a stop, if one
+/// ever arrives, has nothing to release.
+///
+/// `is_continuous` is the line between them, and without this both sides of it
+/// are unwatched: spelling it `matches!(self, Finger)` leaves the suite green.
+#[test]
+fn a_continuous_gesture_coasts_and_a_wheel_does_not() {
+    let mut wheel = H::new();
+    wheel.flick(ScrollSource::Wheel);
+    let at_lift = wheel.offset();
+    wheel.frames(60);
+    let wheel_coast = wheel.offset() - at_lift;
+    assert!(
+        wheel_coast.abs() < 0.01,
+        "a wheel coasted {wheel_coast}px: it has no gesture to have a speed"
+    );
+
+    let mut continuous = H::new();
+    continuous.flick(ScrollSource::Continuous);
+    let at_lift = continuous.offset();
+    continuous.frames(60);
+    let continuous_coast = continuous.offset() - at_lift;
+    assert!(
+        continuous_coast > 10.0,
+        "a continuous gesture coasted {continuous_coast}px after a 60px flick"
     );
 }

--- a/tests/scroll_momentum.rs
+++ b/tests/scroll_momentum.rs
@@ -196,3 +196,37 @@ fn a_continuous_gesture_coasts_and_a_wheel_does_not() {
         "a continuous gesture coasted {continuous_coast}px after a 60px flick"
     );
 }
+
+/// A momentum belongs to a moment as well as to a gesture. If the loop goes
+/// idle with velocity left — the pointer wandered off, nothing asked for a
+/// frame — that motion is over. The frame that eventually arrives, from
+/// whatever asked for it, must not carry on where it left off.
+///
+/// This is the same failure as #246 one gate further along: the gesture *did*
+/// end, so the flag that replaced the timeout is set, and stays set.
+#[test]
+fn a_momentum_left_half_run_is_not_carried_on_by_a_later_frame() {
+    let mut h = H::new();
+    h.flick(ScrollSource::Finger);
+
+    h.frames(5);
+    let interrupted_at = h.offset();
+    assert!(
+        interrupted_at > 60.0,
+        "the flick was coasting when it stopped"
+    );
+
+    // The loop goes idle mid-flight.
+    std::thread::sleep(std::time::Duration::from_millis(400));
+
+    // Re-entering the container starts the scrollbar's hover expansion, which
+    // asks for an animation frame.
+    h.frames(30);
+
+    let after = h.offset();
+    assert!(
+        (after - interrupted_at).abs() < 0.01,
+        "content carried on from {interrupted_at} to {after}: a momentum \
+         abandoned mid-flight was resumed instead of being over"
+    );
+}

--- a/tests/scroll_momentum.rs
+++ b/tests/scroll_momentum.rs
@@ -1,0 +1,120 @@
+//! Momentum belongs to the gesture that ended.
+//!
+//! Both cases here dispatch real `Event::Scroll`s through a real container and
+//! then run animation frames, which is what the loop does. What they assert is
+//! that a frame in the middle of a gesture, or a frame long after one, does not
+//! move the content: only the deltas the user actually produced do.
+
+use guido::layout::{Constraints, Flex};
+use guido::prelude::*;
+use guido::renderer::{PaintContext, RenderNode};
+use guido::tree::{Tree, WidgetId};
+
+struct H {
+    tree: Tree,
+    root: WidgetId,
+}
+
+impl H {
+    fn new() -> Self {
+        let view = container()
+            .width(200.0)
+            .height(200.0)
+            .scrollable(ScrollAxis::Vertical)
+            .child(
+                container()
+                    .layout(Flex::column().spacing(8.0))
+                    .padding(8.0)
+                    .children((0..20).map(|_| container().width(120.0).height(24.0))),
+            );
+
+        let mut tree = Tree::new();
+        let root = tree.register(Box::new(view));
+        tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
+        tree.with_widget_mut(root, |w, id, t| {
+            w.layout(t, id, Constraints::new(0.0, 0.0, 200.0, 200.0))
+        });
+        Self { tree, root }
+    }
+
+    /// One touchpad scroll sample, as a finger moving by `delta` pixels.
+    fn finger_scroll(&mut self, delta: f32) {
+        let root = self.root;
+        let event = Event::Scroll {
+            x: 100.0,
+            y: 100.0,
+            delta_x: 0.0,
+            delta_y: delta,
+            source: ScrollSource::Finger,
+        };
+        self.tree
+            .with_widget_mut(root, |w, id, t| w.event(t, id, &event));
+    }
+
+    /// Run `n` animation frames, as the loop does while anything is animating.
+    fn frames(&mut self, n: usize) {
+        let root = self.root;
+        for _ in 0..n {
+            self.tree
+                .with_widget_mut(root, |w, id, t| w.advance_animations(t, id));
+        }
+    }
+
+    fn offset(&mut self) -> f32 {
+        let root = self.root;
+        let mut node = RenderNode::new(root.as_u64());
+        self.tree.with_widget_mut(root, |w, id, t| {
+            let mut ctx = PaintContext::new(&mut node);
+            w.paint(t, id, &mut ctx);
+        });
+        -node.children[0].local_transform.ty()
+    }
+}
+
+/// A gap between two samples is what "scrolling slowly" is made of, not a
+/// signal that the finger left. Frames taken during the gap must not fling the
+/// list: after two 30px samples the content has moved 60px and no more.
+#[test]
+fn a_gap_inside_a_gesture_does_not_start_the_momentum() {
+    let mut h = H::new();
+
+    h.finger_scroll(30.0);
+    std::thread::sleep(std::time::Duration::from_millis(60));
+    h.frames(10);
+
+    h.finger_scroll(30.0);
+    std::thread::sleep(std::time::Duration::from_millis(60));
+    h.frames(10);
+
+    let offset = h.offset();
+    assert!(
+        (offset - 60.0).abs() < 0.01,
+        "content moved {offset}px for 60px of gesture: a gap between samples \
+         was read as the end of the gesture"
+    );
+}
+
+/// A gesture that never ended leaves nothing behind to be resumed. The finger
+/// is still down as far as the library knows, so however long the surface sits
+/// idle, the frame that eventually runs must not move the content.
+#[test]
+fn a_gesture_that_never_ended_is_not_resumed_by_a_later_frame() {
+    let mut h = H::new();
+
+    h.finger_scroll(30.0);
+    let after_gesture = h.offset();
+
+    // The surface goes idle: nothing advances for a while.
+    std::thread::sleep(std::time::Duration::from_millis(120));
+
+    // Something unrelated asks for an animation frame — re-entering the
+    // container starts the scrollbar's hover expansion, which does exactly this.
+    h.frames(10);
+
+    let offset = h.offset();
+    assert!(
+        (offset - after_gesture).abs() < 0.01,
+        "content drifted from {after_gesture} to {offset} on a later frame: \
+         a momentum nobody advanced was waiting instead of being over"
+    );
+}

--- a/tests/scrollbar_handle_tracking.rs
+++ b/tests/scrollbar_handle_tracking.rs
@@ -181,9 +181,9 @@ fn near(actual: f32, expected: f32) -> bool {
     (actual - expected).abs() < 0.01
 }
 
-/// A mouse wheel never sets a velocity — `apply_scroll` gates that on
-/// `ScrollSource::Finger` — so it always takes the plain `Paint` arm. It is the
-/// ordinary way to scroll, and the handle has to follow it.
+/// A mouse wheel asks for a plain `Paint`: it is not a gesture, so there is no
+/// momentum to advance and no animation frame to carry the handle along. It is
+/// the ordinary way to scroll, and the handle has to follow it.
 #[test]
 fn a_wheel_scroll_moves_the_handle() {
     let mut h = H::vertical();


### PR DESCRIPTION
## What changed

Momentum scrolling was decided from two guesses and a number that was not what
it claimed to be. The velocity was the raw last delta, so 3px in 8ms and 3px in
60ms — speeds seven times apart — were the same number. The end of the gesture
was guessed from a 50ms gap since the last sample, and a slow scroll is made of
gaps longer than that, so the guess fired *inside* the gesture and flung the
list while the finger was still down. And a momentum that became due with
nothing scheduled to run it was never cancelled: it waited, and the next
animation frame from any source resumed it, however much later.

It is now a speed, measured over the interval between samples and smoothed
across the gesture; it begins when the compositor says the finger lifted, which
it has been saying all along; and it expires rather than waiting. Closes #205,
closes #246

## What proves it

`tests/scroll_momentum.rs`, four cases through the real event path, and seven
unit tests beside `ScrollState` where the interval is an argument rather than a
clock:

- `a_gap_inside_a_gesture_does_not_start_the_momentum` — on `main`, *"content
  moved 448px for 60px of gesture"*
- `a_gesture_that_never_ended_is_not_resumed_by_a_later_frame` — on `main`,
  *"content drifted from 30 to 242.10434"*, which is #246's measurement to the
  decimal
- `a_momentum_left_half_run_is_not_carried_on_by_a_later_frame` — 148px, then
  304px after a 400ms wait
- `a_gesture_that_ended_carries_on_past_the_last_sample` and
  `a_continuous_gesture_coasts_and_a_wheel_does_not` — the other half, so
  "never fling" cannot pass for a fix
- `a_gesture_that_covered_its_distance_faster_flings_further` — the point of
  measuring a speed. With the delta stored raw both gestures coast 118.79px,
  to the decimal.

Each decision was checked to be load-bearing by undoing it alone: reverting the
estimator makes the two gestures identical; narrowing `is_continuous` back to
`Finger` fails the continuous case.

Nothing re-blessed; no golden or snapshot moved, which is right — this changes
when momentum runs, not what a frame draws. Full suite, clippy with
`-D warnings`, the nine goldens on lavapipe, `mdbook build book` and
`tests/documentation_references.rs` all green.

## What the review found

The `reviewer` subagent ran over the first two commits, before this pull request
existed. **One blocking finding**, answered:

- *The half nothing automated covers had no record of the hand check, and it is
  now load-bearing* — after this change momentum starts **only** on
  `Event::ScrollEnd`, so if `AxisScroll::stop` never reached that arm on a real
  compositor, touchpad momentum would be gone entirely and every test would stay
  green. Answered by the hand check below.

Two worth answering, both acted on in `d380770`:

- *The new prose stated a guarantee the protocol denies.* `wayland.xml` on
  `wl_pointer.axis_source` promises an `axis_stop` for `finger` only, and says
  clients "must not rely" on one for `wheel` or `continuous`. The book said a
  wheel never sends one, and that a continuous gesture ends with a stop. Both
  wrong, in opposite directions. The prose now says what the protocol says; the
  code is unchanged, because being a gesture and having a reported end are
  different questions, and a continuous source that never terminates simply
  never spends its velocity — which is what it did before this branch.
- *`Continuous` got momentum and nothing would notice if it were undone.* It
  appears in no other test in the repo; it now coasts in a case of its own.

One note, also acted on: the scroll arm asked for an `Animation` job whenever a
sample left a velocity, which after this change schedules a pass that declines
immediately. It asks for a `Paint`.

## What was checked by hand

niri 26.04, `cargo run --example scroll_example`, on a touchpad — the half the
harness cannot see, since there is no headless compositor in it.

- **A slow scroll no longer flings mid-gesture.** This was the reported symptom.
- **A flick coasts and settles.** This is also what answers the blocking
  finding: momentum now starts *only* on `Event::ScrollEnd`, so a flick that
  carries on is proof that `axis_stop` arrives and is read. There is no other
  path to it.
- **Leaving the container and coming back does not resume it** — after
  `94340f7`. The first hand pass found that it did, at 148px then 304px, which
  is where that commit came from.

## Left undone

**The symptom that started this investigation is not fixed here, and this pull
request does not claim it.** Moving from one scrollable onto another's scrollbar
still snaps the first one back to an older position. That was measured through
every stage: the scroll state, the render tree, the damage rect and layout are
all correct, and the commands handed to the GPU stop carrying the position the
widget layer is producing. It is a rendering defect, filed with the full trace
as #247.

Two other real defects were found along the way and are deliberately not here,
each on a branch of its own: `flatten` caching a subtree that contains a clip
(`fix/flatten-cache-skips-clipped-subtrees`), and `mark_needs_paint` stopping at
a stale flag before it reaches the surface root (`fix/needs-paint-reaches-the-root`
— which costs frame time and wants a measurement before it goes anywhere).

`GESTURE_STALE_MS` and `MOMENTUM_STALE_MS` are 100ms and 200ms by judgement, not
by measurement. The tests pin the two sides of each so they cannot drift
silently, but any value in a wide band would pass.
