### PR TITLE
The cleanup runs before anything checks the code, because it edits it

### DIFF
--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -39,7 +39,23 @@ than none.
 Make it. Keep it inside the non-goals. Follow the patterns already in the file
 rather than importing new ones.
 
-## 5. Run the harness, all of it
+## 5. Clean it up, before the harness sees it again
+
+`/simplify` over the change — a built-in skill, not one of this repository's:
+four readings by four agents, none of which wrote the code, for reuse,
+simplification, efficiency and altitude. It is quality only; it does not hunt
+for correctness bugs, which is what step 8 is for.
+
+Here, and not later, for three reasons. It **applies** what it finds rather than
+reporting it, so the harness has to run after it — put it below step 6 and you
+commit code nothing has re-tested since it changed, and if it touched the test
+you wrote in step 3, the red you confirmed there is no longer the red that
+ships. Its edits land inside the commits instead of on top of them, and a
+tidy-up commit is exactly what the review's atomic-commits criterion exists to
+catch. And what it changed is then read by the review, because code that edits
+itself and ships unread is the one thing that step must not become.
+
+## 6. Run the harness, all of it
 
 ```bash
 cargo fmt --all
@@ -57,15 +73,16 @@ moved and why, and let the maintainer decide.
 If the change touched the renderer and *no* golden moved, the scenario that
 should have noticed is missing — add it.
 
-## 6. Commit, atomically
+## 7. Commit, atomically
 
 One focused change per commit, in the order the code was built: data structures,
 then behaviour, then the API that exposes it. Subject lines are sentences that
 say what is now true. No `Co-Authored-By`, no generated-with footer.
 
-## 7. Have it read by somebody who did not write it
+## 8. Have it read by somebody who did not write it
 
-Now the commits exist and the pull request does not, which is the moment the
+Now the commits exist, the cleanup is inside them, and the pull request does
+not — which is the moment the
 `reviewer` subagent is written for: it asks about atomic commits, about what the
 pull request will have to say, and about the diff as a whole.
 
@@ -97,7 +114,7 @@ was skipped, run it again; if it still will not run, say so in the pull request
 in those words. Writing "nothing found" for a review that never happened is the
 same act as re-blessing a golden to make a test pass.
 
-## 8. Open the pull request
+## 9. Open the pull request
 
 Push the branch, `gh pr create`, fill in the template. Link the issue with
 `Closes #$ARGUMENTS`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,18 +174,24 @@ themselves when the task touches them; you do not need to read them up front.
    pieces of work in the same checkout.
 3. **The failing test, then the fix.** In that order, so the test is known to
    test something.
-4. **Run the harness**, all of it, including the goldens.
-5. **Have it read by something that did not write it.** The `reviewer` subagent,
+4. **Clean it up before the harness runs.** `/simplify` — a built-in skill:
+   reuse, simplification, efficiency and altitude, read by four agents that did
+   not write the code. It applies what it finds rather than reporting it, which
+   is what fixes its place: the harness has to run after it, its edits belong
+   inside the commits rather than on top, and what it changed is read below like
+   everything else.
+5. **Run the harness**, all of it, including the goldens.
+6. **Have it read by something that did not write it.** The `reviewer` subagent,
    over the committed change and before the pull request exists — its criteria
    ask about the commits, so they need the commits. Whoever wrote a change is
    the worst judge of whether it grew. One pass, and its findings say what they
    cost: **zero blocking findings is the pass**, notes are not something to
    clear. An architectural finding stops the work — that decision belongs to the
    maintainer wherever it surfaces.
-6. **Open the pull request** with the template filled in: what moved, what
+7. **Open the pull request** with the template filled in: what moved, what
    proves it, what the review found, what you looked at by hand.
 
-`/implement <issue>` does all six.
+`/implement <issue>` does all seven.
 
 ## Commits and pull requests
 

--- a/tests/agent_workflow.rs
+++ b/tests/agent_workflow.rs
@@ -7,9 +7,9 @@
 //!
 //! Mostly this does not read the words. It counts headings and list markers,
 //! compares them to the numbers the prose claims, checks that the files this
-//! documentation names exist, and checks the one ordering the workflow depends
-//! on — that the review comes after the commits, because its criteria ask about
-//! them.
+//! documentation names exist, and checks the two orderings the workflow depends
+//! on: the review comes after the commits, because its criteria ask about them,
+//! and the pass that edits the code comes before every pass that checks it.
 //!
 //! Where it does read them, it is for a sentence that has to appear in two
 //! documents at once: the review's three levels, and the rule about researching
@@ -202,8 +202,8 @@ fn the_pull_request_template_asks_as_many_questions_as_it_says() {
     );
 }
 
-/// Step 7 keeps no copy of the reviewer's criteria — it points at the file that
-/// holds them. A pointer nobody checks is how that file gets moved and the step
+/// The review step keeps no copy of the reviewer's criteria — it points at the
+/// file that holds them. A pointer nobody checks is how that file gets moved and the step
 /// quietly stops saying anything.
 ///
 /// This checks every repository path the agent-facing documentation names, not
@@ -276,6 +276,35 @@ fn the_review_comes_after_the_commits() {
         "the review is step {review} and the commits are step {commit}: its \
          criteria ask about commits that would not exist yet"
     );
+
+    // The cleanup applies what it finds instead of reporting it, so where it
+    // sits decides whether anything checks its work. Before the harness, it is
+    // re-tested; before the commits, its edits land inside them; before the
+    // review, they are read like everything else. Below any of the three and
+    // something ships that nothing looked at.
+    let cleanup = step("clean it up");
+    // "run the harness", not "harness": the cleanup's own heading says it runs
+    // before the harness sees the change again, and a needle that matches both
+    // finds the first one.
+    let harness = step("run the harness");
+
+    // A heading in the right position always survives a renumber, so the
+    // ordering alone would let the step be emptied in one file and dropped
+    // from the other. Both documents have to name the tool that does it.
+    for (doc, name) in [(&text, "/implement"), (&read("AGENTS.md"), "AGENTS.md")] {
+        assert!(
+            doc.contains("`/simplify`"),
+            "{name} never names `/simplify`, so the cleanup is a heading with \
+             nothing behind it"
+        );
+    }
+
+    assert!(
+        cleanup < harness && cleanup < commit && cleanup < review,
+        "the cleanup is step {cleanup}, the harness {harness}, the commits \
+         {commit} and the review {review}: a pass that edits the code has to \
+         run before every pass that checks it"
+    );
 }
 
 /// `/implement` ends by saying how many lines to report back, and the template
@@ -301,39 +330,46 @@ fn the_report_back_matches_the_template() {
     );
 }
 
-/// The three mutations the counting does not see: strip step 7 down to its
-/// heading, take the review section out of the template, or drop the review
+/// The three mutations the counting does not see: strip the review step down to
+/// its heading, take the review section out of the template, or drop the review
 /// from AGENTS.md's list. Each leaves every count consistent and removes the
 /// change entirely.
+///
+/// Found by its heading rather than its number, because inserting a step ahead
+/// of it renumbers it — which is exactly what this file exists to survive.
 #[test]
 fn the_review_step_still_says_what_it_is_for() {
     let implement = read(".claude/commands/implement.md");
-    let step_seven = implement
-        .split("## 7.")
-        .nth(1)
-        .expect("/implement has no step 7")
+    let review_step = implement
         .split("\n## ")
-        .next()
-        .unwrap_or_default();
+        .find(|section| {
+            // The heading, not the body: a neighbouring step that mentions the
+            // review in its prose is not the review.
+            section
+                .lines()
+                .next()
+                .is_some_and(|heading| heading.to_ascii_lowercase().contains("read by"))
+        })
+        .expect("/implement has no step about having the change read");
 
     assert!(
-        step_seven.contains(".claude/agents/reviewer.md"),
-        "step 7 keeps no copy of the criteria, so naming the file that holds \
-         them is the whole of it — and it does not"
+        review_step.contains(".claude/agents/reviewer.md"),
+        "the review step keeps no copy of the criteria, so naming the file that \
+         holds them is the whole of it — and it does not"
     );
     assert!(
-        step_seven.contains("One pass"),
-        "step 7 does not say it is one pass, and a review with no stopping rule \
-         is a review that runs until somebody gets tired"
+        review_step.contains("One pass"),
+        "the review step does not say it is one pass, and a review with no \
+         stopping rule is a review that runs until somebody gets tired"
     );
     assert!(
-        step_seven.contains("Blocks") && step_seven.contains("Note"),
-        "step 7 does not say what to do with each level of finding"
+        review_step.contains("Blocks") && review_step.contains("Note"),
+        "the review step does not say what to do with each level of finding"
     );
     assert!(
-        step_seven.contains("did not run"),
-        "step 7 does not say what to do when the review does not run, and a \
-         review that did not run looks exactly like one that found nothing"
+        review_step.contains("did not run"),
+        "the review step does not say what to do when the review does not run, \
+         and a review that did not run looks exactly like one that found nothing"
     );
 
     let template = read(".github/pull_request_template.md");


### PR DESCRIPTION
## What changed

`/implement` gains a step: **`/simplify` runs over the change before anything checks it.** Four readings by four agents — reuse, simplification, efficiency, altitude — none of which wrote the code. `AGENTS.md`'s process list carries it too, and the steps after it renumber.

It closes a gap rather than duplicating the review. The `reviewer`'s three sections ask whether a change is verified, whether it is the change that was asked for, and whether it follows this repository's rules; **none of them contains the word reuse, or duplication, or complexity**. The reviews on #252, #255, #257 and #258 reported nothing of that kind, which is what a criterion nobody wrote down produces.

**Where it goes is the whole of the decision**, because `/simplify` *applies* what it finds where the reviewer only reports. It runs before the harness — the last gate before the commits — for three reasons that all point the same way:

- put it after and the commit carries code nothing has re-tested since it changed, and if it touched the test written in step 3, the red confirmed there is no longer the red that ships;
- its edits land inside the commits rather than on top, and a tidy-up commit is exactly what the review's atomic-commits criterion exists to catch;
- what it changed is then read by the review like everything else. Code that edits itself and ships unread is the one thing that step must not become.

Corro's `ship` does this job in its first line and hands it to the agent that wrote the code. This does not.

## What proves it

`tests/agent_workflow.rs`: the cleanup precedes all three passes that check the code, and **both documents name the tool** — because a heading in the right position survives any renumber, so position alone would let the step be emptied in one file and dropped from the other.

Six inversions, each applied alone:

| broken on purpose | what fails |
| --- | --- |
| the cleanup step deleted | `the_review_comes_after_the_commits` |
| moved below the harness | `the_review_comes_after_the_commits` |
| moved below the review | `the_review_comes_after_the_commits` |
| gutted to its heading | `the_review_comes_after_the_commits` |
| removed from `AGENTS.md` with the numbering left consistent | `the_review_comes_after_the_commits` |
| a level deleted from `reviewer.md` | `the_reviewer_and_the_command_use_the_same_levels` |

The last confirms the neighbouring test still defends what it did after this change moved it.

`fmt --check`, `clippy --all-targets --all-features -D warnings`, `agent_workflow` (9) and `documentation_references` (2) all clean.

## What the review found

**Zero blocking. Three worth answering, and the first changed where the step goes.**

- **Nothing re-ran the harness after the step that edits the code.** The first version put the cleanup at step 6, between the harness and the commits, so an agent following the document literally committed code the harness had not seen since it changed — and `/simplify` reads the whole diff including the test written in step 3. The step moved above the harness, which is the deeper fix: no loop back, and the harness is the last thing before the commits.
- **Two of my inversions were weaker than I claimed.** The commit said removing the step from `AGENTS.md` goes red; the reviewer showed it goes red only for a naive drop that leaves the count stale — renumber consistently, as anyone editing a list does, and all nine tests passed. It also gutted `/implement`'s step to its heading and everything stayed green, which is the exact mutation class this file already defends against for the review step. Both are closed now, by asserting both documents name `/simplify`.
- **`/simplify` was named in two contract documents and defined in neither.** Every other slash command the documentation names resolves to a file in `.claude/commands/`; this one does not, and nothing said it is built in. It does now.

Notes acted on: three stale "step 7"s left by the renumbering, in the very test this change stopped from depending on the number; and the module header claimed the file checks "the one ordering the workflow depends on", which is now two.

One note not acted on as suggested but worth recording: the reviewer observed the commit's claim about four reviews finding nothing of this kind was unverifiable from the repository. It names the four pull request numbers now, which is as checkable as it can be made.

## What was checked by hand

Nothing needed a compositor. Every inversion above was run and its message read.

## Left undone

**Nothing measures whether the step earns its place.** Four more agents run on every pull request, and the only evidence they are worth it is the absence of this kind of finding from four reviews — which is an absence, not a measurement. #256's implementation is the first diff big enough to tell: platform queue, dispatch, `Tree`, four widgets. If `/simplify` finds nothing there, the step is costing more than it returns and the honest answer is to take it off the required path, exactly as #238 says of the review itself.
