### PR TITLE
The pointer's translation is a function, and eight questions can reach it

### DIFF
--- a/src/platform/input.rs
+++ b/src/platform/input.rs
@@ -15,7 +15,8 @@ use smithay_client_toolkit::{
         Capability, SeatHandler, SeatState,
         keyboard::{KeyEvent, KeyboardHandler, Keysym, Modifiers as WlModifiers, RawModifiers},
         pointer::{
-            PointerEvent, PointerEventKind, PointerHandler, cursor_shape::CursorShapeManager,
+            AxisScroll, PointerEvent, PointerEventKind, PointerHandler,
+            cursor_shape::CursorShapeManager,
         },
         touch::TouchHandler,
     },
@@ -472,74 +473,79 @@ impl PointerHandler for WaylandState {
                     source,
                     ..
                 } => {
-                    // Determine scroll source
-                    let scroll_source = match source {
-                        Some(wl_pointer::AxisSource::Wheel) => ScrollSource::Wheel,
-                        Some(wl_pointer::AxisSource::Finger) => ScrollSource::Finger,
-                        Some(wl_pointer::AxisSource::Continuous) => ScrollSource::Continuous,
-                        Some(wl_pointer::AxisSource::WheelTilt) => ScrollSource::Wheel,
-                        _ => ScrollSource::Wheel,
-                    };
-
-                    // Calculate delta in pixels.
-                    // Wheel steps by preference: value120 (wl_pointer v8+,
-                    // fractional steps from high-resolution wheels) then
-                    // legacy discrete. Touchpad/finger scroll has neither
-                    // and uses absolute (already in pixels).
-                    let wheel_steps =
-                        |scroll: &smithay_client_toolkit::seat::pointer::AxisScroll| {
-                            if scroll.value120 != 0 {
-                                scroll.value120 as f32 / 120.0
-                            } else {
-                                scroll.discrete as f32
-                            }
-                        };
-
-                    let steps_x = wheel_steps(&horizontal);
-                    let delta_x = if steps_x != 0.0 {
-                        steps_x * SCROLL_PIXELS_PER_LINE
-                    } else {
-                        horizontal.absolute as f32
-                    };
-
-                    let steps_y = wheel_steps(&vertical);
-                    let delta_y = if steps_y != 0.0 {
-                        steps_y * SCROLL_PIXELS_PER_LINE
-                    } else {
-                        vertical.absolute as f32
-                    };
-
-                    // An axis event says two things, and a guard on the delta
-                    // alone dropped the second. `axis_stop` is how the hardware
-                    // ends a continuous scroll, and it carries no delta —
-                    // because nothing moved — so it was filtered out one line
-                    // before anything could use it. It is the only unguessed
-                    // answer to when a gesture is over.
-                    let gesture_ended = horizontal.stop || vertical.stop;
-                    let scrolled = delta_x != 0.0 || delta_y != 0.0;
-
-                    if (scrolled || gesture_ended)
-                        && let Some(events) = target_events
-                    {
-                        if scrolled {
-                            events.push(Event::Scroll {
-                                x: self.input.pointer_x,
-                                y: self.input.pointer_y,
-                                delta_x,
-                                delta_y,
-                                source: scroll_source,
-                            });
-                        }
-                        if gesture_ended {
-                            events.push(Event::ScrollEnd {
-                                x: self.input.pointer_x,
-                                y: self.input.pointer_y,
-                            });
-                        }
+                    if let Some(events) = target_events {
+                        translate_axis(
+                            events,
+                            source,
+                            &horizontal,
+                            &vertical,
+                            self.input.pointer_x,
+                            self.input.pointer_y,
+                        );
                     }
                 }
             }
         }
+    }
+}
+
+/// What an axis message asks a widget to do, given where the pointer is.
+///
+/// Free rather than inline, for the same reason `keysym_to_key` is: a callback
+/// that needs a compositor to run is a callback nothing checks, and this is
+/// where the protocol's only statement about a gesture *ending* is read.
+fn translate_axis(
+    events: &mut Vec<Event>,
+    source: Option<wl_pointer::AxisSource>,
+    horizontal: &AxisScroll,
+    vertical: &AxisScroll,
+    x: f32,
+    y: f32,
+) {
+    let scroll_source = match source {
+        Some(wl_pointer::AxisSource::Wheel) => ScrollSource::Wheel,
+        Some(wl_pointer::AxisSource::Finger) => ScrollSource::Finger,
+        Some(wl_pointer::AxisSource::Continuous) => ScrollSource::Continuous,
+        Some(wl_pointer::AxisSource::WheelTilt) => ScrollSource::Wheel,
+        _ => ScrollSource::Wheel,
+    };
+
+    // Wheel steps by preference: value120 (wl_pointer v8+, fractional steps
+    // from high-resolution wheels) then legacy discrete. Touchpad and finger
+    // scroll have neither and report absolute pixels, which pass through —
+    // multiplying those by a line height scrolls a page for a fingertip.
+    let pixels = |scroll: &AxisScroll| {
+        let steps = if scroll.value120 != 0 {
+            scroll.value120 as f32 / 120.0
+        } else {
+            scroll.discrete as f32
+        };
+        if steps != 0.0 {
+            steps * SCROLL_PIXELS_PER_LINE
+        } else {
+            scroll.absolute as f32
+        }
+    };
+
+    let delta_x = pixels(horizontal);
+    let delta_y = pixels(vertical);
+
+    // An axis message says two things, and a guard on the delta alone dropped
+    // the second. `axis_stop` is how the hardware ends a continuous scroll, and
+    // it carries no delta — because nothing moved — so it was filtered out one
+    // line before anything could use it. It is the only unguessed answer to
+    // when a gesture is over.
+    if delta_x != 0.0 || delta_y != 0.0 {
+        events.push(Event::Scroll {
+            x,
+            y,
+            delta_x,
+            delta_y,
+            source: scroll_source,
+        });
+    }
+    if horizontal.stop || vertical.stop {
+        events.push(Event::ScrollEnd { x, y });
     }
 }
 

--- a/src/platform/input.rs
+++ b/src/platform/input.rs
@@ -842,4 +842,213 @@ mod tests {
         let e = Keysym::new(0x65); // 'e', composed into 'é'
         assert_eq!(keysym_to_key(e, Some("é"), true), Some(Key::Char('é')));
     }
+
+    /// The pointer position the events carry, so a test can tell it apart
+    /// from a delta.
+    const PX: f32 = 10.0;
+    const PY: f32 = 20.0;
+
+    fn axis(
+        source: Option<wl_pointer::AxisSource>,
+        horizontal: AxisScroll,
+        vertical: AxisScroll,
+    ) -> Vec<Event> {
+        let mut events = Vec::new();
+        translate_axis(&mut events, source, &horizontal, &vertical, PX, PY);
+        events
+    }
+
+    fn nothing() -> AxisScroll {
+        AxisScroll::default()
+    }
+
+    fn wheel(value120: i32) -> AxisScroll {
+        AxisScroll {
+            value120,
+            ..Default::default()
+        }
+    }
+
+    fn finger(absolute: f64) -> AxisScroll {
+        AxisScroll {
+            absolute,
+            ..Default::default()
+        }
+    }
+
+    fn stopped() -> AxisScroll {
+        AxisScroll {
+            stop: true,
+            ..Default::default()
+        }
+    }
+
+    /// The case #205 rests on. `axis_stop` carries no delta — nothing moved —
+    /// so a guard on the delta alone swallows the only unguessed answer to
+    /// when a gesture is over.
+    #[test]
+    fn a_stop_with_no_delta_is_an_end_and_nothing_else() {
+        let events = axis(Some(wl_pointer::AxisSource::Finger), nothing(), stopped());
+        assert_eq!(events.len(), 1, "one event, got {events:?}");
+        let Event::ScrollEnd { x, y } = events[0] else {
+            panic!("a stop is a ScrollEnd, got {:?}", events[0]);
+        };
+        assert_eq!((x, y), (PX, PY), "and it carries the pointer, not a delta");
+
+        // Either axis alone says it: a vertical gesture ends on the vertical
+        // axis, a horizontal one on the horizontal.
+        let events = axis(Some(wl_pointer::AxisSource::Finger), stopped(), nothing());
+        assert!(
+            matches!(events.as_slice(), [Event::ScrollEnd { .. }]),
+            "the horizontal axis ends a gesture too, got {events:?}"
+        );
+    }
+
+    /// One logical step is one line, and a high-resolution wheel reports it in
+    /// hundred-and-twentieths so half a step is half a line.
+    #[test]
+    fn a_wheel_step_is_a_line_and_a_fraction_of_one_is_a_fraction_of_a_line() {
+        let events = axis(Some(wl_pointer::AxisSource::Wheel), nothing(), wheel(120));
+        let [
+            Event::Scroll {
+                delta_y, source, ..
+            },
+        ] = events.as_slice()
+        else {
+            panic!("a wheel step scrolls, got {events:?}");
+        };
+        assert_eq!(*delta_y, SCROLL_PIXELS_PER_LINE);
+        assert_eq!(*source, ScrollSource::Wheel);
+
+        let events = axis(Some(wl_pointer::AxisSource::Wheel), nothing(), wheel(60));
+        let [Event::Scroll { delta_y, .. }] = events.as_slice() else {
+            panic!("half a step scrolls, got {events:?}");
+        };
+        assert_eq!(*delta_y, SCROLL_PIXELS_PER_LINE / 2.0);
+    }
+
+    /// A compositor that sends both sends the legacy field for the benefit of
+    /// clients that cannot read the other one. Reading `discrete` in
+    /// preference would round a half step down to nothing.
+    #[test]
+    fn value120_answers_before_discrete() {
+        let both = AxisScroll {
+            value120: 60,
+            discrete: 1,
+            ..Default::default()
+        };
+        let events = axis(Some(wl_pointer::AxisSource::Wheel), nothing(), both);
+        let [Event::Scroll { delta_y, .. }] = events.as_slice() else {
+            panic!("expected one scroll, got {events:?}");
+        };
+        assert_eq!(
+            *delta_y,
+            SCROLL_PIXELS_PER_LINE / 2.0,
+            "the high-resolution field decides"
+        );
+    }
+
+    /// A touchpad has neither step field: it already speaks in pixels, and
+    /// multiplying those by a line height would scroll a page for a fingertip.
+    #[test]
+    fn a_touchpad_scrolls_the_pixels_it_reports() {
+        let events = axis(Some(wl_pointer::AxisSource::Finger), nothing(), finger(7.5));
+        let [
+            Event::Scroll {
+                x,
+                y,
+                delta_y,
+                source,
+                ..
+            },
+        ] = events.as_slice()
+        else {
+            panic!("expected one scroll, got {events:?}");
+        };
+        assert_eq!(*delta_y, 7.5, "pixels pass through");
+        assert_eq!(*source, ScrollSource::Finger);
+        // Where the scroll happened, not how far it went: `hit.contains(x, y)`
+        // in `interaction.rs` is what decides whose scroll this is.
+        assert_eq!((*x, *y), (PX, PY), "and it carries the pointer");
+    }
+
+    /// The last message of a flick carries both: the final movement and the
+    /// lifted finger. The movement has to arrive first, or the momentum is
+    /// computed from a sample the gesture had not yet made.
+    #[test]
+    fn a_gesture_that_moves_and_stops_says_both_in_that_order() {
+        let last = AxisScroll {
+            absolute: 12.0,
+            stop: true,
+            ..Default::default()
+        };
+        let events = axis(Some(wl_pointer::AxisSource::Finger), nothing(), last);
+        assert!(
+            matches!(
+                events.as_slice(),
+                [Event::Scroll { .. }, Event::ScrollEnd { .. }]
+            ),
+            "the movement, then the end, got {events:?}"
+        );
+    }
+
+    /// An axis message that says neither is a frame boundary, not an event.
+    /// Pushing for it would wake the surface for nothing.
+    #[test]
+    fn an_axis_message_with_neither_a_delta_nor_a_stop_says_nothing() {
+        let events = axis(Some(wl_pointer::AxisSource::Wheel), nothing(), nothing());
+        assert!(events.is_empty(), "got {events:?}");
+    }
+
+    /// A continuous source is neither of the others: it reports pixels like a
+    /// finger, and since #248 it coasts when the gesture ends where a wheel
+    /// does not. Folding it into either one changes what happens on release.
+    #[test]
+    fn a_continuous_source_stays_continuous() {
+        let events = axis(
+            Some(wl_pointer::AxisSource::Continuous),
+            nothing(),
+            finger(5.0),
+        );
+        let [
+            Event::Scroll {
+                delta_y, source, ..
+            },
+        ] = events.as_slice()
+        else {
+            panic!("expected one scroll, got {events:?}");
+        };
+        assert_eq!(*delta_y, 5.0);
+        assert_eq!(*source, ScrollSource::Continuous);
+    }
+
+    /// A tilted wheel is still a wheel — it steps — and a source the protocol
+    /// grows later is treated as one until somebody teaches it otherwise.
+    #[test]
+    fn a_tilted_wheel_is_a_wheel_and_so_is_an_unnamed_source() {
+        let events = axis(
+            Some(wl_pointer::AxisSource::WheelTilt),
+            wheel(120),
+            nothing(),
+        );
+        let [
+            Event::Scroll {
+                delta_x, source, ..
+            },
+        ] = events.as_slice()
+        else {
+            panic!("expected one scroll, got {events:?}");
+        };
+        assert_eq!(*source, ScrollSource::Wheel);
+        assert_eq!(
+            *delta_x, SCROLL_PIXELS_PER_LINE,
+            "and a tilt steps sideways by a line"
+        );
+
+        let events = axis(None, wheel(120), nothing());
+        let [Event::Scroll { source, .. }] = events.as_slice() else {
+            panic!("expected one scroll, got {events:?}");
+        };
+        assert_eq!(*source, ScrollSource::Wheel);
+    }
 }


### PR DESCRIPTION
## What changed

The same file translated two input devices and only one of them could be asked a question. `keysym_to_key` is a free function with four tests beside it; the pointer's arithmetic sat inside the sctk callback, where reaching it means having a compositor — which is why none of the twenty-four sites building an `Event` in `src/platform/input.rs` had ever been checked.

`translate_axis` now takes what an axis message carries — the source, the two `AxisScroll`s, and where the pointer is — and says which events it asks for. Nothing about it needs a connection: `AxisScroll` is a plain struct with public fields and a `Default`. Behaviour is unchanged; the arithmetic runs after the surface lookup rather than before it, which matters in exactly one case — a surface listed in `surface_lookup` but missing from `surfaces` — and produced nothing then as now.

Two commits: the extraction, then the questions. They read backwards against "the failing test, then the fix" until you say why, and the issue says it: the tests fail before the change because there is nowhere to write them.

Closes #249.

## What proves it

Eight tests beside the function, each run against the one-line change it exists to catch. **Fifteen mutations, applied one at a time with the tree restored between them, every one red:**

| broken on purpose | what fails |
| --- | --- |
| `|| vertical.stop` deleted | `a_stop_with_no_delta_is_an_end_and_nothing_else, a_gesture_that_moves_and_stops_says_both_in_that_order` |
| `horizontal.stop ||` deleted | `a_stop_with_no_delta_is_an_end_and_nothing_else` |
| `discrete` read before `value120` | `value120_answers_before_discrete` |
| a step no longer multiplied by the line height | `a_wheel_step_is_a_line_and_a_fraction_of_one_is_a_fraction_of_a_line, value120_answers_before_discrete, a_tilted_wheel_is_a_wheel_and_so_is_an_unnamed_source` |
| `absolute` no longer passed through | `a_continuous_source_stays_continuous, a_gesture_that_moves_and_stops_says_both_in_that_order, a_touchpad_scrolls_the_pixels_it_reports` |
| `Wheel` mapped to `Finger` | `a_wheel_step_is_a_line_and_a_fraction_of_one_is_a_fraction_of_a_line` |
| `Finger` mapped to `Wheel` | `a_touchpad_scrolls_the_pixels_it_reports` |
| `Continuous` mapped to `Wheel` | `a_continuous_source_stays_continuous` |
| `WheelTilt` mapped to `Finger` | `a_tilted_wheel_is_a_wheel_and_so_is_an_unnamed_source` |
| an unnamed source mapped to `Finger` | `a_tilted_wheel_is_a_wheel_and_so_is_an_unnamed_source` |
| the delta guard removed | `a_stop_with_no_delta_is_an_end_and_nothing_else, an_axis_message_with_neither_a_delta_nor_a_stop_says_nothing` |
| `Scroll` carrying `0.0, 0.0` instead of the pointer | `a_touchpad_scrolls_the_pixels_it_reports` |
| `ScrollEnd` carrying `0.0, 0.0` instead of the pointer | `a_stop_with_no_delta_is_an_end_and_nothing_else` |
| the horizontal delta doubled | `a_tilted_wheel_is_a_wheel_and_so_is_an_unnamed_source` |
| `ScrollEnd` pushed before `Scroll` | `a_gesture_that_moves_and_stops_says_both_in_that_order` |

The first two are the ones #205 rests on. Momentum now starts on `Event::ScrollEnd` and nothing else, so if `axis_stop` stopped producing one, touchpad momentum would disappear completely and the suite would stay green — `tests/scroll_momentum.rs` synthesises the event itself. That line had nothing watching it until now.

Full harness green: 562 lib tests, every integration binary, `cargo fmt --check` and `clippy -D warnings` clean, 9 goldens on lavapipe with no skips.

## What the review found

**Zero blocking.** Three worth answering, all acted on, and one of them was the sharpest finding this branch could have had.

**Four mutations survived the tests as first written, and the worst of them was the failure this issue exists to end.** A `Event::Scroll` carrying the wrong position passed: `src/widgets/container/interaction.rs:328` gates a scroll on `hit.contains(x, y)`, so every wheel tick and touchpad sample would reach the wrong widget or none, and nothing would say so. I had asserted the coordinates on `ScrollEnd` and not on `Scroll`, with the `PX`/`PY` constants sitting there for exactly that purpose. Also unwatched: the horizontal delta's *value*, the source on a plain wheel, and `Continuous` — which since #248 is the difference between coasting and stopping dead. Three assertions and an eighth test close all four; the table above is the re-run, and the four now appear in it as red.

**The one line the change adds inside the callback is executed by nothing.** The call takes two `&AxisScroll` and two `f32`, and swapping either pair compiles in silence. Verified by reading that the order matches the signature and that the fields are the ones the old code pushed — and then by hand, below, which is the only way this line can be reached.

**A sentence in the first commit's body was not true of the code path.** It claimed the reordering makes an axis message for a surface that is not ours stop costing anything; `input.rs:384` `continue`s before the `match`, so such a message never reached the arm at all. The commits were rebuilt with the accurate statement.

One note carried forward rather than acted on: `PointerEventKind::Axis` carries a compositor `time` that the callback discards, while momentum measures the gap with `Instant::now()`. Nothing here depends on it; it would make an issue if velocity ever needs the protocol's clock.

## What was checked by hand

`examples/scroll_example` on **niri**, run by the maintainer, both devices — a wheel tick scrolls vertically by a line in the right direction, and a touchpad flick still coasts after the finger lifts without running away on a slow scroll. That is the only way to reach the call site itself, and the only evidence that the arguments are in the right order.

## Left undone

**Whether the compositor sends `axis_stop` at all.** A claim about the other program, and `wayland.xml:2271-2281` is explicit: with `finger` it *will* be sent; for other sources a client "must not rely" on it and should "treat the scroll sequence as unterminated by default". No test in this repository can establish it, so the manual check #205 needed still stands.

**The other pointer arms** — `MouseDown`, `MouseUp`, `MouseMove`, `MouseEnter`, `MouseLeave`. Same file, same idea, but they resolve the surface and mutate pointer state, so they are not this extraction. A non-goal in #249.

**This does not move the Wayland row of "What proves what".** It removes a slice from the callback; it builds no part of a harness, and the line it adds inside the callback is itself unreachable by any test. The row still reads `nothing automated`, correctly.

---

**The mutation job says the same thing.** It crashed on `No space left on device` partway through its sixteen mutants — an infrastructure failure, not a finding — but before it died it reported one: `MISSED src/platform/input.rs:377: replace <impl PointerHandler for WaylandState>::pointer_frame with ()`. Delete the entire callback body and nothing in the suite notices. That is the second finding above and the third paragraph of *Left undone*, arrived at independently, and it is why the manual check is the only evidence for the call site.

**Update.** #255 merged, so the mutation job now runs to completion on this branch: `16 mutants tested in 8m: 3 missed, 13 caught` ([run](https://github.com/MalpenZibo/guido/actions/runs/33003918614/job/98292513822)). The red X is cargo-mutants reporting survivors, not the crash it was before.

The three survivors are accounted for. `replace pointer_frame with ()` is the finding above and the third paragraph of *Left undone* — the callback no test reaches. The other two, `delete match arm Some(AxisSource::Wheel)` and `Some(AxisSource::WheelTilt)`, are equivalent mutants: both arms map to `ScrollSource::Wheel` and so does the `_` catch-all beneath them, so deleting either changes nothing observable. No test can kill them, and one that appeared to would be asserting the shape of the match rather than its behaviour.
