### PR TITLE
The frame path asks a trait, and Wayland is one answer to it

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -269,10 +269,10 @@ fn close_surface_now(
 /// and log a line saying so, on every resize and every margin change.
 /// `measured` is for the one caller that knows a size the compositor has not
 /// been told about yet: the content-measure pass, which has just computed it.
-fn resync_exclusive_zone(
+fn resync_exclusive_zone<P: SurfaceHost>(
     id: SurfaceId,
     config: &SurfaceConfig,
-    wayland_state: &mut platform::WaylandState,
+    wayland_state: &mut P,
     measured: Option<(u32, u32)>,
 ) {
     if config.exclusive_zone == surface::ExclusiveZone::Auto {
@@ -295,10 +295,10 @@ fn resync_exclusive_zone(
 /// `Auto` reservation follows is always one we own — `follow_axis` gives up on
 /// an axis anchored to both edges, the only kind the compositor sizes — so the
 /// value we asked for is the value that will take effect.
-fn publish_exclusive_zone(
+fn publish_exclusive_zone<P: SurfaceHost>(
     id: SurfaceId,
     config: &SurfaceConfig,
-    wayland_state: &mut platform::WaylandState,
+    wayland_state: &mut P,
     measured: Option<(u32, u32)>,
 ) {
     // A content axis waiting to be measured has no size to reserve for, and the
@@ -320,7 +320,7 @@ fn publish_exclusive_zone(
         return;
     }
 
-    let known = measured.or_else(|| configured_size(wayland_state, id));
+    let known = measured.or_else(|| wayland_state.configured_size(id));
     let width = surface::requested_extent(config.width, known.map(|(w, _)| w));
     let height = surface::requested_extent(config.height, known.map(|(_, h)| h));
     let zone = config
@@ -755,6 +755,195 @@ fn paced_out(frame: &Frame, geometry: &Geometry) -> bool {
 }
 
 /// The physical size, and what about it changed since the last frame.
+/// What a frame asks of whatever is showing it.
+///
+/// Every request the per-frame path makes of a compositor. The seat and the
+/// session lock are not here, and a later step decides whether they join.
+///
+/// Not *only* the frame path, though it is close: `configured_size` is here for
+/// `send_size`, which belongs to the surface-command path, because both paths
+/// share `publish_exclusive_zone` and a generic caller cannot reach an inherent
+/// method. That leak goes when the surface-command path follows.
+///
+/// `WaylandState` is one implementation. The reason this is a trait and not
+/// that type is that a second one — a recorder, keeping what it was asked
+/// instead of asking — is the only way a test can watch this layer at all,
+/// which is what #264 is about.
+///
+/// **One required method.** `open_frame` has no default because a host that
+/// cannot say what a frame is has nothing to host; every other request defaults
+/// to doing nothing and knowing nothing, which is the honest answer for a host
+/// that does not have that protocol. So the second implementation writes down
+/// what it wants to watch and stays silent about the rest.
+///
+/// What that cannot catch is a method added here and forgotten in
+/// `WaylandState`: it would silently do nothing against a real compositor
+/// rather than fail to build. The defaults are for a host that *cannot* do the
+/// thing, never for one that merely has not been taught to.
+pub(crate) trait SurfaceHost {
+    /// The facts a frame is built from, or `None` if this surface has no size
+    /// to draw at yet. Takes the queued input with it, so calling it twice for
+    /// one frame loses events.
+    fn open_frame(&mut self, id: SurfaceId) -> Option<Frame>;
+
+    /// The size the compositor has confirmed, if it has confirmed one.
+    ///
+    /// Not the size that was *requested*: `WaylandSurfaceState` is created
+    /// holding that, which for a content axis is the 1px placeholder — so
+    /// reading it unconditionally would report a number nobody agreed on as
+    /// though it were live, and make `requested_extent`'s "no size yet" branch
+    /// unreachable while the case it describes was still happening.
+    fn configured_size(&self, id: SurfaceId) -> Option<(u32, u32)> {
+        let _ = id;
+        None
+    }
+
+    /// The width an auto-width popup should be measured against.
+    fn popup_auto_width(&self, id: SurfaceId) -> Option<u32> {
+        let _ = id;
+        None
+    }
+
+    /// Tell the compositor an auto-height popup's content changed height.
+    fn reposition_popup_if_changed(&mut self, id: SurfaceId, new_height: u32) {
+        let _ = (id, new_height);
+    }
+
+    /// Ask for a size. A request: the answer arrives as a configure.
+    fn set_surface_size(&mut self, id: SurfaceId, width: u32, height: u32) {
+        let _ = (id, width, height);
+    }
+
+    /// Publish the screen space this surface reserves.
+    fn set_surface_exclusive_zone(&mut self, id: SurfaceId, zone: i32) {
+        let _ = (id, zone);
+    }
+
+    /// Run `f` and let its requests reach the compositor as one commit, so a
+    /// group of them never shows an intermediate surface on the way.
+    fn batch_layer_requests<F: FnOnce(&mut Self)>(&mut self, id: SurfaceId, f: F) {
+        let _ = id;
+        f(self);
+    }
+
+    /// Whether backdrop blur regions can be published at all.
+    fn supports_blur_region(&self) -> bool {
+        false
+    }
+
+    /// Whether this surface has a region published that would have to be
+    /// withdrawn.
+    fn has_published_blur(&self, id: SurfaceId) -> bool {
+        let _ = id;
+        false
+    }
+
+    /// Whether the last published region was dropped and owes republishing.
+    fn take_blur_resync(&mut self, id: SurfaceId) -> bool {
+        let _ = id;
+        false
+    }
+
+    /// Publish the region to blur behind this surface.
+    fn sync_blur_region(&mut self, id: SurfaceId, rects: Vec<blur::BlurRect>, commit: bool) {
+        let _ = (id, rects, commit);
+    }
+
+    /// Ask to be told when this surface's last frame has been shown.
+    fn request_frame_callback(&mut self, id: SurfaceId) {
+        let _ = id;
+    }
+
+    /// Report damaged buffer pixels, in buffer coordinates. Why it has to
+    /// happen before presenting is on the implementation.
+    fn damage_surface(&mut self, id: SurfaceId, x: i32, y: i32, width: i32, height: i32) {
+        let _ = (id, x, y, width, height);
+    }
+
+    /// Record that the callback asked for is now committed.
+    fn mark_frame_callback_pending(&mut self, id: SurfaceId) {
+        let _ = id;
+    }
+}
+
+impl SurfaceHost for platform::WaylandState {
+    fn open_frame(&mut self, id: SurfaceId) -> Option<Frame> {
+        let surface = self.get_surface_mut(id)?;
+        if !surface.configured {
+            return None;
+        }
+        // Taken before the caller's GPU check, not after: a surface still
+        // building its GPU state drops this frame *and* the input queued for
+        // it. Holding the input instead would deliver a burst of stale events —
+        // a pointer position from several frames ago among them — on the first
+        // frame that renders.
+        let events = surface.take_events();
+        let fully_initialized = surface.first_frame_presented && surface.scale_factor_received;
+        Some(Frame {
+            events,
+            scale_factor: surface.scale_factor,
+            width: surface.width,
+            height: surface.height,
+            frame_callback_pending: surface.frame_callback_pending,
+            force_render_surface: !fully_initialized,
+        })
+    }
+
+    fn configured_size(&self, id: SurfaceId) -> Option<(u32, u32)> {
+        self.get_surface(id)
+            .filter(|s| s.configured)
+            .map(|s| (s.width, s.height))
+    }
+
+    fn popup_auto_width(&self, id: SurfaceId) -> Option<u32> {
+        self.popup_auto_width(id)
+    }
+
+    fn reposition_popup_if_changed(&mut self, id: SurfaceId, new_height: u32) {
+        self.reposition_popup_if_changed(id, new_height)
+    }
+
+    fn set_surface_size(&mut self, id: SurfaceId, width: u32, height: u32) {
+        self.set_surface_size(id, width, height)
+    }
+
+    fn set_surface_exclusive_zone(&mut self, id: SurfaceId, zone: i32) {
+        self.set_surface_exclusive_zone(id, zone)
+    }
+
+    fn batch_layer_requests<F: FnOnce(&mut Self)>(&mut self, id: SurfaceId, f: F) {
+        self.batch_layer_requests(id, f)
+    }
+
+    fn supports_blur_region(&self) -> bool {
+        self.supports_blur_region()
+    }
+
+    fn has_published_blur(&self, id: SurfaceId) -> bool {
+        self.has_published_blur(id)
+    }
+
+    fn take_blur_resync(&mut self, id: SurfaceId) -> bool {
+        self.take_blur_resync(id)
+    }
+
+    fn sync_blur_region(&mut self, id: SurfaceId, rects: Vec<blur::BlurRect>, commit: bool) {
+        self.sync_blur_region(id, rects, commit)
+    }
+
+    fn request_frame_callback(&mut self, id: SurfaceId) {
+        self.request_frame_callback(id)
+    }
+
+    fn damage_surface(&mut self, id: SurfaceId, x: i32, y: i32, width: i32, height: i32) {
+        self.damage_surface(id, x, y, width, height)
+    }
+
+    fn mark_frame_callback_pending(&mut self, id: SurfaceId) {
+        self.mark_frame_callback_pending(id)
+    }
+}
+
 struct Geometry {
     physical_width: u32,
     physical_height: u32,
@@ -765,30 +954,11 @@ struct Geometry {
 /// Read the surface's state and take its queued input, or give up on this
 /// frame: an unconfigured surface has no size to render at, and one whose GPU
 /// state has not been built yet gets it on the next iteration.
-fn open_frame(ctx: &mut FrameContext) -> Option<Frame> {
-    let surface = &*ctx.surface;
-    let wayland_surface = ctx.wayland_state.get_surface_mut(ctx.id)?;
-    if !wayland_surface.configured {
-        return None;
-    }
-
-    // Taken before the GPU check, not after: a surface still building its GPU
-    // state drops this frame *and* the input queued for it. Holding the input
-    // instead would deliver a burst of stale events — a pointer position from
-    // several frames ago among them — on the first frame that renders.
-    let events = wayland_surface.take_events();
-    let fully_initialized =
-        wayland_surface.first_frame_presented && wayland_surface.scale_factor_received;
-    let frame = Frame {
-        events,
-        scale_factor: wayland_surface.scale_factor,
-        width: wayland_surface.width,
-        height: wayland_surface.height,
-        frame_callback_pending: wayland_surface.frame_callback_pending,
-        force_render_surface: !fully_initialized,
-    };
-
-    surface.is_gpu_ready().then_some(frame)
+fn open_frame<P: SurfaceHost>(ctx: &mut FrameContext<P>) -> Option<Frame> {
+    // The host answers for the compositor; the GPU readiness is ours, and a
+    // surface still building its swapchain has nowhere to draw.
+    let frame = ctx.wayland_state.open_frame(ctx.id)?;
+    ctx.surface.is_gpu_ready().then_some(frame)
 }
 
 /// Resolve the physical size and bring the swapchain in line with it.
@@ -796,7 +966,7 @@ fn open_frame(ctx: &mut FrameContext) -> Option<Frame> {
 /// Runs after input rather than with the rest of the snapshot: dispatching
 /// events cannot change the surface size, but resizing the swapchain before
 /// the widgets have been told anything would reorder the frame for no gain.
-fn resolve_geometry(ctx: &mut FrameContext, frame: &Frame) -> Geometry {
+fn resolve_geometry<P: SurfaceHost>(ctx: &mut FrameContext<P>, frame: &Frame) -> Geometry {
     let id = ctx.id;
     let surface = &mut *ctx.surface;
     let scale = frame.scale_factor as u32;
@@ -844,8 +1014,8 @@ fn resolve_geometry(ctx: &mut FrameContext, frame: &Frame) -> Geometry {
 /// themselves re-run, from their relayout boundaries. A full layout from the
 /// root happens only on a resize, because that is the one change no widget
 /// can have noticed on its own.
-fn layout_pass(
-    ctx: &mut FrameContext,
+fn layout_pass<P: SurfaceHost>(
+    ctx: &mut FrameContext<P>,
     frame: &Frame,
     geometry: &Geometry,
     has_pending_layouts: bool,
@@ -983,20 +1153,6 @@ fn layout_pass(
     reactive::focus::apply_pending_focus(tree);
 }
 
-/// The size the compositor has confirmed, if it has confirmed one.
-///
-/// `WaylandSurfaceState` is created holding the size that was *requested*, which
-/// for a content axis is the 1px placeholder — so reading it unconditionally
-/// would report a number nobody agreed on as though it were live, and make
-/// `requested_extent`'s "no size yet" branch unreachable while the case it
-/// describes was still happening.
-fn configured_size(wayland_state: &platform::WaylandState, id: SurfaceId) -> Option<(u32, u32)> {
-    wayland_state
-        .get_surface(id)
-        .filter(|s| s.configured)
-        .map(|s| (s.width, s.height))
-}
-
 /// Send the size the surface is currently asking for, and report whether the
 /// content-measure pass has to run before that answer is right.
 ///
@@ -1025,7 +1181,7 @@ fn send_size(
     surface: &ManagedSurface,
     wayland_state: &mut platform::WaylandState,
 ) -> (bool, WidgetId) {
-    let live = configured_size(wayland_state, id);
+    let live = wayland_state.configured_size(id);
     let (ask_w, ask_h, needs_measure) = surface::resize_request(&surface.config, live);
     wayland_state.set_surface_size(id, ask_w, ask_h);
     (needs_measure, surface.widget_id)
@@ -1065,7 +1221,11 @@ fn reconfigure<R>(
 /// are both requested BEFORE presenting, because presenting is what commits
 /// the surface. Anything set afterwards would ride an empty second commit
 /// the compositor cannot use.
-fn paint_and_present(ctx: &mut FrameContext, frame: &Frame, geometry: &Geometry) {
+fn paint_and_present<P: SurfaceHost>(
+    ctx: &mut FrameContext<P>,
+    frame: &Frame,
+    geometry: &Geometry,
+) {
     let id = ctx.id;
     let surface = &mut *ctx.surface;
     let wayland_state = &mut *ctx.wayland_state;
@@ -1220,17 +1380,17 @@ fn paint_and_present(ctx: &mut FrameContext, frame: &Frame, geometry: &Geometry)
 /// and it spares every phase below the parameter list that had already grown
 /// past what anyone reads. Each phase reborrows what it uses, so its body
 /// reads as if it still owned the arguments.
-struct FrameContext<'a> {
+struct FrameContext<'a, P: SurfaceHost> {
     id: SurfaceId,
     surface: &'a mut surface_manager::ManagedSurface,
-    wayland_state: &'a mut platform::WaylandState,
+    wayland_state: &'a mut P,
     renderer: &'a mut Renderer,
     tree: &'a mut Tree,
 }
 
 /// One surface, one frame, in the order the phases have to run.
-fn render_surface(
-    ctx: &mut FrameContext,
+fn render_surface<P: SurfaceHost>(
+    ctx: &mut FrameContext<P>,
     layout_roots: &mut Vec<WidgetId>,
     woken: bool,
     active_roots: &rustc_hash::FxHashSet<WidgetId>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -754,7 +754,6 @@ fn paced_out(frame: &Frame, geometry: &Geometry) -> bool {
         && !geometry.scale_changed
 }
 
-/// The physical size, and what about it changed since the last frame.
 /// What a frame asks of whatever is showing it.
 ///
 /// Every request the per-frame path makes of a compositor. The seat and the
@@ -944,6 +943,7 @@ impl SurfaceHost for platform::WaylandState {
     }
 }
 
+/// The physical size, and what about it changed since the last frame.
 struct Geometry {
     physical_width: u32,
     physical_height: u32,
@@ -2265,5 +2265,82 @@ mod a_frame_is_a_description_not_a_connection {
     #[test]
     fn no_callback_in_flight_paces_nothing_out() {
         assert!(!paced_out(&frame(false, false), &geometry(false, false)));
+    }
+}
+
+/// The frame path asks a compositor for things, and this is the asking written
+/// down. `WaylandState` is one answer to it; a recorder that keeps what it was
+/// asked is another, and having two is the whole point — one implementation is
+/// a rename, two is a seam.
+#[cfg(test)]
+mod a_second_host_can_answer_for_a_compositor {
+    use super::*;
+    use crate::platform::Anchor;
+    use crate::surface::{ExclusiveZone, Margin, SurfaceConfig};
+
+    /// Answers nothing and remembers what it was asked. Overrides the three
+    /// methods these tests read and inherits the rest, which is the point of
+    /// the defaults: a host writes down what it wants to watch.
+    #[derive(Default)]
+    struct Recorder {
+        configured: Option<(u32, u32)>,
+        exclusive_zones: Vec<(SurfaceId, i32)>,
+    }
+
+    impl SurfaceHost for Recorder {
+        fn open_frame(&mut self, _id: SurfaceId) -> Option<Frame> {
+            None
+        }
+
+        fn configured_size(&self, _id: SurfaceId) -> Option<(u32, u32)> {
+            self.configured
+        }
+
+        fn set_surface_exclusive_zone(&mut self, id: SurfaceId, zone: i32) {
+            self.exclusive_zones.push((id, zone));
+        }
+    }
+
+    fn bar() -> SurfaceConfig {
+        SurfaceConfig::new()
+            .height(32)
+            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+            .exclusive_zone(ExclusiveZone::Auto)
+    }
+
+    /// The first thing anything has ever asserted about what a surface *asks
+    /// the compositor for*, rather than about what it draws.
+    #[test]
+    fn a_bar_reserving_automatically_asks_for_the_height_it_declared() {
+        let id = SurfaceId::next();
+        let mut host = Recorder {
+            configured: Some((800, 32)),
+            ..Default::default()
+        };
+        resync_exclusive_zone(id, &bar(), &mut host, None);
+        assert_eq!(host.exclusive_zones, vec![(id, 32)]);
+    }
+
+    /// The margin on the anchored edge is part of the reservation: a bar held
+    /// eight pixels off the top edge occupies forty.
+    #[test]
+    fn a_margin_on_the_anchored_edge_is_reserved_too() {
+        let id = SurfaceId::next();
+        let mut host = Recorder {
+            configured: Some((800, 32)),
+            ..Default::default()
+        };
+        resync_exclusive_zone(id, &bar().margin(Margin::all(8)), &mut host, None);
+        assert_eq!(host.exclusive_zones, vec![(id, 40)]);
+    }
+
+    /// A policy that is not `Auto` sends nothing from here — it was sent once,
+    /// when the surface was configured.
+    #[test]
+    fn a_fixed_reservation_is_not_republished_every_frame() {
+        let id = SurfaceId::next();
+        let mut host = Recorder::default();
+        resync_exclusive_zone(id, &bar().exclusive_zone(48u32), &mut host, None);
+        assert!(host.exclusive_zones.is_empty());
     }
 }


### PR DESCRIPTION
## What changed

**Step 2 of five in #264 — this does not close it.**

Every request a frame makes of a compositor was a call to a concrete type, so
the shape of the asking was spread across five functions and readable only by
reading all five. `SurfaceHost` is that asking written down: fourteen requests
in four groups — what a frame is opened from, what layout asks for, the blur
region, and what present has to send. `WaylandState` implements it; `FrameContext`
and the frame functions are generic over it.

**One required method, thirteen defaulted.** `open_frame` has no default because
a host that cannot say what a frame is has nothing to host; the rest default to
doing nothing and knowing nothing, which is the honest answer for a host without
that protocol. What defaults cannot catch is a method added to the trait and
forgotten in `WaylandState` — it would silently no-op against a real compositor
rather than fail to build. The trait's doc says so.

**This is not the two-level shape agreed on the issue**, and that was raised with
the maintainer before the commits rather than presented after: the agreement was
a thin trait over a per-surface one, and this is flat, with a `SurfaceId` on
almost every method. The maintainer chose to keep it flat and split at step 3,
when a driver can say which shape survives use. Recorded as a comment on #264
with the two visible seams for whoever splits it — `supports_blur_region()`
takes no id because it is a fact about the process, and `batch_layer_requests`'
closure takes the whole host where a per-surface handle would take one surface.
Checked while deciding: the calls in `paint_and_present` are isolated from one
another, so a handle would be taken and dropped around each; the obstacle is
design time, not the borrow checker.

## What proves it

`src/lib.rs`'s `#[cfg(test)] mod a_second_host_can_answer_for_a_compositor` —
a `Recorder` implementing the trait, which is step 2's acceptance criterion, and
three tests. It failed before the change with the stated reason: `cannot find
trait 'SurfaceHost' in this scope`.

The tests assert something nothing anywhere has asserted before: **what a surface
asks the compositor for**, as opposed to what it draws. A bar reserving
automatically asks for the height it declared; a margin on the anchored edge is
part of that reservation; a policy that is not `Auto` sends nothing per frame.
Inverting the `Auto` guard fails all three; ignoring the margin fails one.

Two commits, each clippy-clean alone. It was going to be three — trait, callers,
recorder — but the trait without its callers fails `-D warnings` as dead code,
so trait and callers are one commit. The reviewer reconstructed that
intermediate rather than taking my word and got `error: trait 'SurfaceHost' is
never used`; my own three-way attempt reported `multiple methods are never used`
because its intermediate still had one caller. Either way the split is wrong.

Harness: 714 tests, 0 failures; 9 goldens on lavapipe; `cargo fmt --check`;
clippy with `-D warnings`. No golden or snapshot moved, and none should have.

Static dispatch throughout — no `dyn` anywhere in the diff, and the shipped
binary instantiates the generic frame path once, for `WaylandState`, exactly as
before. `cargo build --lib --all-features` after touching `src/lib.rs`: 1.34s
against 1.33s, three runs each, which is noise.

## What the review found

`/simplify` ran before the commits. Three findings acted on: **the trait had zero
defaults**, against the proportion #264 had already settled — fixed, and
`Recorder` fell from ~50 lines to 20; **needless `platform::WaylandState::foo(self, ..)`
qualification** on twelve methods, saying there was a name collision where an
inherent method already wins; and **an orphaned doc comment**, where deleting the
free `configured_size` left its rationale glued to `send_size`'s doc.

I rejected its claim that the six generic functions are unverified
generalisation — that is what step 2 is for, in the issue's own words. The
reviewer agreed and sharpened it: the generic callers are not an extra, they are
what stops the trait being dead code. Its caveat, worth stating once: only
`resync_exclusive_zone` and `publish_exclusive_zone` get a second instantiation
today, so "a wrong trait shows up here, where it is cheap" is half-collected in
this step and the rest arrives at 3 and 5.

The `reviewer` subagent then read the two commits. **Zero blocking findings.**
Three worth answering, all acted on:

1. **The same orphaned-doc defect, reintroduced by my own fix.** Inserting the
   trait between `Geometry`'s doc comment and `struct Geometry` left the trait
   documented as "The physical size, and what about it changed since the last
   frame" and `Geometry` with no doc at all. That is the third time in this
   session I have moved code and left its explanation behind.
2. **A false claim in a commit body.** It said the tests read a confirmed size.
   They do not — I verified that deleting `configured_size`'s only call from
   `publish_exclusive_zone` leaves the whole suite green. The reviewer proposed a
   `height(content())` case to fix it; I checked instead of applying, and it does
   not work: whenever the zone follows a `Content` axis the content-measure
   deferral returns first, so no case can reach `configured_size`. The commit
   body now says that plainly rather than claiming coverage.
3. **The manual run**, below.

Notes acted on: the module name overstated what it reaches, and a test name said
"the height it has" where the surface had only declared one — both renamed. And
it corrected my reasoning for keeping the trait in `lib.rs`: I said `Frame` being
lib.rs-private constrained it, which is false — a private item at the crate root
is visible in every descendant module, and it verified that. The real reason is
that `SurfaceHost` is the frame path's contract and the frame path is `lib.rs`.
It also disagreed with the agent who cited `docs/ARCHITECTURE.md:198` as
requiring the move; that passage is about `delegate_*` handlers.

## What was checked by hand

niri 26.04. This step re-routes fourteen protocol calls through a trait, and
nothing automated stands under the forwarding bodies.

- **`animation_example`** — springs reach their overshoot and settle. This is
  `request_frame_callback` arriving through the trait, not merely compiling: an
  animation only advances if the loop keeps waking on the callback.
- **`text_input_example`** — typed and deleted, clean, caret blinking. That is
  `damage_surface` on all three `DamageRegion` branches.
- **`popup_example`** — position and size correct: the only example that
  exercises `popup_auto_width` and `reposition_popup_if_changed`.
- **`blur_example`** — checked by protocol trace rather than by eye, because
  #268 means the example publishes nothing at radius zero. With the radius
  temporarily at `1.0`: one `get_background_effect` and 52 `wl_region`, the same
  numbers as before the trait. `sync_blur_region` forwards.

## Left undone

**#270** — `publish_exclusive_zone`'s content-measure deferral guard is watched
by nothing. Deleting it whole leaves all 714 tests green, verified by hand with a
forced recompile. Its own comment says what it prevents: a `width(content())`
surface re-anchored into a side dock reserving an entire monitor and evicting
every window on it. Pre-existing; this change is only what made it reachable by a
test for the first time, and #270's acceptance uses the `Recorder` this PR adds.

**#268** stays open — the blur defect found while verifying step 1.

**Steps 3 through 5 of #264**, each with its own acceptance criterion. Two things
step 3 inherits, both recorded on the issue: `pub(crate)` will not survive it,
because `App::run` is `pub` and a public item generic over a `pub(crate)` trait
fails `private_bounds` under `-D warnings`; and `configured_size` is on the trait
for `send_size`, which belongs to the surface-command path, because both paths
share `publish_exclusive_zone` and a generic caller cannot reach an inherent
method.
