### PR TITLE
Alternatives that were not looked up are a guess wearing the shape of a choice

### DIFF
--- a/.claude/commands/spec.md
+++ b/.claude/commands/spec.md
@@ -18,6 +18,19 @@ If two readings of the request would lead to materially different work, ask —
 once, with the two readings spelled out. Otherwise decide and state the
 assumption in the issue.
 
+**A design decision that is not obvious is researched before it is proposed.**
+If the specification turns on a choice this codebase has not settled — where a
+piece of state lives, which clock a value comes from, how a family of call sites
+is spelled — start with what `AGENTS.md` and the skills already decide, because
+a fork the rules have closed is not a fork. What survives that gets read up:
+what the protocol or the standard says, and what comparable libraries chose.
+Both go in the issue's **Prior art**, with links, before the alternatives are
+written down.
+
+Alternatives offered without that look like a choice and are a guess, and the
+maintainer has nothing to weigh them with. This is not most issues: a defect
+with one obvious fix has no design decision in it and needs none of this.
+
 ## 2. Write it as a specification
 
 The title is a sentence that states the defect or the truth that should hold —
@@ -37,6 +50,10 @@ The body, in this order:
 - **Non-goals** — the neighbouring things this change deliberately does not do,
   so the implementation does not grow into them.
 - **Where it lives** — the files and functions involved.
+- **Prior art** — only when the specification turns on a design decision this
+  codebase has not settled: what the protocol or the standard says, and what
+  comparable libraries chose. With links. Leave it out when there is no such
+  decision, which is most of the time.
 
 Consult the skill for the area (reactive, widgets, renderer, wayland) so the
 issue is written in the terms the codebase already uses.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,26 @@ before you stop. It reads what is written between backticks and skips fenced
 blocks, so the book's code samples — which is most of the book — are not
 covered by it or by anything else.
 
+**A design decision that is not obvious is researched before it is proposed.**
+When a change turns on a choice with no settled answer here — where a piece of
+state lives, which clock a value comes from, how a family of call sites is
+spelled — find out what has already been decided, in this order: **this file and
+the skills**, because a fork the rules have closed is not a fork; then the
+existing code; then the protocol or the standard; then what comparable libraries
+chose. winit, SDL, Chromium, Flutter and GTK have met most of these already, and
+a question one of them has had open since 2019 is itself an answer about how
+settled it is. The sources and the trade-offs go under **Prior art** in the
+issue, or in the pull request, so the decision can be judged rather than taken
+on trust. When the answer is one of the architectural cases below, this research
+is what that case is made of.
+
+Alternatives offered without it are worse than no alternatives: they look like a
+choice and are a guess, and the maintainer has nothing to weigh them with.
+
+Ordinary work is not this — a defect with one obvious fix, a widget method, a
+pattern the codebase already uses. If nobody has to choose, there is nothing to
+research.
+
 **Architectural changes are agreed before they are written.** A new core type or
 trait, a new cross-cutting mechanism, a new ownership or lifetime rule, a change
 to how a whole family of call sites is spelled: explain the problem as it stands

--- a/tests/agent_workflow.rs
+++ b/tests/agent_workflow.rs
@@ -5,11 +5,16 @@
 //! point at files by name. Inserting a step is exactly when those stop
 //! matching, and a count in prose is the part a person is worst at checking.
 //!
-//! Nothing here reads the words. It counts headings and list markers, compares
-//! them to the numbers the prose claims, checks that the files this
+//! Mostly this does not read the words. It counts headings and list markers,
+//! compares them to the numbers the prose claims, checks that the files this
 //! documentation names exist, and checks the one ordering the workflow depends
 //! on — that the review comes after the commits, because its criteria ask about
 //! them.
+//!
+//! Where it does read them, it is for a sentence that has to appear in two
+//! documents at once: the review's three levels, and the rule about researching
+//! a design decision. Pinning a sentence is a poor test of whether a rule is
+//! followed and the only test there is of whether both copies still say it.
 
 use std::path::{Path, PathBuf};
 
@@ -377,5 +382,44 @@ fn the_reviewer_and_the_command_use_the_same_levels() {
         reviewer.contains("how many block"),
         "the reviewer gives no verdict, so `zero blocking findings is the pass` \
          has nothing to read"
+    );
+}
+
+/// The research rule lives in two places, and a rule that is only in the
+/// contract is a rule nothing invokes.
+///
+/// `AGENTS.md` states it; `/spec` is where it is acted on, because that is the
+/// command that writes alternatives down, and it names the section of the issue
+/// the sources go in. Deleting the rule from either leaves the other describing
+/// a step that does not happen; deleting the section leaves the rule asking for
+/// something the issue has no room for.
+///
+/// What this cannot say is whether the research was *done* — only that the
+/// contract asks for it and the issue has somewhere to put the answer.
+#[test]
+fn researching_a_design_decision_is_asked_for_where_the_alternatives_are_written() {
+    let agents = read("AGENTS.md");
+    let spec = read(".claude/commands/spec.md");
+
+    const RULE: &str = "A design decision that is not obvious is researched before it is proposed.";
+    assert!(
+        agents.contains(RULE),
+        "AGENTS.md does not carry the research rule, so nothing states it"
+    );
+    assert!(
+        spec.contains(RULE),
+        "/spec is the command that writes alternatives down and does not ask \
+         for the research behind them — the rule would exist only in the \
+         contract, where nothing invokes it"
+    );
+
+    // Where the answer goes. A rule asking for something the issue has no room
+    // for degrades to "mention it somewhere", so `/spec` names the section, and
+    // the body it enumerates has to contain it.
+    const SLOT: &str = "**Prior art**";
+    assert!(
+        spec.contains(SLOT),
+        "/spec asks for research and its issue body has no {SLOT} for the \
+         answer, so the sources have nowhere to go"
     );
 }


### PR DESCRIPTION
## What changed

A rule in `AGENTS.md`, acted on in `/spec`: **a design decision the codebase has not settled is researched before alternatives are offered.** In order — this file and the skills first, because a fork the rules have already closed is not a fork; then the existing code; then the protocol or the standard; then what comparable libraries chose. The answer goes under **Prior art** in the issue.

It comes from two failures in this session, both mine, with different causes:

- **#229** — I offered three options where this very file had already closed two of them. The macro route changes how a family of call sites is spelled, so it is `needs-design` and can carry no acceptance criterion, which left one real option dressed as three. (Those options were offered in conversation; #229 has no comments, so a reader following that citation will not find them.)
- **#256** — I wrote down three ways to time an input event without looking anything up. A search then found a fourth, which is the one the ecosystem uses: winit has had the question open since 2019 across 29 comments, SDL synthesises the timestamp at delivery, Chromium and Flutter expose one monotonic type and convert underneath, and a commenter in that thread had already built the anchor-and-interpolate approach none of my three named. #256 now carries all of it.

The rule bounds itself the way its neighbour does — *"Ordinary work is not this — a defect with one obvious fix, a widget method, a pattern the codebase already uses"* — because a rule that plausibly fires on everything is read as firing on nothing, which is what the severity bar in #238 exists to stop.

## What proves it

`tests/agent_workflow.rs`, one assertion, verified by inversion — four deletions, each applied alone, each red by its intended test:

| broken on purpose | what fails |
| --- | --- |
| the rule deleted from `AGENTS.md` | `researching_a_design_decision_…` |
| the rule deleted from `/spec` | `researching_a_design_decision_…` |
| `**Prior art**` renamed in `/spec` | `researching_a_design_decision_…` |
| a level deleted from `reviewer.md` | `the_reviewer_and_the_command_use_the_same_levels` |

The fourth is there because this change moved that test; it confirms it still defends what it did.

What the assertion cannot say is whether the research was *done* — only that the contract asks for it and the issue has somewhere to put the answer. Its doc comment says so rather than claiming more.

`fmt --check`, `clippy --all-targets --all-features -D warnings` and `documentation_references` all clean.

## What the review found

**Zero blocking. Five worth answering, and two were defects in the test I had just written.**

- **The second assertion was wrong in both directions.** It grepped the whole document for `sources` and `trade-offs`. The reviewer deleted "sources" from the `AGENTS.md` paragraph and the test stayed green — `AGENTS.md` says "raster and SVG sources" a hundred lines away, about images. Then reworded `/spec` to say the same thing in different nouns, and it went red. It fired on a synonym and missed the deletion it existed to catch. Replaced with a check that the issue body has a **Prior art** section, which has a consumer rather than a noun.
- **The new test's doc comment was appended to the previous test's**, leaving the levels test with no comment and its paragraph explaining the wrong thing. `fmt` and `clippy` are green on that, and nothing else would have caught it.
- **"an issue open for six years" expires on 2026-09-30.** In the file that three paragraphs earlier says documentation "is followed rather than read sceptically". Now "open since 2019".
- **The rule had no statement of what it is not**, unlike every rule around it. It has one now.
- **The sources had nowhere to go**: `/spec` §2 enumerates the issue body "in this order" and none of the five slots was for a source, so the rule degraded to "mention it somewhere". Hence **Prior art**, and hence the assertion above.

Two notes fixed: two assert messages carried literal runs of ten and fourteen spaces from a string collapsed without its `\` continuations, and the module header said *"Nothing here reads the words"* — already untrue, and flatly false once this test pins a sentence. It now says which two tests read words and why.

One note the reviewer raised and I did not act on: it observed that merging this is itself the adoption of a contract rule every agent reads. That is how this repo amends `AGENTS.md`, and it is the maintainer's call rather than something a branch can settle.

## What was checked by hand

Nothing needed a compositor. Every inversion above was run and its message read.

## Left undone

**Nothing checks whether the research happened.** The harness can see that the rule is stated in both places and that the issue has a section for the answer; it cannot see an empty **Prior art** on an issue that needed one. The only sensor for that is the reviewer, and only if it is looking.

`.github/pull_request_template.md` has no slot either — the rule says the sources go "in the issue, or in the pull request", and only the first half has a place. Left that way deliberately: the template's five sections are already counted by a test, and most pull requests carry no design decision at all.
