### PR TITLE
A cache the widget has outgrown is dropped, not kept

### DIFF
--- a/.claude/skills/renderer/SKILL.md
+++ b/.claude/skills/renderer/SKILL.md
@@ -32,7 +32,8 @@ animating surface renders once per callback, an idle surface renders nothing.
 11. GPU: instanced SDF shapes, HiDPI scaling, per-group layer order. On a lost
     or outdated swapchain the dirty state is kept and a retry frame requested
 12. `cache_paint_results()` — `Rc`-share paint output, clear `needs_paint`.
-    Partial paints poison their ancestors and are never cached
+    Partial paints poison their ancestors, are never cached, and drop the
+    entry the last complete paint left
 
 ## Layers and ordering
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,7 @@ at lavapipe. In that job a skip is a failure.
 | shaders, corners, borders, shadows, gradients, clipping, HiDPI, text | `tests/golden_images.rs` — the pixels, on lavapipe |
 | the reactive system | unit tests beside the code in `src/reactive/` |
 | widget behaviour and public API | integration tests in `tests/` |
+| the paint cache and incremental flatten, which only exist across frames | `tests/paint_cache_across_frames.rs` — one retained root node, frame after frame |
 | documented API | doc tests, and `cargo doc` with warnings denied |
 | the user documentation | `mdbook build book` in CI |
 | API names written in *prose* — this file, the skills, `docs/`, the book, the README | `tests/documentation_references.rs` |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -532,7 +532,10 @@ The paint system tracks which widgets need repainting:
   shared) with the position recomposed from the decomposed parent/user transforms.
 - **Partial propagation**: a node whose children were culled (`partial`) poisons its
   ancestors in the cache walk — incomplete paints are never cached, so reuse can never
-  resurrect a subtree with missing children.
+  resurrect a subtree with missing children. Refusing to cache is only half of it: a
+  partial paint also *drops* the entry the last complete one left, because the widget
+  painted this frame and painted something else. Keeping it as a picture of "how this
+  looks with nothing culled" is how a scrolled list came back at rest.
 - **Skip frame**: If the root widget doesn't need paint after job processing and layout,
   the entire paint→flatten→render cycle is skipped.
 - **Damage regions**: `mark_needs_paint()` accumulates surface-relative bounds into a

--- a/docs/RENDERER.md
+++ b/docs/RENDERER.md
@@ -50,7 +50,11 @@ to the same node that sits in the frame's render tree:
   been cached, and flatten writes `cached_flatten` through a `&RenderNode`.
 - `partial` propagates to ancestors during the cache walk: a subtree that
   embeds a partially-painted node (culled children) is never cached, so a
-  later cache reuse cannot resurrect an incomplete paint.
+  later cache reuse cannot resurrect an incomplete paint. It also invalidates:
+  `Tree::clear_cached_paint` drops whatever the last complete paint left, which
+  is a picture of the widget as it no longer is — a list that scrolls culls
+  from its first scrolled frame onward, so the newest complete entry is the
+  list at rest.
 
 Each surface owns a single root `RenderNode` (`ManagedSurface::root_node`),
 cleared and rebuilt from dirty widgets every rendered frame.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -567,6 +567,13 @@ fn measure_natural_size(
 
 /// Walk the render tree after painting and cache each node's output.
 ///
+/// The third phase of a frame, after [`renderer::flatten_root_into`] and in
+/// that order: flatten writes `cached_flatten` onto the nodes, and this walk
+/// is what makes them reusable next frame. Public for the same reason flatten
+/// is — a frame can be driven without a compositor, and the paint cache only
+/// exists across frames, so a test that never runs this one never reaches it.
+/// The loop calls it per child of the surface root, never on the root itself.
+///
 /// Caching is an `Rc::clone` of the node already sitting in the frame's
 /// render tree — O(1) per node instead of the previous deep subtree clone.
 ///
@@ -578,10 +585,7 @@ fn measure_natural_size(
 ///
 /// Also clears needs_paint flags and the per-frame `repainted` marker for
 /// freshly painted widgets (skipping already-clean subtrees entirely).
-pub(crate) fn cache_paint_results(
-    tree: &mut Tree,
-    node: &std::rc::Rc<renderer::RenderNode>,
-) -> bool {
+pub fn cache_paint_results(tree: &mut Tree, node: &std::rc::Rc<renderer::RenderNode>) -> bool {
     if !node.repainted.get() {
         // Reused from cache: its subtree is by construction complete and its
         // cache entries are already valid — nothing to do below it.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -573,7 +573,8 @@ fn measure_natural_size(
 /// Returns whether the subtree is partial (this node or any descendant had
 /// children culled by cull_rect). Partial-ness propagates UP: an ancestor
 /// whose subtree embeds an incomplete paint must not be cached either, or a
-/// later cache reuse would permanently hide the culled grandchildren.
+/// later cache reuse would permanently hide the culled grandchildren. It
+/// invalidates as well as refuses — see the body.
 ///
 /// Also clears needs_paint flags and the per-frame `repainted` marker for
 /// freshly painted widgets (skipping already-clean subtrees entirely).
@@ -594,14 +595,20 @@ pub(crate) fn cache_paint_results(
 
     let widget_id = WidgetId::from_u64(node.id);
     if tree.contains(widget_id) {
-        if !subtree_partial {
+        if subtree_partial {
+            // Partial subtree — this paint cannot be cached, and neither can
+            // the one before it stay: the widget painted this frame, and it
+            // painted something else. Keeping the last complete entry as a
+            // stand-in for "how it looks when nothing is culled" is how a
+            // scrolled list came back at the top — culling starts the moment
+            // it scrolls, so the newest complete entry is the list at rest,
+            // and `reuse_cached` serves it whole the next time some other
+            // widget asks for a frame.
+            tree.clear_cached_paint(widget_id);
+        } else {
             // Complete paint — safe to cache for future reuse.
             tree.cache_paint(widget_id, std::rc::Rc::clone(node));
         }
-        // else: partial subtree — don't cache. Keep the previous complete
-        // cache (if any) so it can be reused when the widget becomes fully
-        // visible. If there's no previous cache, the widget will get a full
-        // paint next frame anyway (cached_paint None → full paint).
         tree.clear_needs_paint(widget_id);
     }
     // Mark as cached/clean for the flattener and future walks. The cache

--- a/src/renderer/tree.rs
+++ b/src/renderer/tree.rs
@@ -118,7 +118,9 @@ pub struct RenderNode {
     /// Partial subtrees are not cached (see `cache_paint_results`, which
     /// propagates partial-ness to ancestors) because their paint is
     /// incomplete — reusing them later would permanently hide the culled
-    /// children.
+    /// children. Nor does the entry from the last complete paint survive: the
+    /// widget painted this frame and painted something else, so that entry is
+    /// a picture of it as it no longer is, and it is dropped.
     pub partial: bool,
 
     /// Cached flattened commands from a previous flatten pass, shared via Rc

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -788,6 +788,15 @@ impl Tree {
             .and_then(|idx| self.dense[idx].cached_paint.as_ref())
     }
 
+    /// Drop a widget's cached paint output, so the next frame paints it in
+    /// full. What a paint that could not be cached has to do with the entry
+    /// the last one left: it is a picture of this widget as it no longer is.
+    pub fn clear_cached_paint(&mut self, id: WidgetId) {
+        if let Some(idx) = self.get_dense_index(id) {
+            self.dense[idx].cached_paint = None;
+        }
+    }
+
     /// Clear all widgets and metadata.
     pub fn clear(&mut self) {
         self.dense.clear();

--- a/src/widgets/paint_children.rs
+++ b/src/widgets/paint_children.rs
@@ -11,7 +11,9 @@
 //!
 //! - A culled child makes the parent's paint **partial**, and a partial paint
 //!   is never cached — otherwise reusing it later would permanently hide the
-//!   children this pass skipped.
+//!   children this pass skipped. It also invalidates whatever the last
+//!   complete paint cached, so `reuse_cached` below cannot serve a picture
+//!   older than the widget's last paint; see `cache_paint_results`.
 //! - A cached node may be re-parented but never re-sized: its commands were
 //!   built for the size it was painted at. A child that changed size ran its
 //!   own layout and marked itself dirty, so it should not reach the reuse

--- a/tests/paint_cache_across_frames.rs
+++ b/tests/paint_cache_across_frames.rs
@@ -1,0 +1,272 @@
+//! The paint cache, across frames.
+//!
+//! Every other test in `tests/` builds a fresh `RenderNode` per frame, which
+//! never reaches `reuse_cached`: with nothing in `Tree`'s paint cache a widget
+//! is always painted in full, so a stale cache entry is structurally invisible.
+//! This one keeps one root node for the life of the surface and clears it per
+//! frame, exactly as `ManagedSurface::root_node` does, and runs the three phases
+//! of a frame in the order `render_surface` runs them — paint, flatten, then
+//! `cache_paint_results`. Widgets come back out of the paint cache as the
+//! frames go by — a scrolling column does not, which is the whole subject
+//! here, but the captions and rows do — so the render tree persists and
+//! `repainted`, `cached_flatten` and `cached_paint` all mean what they mean in
+//! the running loop. The last assertion pins that, because a harness that
+//! quietly stopped reaching `reuse_cached` would go green for the wrong
+//! reason and take the only test of this path with it.
+//!
+//! Two sibling scrollable columns, because the bug needs a second widget to
+//! ask for the frame that the first one is then served stale into.
+
+use guido::layout::{Constraints, Flex};
+use guido::prelude::*;
+use guido::renderer::{
+    CommandLayer, FlattenedCommand, PaintContext, RenderNode, flatten_root_into,
+};
+use guido::tree::{Tree, WidgetId};
+use guido::widgets::Rect;
+
+const VIEWPORT: f32 = 200.0;
+/// The row's padding, and the column's own padding around its rows.
+const PAD: f32 = 8.0;
+/// Between the two columns.
+const GAP: f32 = 16.0;
+/// Stands in for the "Vertical Scroll" caption in `examples/scroll_example.rs`.
+/// A fixed box rather than text: text metrics come from the fonts installed on
+/// the machine, and this test asserts on coordinates.
+const CAPTION: f32 = 17.0;
+/// Between the caption and the scroller.
+const CAPTION_GAP: f32 = 4.0;
+
+const ROW_HEIGHT: f32 = 24.0;
+const ROW_GAP: f32 = 8.0;
+const ROWS: usize = 20;
+/// Far enough that rows leave the viewport, which is what makes the paint
+/// partial — and not a whole number of rows, so a stale offset cannot happen
+/// to land on the same picture.
+const SCROLL: f32 = 120.0;
+
+/// Where each scroller's viewport starts, in surface coordinates.
+const SCROLLER_TOP: f32 = PAD + CAPTION + CAPTION_GAP;
+const COLUMN_A_X: f32 = PAD;
+const COLUMN_B_X: f32 = PAD + VIEWPORT + GAP;
+
+/// A caption and a vertical scroller over `ROWS` rows — one column of
+/// `examples/scroll_example.rs`.
+fn column() -> Container {
+    container()
+        .layout(Flex::column().spacing(CAPTION_GAP))
+        .child(container().width(VIEWPORT).height(CAPTION))
+        .child(
+            container()
+                .width(VIEWPORT)
+                .height(VIEWPORT)
+                .background(Color::rgb(0.15, 0.15, 0.2))
+                .scrollable(ScrollAxis::Vertical)
+                .child(
+                    // The list itself is drawn, not just its rows: it spans
+                    // the whole content, so it is never culled and never
+                    // narrowed away by the visible-range search, and its
+                    // command carries the scroll offset exactly. The rows do
+                    // not — the topmost row painted is always the one at the
+                    // top of the viewport, whatever the offset.
+                    container()
+                        .layout(Flex::column().spacing(ROW_GAP))
+                        .padding(PAD)
+                        .background(Color::rgb(0.1, 0.1, 0.12))
+                        .children((0..ROWS).map(|_| {
+                            container()
+                                .width(120.0)
+                                .height(ROW_HEIGHT)
+                                .background(Color::rgb(0.25, 0.25, 0.35))
+                        })),
+                ),
+        )
+}
+
+/// A surface that renders frame after frame into one retained root node.
+struct Surface {
+    tree: Tree,
+    root: WidgetId,
+    /// Retained across frames and `clear()`ed per frame — `SurfaceState::root_node`.
+    root_node: RenderNode,
+    commands: Vec<FlattenedCommand>,
+    layers: Vec<CommandLayer>,
+    width: f32,
+    height: f32,
+}
+
+impl Surface {
+    fn new() -> Self {
+        let view = container()
+            .layout(Flex::row().spacing(GAP))
+            .padding(PAD)
+            .child(column())
+            .child(column());
+
+        let width = PAD + VIEWPORT + GAP + VIEWPORT + PAD;
+        let height = PAD + CAPTION + CAPTION_GAP + VIEWPORT + PAD;
+
+        let mut tree = Tree::new();
+        let root = tree.register(Box::new(view));
+        tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
+        tree.with_widget_mut(root, |w, id, t| {
+            w.layout(t, id, Constraints::new(0.0, 0.0, width, height))
+        });
+
+        Self {
+            tree,
+            root,
+            root_node: RenderNode::new(root.as_u64()),
+            commands: Vec::new(),
+            layers: Vec::new(),
+            width,
+            height,
+        }
+    }
+
+    /// The scroller inside the nth column: root → column → [caption, scroller].
+    fn scroller(&self, column: usize) -> WidgetId {
+        let col = self.tree.get_children(self.root)[column];
+        self.tree.get_children(col)[1]
+    }
+
+    /// The node the nth column's caption contributed to this frame's render
+    /// tree. `reuse_cached` shares the cached `Rc` itself when the position
+    /// has not moved, so a caption served from the cache is the *same
+    /// allocation* frame after frame, where one that repaints is a new node
+    /// each time. Comparing the tree against the cache would not tell those
+    /// apart: `cache_paint_results` stores whatever was painted.
+    fn caption_node(&self, column: usize) -> std::rc::Rc<RenderNode> {
+        std::rc::Rc::clone(&self.root_node.children[column].children[0])
+    }
+
+    /// One frame: the skip gate, paint into the retained root, flatten, then
+    /// cache — per child of the root and never on the root itself, which is
+    /// what `render_surface` does.
+    fn frame(&mut self) {
+        if !self.tree.needs_paint(self.root) {
+            return;
+        }
+
+        self.root_node.clear();
+        self.root_node.bounds = Rect::new(0.0, 0.0, self.width, self.height);
+
+        let Self {
+            tree,
+            root,
+            root_node,
+            commands,
+            layers,
+            ..
+        } = self;
+        tree.with_widget_mut(*root, |w, id, t| {
+            let mut ctx = PaintContext::new(root_node);
+            w.paint(t, id, &mut ctx);
+        });
+        let _ = flatten_root_into(root_node, commands, layers);
+        for child in &root_node.children {
+            guido::cache_paint_results(tree, child);
+        }
+        tree.clear_needs_paint(*root);
+    }
+
+    /// Scroll the nth column's list, the way the loop does it: the event moves
+    /// the offset, and the `JobRequest::Paint` it asks for arrives as
+    /// `mark_needs_paint` when the job queue is drained (`jobs.rs`).
+    fn scroll(&mut self, column: usize, delta: f32) {
+        let root = self.root;
+        let x = if column == 0 {
+            COLUMN_A_X + VIEWPORT / 2.0
+        } else {
+            COLUMN_B_X + VIEWPORT / 2.0
+        };
+        self.tree.with_widget_mut(root, |w, id, t| {
+            w.event(
+                t,
+                id,
+                &Event::Scroll {
+                    x,
+                    y: SCROLLER_TOP + VIEWPORT / 2.0,
+                    delta_x: 0.0,
+                    delta_y: delta,
+                    source: ScrollSource::Wheel,
+                },
+            )
+        });
+        let scroller = self.scroller(column);
+        self.tree.mark_needs_paint(scroller);
+    }
+
+    /// The top of what the nth column's scroller draws, in surface
+    /// coordinates: the lowest world y among the commands its clip applies to.
+    ///
+    /// Only a scroller sets a clip, and the two are at different x, so this
+    /// picks out one scroller's subtree and nothing else. The lowest command in
+    /// it is the list, translated up by the scroll offset — so this number is
+    /// `SCROLLER_TOP - offset`, read off the commands handed to the GPU.
+    fn drawn_top(&self, column: usize) -> f32 {
+        let column_x = if column == 0 { COLUMN_A_X } else { COLUMN_B_X };
+        self.commands
+            .iter()
+            .filter(|cmd| {
+                cmd.clip
+                    .as_ref()
+                    .is_some_and(|clip| (clip.rect.x - column_x).abs() < 0.01)
+            })
+            .map(|cmd| cmd.world_transform.ty())
+            .fold(f32::INFINITY, f32::min)
+    }
+}
+
+/// Scrolling one list and then repainting for the *other* one must not put the
+/// first list back where it was: the commands the second frame produces have to
+/// carry the offset the first frame scrolled to.
+///
+/// The stale copy comes from the paint cache. A scrolling column culls the rows
+/// that left the viewport, which makes its paint partial and so uncacheable —
+/// and the entry kept from the last complete paint is the list at rest, from
+/// before any of the scrolling happened. Nothing is dirty by the third frame,
+/// so `reuse_cached` serves that entry, content and scrollbar handle together.
+#[test]
+fn a_scrolled_list_survives_a_frame_painted_for_its_sibling() {
+    let mut s = Surface::new();
+
+    s.frame();
+    let caption = s.caption_node(0);
+    let at_rest = s.drawn_top(0);
+    assert_eq!(
+        at_rest, SCROLLER_TOP,
+        "at rest the top of what is drawn is the top of the viewport"
+    );
+
+    s.scroll(0, SCROLL);
+    s.frame();
+    assert_eq!(
+        s.drawn_top(0),
+        SCROLLER_TOP - SCROLL,
+        "the list should be drawn {SCROLL}px above the viewport"
+    );
+
+    // The pointer moves onto the other list's scrollbar: that column repaints,
+    // this one is untouched and clean.
+    let other = s.scroller(1);
+    s.tree.mark_needs_paint(other);
+    s.frame();
+
+    assert_eq!(
+        s.drawn_top(0),
+        SCROLLER_TOP - SCROLL,
+        "the first list snapped back when the second one asked for a frame"
+    );
+    assert_eq!(
+        s.drawn_top(1),
+        SCROLLER_TOP,
+        "the second list was never scrolled"
+    );
+    assert!(
+        std::rc::Rc::ptr_eq(&caption, &s.caption_node(0)),
+        "the caption was repainted rather than served from the paint cache — \
+         a harness that stops reaching `reuse_cached` goes green however \
+         broken the cache is"
+    );
+}


### PR DESCRIPTION
## What changed

A paint that could not be cached now also invalidates the entry the last cacheable one left. `cache_paint_results` used to refuse to cache a partial paint — children culled — and keep the previous complete entry, on the reasoning that it could be reused again once the widget was fully visible. A list culls from its first scrolled frame onwards, so every paint after the first is partial and none is cached, and the newest complete entry is therefore the list *at rest*, from before any scrolling happened. `reuse_cached` serves that whole subtree the moment the column goes clean and some other widget asks for a frame, which is why the content and the scrollbar handle went stale together: they are one reused subtree. `Tree::clear_cached_paint` drops it instead. Closes #247.

## What proves it

`tests/paint_cache_across_frames.rs::a_scrolled_list_survives_a_frame_painted_for_its_sibling`. With the fix commit reverted it fails on the third frame with `left: 29.0, right: -91.0` — 29.0 being `SCROLLER_TOP`, the list back at rest, the same snap-back the issue reports. It passes with the fix.

The harness is the part worth more than the bug. Every other test in `tests/` builds a fresh `RenderNode` per frame and never runs `cache_paint_results`, so `Tree`'s paint cache stays empty and every widget paints in full — a stale entry there is not merely untested but structurally invisible, which is why every probe in the issue's table came back clean. This one keeps one root node for the life of the surface and clears it per frame, as `ManagedSurface::root_node` does, and runs paint → flatten → `cache_paint_results` in the loop's order. `cache_paint_results` becomes public for the same reason `flatten_root_into` is.

A last assertion pins the harness itself: `reuse_cached` shares the cached `Rc` when the position has not moved, so a caption served from the cache is the same allocation three frames running. Without it a harness that quietly stopped reaching the cached path would go green however broken the cache was, and take the only test of that path with it. Verified it bites by forcing `reuse_cached` to bail.

No golden and no snapshot moved, and none could: they all render a single frame, and the paint cache only exists across frames. That is the hole this branch fills rather than one it leaves. Goldens ran on lavapipe, 9 passed, 0 skipped.

## What the review found

The `reviewer` subagent read the two commits before this pull request existed. **Zero findings blocked.** Three were worth answering; all three are acted on, one of them by disagreeing:

1. *The issue's comment asked for one answer covering the two defects recorded there, and the commits were silent.* Answered below under "Left undone".

2. *"The fast path this loses was never a saving — it was the bug" is too strong.* Right conclusion, but the measurement offered against it does not reproduce. The reviewer reported a static overflowing list going from 180/720 to 357/1369; I measure 180 children painted and 720 nodes flattened **before and after**, unchanged, because a list still at the top culls nothing on its first paint, is cached, and stays correct — the entry is only dropped once the widget actually repaints partially. The real loss lands on a list that *has* been scrolled: 180/720 → 360/1440 over 60 frames driven by a sibling, and permanently, because each repaint is partial again. The commit body now states that rather than waving it away, and says what was rejected: the entry could be kept if it were keyed on the cull rect it was painted against, so reuse resumed whenever the offset had not moved. That is a new field on `RenderNode` and a new condition in `reuse_cached` — a decision, not a bug fix, so it is not in this branch.

3. *The symptom was never confirmed on a compositor.* Now it has been; see below.

Notes taken rather than argued: `RenderNode::partial`'s own doc was the one prose site the first pass missed and is updated; the test's header claim that "the children of that root come back from the paint cache" was false for the two columns after the fix and is reworded.

## What was checked by hand

`examples/scroll_example`, debug build from this branch, niri. Scrolled the first list, moved the pointer off it and onto the middle list's scrollbar band — the first list stayed where it was, handle included, where before it snapped back to Item 1.

## Left undone

The two defects recorded in #247's comment are **not merged, and this is the answer to both**.

*`flatten` caches a subtree that contains a clip.* Reuse of `cached_flatten` requires `repainted == false`, and the only way a node with that flag enters a frame's tree is `reuse_cached` — `RenderNode::new` and `clear` both set it true. After this change no subtree that culls anything is ever in the paint cache, so the stale clip-carrying column that was observed replaying 82 times cannot be assembled: `[FLAT-CACHED] node=1` was this same defect seen one layer down, not a second one. A subtree that culls nothing is complete, and its flatten cache describes it as it is. The blunt guard costs the fast path for every column holding a scroller and is not needed.

*`mark_needs_paint` stops at a stale flag.* The state it guards against needs a widget whose `needs_paint` outlived its paint. `reuse_cached` only serves a clean widget, and marking a descendant marks every ancestor — so a stale flag can only be created where one already exists. The maintainer's note says the triggering state was reasoned and never measured, against a cost that was; nothing here changes that, and always walking to the root stays unjustified.

Both branches can be closed. If either turns out to have a case this reasoning misses, it wants its own issue with the state that produces it.
