### PR TITLE
The mutation job builds the tests, not sixty examples it never runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,8 +151,25 @@ jobs:
         env:
           BASE: ${{ github.event.pull_request.base.sha }}
         run: git diff "$BASE"...HEAD > /tmp/pull-request.diff
+      # `--lib --tests` because a plain `cargo test` also builds all sixty
+      # examples, and each of the `-j N` build directories compiles the crate
+      # from scratch — nothing is shared, and `--copy-target` is off by default,
+      # so there is no incremental reuse to soften it. Four trees at 26 GB on a
+      # runner with a few tens of gigabytes. Nothing is lost — the examples are
+      # compiled by the Test job, once, and they carry no tests of their own.
+      # No debug info for the same reason
+      # and because it is most of what remains: what matters here is whether a
+      # test failed, not where. Measured on a clean tree: 26 GB and 84s becomes
+      # 1.4 GB and 47s.
+      #
+      # It costs the doc tests, which target selection excludes and which cargo
+      # refuses to combine with `--doc`. A mutant only a doc test would have
+      # killed now reports as missed.
       - name: Mutate what changed
-        run: cargo mutants --in-diff /tmp/pull-request.diff -j 4 --no-shuffle
+        env:
+          CARGO_PROFILE_DEV_DEBUG: 0
+          CARGO_PROFILE_TEST_DEBUG: 0
+        run: cargo mutants --in-diff /tmp/pull-request.diff -C --lib -C --tests -j 4 --no-shuffle
       - name: Upload what survived
         if: failure()
         uses: actions/upload-artifact@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,7 +120,9 @@ useful than the shape: the background-write queue, the whole of `clipboard`,
 Whole-crate runs take hours; a module at a time is how it is used by hand. On a
 pull request CI mutates only the lines the diff touched, which asks the one
 question worth asking of new code — if this were wrong, would anything have
-noticed. That job reports; it does not block, until somebody decides the
+noticed. That job builds the tests and not the sixty examples, which is what
+keeps it inside the runner's disk, and the price is the doc tests: a mutant only
+a doc test would have killed reports there as missed. That job reports; it does not block, until somebody decides the
 ratchet is worth the friction.
 
 ## Where the rest of it is


### PR DESCRIPTION
## What changed

`cargo mutants` with no cargo arguments runs a plain `cargo test`, which builds every example in the crate. There are sixty, each statically linked against wgpu and carrying full debug info: **26 GB on a clean tree, 18 GB of it `target/debug/examples`**. Each of the `-j N` build directories compiles that from scratch — nothing is shared between them, and `--copy-target` is off by default, so there is no incremental reuse to soften it. Four such trees do not fit a hosted runner.

The job now builds the tests and nothing else, without debug info:

```
env:
  CARGO_PROFILE_DEV_DEBUG: 0
  CARGO_PROFILE_TEST_DEBUG: 0
run: cargo mutants --in-diff /tmp/pull-request.diff -C --lib -C --tests -j 4 --no-shuffle
```

| build | `target/` | of which `examples/` | time |
| --- | --- | --- | --- |
| what CI ran | 26 GB | 18 GB | 84 s |
| `--lib --tests` | 6.8 GB | 0 | 58 s |
| and no debug info | **1.4 GB** | 0 | 47 s |

Nothing substantial is lost: the examples are compiled by the `Test` job already, once, and carry no tests of their own. The price is the doc tests — cargo refuses to combine `--doc` with target selection — so a mutant only a doc test would have killed now reports as missed. `AGENTS.md` says so where it describes the job, because a sensor that has been narrowed and does not say so is what this change is about.

Closes #253.

## What proves it

**A CI run, and it could not be this pull request's own.** `cargo mutants --in-diff` on a diff with no Rust file prints `Diff changes no Rust source files` and exits 0 without building anything — so the job here will go green having exercised nothing. The review blocked on exactly that, and it was right: a green job that did nothing is the failure this change exists to fix.

So the evidence comes from #254, a throwaway pull request — #252's two commits, a real 245-line Rust diff and the very one whose job died, with this fix cherry-picked on top. Opened, observed, closed, branch deleted.

| | before (#252) | after (#254) |
| --- | --- | --- |
| run | [job 98241056700](https://github.com/MalpenZibo/guido/actions/runs/32988752385/job/98241056700) | [job 98283093304](https://github.com/MalpenZibo/guido/actions/runs/33001169670/job/98283093304) |
| mutants tested | **1 of 16** | **16 of 16** |
| build per mutant | 240 s | 36–60 s |
| wall time | 27m41s, then died | 9m00s, complete |
| ended with | `Error: No space left on device (os error 28)` | `16 mutants tested in 9m: 3 missed, 13 caught` |

Exit code 2 is cargo-mutants saying mutants survived, which is the job reporting rather than crashing — the same red X, and this is the second reason the log matters more than the tick.

## What the review found

**One blocking, and it saved this pull request from asserting a proof it did not have.** I had written that the CI run on this branch would be the evidence. It would not: the reviewer ran cargo-mutants against a `ci.yml`-only diff and got `Diff changes no Rust source files`, exit 0, sub-second. Two of the issue's three acceptance criteria would have passed vacuously and the third would have been false. The whole evidence section above exists because of that finding.

Two worth answering, both acted on:

- **The mechanism I wrote was false.** I said `cargo mutants` copies `target/` into every build directory and that `--copy-target` defaults to on. It defaults to **off** — confirmed in `options.rs:362`, in `NEWS.md`, and by planting a 40 MB file in `target/` and watching it not be copied. The real cause is that each build directory compiles from scratch with no reuse, which the failing log corroborates: 184 s baseline, then 240 s for the next mutant. Same arithmetic, same fix, but the comment is what the next person reads when this breaks again, and it pointed at a knob that does nothing. Corrected in the workflow, the commit and #253.
- **`AGENTS.md` overstated the sensor.** It says the job "asks the one question worth asking of new code"; after this change that is untrue for the crate's doc examples — a probe crate confirmed a doc-test-only function goes from two caught to two missed. One sentence added.

One declined, with the reason: the fix is CI-only, so a by-hand `cargo mutants` still runs with debug info and without `--tests`, and `.cargo/mutants.toml` could hold one spelling for both. Left as is deliberately — the by-hand invocation runs a module at a time, where 26 GB on a 1.9 TB disk is not a problem, and putting `--tests` in the config would change what the 168/84/67% baseline recorded in `AGENTS.md` measured. Worth revisiting when that baseline is next re-measured.

Notes carried forward rather than acted on, each worth an issue: `taiki-e/install-action` installs cargo-mutants unpinned, so every behaviour verified here is 27.1.0's and can change under the job without notice; and `CARGO_INCREMENTAL=0` is free further savings in a throwaway build directory.

## What was checked by hand

The three builds in the table, on a clean worktree, timed and measured with `du`. Nothing needed a compositor.

## Left undone

**The job still goes red for two different reasons** — mutants survived, or the job broke — and they look the same from the pull request page. That ambiguity is what made this take a person noticing an X and reading the log. Making it distinguishable is a change to whether the job blocks, which #253 lists as a non-goal and which is a decision rather than a fix.
