### PR TITLE
A frame lands where its surface points, and one of the two is a texture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,15 @@ jobs:
         run: vulkaninfo --summary | head -n 40
       - name: Run golden image tests
         run: cargo test --all-features --test golden_images
+      # The unit tests that need an adapter live in the lib, and the `test` job
+      # has no ICD — so they skip there and report green. This is the job that
+      # has one. `--lib` runs the whole set, which is cheap, and
+      # `GUIDO_GPU_REQUIRED` makes a skip a failure here for the same reason
+      # `GUIDO_GOLDEN_REQUIRED` does above it.
+      - name: Run the unit tests that need a GPU
+        env:
+          GUIDO_GPU_REQUIRED: 1
+        run: cargo test --all-features --lib
       - name: Upload the pixels that moved
         if: failure()
         uses: actions/upload-artifact@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,11 @@ license.workspace = true
 [features]
 default = ["svg", "webp"]
 render-stats = []
+# The apparatus #264 needs to drive a frame with no compositor: an offscreen
+# render target and the readback that makes one worth drawing into. On by
+# nothing, so a normal build ships no render-to-texture API it did not ask for;
+# in-crate tests get it from `cfg(test)` without the feature at all.
+testing = []
 # SVG rendering via resvg (pulls a second text-shaping stack + software
 # rasterizer). Without it, ImageSource::Svg* sources fail to decode with a
 # warning instead of failing to compile.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2494,3 +2494,169 @@ mod what_the_loop_waits_for {
         assert_eq!(wait_for(&pending, now), Some(FRAME));
     }
 }
+
+/// A frame drawn by the application, landing somewhere a test can read.
+///
+/// `tests/golden_images.rs` already renders without a compositor, but it builds
+/// its own target and calls the renderer itself — so it proves the shaders and
+/// nothing above them. This goes through `render_surface`: opening the frame,
+/// resolving the geometry, the pacing gate, layout, paint, flatten, damage and
+/// present. What it reads back is what the compositor would have been handed.
+#[cfg(test)]
+mod a_frame_lands_where_the_surface_points {
+    use super::*;
+    use crate::renderer::{GpuContext, RenderTarget};
+    use crate::surface::SurfaceConfig;
+    use crate::widgets::{Color, container};
+
+    const W: u32 = 100;
+    const H: u32 = 32;
+    const BG: Color = Color::rgb(0.25, 0.5, 0.75);
+
+    /// A host with one surface and nothing else. Every other request the frame
+    /// path makes is answered by the trait's defaults.
+    struct OneSurface {
+        width: u32,
+        height: u32,
+    }
+
+    impl SurfaceHost for OneSurface {
+        fn open_frame(&mut self, _id: SurfaceId) -> Option<Frame> {
+            Some(Frame {
+                events: Vec::new(),
+                scale_factor: 1.0,
+                width: self.width,
+                height: self.height,
+                frame_callback_pending: false,
+                force_render_surface: true,
+            })
+        }
+    }
+
+    /// A surface pointing at a texture, and the pieces the frame path wants.
+    fn surface_on_a_texture(
+        gpu: &GpuContext,
+        tree: &mut Tree,
+        texture: (u32, u32),
+    ) -> surface_manager::ManagedSurface {
+        let (widget, owner) = reactive::with_owner(|| Box::new(container()) as Box<dyn Widget>);
+        let mut surface = surface_manager::ManagedSurface::new(
+            SurfaceId::next(),
+            SurfaceConfig::new().background_color(BG),
+            widget,
+            owner,
+            tree,
+        );
+        surface.wgpu_surface = Some(RenderTarget::offscreen(gpu, texture.0, texture.1));
+        surface
+    }
+
+    /// `None` where there is no adapter at all, unless the caller says a skip is
+    /// a failure. CI's job with a rasterizer sets `GUIDO_GPU_REQUIRED=1`: a
+    /// skipped test that reports green is worth less than no test.
+    fn gpu() -> Option<GpuContext> {
+        match GpuContext::try_new() {
+            Some(gpu) => Some(gpu),
+            None if std::env::var_os("GUIDO_GPU_REQUIRED").is_some() => {
+                panic!("GUIDO_GPU_REQUIRED is set and no GPU adapter was found")
+            }
+            None => {
+                eprintln!("no GPU adapter; skipping");
+                None
+            }
+        }
+    }
+
+    /// The surface's own background reaches the target: the clear colour is what
+    /// the compositor sees where nothing is drawn over it.
+    ///
+    /// The width is chosen so the row padding is load-bearing: 100 pixels is
+    /// 400 bytes, which pads to 512, and a stride computed any other way lands
+    /// somewhere else. Under 64 pixels every arithmetic mistake rounds up to the
+    /// same 256 and the assertion proves nothing.
+    #[test]
+    fn a_surface_background_reaches_the_texture_it_points_at() {
+        let Some(gpu) = gpu() else { return };
+
+        let mut tree = Tree::new();
+        let mut surface = surface_on_a_texture(&gpu, &mut tree, (W, H));
+        let root = surface.widget_id;
+        let mut renderer = Renderer::new(
+            gpu.device.clone(),
+            gpu.queue.clone(),
+            wgpu::TextureFormat::Rgba8Unorm,
+        );
+        let mut host = OneSurface {
+            width: W,
+            height: H,
+        };
+        let id = surface.id;
+        let mut ctx = FrameContext {
+            id,
+            surface: &mut surface,
+            wayland_state: &mut host,
+            renderer: &mut renderer,
+            tree: &mut tree,
+        };
+        render_surface(
+            &mut ctx,
+            &mut Vec::new(),
+            true,
+            &std::iter::once(root).collect(),
+            std::time::Instant::now(),
+        );
+
+        let RenderTarget::Offscreen(target) = surface.wgpu_surface.as_ref().unwrap() else {
+            panic!("the target was replaced");
+        };
+        // Two pixels, in different rows and columns, so neither the stride nor
+        // the offset can be wrong and still land on the right bytes.
+        assert_eq!(target.read_pixel(1, 1), [64, 128, 191, 255]);
+        assert_eq!(target.read_pixel(W - 2, H - 2), [64, 128, 191, 255]);
+    }
+
+    /// A target smaller than its frame is made to fit, and then reports that it
+    /// fits.
+    ///
+    /// The second half is the whole of it: a target that quietly declined would
+    /// pass the first assertion of every frame and report a resize on all of
+    /// them, repainting the entire tree for ever.
+    #[test]
+    fn a_target_the_wrong_size_is_resized_once_and_not_again() {
+        let Some(gpu) = gpu() else { return };
+
+        let mut tree = Tree::new();
+        let mut surface = surface_on_a_texture(&gpu, &mut tree, (8, 8));
+        let mut renderer = Renderer::new(
+            gpu.device.clone(),
+            gpu.queue.clone(),
+            wgpu::TextureFormat::Rgba8Unorm,
+        );
+        let mut host = OneSurface {
+            width: W,
+            height: H,
+        };
+        let id = surface.id;
+        let mut ctx = FrameContext {
+            id,
+            surface: &mut surface,
+            wayland_state: &mut host,
+            renderer: &mut renderer,
+            tree: &mut tree,
+        };
+        let frame = ctx.wayland_state.open_frame(id).unwrap();
+
+        let first = resolve_geometry(&mut ctx, &frame);
+        assert!(first.needs_resize, "an 8x8 target for a 100x32 frame");
+        assert_eq!(
+            (
+                ctx.surface.wgpu_surface.as_ref().unwrap().width(),
+                ctx.surface.wgpu_surface.as_ref().unwrap().height()
+            ),
+            (W, H)
+        );
+
+        let again = resolve_geometry(&mut ctx, &frame);
+        assert!(!again.needs_resize, "the target already fits");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1715,9 +1715,9 @@ impl App {
                 && let Some(ref wgpu_surface) = managed.wgpu_surface
             {
                 let r = Renderer::new(
-                    wgpu_surface.device.clone(),
-                    wgpu_surface.queue.clone(),
-                    wgpu_surface.config.format,
+                    wgpu_surface.device().clone(),
+                    wgpu_surface.queue().clone(),
+                    wgpu_surface.format(),
                 );
                 renderer = Some(r);
             }
@@ -1842,9 +1842,9 @@ fn iterate(
         && let Some(wgpu_surface) = surface_manager.first_gpu_surface()
     {
         *renderer = Some(Renderer::new(
-            wgpu_surface.device.clone(),
-            wgpu_surface.queue.clone(),
-            wgpu_surface.config.format,
+            wgpu_surface.device().clone(),
+            wgpu_surface.queue().clone(),
+            wgpu_surface.format(),
         ));
     }
 

--- a/src/renderer/gpu_context.rs
+++ b/src/renderer/gpu_context.rs
@@ -166,3 +166,168 @@ impl SurfaceState {
         self.config.height
     }
 }
+
+/// Where a drawn frame lands.
+///
+/// A swapchain is a compositor's: it hands out a texture, takes it back, and
+/// shows it. A texture is the caller's, and nobody shows it — which is the only
+/// difference, and the reason a frame can be inspected without a compositor at
+/// all. Everything upstream of here draws the same commands either way.
+pub enum RenderTarget {
+    /// The compositor's swapchain. Acquired per frame, presented after.
+    Swapchain(SurfaceState),
+    /// A texture the caller owns and can read back.
+    #[cfg(any(test, feature = "testing"))]
+    Offscreen(OffscreenTarget),
+}
+
+/// A texture a frame is drawn into, with the handles needed to read it back.
+///
+/// The texture is the only state: it already knows its size and its format, so
+/// storing either beside it would be a second copy of a fact that cannot drift
+/// while it is derived.
+#[cfg(any(test, feature = "testing"))]
+pub struct OffscreenTarget {
+    pub texture: wgpu::Texture,
+    pub device: Arc<Device>,
+    pub queue: Arc<Queue>,
+}
+
+#[cfg(any(test, feature = "testing"))]
+impl OffscreenTarget {
+    /// The colour at one pixel, in the texture's own format.
+    ///
+    /// Reading a target back is the whole reason to draw into one, so it lives
+    /// here rather than beside whoever asks: the row padding wgpu requires and
+    /// the map-then-poll order are the sort of thing that is written correctly
+    /// once and copied wrongly after.
+    pub fn read_pixel(&self, x: u32, y: u32) -> [u8; 4] {
+        let (width, height) = (self.texture.width(), self.texture.height());
+        let bytes_per_row = (width * 4).div_ceil(wgpu::COPY_BYTES_PER_ROW_ALIGNMENT)
+            * wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
+        let buffer = self.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("guido offscreen readback"),
+            size: (bytes_per_row * height) as u64,
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+            mapped_at_creation: false,
+        });
+        let mut encoder = self.device.create_command_encoder(&Default::default());
+        encoder.copy_texture_to_buffer(
+            self.texture.as_image_copy(),
+            wgpu::TexelCopyBufferInfo {
+                buffer: &buffer,
+                layout: wgpu::TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(bytes_per_row),
+                    rows_per_image: Some(height),
+                },
+            },
+            wgpu::Extent3d {
+                width,
+                height,
+                depth_or_array_layers: 1,
+            },
+        );
+        self.queue.submit([encoder.finish()]);
+        buffer.slice(..).map_async(wgpu::MapMode::Read, |_| {});
+        self.device
+            .poll(wgpu::PollType::wait_indefinitely())
+            .expect("readback never completed");
+        let data = buffer.slice(..).get_mapped_range();
+        let at = (y * bytes_per_row + x * 4) as usize;
+        [data[at], data[at + 1], data[at + 2], data[at + 3]]
+    }
+}
+
+impl RenderTarget {
+    /// A target of `width` by `height` physical pixels, drawn into and kept.
+    ///
+    /// `COPY_SRC` because a target nobody presents is only useful if it can be
+    /// read, and `Rgba8Unorm` because eight bits a channel makes an exact byte
+    /// a fair thing to assert.
+    #[cfg(any(test, feature = "testing"))]
+    pub fn offscreen(gpu: &GpuContext, width: u32, height: u32) -> Self {
+        Self::Offscreen(OffscreenTarget {
+            texture: offscreen_texture(&gpu.device, width, height),
+            device: gpu.device.clone(),
+            queue: gpu.queue.clone(),
+        })
+    }
+
+    pub fn width(&self) -> u32 {
+        match self {
+            Self::Swapchain(s) => s.width(),
+            #[cfg(any(test, feature = "testing"))]
+            Self::Offscreen(o) => o.texture.width(),
+        }
+    }
+
+    pub fn height(&self) -> u32 {
+        match self {
+            Self::Swapchain(s) => s.height(),
+            #[cfg(any(test, feature = "testing"))]
+            Self::Offscreen(o) => o.texture.height(),
+        }
+    }
+
+    /// A swapchain is reconfigured; a texture is replaced.
+    ///
+    /// Not a no-op for the texture, however tempting: `resolve_geometry` asks
+    /// whether the target matches the frame and calls this when it does not, so
+    /// a target that quietly declined would report a resize every frame for
+    /// ever, repainting the whole tree each time and defeating the incremental
+    /// paint the rest of the pipeline is built around.
+    pub fn resize(&mut self, width: u32, height: u32) {
+        match self {
+            Self::Swapchain(s) => s.resize(width, height),
+            #[cfg(any(test, feature = "testing"))]
+            Self::Offscreen(o) => {
+                if width > 0 && height > 0 {
+                    o.texture = offscreen_texture(&o.device, width, height);
+                }
+            }
+        }
+    }
+
+    pub fn device(&self) -> &Arc<Device> {
+        match self {
+            Self::Swapchain(s) => &s.device,
+            #[cfg(any(test, feature = "testing"))]
+            Self::Offscreen(o) => &o.device,
+        }
+    }
+
+    pub fn queue(&self) -> &Arc<Queue> {
+        match self {
+            Self::Swapchain(s) => &s.queue,
+            #[cfg(any(test, feature = "testing"))]
+            Self::Offscreen(o) => &o.queue,
+        }
+    }
+
+    pub fn format(&self) -> wgpu::TextureFormat {
+        match self {
+            Self::Swapchain(s) => s.config.format,
+            #[cfg(any(test, feature = "testing"))]
+            Self::Offscreen(o) => o.texture.format(),
+        }
+    }
+}
+
+#[cfg(any(test, feature = "testing"))]
+fn offscreen_texture(device: &Device, width: u32, height: u32) -> wgpu::Texture {
+    device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("guido offscreen target"),
+        size: wgpu::Extent3d {
+            width,
+            height,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Rgba8Unorm,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+        view_formats: &[],
+    })
+}

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -30,7 +30,9 @@ mod types;
 
 pub use commands::{Border, CornerRadii, DrawCommand, EllipticalRadii};
 pub use flatten::{CommandLayer, FlattenedCommand, flatten_root_into};
-pub use gpu_context::{GpuContext, SurfaceState};
+#[cfg(any(test, feature = "testing"))]
+pub use gpu_context::OffscreenTarget;
+pub use gpu_context::{GpuContext, RenderTarget, SurfaceState};
 pub use paint_context::PaintContext;
 pub use render::Renderer;
 pub use text_measurer::{

--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -14,7 +14,7 @@ use super::backdrop_pass::{BackdropRegion, BackdropRenderer};
 use super::commands::{CornerRadii, DrawCommand};
 use super::flatten::{CommandLayer, FlattenedCommand};
 use super::gpu::{QUAD_INDICES, QUAD_VERTICES, QuadVertex, ShaderUniforms, ShapeInstance};
-use super::gpu_context::SurfaceState;
+use super::gpu_context::RenderTarget;
 use super::image_quad::{ImageQuadRenderer, PreparedImageQuad};
 use super::text::TextRenderState;
 use super::text_mask::{MaskSpec, TextMaskRenderer};
@@ -262,19 +262,31 @@ impl Renderer {
         }
     }
 
-    /// Render flattened commands to a surface.
+    /// Draw into whatever this surface points at, and hand it over.
     ///
-    /// Returns `true` if a frame was actually presented. On `false` (lost/
-    /// outdated swapchain, out of memory) nothing reached the screen — the
-    /// caller must keep its dirty state so the content is repainted on the
-    /// next frame instead of showing stale pixels.
+    /// `false` means nothing reached the target and the frame should be drawn
+    /// again — a lost or outdated swapchain, which is common right after a
+    /// resize. A texture cannot fail that way: it is already there.
     pub fn render(
         &mut self,
-        surface: &mut SurfaceState,
+        target: &mut RenderTarget,
         commands: &[FlattenedCommand],
         layers: &[CommandLayer],
         clear_color: Color,
     ) -> bool {
+        let surface = match target {
+            #[cfg(any(test, feature = "testing"))]
+            RenderTarget::Offscreen(offscreen) => {
+                let view = offscreen
+                    .texture
+                    .create_view(&wgpu::TextureViewDescriptor::default());
+                let width = offscreen.texture.width();
+                let height = offscreen.texture.height();
+                self.render_to_view(&view, width, height, commands, layers, clear_color);
+                return true;
+            }
+            RenderTarget::Swapchain(surface) => surface,
+        };
         let output = match surface.surface.get_current_texture() {
             Ok(output) => output,
             Err(wgpu::SurfaceError::Lost) => {

--- a/src/surface_manager.rs
+++ b/src/surface_manager.rs
@@ -10,7 +10,7 @@ use smithay_client_toolkit::reexports::client::Connection;
 use crate::layout::Constraints;
 use crate::platform::{WaylandState, WaylandWindowWrapper};
 use crate::reactive::owner::{OwnerId, dispose_owner_now};
-use crate::renderer::{CommandLayer, FlattenedCommand, GpuContext, RenderNode, SurfaceState};
+use crate::renderer::{CommandLayer, FlattenedCommand, GpuContext, RenderNode, RenderTarget};
 use crate::surface::{SurfaceConfig, SurfaceId};
 use crate::tree::{Tree, WidgetId};
 use crate::widgets::Widget;
@@ -28,8 +28,8 @@ pub struct ManagedSurface {
     pub widget_id: WidgetId,
     /// Owner for reactive primitives created in the widget factory
     owner_id: OwnerId,
-    /// The wgpu surface state (None until GPU init)
-    pub wgpu_surface: Option<SurfaceState>,
+    /// Where this surface's frames land (None until GPU init).
+    pub wgpu_surface: Option<RenderTarget>,
     /// Previous scale factor for detecting changes
     pub previous_scale_factor: f32,
     /// Root render node (reused across frames to avoid allocation)
@@ -104,7 +104,7 @@ impl ManagedSurface {
 
         let wgpu_surface =
             gpu_context.create_surface(window_handle, physical_width, physical_height);
-        self.wgpu_surface = Some(wgpu_surface);
+        self.wgpu_surface = Some(RenderTarget::Swapchain(wgpu_surface));
         self.previous_scale_factor = scale_factor;
 
         // Perform initial layout
@@ -201,7 +201,7 @@ impl SurfaceManager {
     ///
     /// Used to create the shared `Renderer` lazily: apps may start with zero
     /// surfaces and spawn them dynamically (e.g. one bar per output).
-    pub fn first_gpu_surface(&self) -> Option<&SurfaceState> {
+    pub fn first_gpu_surface(&self) -> Option<&RenderTarget> {
         self.surfaces.values().find_map(|s| s.wgpu_surface.as_ref())
     }
 


### PR DESCRIPTION
## What changed

**Step 4 of five in #264 — this does not close it.**

`ManagedSurface` held a swapchain, so a frame had exactly one place it could go.
`Renderer` already knew better — `render_to_view` has drawn into a caller's
texture since the goldens needed one — but nothing above it could choose, so
everything from `paint_and_present` upward needed a compositor to run at all.

`RenderTarget` is the choice: a swapchain is acquired, drawn into and presented;
a texture is drawn into and kept. `render` takes the second in one line, because
`render_to_view` was already the first one's body with the acquire and the
present taken off.

**The `testing` cargo feature now exists**, off by default, which resolves half
of what step 2 left open. The texture half of `RenderTarget` and
`OffscreenTarget::read_pixel` live behind `#[cfg(any(test, feature = "testing"))]`
— a normal build should not acquire a render-to-texture API on the way to
letting a test read a pixel. In-crate tests reach it through `cfg(test)` alone;
step 5's test is outside the crate and will need the feature.

The target carries no size and no format of its own: `wgpu::Texture` knows both,
and a fact derived cannot drift from a fact stored.

## What proves it

`src/lib.rs`'s `#[cfg(test)] mod a_frame_lands_where_the_surface_points`, two
tests. **Step 4's acceptance criterion is met literally — the first time in this
series.** A pixel the application drew is read back without a compositor, and it
arrives through `render_surface`: opening the frame, resolving the geometry, the
pacing gate, layout, paint, flatten, damage and present.

Both verified by inversion. Changing the surface's background changes the byte
read. Replacing `RenderTarget::resize`'s offscreen arm with the no-op it first
was turns the second test red. Mutating the readback stride or its offset turns
the first red.

That last one only after a correction the reviewer's mutation run forced: the
first draft used a 100-pixel width written as 50, and at 50 pixels a row is 200
bytes, which pads to 256 whatever arithmetic produced it — so a broken stride
walked straight through an assertion whose comment claimed to be watching for
exactly that. At 100 the 400 bytes pad to 512 and the mutation dies.

Harness: 721 tests, 0 failures; 9 goldens on lavapipe; fmt; clippy with
`-D warnings`; and `cargo check` clean in `--no-default-features`, default,
`--features testing` and `--all-features` — the gating asymmetry is the failure
mode a new cargo feature has, and I introduced one (an ungated `pub use` of a
gated type) before finding it.

## What the review found

`/simplify` first, three findings, all mine: **a stale doc comment left stacked
above the new one** on `Renderer::render`, so the published doc claimed both
"nothing reached the screen" (untrue for a texture, which cannot fail that way)
and the new explanation — the sixth orphaned-comment defect this session;
**`OffscreenTarget` storing width and height** the texture already knows, which
is *why* `format()` had to write out `Rgba8Unorm` a third time; and **the test
hardcoding that format** where the accessor it was exercising would answer.

Its altitude pass argued `resize` declining for a texture is a trap rather than
a simplification, and it is right: `resolve_geometry` compares the target's size
to the frame's and calls `resize` when they differ, so a target that quietly
kept its own size would report a resize on every frame for ever, repaint the
whole tree each time, and defeat the incremental paint
`tests/paint_cache_across_frames.rs` exists to protect. It reallocates.

The `reviewer` subagent then read the two commits. **Two blocking findings, both
acted on:**

1. **The one decision in the change was executed by nothing.** `cargo mutants`
   on `gpu_context.rs`: `replace RenderTarget::resize with ()` — the exact
   spelling I had just rejected — survived the whole suite, along with every
   comparison in its guard. My doc comment was the only defence, and prose is
   not a sensor. Fixed with the second test, whose second assertion is the
   entire argument.
2. **The new test would never have run in CI.** The `test` job installs no
   Vulkan ICD, so `GpuContext::try_new()` returns `None`, the test prints
   "skipping" and passes; the `golden` job has lavapipe but runs
   `--test golden_images`, which excludes lib unit tests. Neither job would have
   executed a line of this change. Fixed: the golden job now also runs
   `cargo test --all-features --lib` with `GUIDO_GPU_REQUIRED=1`, so a skip
   there is a failure — the rule `GUIDO_GOLDEN_REQUIRED` already applies one
   line above.

Three worth answering. Its point that the test stepped over `open_frame`,
`resolve_geometry`, the gate and `layout_pass` is fixed by the same rewrite —
the test drives `render_surface` now. Its note that the frame reaching the
texture contains no widget output, so what is proved is the clear colour and not
that the paint pass arrived, is true and stated here. And it confirmed my
reasoning for declining a reuse suggestion: making `tests/golden_images.rs` call
`RenderTarget::offscreen` would tie an external test to the `testing` feature and
plain `cargo test` would stop compiling. It named two ways out for step 5 to
settle — a self dev-dependency, or `required-features` on the test target, the
second of which turns a missing feature into a silently skipped one.

## What was checked by hand

niri 26.04. This change alters the type every production surface holds and the
entry point every production frame goes through, and the swapchain arm has no
automated cover at all.

- **`status_bar`** — the surface appears and stays. If the `Swapchain` arm of
  the new `match` were wrong, nothing would be on screen.
- **`animation_example`** — springs reach their overshoot and settle: present
  running sixty times a second rather than once.
- **`surface_runtime`** — anchor, size and margin changed at runtime, which is
  what drives `RenderTarget::resize`'s swapchain arm, the line changed last.

All three reported fine by the maintainer.

## Left undone

**Nothing can create a headless surface through the real path**, recorded on
#264. `ManagedSurface::init_gpu` only ever builds `RenderTarget::Swapchain`, via
a call needing a real window handle; the test reaches an offscreen target by
overwriting the field after construction, bypassing `SurfaceManager`. So the
test goes through the frame path but not through initialisation, and how a
surface is *born* headless is step 5's, on top of what the issue assigned it.
That moves the boundary between 4 and 5 from where the issue drew it.

**`SurfaceHost` is still `pub(crate)` while `App::run` is `pub`** — step 2's
other inherited item. The `testing` feature is now the obvious answer, but
nothing has forced the decision.

**`.claude/skills/renderer/SKILL.md:73` is half stale** — its "Rendering
somewhere other than a screen" section says `render()` is `render_to_view` plus
acquire and present, true now only of the swapchain arm, and it does not mention
the offscreen target. Not edited here because the skill is what the next
renderer change reads and it deserves a considered pass rather than a line
patched in; **#273** files it.

**#268** and **#270** stay open. **Step 5** remains.
