### PR TITLE
The frame stops carrying a connection, and the phases stop passing one

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -737,6 +737,23 @@ struct Frame {
     force_render_surface: bool,
 }
 
+/// Whether this frame would only queue behind one the compositor has not shown.
+///
+/// The three that open the gate anyway — the fields say why each is what it is
+/// — are a surface with nothing on screen yet, a resize, and a scale change:
+/// all three have something to tell the compositor that cannot wait for a
+/// callback.
+///
+/// A function rather than the condition inline, because it is the one decision
+/// in the frame path that can be taken from a `Frame` and a `Geometry` alone,
+/// and so the one a test could reach first.
+fn paced_out(frame: &Frame, geometry: &Geometry) -> bool {
+    frame.frame_callback_pending
+        && !frame.force_render_surface
+        && !geometry.needs_resize
+        && !geometry.scale_changed
+}
+
 /// The physical size, and what about it changed since the last frame.
 struct Geometry {
     physical_width: u32,
@@ -1232,11 +1249,7 @@ fn render_surface(
     // loop iteration would re-ping the wakeup each time and spin the loop
     // flat out between frame callbacks. Input was dispatched above, so it is
     // never delayed by the gate; initialisation and resizes bypass it.
-    if frame.frame_callback_pending
-        && !frame.force_render_surface
-        && !geometry.needs_resize
-        && !geometry.scale_changed
-    {
+    if paced_out(&frame, &geometry) {
         render_stats::record_frame_skipped();
         return;
     }
@@ -2038,5 +2051,59 @@ mod dispatch_declares_the_moment {
             "the moment has to be cleared when the dispatch ends, got {after:?} \
              for an event from an hour ago"
         );
+    }
+}
+
+/// A frame is a description of what the compositor said, and the pacing gate is
+/// a decision taken from that description. Neither needs a compositor to exist,
+/// and until the Wayland types came out of the frame path neither could be
+/// named here: `Frame` held a live `WlSurface`, and a test has no display to
+/// get one from.
+#[cfg(test)]
+mod a_frame_is_a_description_not_a_connection {
+    use super::*;
+
+    fn frame(callback_pending: bool, force: bool) -> Frame {
+        Frame {
+            events: Vec::new(),
+            scale_factor: 1.0,
+            width: 200,
+            height: 50,
+            frame_callback_pending: callback_pending,
+            force_render_surface: force,
+        }
+    }
+
+    fn geometry(needs_resize: bool, scale_changed: bool) -> Geometry {
+        Geometry {
+            physical_width: 200,
+            physical_height: 50,
+            needs_resize,
+            scale_changed,
+        }
+    }
+
+    #[test]
+    fn a_frame_can_be_described_without_a_display() {
+        let f = frame(false, false);
+        assert_eq!((f.width, f.height), (200, 50));
+    }
+
+    #[test]
+    fn a_callback_still_in_flight_paces_a_frame_out() {
+        assert!(paced_out(&frame(true, false), &geometry(false, false)));
+    }
+
+    /// Each on its own, because any one of them alone has to open the gate.
+    #[test]
+    fn a_first_frame_a_resize_and_a_scale_change_each_bypass_the_gate() {
+        assert!(!paced_out(&frame(true, true), &geometry(false, false)));
+        assert!(!paced_out(&frame(true, false), &geometry(true, false)));
+        assert!(!paced_out(&frame(true, false), &geometry(false, true)));
+    }
+
+    #[test]
+    fn no_callback_in_flight_paces_nothing_out() {
+        assert!(!paced_out(&frame(false, false), &geometry(false, false)));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,7 +227,6 @@ pub mod widget_prelude {
 }
 
 use smithay_client_toolkit::reexports::client::QueueHandle;
-use smithay_client_toolkit::reexports::client::protocol::wl_surface::WlSurface;
 
 use crate::{
     jobs::{get_exit_request, has_pending_jobs, init_wakeup, process_jobs, take_wake_request},
@@ -736,7 +735,6 @@ struct Frame {
     /// pacing gate and repaints in full — it has nothing on screen to pace
     /// against.
     force_render_surface: bool,
-    wl_surface: WlSurface,
 }
 
 /// The physical size, and what about it changed since the last frame.
@@ -771,7 +769,6 @@ fn open_frame(ctx: &mut FrameContext) -> Option<Frame> {
         height: wayland_surface.height,
         frame_callback_pending: wayland_surface.frame_callback_pending,
         force_render_surface: !fully_initialized,
-        wl_surface: wayland_surface.wl_surface.clone(),
     };
 
     surface.is_gpu_ready().then_some(frame)
@@ -842,7 +839,6 @@ fn layout_pass(
     let wayland_state = &mut *ctx.wayland_state;
     let renderer = &mut *ctx.renderer;
     let tree = &mut *ctx.tree;
-    let qh = ctx.qh;
 
     // Update renderer for this surface
     renderer.set_screen_size(
@@ -891,7 +887,7 @@ fn layout_pass(
         tree.with_widget_mut(surface.widget_id, |widget, wid, tree| {
             widget.layout(tree, wid, constraints);
         });
-        wayland_state.reposition_popup_if_changed(id, natural, qh);
+        wayland_state.reposition_popup_if_changed(id, natural);
     } else if (has_pending_layouts || frame.force_render_surface)
         && surface::needs_content_measure(&surface.config)
     {
@@ -1058,7 +1054,6 @@ fn paint_and_present(ctx: &mut FrameContext, frame: &Frame, geometry: &Geometry)
     let wayland_state = &mut *ctx.wayland_state;
     let renderer = &mut *ctx.renderer;
     let tree = &mut *ctx.tree;
-    let qh = ctx.qh;
 
     // Force full repaint on resize, scale change, or during initialization
     if frame.force_render_surface || geometry.needs_resize || geometry.scale_changed {
@@ -1076,7 +1071,7 @@ fn paint_and_present(ctx: &mut FrameContext, frame: &Frame, geometry: &Geometry)
         // drops its regions, and that says so.
         if wayland_state.take_blur_resync(id) {
             let blur_rects = blur::regions_from_commands(&surface.flattened_commands);
-            wayland_state.sync_blur_region(id, blur_rects, qh, true);
+            wayland_state.sync_blur_region(id, blur_rects, true);
         }
         render_stats::record_frame_skipped();
         render_stats::end_frame(&DamageRegion::None);
@@ -1122,27 +1117,21 @@ fn paint_and_present(ctx: &mut FrameContext, frame: &Frame, geometry: &Geometry)
         && (compositor_blur || wayland_state.has_published_blur(id))
     {
         let blur_rects = blur::regions_from_commands(&surface.flattened_commands);
-        wayland_state.sync_blur_region(id, blur_rects, qh, false);
+        wayland_state.sync_blur_region(id, blur_rects, false);
     }
 
-    // Re-arm the frame callback BEFORE presenting so the request rides
-    // the same commit as the buffer (present() commits internally). The
-    // callback's arrival is the signal that this surface may render its
-    // next frame. Previously the callback was requested exactly once at
-    // startup and never again — the only pacing was the event loop
+    // Here, above `present`, because both of these have to ride its commit —
+    // why is on the two methods. Previously the callback was requested exactly
+    // once at startup and never again, and the only pacing was the event loop
     // blocking inside the Fifo swapchain.
-    frame.wl_surface.frame(qh, frame.wl_surface.clone());
+    wayland_state.request_frame_callback(id);
 
-    // Report damage BEFORE presenting: presenting attaches the buffer and
-    // commits the frame.wl_surface (inside wgpu/the driver's Wayland path), so
-    // pending damage set now is part of that commit. The previous code
-    // damaged + committed AFTER present, attaching the damage to an empty
-    // second commit the compositor could not use.
     let damage = tree.take_damage(surface.widget_id);
     match damage {
         DamageRegion::None => {
             // Shouldn't happen since we're rendering, but report full damage to be safe
-            frame.wl_surface.damage_buffer(
+            wayland_state.damage_surface(
+                id,
                 0,
                 0,
                 geometry.physical_width as i32,
@@ -1151,7 +1140,8 @@ fn paint_and_present(ctx: &mut FrameContext, frame: &Frame, geometry: &Geometry)
         }
         DamageRegion::Partial(rect) => {
             let scale = frame.scale_factor;
-            frame.wl_surface.damage_buffer(
+            wayland_state.damage_surface(
+                id,
                 (rect.x * scale) as i32,
                 (rect.y * scale) as i32,
                 (rect.width * scale).ceil() as i32,
@@ -1159,7 +1149,8 @@ fn paint_and_present(ctx: &mut FrameContext, frame: &Frame, geometry: &Geometry)
             );
         }
         DamageRegion::Full => {
-            frame.wl_surface.damage_buffer(
+            wayland_state.damage_surface(
+                id,
                 0,
                 0,
                 geometry.physical_width as i32,
@@ -1203,11 +1194,7 @@ fn paint_and_present(ctx: &mut FrameContext, frame: &Frame, geometry: &Geometry)
     render_stats::record_frame_painted();
     render_stats::end_frame(&damage);
 
-    // The frame callback requested before present is now committed;
-    // rendering for this surface is gated until it fires.
-    if let Some(ws) = wayland_state.get_surface_mut(id) {
-        ws.frame_callback_pending = true;
-    }
+    wayland_state.mark_frame_callback_pending(id);
 }
 
 /// The borrows a frame needs from start to finish, in one place.
@@ -1222,7 +1209,6 @@ struct FrameContext<'a> {
     wayland_state: &'a mut platform::WaylandState,
     renderer: &'a mut Renderer,
     tree: &'a mut Tree,
-    qh: &'a QueueHandle<platform::WaylandState>,
 }
 
 /// One surface, one frame, in the order the phases have to run.
@@ -1241,10 +1227,6 @@ fn render_surface(
 
     let geometry = resolve_geometry(ctx, &frame);
 
-    // Frame pacing: while a `wl_surface.frame` callback is in flight the
-    // compositor has not shown the previous frame, so another one would only
-    // queue behind it.
-    //
     // This returns BEFORE draining jobs, and that is the whole point:
     // animation continuations have to stay queued. Advancing them on every
     // loop iteration would re-ping the wakeup each time and spin the loop
@@ -1679,7 +1661,6 @@ impl App {
                         wayland_state: &mut wayland_state,
                         renderer,
                         tree: &mut self.tree,
-                        qh: &qh,
                     };
                     render_surface(&mut ctx, layout_roots, woken, &active_roots);
                 }

--- a/src/platform/backdrop.rs
+++ b/src/platform/backdrop.rs
@@ -91,13 +91,7 @@ impl WaylandState {
     /// an *empty* region, never NULL: NULL only withdraws our opinion and
     /// lets such a rule blur the whole surface, where an empty region says
     /// "blur exactly nothing".
-    pub(crate) fn sync_blur_region(
-        &mut self,
-        id: SurfaceId,
-        rects: Vec<BlurRect>,
-        qh: &QueueHandle<Self>,
-        commit: bool,
-    ) {
+    pub(crate) fn sync_blur_region(&mut self, id: SurfaceId, rects: Vec<BlurRect>, commit: bool) {
         if !self.backdrop.bg_effect_supports_blur {
             return;
         }
@@ -123,7 +117,7 @@ impl WaylandState {
 
         // Asking the manager twice for the same surface is a protocol error.
         let effect = surface_state.bg_effect_surface.get_or_insert_with(|| {
-            manager.get_background_effect(&surface_state.wl_surface, qh, ())
+            manager.get_background_effect(&surface_state.wl_surface, &self.qh, ())
         });
 
         let Ok(region) = Region::new(&self.compositor_state) else {

--- a/src/platform/popups.rs
+++ b/src/platform/popups.rs
@@ -254,13 +254,7 @@ impl WaylandState {
 
     /// Reposition an auto-height popup when its content height changed.
     /// The compositor answers with a new configure carrying the final size.
-    pub(crate) fn reposition_popup_if_changed(
-        &mut self,
-        id: SurfaceId,
-        new_height: u32,
-        qh: &QueueHandle<Self>,
-    ) {
-        let _ = qh;
+    pub(crate) fn reposition_popup_if_changed(&mut self, id: SurfaceId, new_height: u32) {
         let Some(ref xdg_shell) = self.popups.xdg_shell else {
             return;
         };

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -191,6 +191,15 @@ fn batching<R>(id: SurfaceId, f: impl FnOnce() -> R) -> (bool, R) {
 }
 
 pub struct WaylandState {
+    /// The queue every protocol request made from here goes onto.
+    ///
+    /// Held rather than passed: the frame path used to thread a
+    /// `&QueueHandle<WaylandState>` through `layout_pass` and
+    /// `paint_and_present` for the two or three calls that needed one, which
+    /// made every function between here and there name a Wayland type it had
+    /// no other use for. The handle is `Clone` and refers to the queue, not to
+    /// this state, so owning one costs nothing and closes that seam.
+    pub(crate) qh: QueueHandle<WaylandState>,
     pub registry_state: RegistryState,
     pub compositor_state: CompositorState,
     pub output_state: OutputState,
@@ -332,6 +341,7 @@ pub fn create_wayland_app(
     }
 
     let state = WaylandState {
+        qh: qh.clone(),
         registry_state: RegistryState::new(&globals),
         compositor_state,
         output_state,
@@ -354,6 +364,38 @@ pub fn create_wayland_app(
 }
 
 impl WaylandState {
+    /// Ask for a `wl_surface.frame` callback on this surface.
+    ///
+    /// Requested before presenting so it rides the same commit as the buffer.
+    /// The callback's arrival is what lets this surface render its next frame.
+    pub fn request_frame_callback(&mut self, id: SurfaceId) {
+        if let Some(surface) = self.surfaces.get(&id) {
+            surface
+                .wl_surface
+                .frame(&self.qh, surface.wl_surface.clone());
+        }
+    }
+
+    /// Report damaged buffer pixels, in buffer coordinates.
+    ///
+    /// Set before presenting: `present` attaches the buffer and commits the
+    /// surface inside wgpu's Wayland path, so damage pending now is part of
+    /// that commit. Damaging afterwards attaches it to an empty second commit
+    /// the compositor cannot use.
+    pub fn damage_surface(&mut self, id: SurfaceId, x: i32, y: i32, width: i32, height: i32) {
+        if let Some(surface) = self.surfaces.get(&id) {
+            surface.wl_surface.damage_buffer(x, y, width, height);
+        }
+    }
+
+    /// The frame callback asked for before present is now committed, and this
+    /// surface is gated until it fires.
+    pub fn mark_frame_callback_pending(&mut self, id: SurfaceId) {
+        if let Some(surface) = self.surfaces.get_mut(&id) {
+            surface.frame_callback_pending = true;
+        }
+    }
+
     /// Build a wl_region from logical-coordinate rects, rounded outward so a
     /// fractional widget bound never loses its edge pixels.
     fn build_region(&self, rects: &[Rect]) -> Option<Region> {


### PR DESCRIPTION
## What changed

**Step 1 of five in #264 — this does not close it.** The issue is implemented
one step at a time; the current step is the first one not done.

Wayland protocol types come out of the per-frame code path. `Frame` was a plain
description of what the compositor said — events, scale, size, two flags — that
also carried a live `WlSurface`, and `FrameContext` carried a
`&QueueHandle<WaylandState>` because two calls somewhere below wanted one. So
`layout_pass` and `paint_and_present` each opened by unpacking a Wayland type
they had no use of their own for, and `resolve_geometry` sat between them
touching neither.

**The design content the issue asked to be named first:** what replaces
`wl_surface` as the thing `paint_and_present` commits and requests a frame
callback on. The answer is that `WaylandState` owns its own `QueueHandle` — it
had none, which is why the handle was being threaded down from `App::run` — and
the frame path asks it by `SurfaceId` through three methods:
`request_frame_callback`, `damage_surface`, `mark_frame_callback_pending`. That
is `fn(&mut self, id: SurfaceId)`, the same spelling as the fifteen sibling
methods either side of them, and those three signatures are what step 2 turns
into the trait's first methods.

Two effects worth naming. `lib.rs` no longer contains the word `WlSurface`
anywhere; the import went with it. And `open_frame` used to clone that surface
handle for every frame it opened, *before* the pacing gate decided whether the
frame would be drawn — so a bar sitting still paid a clone per compositor
callback to throw it away. Paced-out frames no longer pay it, and `Frame` goes
from **104 bytes to 40** (measured, not estimated) for the ones that do.

## What proves it

`src/lib.rs`'s new `#[cfg(test)] mod a_frame_is_a_description_not_a_connection`
— four tests. It is #264's stated acceptance criterion for this step, and it
failed before the change with exactly the stated reason:
`error[E0063]: missing field 'wl_surface' in initializer of 'Frame'`.

Constructing a `Frame` is most of it. The rest is `paced_out`, the gate's four
conditions given a name — the one decision in the frame path that follows from
a `Frame` and a `Geometry` alone, and so the first one a test can reach now
that neither holds a connection. The reviewer mutated it six ways (each of the
four operands dropped, plus forcing the whole function `true` and `false`) and
all six were caught.

**Being precise about the criterion:** it reads "constructs a `Frame` *and
drives the frame path with it*". What landed constructs a `Frame` and drives
the pacing gate. `open_frame`, `resolve_geometry`, `layout_pass` and
`paint_and_present` are still unreachable from a test, because `FrameContext`
still needs a `ManagedSurface`, a `WaylandState` and a `Renderer`. That is the
honest maximum at step 1; steps 3 and 5 are where the rest becomes reachable.

Three commits, each compiling and clippy-clean on its own — the reviewer
verified this by extracting each commit's tree and building it, rather than
taking my word.

Harness: 711 tests, 0 failures; 9 goldens on lavapipe (passed, not skipped);
`cargo fmt --check`; clippy with `-D warnings`. No golden or snapshot moved,
and none should have — this draws no pixels differently.

## What the review found

`/simplify` ran before the commits, so its edits are inside them. Two findings
that mattered: **two `self.qh.clone()` calls I had written to dodge a borrow
conflict that does not exist** — `surfaces.get()` takes a shared borrow, and
edition 2024's precise closure captures make `&self.qh` fine inside
`get_or_insert_with` — and **four copies of one explanation**, three of them
added by me. Both fixed. Its reuse and altitude passes came back clean.

I **rejected** one finding: that the three new methods should call
`get_surface`/`get_surface_mut` rather than indexing `self.surfaces`. Two
agents disagreed about it, and the reviewer settled it — direct indexing is
used at six sites in `wayland.rs`, five in `popups.rs`, ten in `input.rs`; the
accessors are used only from outside `platform::wayland`. Clean in-module /
out-of-module split, and these are in-module.

The `reviewer` subagent then read the three commits. **One blocking finding:**
nothing proved the behavioural half. It replaced all three new methods with
no-ops — no frame callback ever requested, no damage ever reported — and the
entire suite passed, the four new tests included. That is accurate and it is
the point of #264: this layer has no sensor. The block was on the hand-run
being done and recorded, which is the next section.

Three findings worth answering, all acted on: naming the replacement in the PR
rather than only in a commit body (above); being explicit about what "drives
the frame path" came to mean (above); and not closing #264 (the body says so
and no commit uses a closing keyword). One note acted on: it measured `Frame`
at 104 → 40 bytes where a commit body of mine said "some forty bytes smaller",
estimating `size_of::<WlSurface>()`. Corrected on rebase.

Its notes on scope holding, and on the docs being right to leave alone
(`docs/ARCHITECTURE.md:146,160` describes protocol traffic, which is
byte-identical), are recorded here rather than acted on.

## What was checked by hand

niri 26.04, four examples.

- **`animation_example`** — springs run to their overshoot and settle, smoothly.
  This is the sensor that matters: an animation only advances if the loop keeps
  waking, and the loop wakes on the frame callback. A broken
  `request_frame_callback` would show as one frame drawn and everything frozen,
  with no error and green CI.
- **`text_input_example`** — typed and deleted; text appeared and disappeared
  cleanly, no stale glyphs underneath, nothing truncated. That is
  `damage_surface` on the `DamageRegion::Partial` branch, scale multiplication
  included.
- **`popup_example`** — positioning correct. `reposition_popup_if_changed` lost
  a parameter it never read.
- **`blur_example`** — **not a usable sensor on this machine**, and finding out
  why produced #268 below.

I first proposed `status_bar` here and was wrong: it is 36 lines of static text
and proves only that a surface configures and draws once. It cannot see the
frame callback re-arming, which is the thing most worth seeing.

## Left undone

**#268** — a blur only the compositor performs is dropped for having no radius
of its own. `container/mod.rs:1729` gates the whole `BackdropBlur` command on
`radius > 0.0`, where `radius` is guido's own shader radius and the
documentation on `BackdropSources::COMPOSITOR` says it does not apply to that
source. So `BackdropBlur::new(0.0).sources(COMPOSITOR)` — the documented
spelling for "let the compositor blur behind me" — publishes no region at all.
Confirmed with `WAYLAND_DEBUG=1`: at radius `0.0`, zero `get_background_effect`
and zero `wl_region`; at `1.0`, one and fifty-two. **Pre-existing** — verified
identical on `main` at 8f2f059 before attributing.

**Steps 2 through 5 of #264** stay in the issue, which carries an acceptance
criterion for each. Nothing this step defers was touched: `configured_size`,
`send_size` and `reconfigure` are untouched, no trait exists yet, the loop body
is still inline in `App::run`, and `src/lib.rs:1257` still reads
`Instant::now()` for the frame instant.
