### PR TITLE
What is left undone gets an issue, not a paragraph in a body nobody reopens

### DIFF
--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -119,5 +119,9 @@ same act as re-blessing a golden to make a test pass.
 Push the branch, `gh pr create`, fill in the template. Link the issue with
 `Closes #$ARGUMENTS`.
 
+Whatever goes under **Left undone** that has to outlive this change gets an
+issue in the same act, and the template gets its number. `AGENTS.md` says why.
+
 Then report back, in five lines: what changed, what proves it, what the review
-found, what you looked at by hand, and anything you left undone and why.
+found, what you looked at by hand, and anything you left undone, why, and
+its issue number.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -46,6 +46,8 @@ time. Which example, which compositor, what you saw. Screenshots welcome.
 ## Left undone
 
 <!--
-Anything deliberately out of scope, and why. A follow-up issue number if there
-is one. "Nothing" is a fine answer.
+Anything deliberately out of scope, and why. "Nothing" is a fine answer.
+
+Whatever has to outlive this change gets an issue in the same act; put its
+number here.
 -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,7 +189,10 @@ themselves when the task touches them; you do not need to read them up front.
    clear. An architectural finding stops the work — that decision belongs to the
    maintainer wherever it surfaces.
 7. **Open the pull request** with the template filled in: what moved, what
-   proves it, what the review found, what you looked at by hand.
+   proves it, what the review found, what you looked at by hand, and what is
+   left undone. Whatever of that last one has to outlive the change gets an
+   issue in the same act — nobody opens a merged pull request's body again, and
+   a follow-up recorded only there is written down and lost in one motion.
 
 `/implement <issue>` does all seven.
 

--- a/tests/agent_workflow.rs
+++ b/tests/agent_workflow.rs
@@ -89,6 +89,30 @@ fn backticked(text: &str) -> Vec<String> {
         .collect()
 }
 
+/// A file's prose with its line wrapping removed, so that a sentence pinned by
+/// this file can be re-wrapped by whoever edits the document. Pinning a literal
+/// against wrapped markdown fails the moment a word is added ahead of it, which
+/// is a build failure for a reason nobody meant.
+fn unwrapped(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// From `needle` to the next `until`, or to the end. Two sections here are found
+/// by where they start rather than by index: a `## ` heading runs to the next
+/// heading, a numbered item runs to the blank line after it.
+fn section_from<'a>(text: &'a str, needle: &str, until: &str) -> &'a str {
+    let start = text
+        .find(needle)
+        .unwrap_or_else(|| panic!("this document has no `{needle}`"));
+    let rest = &text[start..];
+    // Searched past the needle, so a delimiter the needle itself begins with
+    // cannot end the section on its own first character.
+    match rest[needle.len()..].find(until) {
+        Some(offset) => &rest[..needle.len() + offset],
+        None => rest,
+    }
+}
+
 /// "six" -> 6, for the counts that are written as words.
 fn number_word(word: &str) -> Option<usize> {
     const WORDS: &[&str] = &[
@@ -150,16 +174,9 @@ fn implement_numbers_its_steps_in_order() {
 #[test]
 fn agents_md_counts_the_steps_it_lists() {
     let text = read("AGENTS.md");
-    let start = text
-        .find("## Working on a change")
-        .expect("AGENTS.md has no `Working on a change` section");
     // To the next heading, not to the end of the file: a numbered list further
     // down the document is not this list.
-    let rest = &text[start..];
-    let section = match rest[3..].find("\n## ") {
-        Some(offset) => &rest[..offset + 3],
-        None => rest,
-    };
+    let section = section_from(&text, "## Working on a change", "\n## ");
     let steps = numbered_items(section);
     assert_contiguous(&steps, "AGENTS.md");
 
@@ -434,8 +451,8 @@ fn the_reviewer_and_the_command_use_the_same_levels() {
 /// contract asks for it and the issue has somewhere to put the answer.
 #[test]
 fn researching_a_design_decision_is_asked_for_where_the_alternatives_are_written() {
-    let agents = read("AGENTS.md");
-    let spec = read(".claude/commands/spec.md");
+    let agents = unwrapped(&read("AGENTS.md"));
+    let spec = unwrapped(&read(".claude/commands/spec.md"));
 
     const RULE: &str = "A design decision that is not obvious is researched before it is proposed.";
     assert!(

--- a/tests/agent_workflow.rs
+++ b/tests/agent_workflow.rs
@@ -113,6 +113,18 @@ fn section_from<'a>(text: &'a str, needle: &str, until: &str) -> &'a str {
     }
 }
 
+/// The `## N. Title` section whose heading mentions `about`, to the next
+/// heading. Found by the heading's words rather than its number, because
+/// inserting a step renumbers it — which is what this file exists to survive.
+fn step_about<'a>(text: &'a str, about: &str) -> &'a str {
+    let heading = text
+        .lines()
+        .filter(|line| line.starts_with("## "))
+        .find(|line| line.to_ascii_lowercase().contains(about))
+        .unwrap_or_else(|| panic!("no step about `{about}`"));
+    section_from(text, heading, "\n## ")
+}
+
 /// "six" -> 6, for the counts that are written as words.
 fn number_word(word: &str) -> Option<usize> {
     const WORDS: &[&str] = &[
@@ -474,5 +486,64 @@ fn researching_a_design_decision_is_asked_for_where_the_alternatives_are_written
         spec.contains(SLOT),
         "/spec asks for research and its issue body has no {SLOT} for the \
          answer, so the sources have nowhere to go"
+    );
+}
+
+/// Four of the template's five questions are answered by the change and die
+/// with it. **Left undone** is the one that points forward, and the place it is
+/// written is a merged pull request's body — which nobody opens again. So the
+/// answer needs a home outside the pull request, made in the same act as the
+/// sentence, or the sentence is where the work goes to be forgotten.
+///
+/// `AGENTS.md` owns the rule and the reason for it; `/implement` and the
+/// template carry the instruction and point back. So all three name it and only
+/// one explains it — and all three are pinned here, the contract included,
+/// because the document that would be reworded first is the one that reads
+/// least like a checklist.
+///
+/// Pinning a sentence says nothing about whether an issue was ever filed. It
+/// says the ask survives an edit to any one of the three, which is the failure
+/// that actually happened.
+#[test]
+fn what_is_left_undone_is_given_a_home_outside_the_pull_request() {
+    const RULE: &str = "gets an issue in the same act";
+
+    // Where each document says it, not merely that it does somewhere. The
+    // template's comment is read while the body is being filled in; a sentence
+    // that drifts into another section is a sentence nobody sees at the moment
+    // it applies, and a whole-file search cannot tell that from a rule that is
+    // still in place.
+    let agents = read("AGENTS.md");
+    let implement = read(".claude/commands/implement.md");
+    let template = read(".github/pull_request_template.md");
+    let step_seven = section_from(&agents, "**Open the pull request**", "\n\n");
+
+    for (name, section) in [
+        ("AGENTS.md's step 7", step_seven),
+        (
+            "/implement's step about the pull request",
+            step_about(&implement, "pull request"),
+        ),
+        (
+            "the template's `Left undone`",
+            section_from(&template, "## Left undone", "\n## "),
+        ),
+    ] {
+        assert!(
+            unwrapped(section).contains(RULE),
+            "{name} does not say that what is left undone `{RULE}`, so it is \
+             recorded only where a merged pull request keeps it"
+        );
+    }
+
+    // And the contract's own enumeration of what the template asks. Stopping at
+    // four of five is how the question that outlives the pull request ends up
+    // absent from the document that introduces the step.
+    assert!(
+        unwrapped(step_seven)
+            .to_ascii_lowercase()
+            .contains("left undone"),
+        "AGENTS.md's step 7 lists what the template asks and leaves out the one \
+         question whose answer points past this change"
     );
 }


### PR DESCRIPTION
## What changed

The pull request template's fifth question, **Left undone**, is the only one
whose answer points forward — the other four describe the change and die with
it. It was being answered into a merged pull request's body, which nobody opens
again. Now anything that has to outlive the change gets an issue in the same
act. `AGENTS.md` owns the rule and the reason; `/implement` and the template
carry the instruction and point back, which is how this repository already
handles a rule that two documents share. `AGENTS.md`'s step 7 also enumerated
the template's questions and stopped at four of five — the one it left out was
this one.

No issue: you asked for this directly in conversation, after we found the two
follow-ups from #262 sitting exactly where the rule now forbids. The reasoning
is here rather than in a spec.

## What proves it

`tests/agent_workflow.rs::what_is_left_undone_is_given_a_home_outside_the_pull_request`.

It reads each document **at the place the sentence has to be** — the template's
`## Left undone` comment, `/implement`'s step about the pull request found by
its heading's words rather than its number, `AGENTS.md`'s step 7 — not anywhere
in the file. That distinction is the review's, and it is load-bearing: the
template's comment is what an author has in front of them while filling the body
in, so a sentence that drifts into another section is a sentence nobody sees at
the moment it applies.

Verified by inversion, seven ways, each run separately:

- deleting the sentence from any one of the three documents → red
- **moving** the sentence out of its section into another part of the same
  document, for the template and for `AGENTS.md` → red
- deleting `and what is left undone` from step 7's enumeration while leaving the
  rule in place → red at the second assertion, so it earns its keep rather than
  restating the first

The first commit is groundwork and changes no assertion: `unwrapped` collapses
whitespace before a pinned literal is searched for, so re-wrapping a paragraph
no longer fails a test with a message about a rule that is still there —
demonstrated against `main`'s test file, where a wrap-only edit to `/spec` goes
red. `section_from` names the slice that the next commit needs a second copy of.

Harness: 569 lib tests, 10 in `agent_workflow`, 9 goldens on lavapipe (passed,
not skipped), `cargo fmt --check`, clippy with `-D warnings`.

## What the review found

The `reviewer` subagent read the two commits before this pull request existed.
**Zero blocking findings.** Four worth answering, all acted on:

1. *The change argues that a follow-up recorded only in a merged body is lost,
   and then left one there.* Correct — the second of #262's two follow-ups had
   no issue. Filed as **#265**, which is the rule applied to itself.
2. *The pins were file-scoped where this codebase's pattern is section-scoped*,
   proved by moving each sentence to another section with the test still green.
   Fixed and re-verified above.
3. *The first commit's body described a duplication that did not exist.* Also
   correct: on `main` there was one such slice, not two — the second arrives in
   the next commit. Reworded on rebase to say the helper is extracted ahead of
   its second caller, not because of it.
4. *No issue to close, on a change that adds an obligation to every future pull
   request.* Answered in **What changed** above rather than by filing one
   retroactively.

Its note that `/implement`'s closing line still said "anything you left undone
and why" without the number, four lines under the paragraph asking for it, is
fixed too.

`/simplify` ran before the harness. Its sharpest finding was that `unwrapped`
was not applied to the third of the three reads in the very test that introduced
it — so the trap the helper exists to close was still open on `AGENTS.md`. The
altitude pass found the matching asymmetry: the rule was pinned in two documents
and only loosely checked in the third, which is the contract.

## What was checked by hand

Nothing. This is agent-facing process documentation and a test that reads it;
the harness covers all of it.

## Left undone

**#266** — nothing reads a *filled-in* pull request body. This change makes all
three documents ask for the issue; whether one was filed is unwatched, and
structurally unwatchable by the current pipeline, since the reviewer runs before
the body exists. #266 proposes an advisory `pull_request` job, deliberately
non-blocking for the same reason the mutation job is.

Two smaller residuals, recorded here without issues because neither is work
anybody would pick up:

- `unwrapped` collapses the whole file, fenced blocks included, so a pinned
  literal could in principle match across a fence. Harmless for a five-word
  literal in these three documents; it would matter if the pins got shorter.
- Pinning a sentence cannot distinguish it from a sentence that negates it.
  That is inherent to the mechanism, and the test's docstring says so.
