### PR TITLE
An event knows when it happened, and says so

### DIFF
--- a/book/src/architecture/rendering.md
+++ b/book/src/architecture/rendering.md
@@ -10,7 +10,9 @@ Main loop (once per iteration):
  2. take_frame_request()           → Check if a frame was requested
 
 Per-surface rendering:
- 3. Dispatch events                → Route input events (MouseMoves coalesced)
+ 3. Dispatch events                → Route input events (MouseMoves coalesced),
+                                     each one declaring when the compositor saw
+                                     it happen — not when this loop got to it
  4. Frame-pacing gate              → Return if the compositor hasn't shown the
                                      previous frame yet (jobs stay queued)
  5. set_frame_instant(now)         → What time it is, for this whole frame:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -428,13 +428,20 @@ pub trait Widget {
 
 **Note:** Widget bounds and origins are stored in the `Tree`, not on individual widgets. Use `tree.get_bounds(id)` to retrieve a widget's bounds and `tree.set_origin(id, x, y)` to position widgets during layout.
 
-**Note:** So is what time it is. A widget that advances something over time asks
-`tree.frame_instant()` rather than the clock: a frame declares its instant once,
-around the jobs, the layout and the paint, so everything advancing in that frame
-is asked about the same moment. Reading the clock inside a widget makes one
-frame several instants, and makes the middle of an animation something no test
-can ask about — only sleep towards. `tree.set_frame_instant(Some(now))` is how a
-test names the moment it wants to ask about.
+**Note:** So is what time it is, and there are two answers because they are two
+questions. A widget **advancing** something over time asks `tree.frame_instant()`
+— a frame declares its instant once, around the jobs, the layout and the paint,
+so everything moving in that frame is asked about the same moment. A widget
+handling an **event** asks `tree.event_instant()`, which is when the compositor
+saw it happen, not when the handler ran: the two differ by however long the
+event sat in the queue, and that difference is what a velocity or a
+double-keystroke window would otherwise measure by mistake.
+
+Neither is `Instant::now()`. Reading the clock inside a widget makes one frame
+several instants, and makes the middle of an animation — or the gap between two
+keystrokes — something no test can ask about, only sleep towards.
+`set_frame_instant` and `set_event_instant` are how a test names the moment it
+is asking about.
 
 ### Widgets written outside the crate
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -632,18 +632,22 @@ pub fn cache_paint_results(tree: &mut Tree, node: &std::rc::Rc<renderer::RenderN
 /// the inbox, and distributing them here is what keeps hover from lagging a
 /// frame behind the pointer: the drain later in this same frame picks them up.
 fn dispatch_events(
-    events: &[widgets::Event],
+    events: &[(std::time::Instant, widgets::Event)],
     root: WidgetId,
     tree: &mut Tree,
     active_roots: &rustc_hash::FxHashSet<WidgetId>,
 ) {
-    for event in events {
+    for (at, event) in events {
+        // Declared per event, not per pass: they are delivered one at a time
+        // and each has its own moment.
+        tree.set_event_instant(Some(*at));
         reactive::diagnostics::snapshot_zone(|| {
             tree.with_widget_mut(root, |widget, id, tree| {
                 widget.event(tree, id, event);
             });
         });
     }
+    tree.set_event_instant(None);
 
     jobs::distribute_jobs(tree, active_roots);
 }
@@ -720,7 +724,8 @@ fn run_jobs(
 /// need mutably — and nothing the compositor sends can change it before this
 /// frame ends anyway.
 struct Frame {
-    events: Vec<widgets::Event>,
+    /// What arrived for this surface, each with when it happened.
+    events: Vec<(std::time::Instant, widgets::Event)>,
     scale_factor: f32,
     width: u32,
     height: u32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1991,3 +1991,71 @@ mod font_registry_tests {
         );
     }
 }
+
+#[cfg(test)]
+mod dispatch_declares_the_moment {
+    use super::*;
+    use crate::layout::Size;
+    use crate::widgets::widget::{Event, EventResponse};
+
+    /// A widget that records what time the tree said it was when it was handed
+    /// an event.
+    struct Spy(std::rc::Rc<std::cell::Cell<Option<std::time::Instant>>>);
+
+    impl widgets::Widget for Spy {
+        fn layout(
+            &mut self,
+            tree: &mut Tree,
+            id: WidgetId,
+            constraints: crate::layout::Constraints,
+        ) -> Size {
+            let size = Size::new(constraints.max_width, constraints.max_height);
+            tree.cache_layout(id, constraints, size);
+            size
+        }
+
+        fn paint(&self, _tree: &Tree, _id: WidgetId, _ctx: &mut crate::renderer::PaintContext) {}
+
+        fn event(&mut self, tree: &mut Tree, _id: WidgetId, _event: &Event) -> EventResponse {
+            self.0.set(Some(tree.event_instant()));
+            EventResponse::Handled
+        }
+    }
+
+    /// The queue carries each event's moment and `dispatch_events` is what puts
+    /// it where a widget can read it. Without that one line every widget falls
+    /// back to the clock, which is what they all did before this existed — and
+    /// the tests of the widgets themselves cannot tell, because they declare
+    /// the instant by hand.
+    ///
+    /// So this one does not: it goes through the dispatcher, as the loop does.
+    #[test]
+    fn a_widget_is_told_when_the_event_it_is_handed_happened() {
+        let seen = std::rc::Rc::new(std::cell::Cell::new(None));
+        let mut tree = Tree::new();
+        let root = tree.register(Box::new(Spy(seen.clone())));
+        tree.set_origin(root, 0.0, 0.0);
+
+        // An hour ago: no clock this process could read would answer with it,
+        // so the widget can only have got it from the event.
+        let happened = std::time::Instant::now() - std::time::Duration::from_secs(3600);
+        let events = [(happened, Event::MouseMove { x: 10.0, y: 10.0 })];
+
+        dispatch_events(&events, root, &mut tree, &Default::default());
+
+        assert_eq!(
+            seen.get(),
+            Some(happened),
+            "the widget has to be told the moment the queue carried, not the \
+             moment the dispatch ran"
+        );
+        // And once the dispatch is over the moment is gone: what a later
+        // reader gets is the clock, not the last event's time.
+        let after = tree.event_instant();
+        assert!(
+            after > happened,
+            "the moment has to be cleared when the dispatch ends, got {after:?} \
+             for an event from an hour ago"
+        );
+    }
+}

--- a/src/platform/input.rs
+++ b/src/platform/input.rs
@@ -966,6 +966,42 @@ mod tests {
         assert_eq!(keysym_to_key(e, Some("é"), true), Some(Key::Char('é')));
     }
 
+    /// A timestamp equal to the anchor's is the anchor's instant, and one after
+    /// it is that far after. Nothing else about the compositor's epoch matters:
+    /// the protocol says only that its milliseconds increase, so a difference
+    /// is the only thing that can be read out of them.
+    #[test]
+    fn an_events_time_is_read_as_a_distance_from_the_anchor() {
+        let t0 = Instant::now();
+        let clock = EventClock::anchored(1_000, t0);
+
+        assert_eq!(clock.instant(1_000), t0, "the anchor is where it says");
+        assert_eq!(
+            clock.instant(1_250),
+            t0 + Duration::from_millis(250),
+            "and a quarter second later is a quarter second later"
+        );
+    }
+
+    /// The compositor's clock is a `u32` of milliseconds, so it wraps roughly
+    /// every 49 days and a client that has been running across one sees the
+    /// number fall. Subtracting it the ordinary way makes 16ms after the wrap
+    /// look like 49 days before it — a scroll gesture that ended in the far
+    /// past, a caret that never blinks again.
+    #[test]
+    fn a_clock_that_has_wrapped_still_moves_forwards() {
+        let t0 = Instant::now();
+        let clock = EventClock::anchored(u32::MAX - 4, t0);
+
+        // Five milliseconds later the counter has gone round: MAX-4 → MAX → 0
+        // → 11 is sixteen milliseconds of real time.
+        assert_eq!(
+            clock.instant(11),
+            t0 + Duration::from_millis(16),
+            "the wrap is sixteen milliseconds forwards, not forty-nine days back"
+        );
+    }
+
     /// The pointer position the events carry, so a test can tell it apart
     /// from a delta.
     const PX: f32 = 10.0;

--- a/src/platform/input.rs
+++ b/src/platform/input.rs
@@ -38,25 +38,6 @@ use crate::widgets::{Event, Key, Modifiers, MouseButton, ScrollSource};
 /// Pixels per line for discrete scroll (mouse wheel)
 const SCROLL_PIXELS_PER_LINE: f32 = 40.0;
 
-/// The compositor's clock, expressed in this process's.
-///
-/// Every input event carries a `uint` of milliseconds — `wl_pointer.motion`,
-/// `.button` and `.axis`, `wl_touch.down`, and `KeyEvent::time` all do. The
-/// protocol promises only that those milliseconds increase; the epoch is the
-/// compositor's and there is no request that asks what it is. So the number
-/// means nothing on its own and a *difference* between two of them means
-/// everything, which is what an anchor turns into an `Instant`.
-///
-/// Reading the clock when the event is handled instead would be simpler and
-/// wrong in one specific way: a handler runs some time after the event
-/// happened, and that delay varies with how busy this process is. A velocity is
-/// a ratio of differences, so a *constant* delay cancels out — but a varying
-/// one does not, and an application too busy to draw is exactly when a gesture
-/// most needs its speed read correctly.
-///
-/// On Linux the two clocks are the same one: libinput timestamps in
-/// `CLOCK_MONOTONIC`, and so does `Instant`. The anchor is a change of origin
-/// rather than a change of clock, so it cannot drift.
 /// Queue a move, replacing the last one if it was also a move.
 ///
 /// Only the latest position matters for hover state, and every queued move
@@ -93,6 +74,28 @@ fn untimed() -> Instant {
     Instant::now()
 }
 
+/// The compositor's clock, expressed in this process's.
+///
+/// Every input event carries a `uint` of milliseconds — `wl_pointer.motion`,
+/// `.button` and `.axis`, `wl_touch.down`, and `KeyEvent::time` all do. The
+/// protocol promises only that those milliseconds increase; the epoch is the
+/// compositor's and there is no request that asks what it is. So the number
+/// means nothing on its own and a *difference* between two of them means
+/// everything, which is what an anchor turns into an `Instant`.
+///
+/// Reading the clock when the event is handled instead would be simpler and
+/// wrong in one specific way: a handler runs some time after the event
+/// happened, and that delay varies with how busy this process is. A velocity is
+/// a ratio of differences, so a *constant* delay cancels out — but a varying
+/// one does not, and an application too busy to draw is exactly when a gesture
+/// most needs its speed read correctly.
+///
+/// On Linux the two clocks are the same one: libinput timestamps in
+/// `CLOCK_MONOTONIC`, and so does `Instant`. The anchor is a change of origin
+/// rather than a change of clock, so it cannot drift. What it does carry for
+/// good is however late the *first* timestamped event was read: every instant
+/// it yields is offset by that, which cancels between two events and does not
+/// cancel against the frame clock.
 pub(super) struct EventClock {
     /// The compositor's milliseconds at the moment `anchor` was read.
     anchor_ms: u32,

--- a/src/platform/input.rs
+++ b/src/platform/input.rs
@@ -8,6 +8,7 @@
 //! pipeline: the first finger down drives it, and a tap becomes a click.
 
 use std::collections::HashMap;
+use std::time::{Duration, Instant};
 
 use smithay_client_toolkit::{
     delegate_keyboard, delegate_pointer, delegate_seat, delegate_touch,
@@ -37,6 +38,103 @@ use crate::widgets::{Event, Key, Modifiers, MouseButton, ScrollSource};
 /// Pixels per line for discrete scroll (mouse wheel)
 const SCROLL_PIXELS_PER_LINE: f32 = 40.0;
 
+/// The compositor's clock, expressed in this process's.
+///
+/// Every input event carries a `uint` of milliseconds — `wl_pointer.motion`,
+/// `.button` and `.axis`, `wl_touch.down`, and `KeyEvent::time` all do. The
+/// protocol promises only that those milliseconds increase; the epoch is the
+/// compositor's and there is no request that asks what it is. So the number
+/// means nothing on its own and a *difference* between two of them means
+/// everything, which is what an anchor turns into an `Instant`.
+///
+/// Reading the clock when the event is handled instead would be simpler and
+/// wrong in one specific way: a handler runs some time after the event
+/// happened, and that delay varies with how busy this process is. A velocity is
+/// a ratio of differences, so a *constant* delay cancels out — but a varying
+/// one does not, and an application too busy to draw is exactly when a gesture
+/// most needs its speed read correctly.
+///
+/// On Linux the two clocks are the same one: libinput timestamps in
+/// `CLOCK_MONOTONIC`, and so does `Instant`. The anchor is a change of origin
+/// rather than a change of clock, so it cannot drift.
+/// Queue a move, replacing the last one if it was also a move.
+///
+/// Only the latest position matters for hover state, and every queued move
+/// costs a full event-dispatch walk of the widget tree. The coalesced one keeps
+/// the newest instant: it stands for where the pointer is now, not for where it
+/// was when the run began.
+fn push_move(events: &mut Vec<(Instant, Event)>, at: Instant, x: f32, y: f32) {
+    if let Some(last @ (_, Event::MouseMove { .. })) = events.last_mut() {
+        *last = (at, Event::MouseMove { x, y });
+    } else {
+        events.push((at, Event::MouseMove { x, y }));
+    }
+}
+
+/// The finger is gone: release the synthesized press, and clear hover, because
+/// unlike a real pointer nothing hovers after a lift.
+fn push_release(events: &mut Vec<(Instant, Event)>, at: Instant, x: f32, y: f32) {
+    events.push((
+        at,
+        Event::MouseUp {
+            x,
+            y,
+            button: MouseButton::Left,
+        },
+    ));
+    events.push((at, Event::MouseLeave));
+}
+
+/// For the events the protocol gives no timestamp: `wl_pointer.enter` and
+/// `.leave` carry a serial and nothing else, and `wl_touch.cancel` carries
+/// neither. Now is the best available answer, and it is the answer everything
+/// used before this existed.
+fn untimed() -> Instant {
+    Instant::now()
+}
+
+pub(super) struct EventClock {
+    /// The compositor's milliseconds at the moment `anchor` was read.
+    anchor_ms: u32,
+    anchor: Instant,
+}
+
+impl InputState {
+    /// When an event carrying `ms` happened, anchoring the clock if this is the
+    /// first one.
+    ///
+    /// The anchor is read here rather than at construction because the seat
+    /// exists long before anything is pressed, and an anchor taken then would
+    /// pair a compositor timestamp with an `Instant` from minutes earlier.
+    pub(super) fn at(&mut self, ms: u32) -> Instant {
+        self.event_clock
+            .get_or_insert_with(|| EventClock::anchored(ms, Instant::now()))
+            .instant(ms)
+    }
+}
+
+impl EventClock {
+    /// Anchor on the first event to arrive, whose timestamp is as close to
+    /// `Instant::now()` as this process can observe.
+    fn anchored(ms: u32, now: Instant) -> Self {
+        Self {
+            anchor_ms: ms,
+            anchor: now,
+        }
+    }
+
+    /// When an event carrying `ms` happened.
+    ///
+    /// `wrapping_sub` because the counter is a `u32` and goes round about every
+    /// forty-nine days: subtracting it the ordinary way turns the first event
+    /// after a wrap into one from seven weeks ago. The difference is correct as
+    /// long as two events are less than that far apart, which is the same thing
+    /// the protocol's own monotonicity promises.
+    fn instant(&self, ms: u32) -> Instant {
+        self.anchor + Duration::from_millis(ms.wrapping_sub(self.anchor_ms) as u64)
+    }
+}
+
 /// The seat's three devices and the state that tracks them.
 pub struct InputState {
     // Pointer
@@ -54,6 +152,11 @@ pub struct InputState {
     /// only understand pointer events, so the primary finger synthesizes
     /// MouseMove/MouseDown/MouseUp — a tap becomes a click.
     pub(super) primary_finger: Option<i32>,
+
+    /// The compositor's clock expressed in ours, anchored on the first event
+    /// that carries a timestamp. `None` until one does — which is why every
+    /// reader goes through `at`.
+    pub(super) event_clock: Option<EventClock>,
 
     // Cursor shape
     pub(super) cursor_shape_manager: Option<CursorShapeManager>,
@@ -88,6 +191,7 @@ impl InputState {
             touch: None,
             touch_fingers: HashMap::new(),
             primary_finger: None,
+            event_clock: None,
             cursor_shape_manager,
             keyboard: None,
             modifiers: Modifiers::default(),
@@ -243,7 +347,7 @@ impl TouchHandler for WaylandState {
         _qh: &QueueHandle<Self>,
         _touch: &wl_touch::WlTouch,
         serial: u32,
-        _time: u32,
+        time: u32,
         surface: wl_surface::WlSurface,
         id: i32,
         position: (f64, f64),
@@ -252,6 +356,7 @@ impl TouchHandler for WaylandState {
         let Some(surface_id) = self.surface_lookup.get(&surface.id()).copied() else {
             return;
         };
+        let at = self.input.at(time);
         let (x, y) = (position.0 as f32, position.1 as f32);
         self.input.touch_fingers.insert(id, (surface_id, x, y));
 
@@ -260,12 +365,17 @@ impl TouchHandler for WaylandState {
         if self.input.primary_finger.is_none() {
             self.input.primary_finger = Some(id);
             if let Some(surface_state) = self.surfaces.get_mut(&surface_id) {
-                surface_state.pending_events.push(Event::MouseMove { x, y });
-                surface_state.pending_events.push(Event::MouseDown {
-                    x,
-                    y,
-                    button: MouseButton::Left,
-                });
+                surface_state
+                    .pending_events
+                    .push((at, Event::MouseMove { x, y }));
+                surface_state.pending_events.push((
+                    at,
+                    Event::MouseDown {
+                        x,
+                        y,
+                        button: MouseButton::Left,
+                    },
+                ));
             }
         }
     }
@@ -276,23 +386,17 @@ impl TouchHandler for WaylandState {
         _qh: &QueueHandle<Self>,
         _touch: &wl_touch::WlTouch,
         _serial: u32,
-        _time: u32,
+        time: u32,
         id: i32,
     ) {
         let Some((surface_id, x, y)) = self.input.touch_fingers.remove(&id) else {
             return;
         };
+        let at = self.input.at(time);
         if self.input.primary_finger == Some(id) {
             self.input.primary_finger = None;
             if let Some(surface_state) = self.surfaces.get_mut(&surface_id) {
-                surface_state.pending_events.push(Event::MouseUp {
-                    x,
-                    y,
-                    button: MouseButton::Left,
-                });
-                // Unlike a real pointer, nothing hovers after lifting the
-                // finger — clear hover state.
-                surface_state.pending_events.push(Event::MouseLeave);
+                push_release(&mut surface_state.pending_events, at, x, y);
             }
         }
     }
@@ -302,7 +406,7 @@ impl TouchHandler for WaylandState {
         _conn: &Connection,
         _qh: &QueueHandle<Self>,
         _touch: &wl_touch::WlTouch,
-        _time: u32,
+        time: u32,
         id: i32,
         position: (f64, f64),
     ) {
@@ -313,17 +417,12 @@ impl TouchHandler for WaylandState {
         finger.1 = x;
         finger.2 = y;
         let surface_id = finger.0;
+        let at = self.input.at(time);
 
         if self.input.primary_finger == Some(id)
             && let Some(surface_state) = self.surfaces.get_mut(&surface_id)
         {
-            // Coalesce runs of MouseMove like the pointer path does.
-            let events = &mut surface_state.pending_events;
-            if let Some(last @ Event::MouseMove { .. }) = events.last_mut() {
-                *last = Event::MouseMove { x, y };
-            } else {
-                events.push(Event::MouseMove { x, y });
-            }
+            push_move(&mut surface_state.pending_events, at, x, y);
         }
     }
 
@@ -355,12 +454,9 @@ impl TouchHandler for WaylandState {
             && let Some((surface_id, x, y)) = self.input.touch_fingers.get(&id).copied()
             && let Some(surface_state) = self.surfaces.get_mut(&surface_id)
         {
-            surface_state.pending_events.push(Event::MouseUp {
-                x,
-                y,
-                button: MouseButton::Left,
-            });
-            surface_state.pending_events.push(Event::MouseLeave);
+            // The compositor is telling us the gesture is not ours any more.
+            let at = untimed();
+            push_release(&mut surface_state.pending_events, at, x, y);
         }
         self.input.touch_fingers.clear();
     }
@@ -378,8 +474,19 @@ impl PointerHandler for WaylandState {
             // Try to find the surface ID for this event's wl_surface
             let surface_id = self.surface_lookup.get(&event.surface.id()).copied();
 
+            // When this one happened. `enter` and `leave` carry a serial and no
+            // timestamp, so they get now — which is what everything got before
+            // the clock existed.
+            let at = match event.kind {
+                PointerEventKind::Motion { time }
+                | PointerEventKind::Press { time, .. }
+                | PointerEventKind::Release { time, .. }
+                | PointerEventKind::Axis { time, .. } => self.input.at(time),
+                PointerEventKind::Enter { .. } | PointerEventKind::Leave { .. } => untimed(),
+            };
+
             // Get the target event queue for this surface
-            let target_events: Option<&mut Vec<Event>> = if let Some(id) = surface_id {
+            let target_events: Option<&mut Vec<(Instant, Event)>> = if let Some(id) = surface_id {
                 self.surfaces.get_mut(&id).map(|s| &mut s.pending_events)
             } else if !matches!(event.kind, PointerEventKind::Leave { .. }) {
                 // Not our surface and not a leave event, skip
@@ -400,14 +507,20 @@ impl PointerHandler for WaylandState {
                     self.current_pointer_surface = surface_id;
 
                     if let Some(events) = target_events {
-                        events.push(Event::MouseEnter {
-                            x: self.input.pointer_x,
-                            y: self.input.pointer_y,
-                        });
-                        events.push(Event::MouseMove {
-                            x: self.input.pointer_x,
-                            y: self.input.pointer_y,
-                        });
+                        events.push((
+                            at,
+                            Event::MouseEnter {
+                                x: self.input.pointer_x,
+                                y: self.input.pointer_y,
+                            },
+                        ));
+                        events.push((
+                            at,
+                            Event::MouseMove {
+                                x: self.input.pointer_x,
+                                y: self.input.pointer_y,
+                            },
+                        ));
                     }
                 }
                 PointerEventKind::Leave { .. } => {
@@ -418,7 +531,7 @@ impl PointerHandler for WaylandState {
                         if let Some(id) = self.current_pointer_surface
                             && let Some(surface_state) = self.surfaces.get_mut(&id)
                         {
-                            surface_state.pending_events.push(Event::MouseLeave);
+                            surface_state.pending_events.push((at, Event::MouseLeave));
                         }
 
                         self.current_pointer_surface = None;
@@ -428,20 +541,7 @@ impl PointerHandler for WaylandState {
                     self.input.pointer_x = event.position.0 as f32;
                     self.input.pointer_y = event.position.1 as f32;
                     if let Some(events) = target_events {
-                        // Coalesce runs of MouseMove: only the latest position
-                        // matters for hover state, and every queued move costs
-                        // a full event-dispatch walk of the widget tree.
-                        if let Some(last @ Event::MouseMove { .. }) = events.last_mut() {
-                            *last = Event::MouseMove {
-                                x: self.input.pointer_x,
-                                y: self.input.pointer_y,
-                            };
-                        } else {
-                            events.push(Event::MouseMove {
-                                x: self.input.pointer_x,
-                                y: self.input.pointer_y,
-                            });
-                        }
+                        push_move(events, at, self.input.pointer_x, self.input.pointer_y);
                     }
                 }
                 PointerEventKind::Press { button, serial, .. } => {
@@ -449,22 +549,28 @@ impl PointerHandler for WaylandState {
                     if let Some(mouse_button) = wayland_button_to_mouse_button(button)
                         && let Some(events) = target_events
                     {
-                        events.push(Event::MouseDown {
-                            x: self.input.pointer_x,
-                            y: self.input.pointer_y,
-                            button: mouse_button,
-                        });
+                        events.push((
+                            at,
+                            Event::MouseDown {
+                                x: self.input.pointer_x,
+                                y: self.input.pointer_y,
+                                button: mouse_button,
+                            },
+                        ));
                     }
                 }
                 PointerEventKind::Release { button, .. } => {
                     if let Some(mouse_button) = wayland_button_to_mouse_button(button)
                         && let Some(events) = target_events
                     {
-                        events.push(Event::MouseUp {
-                            x: self.input.pointer_x,
-                            y: self.input.pointer_y,
-                            button: mouse_button,
-                        });
+                        events.push((
+                            at,
+                            Event::MouseUp {
+                                x: self.input.pointer_x,
+                                y: self.input.pointer_y,
+                                button: mouse_button,
+                            },
+                        ));
                     }
                 }
                 PointerEventKind::Axis {
@@ -476,6 +582,7 @@ impl PointerHandler for WaylandState {
                     if let Some(events) = target_events {
                         translate_axis(
                             events,
+                            at,
                             source,
                             &horizontal,
                             &vertical,
@@ -495,7 +602,8 @@ impl PointerHandler for WaylandState {
 /// that needs a compositor to run is a callback nothing checks, and this is
 /// where the protocol's only statement about a gesture *ending* is read.
 fn translate_axis(
-    events: &mut Vec<Event>,
+    events: &mut Vec<(Instant, Event)>,
+    at: Instant,
     source: Option<wl_pointer::AxisSource>,
     horizontal: &AxisScroll,
     vertical: &AxisScroll,
@@ -536,16 +644,19 @@ fn translate_axis(
     // line before anything could use it. It is the only unguessed answer to
     // when a gesture is over.
     if delta_x != 0.0 || delta_y != 0.0 {
-        events.push(Event::Scroll {
-            x,
-            y,
-            delta_x,
-            delta_y,
-            source: scroll_source,
-        });
+        events.push((
+            at,
+            Event::Scroll {
+                x,
+                y,
+                delta_x,
+                delta_y,
+                source: scroll_source,
+            },
+        ));
     }
     if horizontal.stop || vertical.stop {
-        events.push(Event::ScrollEnd { x, y });
+        events.push((at, Event::ScrollEnd { x, y }));
     }
 }
 
@@ -585,7 +696,9 @@ impl KeyboardHandler for WaylandState {
         if let Some(id) = surface_id
             && let Some(surface_state) = self.surfaces.get_mut(&id)
         {
-            surface_state.pending_events.push(Event::FocusIn);
+            surface_state
+                .pending_events
+                .push((untimed(), Event::FocusIn));
         }
     }
 
@@ -604,7 +717,9 @@ impl KeyboardHandler for WaylandState {
         if let Some(id) = surface_id
             && let Some(surface_state) = self.surfaces.get_mut(&id)
         {
-            surface_state.pending_events.push(Event::FocusOut);
+            surface_state
+                .pending_events
+                .push((untimed(), Event::FocusOut));
         }
 
         self.current_keyboard_surface = None;
@@ -627,6 +742,7 @@ impl KeyboardHandler for WaylandState {
             // (e.g., composed 'é' instead of raw 'e' after a compose sequence)
             self.input.pressed_keys.insert(event.raw_code, key);
 
+            let at = self.input.at(event.time);
             let key_event = Event::KeyDown {
                 key,
                 modifiers: self.input.modifiers,
@@ -636,7 +752,7 @@ impl KeyboardHandler for WaylandState {
             if let Some(id) = self.current_keyboard_surface
                 && let Some(surface_state) = self.surfaces.get_mut(&id)
             {
-                surface_state.pending_events.push(key_event);
+                surface_state.pending_events.push((at, key_event));
             }
         }
     }
@@ -658,6 +774,7 @@ impl KeyboardHandler for WaylandState {
             .or_else(|| keysym_to_key(event.keysym, event.utf8.as_deref(), false));
 
         if let Some(key) = key {
+            let at = self.input.at(event.time);
             let key_event = Event::KeyUp {
                 key,
                 modifiers: self.input.modifiers,
@@ -667,7 +784,7 @@ impl KeyboardHandler for WaylandState {
             if let Some(id) = self.current_keyboard_surface
                 && let Some(surface_state) = self.surfaces.get_mut(&id)
             {
-                surface_state.pending_events.push(key_event);
+                surface_state.pending_events.push((at, key_event));
             }
         }
     }
@@ -718,6 +835,12 @@ impl WaylandState {
         let Some(key) = keysym_to_key(event.keysym, event.utf8.as_deref(), true) else {
             return;
         };
+        // A repeat's `time` is the original press advanced by the repeat gap
+        // rather than something the compositor observed — sctk's timer computes
+        // it. It is still in the compositor's clock and still increases, which
+        // is all the conversion needs, and a held key spaced by the compositor's
+        // own repeat rate is a truer account than the moment a timer fired here.
+        let at = self.input.at(event.time);
         let key_event = Event::KeyDown {
             key,
             modifiers: self.input.modifiers,
@@ -727,7 +850,7 @@ impl WaylandState {
         if let Some(id) = self.current_keyboard_surface
             && let Some(surface_state) = self.surfaces.get_mut(&id)
         {
-            surface_state.pending_events.push(key_event);
+            surface_state.pending_events.push((at, key_event));
         }
     }
 }
@@ -854,8 +977,16 @@ mod tests {
         vertical: AxisScroll,
     ) -> Vec<Event> {
         let mut events = Vec::new();
-        translate_axis(&mut events, source, &horizontal, &vertical, PX, PY);
-        events
+        translate_axis(
+            &mut events,
+            Instant::now(),
+            source,
+            &horizontal,
+            &vertical,
+            PX,
+            PY,
+        );
+        events.into_iter().map(|(_, event)| event).collect()
     }
 
     fn nothing() -> AxisScroll {

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -98,7 +98,13 @@ pub struct WaylandSurfaceState {
     /// would outpace it. Cleared by the frame-done handler.
     pub frame_callback_pending: bool,
     /// Pending events for this surface
-    pub pending_events: Vec<Event>,
+    /// Events waiting for the next frame, each with when it happened.
+    ///
+    /// The instant travels with the event because the two are separated in
+    /// time: an event is queued when the compositor sends it and read when the
+    /// frame runs, and the gap between those is exactly what a handler reading
+    /// the clock for itself would mistake for the event's own time.
+    pub pending_events: Vec<(std::time::Instant, Event)>,
     /// Blur proxy for this surface, created lazily on first use (asking the
     /// manager twice for the same surface is a protocol error).
     pub(super) bg_effect_surface: Option<ExtBackgroundEffectSurfaceV1>,
@@ -143,7 +149,7 @@ impl WaylandSurfaceState {
     }
 
     /// Take all pending events (drains the queue)
-    pub fn take_events(&mut self) -> Vec<Event> {
+    pub fn take_events(&mut self) -> Vec<(std::time::Instant, Event)> {
         std::mem::take(&mut self.pending_events)
     }
 }

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -97,7 +97,6 @@ pub struct WaylandSurfaceState {
     /// compositor has not yet shown the last frame — rendering another one
     /// would outpace it. Cleared by the frame-done handler.
     pub frame_callback_pending: bool,
-    /// Pending events for this surface
     /// Events waiting for the next frame, each with when it happened.
     ///
     /// The instant travels with the event because the two are separated in

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -167,6 +167,16 @@ pub struct Tree {
     /// paint draws it. `None` between frames, where nobody should be reading
     /// it.
     frame_instant: Option<std::time::Instant>,
+    /// When the event now being dispatched happened.
+    ///
+    /// Not the same question as `frame_instant`: a frame advances what is
+    /// already moving, an event says something started. They are different
+    /// moments, and an event's is the older of the two — it was queued when the
+    /// compositor sent it and is read when the frame runs.
+    ///
+    /// `dispatch_events` writes it, once per event, because it delivers them one
+    /// at a time. `None` outside a dispatch, where nobody should be reading it.
+    event_instant: Option<std::time::Instant>,
 }
 
 impl Tree {
@@ -178,6 +188,7 @@ impl Tree {
             free_indices: Vec::new(),
             damage: std::collections::HashMap::new(),
             frame_instant: None,
+            event_instant: None,
         }
     }
 
@@ -187,6 +198,23 @@ impl Tree {
     /// behaviour every caller had before there was a frame instant at all.
     pub fn frame_instant(&self) -> std::time::Instant {
         self.frame_instant.unwrap_or_else(std::time::Instant::now)
+    }
+
+    /// When the event being dispatched happened.
+    ///
+    /// Falls back to the clock outside a dispatch — the behaviour every caller
+    /// had before an event carried its own time.
+    pub fn event_instant(&self) -> std::time::Instant {
+        self.event_instant.unwrap_or_else(std::time::Instant::now)
+    }
+
+    /// Declare when the event about to be dispatched happened, or `None` when
+    /// the dispatch is over.
+    ///
+    /// `dispatch_events` is the caller in the loop; a test that wants to place
+    /// an event in time is the other one.
+    pub fn set_event_instant(&mut self, at: Option<std::time::Instant>) {
+        self.event_instant = at;
     }
 
     /// Declare the instant of the frame about to run, or `None` when it is

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -1221,7 +1221,10 @@ fn a_press_held_for_a_named_time_has_grown_by_a_named_amount() {
     );
     h.fit(400.0, 400.0);
 
-    let t0 = std::time::Instant::now();
+    // A minute ago, and that is the point: if the press took its moment from the
+    // clock instead of from the event, the disc would be a minute old by the
+    // first frame and there would be nothing left to draw.
+    let t0 = std::time::Instant::now() - std::time::Duration::from_secs(60);
     send_at(
         &mut h,
         t0,

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -1195,6 +1195,83 @@ fn a_ripple_and_a_transition_are_asked_about_the_same_moment() {
     );
 }
 
+/// An event delivered at a named moment, the way `dispatch_events` delivers
+/// one.
+fn send_at(h: &mut H, at: std::time::Instant, event: Event) -> EventResponse {
+    h.tree.set_event_instant(Some(at));
+    let response = h.send(event);
+    h.tree.set_event_instant(None);
+    response
+}
+
+/// A ripple held for a named length of time has grown by a named amount.
+///
+/// It could not be asked before. A ripple begins when the press arrives and
+/// grows from there, and both ends of that were `Instant::now()` — one read in
+/// the event handler and one in the frame — so a test could hold a press only
+/// by sleeping, and assert only that something had happened.
+#[test]
+fn a_press_held_for_a_named_time_has_grown_by_a_named_amount() {
+    let mut h = H::new(
+        container()
+            .width(100.0)
+            .height(100.0)
+            .when_pressed(|s| s.ripple())
+            .on_click(|| {}),
+    );
+    h.fit(400.0, 400.0);
+
+    let t0 = std::time::Instant::now();
+    send_at(
+        &mut h,
+        t0,
+        Event::MouseDown {
+            x: 50.0,
+            y: 50.0,
+            button: MouseButton::Left,
+        },
+    );
+
+    // A frame later, because the press and the frame are now genuinely the same
+    // instant: at t0 exactly nothing has elapsed and the disc has no opacity to
+    // be drawn with.
+    frame_at(
+        &mut h,
+        t0 + std::time::Duration::from_millis(8),
+        400.0,
+        400.0,
+    );
+    let started = painted_ripple_radius(&mut h).expect("the press starts a ripple");
+
+    frame_at(
+        &mut h,
+        t0 + std::time::Duration::from_millis(120),
+        400.0,
+        400.0,
+    );
+    let held = painted_ripple_radius(&mut h).expect("and holding it keeps one");
+
+    // Asked about the same moment again, it answers the same: the disc is a
+    // function of how long the press has lasted, and nothing else.
+    frame_at(
+        &mut h,
+        t0 + std::time::Duration::from_millis(120),
+        400.0,
+        400.0,
+    );
+    assert_eq!(
+        painted_ripple_radius(&mut h),
+        Some(held),
+        "the same instant twice is the same disc"
+    );
+
+    assert!(
+        held > started,
+        "a hundred and twenty milliseconds of press has to have grown it, \
+         from {started} to {held}"
+    );
+}
+
 /// Lay out, run the queued jobs, paint, and report the first text colour.
 fn painted_text_color(h: &mut H) -> Color {
     pump(h);

--- a/src/widgets/container/interaction.rs
+++ b/src/widgets/container/interaction.rs
@@ -106,7 +106,13 @@ impl Container {
     /// Update hover state and fire the pointer-move callback, before children
     /// get the event: a child that handles a `MouseMove` must not stop its
     /// ancestors from tracking their own hover.
-    pub(super) fn track_pointer(&mut self, id: WidgetId, hit: &HitContext, event: &Event) {
+    pub(super) fn track_pointer(
+        &mut self,
+        id: WidgetId,
+        hit: &HitContext,
+        event: &Event,
+        at: Instant,
+    ) {
         let has_animated = self.has_animated_state_properties();
         // Read before the mutable borrow: cancelling a ripple below needs it.
         let ripple_config = self.interaction.as_ref().and_then(|ix| ix.ripple_config());
@@ -153,7 +159,7 @@ impl Container {
                     && ix.ripple.is_active()
                     && let Some(ref config) = ripple_config
                 {
-                    ix.ripple.cancel(config, Instant::now());
+                    ix.ripple.cancel(config, at);
                     request_job(id, JobRequest::Animation(RequiredJob::Paint));
                 }
 
@@ -182,6 +188,7 @@ impl Container {
         hit: &HitContext,
         event: &Event,
         local: &Event,
+        at: Instant,
     ) -> EventResponse {
         match local {
             // Hover was tracked before the children ran. Returning Ignored
@@ -220,7 +227,7 @@ impl Container {
                     if has_ripple {
                         let (screen_x, screen_y) = event.coords().unwrap_or((*x, *y));
                         let (local_x, local_y) = hit.local(screen_x, screen_y);
-                        ix.ripple.start(local_x, local_y, Instant::now());
+                        ix.ripple.start(local_x, local_y, at);
                         request_job(id, JobRequest::Animation(RequiredJob::Paint));
                     }
 
@@ -259,11 +266,10 @@ impl Container {
                     if ix.ripple.is_active()
                         && let Some(config) = ix.ripple_config()
                     {
-                        let now = Instant::now();
                         if hit.contains(*x, *y) {
-                            ix.ripple.release(&config, now);
+                            ix.ripple.release(&config, at);
                         } else {
-                            ix.ripple.cancel(&config, now);
+                            ix.ripple.cancel(&config, at);
                         }
                         request_job(id, JobRequest::Animation(RequiredJob::Paint));
                     }
@@ -313,7 +319,7 @@ impl Container {
                     if ix.ripple.is_active()
                         && let Some(config) = ix.ripple_config()
                     {
-                        ix.ripple.cancel(&config, Instant::now());
+                        ix.ripple.cancel(&config, at);
                         request_job(id, JobRequest::Animation(RequiredJob::Paint));
                     }
 
@@ -336,7 +342,7 @@ impl Container {
                     // Our own scrolling consumes the event first; the callback
                     // only sees what scrolling did not take.
                     if self.scroll_axis != ScrollAxis::None
-                        && self.apply_scroll(*delta_x, *delta_y, *source)
+                        && self.apply_scroll(*delta_x, *delta_y, *source, at)
                     {
                         // A paint, and only a paint. A sample means the finger
                         // is still down, so there is no momentum for an
@@ -369,13 +375,8 @@ impl Container {
             // frame happens along next.
             Event::ScrollEnd { x, y } => {
                 if self.scroll_axis != ScrollAxis::None && hit.contains(*x, *y) {
-                    let since_ms = self
-                        .scroll()
-                        .scroll_state
-                        .last_scroll_time
-                        .map(|t| t.elapsed().as_secs_f32() * 1000.0);
                     let sd = self.scroll_mut();
-                    sd.scroll_state.end_gesture(since_ms);
+                    sd.scroll_state.end_gesture(at);
                     if sd.scroll_state.should_apply_momentum() {
                         request_job(id, JobRequest::Animation(RequiredJob::Paint));
                     }

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -1410,7 +1410,7 @@ impl Widget for Container {
             let has_scroll_velocity =
                 sd.scroll_state.velocity_x.abs() > 0.5 || sd.scroll_state.velocity_y.abs() > 0.5;
             if has_scroll_velocity {
-                let scroll_animating = sd.scroll_state.advance_momentum();
+                let scroll_animating = sd.scroll_state.advance_momentum(now);
                 if scroll_animating {
                     // Kinetic scroll is paint-only, request animation continuation with paint
                     request_job(id, JobRequest::Animation(RequiredJob::Paint));
@@ -1621,7 +1621,8 @@ impl Widget for Container {
             return response;
         }
 
-        self.track_pointer(id, &hit, &local_event);
+        let at = tree.event_instant();
+        self.track_pointer(id, &hit, &local_event, at);
 
         // Children are positioned relative to our origin (and to the scroll
         // offset, when we scroll), so their events have to be too.
@@ -1659,7 +1660,7 @@ impl Widget for Container {
             }
         }
 
-        self.handle_own_event(id, &hit, event, &local_event)
+        self.handle_own_event(id, &hit, event, &local_event, at)
     }
 
     fn paint(&self, tree: &Tree, id: WidgetId, ctx: &mut PaintContext) {

--- a/src/widgets/container/scrollable.rs
+++ b/src/widgets/container/scrollable.rs
@@ -913,6 +913,7 @@ impl Container {
         delta_x: f32,
         delta_y: f32,
         source: ScrollSource,
+        at: std::time::Instant,
     ) -> bool {
         let axis = self.scroll_axis;
         let sd = self.scroll_mut();
@@ -940,11 +941,10 @@ impl Container {
         // Only a continuous source has a gesture to measure. Both of them do,
         // and both end with an `axis_stop`; a wheel has neither.
         if source.is_continuous() {
-            let now = std::time::Instant::now();
             let dt_ms = sd
                 .scroll_state
                 .last_scroll_time
-                .map(|t| now.duration_since(t).as_secs_f32() * 1000.0);
+                .map(|t| at.duration_since(t).as_secs_f32() * 1000.0);
             let (sample_x, sample_y) = match axis {
                 ScrollAxis::Vertical => (0.0, delta_y),
                 ScrollAxis::Horizontal => (delta_x, 0.0),
@@ -953,7 +953,7 @@ impl Container {
             };
             sd.scroll_state
                 .record_gesture_sample(sample_x, sample_y, dt_ms);
-            sd.scroll_state.last_scroll_time = Some(now);
+            sd.scroll_state.last_scroll_time = Some(at);
         }
 
         old_x != sd.scroll_state.offset_x || old_y != sd.scroll_state.offset_y

--- a/src/widgets/scroll.rs
+++ b/src/widgets/scroll.rs
@@ -349,15 +349,13 @@ impl ScrollState {
 
     /// The gesture ended — the finger lifted.
     ///
-    /// `since_last_sample_ms` is how long ago the gesture last moved. A
-    /// momentum belongs to the gesture that produced it: a finger resting
+    /// A momentum belongs to the gesture that produced it: a finger resting
     /// before it lifts is not throwing anything, so a velocity that old is
     /// spent rather than released.
-    /// The gesture is over.
     ///
-    /// The gap since the last sample is computed here rather than passed in:
-    /// `last_scroll_time` is this state's own field, and a caller measuring it
-    /// with a second clock is how the sample path and the end path came to
+    /// How long ago the gesture last moved is computed here rather than passed
+    /// in. `last_scroll_time` is this state's own field, and a caller measuring
+    /// it with a second clock is how the sample path and the end path came to
     /// disagree about what time it was inside one gesture.
     pub fn end_gesture(&mut self, at: std::time::Instant) {
         let since_last_sample_ms = self

--- a/src/widgets/scroll.rs
+++ b/src/widgets/scroll.rs
@@ -353,7 +353,16 @@ impl ScrollState {
     /// momentum belongs to the gesture that produced it: a finger resting
     /// before it lifts is not throwing anything, so a velocity that old is
     /// spent rather than released.
-    pub fn end_gesture(&mut self, since_last_sample_ms: Option<f32>) {
+    /// The gesture is over.
+    ///
+    /// The gap since the last sample is computed here rather than passed in:
+    /// `last_scroll_time` is this state's own field, and a caller measuring it
+    /// with a second clock is how the sample path and the end path came to
+    /// disagree about what time it was inside one gesture.
+    pub fn end_gesture(&mut self, at: std::time::Instant) {
+        let since_last_sample_ms = self
+            .last_scroll_time
+            .map(|t| at.duration_since(t).as_secs_f32() * 1000.0);
         /// Longer than this between the last movement and the lift, and the
         /// gesture had already stopped.
         const GESTURE_STALE_MS: f32 = 100.0;
@@ -364,7 +373,7 @@ impl ScrollState {
         }
         self.gesture_ended = true;
         self.gesture_samples = 0;
-        self.momentum_since = Some(std::time::Instant::now());
+        self.momentum_since = Some(at);
     }
 
     /// Discard a momentum that stopped being advanced `idle_ms` ago.
@@ -395,9 +404,9 @@ impl ScrollState {
     }
 
     /// How long since the momentum was last advanced, if one is due.
-    pub fn momentum_idle_ms(&self) -> Option<f32> {
+    pub fn momentum_idle_ms(&self, now: std::time::Instant) -> Option<f32> {
         self.momentum_since
-            .map(|t| t.elapsed().as_secs_f32() * 1000.0)
+            .map(|t| now.duration_since(t).as_secs_f32() * 1000.0)
     }
 
     /// Whether the momentum may run: the gesture is over and it left a speed.
@@ -417,13 +426,13 @@ impl ScrollState {
     }
 
     /// Advance kinetic scrolling animation, returns true if still animating
-    pub fn advance_momentum(&mut self) -> bool {
+    pub fn advance_momentum(&mut self, now: std::time::Instant) -> bool {
         const FRICTION: f32 = 0.92;
         const VELOCITY_THRESHOLD: f32 = 0.5;
 
         // A motion nobody has advanced for long enough is not this motion any
         // more, whatever velocity is left of it.
-        if let Some(idle_ms) = self.momentum_idle_ms() {
+        if let Some(idle_ms) = self.momentum_idle_ms(now) {
             self.expire_stale_momentum(idle_ms);
         }
 
@@ -434,7 +443,7 @@ impl ScrollState {
             return false;
         }
 
-        self.momentum_since = Some(std::time::Instant::now());
+        self.momentum_since = Some(now);
 
         let mut animating = false;
 
@@ -703,6 +712,15 @@ impl ScrollState {
 
 #[cfg(test)]
 mod tests {
+
+    /// Lift the finger `gap_ms` after the last sample, which is what the
+    /// production path records in `last_scroll_time` before ending a gesture.
+    fn end_gesture_after(state: &mut ScrollState, gap_ms: f32) {
+        let at = std::time::Instant::now();
+        state.last_scroll_time =
+            Some(at - std::time::Duration::from_micros((gap_ms * 1000.0) as u64));
+        state.end_gesture(at);
+    }
     use super::*;
 
     /// A scroller with room to fling in.
@@ -720,14 +738,14 @@ mod tests {
             let dt = (i > 0).then_some(dt_ms);
             state.record_gesture_sample(0.0, delta, dt);
         }
-        state.end_gesture(Some(dt_ms));
+        end_gesture_after(state, dt_ms);
     }
 
     /// How far the momentum carries the content once the finger has lifted.
     fn coast(state: &mut ScrollState) -> f32 {
         let start = state.offset_y;
         for _ in 0..600 {
-            if !state.advance_momentum() {
+            if !state.advance_momentum(std::time::Instant::now()) {
                 break;
             }
         }
@@ -766,7 +784,7 @@ mod tests {
         assert!(state.velocity_y.abs() > 0.5, "the gesture built a speed");
 
         // ... and then the finger sat still for a while before lifting.
-        state.end_gesture(Some(400.0));
+        end_gesture_after(&mut state, 400.0);
 
         assert!(!state.should_apply_momentum());
         assert_eq!(coast(&mut state), 0.0);
@@ -784,7 +802,7 @@ mod tests {
         assert!(state.velocity_y.abs() > 0.5, "the gesture built a speed");
         assert!(!state.should_apply_momentum(), "but it is not due");
         assert!(
-            !state.advance_momentum(),
+            !state.advance_momentum(std::time::Instant::now()),
             "and nothing is animating, so the loop is not kept awake for it"
         );
         assert_eq!(coast(&mut state), 0.0);
@@ -799,7 +817,7 @@ mod tests {
         assert!(state.should_apply_momentum(), "the flick is due");
 
         // A few frames run, and then nothing does.
-        state.advance_momentum();
+        state.advance_momentum(std::time::Instant::now());
         assert!(state.should_apply_momentum(), "still due between frames");
 
         state.expire_stale_momentum(400.0);
@@ -842,7 +860,7 @@ mod tests {
         state.record_gesture_sample(0.0, 30.0, None);
 
         assert_eq!(state.velocity_y, 0.0);
-        state.end_gesture(Some(8.0));
+        end_gesture_after(&mut state, 8.0);
         assert!(!state.should_apply_momentum());
     }
 

--- a/src/widgets/text_input.rs
+++ b/src/widgets/text_input.rs
@@ -47,6 +47,19 @@ const SCROLL_PADDING: f32 = 2.0;
 /// Time window for coalescing similar edits (in milliseconds)
 const HISTORY_COALESCE_MS: u64 = 500;
 
+/// The ambient facts of one edit: the width the caret has to stay inside, and
+/// when the event that caused it happened.
+///
+/// Built once in `event` and carried down, the way `Container` carries a
+/// `HitContext`. They travelled as two positional parameters through thirteen
+/// private methods, of which two actually read the instant — and the next
+/// ambient fact would have been a fourteenth.
+#[derive(Clone, Copy)]
+struct Edit {
+    width: f32,
+    at: Instant,
+}
+
 /// Type alias for text input callbacks
 type TextCallback = Box<dyn Fn(&str)>;
 
@@ -70,7 +83,7 @@ enum EditType {
 
 /// Undo/redo history manager
 struct History {
-    /// Stack of past states (most recent at end)
+    /// Stack of past states (most recent edit.at end)
     undo_stack: VecDeque<HistoryEntry>,
     /// Stack of undone states for redo
     redo_stack: VecDeque<HistoryEntry>,
@@ -92,9 +105,8 @@ impl History {
 
     /// Push a new state to history (clears redo stack)
     /// Uses coalescing to merge similar edits within a time window
-    fn push(&mut self, entry: HistoryEntry, edit_type: EditType) {
-        let now = Instant::now();
-        let since_last = now.duration_since(self.last_edit_time);
+    fn push(&mut self, entry: HistoryEntry, edit_type: EditType, at: Instant) {
+        let since_last = at.duration_since(self.last_edit_time);
 
         // Don't push if it's the same as the last entry
         if let Some(last) = self.undo_stack.back()
@@ -125,7 +137,7 @@ impl History {
             }
         }
 
-        self.last_edit_time = now;
+        self.last_edit_time = at;
         self.last_edit_type = Some(edit_type);
     }
 
@@ -165,7 +177,7 @@ pub struct Selection {
 }
 
 impl Selection {
-    /// Create a new selection with cursor at given position (no selection)
+    /// Create a new selection with cursor edit.at given position (no selection)
     pub fn new(pos: usize) -> Self {
         Self {
             anchor: pos,
@@ -205,7 +217,7 @@ pub struct TextInput {
     // Measurement cache (avoid repeated text shaping in paint)
     /// Total width of display text
     cached_text_width: f32,
-    /// Cumulative width at each character index (length = char_count + 1)
+    /// Cumulative width edit.at each character index (length = char_count + 1)
     /// cached_glyph_positions[i] = width of text[0..i]
     cached_glyph_positions: Vec<f32>,
     /// Whether measurements need to be recalculated
@@ -221,7 +233,7 @@ pub struct TextInput {
     is_password: bool,
     mask_char: char,
 
-    /// Whether a caret is drawn at all. Off costs nothing: no caret, no blink,
+    /// Whether a caret is drawn edit.at all. Off costs nothing: no caret, no blink,
     /// nothing to wake the loop for.
     caret: bool,
 
@@ -386,7 +398,7 @@ impl TextInput {
 
     /// Text to show while the field is empty.
     ///
-    /// Drawn in the placeholder colour — this field's text colour at reduced
+    /// Drawn in the placeholder colour — this field's text colour edit.at reduced
     /// alpha unless it declares
     /// [`placeholder_color`](crate::widgets::InputStyled::placeholder_color) — and
     /// never masked, since it is a label rather than a value: a password field
@@ -402,12 +414,12 @@ impl TextInput {
     /// position, drag to select, the keyboard.
     ///
     /// For a field where the caret says nothing: a masked one, where every
-    /// character looks the same and you are always at the end. swaylock draws no
+    /// character looks the same and you are always edit.at the end. swaylock draws no
     /// caret for that reason.
     ///
     /// It is also the cheapest field there is. A blinking caret is the one thing
     /// a still screen redraws on its own, twice a second, forever; without it an
-    /// idle surface wakes the loop for nothing at all.
+    /// idle surface wakes the loop for nothing edit.at all.
     pub fn no_caret(mut self) -> Self {
         self.caret = false;
         self
@@ -420,7 +432,7 @@ impl TextInput {
     /// the wrong answer, and where there is no cursor to click *with* on a
     /// surface that has no pointer.
     ///
-    /// The offer is made once, at the input's first layout, and only when no
+    /// The offer is made once, edit.at the input's first layout, and only when no
     /// widget holds focus. Both halves matter:
     ///
     /// - *once*, so a relayout does not drag focus back from wherever the user
@@ -501,7 +513,7 @@ impl TextInput {
         self.measurements_dirty = false;
     }
 
-    /// Get cached width at a character index (0 to char_count inclusive)
+    /// Get cached width edit.at a character index (0 to char_count inclusive)
     fn cached_width_at_char(&self, char_index: usize) -> f32 {
         self.cached_glyph_positions
             .get(char_index)
@@ -575,10 +587,10 @@ impl TextInput {
 
     /// Advance the blink, and ask to be woken when it next changes.
     ///
-    /// Returns whether the caret is drawn at all.
+    /// Returns whether the caret is drawn edit.at all.
     ///
     /// The wake is *scheduled*, not animated. Asking for an animation frame —
-    /// which is what this did — pins the loop at 60 fps for a square wave that
+    /// which is what this did — pins the loop edit.at 60 fps for a square wave that
     /// changes twice a second, so 113 frames out of 114 repaint the same pixels.
     /// A focused field is the normal state of a lock screen, and that ran all
     /// night.
@@ -595,9 +607,9 @@ impl TextInput {
     }
 
     /// Reset cursor to visible (called on input)
-    fn reset_cursor_blink(&mut self) {
+    fn reset_cursor_blink(&mut self, at: Instant) {
         self.cursor_visible = true;
-        self.last_cursor_toggle = Instant::now();
+        self.last_cursor_toggle = at;
     }
 
     /// Get character index from x coordinate relative to text start.
@@ -654,12 +666,12 @@ impl TextInput {
     }
 
     /// Ensure the cursor is visible by adjusting scroll offset
-    fn ensure_cursor_visible(&mut self, bounds_width: f32) {
+    fn ensure_cursor_visible(&mut self, width: f32) {
         // Ensure measurements are up to date
         self.update_measurements();
 
         let cursor_x = self.cached_width_at_char(self.selection.cursor);
-        let visible_width = bounds_width - SCROLL_PADDING * 2.0;
+        let visible_width = width - SCROLL_PADDING * 2.0;
 
         if visible_width <= 0.0 {
             return;
@@ -678,10 +690,10 @@ impl TextInput {
         self.scroll_offset = self.scroll_offset.max(0.0);
     }
 
-    /// Insert text at cursor, replacing any selection
-    fn insert_text(&mut self, text: &str, bounds_width: f32) {
+    /// Insert text edit.at cursor, replacing any selection
+    fn insert_text(&mut self, text: &str, edit: Edit) {
         // Save state before modification
-        self.save_to_history(EditType::Insert);
+        self.save_to_history(EditType::Insert, edit.at);
 
         let (start, end) = self.selection.range();
         let (byte_start, byte_end) = self.char_range_to_byte_range(start, end);
@@ -701,12 +713,12 @@ impl TextInput {
         self.selection = Selection::new(start + inserted_char_count);
 
         self.notify_change();
-        self.reset_cursor_blink();
-        self.ensure_cursor_visible(bounds_width);
+        self.reset_cursor_blink(edit.at);
+        self.ensure_cursor_visible(edit.width);
     }
 
     /// Delete selected text or character before/after cursor
-    fn delete(&mut self, forward: bool, bounds_width: f32) {
+    fn delete(&mut self, forward: bool, edit: Edit) {
         // Check if there's anything to delete
         let has_content_to_delete = if self.selection.has_selection() {
             true
@@ -718,7 +730,7 @@ impl TextInput {
 
         // Save state before modification (only if we'll actually delete something)
         if has_content_to_delete {
-            self.save_to_history(EditType::Delete);
+            self.save_to_history(EditType::Delete, edit.at);
         }
 
         if self.selection.has_selection() {
@@ -738,8 +750,8 @@ impl TextInput {
                 self.selection = Selection::new(self.selection.cursor - 1);
             }
         }
-        self.reset_cursor_blink();
-        self.ensure_cursor_visible(bounds_width);
+        self.reset_cursor_blink(edit.at);
+        self.ensure_cursor_visible(edit.width);
     }
 
     /// Delete a range of characters
@@ -758,13 +770,7 @@ impl TextInput {
     }
 
     /// Move cursor left/right, optionally extending selection
-    fn move_cursor(
-        &mut self,
-        direction: i32,
-        extend_selection: bool,
-        word: bool,
-        bounds_width: f32,
-    ) {
+    fn move_cursor(&mut self, direction: i32, extend_selection: bool, word: bool, edit: Edit) {
         let new_pos = if word {
             self.find_word_boundary(self.selection.cursor, direction)
         } else if direction < 0 {
@@ -777,8 +783,8 @@ impl TextInput {
         if !extend_selection {
             self.selection.collapse();
         }
-        self.reset_cursor_blink();
-        self.ensure_cursor_visible(bounds_width);
+        self.reset_cursor_blink(edit.at);
+        self.ensure_cursor_visible(edit.width);
     }
 
     /// Find word boundary in given direction
@@ -833,21 +839,21 @@ impl TextInput {
     }
 
     /// Move cursor to start/end
-    fn move_to_edge(&mut self, to_start: bool, extend_selection: bool, bounds_width: f32) {
+    fn move_to_edge(&mut self, to_start: bool, extend_selection: bool, edit: Edit) {
         self.selection.cursor = if to_start { 0 } else { self.cached_char_count };
         if !extend_selection {
             self.selection.collapse();
         }
-        self.reset_cursor_blink();
-        self.ensure_cursor_visible(bounds_width);
+        self.reset_cursor_blink(edit.at);
+        self.ensure_cursor_visible(edit.width);
     }
 
     /// Select all text
-    fn select_all(&mut self, bounds_width: f32) {
+    fn select_all(&mut self, edit: Edit) {
         self.selection.anchor = 0;
         self.selection.cursor = self.cached_char_count;
-        self.reset_cursor_blink();
-        self.ensure_cursor_visible(bounds_width);
+        self.reset_cursor_blink(edit.at);
+        self.ensure_cursor_visible(edit.width);
     }
 
     /// Get selected text
@@ -866,7 +872,7 @@ impl TextInput {
     /// `None` in password mode. What a masked field holds must not reach the
     /// clipboard or the primary selection, and the leak that matters is not
     /// Ctrl+C — it is the primary selection, which an ordinary mouse drag fills
-    /// with no keystroke at all, ready for a middle-click anywhere else. GTK4's
+    /// with no keystroke edit.at all, ready for a middle-click anywhere else. GTK4's
     /// `GtkPasswordEntry` refuses to export for the same reason; GTK3 exported
     /// the mask instead, which is a row of bullets that is no use to paste.
     ///
@@ -888,7 +894,7 @@ impl TextInput {
     }
 
     /// Cut selected text (copy and delete)
-    fn cut_selection(&mut self, bounds_width: f32) {
+    fn cut_selection(&mut self, edit: Edit) {
         // A cut that cannot copy is not a cut. Refusing the gesture outright is
         // what GtkPasswordEntry does, and it keeps Ctrl+X from quietly becoming
         // a delete while the user believes the clipboard was filled.
@@ -897,19 +903,19 @@ impl TextInput {
         }
         if self.selection.has_selection() {
             self.copy_selection();
-            self.delete(false, bounds_width); // Delete the selection
+            self.delete(false, edit); // Delete the selection
         }
     }
 
     /// Paste text from clipboard
-    fn paste(&mut self, bounds_width: f32) {
+    fn paste(&mut self, edit: Edit) {
         if let Some(text) = clipboard_paste() {
-            self.insert_text(&text, bounds_width);
+            self.insert_text(&text, edit);
         }
     }
 
     /// Save current state to history (call before making changes)
-    fn save_to_history(&mut self, edit_type: EditType) {
+    fn save_to_history(&mut self, edit_type: EditType, at: Instant) {
         self.history.push(
             HistoryEntry {
                 text: self.cached_value.clone(),
@@ -917,6 +923,7 @@ impl TextInput {
                 anchor: self.selection.anchor,
             },
             edit_type,
+            at,
         );
     }
 
@@ -930,7 +937,7 @@ impl TextInput {
     }
 
     /// Undo the last change
-    fn undo(&mut self, bounds_width: f32) {
+    fn undo(&mut self, edit: Edit) {
         let current = self.current_history_entry();
         if let Some(previous) = self.history.undo(current) {
             self.cached_value = previous.text;
@@ -941,13 +948,13 @@ impl TextInput {
             self.selection.anchor = previous.anchor;
             self.history.reset_coalescing();
             self.notify_change();
-            self.reset_cursor_blink();
-            self.ensure_cursor_visible(bounds_width);
+            self.reset_cursor_blink(edit.at);
+            self.ensure_cursor_visible(edit.width);
         }
     }
 
     /// Redo the last undone change
-    fn redo(&mut self, bounds_width: f32) {
+    fn redo(&mut self, edit: Edit) {
         let current = self.current_history_entry();
         if let Some(next) = self.history.redo(current) {
             self.cached_value = next.text;
@@ -958,8 +965,8 @@ impl TextInput {
             self.selection.anchor = next.anchor;
             self.history.reset_coalescing();
             self.notify_change();
-            self.reset_cursor_blink();
-            self.ensure_cursor_visible(bounds_width);
+            self.reset_cursor_blink(edit.at);
+            self.ensure_cursor_visible(edit.width);
         }
     }
 
@@ -974,20 +981,14 @@ impl TextInput {
     }
 
     /// Handle key down event
-    fn handle_key(
-        &mut self,
-        key: &Key,
-        ctrl: bool,
-        shift: bool,
-        bounds_width: f32,
-    ) -> EventResponse {
+    fn handle_key(&mut self, key: &Key, ctrl: bool, shift: bool, edit: Edit) -> EventResponse {
         match key {
             Key::Backspace => {
-                self.delete(false, bounds_width);
+                self.delete(false, edit);
                 EventResponse::Handled
             }
             Key::Delete => {
-                self.delete(true, bounds_width);
+                self.delete(true, edit);
                 EventResponse::Handled
             }
             Key::Enter => {
@@ -1001,9 +1002,9 @@ impl TextInput {
                     // Collapse to start of selection
                     let (start, _) = self.selection.range();
                     self.selection = Selection::new(start);
-                    self.reset_cursor_blink();
+                    self.reset_cursor_blink(edit.at);
                 } else {
-                    self.move_cursor(-1, shift, ctrl, bounds_width);
+                    self.move_cursor(-1, shift, ctrl, edit);
                 }
                 EventResponse::Handled
             }
@@ -1012,25 +1013,25 @@ impl TextInput {
                     // Collapse to end of selection
                     let (_, end) = self.selection.range();
                     self.selection = Selection::new(end);
-                    self.reset_cursor_blink();
+                    self.reset_cursor_blink(edit.at);
                 } else {
-                    self.move_cursor(1, shift, ctrl, bounds_width);
+                    self.move_cursor(1, shift, ctrl, edit);
                 }
                 EventResponse::Handled
             }
             Key::Home => {
-                self.move_to_edge(true, shift, bounds_width);
+                self.move_to_edge(true, shift, edit);
                 EventResponse::Handled
             }
             Key::End => {
-                self.move_to_edge(false, shift, bounds_width);
+                self.move_to_edge(false, shift, edit);
                 EventResponse::Handled
             }
             Key::Char(c) => {
                 if ctrl {
                     match c.to_ascii_lowercase() {
                         'a' => {
-                            self.select_all(bounds_width);
+                            self.select_all(edit);
                             EventResponse::Handled
                         }
                         'c' => {
@@ -1038,31 +1039,31 @@ impl TextInput {
                             EventResponse::Handled
                         }
                         'x' => {
-                            self.cut_selection(bounds_width);
+                            self.cut_selection(edit);
                             EventResponse::Handled
                         }
                         'v' => {
-                            self.paste(bounds_width);
+                            self.paste(edit);
                             EventResponse::Handled
                         }
                         'z' => {
                             // Ctrl+Shift+Z = redo, Ctrl+Z = undo
                             if shift {
-                                self.redo(bounds_width);
+                                self.redo(edit);
                             } else {
-                                self.undo(bounds_width);
+                                self.undo(edit);
                             }
                             EventResponse::Handled
                         }
                         'y' => {
                             // Ctrl+Y = redo
-                            self.redo(bounds_width);
+                            self.redo(edit);
                             EventResponse::Handled
                         }
                         _ => EventResponse::Ignored,
                     }
                 } else if !c.is_control() {
-                    self.insert_text(&c.to_string(), bounds_width);
+                    self.insert_text(&c.to_string(), edit);
                     EventResponse::Handled
                 } else {
                     EventResponse::Ignored
@@ -1140,7 +1141,7 @@ impl Widget for TextInput {
             register_widget_ref(id, widget_ref);
         }
 
-        // Here rather than at construction because focus needs the tree, and
+        // Here rather than edit.at construction because focus needs the tree, and
         // this is the first moment the input is in one — the same reason Flutter
         // makes you wait for a post-frame callback to request focus by hand.
         if self.autofocus_pending {
@@ -1197,7 +1198,7 @@ impl Widget for TextInput {
             });
 
         // The text scrolls horizontally under a fixed viewport, so whatever
-        // slid past either edge has to be cut at the widget's bounds.
+        // slid past either edge has to be cut edit.at the widget's bounds.
         //
         // Horizontally only: the vertical axis never scrolls, and closing it
         // would trim descenders and any glyph stroke or shadow, which the
@@ -1248,11 +1249,11 @@ impl Widget for TextInput {
         // The caret, and the wake that keeps it blinking.
         //
         // `self.caret` gates the *drawing*, not only the blink: stopping the blink
-        // leaves `cursor_visible` at whatever it last was — true, from the
+        // leaves `cursor_visible` edit.at whatever it last was — true, from the
         // constructor — and a field asked for no caret got a permanent one.
         if self.caret && is_focused {
             // The toggle happens in `advance_animations`, and this is what asks
-            // for the wake that runs it. It has to be here, not at the moment
+            // for the wake that runs it. It has to be here, not edit.at the moment
             // focus arrives: focus comes from a click, from `autofocus`, or from
             // `WidgetRef::focus()`, and all three only queue a repaint. Asking
             // from the repaint covers every one of them, and covers the half of
@@ -1278,6 +1279,12 @@ impl Widget for TextInput {
     }
 
     fn event(&mut self, tree: &mut Tree, id: WidgetId, event: &Event) -> EventResponse {
+        // When this event happened, which every edit below is timed against —
+        // the undo-coalescing window and the caret restarting on input.
+        let edit = Edit {
+            width: tree.get_bounds(id).unwrap_or_default().width,
+            at: tree.event_instant(),
+        };
         // Get bounds from Tree for hit testing
         let bounds = tree.get_bounds(id).unwrap_or_default();
 
@@ -1294,7 +1301,7 @@ impl Widget for TextInput {
                 let char_index = self.char_index_at_x(*x, bounds);
                 self.selection = Selection::new(char_index);
                 self.is_dragging = true;
-                self.reset_cursor_blink();
+                self.reset_cursor_blink(edit.at);
                 self.ensure_cursor_visible(bounds.width);
 
                 return EventResponse::Handled;
@@ -1339,14 +1346,14 @@ impl Widget for TextInput {
                 let char_index = self.char_index_at_x(*x, bounds);
                 self.selection = Selection::new(char_index);
                 if let Some(text) = primary_paste() {
-                    self.insert_text(&text, bounds.width);
+                    self.insert_text(&text, edit);
                 }
-                self.reset_cursor_blink();
+                self.reset_cursor_blink(edit.at);
                 request_job(id, JobRequest::Paint);
                 return EventResponse::Handled;
             }
             Event::KeyDown { key, modifiers } if has_focus(id) => {
-                let response = self.handle_key(key, modifiers.ctrl, modifiers.shift, bounds.width);
+                let response = self.handle_key(key, modifiers.ctrl, modifiers.shift, edit);
                 if response == EventResponse::Handled {
                     request_job(id, JobRequest::Paint);
                 }

--- a/src/widgets/text_input.rs
+++ b/src/widgets/text_input.rs
@@ -83,7 +83,7 @@ enum EditType {
 
 /// Undo/redo history manager
 struct History {
-    /// Stack of past states (most recent edit.at end)
+    /// Stack of past states (most recent at end)
     undo_stack: VecDeque<HistoryEntry>,
     /// Stack of undone states for redo
     redo_stack: VecDeque<HistoryEntry>,
@@ -177,7 +177,7 @@ pub struct Selection {
 }
 
 impl Selection {
-    /// Create a new selection with cursor edit.at given position (no selection)
+    /// Create a new selection with cursor at given position (no selection)
     pub fn new(pos: usize) -> Self {
         Self {
             anchor: pos,
@@ -217,7 +217,7 @@ pub struct TextInput {
     // Measurement cache (avoid repeated text shaping in paint)
     /// Total width of display text
     cached_text_width: f32,
-    /// Cumulative width edit.at each character index (length = char_count + 1)
+    /// Cumulative width at each character index (length = char_count + 1)
     /// cached_glyph_positions[i] = width of text[0..i]
     cached_glyph_positions: Vec<f32>,
     /// Whether measurements need to be recalculated
@@ -233,7 +233,7 @@ pub struct TextInput {
     is_password: bool,
     mask_char: char,
 
-    /// Whether a caret is drawn edit.at all. Off costs nothing: no caret, no blink,
+    /// Whether a caret is drawn at all. Off costs nothing: no caret, no blink,
     /// nothing to wake the loop for.
     caret: bool,
 
@@ -398,7 +398,7 @@ impl TextInput {
 
     /// Text to show while the field is empty.
     ///
-    /// Drawn in the placeholder colour — this field's text colour edit.at reduced
+    /// Drawn in the placeholder colour — this field's text colour at reduced
     /// alpha unless it declares
     /// [`placeholder_color`](crate::widgets::InputStyled::placeholder_color) — and
     /// never masked, since it is a label rather than a value: a password field
@@ -414,12 +414,12 @@ impl TextInput {
     /// position, drag to select, the keyboard.
     ///
     /// For a field where the caret says nothing: a masked one, where every
-    /// character looks the same and you are always edit.at the end. swaylock draws no
+    /// character looks the same and you are always at the end. swaylock draws no
     /// caret for that reason.
     ///
     /// It is also the cheapest field there is. A blinking caret is the one thing
     /// a still screen redraws on its own, twice a second, forever; without it an
-    /// idle surface wakes the loop for nothing edit.at all.
+    /// idle surface wakes the loop for nothing at all.
     pub fn no_caret(mut self) -> Self {
         self.caret = false;
         self
@@ -432,7 +432,7 @@ impl TextInput {
     /// the wrong answer, and where there is no cursor to click *with* on a
     /// surface that has no pointer.
     ///
-    /// The offer is made once, edit.at the input's first layout, and only when no
+    /// The offer is made once, at the input's first layout, and only when no
     /// widget holds focus. Both halves matter:
     ///
     /// - *once*, so a relayout does not drag focus back from wherever the user
@@ -513,7 +513,7 @@ impl TextInput {
         self.measurements_dirty = false;
     }
 
-    /// Get cached width edit.at a character index (0 to char_count inclusive)
+    /// Get cached width at a character index (0 to char_count inclusive)
     fn cached_width_at_char(&self, char_index: usize) -> f32 {
         self.cached_glyph_positions
             .get(char_index)
@@ -587,10 +587,10 @@ impl TextInput {
 
     /// Advance the blink, and ask to be woken when it next changes.
     ///
-    /// Returns whether the caret is drawn edit.at all.
+    /// Returns whether the caret is drawn at all.
     ///
     /// The wake is *scheduled*, not animated. Asking for an animation frame —
-    /// which is what this did — pins the loop edit.at 60 fps for a square wave that
+    /// which is what this did — pins the loop at 60 fps for a square wave that
     /// changes twice a second, so 113 frames out of 114 repaint the same pixels.
     /// A focused field is the normal state of a lock screen, and that ran all
     /// night.
@@ -690,7 +690,7 @@ impl TextInput {
         self.scroll_offset = self.scroll_offset.max(0.0);
     }
 
-    /// Insert text edit.at cursor, replacing any selection
+    /// Insert text at cursor, replacing any selection
     fn insert_text(&mut self, text: &str, edit: Edit) {
         // Save state before modification
         self.save_to_history(EditType::Insert, edit.at);
@@ -872,7 +872,7 @@ impl TextInput {
     /// `None` in password mode. What a masked field holds must not reach the
     /// clipboard or the primary selection, and the leak that matters is not
     /// Ctrl+C — it is the primary selection, which an ordinary mouse drag fills
-    /// with no keystroke edit.at all, ready for a middle-click anywhere else. GTK4's
+    /// with no keystroke at all, ready for a middle-click anywhere else. GTK4's
     /// `GtkPasswordEntry` refuses to export for the same reason; GTK3 exported
     /// the mask instead, which is a row of bullets that is no use to paste.
     ///
@@ -1141,7 +1141,7 @@ impl Widget for TextInput {
             register_widget_ref(id, widget_ref);
         }
 
-        // Here rather than edit.at construction because focus needs the tree, and
+        // Here rather than at construction because focus needs the tree, and
         // this is the first moment the input is in one — the same reason Flutter
         // makes you wait for a post-frame callback to request focus by hand.
         if self.autofocus_pending {
@@ -1198,7 +1198,7 @@ impl Widget for TextInput {
             });
 
         // The text scrolls horizontally under a fixed viewport, so whatever
-        // slid past either edge has to be cut edit.at the widget's bounds.
+        // slid past either edge has to be cut at the widget's bounds.
         //
         // Horizontally only: the vertical axis never scrolls, and closing it
         // would trim descenders and any glyph stroke or shadow, which the
@@ -1249,11 +1249,11 @@ impl Widget for TextInput {
         // The caret, and the wake that keeps it blinking.
         //
         // `self.caret` gates the *drawing*, not only the blink: stopping the blink
-        // leaves `cursor_visible` edit.at whatever it last was — true, from the
+        // leaves `cursor_visible` at whatever it last was — true, from the
         // constructor — and a field asked for no caret got a permanent one.
         if self.caret && is_focused {
             // The toggle happens in `advance_animations`, and this is what asks
-            // for the wake that runs it. It has to be here, not edit.at the moment
+            // for the wake that runs it. It has to be here, not at the moment
             // focus arrives: focus comes from a click, from `autofocus`, or from
             // `WidgetRef::focus()`, and all three only queue a repaint. Asking
             // from the repaint covers every one of them, and covers the half of

--- a/src/widgets/text_input.rs
+++ b/src/widgets/text_input.rs
@@ -1395,6 +1395,52 @@ mod tests {
     use crate::layout::Constraints;
     use crate::reactive::create_signal;
 
+    /// Two keystrokes inside the window are one undo, and two outside it are
+    /// two — which is what `HISTORY_COALESCE_MS` promises and nothing could
+    /// ask before.
+    ///
+    /// The window is half a second. A test that wanted to stand on either side
+    /// of it had to sleep for real, so the far side cost five seconds of wall
+    /// clock and the near side was a race against how long the assertions took.
+    /// Both moments are named now.
+    #[test]
+    fn the_coalescing_window_has_two_sides_and_they_can_both_be_asked_about() {
+        let entry = |text: &str| HistoryEntry {
+            text: text.to_string(),
+            cursor: text.chars().count(),
+            anchor: text.chars().count(),
+        };
+
+        let inside = {
+            let t0 = Instant::now();
+            let mut history = History::new();
+            history.push(entry("a"), EditType::Insert, t0);
+            history.push(
+                entry("ab"),
+                EditType::Insert,
+                t0 + Duration::from_millis(50),
+            );
+            history.undo_stack.len()
+        };
+        assert_eq!(
+            inside, 1,
+            "two keystrokes fifty milliseconds apart are one thing to undo"
+        );
+
+        let outside = {
+            let t0 = Instant::now();
+            let mut history = History::new();
+            history.push(entry("a"), EditType::Insert, t0);
+            history.push(entry("ab"), EditType::Insert, t0 + Duration::from_secs(5));
+            history.undo_stack.len()
+        };
+        assert_eq!(
+            outside, 2,
+            "and five seconds apart they are two, because the sentence in \
+             between was a different thought"
+        );
+    }
+
     /// A laid-out input, focused unless told otherwise.
     fn field(input: TextInput, focused: bool) -> (Tree, WidgetId) {
         clear_pending_jobs();

--- a/tests/scroll_momentum.rs
+++ b/tests/scroll_momentum.rs
@@ -42,6 +42,20 @@ impl H {
         self.scroll(delta, ScrollSource::Finger);
     }
 
+    /// One scroll sample from any source, at a named moment.
+    fn scroll_at(&mut self, delta: f32, source: ScrollSource, at: std::time::Instant) {
+        self.tree.set_event_instant(Some(at));
+        self.scroll(delta, source);
+        self.tree.set_event_instant(None);
+    }
+
+    /// The finger lifted at a named moment.
+    fn scroll_end_at(&mut self, at: std::time::Instant) {
+        self.tree.set_event_instant(Some(at));
+        self.scroll_end();
+        self.tree.set_event_instant(None);
+    }
+
     /// One scroll sample from any source.
     fn scroll(&mut self, delta: f32, source: ScrollSource) {
         let root = self.root;
@@ -228,5 +242,47 @@ fn a_momentum_left_half_run_is_not_carried_on_by_a_later_frame() {
         (after - interrupted_at).abs() < 0.01,
         "content carried on from {interrupted_at} to {after}: a momentum \
          abandoned mid-flight was resumed instead of being over"
+    );
+}
+
+/// The same gesture, twice as fast, coasts further — and by how much is a
+/// number, on any machine, with nothing asleep.
+///
+/// This could not be written before. A velocity is distance over time, and the
+/// only time available was whatever had elapsed between two `sleep`s, so the
+/// suite could ask that the content moved and never how fast. `Event::Scroll`
+/// now arrives with the moment the compositor saw it, and a test can say what
+/// that moment is.
+#[test]
+fn the_speed_of_a_flick_is_the_distance_over_the_time_it_took() {
+    // Sixty pixels of finger, in six samples. The only difference between the
+    // two gestures is how long they took.
+    fn coast(sample_gap_ms: u64) -> f32 {
+        let mut h = H::new();
+        let t0 = std::time::Instant::now();
+        for i in 1..=6u64 {
+            h.scroll_at(
+                10.0,
+                ScrollSource::Finger,
+                t0 + std::time::Duration::from_millis(i * sample_gap_ms),
+            );
+        }
+        let lifted = h.offset();
+        h.scroll_end_at(t0 + std::time::Duration::from_millis(6 * sample_gap_ms));
+        h.frames(60);
+        h.offset() - lifted
+    }
+
+    let slow = coast(16);
+    let fast = coast(8);
+
+    assert!(
+        slow > 0.0,
+        "a flick has to coast at all before its speed can be compared, got {slow}"
+    );
+    assert!(
+        fast > slow,
+        "the same sixty pixels in half the time is twice the speed and has to \
+         coast further: 8ms samples gave {fast}, 16ms samples {slow}"
     );
 }


### PR DESCRIPTION
## What changed

Every input handler that needed to know *when* something happened read the clock where it stood — the ripple's press, the momentum's samples, the undo-coalescing window, the caret restarting on input. Eleven sites, and none could be asked a question: a handler runs some time after the event it handles, so a test could only sleep and assert a band around wherever the machine had got to.

The protocol carries the answer and it was being thrown away. `wl_pointer.motion`, `.button` and `.axis`, `wl_touch.down` and `KeyEvent` all carry a `uint` of milliseconds, and `input.rs` named it `_time`. `EventClock` anchors that against one `Instant` and reads every later timestamp as a distance from it — `wrapping_sub`, because the counter goes round about every forty-nine days and an ordinary subtraction turns the first event after a wrap into one from seven weeks ago.

The instant then travels **with** the event, because the two are separated in time: an event is queued when the compositor sends it and read when the frame runs, and that gap is exactly what a handler reading the clock would mistake for the event's own time. So the queue carries `(Instant, Event)` and `dispatch_events` declares each one on the `Tree` before delivering it. **`Event` itself does not change** — its sixty-one construction sites and seventeen exhaustive matches stay as they are, and so does the public API.

`enter`, `leave` and `wl_touch.cancel` carry no timestamp at all. They get `untimed()`, which is the wall clock and says so in one place.

Closes #256.

## What proves it

Five tests, each impossible before, each run against the one-line change it exists to catch:

| broken on purpose | what fails |
| --- | --- |
| the anchor ignored | `an_events_time_is_read_as_a_distance_from_the_anchor`, `a_clock_that_has_wrapped_still_moves_forwards` |
| `wrapping_sub` made an ordinary subtraction | `a_clock_that_has_wrapped_still_moves_forwards` (overflow) |
| the coalescing window ignored, either direction | `the_coalescing_window_has_two_sides_and_they_can_both_be_asked_about` |
| `apply_scroll` back on `Instant::now()` | `the_speed_of_a_flick_is_the_distance_over_the_time_it_took` |
| `ripple.start` back on `Instant::now()` | `a_press_held_for_a_named_time_has_grown_by_a_named_amount` |
| `set_event_instant` deleted from `dispatch_events` | `a_widget_is_told_when_the_event_it_is_handed_happened` |
| the dispatch's clear deleted | the same |

The last two exist because of a blocking finding — see below.

Full harness green: 568 lib tests, every integration binary, doc tests, `fmt --check`, `clippy --all-targets --all-features -D warnings`, 9 goldens on lavapipe with no skips, `mdbook build`.

## What the cleanup found

**This is the first change to go through `/simplify` (#259), and it paid for the step on the first try.** It did not return nits — it found a conversion I had left half-done, with a behavioural cost:

- **Two clocks inside one gesture.** `interaction.rs` measured the gap since the last scroll sample with `t.elapsed()` while `scrollable.rs` wrote that same field with the event's instant, four lines apart. `end_gesture(at)` now computes the gap from its own field, so a caller cannot bring a second clock.
- **`momentum_idle_ms()` differenced an event instant against the wall clock.** With `MOMENTUM_STALE_MS` at 200 ms, a loop that far behind would expire a flick on its first frame — and a loop that far behind is the case the feature exists for. It takes the frame instant now, which is not what #256 asked for but is required by it: `momentum_since` is written from the event clock, so advancing against `Instant::now()` would be the mixing this change removes.
- **`cargo fmt --check` failed**, which I had not run.

Two agents independently flagged the same shape twice, and both were taken: thirteen private methods in `text_input.rs` carrying two ambient values became an `Edit { width, at }` bundle, on the model of `HitContext`; and the duplicated move-coalescing and press-release blocks became `push_move` and `push_release`.

The efficiency pass measured rather than guessed: **11 clock-read sites in the event path became 0** — about 6 µs saved per flick and 9 µs per hundred keystrokes — against +1 read on the five untimed event kinds. `(Instant, Event)` is 40 bytes against 20, and folding the instant into `Event` measures 40 too, so the tuple costs nothing the alternative would save; `push_move` collapses a run of moves to one entry, so the queue is 1–5 deep in steady state.

## What the review found

**Three blocking, all mine, all closed.**

- **Nothing watched the mechanism.** Deleting `set_event_instant` from `dispatch_events` left 568 tests green: every widget falls back to the clock, which is what they all did before, and the four tests written for the acceptance criteria declare the instant *by hand*, so they pin the readers and not the delivery. `a_widget_is_told_when_the_event_it_is_handed_happened` goes through the dispatcher with an event from an hour ago — a moment no clock in this process would answer with.
- **The ripple test proved nothing.** Its `t0` came from `Instant::now()`, so the named instant and the handler's own clock read were the same moment: putting `ripple.start` back on the clock left it green. Its `t0` is a minute ago now, and that mutation is red.
- **A mechanical rewrite corrupted seventeen comments**, five of them rustdoc on `Selection::new`, `placeholder`, `no_caret` and `autofocus` — all in the prelude, all bound for docs.rs reading "cursor edit.at given position". Threading `Edit` had replaced the word in prose as well as in code. Three doc blocks that had been merged into their neighbours are separated again: `EventClock`'s whole justification had become the doc comment of a mouse-move helper.

Worth answering, acted on: `docs/ARCHITECTURE.md` told a widget author to ask `tree.frame_instant()` "rather than the clock", which named one of two clocks the moment this change created the second; it and the book's pipeline now say which question each answers.

Worth answering, recorded rather than acted on: **the anchor carries the first timestamped event's delivery latency for the life of the process.** Differences between two events are exact, which is the point, but anything compared against the frame clock is biased by it. Re-anchoring whenever a converted instant lands after `Instant::now()` would bound it. Small, and a change to the mechanism rather than a fix to it. Likewise, `wrapping_sub` cannot distinguish "just after the wrap" from "just before the anchor", which would put an instant seven weeks in the future; it needs the compositor's timestamps to be monotone across all three devices, which the protocol does not promise.

## What was checked by hand

`src/platform/` has nothing automated and this change touches every input path, so: **`examples/scroll_example` and `examples/text_input_example` on niri, run by the maintainer.**

- A slow touchpad scroll does not run away on lift; a real flick still coasts and stops on its own.
- Typing a few letters quickly and pressing `Ctrl+Z` undoes them together; typing, waiting two or three seconds, typing again and pressing `Ctrl+Z` undoes only the second group. That is the coalescing window from the outside, and the half that used to cost five seconds of real waiting to observe.
- The caret blinks at its usual rhythm and restarts lit on a keystroke.

**Two defects were found during that pass and are not this change's.** The horizontal scrollbar's handle answers neither hover nor press (#260), and a press reaches only one quarter of the vertical handle with the ripple starting somewhere other than the click (#261). Both reproduce identically on `main` — checked by running the same example from both — so they are recorded rather than fixed here.

## Left undone

**Five of the six tests in `tests/scroll_momentum.rs` still sleep.** `H::frames` never names a frame instant, so momentum staleness there is still timed against the wall clock. The mechanism to fix it exists (`set_frame_instant`, from #250) and this change did not use it; worth an issue.

**Events are the second of two ambient clocks on `Tree`, and reading the wrong one still compiles.** `frame_instant` and `event_instant` both fall back silently to `Instant::now()`, which is the pre-change behaviour and therefore invisible. The cheapest guard is the documentation now written; a `debug_assert` on the getters would be a change to both mechanisms and belongs with whoever decides that.

---

**The mutation job, read rather than believed.** `86 mutants tested in 19m: 37 missed, 39 caught, 10 unviable` ([run](https://github.com/MalpenZibo/guido/actions/runs/33064104939/job/98489831026)) — the largest diff that job has seen since #255 fixed its disk usage, and it completed.

Thirty-seven survivors is a lot, so: **none of them is new logic that nothing watches.** They are two pre-existing holes this diff dragged into the job's view, because mutating "the lines the diff touched" now includes every signature the threading changed.

- **Twelve in `src/platform/input.rs`** — every Wayland handler replaced with `()`, plus the two new `push_move`/`push_release` helpers, which are only reachable through those handlers. This is the row `AGENTS.md` already calls the hole in the harness, and it is why the manual pass above exists.
- **Twenty-five in `src/widgets/text_input.rs`** — `undo`, `redo`, `delete`, `move_cursor`, `cut_selection`, `save_to_history`, every arm of `handle_key`, and the `has_focus` guard on `KeyDown`. Text editing has almost no tests, and this is the first time anything said so. Filed as **#263**, with the mutation table as its acceptance criterion.

What this change *built* is watched: `EventClock`, `translate_axis`, the coalescing window, the flick's speed, the ripple's growth, and the dispatcher's own line. What is not, is the code around it that the threading touched.
