### PR TITLE
A frame is one instant, and it says which one

### DIFF
--- a/book/src/architecture/rendering.md
+++ b/book/src/architecture/rendering.md
@@ -13,17 +13,21 @@ Per-surface rendering:
  3. Dispatch events                → Route input events (MouseMoves coalesced)
  4. Frame-pacing gate              → Return if the compositor hasn't shown the
                                      previous frame yet (jobs stay queued)
- 5. drain_pending_jobs()           → Process jobs: unregister, advance
+ 5. set_frame_instant(now)         → What time it is, for this whole frame:
+                                     everything below is asked about this one
+                                     moment rather than reading a clock of its
+                                     own (cleared again after step 13)
+ 6. drain_pending_jobs()           → Process jobs: unregister, advance
     + process_jobs()                 animations, reconcile children, mark dirty
- 6. Partial layout                 → Only dirty subtrees re-layout
- 7. Skip-frame check               → Skip paint if root is clean
- 8. widget.paint(tree, ctx)        → Build render tree (Rc cache reuse for clean children)
- 9. flatten_root_into()            → Flatten to draw commands (incremental for clean subtrees)
-10. frame() + damage_buffer()      → Re-arm the frame callback and report damage,
+ 7. Partial layout                 → Only dirty subtrees re-layout
+ 8. Skip-frame check               → Skip paint if root is clean
+ 9. widget.paint(tree, ctx)        → Build render tree (Rc cache reuse for clean children)
+10. flatten_root_into()            → Flatten to draw commands (incremental for clean subtrees)
+11. frame() + damage_buffer()      → Re-arm the frame callback and report damage,
                                      both BEFORE presenting
-11. GPU rendering + present()      → Instanced SDF shapes with HiDPI scaling;
+12. GPU rendering + present()      → Instanced SDF shapes with HiDPI scaling;
                                      present() commits the surface
-12. cache_paint_results()          → Rc-share rendered nodes into the cache,
+13. cache_paint_results()          → Rc-share rendered nodes into the cache,
                                      clear needs_paint flags
 ```
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -428,6 +428,14 @@ pub trait Widget {
 
 **Note:** Widget bounds and origins are stored in the `Tree`, not on individual widgets. Use `tree.get_bounds(id)` to retrieve a widget's bounds and `tree.set_origin(id, x, y)` to position widgets during layout.
 
+**Note:** So is what time it is. A widget that advances something over time asks
+`tree.frame_instant()` rather than the clock: a frame declares its instant once,
+around the jobs, the layout and the paint, so everything advancing in that frame
+is asked about the same moment. Reading the clock inside a widget makes one
+frame several instants, and makes the middle of an animation something no test
+can ask about — only sleep towards. `tree.set_frame_instant(Some(now))` is how a
+test names the moment it wants to ask about.
+
 ### Widgets written outside the crate
 
 The trait is implementable from anywhere, and a leaf needs only `layout` and

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1254,6 +1254,13 @@ fn render_surface(
         return;
     }
 
+    // What time it is, for this whole frame. Declared once here because a
+    // frame is these three passes: the animations advance, layout measures what
+    // they produced, paint draws it. Asking the clock inside each of them made
+    // one frame several instants, and made the middle of an animation something
+    // no test could ask about — only sleep towards.
+    ctx.tree.set_frame_instant(Some(std::time::Instant::now()));
+
     run_jobs(root, ctx.tree, layout_roots, active_roots);
 
     // Nothing moved and nothing is starting up: there is no frame to draw.
@@ -1265,11 +1272,16 @@ fn render_surface(
         || geometry.scale_changed
         || ctx.tree.needs_paint(root))
     {
+        ctx.tree.set_frame_instant(None);
         return;
     }
 
     layout_pass(ctx, &frame, &geometry, has_pending_layouts, layout_roots);
     paint_and_present(ctx, &frame, &geometry);
+    // The frame is over, and so is its instant. Leaving it set would let a
+    // later call read a time that has nothing to do with it, silently — the
+    // failure a stale clock always has.
+    ctx.tree.set_frame_instant(None);
 }
 
 pub struct App {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -153,6 +153,18 @@ pub struct Tree {
     /// surface's root widget. Per-surface so that one surface's render
     /// cannot consume (or misreport) damage accumulated by another.
     damage: std::collections::HashMap<WidgetId, DamageRegion>,
+    /// What time it is, for the pass currently running.
+    ///
+    /// A frame advances every animation in it, and asking the clock once per
+    /// animation makes one frame several instants a few microseconds apart.
+    /// More to the point, a widget that asks the clock cannot be asked about
+    /// the middle of an animation: a test can only sleep and assert a band
+    /// wide enough to survive a loaded machine, which is a band both a linear
+    /// and an eased curve fit inside.
+    ///
+    /// `process_jobs` writes it, because a pass is what a frame is made of.
+    /// `None` between passes, where nobody should be reading it.
+    frame_instant: Option<std::time::Instant>,
 }
 
 impl Tree {
@@ -163,7 +175,22 @@ impl Tree {
             sparse: Vec::new(),
             free_indices: Vec::new(),
             damage: std::collections::HashMap::new(),
+            frame_instant: None,
         }
+    }
+
+    /// What time it is for the pass now running.
+    ///
+    /// Falls back to the clock for a call that arrives outside a pass — the
+    /// behaviour every caller had before there was a frame instant at all.
+    pub fn frame_instant(&self) -> std::time::Instant {
+        self.frame_instant.unwrap_or_else(std::time::Instant::now)
+    }
+
+    /// Declare the instant of the pass about to run. `process_jobs` is the
+    /// caller; a test that wants to name a moment is the other one.
+    pub(crate) fn set_frame_instant(&mut self, now: Option<std::time::Instant>) {
+        self.frame_instant = now;
     }
 
     /// Register a widget in the tree and return its unique ID.

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -162,8 +162,10 @@ pub struct Tree {
     /// wide enough to survive a loaded machine, which is a band both a linear
     /// and an eased curve fit inside.
     ///
-    /// `process_jobs` writes it, because a pass is what a frame is made of.
-    /// `None` between passes, where nobody should be reading it.
+    /// `render_surface` writes it, around the three passes a frame is made of:
+    /// the jobs advance the animations, layout measures what they produced,
+    /// paint draws it. `None` between frames, where nobody should be reading
+    /// it.
     frame_instant: Option<std::time::Instant>,
 }
 
@@ -187,9 +189,15 @@ impl Tree {
         self.frame_instant.unwrap_or_else(std::time::Instant::now)
     }
 
-    /// Declare the instant of the pass about to run. `process_jobs` is the
-    /// caller; a test that wants to name a moment is the other one.
-    pub(crate) fn set_frame_instant(&mut self, now: Option<std::time::Instant>) {
+    /// Declare the instant of the frame about to run, or `None` when it is
+    /// over.
+    ///
+    /// `render_surface` is the caller in the loop. The other one is a test —
+    /// including a test of a widget written outside this crate, which is why
+    /// this is public: a widget that can read the frame's instant is a widget
+    /// whose behaviour over time can be asked about, and that needs somebody
+    /// able to name the moment.
+    pub fn set_frame_instant(&mut self, now: Option<std::time::Instant>) {
         self.frame_instant = now;
     }
 

--- a/src/widgets/container/anim_bridge.rs
+++ b/src/widgets/container/anim_bridge.rs
@@ -91,7 +91,7 @@ impl Container {
                 // later changes animate instead of snapping.
                 anim.set_immediate(target);
             } else if (target - *anim.target()).abs() > 0.001 {
-                anim.animate_to(target);
+                anim.animate_to(target, tree.frame_instant());
                 retargeted = true;
             }
         }
@@ -109,7 +109,7 @@ impl Container {
     /// value its signal actually holds, not the one captured at construction.
     ///
     /// See the module docs for why this cannot wait for the first paint.
-    pub(super) fn seed_animations(&mut self, id: WidgetId) {
+    pub(super) fn seed_animations(&mut self, id: WidgetId, now: std::time::Instant) {
         // Written out one by one: each property animates a different type, so
         // there is no single accessor to loop over.
         let anims = self.anims.as_ref();
@@ -180,13 +180,13 @@ impl Container {
         // each component animates a different type.
         let mut entered = false;
         if let (Some(anim), Some(target)) = (&mut anims.translate, tr_target) {
-            entered |= seed_or_enter(anim, target);
+            entered |= seed_or_enter(anim, target, now);
         }
         if let (Some(anim), Some(target)) = (&mut anims.rotate, ro_target) {
-            entered |= seed_or_enter(anim, target);
+            entered |= seed_or_enter(anim, target, now);
         }
         if let (Some(anim), Some(target)) = (&mut anims.scale, sc_target) {
-            entered |= seed_or_enter(anim, target);
+            entered |= seed_or_enter(anim, target, now);
         }
         if entered {
             request_job(id, JobRequest::Animation(RequiredJob::Paint));
@@ -286,10 +286,14 @@ impl Container {
 
 /// Start one component at its seeded target, or begin its enter transition.
 /// Returns whether an enter was begun, which is what needs a paint job.
-fn seed_or_enter<T: crate::animation::Animatable>(anim: &mut AnimationState<T>, target: T) -> bool {
+fn seed_or_enter<T: crate::animation::Animatable>(
+    anim: &mut AnimationState<T>,
+    target: T,
+    now: std::time::Instant,
+) -> bool {
     match anim.take_enter_from() {
         Some(enter) => {
-            anim.begin_from(enter, target);
+            anim.begin_from(enter, target, now);
             true
         }
         None => {

--- a/src/widgets/container/animations.rs
+++ b/src/widgets/container/animations.rs
@@ -59,7 +59,10 @@ pub struct AnimationState<T: Animatable> {
     /// Progress from 0.0 to 1.0 (or beyond for overshoot)
     progress: f32,
     /// Time when animation started
-    start_time: Instant,
+    /// When the running segment began, if one is running. `None` until the
+    /// first one does: a state that has never animated has no start, and a
+    /// placeholder instant would be a time nobody chose.
+    start_time: Option<Instant>,
     /// Forward transition (used when value increases or no reverse is set)
     transition: Transition,
     /// Optional reverse transition (used when value decreases)
@@ -98,7 +101,7 @@ impl<T: Animatable> AnimationState<T> {
             target: initial_value,
             start: initial_value,
             progress: 1.0, // Start completed
-            start_time: Instant::now(),
+            start_time: None,
             transition: config.forward,
             reverse_transition: config.reverse,
             using_reverse: false,
@@ -120,7 +123,7 @@ impl<T: Animatable> AnimationState<T> {
     }
 
     /// Start animating to a new target value
-    pub fn animate_to(&mut self, new_target: T) {
+    pub fn animate_to(&mut self, new_target: T, now: Instant) {
         // Don't restart if we're already animating to this target
         if new_target == self.target {
             return;
@@ -143,16 +146,16 @@ impl<T: Animatable> AnimationState<T> {
         };
 
         self.target = new_target;
-        self.begin_segment(self.current, carried);
+        self.begin_segment(self.current, carried, now);
     }
 
     /// Start a fresh run toward the current target, from rest.
-    fn begin_segment_from(&mut self, from: T) {
-        self.begin_segment(from, 0.0);
+    fn begin_segment_from(&mut self, from: T, now: Instant) {
+        self.begin_segment(from, 0.0, now);
     }
 
     /// The bookkeeping every new segment shares.
-    fn begin_segment(&mut self, from: T, carried: f32) {
+    fn begin_segment(&mut self, from: T, carried: f32, now: Instant) {
         let is_spring = matches!(
             self.active_transition().timing,
             crate::animation::TimingFunction::Spring(_)
@@ -160,7 +163,7 @@ impl<T: Animatable> AnimationState<T> {
         self.start = from;
         self.current = from;
         self.progress = 0.0;
-        self.start_time = Instant::now();
+        self.start_time = Some(now);
         self.spring_state = if is_spring {
             Some(SpringState::moving_at(carried))
         } else {
@@ -199,11 +202,11 @@ impl<T: Animatable> AnimationState<T> {
     }
 
     /// Advance the animation and return whether the value changed
-    pub fn advance(&mut self) -> AdvanceResult<T> {
+    pub fn advance(&mut self, now: Instant) -> AdvanceResult<T> {
         // A sequence speaks for the property while it runs, and nothing else
         // does — the same rule the cascade gives a CSS animation over a normal
         // declaration.
-        if let Some(result) = self.advance_timeline() {
+        if let Some(result) = self.advance_timeline(now) {
             return result;
         }
         if self.progress >= 1.0 && self.spring_state.is_none() {
@@ -222,7 +225,11 @@ impl<T: Animatable> AnimationState<T> {
             _ => None,
         };
 
-        let elapsed = self.start_time.elapsed().as_secs_f32() * 1000.0; // Convert to ms
+        // No segment has begun, so no time has passed in one.
+        let Some(started) = self.start_time else {
+            return AdvanceResult::NoChange;
+        };
+        let elapsed = now.duration_since(started).as_secs_f32() * 1000.0;
         let adjusted_elapsed = (elapsed - delay_ms).max(0.0);
 
         if adjusted_elapsed <= 0.0 {
@@ -404,17 +411,17 @@ impl<T: Animatable> AnimationState<T> {
 
     /// Start the sequence, from the top. Playing it again while it runs
     /// restarts it: the second refusal is not half a shake.
-    pub(crate) fn play(&mut self) {
+    pub(crate) fn play(&mut self, now: Instant) {
         if let Some(timeline) = &mut self.timeline
             && !timeline.keyframes.is_empty()
         {
-            timeline.playing = Some(Instant::now());
+            timeline.playing = Some(now);
         }
     }
 
     /// Advance the running timeline. `None` when there is none, or when the
     /// one that was running has just handed the property back.
-    fn advance_timeline(&mut self) -> Option<AdvanceResult<T>> {
+    fn advance_timeline(&mut self, now: Instant) -> Option<AdvanceResult<T>> {
         // Both halves together, so a `playing` without a sequence to play
         // cannot survive the question. On its own it would keep
         // `is_animating` true for good: a surface asking for a frame every
@@ -424,7 +431,7 @@ impl<T: Animatable> AnimationState<T> {
         };
         let started = timeline.playing?;
 
-        let elapsed = started.elapsed().as_secs_f32() * 1000.0;
+        let elapsed = now.duration_since(started).as_secs_f32() * 1000.0;
         let Some(value) = timeline.keyframes.value_at(elapsed) else {
             // Over. The property goes back to whatever declares it — by
             // *animating* there from where the sequence left it, not by
@@ -433,7 +440,7 @@ impl<T: Animatable> AnimationState<T> {
             // what made a card jump the moment a hover arrived mid-shake.
             timeline.playing = None;
             let landed = self.current;
-            self.begin_segment_from(landed);
+            self.begin_segment_from(landed, now);
             // Returning `None` lets this frame run the ordinary path, so the
             // hand-back is animated by the declared transition and reaches
             // its completion edge — which is what fires `on_complete`.
@@ -475,7 +482,7 @@ impl<T: Animatable> AnimationState<T> {
 
     /// Begin animating from an explicit value (enter transitions): the
     /// widget appears mid-animation instead of snapping to its target.
-    pub(crate) fn begin_from(&mut self, from: T, target: T) {
+    pub(crate) fn begin_from(&mut self, from: T, target: T, now: Instant) {
         self.current = from;
         self.start = from;
         self.initialized = true;
@@ -483,7 +490,7 @@ impl<T: Animatable> AnimationState<T> {
         // starts from `current`, which is now the enter value
         let t = target;
         self.target = from; // force the retarget below to fire
-        self.animate_to(t);
+        self.animate_to(t, now);
     }
 
     /// Set value immediately without animation (for initialization)
@@ -507,11 +514,11 @@ impl<T: Animatable> AnimationState<T> {
 #[macro_export]
 macro_rules! advance_anim {
     // Layout animation: marks needs_layout when value changes
-    ($self:expr, $anim:ident, $id:expr, $any_animating:expr, layout) => {
+    ($self:expr, $anim:ident, $id:expr, $any_animating:expr, $now:expr, layout) => {
         if let Some(ref mut anim) = $self.$anim {
             if anim.is_animating() {
                 $any_animating = true;
-                let required = if anim.advance().is_changed() {
+                let required = if anim.advance($now).is_changed() {
                     $crate::jobs::RequiredJob::Layout
                 } else {
                     $crate::jobs::RequiredJob::None
@@ -521,12 +528,12 @@ macro_rules! advance_anim {
         }
     };
     // Layout animation with target update
-    ($self:expr, $anim:ident, $target_expr:expr, $id:expr, $any_animating:expr, layout) => {
+    ($self:expr, $anim:ident, $target_expr:expr, $id:expr, $any_animating:expr, $now:expr, layout) => {
         if let Some(ref mut anim) = $self.$anim {
-            anim.animate_to($target_expr);
+            anim.animate_to($target_expr, $now);
             if anim.is_animating() {
                 $any_animating = true;
-                let required = if anim.advance().is_changed() {
+                let required = if anim.advance($now).is_changed() {
                     $crate::jobs::RequiredJob::Layout
                 } else {
                     $crate::jobs::RequiredJob::None
@@ -536,11 +543,11 @@ macro_rules! advance_anim {
         }
     };
     // Paint animation: push paint job when value changes
-    ($self:expr, $anim:ident, $id:expr, $any_animating:expr, paint) => {
+    ($self:expr, $anim:ident, $id:expr, $any_animating:expr, $now:expr, paint) => {
         if let Some(ref mut anim) = $self.$anim {
             if anim.is_animating() {
                 $any_animating = true;
-                let required = if anim.advance().is_changed() {
+                let required = if anim.advance($now).is_changed() {
                     $crate::jobs::RequiredJob::Paint
                 } else {
                     $crate::jobs::RequiredJob::None
@@ -550,12 +557,12 @@ macro_rules! advance_anim {
         }
     };
     // Paint animation with target update
-    ($self:expr, $anim:ident, $target_expr:expr, $id:expr, $any_animating:expr, paint) => {
+    ($self:expr, $anim:ident, $target_expr:expr, $id:expr, $any_animating:expr, $now:expr, paint) => {
         if let Some(ref mut anim) = $self.$anim {
-            anim.animate_to($target_expr);
+            anim.animate_to($target_expr, $now);
             if anim.is_animating() {
                 $any_animating = true;
-                let required = if anim.advance().is_changed() {
+                let required = if anim.advance($now).is_changed() {
                     $crate::jobs::RequiredJob::Paint
                 } else {
                     $crate::jobs::RequiredJob::None
@@ -641,26 +648,28 @@ mod tests {
         );
         anim.set_immediate(0.0);
 
-        anim.animate_to(1.0);
+        anim.animate_to(1.0, Instant::now());
         std::thread::sleep(std::time::Duration::from_millis(10));
-        anim.advance();
+        anim.advance(Instant::now());
         assert_eq!(fired.get(), 1, "settle must fire the callback once");
-        anim.advance();
+        anim.advance(Instant::now());
         assert_eq!(fired.get(), 1, "no refire after completion");
 
-        anim.animate_to(2.0);
+        anim.animate_to(2.0, Instant::now());
         std::thread::sleep(std::time::Duration::from_millis(10));
-        anim.advance();
+        anim.advance(Instant::now());
         assert_eq!(fired.get(), 2, "a new completed run fires again");
     }
     use crate::animation::TimingFunction;
 
     /// Step a running sequence to `ms` into its run.
     fn play_at<T: Animatable>(anim: &mut AnimationState<T>, ms: u64) {
-        if let Some(timeline) = anim.timeline.as_mut() {
-            timeline.playing = Some(Instant::now() - std::time::Duration::from_millis(ms));
-        }
-        anim.advance();
+        let started = anim
+            .timeline
+            .as_ref()
+            .and_then(|t| t.playing)
+            .expect("a sequence is playing");
+        anim.advance(started + std::time::Duration::from_millis(ms));
     }
 
     /// While a sequence runs it speaks for the property, and when it ends the
@@ -674,7 +683,7 @@ mod tests {
         anim.set_immediate(0.0);
         anim.set_timeline(Keyframes::new(60.0).at(0.0, 0.0).at(0.5, 10.0).at(1.0, 0.0));
 
-        anim.play();
+        anim.play(Instant::now());
         assert!(anim.is_animating(), "a playing timeline is an animation");
 
         play_at(&mut anim, 30);
@@ -685,7 +694,7 @@ mod tests {
         );
 
         // The declared value moves while the sequence is running.
-        anim.animate_to(3.0);
+        anim.animate_to(3.0, Instant::now());
         play_at(&mut anim, 70);
         at(&mut anim, 10);
         assert_eq!(*anim.current(), 3.0, "over, and back to what is declared");
@@ -702,12 +711,12 @@ mod tests {
         anim.set_immediate(0.0);
         anim.set_timeline(Keyframes::new(80.0).at(0.0, 0.0).at(1.0, 8.0));
 
-        anim.play();
+        anim.play(Instant::now());
         play_at(&mut anim, 60);
         let far = *anim.current();
 
-        anim.play();
-        anim.advance();
+        anim.play(Instant::now());
+        anim.advance(Instant::now());
         assert!(
             *anim.current() < far,
             "back near the top of the run, got {} after {far}",
@@ -729,11 +738,11 @@ mod tests {
         anim.set_immediate(0.0);
         anim.set_timeline(Keyframes::new(60.0).at(0.0, 0.0).at(1.0, 10.0));
 
-        anim.play();
+        anim.play(Instant::now());
         play_at(&mut anim, 30);
 
         // Something declares a new value while the sequence is running.
-        anim.animate_to(100.0);
+        anim.animate_to(100.0, Instant::now());
 
         // The sequence runs out.
         play_at(&mut anim, 70);
@@ -766,8 +775,8 @@ mod tests {
         anim.set_immediate(0.0);
         anim.set_timeline(Keyframes::new(60.0).at(0.0, 0.0).at(1.0, 5.0));
 
-        anim.animate_to(1.0);
-        anim.play();
+        anim.animate_to(1.0, Instant::now());
+        anim.play(Instant::now());
         play_at(&mut anim, 30);
         assert_eq!(fired.get(), 0, "nothing has arrived yet");
 
@@ -783,8 +792,8 @@ mod tests {
     fn a_play_without_a_sequence_does_not_pin_the_frame_loop() {
         let mut anim = AnimationState::new(0.0_f32, Transition::new(10.0, TimingFunction::Linear));
         anim.set_immediate(0.0);
-        anim.play();
-        anim.advance();
+        anim.play(Instant::now());
+        anim.advance(Instant::now());
         assert!(!anim.is_animating(), "nothing to play, nothing to animate");
     }
 
@@ -812,14 +821,16 @@ mod tests {
 
     /// Step an animation to `ms` after its segment began.
     ///
-    /// `advance` reads the clock through `start_time`, so moving that back is
-    /// the whole simulation. Sleeping instead would make the interruption
-    /// point depend on how loaded the machine is — and the interesting half of
-    /// a spring's phase space is on the far side of its overshoot, which a
-    /// stretched sleep wanders into by accident.
+    /// The instant is an argument now, so the helper *reads* when the segment
+    /// began and asks about `ms` after it, where it used to rewrite that start
+    /// behind the animation's back. Sleeping
+    /// instead would make the interruption point depend on how loaded the
+    /// machine is — and the interesting half of a spring's phase space is on
+    /// the far side of its overshoot, which a stretched sleep wanders into by
+    /// accident.
     fn at<T: Animatable>(anim: &mut AnimationState<T>, ms: u64) {
-        anim.start_time = Instant::now() - std::time::Duration::from_millis(ms);
-        anim.advance();
+        let started = anim.start_time.expect("a segment has begun");
+        anim.advance(started + std::time::Duration::from_millis(ms));
     }
 
     /// Step through `ms` in 8ms frames, returning the extremes reached.
@@ -854,14 +865,14 @@ mod tests {
 
         let mut anim = AnimationState::new(0.0_f32, spring(SpringConfig::BOUNCY));
         anim.set_immediate(0.0);
-        anim.animate_to(1.0);
+        anim.animate_to(1.0, Instant::now());
         run(&mut anim, 40);
         assert!(
             *anim.current() > 0.0,
             "the spring has to be moving before it can be interrupted"
         );
 
-        anim.animate_to(0.0);
+        anim.animate_to(0.0, Instant::now());
         let velocity = velocity_of(&anim);
         assert!(
             velocity < 0.0,
@@ -878,9 +889,9 @@ mod tests {
 
         let mut anim = AnimationState::new(0.0_f32, spring(SpringConfig::BOUNCY));
         anim.set_immediate(0.0);
-        anim.animate_to(1.0);
+        anim.animate_to(1.0, Instant::now());
         run(&mut anim, 40);
-        anim.animate_to(0.0);
+        anim.animate_to(0.0, Instant::now());
         let (low, _) = run(&mut anim, 400);
 
         assert!(
@@ -897,10 +908,10 @@ mod tests {
 
         let mut anim = AnimationState::new(0.0_f32, spring(SpringConfig::DEFAULT));
         anim.set_immediate(0.0);
-        anim.animate_to(1.0);
+        anim.animate_to(1.0, Instant::now());
         run(&mut anim, 40);
 
-        anim.animate_to(2.0);
+        anim.animate_to(2.0, Instant::now());
         assert!(
             velocity_of(&anim) > 0.0,
             "still heading there, got {}",
@@ -920,11 +931,11 @@ mod tests {
 
         let mut anim = AnimationState::new(0.0_f32, spring(SpringConfig::DEFAULT));
         anim.set_immediate(0.0);
-        anim.animate_to(1.0);
+        anim.animate_to(1.0, Instant::now());
         run(&mut anim, 1200);
         assert!(!anim.is_animating(), "it has to have settled first");
 
-        anim.animate_to(1.0001);
+        anim.animate_to(1.0001, Instant::now());
         assert_eq!(
             velocity_of(&anim),
             0.0,
@@ -945,7 +956,7 @@ mod tests {
 
         let mut anim = AnimationState::new(0.0_f32, spring(SpringConfig::BOUNCY));
         anim.set_immediate(0.0);
-        anim.animate_to(1.0);
+        anim.animate_to(1.0, Instant::now());
         run(&mut anim, 184);
 
         assert!(
@@ -957,7 +968,7 @@ mod tests {
         );
 
         // Falling toward 1.0 from above is falling toward 0.0 as well.
-        anim.animate_to(0.0);
+        anim.animate_to(0.0, Instant::now());
         assert!(
             velocity_of(&anim) > 0.0,
             "it was already heading that way, so the new segment closes on its \
@@ -981,14 +992,14 @@ mod tests {
 
         let mut anim = AnimationState::new(Translate::NONE, spring(SpringConfig::DEFAULT));
         anim.set_immediate(Translate::NONE);
-        anim.animate_to(Translate::new(200.0, 0.0));
+        anim.animate_to(Translate::new(200.0, 0.0), Instant::now());
         at(&mut anim, 40);
         assert!(velocity_of(&anim) > 0.0, "it has to be moving first");
 
         // Straight down from wherever the rightward slide got to: the y
         // channel moves, the x channel does not.
         let here = *anim.current();
-        anim.animate_to(Translate::new(here.x, here.y + 200.0));
+        anim.animate_to(Translate::new(here.x, here.y + 200.0), Instant::now());
 
         assert!(
             velocity_of(&anim).abs() < 0.5,
@@ -1007,7 +1018,7 @@ mod tests {
 
         let mut anim = AnimationState::new(0.0_f32, Transition::new(100.0, TimingFunction::Linear));
         anim.set_immediate(0.0);
-        anim.animate_to(180.0);
+        anim.animate_to(180.0, Instant::now());
 
         let mut smallest = f32::INFINITY;
         for frame in 0..=25 {
@@ -1029,7 +1040,7 @@ mod tests {
     fn a_full_turn_is_a_turn_and_not_a_no_op() {
         let mut anim = AnimationState::new(0.0_f32, Transition::new(100.0, TimingFunction::Linear));
         anim.set_immediate(0.0);
-        anim.animate_to(360.0);
+        anim.animate_to(360.0, Instant::now());
 
         at(&mut anim, 50);
         let halfway = *anim.current();
@@ -1053,7 +1064,7 @@ mod tests {
     fn an_angle_past_the_wrap_keeps_going_forward() {
         let mut anim = AnimationState::new(0.0_f32, Transition::new(100.0, TimingFunction::Linear));
         anim.set_immediate(350.0);
-        anim.animate_to(370.0);
+        anim.animate_to(370.0, Instant::now());
 
         at(&mut anim, 50);
         let halfway = *anim.current();
@@ -1070,7 +1081,7 @@ mod tests {
     fn the_angle_moves_at_the_rate_the_easing_asks_for() {
         let mut anim = AnimationState::new(0.0_f32, Transition::new(100.0, TimingFunction::Linear));
         anim.set_immediate(0.0);
-        anim.animate_to(90.0);
+        anim.animate_to(90.0, Instant::now());
 
         at(&mut anim, 25);
         assert!(
@@ -1091,7 +1102,7 @@ mod tests {
 
         // 40 frames of the target creeping upward, then it stops.
         for frame in 1..=40u64 {
-            anim.animate_to(frame as f32);
+            anim.animate_to(frame as f32, Instant::now());
             at(&mut anim, 8);
         }
         let (_, high) = run(&mut anim, 800);
@@ -1112,7 +1123,7 @@ mod tests {
     fn a_property_with_no_timeline_cannot_be_played() {
         let mut anim = AnimationState::new(0.0_f32, Transition::new(10.0, TimingFunction::Linear));
         anim.set_immediate(0.0);
-        anim.play();
+        anim.play(Instant::now());
         assert!(!anim.is_animating(), "nothing to play");
     }
 
@@ -1126,11 +1137,11 @@ mod tests {
         let delayed = Transition::new(0.0, TimingFunction::Spring(SpringConfig::BOUNCY)).delay(200);
         let mut anim = AnimationState::new(0.0_f32, delayed);
         anim.set_immediate(0.0);
-        anim.animate_to(1.0);
+        anim.animate_to(1.0, Instant::now());
         run(&mut anim, 400);
         assert!(*anim.current() > 0.0, "past the delay and moving");
 
-        anim.animate_to(0.0);
+        anim.animate_to(0.0, Instant::now());
         assert_eq!(velocity_of(&anim), 0.0);
     }
 
@@ -1140,9 +1151,9 @@ mod tests {
     fn a_timed_transition_has_no_spring_to_carry() {
         let mut anim = AnimationState::new(0.0_f32, Transition::new(100.0, TimingFunction::Linear));
         anim.set_immediate(0.0);
-        anim.animate_to(1.0);
+        anim.animate_to(1.0, Instant::now());
         run(&mut anim, 24);
-        anim.animate_to(0.0);
+        anim.animate_to(0.0, Instant::now());
         assert!(anim.spring_state.is_none());
     }
 
@@ -1162,7 +1173,7 @@ mod tests {
         let transition = Transition::new(300.0, TimingFunction::Linear);
         let mut state = AnimationState::new(0.0f32, transition);
 
-        state.animate_to(100.0);
+        state.animate_to(100.0, Instant::now());
 
         assert_eq!(*state.target(), 100.0);
         assert!(state.is_animating());
@@ -1173,11 +1184,11 @@ mod tests {
         let transition = Transition::new(300.0, TimingFunction::Linear);
         let mut state = AnimationState::new(0.0f32, transition);
 
-        state.animate_to(100.0);
+        state.animate_to(100.0, Instant::now());
         let first_start_time = state.start_time;
 
         // Animate to same target should not restart
-        state.animate_to(100.0);
+        state.animate_to(100.0, Instant::now());
         assert_eq!(state.start_time, first_start_time);
     }
 

--- a/src/widgets/container/animations.rs
+++ b/src/widgets/container/animations.rs
@@ -821,13 +821,14 @@ mod tests {
 
     /// Step an animation to `ms` after its segment began.
     ///
-    /// The instant is an argument now, so the helper *reads* when the segment
+    /// The instant is an argument now, so the helper reads when the segment
     /// began and asks about `ms` after it, where it used to rewrite that start
-    /// behind the animation's back. Sleeping
-    /// instead would make the interruption point depend on how loaded the
-    /// machine is — and the interesting half of a spring's phase space is on
-    /// the far side of its overshoot, which a stretched sleep wanders into by
-    /// accident.
+    /// behind the animation's back.
+    ///
+    /// Sleeping instead would make the interruption point depend on how loaded
+    /// the machine is — and the interesting half of a spring's phase space is
+    /// on the far side of its overshoot, which a stretched sleep wanders into
+    /// by accident.
     fn at<T: Animatable>(anim: &mut AnimationState<T>, ms: u64) {
         let started = anim.start_time.expect("a segment has begun");
         anim.advance(started + std::time::Duration::from_millis(ms));

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -1062,6 +1062,19 @@ fn pump(h: &mut H) -> bool {
     animating
 }
 
+/// A whole frame that declares what time it is: jobs, then layout, as the loop
+/// runs them.
+///
+/// `pump` asks the clock, so two frames are however far apart the machine
+/// happened to make them; this one names the instant, so a curve can be
+/// asserted at a value instead of inside a band.
+fn frame_at(h: &mut H, now: std::time::Instant, width: f32, height: f32) {
+    h.tree.set_frame_instant(Some(now));
+    pump(h);
+    h.fit(width, height);
+    h.tree.set_frame_instant(None);
+}
+
 /// Lay out, run the queued jobs, paint, and report the first text colour.
 fn painted_text_color(h: &mut H) -> Color {
     pump(h);
@@ -1136,9 +1149,18 @@ fn a_container_wakes_when_its_timeline_is_asked_to_play() {
 
 /// The transform this container is painted with, once the queued jobs have
 /// run. A rotation shows up as a matrix that is no longer the identity.
+/// The transform a sequence has reached at the peak of its middle keyframe.
+///
+/// Two frames, because they are two different things: the first sees the
+/// trigger move and starts the sequence, the second is 100ms later and is the
+/// one with something to show. They used to be the same frame, and what made
+/// that work was the few nanoseconds between `Instant::now()` in `play` and
+/// `Instant::now()` inside `advance` — a gap this test was reading and nobody
+/// had chosen.
 fn played_transform(h: &mut H) -> Transform {
-    pump(h);
-    h.fit(200.0, 200.0);
+    let t0 = std::time::Instant::now();
+    frame_at(h, t0, 200.0, 200.0);
+    frame_at(h, t0 + std::time::Duration::from_millis(100), 200.0, 200.0);
     h.paint().children[0].local_transform
 }
 
@@ -1260,15 +1282,26 @@ fn an_animated_translate_reaches_the_paint() {
 
     offset.set(Translate::new(40.0, 0.0));
 
-    // One frame in: moving, and not arrived. Without this the test passes with
-    // the animation deleted outright — `get_animated_value` falls back to the
-    // signal, and paint lands on 40 the first time it is asked.
-    pump(&mut h);
-    h.fit(200.0, 200.0);
+    // Moving, and not arrived. Without this the test passes with the animation
+    // deleted outright — `get_animated_value` falls back to the signal, and
+    // paint lands on 40 the first time it is asked.
+    //
+    // A tenth of the way through a linear six hundred milliseconds is a tenth
+    // of the distance, so this is a number rather than the band it used to be:
+    // the band existed because the only "midway" available was however far the
+    // clock had moved between two reads of it.
+    let t0 = std::time::Instant::now();
+    frame_at(&mut h, t0, 200.0, 200.0);
+    frame_at(
+        &mut h,
+        t0 + std::time::Duration::from_millis(60),
+        200.0,
+        200.0,
+    );
     let midway = h.paint().children[0].local_transform.tx();
-    assert!(
-        midway > 0.0 && midway < 39.0,
-        "it has to animate towards the target rather than snap to it, got {midway}"
+    assert_eq!(
+        midway, 4.0,
+        "it has to animate towards the target rather than snap to it"
     );
 
     settle(&mut h, 400);

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -1267,9 +1267,8 @@ fn a_container_wakes_when_its_timeline_is_asked_to_play() {
     );
 }
 
-/// The transform this container is painted with, once the queued jobs have
-/// run. A rotation shows up as a matrix that is no longer the identity.
 /// The transform a sequence has reached at the peak of its middle keyframe.
+/// A rotation shows up as a matrix that is no longer the identity.
 ///
 /// Two frames, because they are two different things: the first sees the
 /// trigger move and starts the sequence, the second is 100ms later and is the

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -1075,6 +1075,126 @@ fn frame_at(h: &mut H, now: std::time::Instant, width: f32, height: f32) {
     h.tree.set_frame_instant(None);
 }
 
+/// Halfway through a linear hundred milliseconds is halfway to the target —
+/// exactly, on any machine, with nothing asleep.
+///
+/// The value of naming the instant is that this asserts the *curve*, which is
+/// the half of an animation nothing outside `animations.rs`, `keyframes.rs`
+/// and `timing.rs` can see. Every other test here watches where an animation
+/// lands, and an easing that is wrong, a delay that is ignored, a reverse
+/// transition used in place of the forward one and a property that skips the
+/// animation entirely all land in the same place.
+#[test]
+fn a_linear_animation_is_halfway_at_half_its_duration() {
+    let w = create_signal(0.0f32);
+    let mut h = H::new(
+        container()
+            .height(10.0)
+            .width(w)
+            .animate_width(Transition::new(100.0, TimingFunction::Linear)),
+    );
+    h.fit(400.0, 400.0);
+
+    let t0 = std::time::Instant::now();
+    w.set(100.0);
+    frame_at(&mut h, t0, 400.0, 400.0);
+    assert_eq!(
+        h.tree.cached_size(h.root).unwrap().width,
+        0.0,
+        "the segment begins where it was, not where it is going"
+    );
+
+    frame_at(
+        &mut h,
+        t0 + std::time::Duration::from_millis(50),
+        400.0,
+        400.0,
+    );
+    assert_eq!(
+        h.tree.cached_size(h.root).unwrap().width,
+        50.0,
+        "half the duration of a linear curve is half the distance"
+    );
+}
+
+/// The radius of the ripple drawn by this frame, if one is drawn.
+fn painted_ripple_radius(h: &mut H) -> Option<f32> {
+    h.paint()
+        .overlay_commands
+        .iter()
+        .find_map(|cmd| match &**cmd {
+            DrawCommand::Circle { radius, .. } => Some(*radius),
+            _ => None,
+        })
+}
+
+/// One frame is one instant: the ripple and the declared transition in the
+/// same container are asked about the same moment.
+///
+/// They could not be before. The ripple already took an `Instant` and the
+/// caller handed it `Instant::now()`, freshly read, some microseconds after
+/// every animation beside it had read its own — so a frame was several
+/// instants, and none of them was one a test could name.
+#[test]
+fn a_ripple_and_a_transition_are_asked_about_the_same_moment() {
+    // Wide enough at rest to be clicked: the press has to land on the box.
+    let w = create_signal(20.0f32);
+    let mut h = H::new(
+        container()
+            .height(100.0)
+            .width(w)
+            .animate_width(Transition::new(100.0, TimingFunction::Linear))
+            .when_pressed(|s| s.ripple())
+            .on_click(|| {}),
+    );
+    h.fit(400.0, 400.0);
+
+    h.send(Event::MouseDown {
+        x: 10.0,
+        y: 50.0,
+        button: MouseButton::Left,
+    });
+    w.set(120.0);
+
+    // After the press, because a ripple begins at the instant its event
+    // arrived and that clock is the event's, not the frame's — a separate
+    // question, and not this one.
+    let t0 = std::time::Instant::now();
+
+    frame_at(&mut h, t0, 400.0, 400.0);
+    let started = painted_ripple_radius(&mut h).expect("the press starts a ripple");
+
+    frame_at(
+        &mut h,
+        t0 + std::time::Duration::from_millis(50),
+        400.0,
+        400.0,
+    );
+    assert_eq!(
+        h.tree.cached_size(h.root).unwrap().width,
+        70.0,
+        "the transition is halfway: 20 plus half of the hundred it travels"
+    );
+    let grown = painted_ripple_radius(&mut h).expect("and the ripple is still drawn");
+    assert!(
+        grown > started,
+        "the ripple grew over the same 50ms, from {started} to {grown}"
+    );
+
+    // The same instant twice: nothing moves, because nothing has.
+    frame_at(
+        &mut h,
+        t0 + std::time::Duration::from_millis(50),
+        400.0,
+        400.0,
+    );
+    assert_eq!(
+        painted_ripple_radius(&mut h),
+        Some(grown),
+        "asked about the same moment, a frame answers the same"
+    );
+}
+
 /// Lay out, run the queued jobs, paint, and report the first text colour.
 fn painted_text_color(h: &mut H) -> Color {
     pump(h);

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -1235,6 +1235,10 @@ impl Widget for Container {
     fn advance_animations(&mut self, tree: &mut Tree, id: WidgetId) -> bool {
         // Use advance_animations_self for this widget's animations
         let mut any_animating = false;
+        // One frame, one instant. Every animation below is asked about the
+        // same moment — the ripple included, which used to read a clock of its
+        // own a few microseconds later than the rest.
+        let now = tree.frame_instant();
 
         #[allow(clippy::unnecessary_unwrap)]
         // Intentional: compute targets with &self before &mut borrow
@@ -1308,9 +1312,17 @@ impl Widget for Container {
             let anims = self.anims.as_mut().unwrap();
 
             // Layout-affecting animations: width, height, padding
-            advance_anim!(anims, width, id, any_animating, layout);
-            advance_anim!(anims, height, id, any_animating, layout);
-            advance_anim!(anims, padding, padding_target, id, any_animating, layout);
+            advance_anim!(anims, width, id, any_animating, now, layout);
+            advance_anim!(anims, height, id, any_animating, now, layout);
+            advance_anim!(
+                anims,
+                padding,
+                padding_target,
+                id,
+                any_animating,
+                now,
+                layout
+            );
 
             // Paint-only animations: border_width, background, corners,
             // border_color, and the three transform components
@@ -1320,17 +1332,35 @@ impl Widget for Container {
                 border_width_target,
                 id,
                 any_animating,
+                now,
                 paint
             );
-            advance_anim!(anims, background, bg_target, id, any_animating, paint);
-            advance_anim!(anims, corners, corners_target, id, any_animating, paint);
-            advance_anim!(anims, elevation, elevation_target, id, any_animating, paint);
+            advance_anim!(anims, background, bg_target, id, any_animating, now, paint);
+            advance_anim!(
+                anims,
+                corners,
+                corners_target,
+                id,
+                any_animating,
+                now,
+                paint
+            );
+            advance_anim!(
+                anims,
+                elevation,
+                elevation_target,
+                id,
+                any_animating,
+                now,
+                paint
+            );
             advance_anim!(
                 anims,
                 border_color,
                 border_color_target,
                 id,
                 any_animating,
+                now,
                 paint
             );
             // A trigger that has moved starts the sequence, before the frame
@@ -1342,16 +1372,24 @@ impl Widget for Container {
                     if let Some(anim) = anims.$field.as_mut()
                         && crate::reactive::diagnostics::snapshot_zone(|| anim.take_play())
                     {
-                        anim.play();
+                        anim.play(now);
                     }
                 };
             }
             start_timeline!(translate);
             start_timeline!(rotate);
             start_timeline!(scale);
-            advance_anim!(anims, translate, translate_target, id, any_animating, paint);
-            advance_anim!(anims, rotate, rotate_target, id, any_animating, paint);
-            advance_anim!(anims, scale, scale_target, id, any_animating, paint);
+            advance_anim!(
+                anims,
+                translate,
+                translate_target,
+                id,
+                any_animating,
+                now,
+                paint
+            );
+            advance_anim!(anims, rotate, rotate_target, id, any_animating, now, paint);
+            advance_anim!(anims, scale, scale_target, id, any_animating, now, paint);
         }
 
         // Advance ripple animation
@@ -1359,7 +1397,7 @@ impl Widget for Container {
             && ix.ripple.is_active()
             && let Some(config) = ix.ripple_config()
         {
-            let ripple_animating = ix.ripple.advance(&config, std::time::Instant::now());
+            let ripple_animating = ix.ripple.advance(&config, now);
             if ripple_animating {
                 // Ripple is paint-only, request animation continuation with paint
                 request_job(id, JobRequest::Animation(RequiredJob::Paint));
@@ -1390,7 +1428,7 @@ impl Widget for Container {
 
         // Advance scrollbar scale animations (for hover expansion effect)
         // Must be done here since scroll/hover is paint-only and layout may not run
-        if self.advance_scrollbar_scale_animations_internal(id) {
+        if self.advance_scrollbar_scale_animations_internal(id, now) {
             any_animating = true;
         }
 
@@ -1521,7 +1559,7 @@ impl Widget for Container {
         }
 
         self.update_size_targets(tree, id, &lengths, content_size);
-        self.seed_animations(id);
+        self.seed_animations(id, tree.frame_instant());
 
         let size = self.resolve_size(&lengths, constraints, content_size);
 

--- a/src/widgets/container/scrollable.rs
+++ b/src/widgets/container/scrollable.rs
@@ -192,9 +192,10 @@ impl Container {
         };
 
         if let Some(anim) = scale_anim {
-            anim.animate_to(target_scale);
+            let now = tree.frame_instant();
+            anim.animate_to(target_scale, now);
             if anim.is_animating() {
-                let _ = anim.advance(); // Paint-only, ignore result
+                let _ = anim.advance(now); // Paint-only, ignore result
                 request_job(id, JobRequest::Animation(RequiredJob::Paint));
             }
         }
@@ -232,7 +233,11 @@ impl Container {
     /// Advance scrollbar scale animations and apply transforms.
     /// Called from advance_animations since scroll is paint-only and layout
     /// may not run during hover events.
-    pub(super) fn advance_scrollbar_scale_animations_internal(&mut self, id: WidgetId) -> bool {
+    pub(super) fn advance_scrollbar_scale_animations_internal(
+        &mut self,
+        id: WidgetId,
+        now: std::time::Instant,
+    ) -> bool {
         if self.scroll_axis == ScrollAxis::None
             || self.scroll().scrollbar_visibility == ScrollbarVisibility::Hidden
         {
@@ -248,13 +253,13 @@ impl Container {
         // Advance vertical scrollbar scale animation
         if self.scroll_axis.allows_vertical() && needs_vertical {
             any_animating |=
-                self.advance_scrollbar_scale_axis(ScrollbarAxis::Vertical, scale_factor, id);
+                self.advance_scrollbar_scale_axis(ScrollbarAxis::Vertical, scale_factor, id, now);
         }
 
         // Advance horizontal scrollbar scale animation
         if self.scroll_axis.allows_horizontal() && needs_horizontal {
             any_animating |=
-                self.advance_scrollbar_scale_axis(ScrollbarAxis::Horizontal, scale_factor, id);
+                self.advance_scrollbar_scale_axis(ScrollbarAxis::Horizontal, scale_factor, id, now);
         }
 
         any_animating
@@ -265,6 +270,7 @@ impl Container {
         axis: ScrollbarAxis,
         scale_factor: f32,
         id: WidgetId,
+        now: std::time::Instant,
     ) -> bool {
         // Determine target scale based on hover state
         let sd = self.scroll();
@@ -283,9 +289,9 @@ impl Container {
         // Scale transforms are applied during paint, not stored on widgets.
         let mut animating = false;
         if let Some(anim) = scale_anim {
-            anim.animate_to(target_scale);
+            anim.animate_to(target_scale, now);
             if anim.is_animating() {
-                let required = if anim.advance().is_changed() {
+                let required = if anim.advance(now).is_changed() {
                     RequiredJob::Paint
                 } else {
                     RequiredJob::None

--- a/src/widgets/text_input.rs
+++ b/src/widgets/text_input.rs
@@ -582,12 +582,11 @@ impl TextInput {
     /// changes twice a second, so 113 frames out of 114 repaint the same pixels.
     /// A focused field is the normal state of a lock screen, and that ran all
     /// night.
-    fn update_cursor_blink(&mut self, id: WidgetId) -> bool {
+    fn update_cursor_blink(&mut self, id: WidgetId, now: Instant) -> bool {
         if !self.caret || !has_focus(id) {
             return false;
         }
         let period = Duration::from_millis(CURSOR_BLINK_MS);
-        let now = Instant::now();
         if now.duration_since(self.last_cursor_toggle) >= period {
             self.cursor_visible = !self.cursor_visible;
             self.last_cursor_toggle = now;
@@ -1095,8 +1094,8 @@ impl InputStyled for TextInput {
 }
 
 impl Widget for TextInput {
-    fn advance_animations(&mut self, _tree: &mut Tree, id: WidgetId) -> bool {
-        self.update_cursor_blink(id)
+    fn advance_animations(&mut self, tree: &mut Tree, id: WidgetId) -> bool {
+        self.update_cursor_blink(id, tree.frame_instant())
     }
 
     fn layout(&mut self, tree: &mut Tree, id: WidgetId, constraints: Constraints) -> Size {


### PR DESCRIPTION
## What changed

Every animation asked the clock for itself. `AnimationState::advance` read `start_time.elapsed()`, `Container::advance_animations` handed the ripple a freshly read `Instant::now()` some microseconds later, and `text_input`'s caret read a third one — from an `advance_animations` whose `&mut Tree` it named `_tree` and never used. One frame was several instants.

None of that showed: microseconds do not. What it cost was the question. A widget that reads the clock cannot be asked about the *middle* of an animation, only about where one lands — a test can sleep and assert a band, and the band has to be wide enough to survive a loaded machine, which is a band a linear curve and an eased one both fit inside. So an easing that is wrong, a delay that is ignored, a reverse transition used in place of the forward one, and a property that skips its animation entirely all pass: all four land in the same place.

A frame now declares its instant once, in `render_surface`, around the three passes it is made of — the jobs advance the animations, layout measures what they produced, paint draws it — and carries it on the `Tree` that every widget method already receives. `advance`, `play`, `animate_to` and `begin_segment` take it. `start_time` becomes `Option<Instant>`, `None` until a segment begins, which is the shape `Timeline::playing` already had.

Closes #250.

## What proves it

**The measurement the issue is built on, re-run.** Changing `TimingFunction::Linear` from `t` to `t * t` — the same endpoints, the wrong path between them — used to kill **6** tests, all in `animations.rs`, `keyframes.rs` and `timing.rs`, leaving all eighteen integration binaries and the whole of `characterization.rs` green. It now kills **9**, and three of the new killers are in `characterization.rs`, which could see none of it before.

Two tests that could not be written before:

- `a_linear_animation_is_halfway_at_half_its_duration` — halfway through a linear hundred milliseconds is fifty pixels. Exactly, on any machine, with nothing asleep.
- `a_ripple_and_a_transition_are_asked_about_the_same_moment` — a ripple and a declared transition advanced to the same named instant both move, and asked about that moment *twice*, both answer the same. The review verified this pins what it claims: putting the ripple back on `Instant::now()` fails its third assertion, and the first two alone would not have.

**Three pre-existing tests were passing on the gap between two clock reads.** `animate_to` wrote `Instant::now()` and `advance` read another a few nanoseconds later, so "one frame in, moving" was true by a hair — `an_animated_translate_reaches_the_paint` was asserting `midway > 0.0 && midway < 39.0` against a translate of about 2e-5 px. With one instant per frame, the frame that starts a segment is at its start and the next one is the one with something to show. They now name both moments and assert numbers: `4.0`, not "between 0 and 39". Both survived the Linear mutant before; the new form kills it.

Full harness green: 564 lib tests, every integration binary, doc tests, `fmt --check`, `clippy --all-targets --all-features -D warnings`, 9 goldens on lavapipe with no skips, `mdbook build`. No golden or snapshot moved, and none should have — nothing about a settled frame changes.

## What the review found

**One blocking, and it was right.** I had claimed the harness proves this change. It proves the widget half. The reviewer deleted all three `set_frame_instant` calls in `lib.rs` and ran the suite: **24 binaries, zero failures.** Every reader falls back to `Tree::frame_instant()`'s `Instant::now()`, which is the pre-change behaviour, so the harness cannot tell the wired loop from the unwired one — the three new killers all go through `frame_at`, a test-local re-implementation of the loop.

`render_surface` needs a `QueueHandle` and a live surface, so this is the case `AGENTS.md` has an escape hatch for: **the loop wiring cannot be verified automatically.** What replaced it is in *What was checked by hand*, below. The reviewer read the set/clear pairing on every path out of `render_surface` and found it correct — one early return between them, and it clears — but read is not run, and that is the point.

Four worth answering, all acted on:

- **`set_frame_instant` was `pub(crate)`**, so a widget written outside the crate could read the frame's instant and never name one — left exactly where this change found the internal widgets. It is `pub` now; `tests/external_widget.rs` says the extension point is real.
- **`text_input` was an explicit non-goal in #250** and came along anyway. It is here because its `advance_animations` was already being handed a `&mut Tree` it discarded, so it was one line rather than a change; the reviewer traced the deadline path and confirmed the blink period does not drift. Saying so rather than leaving it to be reconstructed.
- **The design departs from the issue's "Where it lives", and only a conversation recorded that.** #250 said the clock read would stay inside `Container::advance_animations`. It cannot: a width animation's segment begins during *layout*, in `anim_bridge::update_size_targets`, and `layout(tree, id, constraints)` has nowhere to put a `now`. So the instant spans the frame and rides on the `Tree` — agreed with the maintainer before it was written, and now written down. **#250 has been edited to say the same.**
- **A new public method was in no documentation.** `docs/ARCHITECTURE.md` has it beside the note that bounds live in the tree — the same kind of fact — and the book's per-surface pipeline has it as the step where it is declared.

Two notes fixed (two doc comments credited `process_jobs`, which exists, so nothing caught the wrong name; two rewrapped docstrings), and one arithmetic correction: commit `9a2bf73` says "three of the three new ones are here" — measured, the production commit alone takes the mutant from 6 kills to 7, so it is two of the three.

## What was checked by hand

`examples/animation_example` and `examples/text_input_example` on **niri**, run by the maintainer: animations start and run at the speed they always did, and a focused text input's caret blinks at its usual rhythm. That is the evidence for the loop wiring, which no test can reach — and the caret is the sharpest of the three, since it is the widget that used to read a clock of its own.

## Left undone

**Layout that happens outside a frame still starts a segment at an unnamed instant.** `surface_manager.rs:111` and `lib.rs:475` lay out before any frame runs, so an enter transition seeded at surface creation takes `frame_instant()`'s fallback. It is the pre-change behaviour and no inversion can show it — every fallback read is later than the previous frame and earlier than the next — but it is the one production path where the fallback is load-bearing rather than a test convenience. Found by the review; worth an issue if the fallback is ever meant to be an assertion instead.

**`frame_at` models jobs and layout, and the loop also spans paint.** Nothing reads the instant during paint today — all five read sites are in `advance_animations` or `layout` — so the two agree. The day a paint-time read is added, the tests would fall back to the clock and stay green while diverging from the loop.

**Events are still timed by whoever handles them**, with whatever clock is nearest: the ripple's press, the momentum's velocity, the undo coalescing window. That is #256, `needs-design`, because the time of an event is not an `Instant` — Wayland sends a `u32` of milliseconds in the compositor's epoch — and `Event` is public API.

---

**The mutation job, which ran to completion.** `48 mutants tested in 13m: 14 missed, 25 caught, 9 unviable` ([run](https://github.com/MalpenZibo/guido/actions/runs/33054210766/job/98456836978)) — the first big diff since #255 fixed that job's disk usage, so this is also its second confirmation.

The fourteen survivors are worth naming, because none of them is this change's new behaviour and all of them are lines it touched:

- **`render_surface` replaced with `()`** (`lib.rs:1230`) — the blocking finding above, in the sensor's own words. The whole frame function deletes without a test noticing, which is why the manual run is the evidence here.
- **`advance_scrollbar_scale_animations_internal` and `advance_scrollbar_scale_axis`** (`scrollable.rs` :241, :255, :261, :276 ×2) — return `true`, return `false`, or `&=` instead of `|=` for whether anything is animating, and nothing objects. The scrollbar's hover-widening animation is untested. Pre-existing; my diff only added a `now` parameter to those signatures.
- **`seed_animations`'s three `|=`** (`anim_bridge.rs` :183, :186, :189) and its retarget threshold (`:93`: `-` → `+`, `-` → `/`, `>` → `>=`) — same shape, same reason.
- **`begin_segment_from` replaced with `()`** (`animations.rs:154`) — the hand-back at the end of a keyframe sequence. The sequence tests assert the property moved, not that it animates back rather than snapping.
- **`update_cursor_blink`'s `>=` → `<`** (`text_input.rs:590`) — the caret's blink period, which is what the manual run looked at and what no test can.

Each would make an issue. I have not opened them here because they are one theme — *the animations nobody drives from a test* — and the honest next question is #256's, not five separate ones.
