### PR TITLE
An application runs with a recorder where the compositor was

### DIFF
--- a/.claude/skills/wayland/SKILL.md
+++ b/.claude/skills/wayland/SKILL.md
@@ -40,9 +40,24 @@ Multiple surfaces share one reactive state and one renderer.
 
 ## The thing to know before changing it
 
-**None of this is covered by an automated test.** There is no headless
-compositor in the harness, so protocol behaviour is verified by running an
-example on a real compositor and looking. When you change this layer:
+**Half of this is covered now, and half is not.**
+
+`tests/headless_app.rs` drives the real loop — `iterate`, the function
+`App::run` calls — with a `guido::testing::Headless` standing where the
+compositor would be: a recorder implementing `Platform` and `Surface` that
+answers for one surface and keeps what it was asked. So a surface configuring, a
+frame opening, input routing, layout, paint, and *what the surface asks the
+compositor for* all have a sensor. It needs the `testing` feature and a GPU
+adapter.
+
+What has none: what goes out on the wire, and what a compositor does with it.
+The recorder proves guido asks for an exclusive zone of 50; it cannot prove niri
+reserves 50. And it drives one static surface, so **dynamic spawn and close,
+popups, the session lock and output hotplug are still verified by running an
+example and looking** — they type-check against the same trait and nothing
+exercises them.
+
+When you change this layer:
 
 - run at least one example that exercises it (`cargo run --example status_bar`,
   `text_input_example`, and the popup and lock examples where relevant)
@@ -50,5 +65,7 @@ example on a real compositor and looking. When you change this layer:
 - `WAYLAND_DEBUG=1` prints the protocol traffic; `RUST_LOG=guido=debug` prints
   the library's own view of it
 
-Closing this hole — a headless compositor, or an event-injection harness that
-drives `ingress` directly — is the next thing worth building in the harness.
+The second of those two — an application driven with no compositor — is built,
+in `src/testing.rs`. What would close the rest is a headless compositor, which
+would answer a different question: not whether guido asks correctly, but whether
+the other end of the socket agrees.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,10 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libwayland-dev libxkbcommon-dev
       - name: Run tests
         run: cargo test --all-features
+      # Every other job builds with --all-features, so a test file that needs an
+      # optional feature and does not say so compiles there and nowhere else.
+      - name: Build the tests with the default features
+        run: cargo check --tests
 
   golden:
     name: Golden images

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,11 +115,20 @@ at lavapipe. In that job a skip is a failure.
 | API names written in *prose* — this file, the skills, `docs/`, the book, the README | `tests/documentation_references.rs` |
 | API names written in the book's *code samples* | **nothing yet.** The book teaches almost entirely through samples, and until they compile a rename is invisible there |
 | the workflow this file, `/implement` and the templates describe | `tests/agent_workflow.rs` |
-| Wayland protocol behaviour, compositor integration | **nothing automated.** Run an example and say what you saw in the pull request |
+| the application above the compositor — a surface configuring, a frame opening, input routing, what a surface asks for in return | `tests/headless_app.rs` — the real loop, with a recorder where the compositor is |
+| Wayland protocol behaviour: what actually goes out on the wire, and what a compositor does with it | **nothing automated.** Run an example and say what you saw in the pull request |
 
-That last row is the hole in the harness. It is the one place where "I ran it
-and it looked right" is still the standard, and the one place worth closing
-next.
+That last row is what is left of the hole. Until #264 it was the whole of it:
+nothing could construct an application, so everything it does with what the
+compositor says was watched by a person running an example. `Headless` closes
+that half — it drives `iterate`, the same function `App::run` drives, against a
+recorder that answers for one surface and keeps what it was asked.
+
+What it cannot close is the half below it. The recorder is not a compositor: it
+proves guido asks for an exclusive zone of 50, never that niri does the right
+thing with one. And it answers for one static surface, so dynamic spawn and
+close, popups and the session lock are still watched by a person, even though
+they type-check against the same trait.
 
 ## What watches the harness
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,8 @@ pub mod render_stats;
 pub mod session_lock;
 pub mod surface;
 mod surface_manager;
+#[cfg(feature = "testing")]
+pub mod testing;
 pub mod transform;
 pub mod tree;
 pub mod widget_ref;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,8 +226,6 @@ pub mod widget_prelude {
     pub use crate::widgets::{LayoutHints, Widget};
 }
 
-use smithay_client_toolkit::reexports::client::QueueHandle;
-
 use crate::{
     jobs::{get_exit_request, has_pending_jobs, init_wakeup, process_jobs, take_wake_request},
     tree::{DamageRegion, Tree, WidgetId},
@@ -246,10 +244,10 @@ struct SurfaceDefinition {
 /// FIRST — its wgpu `Surface<'static>` borrows the wl_surface through
 /// erased raw pointers, so the GPU surface must die before the Wayland
 /// surface it points at.
-fn close_surface_now(
+fn close_surface_now<P: Platform>(
     id: SurfaceId,
     surface_manager: &mut SurfaceManager,
-    wayland_state: &mut platform::WaylandState,
+    wayland_state: &mut P,
     tree: &mut Tree,
 ) {
     surface::mark_popup_dismissed(id);
@@ -269,14 +267,13 @@ fn close_surface_now(
 /// and log a line saying so, on every resize and every margin change.
 /// `measured` is for the one caller that knows a size the compositor has not
 /// been told about yet: the content-measure pass, which has just computed it.
-fn resync_exclusive_zone<P: SurfaceHost>(
-    id: SurfaceId,
+fn resync_exclusive_zone<S: Surface>(
+    surface: &mut S,
     config: &SurfaceConfig,
-    wayland_state: &mut P,
     measured: Option<(u32, u32)>,
 ) {
     if config.exclusive_zone == surface::ExclusiveZone::Auto {
-        publish_exclusive_zone(id, config, wayland_state, measured);
+        publish_exclusive_zone(surface, config, measured);
     }
 }
 
@@ -295,10 +292,9 @@ fn resync_exclusive_zone<P: SurfaceHost>(
 /// `Auto` reservation follows is always one we own — `follow_axis` gives up on
 /// an axis anchored to both edges, the only kind the compositor sizes — so the
 /// value we asked for is the value that will take effect.
-fn publish_exclusive_zone<P: SurfaceHost>(
-    id: SurfaceId,
+fn publish_exclusive_zone<S: Surface>(
+    surface: &mut S,
     config: &SurfaceConfig,
-    wayland_state: &mut P,
     measured: Option<(u32, u32)>,
 ) {
     // A content axis waiting to be measured has no size to reserve for, and the
@@ -320,21 +316,20 @@ fn publish_exclusive_zone<P: SurfaceHost>(
         return;
     }
 
-    let known = measured.or_else(|| wayland_state.configured_size(id));
+    let known = measured.or_else(|| surface.configured_size());
     let width = surface::requested_extent(config.width, known.map(|(w, _)| w));
     let height = surface::requested_extent(config.height, known.map(|(_, h)| h));
     let zone = config
         .exclusive_zone
         .resolve(config.anchor, config.margin, width, height);
-    wayland_state.set_surface_exclusive_zone(id, zone);
+    surface.set_exclusive_zone(zone);
 }
 
 /// Process dynamic surface commands (create, close, property changes).
 /// Returns false if all surfaces have been closed and the app should exit.
-fn process_surface_commands(
+fn process_surface_commands<P: Platform>(
     surface_manager: &mut SurfaceManager,
-    wayland_state: &mut platform::WaylandState,
-    qh: &QueueHandle<platform::WaylandState>,
+    wayland_state: &mut P,
     tree: &mut Tree,
 ) -> bool {
     for cmd in drain_surface_commands() {
@@ -347,7 +342,7 @@ fn process_surface_commands(
                 log::info!("Creating dynamic surface {:?}", id);
 
                 // Create Wayland surface
-                wayland_state.create_surface_with_id(qh, id, &config);
+                wayland_state.create_surface(id, &config);
 
                 // Create the widget inside an owner scope so that signals/effects
                 // created in the factory are properly owned.
@@ -367,37 +362,37 @@ fn process_surface_commands(
 
                 // If no surfaces left, exit
                 if surface_manager.is_empty() {
-                    wayland_state.exit = true;
+                    wayland_state.request_exit();
                     return false;
                 }
             }
             SurfaceCommand::SetLayer { id, layer } => {
-                wayland_state.set_surface_layer(id, layer);
+                with_surface(wayland_state, id, |s| s.set_layer(layer));
             }
             SurfaceCommand::SetKeyboardInteractivity { id, mode } => {
-                wayland_state.set_surface_keyboard_interactivity(id, mode);
+                with_surface(wayland_state, id, |s| s.set_keyboard_interactivity(mode));
             }
             SurfaceCommand::SetAnchor { id, anchor } => {
-                let asked = reconfigure(id, surface_manager, wayland_state, |surface, wayland| {
-                    surface.config.anchor = anchor;
-                    wayland.set_surface_anchor(id, anchor);
+                let asked = reconfigure(id, surface_manager, wayland_state, |managed, surface| {
+                    managed.config.anchor = anchor;
+                    surface.set_anchor(anchor);
                     // The size goes with it: which axes are the compositor's
                     // follows from the anchor, so a bar re-anchored to one edge
                     // has to stop asking for zero on the axis it now owns.
-                    send_size(id, surface, wayland)
+                    send_size(managed, surface)
                 });
                 if let Some((true, root)) = asked {
                     jobs::request_job(root, jobs::JobRequest::Layout);
                 }
             }
             SurfaceCommand::SetSize { id, width, height } => {
-                let asked = reconfigure(id, surface_manager, wayland_state, |surface, wayland| {
-                    surface.config.width = width;
-                    surface.config.height = height;
+                let asked = reconfigure(id, surface_manager, wayland_state, |managed, surface| {
+                    managed.config.width = width;
+                    managed.config.height = height;
                     // Here every value is one the caller just named, so anything
                     // the anchor discards is worth saying.
-                    surface::warn_size_request_on_stretched_axis(id, &surface.config);
-                    send_size(id, surface, wayland)
+                    surface::warn_size_request_on_stretched_axis(id, &managed.config);
+                    send_size(managed, surface)
                 });
                 if let Some((true, root)) = asked {
                     jobs::request_job(root, jobs::JobRequest::Layout);
@@ -411,10 +406,10 @@ fn process_surface_commands(
                 //
                 // The other policies are numbers the resync skips, so they
                 // publish here.
-                let asked = reconfigure(id, surface_manager, wayland_state, |surface, wayland| {
-                    surface.config.exclusive_zone = zone;
+                let asked = reconfigure(id, surface_manager, wayland_state, |managed, surface| {
+                    managed.config.exclusive_zone = zone;
                     if zone != surface::ExclusiveZone::Auto {
-                        publish_exclusive_zone(id, &surface.config, wayland, None);
+                        publish_exclusive_zone(surface, &managed.config, None);
                     }
                     // Like its three sisters. Declaring `Auto` on a content
                     // surface leaves the resync waiting for a measure — this arm
@@ -422,8 +417,8 @@ fn process_surface_commands(
                     // without asking for a layout the measure pass never runs on
                     // a settled UI and the reservation is never sent at all.
                     (
-                        surface::needs_content_measure(&surface.config),
-                        surface.widget_id,
+                        surface::needs_content_measure(&managed.config),
+                        managed.widget_id,
                     )
                 });
                 if let Some((true, root)) = asked {
@@ -431,9 +426,9 @@ fn process_surface_commands(
                 }
             }
             SurfaceCommand::SetMargin { id, margin } => {
-                let asked = reconfigure(id, surface_manager, wayland_state, |surface, wayland| {
-                    surface.config.margin = margin;
-                    wayland.set_surface_margin(id, margin);
+                let asked = reconfigure(id, surface_manager, wayland_state, |managed, surface| {
+                    managed.config.margin = margin;
+                    surface.set_margin(margin);
                     // Like its three sisters. An `Auto` reservation is the margin
                     // *plus* the extent, so moving the margin moves it — and on a
                     // content axis the resync declines to guess and waits for a
@@ -441,8 +436,8 @@ fn process_surface_commands(
                     // the measure pass never runs, and the reservation keeps the
                     // old margin for as long as the surface lives.
                     (
-                        surface::needs_content_measure(&surface.config),
-                        surface.widget_id,
+                        surface::needs_content_measure(&managed.config),
+                        managed.widget_id,
                     )
                 });
                 if let Some((true, root)) = asked {
@@ -450,7 +445,7 @@ fn process_surface_commands(
                 }
             }
             SurfaceCommand::SetInputRegion { id, rects } => {
-                wayland_state.set_surface_input_region(id, rects.as_deref());
+                with_surface(wayland_state, id, |s| s.set_input_region(rects.as_deref()));
             }
             SurfaceCommand::CreatePopup {
                 id,
@@ -487,13 +482,7 @@ fn process_surface_commands(
                     }
                 }
 
-                if wayland_state.create_popup_surface_with_id(
-                    qh,
-                    id,
-                    parent,
-                    &config,
-                    (config.width, height),
-                ) {
+                if wayland_state.create_popup(id, parent, &config, (config.width, height)) {
                     surface_manager.add(managed);
                 } else {
                     // Creation failed (no xdg_wm_base, parent gone): drop the
@@ -664,18 +653,15 @@ fn dispatch_events(
 /// loop's pre-block check reads that queue and would have called it a lost
 /// wakeup, which it is not: the producer woke the loop, and the loop had
 /// nowhere to put the work.
-fn sync_platform_state(
-    wayland_state: &mut platform::WaylandState,
-    qh: &QueueHandle<platform::WaylandState>,
-) {
+fn sync_platform_state<P: Platform>(wayland_state: &mut P) {
     if let Some(text) = take_clipboard_change() {
-        wayland_state.set_clipboard(text, qh);
+        wayland_state.set_clipboard(text);
     }
     if let Some(text) = reactive::take_primary_change() {
-        wayland_state.set_primary(text, qh);
+        wayland_state.set_primary(text);
     }
     if let Some(cursor) = take_cursor_change() {
-        wayland_state.set_cursor(cursor, qh);
+        wayland_state.set_cursor(cursor);
     }
 }
 
@@ -754,36 +740,28 @@ fn paced_out(frame: &Frame, geometry: &Geometry) -> bool {
         && !geometry.scale_changed
 }
 
-/// What a frame asks of whatever is showing it.
+/// What the frame path asks of whatever is showing one surface.
 ///
-/// Every request the per-frame path makes of a compositor. The seat and the
-/// session lock are not here, and a later step decides whether they join.
+/// Every request a frame makes of a compositor, and nothing that is not about
+/// this surface: no id parameter, because a handle already knows which one it
+/// is. `supports_blur_region` is the one that is not here — a capability
+/// belongs to the connection, not to a window — and it lives on [`Platform`].
 ///
-/// Not *only* the frame path, though it is close: `configured_size` is here for
-/// `send_size`, which belongs to the surface-command path, because both paths
-/// share `publish_exclusive_zone` and a generic caller cannot reach an inherent
-/// method. That leak goes when the surface-command path follows.
-///
-/// `WaylandState` is one implementation. The reason this is a trait and not
-/// that type is that a second one — a recorder, keeping what it was asked
-/// instead of asking — is the only way a test can watch this layer at all,
-/// which is what #264 is about.
-///
-/// **One required method.** `open_frame` has no default because a host that
-/// cannot say what a frame is has nothing to host; every other request defaults
-/// to doing nothing and knowing nothing, which is the honest answer for a host
-/// that does not have that protocol. So the second implementation writes down
+/// One required method. `open_frame` has no default because a surface that
+/// cannot say what a frame is has nothing to show; every other request defaults
+/// to doing nothing and knowing nothing, which is the honest answer for a surface
+/// that does not have that protocol. So a second implementation writes down
 /// what it wants to watch and stays silent about the rest.
 ///
-/// What that cannot catch is a method added here and forgotten in
-/// `WaylandState`: it would silently do nothing against a real compositor
-/// rather than fail to build. The defaults are for a host that *cannot* do the
-/// thing, never for one that merely has not been taught to.
-pub(crate) trait SurfaceHost {
+/// What that cannot catch is a method added here and forgotten in the Wayland
+/// implementation: it would silently do nothing against a real compositor
+/// rather than fail to build. The defaults are for a surface that *cannot* do
+/// the thing, never for one that has not been taught to.
+pub(crate) trait Surface {
     /// The facts a frame is built from, or `None` if this surface has no size
     /// to draw at yet. Takes the queued input with it, so calling it twice for
     /// one frame loses events.
-    fn open_frame(&mut self, id: SurfaceId) -> Option<Frame>;
+    fn open_frame(&mut self) -> Option<Frame>;
 
     /// The size the compositor has confirmed, if it has confirmed one.
     ///
@@ -792,82 +770,233 @@ pub(crate) trait SurfaceHost {
     /// reading it unconditionally would report a number nobody agreed on as
     /// though it were live, and make `requested_extent`'s "no size yet" branch
     /// unreachable while the case it describes was still happening.
-    fn configured_size(&self, id: SurfaceId) -> Option<(u32, u32)> {
-        let _ = id;
+    fn configured_size(&self) -> Option<(u32, u32)> {
+        None
+    }
+
+    /// The scale the compositor confirmed for this surface, if it has.
+    fn scale_factor(&self) -> Option<f32> {
         None
     }
 
     /// The width an auto-width popup should be measured against.
-    fn popup_auto_width(&self, id: SurfaceId) -> Option<u32> {
-        let _ = id;
+    fn popup_auto_width(&self) -> Option<u32> {
         None
     }
 
     /// Tell the compositor an auto-height popup's content changed height.
-    fn reposition_popup_if_changed(&mut self, id: SurfaceId, new_height: u32) {
-        let _ = (id, new_height);
+    fn reposition_popup_if_changed(&mut self, new_height: u32) {
+        let _ = new_height;
     }
 
     /// Ask for a size. A request: the answer arrives as a configure.
-    fn set_surface_size(&mut self, id: SurfaceId, width: u32, height: u32) {
-        let _ = (id, width, height);
+    fn set_size(&mut self, width: u32, height: u32) {
+        let _ = (width, height);
     }
 
     /// Publish the screen space this surface reserves.
-    fn set_surface_exclusive_zone(&mut self, id: SurfaceId, zone: i32) {
-        let _ = (id, zone);
+    fn set_exclusive_zone(&mut self, zone: i32) {
+        let _ = zone;
     }
 
     /// Run `f` and let its requests reach the compositor as one commit, so a
     /// group of them never shows an intermediate surface on the way.
-    fn batch_layer_requests<F: FnOnce(&mut Self)>(&mut self, id: SurfaceId, f: F) {
-        let _ = id;
+    fn batch_layer_requests<F: FnOnce(&mut Self)>(&mut self, f: F) {
         f(self);
     }
 
-    /// Whether backdrop blur regions can be published at all.
-    fn supports_blur_region(&self) -> bool {
-        false
-    }
-
-    /// Whether this surface has a region published that would have to be
+    /// Whether this surface has a blur region published that would have to be
     /// withdrawn.
-    fn has_published_blur(&self, id: SurfaceId) -> bool {
-        let _ = id;
+    fn has_published_blur(&self) -> bool {
         false
     }
 
     /// Whether the last published region was dropped and owes republishing.
-    fn take_blur_resync(&mut self, id: SurfaceId) -> bool {
-        let _ = id;
+    fn take_blur_resync(&mut self) -> bool {
         false
     }
 
     /// Publish the region to blur behind this surface.
-    fn sync_blur_region(&mut self, id: SurfaceId, rects: Vec<blur::BlurRect>, commit: bool) {
-        let _ = (id, rects, commit);
+    fn sync_blur_region(&mut self, rects: Vec<blur::BlurRect>, commit: bool) {
+        let _ = (rects, commit);
     }
 
     /// Ask to be told when this surface's last frame has been shown.
-    fn request_frame_callback(&mut self, id: SurfaceId) {
-        let _ = id;
-    }
+    fn request_frame_callback(&mut self) {}
 
     /// Report damaged buffer pixels, in buffer coordinates. Why it has to
     /// happen before presenting is on the implementation.
-    fn damage_surface(&mut self, id: SurfaceId, x: i32, y: i32, width: i32, height: i32) {
-        let _ = (id, x, y, width, height);
+    fn damage(&mut self, x: i32, y: i32, width: i32, height: i32) {
+        let _ = (x, y, width, height);
     }
 
     /// Record that the callback asked for is now committed.
-    fn mark_frame_callback_pending(&mut self, id: SurfaceId) {
-        let _ = id;
+    fn mark_frame_callback_pending(&mut self) {}
+
+    /// Move this surface between the compositor's layers.
+    fn set_layer(&mut self, layer: platform::Layer) {
+        let _ = layer;
+    }
+
+    /// Re-anchor it, which also decides which axes the compositor owns.
+    fn set_anchor(&mut self, anchor: platform::Anchor) {
+        let _ = anchor;
+    }
+
+    /// Hold it off the edges it is anchored to.
+    fn set_margin(&mut self, margin: surface::Margin) {
+        let _ = margin;
+    }
+
+    /// Restrict where input reaches it. `None` is the whole surface.
+    fn set_input_region(&mut self, rects: Option<&[widgets::Rect]>) {
+        let _ = rects;
+    }
+
+    /// How much of the keyboard this surface wants.
+    fn set_keyboard_interactivity(&mut self, mode: platform::KeyboardInteractivity) {
+        let _ = mode;
     }
 }
 
-impl SurfaceHost for platform::WaylandState {
-    fn open_frame(&mut self, id: SurfaceId) -> Option<Frame> {
-        let surface = self.get_surface_mut(id)?;
+/// Whatever the application is running on.
+///
+/// The thin half: it hands out surfaces and answers for the things that belong
+/// to the connection rather than to any one window. `WaylandState` is one
+/// implementation; a recorder that keeps what it was asked is the other.
+pub(crate) trait Platform {
+    /// One surface, borrowed for as long as the caller needs it.
+    ///
+    /// A handle rather than an id on every method, because a Wayland surface is
+    /// its own state *and* the connection's — `sync_blur_region` needs the
+    /// effect manager, `set_size` needs the layer surface — so what a caller
+    /// holds has to be able to reach both.
+    type Surface<'a>: Surface
+    where
+        Self: 'a;
+
+    fn surface(&mut self, id: SurfaceId) -> Option<Self::Surface<'_>>;
+
+    /// Whether backdrop blur regions can be published at all. A capability of
+    /// the connection, which is why it is here and not on a surface.
+    fn supports_blur_region(&self) -> bool {
+        false
+    }
+
+    /// Bring a surface into being. It has no size until a configure arrives.
+    fn create_surface(&mut self, id: SurfaceId, config: &SurfaceConfig) {
+        let _ = (id, config);
+    }
+
+    /// Bring a popup into being, anchored to another surface. `false` where
+    /// popups are unavailable or the parent cannot host one.
+    fn create_popup(
+        &mut self,
+        id: SurfaceId,
+        parent: SurfaceId,
+        config: &surface::PopupConfig,
+        size: (u32, u32),
+    ) -> bool {
+        let _ = (id, parent, config, size);
+        false
+    }
+
+    /// Take a surface away.
+    fn destroy_surface(&mut self, id: SurfaceId) {
+        let _ = id;
+    }
+
+    /// Popups holding a grab that a new one under `parent` would conflict with,
+    /// which have to be dismissed before it opens.
+    fn conflicting_grab_popups(&self, parent: SurfaceId) -> Vec<SurfaceId> {
+        let _ = parent;
+        Vec::new()
+    }
+
+    /// A popup's descendants, deepest first — the order they must close in.
+    fn popup_descendants_bottom_up(&self, root: SurfaceId) -> Vec<SurfaceId> {
+        let _ = root;
+        Vec::new()
+    }
+
+    /// Ask to lock the session. `false` where the protocol is unavailable.
+    fn start_session_lock(&mut self) -> bool {
+        false
+    }
+
+    /// Give one output its lock surface. `false` without an active lock.
+    fn create_lock_surface(&mut self, id: SurfaceId, output: outputs::OutputId) -> bool {
+        let _ = (id, output);
+        false
+    }
+
+    /// What the lock has said since this was last asked.
+    fn take_lock_events(&mut self) -> Vec<platform::LockEvent> {
+        Vec::new()
+    }
+
+    /// Release the session.
+    fn unlock_session(&mut self) {}
+
+    /// Whether the platform has asked the application to stop — the compositor
+    /// went away, or the connection died.
+    fn should_exit(&self) -> bool {
+        false
+    }
+
+    /// Ask it to stop: the last surface closed, so there is nothing to show.
+    fn request_exit(&mut self) {}
+
+    /// Hand the seat what the widgets changed this iteration.
+    fn set_clipboard(&mut self, text: String) {
+        let _ = text;
+    }
+
+    fn set_primary(&mut self, text: String) {
+        let _ = text;
+    }
+
+    fn set_cursor(&self, cursor: reactive::CursorIcon) {
+        let _ = cursor;
+    }
+
+    /// Send everything this iteration queued. `false` means the connection is
+    /// gone and the application is over.
+    fn flush(&self) -> bool {
+        true
+    }
+
+    /// Where this surface's frames should land, once it has a size.
+    ///
+    /// The one place the two implementations genuinely differ rather than one
+    /// recording what the other sends: a compositor hands out a swapchain tied
+    /// to a real window, and a driver with no compositor allocates a texture.
+    /// `None` where the surface is not ready to be given one.
+    fn create_render_target(
+        &self,
+        id: SurfaceId,
+        gpu: &renderer::GpuContext,
+        size: (u32, u32),
+    ) -> Option<renderer::RenderTarget> {
+        let _ = (id, gpu, size);
+        None
+    }
+}
+
+/// One Wayland surface, and the connection it needs to speak.
+///
+/// A pair rather than a borrow of `WaylandSurfaceState`, because half of what a
+/// surface does reaches past itself: the blur region wants the effect manager,
+/// a layer request wants the layer surface *and* the queue. Both live on the
+/// state, so the handle carries the state and the name of one surface in it.
+pub(crate) struct WaylandSurface<'a> {
+    state: &'a mut platform::WaylandState,
+    id: SurfaceId,
+}
+
+impl Surface for WaylandSurface<'_> {
+    fn open_frame(&mut self) -> Option<Frame> {
+        let surface = self.state.get_surface_mut(self.id)?;
         if !surface.configured {
             return None;
         }
@@ -888,58 +1017,181 @@ impl SurfaceHost for platform::WaylandState {
         })
     }
 
-    fn configured_size(&self, id: SurfaceId) -> Option<(u32, u32)> {
-        self.get_surface(id)
+    fn configured_size(&self) -> Option<(u32, u32)> {
+        self.state
+            .get_surface(self.id)
             .filter(|s| s.configured)
             .map(|s| (s.width, s.height))
     }
 
-    fn popup_auto_width(&self, id: SurfaceId) -> Option<u32> {
-        self.popup_auto_width(id)
+    fn scale_factor(&self) -> Option<f32> {
+        Some(self.state.get_surface(self.id)?.scale_factor)
     }
 
-    fn reposition_popup_if_changed(&mut self, id: SurfaceId, new_height: u32) {
-        self.reposition_popup_if_changed(id, new_height)
+    fn popup_auto_width(&self) -> Option<u32> {
+        self.state.popup_auto_width(self.id)
     }
 
-    fn set_surface_size(&mut self, id: SurfaceId, width: u32, height: u32) {
-        self.set_surface_size(id, width, height)
+    fn reposition_popup_if_changed(&mut self, new_height: u32) {
+        self.state.reposition_popup_if_changed(self.id, new_height)
     }
 
-    fn set_surface_exclusive_zone(&mut self, id: SurfaceId, zone: i32) {
-        self.set_surface_exclusive_zone(id, zone)
+    fn set_size(&mut self, width: u32, height: u32) {
+        self.state.set_surface_size(self.id, width, height)
     }
 
-    fn batch_layer_requests<F: FnOnce(&mut Self)>(&mut self, id: SurfaceId, f: F) {
-        self.batch_layer_requests(id, f)
+    fn set_exclusive_zone(&mut self, zone: i32) {
+        self.state.set_surface_exclusive_zone(self.id, zone)
+    }
+
+    fn batch_layer_requests<F: FnOnce(&mut Self)>(&mut self, f: F) {
+        let id = self.id;
+        // The batching is the state's — one commit for the group — and what the
+        // closure is handed back is this surface, so nothing inside it can
+        // reach another one.
+        let batch = self.state.open_layer_batch(id);
+        f(self);
+        self.state.close_layer_batch(batch);
+    }
+
+    fn has_published_blur(&self) -> bool {
+        self.state.has_published_blur(self.id)
+    }
+
+    fn take_blur_resync(&mut self) -> bool {
+        self.state.take_blur_resync(self.id)
+    }
+
+    fn sync_blur_region(&mut self, rects: Vec<blur::BlurRect>, commit: bool) {
+        self.state.sync_blur_region(self.id, rects, commit)
+    }
+
+    fn request_frame_callback(&mut self) {
+        self.state.request_frame_callback(self.id)
+    }
+
+    fn damage(&mut self, x: i32, y: i32, width: i32, height: i32) {
+        self.state.damage_surface(self.id, x, y, width, height)
+    }
+
+    fn mark_frame_callback_pending(&mut self) {
+        self.state.mark_frame_callback_pending(self.id)
+    }
+
+    fn set_layer(&mut self, layer: platform::Layer) {
+        self.state.set_surface_layer(self.id, layer)
+    }
+
+    fn set_anchor(&mut self, anchor: platform::Anchor) {
+        self.state.set_surface_anchor(self.id, anchor)
+    }
+
+    fn set_margin(&mut self, margin: surface::Margin) {
+        self.state.set_surface_margin(self.id, margin)
+    }
+
+    fn set_input_region(&mut self, rects: Option<&[widgets::Rect]>) {
+        self.state.set_surface_input_region(self.id, rects)
+    }
+
+    fn set_keyboard_interactivity(&mut self, mode: platform::KeyboardInteractivity) {
+        self.state.set_surface_keyboard_interactivity(self.id, mode)
+    }
+}
+
+impl Platform for platform::WaylandState {
+    type Surface<'a> = WaylandSurface<'a>;
+
+    fn surface(&mut self, id: SurfaceId) -> Option<WaylandSurface<'_>> {
+        self.get_surface(id)?;
+        Some(WaylandSurface { state: self, id })
     }
 
     fn supports_blur_region(&self) -> bool {
         self.supports_blur_region()
     }
 
-    fn has_published_blur(&self, id: SurfaceId) -> bool {
-        self.has_published_blur(id)
+    fn create_surface(&mut self, id: SurfaceId, config: &SurfaceConfig) {
+        self.create_surface_with_id(id, config)
     }
 
-    fn take_blur_resync(&mut self, id: SurfaceId) -> bool {
-        self.take_blur_resync(id)
+    fn create_popup(
+        &mut self,
+        id: SurfaceId,
+        parent: SurfaceId,
+        config: &surface::PopupConfig,
+        size: (u32, u32),
+    ) -> bool {
+        self.create_popup_surface_with_id(id, parent, config, size)
     }
 
-    fn sync_blur_region(&mut self, id: SurfaceId, rects: Vec<blur::BlurRect>, commit: bool) {
-        self.sync_blur_region(id, rects, commit)
+    fn destroy_surface(&mut self, id: SurfaceId) {
+        self.destroy_surface(id)
     }
 
-    fn request_frame_callback(&mut self, id: SurfaceId) {
-        self.request_frame_callback(id)
+    fn conflicting_grab_popups(&self, parent: SurfaceId) -> Vec<SurfaceId> {
+        self.conflicting_grab_popups(parent)
     }
 
-    fn damage_surface(&mut self, id: SurfaceId, x: i32, y: i32, width: i32, height: i32) {
-        self.damage_surface(id, x, y, width, height)
+    fn popup_descendants_bottom_up(&self, root: SurfaceId) -> Vec<SurfaceId> {
+        self.popup_descendants_bottom_up(root)
     }
 
-    fn mark_frame_callback_pending(&mut self, id: SurfaceId) {
-        self.mark_frame_callback_pending(id)
+    fn start_session_lock(&mut self) -> bool {
+        self.start_session_lock()
+    }
+
+    fn create_lock_surface(&mut self, id: SurfaceId, output: outputs::OutputId) -> bool {
+        self.create_lock_surface_with_id(id, output)
+    }
+
+    fn take_lock_events(&mut self) -> Vec<platform::LockEvent> {
+        self.take_lock_events()
+    }
+
+    fn unlock_session(&mut self) {
+        self.unlock_session()
+    }
+
+    fn should_exit(&self) -> bool {
+        self.exit
+    }
+
+    fn request_exit(&mut self) {
+        self.exit = true;
+    }
+
+    fn set_clipboard(&mut self, text: String) {
+        self.set_clipboard(text)
+    }
+
+    fn set_primary(&mut self, text: String) {
+        self.set_primary(text)
+    }
+
+    fn set_cursor(&self, cursor: reactive::CursorIcon) {
+        self.set_cursor(cursor)
+    }
+
+    fn flush(&self) -> bool {
+        if let Err(e) = self.connection.flush() {
+            log::error!("Wayland connection flush failed: {e}");
+            return false;
+        }
+        true
+    }
+
+    fn create_render_target(
+        &self,
+        id: SurfaceId,
+        gpu: &renderer::GpuContext,
+        size: (u32, u32),
+    ) -> Option<renderer::RenderTarget> {
+        let wl_surface = &self.get_surface(id)?.wl_surface;
+        let window = platform::WaylandWindowWrapper::new(&self.connection, wl_surface);
+        Some(renderer::RenderTarget::Swapchain(
+            gpu.create_surface(window, size.0, size.1),
+        ))
     }
 }
 
@@ -954,10 +1206,10 @@ struct Geometry {
 /// Read the surface's state and take its queued input, or give up on this
 /// frame: an unconfigured surface has no size to render at, and one whose GPU
 /// state has not been built yet gets it on the next iteration.
-fn open_frame<P: SurfaceHost>(ctx: &mut FrameContext<P>) -> Option<Frame> {
+fn open_frame<P: Platform>(ctx: &mut FrameContext<P>) -> Option<Frame> {
     // The host answers for the compositor; the GPU readiness is ours, and a
     // surface still building its swapchain has nowhere to draw.
-    let frame = ctx.wayland_state.open_frame(ctx.id)?;
+    let frame = ctx.wayland_state.surface(ctx.id)?.open_frame()?;
     ctx.surface.is_gpu_ready().then_some(frame)
 }
 
@@ -966,7 +1218,7 @@ fn open_frame<P: SurfaceHost>(ctx: &mut FrameContext<P>) -> Option<Frame> {
 /// Runs after input rather than with the rest of the snapshot: dispatching
 /// events cannot change the surface size, but resizing the swapchain before
 /// the widgets have been told anything would reorder the frame for no gain.
-fn resolve_geometry<P: SurfaceHost>(ctx: &mut FrameContext<P>, frame: &Frame) -> Geometry {
+fn resolve_geometry<P: Platform>(ctx: &mut FrameContext<P>, frame: &Frame) -> Geometry {
     let id = ctx.id;
     let surface = &mut *ctx.surface;
     let scale = frame.scale_factor as u32;
@@ -1014,7 +1266,7 @@ fn resolve_geometry<P: SurfaceHost>(ctx: &mut FrameContext<P>, frame: &Frame) ->
 /// themselves re-run, from their relayout boundaries. A full layout from the
 /// root happens only on a resize, because that is the one change no widget
 /// can have noticed on its own.
-fn layout_pass<P: SurfaceHost>(
+fn layout_pass<P: Platform>(
     ctx: &mut FrameContext<P>,
     frame: &Frame,
     geometry: &Geometry,
@@ -1069,12 +1321,16 @@ fn layout_pass<P: SurfaceHost>(
     // compositor to reposition if it changed (submenus expanding, lists
     // growing). The measure pass runs under different constraints, so
     // the real layout is restored right after.
-    if has_pending_layouts && let Some(popup_width) = wayland_state.popup_auto_width(id) {
+    if has_pending_layouts
+        && let Some(popup_width) = wayland_state.surface(id).and_then(|s| s.popup_auto_width())
+    {
         let natural = measure_popup_height(tree, surface.widget_id, popup_width, id);
         tree.with_widget_mut(surface.widget_id, |widget, wid, tree| {
             widget.layout(tree, wid, constraints);
         });
-        wayland_state.reposition_popup_if_changed(id, natural);
+        with_surface(wayland_state, id, |s| {
+            s.reposition_popup_if_changed(natural)
+        });
     } else if (has_pending_layouts || frame.force_render_surface)
         && surface::needs_content_measure(&surface.config)
     {
@@ -1116,21 +1372,23 @@ fn layout_pass<P: SurfaceHost>(
             // frame show the compositor the new size against the old reservation
             // in between.
             let config = &surface.config;
-            wayland_state.batch_layer_requests(id, |wayland| {
-                if resizing {
-                    // Through the same rule as every other resize: a measured
-                    // number on an axis the compositor owns hands back an axis
-                    // that is not ours, and a full-width bar would then stay at
-                    // whatever the screen was when it was measured.
-                    let (ask_w, ask_h) = asking;
-                    wayland.set_surface_size(id, ask_w, ask_h);
-                }
-                // An `Auto` reservation follows an automatic resize too, and this
-                // is the one caller that knows the measured size before the
-                // compositor does — so it passes it rather than letting the
-                // helper look it up.
-                resync_exclusive_zone(id, config, wayland, Some((nw, nh)));
-            });
+            if let Some(mut handle) = wayland_state.surface(id) {
+                handle.batch_layer_requests(|surface| {
+                    if resizing {
+                        // Through the same rule as every other resize: a measured
+                        // number on an axis the compositor owns hands back an axis
+                        // that is not ours, and a full-width bar would then stay at
+                        // whatever the screen was when it was measured.
+                        let (ask_w, ask_h) = asking;
+                        surface.set_size(ask_w, ask_h);
+                    }
+                    // An `Auto` reservation follows an automatic resize too, and this
+                    // is the one caller that knows the measured size before the
+                    // compositor does — so it passes it rather than letting the
+                    // helper look it up.
+                    resync_exclusive_zone(surface, config, Some((nw, nh)));
+                });
+            }
         }
     }
 
@@ -1176,15 +1434,11 @@ fn layout_pass<P: SurfaceHost>(
 /// the noise
 /// [`warn_content_on_stretched_axis`](surface::warn_content_on_stretched_axis)
 /// was split off to avoid. The caller that was handed a size says so.
-fn send_size(
-    id: SurfaceId,
-    surface: &ManagedSurface,
-    wayland_state: &mut platform::WaylandState,
-) -> (bool, WidgetId) {
-    let live = wayland_state.configured_size(id);
-    let (ask_w, ask_h, needs_measure) = surface::resize_request(&surface.config, live);
-    wayland_state.set_surface_size(id, ask_w, ask_h);
-    (needs_measure, surface.widget_id)
+fn send_size<S: Surface>(managed: &ManagedSurface, surface: &mut S) -> (bool, WidgetId) {
+    let live = surface.configured_size();
+    let (ask_w, ask_h, needs_measure) = surface::resize_request(&managed.config, live);
+    surface.set_size(ask_w, ask_h);
+    (needs_measure, managed.widget_id)
 }
 
 /// Apply a change to a surface, then re-publish what follows from it.
@@ -1197,20 +1451,21 @@ fn send_size(
 ///
 /// The change records on the config *and* sends the protocol request, because
 /// the two must not drift: the content-sizing pass reads the config every frame.
-fn reconfigure<R>(
+fn reconfigure<P: Platform, R>(
     id: SurfaceId,
     surface_manager: &mut SurfaceManager,
-    wayland_state: &mut platform::WaylandState,
-    change: impl FnOnce(&mut ManagedSurface, &mut platform::WaylandState) -> R,
+    platform: &mut P,
+    change: impl FnOnce(&mut ManagedSurface, &mut P::Surface<'_>) -> R,
 ) -> Option<R> {
-    let surface = surface_manager.get_mut(id)?;
+    let managed = surface_manager.get_mut(id)?;
+    let mut handle = platform.surface(id)?;
     let mut result = None;
     // One commit for the group. A re-anchoring sends the anchor, the size and
     // the reservation, and each request committing on its own would show the
     // compositor two intermediate surfaces on the way.
-    wayland_state.batch_layer_requests(id, |wayland| {
-        result = Some(change(surface, wayland));
-        resync_exclusive_zone(id, &surface.config, wayland, None);
+    handle.batch_layer_requests(|surface| {
+        result = Some(change(managed, surface));
+        resync_exclusive_zone(surface, &managed.config, None);
     });
     result
 }
@@ -1221,11 +1476,7 @@ fn reconfigure<R>(
 /// are both requested BEFORE presenting, because presenting is what commits
 /// the surface. Anything set afterwards would ride an empty second commit
 /// the compositor cannot use.
-fn paint_and_present<P: SurfaceHost>(
-    ctx: &mut FrameContext<P>,
-    frame: &Frame,
-    geometry: &Geometry,
-) {
+fn paint_and_present<P: Platform>(ctx: &mut FrameContext<P>, frame: &Frame, geometry: &Geometry) {
     let id = ctx.id;
     let surface = &mut *ctx.surface;
     let wayland_state = &mut *ctx.wayland_state;
@@ -1246,9 +1497,11 @@ fn paint_and_present<P: SurfaceHost>(
         // to arrive at the region it published already. The one thing that can
         // change while nothing paints is the compositor's blur capability, which
         // drops its regions, and that says so.
-        if wayland_state.take_blur_resync(id) {
+        if let Some(mut handle) = wayland_state.surface(id)
+            && handle.take_blur_resync()
+        {
             let blur_rects = blur::regions_from_commands(&surface.flattened_commands);
-            wayland_state.sync_blur_region(id, blur_rects, true);
+            handle.sync_blur_region(blur_rects, true);
         }
         render_stats::record_frame_skipped();
         render_stats::end_frame(&DamageRegion::None);
@@ -1291,48 +1544,52 @@ fn paint_and_present<P: SurfaceHost>(
     // frame that has to be walked without carrying one is the frame that stops:
     // it owes the compositor the empty region that withdraws the last one.
     if wayland_state.supports_blur_region()
-        && (compositor_blur || wayland_state.has_published_blur(id))
+        && let Some(mut handle) = wayland_state.surface(id)
+        && (compositor_blur || handle.has_published_blur())
     {
         let blur_rects = blur::regions_from_commands(&surface.flattened_commands);
-        wayland_state.sync_blur_region(id, blur_rects, false);
+        handle.sync_blur_region(blur_rects, false);
     }
 
     // Here, above `present`, because both of these have to ride its commit —
     // why is on the two methods. Previously the callback was requested exactly
     // once at startup and never again, and the only pacing was the event loop
     // blocking inside the Fifo swapchain.
-    wayland_state.request_frame_callback(id);
+    with_surface(wayland_state, id, |s| s.request_frame_callback());
 
     let damage = tree.take_damage(surface.widget_id);
     match damage {
         DamageRegion::None => {
             // Shouldn't happen since we're rendering, but report full damage to be safe
-            wayland_state.damage_surface(
-                id,
-                0,
-                0,
-                geometry.physical_width as i32,
-                geometry.physical_height as i32,
-            );
+            with_surface(wayland_state, id, |s| {
+                s.damage(
+                    0,
+                    0,
+                    geometry.physical_width as i32,
+                    geometry.physical_height as i32,
+                )
+            });
         }
         DamageRegion::Partial(rect) => {
             let scale = frame.scale_factor;
-            wayland_state.damage_surface(
-                id,
-                (rect.x * scale) as i32,
-                (rect.y * scale) as i32,
-                (rect.width * scale).ceil() as i32,
-                (rect.height * scale).ceil() as i32,
-            );
+            with_surface(wayland_state, id, |s| {
+                s.damage(
+                    (rect.x * scale) as i32,
+                    (rect.y * scale) as i32,
+                    (rect.width * scale).ceil() as i32,
+                    (rect.height * scale).ceil() as i32,
+                )
+            });
         }
         DamageRegion::Full => {
-            wayland_state.damage_surface(
-                id,
-                0,
-                0,
-                geometry.physical_width as i32,
-                geometry.physical_height as i32,
-            );
+            with_surface(wayland_state, id, |s| {
+                s.damage(
+                    0,
+                    0,
+                    geometry.physical_width as i32,
+                    geometry.physical_height as i32,
+                )
+            });
         }
     }
 
@@ -1371,7 +1628,7 @@ fn paint_and_present<P: SurfaceHost>(
     render_stats::record_frame_painted();
     render_stats::end_frame(&damage);
 
-    wayland_state.mark_frame_callback_pending(id);
+    with_surface(wayland_state, id, |s| s.mark_frame_callback_pending());
 }
 
 /// The borrows a frame needs from start to finish, in one place.
@@ -1380,7 +1637,7 @@ fn paint_and_present<P: SurfaceHost>(
 /// and it spares every phase below the parameter list that had already grown
 /// past what anyone reads. Each phase reborrows what it uses, so its body
 /// reads as if it still owned the arguments.
-struct FrameContext<'a, P: SurfaceHost> {
+struct FrameContext<'a, P: Platform> {
     id: SurfaceId,
     surface: &'a mut surface_manager::ManagedSurface,
     wayland_state: &'a mut P,
@@ -1428,8 +1685,19 @@ fn wait_for(pending: &Pending, now: std::time::Instant) -> Option<std::time::Dur
         .map(|deadline| deadline.saturating_duration_since(now))
 }
 
+/// Ask one surface for something, if it is still there.
+///
+/// Nine call sites want exactly this, and none has anything to say about a
+/// surface that vanished between the frame opening and the request being made —
+/// so the lookup is here rather than spelled out at each of them.
+fn with_surface<P: Platform>(platform: &mut P, id: SurfaceId, f: impl FnOnce(&mut P::Surface<'_>)) {
+    if let Some(mut surface) = platform.surface(id) {
+        f(&mut surface);
+    }
+}
+
 /// One surface, one frame, in the order the phases have to run.
-fn render_surface<P: SurfaceHost>(
+fn render_surface<P: Platform>(
     ctx: &mut FrameContext<P>,
     layout_roots: &mut Vec<WidgetId>,
     woken: bool,
@@ -1654,7 +1922,7 @@ impl App {
             );
         }
 
-        let (connection, mut event_queue, mut wayland_state, qh) =
+        let (connection, mut event_queue, mut wayland_state) =
             match create_wayland_app(loop_handle.clone()) {
                 Ok(app) => app,
                 Err(e) => {
@@ -1665,18 +1933,18 @@ impl App {
 
         // Create surfaces from add_surface() calls
         for def in &self.surface_definitions {
-            wayland_state.create_surface_with_id(&qh, def.id, &def.config);
+            wayland_state.create_surface_with_id(def.id, &def.config);
         }
 
         // Wait for all surfaces to configure
-        while !wayland_state.all_surfaces_configured() && !wayland_state.exit {
+        while !wayland_state.all_surfaces_configured() && !wayland_state.should_exit() {
             if let Err(e) = event_queue.blocking_dispatch(&mut wayland_state) {
                 log::error!("Wayland dispatch failed during configure: {e}");
                 return ExitReason::Error(platform::PlatformError::ConnectionLost);
             }
         }
 
-        if wayland_state.exit {
+        if wayland_state.should_exit() {
             return ExitReason::Quit;
         }
 
@@ -1702,8 +1970,7 @@ impl App {
             // Initialize GPU surface
             managed.init_gpu(
                 &gpu_context,
-                &connection,
-                &wayland_surface.wl_surface,
+                &wayland_state,
                 wayland_surface.width,
                 wayland_surface.height,
                 wayland_surface.scale_factor,
@@ -1751,8 +2018,6 @@ impl App {
             }
 
             let ctx = LoopContext {
-                connection: &connection,
-                qh: &qh,
                 wayland_state: &mut wayland_state,
                 surface_manager: &mut surface_manager,
                 gpu_context: &gpu_context,
@@ -1766,10 +2031,8 @@ impl App {
 }
 
 /// Every handle one iteration needs, in one place.
-struct LoopContext<'a> {
-    connection: &'a smithay_client_toolkit::reexports::client::Connection,
-    qh: &'a QueueHandle<platform::WaylandState>,
-    wayland_state: &'a mut platform::WaylandState,
+struct LoopContext<'a, P: Platform> {
+    wayland_state: &'a mut P,
     surface_manager: &'a mut SurfaceManager,
     gpu_context: &'a GpuContext,
     renderer: &'a mut Option<Renderer>,
@@ -1789,15 +2052,13 @@ struct LoopContext<'a> {
 /// one — the whole of `Renderer::new`.
 ///
 /// `Some` ends the loop with that reason.
-fn iterate(
-    ctx: LoopContext<'_>,
+fn iterate<P: Platform>(
+    ctx: LoopContext<'_, P>,
     tree: &mut Tree,
     layout_roots: &mut rustc_hash::FxHashMap<WidgetId, Vec<WidgetId>>,
     frame_at: Option<std::time::Instant>,
 ) -> Option<ExitReason> {
     let LoopContext {
-        connection,
-        qh,
         gpu_context,
         wayland_state,
         surface_manager,
@@ -1815,25 +2076,25 @@ fn iterate(
         jobs::ExitRequest::Running => {}
     }
 
-    if wayland_state.exit {
+    if wayland_state.should_exit() {
         return Some(ExitReason::Quit);
     }
 
     // Drive the session-lock state machine (lock/unlock requests,
     // grant/denial events, per-output lock surfaces)
-    session_lock::process_session_lock(surface_manager, wayland_state, qh, tree);
+    session_lock::process_session_lock(surface_manager, wayland_state, tree);
 
     // Run deferred owner disposals (public dispose_owner). Safe
     // here: no user closure is on the stack.
     reactive::owner::flush_pending_disposals();
 
     // Process dynamic surface commands
-    if !process_surface_commands(surface_manager, wayland_state, qh, tree) {
+    if !process_surface_commands(surface_manager, wayland_state, tree) {
         return Some(ExitReason::Quit);
     }
 
     // Initialize GPU for any pending surfaces (newly created dynamic surfaces)
-    surface_manager.init_pending_gpu(gpu_context, connection, wayland_state, tree);
+    surface_manager.init_pending_gpu(gpu_context, wayland_state, tree);
 
     // Lazily create the shared renderer once the first surface has a
     // GPU state (apps may start with zero surfaces and spawn them
@@ -1909,11 +2170,10 @@ fn iterate(
     // pass, so a copy or a cursor set by this iteration's event
     // handling still goes out in this iteration, and outside it, so
     // it goes out whether or not any surface had a frame to draw.
-    sync_platform_state(wayland_state, qh);
+    sync_platform_state(wayland_state);
 
-    // Flush the connection once for all surfaces
-    if let Err(e) = connection.flush() {
-        log::error!("Wayland connection flush failed: {e}");
+    // Everything this iteration queued goes out at once.
+    if !wayland_state.flush() {
         return Some(ExitReason::Error(platform::PlatformError::ConnectionLost));
     }
     None
@@ -2341,26 +2601,26 @@ mod a_second_host_can_answer_for_a_compositor {
     use crate::platform::Anchor;
     use crate::surface::{ExclusiveZone, Margin, SurfaceConfig};
 
-    /// Answers nothing and remembers what it was asked. Overrides the three
-    /// methods these tests read and inherits the rest, which is the point of
-    /// the defaults: a host writes down what it wants to watch.
+    /// Answers nothing and remembers what it was asked. Overrides `open_frame`,
+    /// which is required, and the two methods these tests read; inherits the
+    /// other sixteen, which is the point of the defaults.
     #[derive(Default)]
     struct Recorder {
         configured: Option<(u32, u32)>,
-        exclusive_zones: Vec<(SurfaceId, i32)>,
+        exclusive_zones: Vec<i32>,
     }
 
-    impl SurfaceHost for Recorder {
-        fn open_frame(&mut self, _id: SurfaceId) -> Option<Frame> {
+    impl Surface for Recorder {
+        fn open_frame(&mut self) -> Option<Frame> {
             None
         }
 
-        fn configured_size(&self, _id: SurfaceId) -> Option<(u32, u32)> {
+        fn configured_size(&self) -> Option<(u32, u32)> {
             self.configured
         }
 
-        fn set_surface_exclusive_zone(&mut self, id: SurfaceId, zone: i32) {
-            self.exclusive_zones.push((id, zone));
+        fn set_exclusive_zone(&mut self, zone: i32) {
+            self.exclusive_zones.push(zone);
         }
     }
 
@@ -2375,36 +2635,33 @@ mod a_second_host_can_answer_for_a_compositor {
     /// the compositor for*, rather than about what it draws.
     #[test]
     fn a_bar_reserving_automatically_asks_for_the_height_it_declared() {
-        let id = SurfaceId::next();
-        let mut host = Recorder {
+        let mut surface = Recorder {
             configured: Some((800, 32)),
             ..Default::default()
         };
-        resync_exclusive_zone(id, &bar(), &mut host, None);
-        assert_eq!(host.exclusive_zones, vec![(id, 32)]);
+        resync_exclusive_zone(&mut surface, &bar(), None);
+        assert_eq!(surface.exclusive_zones, vec![32]);
     }
 
     /// The margin on the anchored edge is part of the reservation: a bar held
     /// eight pixels off the top edge occupies forty.
     #[test]
     fn a_margin_on_the_anchored_edge_is_reserved_too() {
-        let id = SurfaceId::next();
-        let mut host = Recorder {
+        let mut surface = Recorder {
             configured: Some((800, 32)),
             ..Default::default()
         };
-        resync_exclusive_zone(id, &bar().margin(Margin::all(8)), &mut host, None);
-        assert_eq!(host.exclusive_zones, vec![(id, 40)]);
+        resync_exclusive_zone(&mut surface, &bar().margin(Margin::all(8)), None);
+        assert_eq!(surface.exclusive_zones, vec![40]);
     }
 
     /// A policy that is not `Auto` sends nothing from here — it was sent once,
     /// when the surface was configured.
     #[test]
     fn a_fixed_reservation_is_not_republished_every_frame() {
-        let id = SurfaceId::next();
-        let mut host = Recorder::default();
-        resync_exclusive_zone(id, &bar().exclusive_zone(48u32), &mut host, None);
-        assert!(host.exclusive_zones.is_empty());
+        let mut surface = Recorder::default();
+        resync_exclusive_zone(&mut surface, &bar().exclusive_zone(48u32), None);
+        assert!(surface.exclusive_zones.is_empty());
     }
 }
 
@@ -2495,33 +2752,30 @@ mod what_the_loop_waits_for {
     }
 }
 
-/// A frame drawn by the application, landing somewhere a test can read.
+/// The frame path, driven with nothing behind it.
 ///
-/// `tests/golden_images.rs` already renders without a compositor, but it builds
-/// its own target and calls the renderer itself — so it proves the shaders and
-/// nothing above them. This goes through `render_surface`: opening the frame,
-/// resolving the geometry, the pacing gate, layout, paint, flatten, damage and
-/// present. What it reads back is what the compositor would have been handed.
+/// What a test can reach from outside the crate is [`crate::testing::Headless`],
+/// and `tests/headless_app.rs` uses it. This module keeps only what needs the
+/// internals: `resolve_geometry`'s answer, which a driver deliberately does not
+/// expose.
 #[cfg(test)]
 mod a_frame_lands_where_the_surface_points {
     use super::*;
     use crate::renderer::{GpuContext, RenderTarget};
     use crate::surface::SurfaceConfig;
-    use crate::widgets::{Color, container};
+    use crate::widgets::container;
 
     const W: u32 = 100;
     const H: u32 = 32;
-    const BG: Color = Color::rgb(0.25, 0.5, 0.75);
 
-    /// A host with one surface and nothing else. Every other request the frame
-    /// path makes is answered by the trait's defaults.
+    /// A surface with one frame's worth of facts and nothing else.
     struct OneSurface {
         width: u32,
         height: u32,
     }
 
-    impl SurfaceHost for OneSurface {
-        fn open_frame(&mut self, _id: SurfaceId) -> Option<Frame> {
+    impl Surface for OneSurface {
+        fn open_frame(&mut self) -> Option<Frame> {
             Some(Frame {
                 events: Vec::new(),
                 scale_factor: 1.0,
@@ -2533,27 +2787,27 @@ mod a_frame_lands_where_the_surface_points {
         }
     }
 
-    /// A surface pointing at a texture, and the pieces the frame path wants.
-    fn surface_on_a_texture(
-        gpu: &GpuContext,
-        tree: &mut Tree,
-        texture: (u32, u32),
-    ) -> surface_manager::ManagedSurface {
-        let (widget, owner) = reactive::with_owner(|| Box::new(container()) as Box<dyn Widget>);
-        let mut surface = surface_manager::ManagedSurface::new(
-            SurfaceId::next(),
-            SurfaceConfig::new().background_color(BG),
-            widget,
-            owner,
-            tree,
-        );
-        surface.wgpu_surface = Some(RenderTarget::offscreen(gpu, texture.0, texture.1));
-        surface
+    struct OnePlatform(OneSurface);
+
+    /// The handle, as the two real implementations spell it: a newtype over
+    /// what it borrows, so the trait does not have to be implemented for
+    /// references as well.
+    struct OneHandle<'a>(&'a mut OneSurface);
+
+    impl Surface for OneHandle<'_> {
+        fn open_frame(&mut self) -> Option<Frame> {
+            self.0.open_frame()
+        }
     }
 
-    /// `None` where there is no adapter at all, unless the caller says a skip is
-    /// a failure. CI's job with a rasterizer sets `GUIDO_GPU_REQUIRED=1`: a
-    /// skipped test that reports green is worth less than no test.
+    impl Platform for OnePlatform {
+        type Surface<'a> = OneHandle<'a>;
+
+        fn surface(&mut self, _id: SurfaceId) -> Option<OneHandle<'_>> {
+            Some(OneHandle(&mut self.0))
+        }
+    }
+
     fn gpu() -> Option<GpuContext> {
         match GpuContext::try_new() {
             Some(gpu) => Some(gpu),
@@ -2567,54 +2821,6 @@ mod a_frame_lands_where_the_surface_points {
         }
     }
 
-    /// The surface's own background reaches the target: the clear colour is what
-    /// the compositor sees where nothing is drawn over it.
-    ///
-    /// The width is chosen so the row padding is load-bearing: 100 pixels is
-    /// 400 bytes, which pads to 512, and a stride computed any other way lands
-    /// somewhere else. Under 64 pixels every arithmetic mistake rounds up to the
-    /// same 256 and the assertion proves nothing.
-    #[test]
-    fn a_surface_background_reaches_the_texture_it_points_at() {
-        let Some(gpu) = gpu() else { return };
-
-        let mut tree = Tree::new();
-        let mut surface = surface_on_a_texture(&gpu, &mut tree, (W, H));
-        let root = surface.widget_id;
-        let mut renderer = Renderer::new(
-            gpu.device.clone(),
-            gpu.queue.clone(),
-            wgpu::TextureFormat::Rgba8Unorm,
-        );
-        let mut host = OneSurface {
-            width: W,
-            height: H,
-        };
-        let id = surface.id;
-        let mut ctx = FrameContext {
-            id,
-            surface: &mut surface,
-            wayland_state: &mut host,
-            renderer: &mut renderer,
-            tree: &mut tree,
-        };
-        render_surface(
-            &mut ctx,
-            &mut Vec::new(),
-            true,
-            &std::iter::once(root).collect(),
-            std::time::Instant::now(),
-        );
-
-        let RenderTarget::Offscreen(target) = surface.wgpu_surface.as_ref().unwrap() else {
-            panic!("the target was replaced");
-        };
-        // Two pixels, in different rows and columns, so neither the stride nor
-        // the offset can be wrong and still land on the right bytes.
-        assert_eq!(target.read_pixel(1, 1), [64, 128, 191, 255]);
-        assert_eq!(target.read_pixel(W - 2, H - 2), [64, 128, 191, 255]);
-    }
-
     /// A target smaller than its frame is made to fit, and then reports that it
     /// fits.
     ///
@@ -2626,25 +2832,33 @@ mod a_frame_lands_where_the_surface_points {
         let Some(gpu) = gpu() else { return };
 
         let mut tree = Tree::new();
-        let mut surface = surface_on_a_texture(&gpu, &mut tree, (8, 8));
+        let (widget, owner) = reactive::with_owner(|| Box::new(container()) as Box<dyn Widget>);
+        let mut surface = surface_manager::ManagedSurface::new(
+            SurfaceId::next(),
+            SurfaceConfig::new(),
+            widget,
+            owner,
+            &mut tree,
+        );
+        surface.wgpu_surface = Some(RenderTarget::offscreen(&gpu, 8, 8));
         let mut renderer = Renderer::new(
             gpu.device.clone(),
             gpu.queue.clone(),
             wgpu::TextureFormat::Rgba8Unorm,
         );
-        let mut host = OneSurface {
+        let mut platform = OnePlatform(OneSurface {
             width: W,
             height: H,
-        };
+        });
         let id = surface.id;
         let mut ctx = FrameContext {
             id,
             surface: &mut surface,
-            wayland_state: &mut host,
+            wayland_state: &mut platform,
             renderer: &mut renderer,
             tree: &mut tree,
         };
-        let frame = ctx.wayland_state.open_frame(id).unwrap();
+        let frame = ctx.wayland_state.surface(id).unwrap().open_frame().unwrap();
 
         let first = resolve_geometry(&mut ctx, &frame);
         assert!(first.needs_resize, "an 8x8 target for a 100x32 frame");

--- a/src/platform/input.rs
+++ b/src/platform/input.rs
@@ -208,7 +208,8 @@ impl InputState {
 
 impl WaylandState {
     /// Set the cursor shape
-    pub fn set_cursor(&self, cursor: CursorIcon, qh: &QueueHandle<Self>) {
+    pub fn set_cursor(&self, cursor: CursorIcon) {
+        let qh = &self.qh;
         let Some(ref manager) = self.input.cursor_shape_manager else {
             return;
         };

--- a/src/platform/lock.rs
+++ b/src/platform/lock.rs
@@ -56,7 +56,8 @@ impl WaylandState {
     /// Returns false when a lock is already active or the compositor lacks
     /// ext-session-lock-v1. The grant (or denial) arrives asynchronously as
     /// a [`LockEvent`].
-    pub fn start_session_lock(&mut self, qh: &QueueHandle<Self>) -> bool {
+    pub fn start_session_lock(&mut self) -> bool {
+        let qh = &self.qh;
         if self.lock.active_lock.is_some() {
             log::warn!("Session lock requested while a lock is already active");
             return false;
@@ -95,12 +96,8 @@ impl WaylandState {
     /// The surface starts at 0×0 — its real size arrives with the first
     /// lock-surface configure. Returns false without an active lock or when
     /// the output disconnected.
-    pub fn create_lock_surface_with_id(
-        &mut self,
-        qh: &QueueHandle<Self>,
-        id: SurfaceId,
-        output: OutputId,
-    ) -> bool {
+    pub fn create_lock_surface_with_id(&mut self, id: SurfaceId, output: OutputId) -> bool {
+        let qh = &self.qh;
         let Some(lock) = self.lock.active_lock.clone() else {
             log::warn!("Cannot create lock surface without an active session lock");
             return false;

--- a/src/platform/popups.rs
+++ b/src/platform/popups.rs
@@ -82,12 +82,12 @@ impl WaylandState {
     /// parent can't host popups.
     pub fn create_popup_surface_with_id(
         &mut self,
-        qh: &QueueHandle<Self>,
         id: SurfaceId,
         parent: SurfaceId,
         config: &crate::surface::PopupConfig,
         size: (u32, u32),
     ) -> bool {
+        let qh = &self.qh;
         let Some(ref xdg_shell) = self.popups.xdg_shell else {
             log::error!("Cannot create popup: compositor lacks xdg_wm_base");
             return false;

--- a/src/platform/selections.rs
+++ b/src/platform/selections.rs
@@ -116,7 +116,8 @@ impl Selections {
 
 impl WaylandState {
     /// Set clipboard content (copy)
-    pub fn set_clipboard(&mut self, text: String, qh: &QueueHandle<Self>) {
+    pub fn set_clipboard(&mut self, text: String) {
+        let qh = &self.qh;
         if let Some(ref manager) = self.selections.data_device_manager {
             // Create a data source for the clipboard
             let source = manager.create_copy_paste_source(
@@ -142,7 +143,8 @@ impl WaylandState {
     }
 
     /// Set the primary selection content (select-to-copy).
-    pub fn set_primary(&mut self, text: String, qh: &QueueHandle<Self>) {
+    pub fn set_primary(&mut self, text: String) {
+        let qh = &self.qh;
         let Some(ref manager) = self.selections.primary_selection_manager else {
             return;
         };

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -172,25 +172,12 @@ thread_local! {
     static BATCHING: Cell<Option<SurfaceId>> = const { Cell::new(None) };
 }
 
-/// Run `f` inside a batching scope for `id`, and report whether it opened it.
-///
-/// Restored on the way out however that happens, which is the whole point. A
-/// group nested inside one on *another* surface opens its own, because the
-/// commit it owes is not the one the outer group will make.
-fn batching<R>(id: SurfaceId, f: impl FnOnce() -> R) -> (bool, R) {
-    struct Restore(Option<SurfaceId>);
-    impl Drop for Restore {
-        fn drop(&mut self) {
-            BATCHING.with(|b| b.set(self.0));
-        }
-    }
-
-    let outer = BATCHING.with(|b| b.replace(Some(id)));
-    let _restore = Restore(outer);
-    (outer != Some(id), f())
-}
-
 pub struct WaylandState {
+    /// The connection every surface is built on. Held for the same reason as
+    /// the queue below it: a target is made from a window handle, and a window
+    /// handle is made from this — so a loop that did not hold one could not ask
+    /// for a surface without being handed the connection as well.
+    pub(crate) connection: Connection,
     /// The queue every protocol request made from here goes onto.
     ///
     /// Held rather than passed: the frame path used to thread a
@@ -275,18 +262,9 @@ impl std::fmt::Display for PlatformError {
 
 impl std::error::Error for PlatformError {}
 
-#[allow(clippy::type_complexity)]
 pub fn create_wayland_app(
     loop_handle: LoopHandle<'static, WaylandState>,
-) -> Result<
-    (
-        Connection,
-        EventQueue<WaylandState>,
-        WaylandState,
-        QueueHandle<WaylandState>,
-    ),
-    PlatformError,
-> {
+) -> Result<(Connection, EventQueue<WaylandState>, WaylandState), PlatformError> {
     let connection = Connection::connect_to_env().map_err(|e| {
         log::error!("Failed to connect to Wayland: {e}");
         PlatformError::Connect
@@ -341,6 +319,7 @@ pub fn create_wayland_app(
     }
 
     let state = WaylandState {
+        connection: connection.clone(),
         qh: qh.clone(),
         registry_state: RegistryState::new(&globals),
         compositor_state,
@@ -360,7 +339,46 @@ pub fn create_wayland_app(
         selections: Selections::new(data_device_manager, primary_selection_manager),
     };
 
-    Ok((connection, event_queue, state, qh))
+    Ok((connection, event_queue, state))
+}
+
+/// An open group of layer-shell requests, held for as long as the group lasts.
+///
+/// A scope a panic can leave open is not a scope: left open, every later
+/// layer-shell request holds its commit for a group that ended and the surface
+/// stops answering its handle, in silence. So closing is `Drop`'s, and the
+/// commit — which a panicking group has not earned — is
+/// [`close_layer_batch`](WaylandState::close_layer_batch)'s.
+pub(crate) struct LayerBatch {
+    /// The surface this group is for. Held so a caller cannot close one group
+    /// while committing another's.
+    id: SurfaceId,
+    /// What was open before, put back on the way out. Setting `None` instead
+    /// would let a nested group close the one containing it, and every request
+    /// after it would commit on its own.
+    previous: Option<SurfaceId>,
+    outermost: bool,
+}
+
+impl LayerBatch {
+    pub(crate) fn open(id: SurfaceId) -> Self {
+        let previous = BATCHING.with(|b| b.replace(Some(id)));
+        Self {
+            id,
+            previous,
+            outermost: previous != Some(id),
+        }
+    }
+
+    pub(crate) fn is_outermost(&self) -> bool {
+        self.outermost
+    }
+}
+
+impl Drop for LayerBatch {
+    fn drop(&mut self) {
+        BATCHING.with(|b| b.set(self.previous));
+    }
 }
 
 impl WaylandState {
@@ -448,10 +466,10 @@ impl WaylandState {
     /// Create a layer surface with a specific SurfaceId.
     pub fn create_surface_with_id(
         &mut self,
-        qh: &QueueHandle<Self>,
         id: SurfaceId,
         config: &crate::surface::SurfaceConfig,
     ) {
+        let qh = &self.qh;
         // Resolve the requested output; fall back to letting the compositor
         // choose if it was disconnected in the meantime.
         let target_output = config.output.and_then(|oid| {
@@ -482,26 +500,12 @@ impl WaylandState {
         // that dimension: set it to 0 so it stretches. Content sizing on
         // such an axis can never take effect — warn loudly.
         crate::surface::warn_content_on_stretched_axis(id, config);
-        // The same rule the runtime resize uses, so creation and re-anchoring
-        // cannot disagree about which axes are the compositor's.
-        let (use_width, use_height, _) = crate::surface::resize_request(config, None);
-        // Before the honouring: the size the surface believes it has, and the
-        // one a reservation resolves against. Through the same helper as the
-        // request, not `SurfaceExtent::initial()`, which happens to agree today
-        // only because `requested_extent` with no configure falls back to it.
-        let initial_width = crate::surface::requested_extent(config.width, None);
-        let initial_height = crate::surface::requested_extent(config.height, None);
+        let declared = crate::surface::initial_declaration(config);
+        let (initial_width, initial_height) = declared.believed;
 
-        layer_surface.set_size(use_width, use_height);
+        layer_surface.set_size(declared.asked.0, declared.asked.1);
         layer_surface.set_keyboard_interactivity(config.keyboard_interactivity);
-
-        let zone = config.exclusive_zone.resolve(
-            config.anchor,
-            config.margin,
-            initial_width,
-            initial_height,
-        );
-        layer_surface.set_exclusive_zone(zone);
+        layer_surface.set_exclusive_zone(declared.exclusive_zone);
 
         let margin = config.margin;
         if !margin.is_zero() {
@@ -580,8 +584,20 @@ impl WaylandState {
     /// session-lock or popup surface applies nothing. Committing anyway would
     /// send a bare commit to exactly the roles the per-request path refuses to
     /// touch.
-    pub fn batch_layer_requests(&mut self, id: SurfaceId, f: impl FnOnce(&mut Self)) {
-        let (outermost, ()) = batching(id, || f(self));
+    /// Start grouping this surface's layer requests.
+    ///
+    /// Split from [`batch_layer_requests`](Self::batch_layer_requests) so a
+    /// caller that already holds a borrow of this state — the per-surface
+    /// handle the frame path uses — can group without handing the whole state
+    /// to a closure it cannot produce.
+    pub(crate) fn open_layer_batch(&mut self, id: SurfaceId) -> LayerBatch {
+        LayerBatch::open(id)
+    }
+
+    /// End the group, and commit if this was the outermost one.
+    pub(crate) fn close_layer_batch(&mut self, batch: LayerBatch) {
+        let (id, outermost) = (batch.id, batch.is_outermost());
+        drop(batch);
         if outermost
             && let Some(state) = self.surfaces.get(&id)
             && matches!(state.role, SurfaceRole::Layer(_))
@@ -892,7 +908,14 @@ delegate_registry!(WaylandState);
 
 #[cfg(test)]
 mod batching_tests {
-    use super::{BATCHING, SurfaceId, batching};
+    use super::{BATCHING, LayerBatch, SurfaceId};
+
+    /// The guard alone, without a state to commit on.
+    fn batching<R>(id: SurfaceId, f: impl FnOnce() -> R) -> (bool, R) {
+        let batch = LayerBatch::open(id);
+        let outermost = batch.is_outermost();
+        (outermost, f())
+    }
 
     /// Distinct ids; the counter is global and the numbers do not matter.
     fn surface() -> SurfaceId {
@@ -912,6 +935,26 @@ mod batching_tests {
             BATCHING.with(|b| b.get()).is_none(),
             "and the scope closed on its way out"
         );
+    }
+
+    /// A nested group ends without ending the one containing it. Setting the
+    /// scope to `None` on the way out instead reads the same from inside the
+    /// outer group and lets every request after the inner one commit on its
+    /// own — which is the state the grouping exists to prevent.
+    #[test]
+    fn an_inner_batch_leaves_the_outer_one_open() {
+        let (a, b) = (surface(), surface());
+        let outer = LayerBatch::open(a);
+        {
+            let _inner = LayerBatch::open(b);
+        }
+        assert_eq!(
+            BATCHING.with(|s| s.get()),
+            Some(a),
+            "the outer group is still the one open"
+        );
+        drop(outer);
+        assert!(BATCHING.with(|s| s.get()).is_none(), "and then nothing is");
     }
 
     /// Only the outermost group commits, or a nested batch would commit halfway

--- a/src/session_lock.rs
+++ b/src/session_lock.rs
@@ -23,10 +23,8 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
 
-use smithay_client_toolkit::reexports::client::QueueHandle;
-
 use crate::outputs::{self, OutputId, OutputInfo};
-use crate::platform::{LockEvent, WaylandState};
+use crate::platform::LockEvent;
 use crate::reactive::global::GlobalSignal;
 use crate::reactive::owner::with_owner;
 use crate::reactive::{RwSignal, Signal};
@@ -151,10 +149,9 @@ pub fn unlock_session() {
 
 /// Drive the session-lock state machine. Called once per main-loop
 /// iteration, before surface commands are processed.
-pub(crate) fn process_session_lock(
+pub(crate) fn process_session_lock<P: crate::Platform>(
     surface_manager: &mut SurfaceManager,
-    wayland_state: &mut WaylandState,
-    qh: &QueueHandle<WaylandState>,
+    wayland_state: &mut P,
     tree: &mut Tree,
 ) {
     // 1. Pending request. A lock goes out now; an unlock waits for step 3,
@@ -165,7 +162,7 @@ pub(crate) fn process_session_lock(
     match REQUEST.with(|request| request.take()) {
         Some(LockRequest::Lock(factory)) => {
             LOCK.with(|l| l.borrow_mut().factory = Some(factory));
-            if wayland_state.start_session_lock(qh) {
+            if wayland_state.start_session_lock() {
                 set_state(LockState::Locking);
             } else {
                 LOCK.with(|l| l.borrow_mut().factory = None);
@@ -231,7 +228,7 @@ pub(crate) fn process_session_lock(
             }
 
             let id = SurfaceId::next();
-            if !wayland_state.create_lock_surface_with_id(qh, id, info.id) {
+            if !wayland_state.create_lock_surface(id, info.id) {
                 continue;
             }
 
@@ -258,9 +255,9 @@ pub(crate) fn process_session_lock(
     }
 }
 
-fn teardown_lock_surfaces(
+fn teardown_lock_surfaces<P: crate::Platform>(
     surface_manager: &mut SurfaceManager,
-    wayland_state: &mut WaylandState,
+    wayland_state: &mut P,
     tree: &mut crate::tree::Tree,
 ) {
     let surfaces: Vec<SurfaceId> = LOCK.with(|l| {

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -309,6 +309,43 @@ pub(crate) fn resize_request(config: &SurfaceConfig, live: Option<(u32, u32)>) -
     (width, height, needs_content_measure(config))
 }
 
+/// What a surface declares the moment it is created.
+///
+/// One function because there are two callers and they must not disagree — the
+/// layer surface being built for a compositor, and a surface being driven
+/// without one.
+pub(crate) struct InitialDeclaration {
+    /// The size to ask for, with the axes the compositor owns zeroed. Through
+    /// the same rule a runtime resize uses, so creation and re-anchoring cannot
+    /// differ about which axes those are.
+    pub asked: (u32, u32),
+    /// The size the surface believes it has before any configure has arrived,
+    /// which is what a reservation resolves against. Through `requested_extent`
+    /// rather than `SurfaceExtent::initial()`, which agrees today only because
+    /// the former falls back to it.
+    pub believed: (u32, u32),
+    /// The screen space to reserve, resolved against `believed`.
+    pub exclusive_zone: i32,
+}
+
+pub(crate) fn initial_declaration(config: &SurfaceConfig) -> InitialDeclaration {
+    let (ask_w, ask_h, _) = resize_request(config, None);
+    let believed = (
+        requested_extent(config.width, None),
+        requested_extent(config.height, None),
+    );
+    InitialDeclaration {
+        asked: (ask_w, ask_h),
+        believed,
+        exclusive_zone: config.exclusive_zone.resolve(
+            config.anchor,
+            config.margin,
+            believed.0,
+            believed.1,
+        ),
+    }
+}
+
 /// Whether this surface has a `content()` axis worth measuring.
 ///
 /// A content axis the compositor owns is not one: the measure runs, and

--- a/src/surface_manager.rs
+++ b/src/surface_manager.rs
@@ -5,15 +5,13 @@
 
 use std::collections::HashMap;
 
-use smithay_client_toolkit::reexports::client::Connection;
-
 use crate::layout::Constraints;
-use crate::platform::{WaylandState, WaylandWindowWrapper};
 use crate::reactive::owner::{OwnerId, dispose_owner_now};
 use crate::renderer::{CommandLayer, FlattenedCommand, GpuContext, RenderNode, RenderTarget};
 use crate::surface::{SurfaceConfig, SurfaceId};
 use crate::tree::{Tree, WidgetId};
 use crate::widgets::Widget;
+use crate::{Platform, Surface};
 
 /// A surface with unified GPU lifecycle management.
 ///
@@ -72,12 +70,10 @@ impl ManagedSurface {
     }
 
     /// Initialize GPU surface. Returns true if successful.
-    #[allow(clippy::too_many_arguments)]
-    pub fn init_gpu(
+    pub fn init_gpu<P: Platform>(
         &mut self,
         gpu_context: &GpuContext,
-        connection: &Connection,
-        wl_surface: &smithay_client_toolkit::reexports::client::protocol::wl_surface::WlSurface,
+        platform: &P,
         width: u32,
         height: u32,
         scale_factor: f32,
@@ -87,13 +83,12 @@ impl ManagedSurface {
             return true; // Already initialized
         }
 
-        let window_handle = WaylandWindowWrapper::new(connection, wl_surface);
         let initial_scale = scale_factor.max(1.0) as u32;
         let physical_width = width * initial_scale;
         let physical_height = height * initial_scale;
 
         log::info!(
-            "Creating wgpu surface for {:?}: logical {}x{}, physical {}x{}, scale {}",
+            "Creating render target for {:?}: logical {}x{}, physical {}x{}, scale {}",
             self.id,
             width,
             height,
@@ -102,9 +97,12 @@ impl ManagedSurface {
             initial_scale
         );
 
-        let wgpu_surface =
-            gpu_context.create_surface(window_handle, physical_width, physical_height);
-        self.wgpu_surface = Some(RenderTarget::Swapchain(wgpu_surface));
+        let Some(target) =
+            platform.create_render_target(self.id, gpu_context, (physical_width, physical_height))
+        else {
+            return false;
+        };
+        self.wgpu_surface = Some(target);
         self.previous_scale_factor = scale_factor;
 
         // Perform initial layout
@@ -209,11 +207,10 @@ impl SurfaceManager {
     ///
     /// This iterates over all surfaces and initializes GPU for any
     /// that are configured in Wayland but don't yet have a wgpu surface.
-    pub fn init_pending_gpu(
+    pub fn init_pending_gpu<P: Platform>(
         &mut self,
         gpu_context: &GpuContext,
-        connection: &Connection,
-        wayland_state: &WaylandState,
+        wayland_state: &mut P,
         tree: &mut Tree,
     ) {
         for (id, surface) in self.surfaces.iter_mut() {
@@ -221,25 +218,16 @@ impl SurfaceManager {
                 continue;
             }
 
-            // Get wayland surface state
-            let Some(wayland_surface) = wayland_state.get_surface(*id) else {
+            // A surface with no confirmed size has nothing to build a target
+            // at, and one with no confirmed scale would build it at the wrong
+            // one.
+            let facts = wayland_state
+                .surface(*id)
+                .and_then(|s| Some((s.configured_size()?, s.scale_factor()?)));
+            let Some(((width, height), scale)) = facts else {
                 continue;
             };
-
-            // Skip if not configured yet
-            if !wayland_surface.configured {
-                continue;
-            }
-
-            surface.init_gpu(
-                gpu_context,
-                connection,
-                &wayland_surface.wl_surface,
-                wayland_surface.width,
-                wayland_surface.height,
-                wayland_surface.scale_factor,
-                tree,
-            );
+            surface.init_gpu(gpu_context, wayland_state, width, height, scale, tree);
         }
     }
 }

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -1,0 +1,299 @@
+//! An application driven without a compositor.
+//!
+//! `App::run` needs a Wayland connection to do anything at all: it dials the
+//! compositor, waits for a configure, and only then is there a surface to draw
+//! on. So everything the application does with what the compositor says — input
+//! routing, the frame's phases, what the surface asks for in return — could only
+//! be watched by a person running an example and looking.
+//!
+//! [`Headless`] is the other caller. It holds the same tree, the same renderer
+//! and the same frame path, with a recorder where the compositor was: it answers
+//! for one surface, keeps what it was asked, and never talks to anything. A test
+//! says what the compositor said and then reads both halves — what the widgets
+//! became, and what the surface asked for.
+//!
+//! It is not a compositor and cannot be. What it proves is guido's half; what
+//! niri does with an exclusive zone of 50 is still a question no test here can
+//! settle.
+
+use std::time::Instant;
+
+use crate::reactive::{self, OwnerId};
+use crate::renderer::{GpuContext, RenderTarget, Renderer};
+use crate::surface::{SurfaceConfig, SurfaceId};
+use crate::surface_manager::{ManagedSurface, SurfaceManager};
+use crate::tree::{Tree, WidgetId};
+use crate::widgets::{Event, MouseButton, Widget};
+use crate::{Frame, LoopContext, Platform, Surface, iterate};
+
+/// The compositor's half of one surface: what it has said, and what it has been
+/// asked for.
+#[derive(Default)]
+struct Recorder {
+    width: u32,
+    height: u32,
+    scale: f32,
+    configured: bool,
+    events: Vec<(Instant, Event)>,
+    first_frame_presented: bool,
+    exclusive_zones: Vec<i32>,
+    sizes_asked: Vec<(u32, u32)>,
+    frame_callbacks: u32,
+}
+
+/// The one surface a `Headless` has, borrowed for a frame.
+struct RecordedSurface<'a>(&'a mut Recorder);
+
+impl Surface for RecordedSurface<'_> {
+    fn open_frame(&mut self) -> Option<Frame> {
+        if !self.0.configured {
+            return None;
+        }
+        Some(Frame {
+            events: std::mem::take(&mut self.0.events),
+            scale_factor: self.0.scale,
+            width: self.0.width,
+            height: self.0.height,
+            // Never pending: a driver that had to wait for a callback nobody
+            // sends would step once and stop.
+            frame_callback_pending: false,
+            force_render_surface: !self.0.first_frame_presented,
+        })
+    }
+
+    fn configured_size(&self) -> Option<(u32, u32)> {
+        self.0.configured.then_some((self.0.width, self.0.height))
+    }
+
+    fn scale_factor(&self) -> Option<f32> {
+        self.0.configured.then_some(self.0.scale)
+    }
+
+    fn set_size(&mut self, width: u32, height: u32) {
+        self.0.sizes_asked.push((width, height));
+    }
+
+    fn set_exclusive_zone(&mut self, zone: i32) {
+        self.0.exclusive_zones.push(zone);
+    }
+
+    fn request_frame_callback(&mut self) {
+        self.0.frame_callbacks += 1;
+    }
+
+    fn mark_frame_callback_pending(&mut self) {
+        self.0.first_frame_presented = true;
+    }
+}
+
+impl Platform for Recorder {
+    type Surface<'a> = RecordedSurface<'a>;
+
+    fn surface(&mut self, _id: SurfaceId) -> Option<RecordedSurface<'_>> {
+        Some(RecordedSurface(self))
+    }
+
+    /// A texture, where a compositor would hand out a swapchain. The one place
+    /// the two implementations differ by doing rather than by recording — and
+    /// the reason a surface can be *born* without a compositor rather than only
+    /// driven after somebody else built it one.
+    fn create_surface(&mut self, _id: SurfaceId, config: &crate::surface::SurfaceConfig) {
+        // The same function the layer-shell path uses, so what a surface says
+        // at birth cannot differ between the two.
+        let declared = crate::surface::initial_declaration(config);
+        self.sizes_asked.push(declared.asked);
+        self.exclusive_zones.push(declared.exclusive_zone);
+    }
+
+    fn create_render_target(
+        &self,
+        _id: SurfaceId,
+        gpu: &crate::renderer::GpuContext,
+        size: (u32, u32),
+    ) -> Option<crate::renderer::RenderTarget> {
+        Some(crate::renderer::RenderTarget::offscreen(
+            gpu, size.0, size.1,
+        ))
+    }
+}
+
+/// One application, one surface, stepped by hand.
+pub struct Headless {
+    gpu: GpuContext,
+    tree: Tree,
+    renderer: Option<Renderer>,
+    surfaces: SurfaceManager,
+    id: Option<SurfaceId>,
+    host: Recorder,
+    owner: Option<OwnerId>,
+    layout_roots: rustc_hash::FxHashMap<WidgetId, Vec<WidgetId>>,
+}
+
+impl Headless {
+    /// `None` where there is no GPU adapter at all — a frame has to land
+    /// somewhere, and the somewhere is a texture this allocates.
+    pub fn new() -> Option<Self> {
+        Some(Self {
+            gpu: GpuContext::try_new()?,
+            tree: Tree::new(),
+            renderer: None,
+            surfaces: SurfaceManager::new(),
+            id: None,
+            host: Recorder {
+                scale: 1.0,
+                ..Default::default()
+            },
+            owner: None,
+            layout_roots: rustc_hash::FxHashMap::default(),
+        })
+    }
+
+    /// Declare the surface, as `App::add_surface` does. One only, for now.
+    pub fn surface<W, F>(&mut self, config: SurfaceConfig, widget_fn: F)
+    where
+        W: Widget + 'static,
+        F: FnOnce() -> W,
+    {
+        let (widget, owner) = reactive::with_owner(|| Box::new(widget_fn()) as Box<dyn Widget>);
+        self.owner = Some(owner);
+
+        let id = SurfaceId::next();
+        self.id = Some(id);
+
+        // Through the trait, not beside it: a fixed-size bar declares its
+        // reservation once, at birth, and if the driver wrote that number down
+        // itself the recorder would be holding an answer rather than a request.
+        self.host.create_surface(id, &config);
+        self.surfaces.add(ManagedSurface::new(
+            id,
+            config,
+            widget,
+            owner,
+            &mut self.tree,
+        ));
+    }
+
+    /// Say what the compositor confirmed. Until this is called there is no size
+    /// to draw at, and [`step`](Self::step) does nothing — which is what an
+    /// unconfigured surface does in the real loop.
+    pub fn configure(&mut self, width: u32, height: u32, scale: f32) {
+        self.host.width = width;
+        self.host.height = height;
+        self.host.scale = scale;
+        self.host.configured = true;
+    }
+
+    /// Queue a press and a release at a point, in logical coordinates.
+    ///
+    /// They are delivered by the next [`step`](Self::step), because that is when
+    /// the frame that carries them opens — the same order the compositor's own
+    /// events arrive in.
+    pub fn click(&mut self, x: f32, y: f32) {
+        self.click_at(x, y, Instant::now());
+    }
+
+    /// [`click`](Self::click), at a moment you name — so a gesture can be
+    /// played through the application at the speed it is meant to have.
+    pub fn click_at(&mut self, x: f32, y: f32, now: Instant) {
+        self.host.events.push((
+            now,
+            Event::MouseDown {
+                x,
+                y,
+                button: MouseButton::Left,
+            },
+        ));
+        self.host.events.push((
+            now,
+            Event::MouseUp {
+                x,
+                y,
+                button: MouseButton::Left,
+            },
+        ));
+    }
+
+    /// One frame: open it, route what is queued, measure, paint, present.
+    ///
+    /// The moment is the caller's, so an animation can be walked through
+    /// without sleeping.
+    pub fn step(&mut self) {
+        self.step_at(Instant::now());
+    }
+
+    /// [`step`](Self::step), at a moment you name.
+    pub fn step_at(&mut self, at: Instant) {
+        let ctx = LoopContext {
+            wayland_state: &mut self.host,
+            surface_manager: &mut self.surfaces,
+            gpu_context: &self.gpu,
+            renderer: &mut self.renderer,
+        };
+        iterate(ctx, &mut self.tree, &mut self.layout_roots, Some(at));
+    }
+
+    fn root(&self) -> WidgetId {
+        self.surfaces
+            .get(self.id.expect("no surface"))
+            .expect("no surface")
+            .widget_id
+    }
+
+    fn target(&self) -> &RenderTarget {
+        self.surfaces
+            .get(self.id.expect("no surface"))
+            .and_then(|s| s.wgpu_surface.as_ref())
+            .expect("no target; step once after configuring")
+    }
+
+    /// The size the root widget was measured at, in logical pixels.
+    pub fn root_size(&self) -> (f32, f32) {
+        let bounds = self.tree.get_bounds(self.root()).unwrap_or_default();
+        (bounds.width, bounds.height)
+    }
+
+    /// The size of the buffer the last frame was drawn into, in physical
+    /// pixels — the logical size times the scale the compositor confirmed.
+    pub fn physical_size(&self) -> (u32, u32) {
+        let target = self.target();
+        (target.width(), target.height())
+    }
+
+    /// The screen space this surface last asked the compositor to reserve.
+    pub fn exclusive_zone_asked(&self) -> Option<i32> {
+        self.host.exclusive_zones.last().copied()
+    }
+
+    /// Every reservation this surface has asked for, oldest first. A frame that
+    /// republishes one it already sent is not the same as one that says nothing,
+    /// and only a list can tell them apart.
+    pub fn exclusive_zones_asked(&self) -> &[i32] {
+        &self.host.exclusive_zones
+    }
+
+    /// The sizes this surface has asked for, oldest first.
+    pub fn sizes_asked(&self) -> &[(u32, u32)] {
+        &self.host.sizes_asked
+    }
+
+    /// How many frames have been presented and had their callback re-armed.
+    pub fn frames_presented(&self) -> u32 {
+        self.host.frame_callbacks
+    }
+
+    /// The colour at one pixel of the last frame, in physical coordinates.
+    pub fn read_pixel(&self, x: u32, y: u32) -> [u8; 4] {
+        match self.target() {
+            RenderTarget::Offscreen(offscreen) => offscreen.read_pixel(x, y),
+            RenderTarget::Swapchain(_) => panic!("a headless surface has no swapchain"),
+        }
+    }
+}
+
+impl Drop for Headless {
+    fn drop(&mut self) {
+        if let Some(owner) = self.owner.take() {
+            reactive::dispose_owner_now(owner);
+        }
+    }
+}

--- a/tests/headless_app.rs
+++ b/tests/headless_app.rs
@@ -1,0 +1,180 @@
+#![cfg(feature = "testing")]
+//! An application, stepped without a compositor.
+//!
+//! Everything else in `tests/` reaches below the application: a `Tree` and a
+//! widget, or the renderer and a texture. This drives what `App::run` drives —
+//! a surface that configures, a frame that opens, input that routes, layout
+//! that measures, a paint that lands — with a recorder where the compositor
+//! would be. What it asserts is the half nothing could see before: not what the
+//! frame drew, but what the surface *asked the compositor for*.
+//!
+//! Compiled only under the `testing` feature — without it the file is empty,
+//! so a default `cargo test` still builds. With it, a machine that has no GPU
+//! adapter skips, unless `GUIDO_GPU_REQUIRED` says a skip is a failure.
+
+use guido::prelude::*;
+use guido::testing::Headless;
+
+/// A bar of the shape the acceptance criterion names: anchored to the top,
+/// reserving automatically, with something clickable in it.
+fn bar(clicks: RwSignal<u32>) -> Container {
+    container().width(fill()).height(fill()).child(
+        container()
+            .width(80.0)
+            .height(20.0)
+            .on_click(move || clicks.update(|c| *c += 1)),
+    )
+}
+
+fn headless() -> Option<Headless> {
+    match Headless::new() {
+        Some(app) => Some(app),
+        None if std::env::var_os("GUIDO_GPU_REQUIRED").is_some() => {
+            panic!("GUIDO_GPU_REQUIRED is set and no GPU adapter was found")
+        }
+        None => {
+            eprintln!("no GPU adapter; skipping");
+            None
+        }
+    }
+}
+
+/// The frame ran: the tree was measured against the size the compositor
+/// confirmed, at the scale it confirmed.
+#[test]
+fn a_configured_surface_lays_out_at_the_size_it_was_given() {
+    let Some(mut app) = headless() else { return };
+    let clicks = create_signal(0u32);
+    app.surface(
+        SurfaceConfig::new()
+            .height(50)
+            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+            .exclusive_zone(ExclusiveZone::Auto),
+        move || bar(clicks),
+    );
+    app.configure(200, 50, 2.0);
+    app.step();
+
+    assert_eq!(
+        app.root_size(),
+        (200.0, 50.0),
+        "logical, what layout measures"
+    );
+    assert_eq!(
+        app.physical_size(),
+        (400, 100),
+        "physical, what the buffer is: the scale the compositor confirmed"
+    );
+}
+
+/// The event reached the widget under it, and only that one.
+#[test]
+fn a_click_inside_runs_the_handler_and_one_outside_does_not() {
+    let Some(mut app) = headless() else { return };
+    let clicks = create_signal(0u32);
+    app.surface(
+        SurfaceConfig::new()
+            .height(50)
+            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT),
+        move || bar(clicks),
+    );
+    app.configure(200, 50, 2.0);
+    app.step();
+
+    app.click(10.0, 10.0);
+    app.step();
+    assert_eq!(clicks.get(), 1, "a click inside the child");
+
+    app.click(150.0, 40.0);
+    app.step();
+    assert_eq!(clicks.get(), 1, "a click outside it changes nothing");
+}
+
+/// The reservation a fixed-height bar declares, which it declares once — at
+/// creation, the way `create_surface_with_id` does, and never again.
+///
+/// This passes without a frame ever running, and that is where the value comes
+/// from rather than a weakness in the test: `layout_pass` resyncs a reservation
+/// only for a surface whose size follows its content. The frame-path half is
+/// the test below.
+#[test]
+fn a_bar_reserving_automatically_declares_its_height_when_it_is_created() {
+    let Some(mut app) = headless() else { return };
+    let clicks = create_signal(0u32);
+    app.surface(
+        SurfaceConfig::new()
+            .height(50)
+            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+            .exclusive_zone(ExclusiveZone::Auto),
+        move || bar(clicks),
+    );
+    app.configure(200, 50, 2.0);
+    app.step();
+
+    assert_eq!(
+        app.exclusive_zones_asked(),
+        [50],
+        "once, at creation, and the frames after it say nothing"
+    );
+}
+
+/// A surface whose height follows its content cannot resolve its reservation
+/// until something has measured it — so this one *is* the frame path, and the
+/// half the recorder exists for.
+///
+/// At creation there is nothing to resolve against: `requested_extent` on an
+/// unmeasured content axis falls back to the 1px placeholder, so the surface is
+/// born reserving one pixel. The measure runs inside `layout_pass` and the
+/// reservation follows it.
+#[test]
+fn a_content_sized_surface_reserves_only_once_a_frame_has_measured_it() {
+    let Some(mut app) = headless() else { return };
+    app.surface(
+        SurfaceConfig::new()
+            .height(content())
+            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+            .exclusive_zone(ExclusiveZone::Auto),
+        || container().height(24.0).child(container().height(24.0)),
+    );
+
+    assert_eq!(
+        app.exclusive_zones_asked(),
+        [1],
+        "born reserving the placeholder, which is wrong until a frame has run"
+    );
+
+    app.configure(200, 24, 1.0);
+    app.step();
+
+    assert_eq!(
+        app.exclusive_zones_asked(),
+        [1, 24],
+        "the frame measured the content and the reservation followed"
+    );
+}
+
+/// And the pixels: what the compositor would have been handed.
+///
+/// The assertion is the surface's own background — the least interesting thing
+/// on the frame, and the only one exactly predictable on any adapter, which is
+/// why this needs an adapter rather than lavapipe the way a golden does.
+///
+/// Two pixels in different rows and columns, at a width whose rows need padding
+/// (100 pixels is 400 bytes, which pads to 512), so neither the stride nor the
+/// offset can be wrong and still land on the right bytes.
+#[test]
+fn the_frame_that_was_drawn_can_be_read_back() {
+    let Some(mut app) = headless() else { return };
+    app.surface(
+        SurfaceConfig::new()
+            .height(32)
+            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+            .background_color(Color::rgb(0.25, 0.5, 0.75)),
+        container,
+    );
+    app.configure(100, 32, 1.0);
+    app.step();
+
+    assert_eq!(app.read_pixel(1, 1), [64, 128, 191, 255]);
+    assert_eq!(app.read_pixel(98, 30), [64, 128, 191, 255]);
+}

--- a/tests/scroll_momentum.rs
+++ b/tests/scroll_momentum.rs
@@ -5,6 +5,8 @@
 //! that a frame in the middle of a gesture, or a frame long after one, does not
 //! move the content: only the deltas the user actually produced do.
 
+use std::time::{Duration, Instant};
+
 use guido::layout::{Constraints, Flex};
 use guido::prelude::*;
 use guido::renderer::{PaintContext, RenderNode};
@@ -37,11 +39,6 @@ impl H {
         Self { tree, root }
     }
 
-    /// One touchpad scroll sample, as a finger moving by `delta` pixels.
-    fn finger_scroll(&mut self, delta: f32) {
-        self.scroll(delta, ScrollSource::Finger);
-    }
-
     /// One scroll sample from any source, at a named moment.
     fn scroll_at(&mut self, delta: f32, source: ScrollSource, at: std::time::Instant) {
         self.tree.set_event_instant(Some(at));
@@ -70,22 +67,38 @@ impl H {
             .with_widget_mut(root, |w, id, t| w.event(t, id, &event));
     }
 
-    /// Play a flick of `samples` movements and lift, from `source`.
-    fn flick(&mut self, source: ScrollSource) {
+    /// Play a flick of six samples eight milliseconds apart, and lift.
+    ///
+    /// The instants are named rather than slept through: a flick's velocity is
+    /// the distance over the gap between samples, so a test that sleeps is
+    /// measuring the scheduler as much as the gesture — and on a loaded machine
+    /// it measures something else again.
+    ///
+    /// Returns the moment of the lift, which is where whatever comes next
+    /// starts counting from.
+    fn flick_from(&mut self, source: ScrollSource, start: Instant) -> Instant {
+        let mut at = start;
         for _ in 0..6 {
-            self.scroll(10.0, source);
-            std::thread::sleep(std::time::Duration::from_millis(8));
+            self.scroll_at(10.0, source, at);
+            at += Duration::from_millis(8);
         }
-        self.scroll_end();
+        self.scroll_end_at(at);
+        at
     }
 
-    /// Run `n` animation frames, as the loop does while anything is animating.
-    fn frames(&mut self, n: usize) {
+    /// Run `n` animation frames at sixty a second from `start`, as the loop does
+    /// while anything is animating, and return the moment of the last one.
+    fn frames_from(&mut self, n: usize, start: Instant) -> Instant {
         let root = self.root;
+        let mut at = start;
         for _ in 0..n {
+            at += Duration::from_millis(16);
+            self.tree.set_frame_instant(Some(at));
             self.tree
                 .with_widget_mut(root, |w, id, t| w.advance_animations(t, id));
         }
+        self.tree.set_frame_instant(None);
+        at
     }
 
     /// The finger lifted, as the compositor's `axis_stop` reaches the tree.
@@ -114,13 +127,12 @@ impl H {
 fn a_gap_inside_a_gesture_does_not_start_the_momentum() {
     let mut h = H::new();
 
-    h.finger_scroll(30.0);
-    std::thread::sleep(std::time::Duration::from_millis(60));
-    h.frames(10);
+    let t0 = Instant::now();
+    h.scroll_at(30.0, ScrollSource::Finger, t0);
+    let after = h.frames_from(10, t0 + Duration::from_millis(60));
 
-    h.finger_scroll(30.0);
-    std::thread::sleep(std::time::Duration::from_millis(60));
-    h.frames(10);
+    h.scroll_at(30.0, ScrollSource::Finger, after);
+    h.frames_from(10, after + Duration::from_millis(60));
 
     let offset = h.offset();
     assert!(
@@ -137,15 +149,16 @@ fn a_gap_inside_a_gesture_does_not_start_the_momentum() {
 fn a_gesture_that_never_ended_is_not_resumed_by_a_later_frame() {
     let mut h = H::new();
 
-    h.finger_scroll(30.0);
+    let t0 = Instant::now();
+    h.scroll_at(30.0, ScrollSource::Finger, t0);
     let after_gesture = h.offset();
 
-    // The surface goes idle: nothing advances for a while.
-    std::thread::sleep(std::time::Duration::from_millis(120));
-
-    // Something unrelated asks for an animation frame — re-entering the
+    // The surface goes idle: nothing advances for a while. Named rather than
+    // slept, so "a while" is a number and the test costs nothing.
+    //
+    // Something unrelated then asks for an animation frame — re-entering the
     // container starts the scrollbar's hover expansion, which does exactly this.
-    h.frames(10);
+    h.frames_from(10, t0 + Duration::from_millis(120));
 
     let offset = h.offset();
     assert!(
@@ -162,9 +175,11 @@ fn a_gesture_that_never_ended_is_not_resumed_by_a_later_frame() {
 fn a_gesture_that_ended_carries_on_past_the_last_sample() {
     let mut h = H::new();
 
+    let t0 = Instant::now();
+    let mut at = t0;
     for _ in 0..6 {
-        h.finger_scroll(10.0);
-        std::thread::sleep(std::time::Duration::from_millis(8));
+        h.scroll_at(10.0, ScrollSource::Finger, at);
+        at += Duration::from_millis(8);
     }
     let at_lift = h.offset();
     assert!(
@@ -172,8 +187,8 @@ fn a_gesture_that_ended_carries_on_past_the_last_sample() {
         "the gesture itself moved {at_lift}px, not the 60px dispatched"
     );
 
-    h.scroll_end();
-    h.frames(60);
+    h.scroll_end_at(at);
+    h.frames_from(60, at);
 
     let coasted = h.offset() - at_lift;
     assert!(
@@ -191,9 +206,9 @@ fn a_gesture_that_ended_carries_on_past_the_last_sample() {
 #[test]
 fn a_continuous_gesture_coasts_and_a_wheel_does_not() {
     let mut wheel = H::new();
-    wheel.flick(ScrollSource::Wheel);
+    let lifted = wheel.flick_from(ScrollSource::Wheel, Instant::now());
     let at_lift = wheel.offset();
-    wheel.frames(60);
+    wheel.frames_from(60, lifted);
     let wheel_coast = wheel.offset() - at_lift;
     assert!(
         wheel_coast.abs() < 0.01,
@@ -201,9 +216,9 @@ fn a_continuous_gesture_coasts_and_a_wheel_does_not() {
     );
 
     let mut continuous = H::new();
-    continuous.flick(ScrollSource::Continuous);
+    let lifted = continuous.flick_from(ScrollSource::Continuous, Instant::now());
     let at_lift = continuous.offset();
-    continuous.frames(60);
+    continuous.frames_from(60, lifted);
     let continuous_coast = continuous.offset() - at_lift;
     assert!(
         continuous_coast > 10.0,
@@ -221,21 +236,19 @@ fn a_continuous_gesture_coasts_and_a_wheel_does_not() {
 #[test]
 fn a_momentum_left_half_run_is_not_carried_on_by_a_later_frame() {
     let mut h = H::new();
-    h.flick(ScrollSource::Finger);
+    let lifted = h.flick_from(ScrollSource::Finger, Instant::now());
 
-    h.frames(5);
+    let stopped = h.frames_from(5, lifted);
     let interrupted_at = h.offset();
     assert!(
         interrupted_at > 60.0,
         "the flick was coasting when it stopped"
     );
 
-    // The loop goes idle mid-flight.
-    std::thread::sleep(std::time::Duration::from_millis(400));
-
-    // Re-entering the container starts the scrollbar's hover expansion, which
-    // asks for an animation frame.
-    h.frames(30);
+    // The loop goes idle mid-flight, and then something unrelated asks for an
+    // animation frame — re-entering the container starts the scrollbar's hover
+    // expansion, which does exactly this.
+    h.frames_from(30, stopped + Duration::from_millis(400));
 
     let after = h.offset();
     assert!(
@@ -259,17 +272,18 @@ fn the_speed_of_a_flick_is_the_distance_over_the_time_it_took() {
     // two gestures is how long they took.
     fn coast(sample_gap_ms: u64) -> f32 {
         let mut h = H::new();
-        let t0 = std::time::Instant::now();
+        let t0 = Instant::now();
         for i in 1..=6u64 {
             h.scroll_at(
                 10.0,
                 ScrollSource::Finger,
-                t0 + std::time::Duration::from_millis(i * sample_gap_ms),
+                t0 + Duration::from_millis(i * sample_gap_ms),
             );
         }
         let lifted = h.offset();
-        h.scroll_end_at(t0 + std::time::Duration::from_millis(6 * sample_gap_ms));
-        h.frames(60);
+        let at = t0 + Duration::from_millis(6 * sample_gap_ms);
+        h.scroll_end_at(at);
+        h.frames_from(60, at);
         h.offset() - lifted
     }
 


### PR DESCRIPTION
## What changed

**Step 5 of five in #264 — the last, and this one closes it.**

Closes #264.

The maintainer asked for this done properly rather than deferred, and chose the
two-level trait shape that step 2 had agreed and then flattened. So the flat
`SurfaceHost` became two:

- **`Surface`** — what a frame asks of one window. No `SurfaceId` on any method,
  because a handle already knows which one it is. One required method,
  `open_frame`; eighteen defaults.
- **`Platform`** — what it asks of the connection: hand out a surface, make a
  render target, create and destroy, lock the session, speak to the seat, flush.
  One required method, `surface`.

The two seams step 2's comment named as the flattening's damage close by
themselves. `supports_blur_region` takes no id now, because a capability belongs
to a connection and not a window. And `batch_layer_requests` hands its closure
one surface where it used to hand it the whole host.

**`iterate` and `LoopContext` are generic**, and `LoopContext` names no Wayland
type at all — not the connection, not the queue, not `WaylandState`. The four
functions step 3 recorded as blocking that are generic with it. `WaylandState`
now holds the connection as well as the queue, for the reason it already held
the queue; six inherent methods stopped taking a `&QueueHandle`, and
`create_wayland_app` does not return one.

**`Headless` drives the real `iterate`** — the same function `App::run` calls,
with a recorder implementing both traits. Not a second loop.

## What proves it

`tests/headless_app.rs`, five tests, #264's acceptance criterion. A bar
configured 200×50 at scale 2 lays out at 200×50 and draws into a 400×100 buffer;
a click inside the child runs its handler and one outside does not; the
reservation reaches the recorder; a content-sized surface's reservation is
published by the *frame*; a pixel of the drawn frame reads back.

Two of those five exist because the reviewer proved the originals shallow, and I
confirmed both by hand: the exclusive-zone test passed with `configure()` and
`step()` deleted, and every test passed at scale 1.0. The content-sized case and
the physical-size assertion are the repairs, and both fail when their subject
breaks.

**The second half of the acceptance is `tests/scroll_momentum.rs`**: all six
`sleep`s gone, the file runs in no measurable time, assertions unchanged. Worth
naming, since the issue calls this "the second test": it landed at the `Tree`
level, not through `Headless`, because the driver cannot name an event's
instant — #276.

Harness: 726 tests, 9 goldens on lavapipe, `--all-features` clippy, `cargo doc`
with `-D warnings`, `--no-default-features`, `cargo check --tests` with the
default ones, and `GUIDO_GPU_REQUIRED=1` so the headless tests fail rather than
skip. Four commits, each clean alone.

## What CI found that the review did not

The first push went red on **Mutation testing**, and not for a surviving mutant:
`cargo build failed in an unmutated tree`. `tests/headless_app.rs` used
`guido::testing` without saying it needs the `testing` feature, so a plain
`cargo test` did not compile — on this branch, for anyone.

Every other job builds `--all-features`, which is why only the job that builds
an unmutated tree first could see it. The gate is squashed into the commit that
added the file; the sensor is its own: `cargo check --tests` with the default
features, in the job whose name says what broke. It fails on the same line, one
job earlier, with a red that means what it says.

## What the review found

`/simplify` found eleven, all applied. Three were repeats of defects I had
already fixed in earlier steps of this same issue: needless
`platform::WaylandState::foo(self, ..)` qualification (step 2), `.clone()`s
guarding a borrow conflict that does not exist (step 4), and a stale
`#[allow(clippy::too_many_arguments)]` for a problem the same diff removed. Two
were structural: a 55-line blanket `impl<S: Surface> Surface for &mut S` added
to serve one test fixture where a five-line newtype does — the pattern the diff
already used twice — and nine call sites repeating a shape I had extracted a
helper for and then used at three of them.

And the eighth instance this session of a comment drifting from its code, in its
worst form: I *edited* a doc from "three" to "two" while tidying, with the method
count unchanged. It says what the code does now.

The `reviewer` then read the three commits. **One blocking finding: `cargo doc
--all-features` failed under `-D warnings`** — a `///` I put on the `mod testing`
declaration merged with the file's own `//!` and dragged an intra-doc link's
scope to the crate root. CI's `check` job would have gone red. Fixed.

Four worth answering, all acted on:

1. **`LayerBatch` had not restored the whole of the guard it replaced.** Its
   `Drop` set the scope to `None` instead of putting back what it displaced, so
   a nested group would end the one containing it and every request after it
   would commit alone. Unreachable today — both openers group one surface — but
   the commit body claimed the guard survived, and the test written for that
   property samples the flag *before* the inner group, so nothing could see it.
   Restored, and `an_inner_batch_leaves_the_outer_one_open` is the test that
   sees it. This is the second regression in this one guard; the first (a panic
   leaving the group open) was caught by the test that already existed.
2. **`AGENTS.md`'s harness table and the `wayland` skill still said this layer
   had nothing automated.** They now say which half it has and which half it
   does not — and the skill's "closing this hole is the next thing worth
   building" is rewritten around what a recorder cannot do.
3. **`Headless::surface` computed the creation declaration itself** rather than
   going through `Platform::create_surface`, so the recorder held a number the
   driver worked out rather than a request the application made. It goes through
   the trait now.
4. **`Recorder::exclusive_zone` was an `Option` overwritten in place**, so a
   frame republishing 50 every iteration was indistinguishable from silence —
   while the test's doc said "once, and never again". It is a list, and the
   assertion is the sequence.

Its notes on a dead `pub fn batch_layer_requests`, a stale
`#[allow(clippy::type_complexity)]`, a `frames_from` doc naming the wrong moment,
and a commit body saying "thirty-one methods" where there are 37 are all fixed.
Its note that `Surface::scale_factor` is watched by nothing is true and left:
the value only sizes the initial target, which the first frame reallocates.

## What was checked by hand

niri 26.04. This change touches every path in the layer, and four examples cover
the four groups the trait split:

- **`surface_runtime`** — anchor, size, margin and reservation changed at
  runtime: `process_surface_commands` and `reconfigure`, whose closure now gets
  a handle instead of the whole state. The reservation followed the bar and no
  intermediate state showed, which is the batching.
- **`popup_example`** — `create_popup`, `conflicting_grab_popups` and
  `popup_descendants_bottom_up`, where a wrong teardown order makes the
  compositor kill the connection.
- **`animation_example`** — the frame callback, damage and present through a
  handle, sixty times a second.
- **`text_input_example`** — the seat: `set_clipboard`, `set_primary`,
  `set_cursor`, the only example that reaches them.

All four reported fine by the maintainer.

## Left undone

**#275** — a headless application drives one static surface. A second surface,
runtime spawn and close, popups, the session lock and output hotplug all
type-check against `Platform` now and nothing drives them. #264's acceptance
asked for one surface and got it; its **Expected** says "one or more", and that
is the difference.

**#276** — an input event reaches the driver at whatever time it is now. `click_at`
names one; a scroll, a key or a move have no way in, which is why this PR's own
momentum work had to stay at the `Tree` level.

Both filed in the same act as this body, which is the rule this issue's own
series added.

