### PR TITLE
The deferral that stops a dock reserving a whole monitor is watched

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2626,6 +2626,16 @@ mod a_second_host_can_answer_for_a_compositor {
         }
     }
 
+    /// A surface the compositor has already sized. Every test here needs one or
+    /// deliberately does not, and the distinction is easier to read as a name
+    /// than as a struct-update literal.
+    fn confirmed(width: u32, height: u32) -> Recorder {
+        Recorder {
+            configured: Some((width, height)),
+            ..Default::default()
+        }
+    }
+
     fn bar() -> SurfaceConfig {
         SurfaceConfig::new()
             .height(32)
@@ -2637,10 +2647,7 @@ mod a_second_host_can_answer_for_a_compositor {
     /// the compositor for*, rather than about what it draws.
     #[test]
     fn a_bar_reserving_automatically_asks_for_the_height_it_declared() {
-        let mut surface = Recorder {
-            configured: Some((800, 32)),
-            ..Default::default()
-        };
+        let mut surface = confirmed(800, 32);
         resync_exclusive_zone(&mut surface, &bar(), None);
         assert_eq!(surface.exclusive_zones, vec![32]);
     }
@@ -2649,10 +2656,7 @@ mod a_second_host_can_answer_for_a_compositor {
     /// eight pixels off the top edge occupies forty.
     #[test]
     fn a_margin_on_the_anchored_edge_is_reserved_too() {
-        let mut surface = Recorder {
-            configured: Some((800, 32)),
-            ..Default::default()
-        };
+        let mut surface = confirmed(800, 32);
         resync_exclusive_zone(&mut surface, &bar().margin(Margin::all(8)), None);
         assert_eq!(surface.exclusive_zones, vec![40]);
     }
@@ -2664,6 +2668,63 @@ mod a_second_host_can_answer_for_a_compositor {
         let mut surface = Recorder::default();
         resync_exclusive_zone(&mut surface, &bar().exclusive_zone(48u32), None);
         assert!(surface.exclusive_zones.is_empty());
+    }
+
+    /// A dock down the left edge, as wide as whatever it holds. Its reservation
+    /// follows the width, and the width is the one axis it owns — `TOP | BOTTOM`
+    /// hands the height to the compositor, `LEFT` alone leaves the width to the
+    /// surface.
+    ///
+    /// The anchor is what makes this a dock rather than a corner: `follow_axis`
+    /// gives up on a surface pinned to one edge of each axis, so `TOP | LEFT`
+    /// would reserve nothing whatever the width, and every assertion below would
+    /// hold for the wrong reason.
+    fn side_dock() -> SurfaceConfig {
+        SurfaceConfig::new()
+            .width(surface::content())
+            .anchor(Anchor::LEFT | Anchor::TOP | Anchor::BOTTOM)
+            .exclusive_zone(ExclusiveZone::Auto)
+    }
+
+    /// An unmeasured content axis publishes nothing and waits for the measure.
+    /// This is the case the guard in `publish_exclusive_zone` exists for, and
+    /// its comment says what 1920 would cost; here it is only the number the
+    /// guard has to refuse.
+    #[test]
+    fn a_dock_whose_width_is_unmeasured_reserves_nothing_rather_than_the_whole_output() {
+        let mut surface = confirmed(1920, 1080);
+        resync_exclusive_zone(&mut surface, &side_dock(), None);
+        assert!(
+            surface.exclusive_zones.is_empty(),
+            "reserved {:?} against a width the compositor imposed",
+            surface.exclusive_zones
+        );
+    }
+
+    /// The deferral lasts until the measure lands, not for ever. The measured
+    /// width is what is reserved, and it is not the confirmed one: the surface
+    /// is still 1920 wide as far as the compositor knows.
+    #[test]
+    fn the_dock_reserves_the_measured_width_not_the_confirmed_one() {
+        let mut surface = confirmed(1920, 1080);
+        resync_exclusive_zone(&mut surface, &side_dock(), Some((240, 1080)));
+        assert_eq!(surface.exclusive_zones, vec![240]);
+    }
+
+    /// A constant on the same unmeasured surface goes out at once: the guard is
+    /// `Auto`-only, and `publish_exclusive_zone` says what deferring one would
+    /// cost.
+    ///
+    /// This is the one test here that calls `publish_exclusive_zone` rather than
+    /// `resync_exclusive_zone`, because `resync` drops everything that is not
+    /// `Auto` before the guard ever sees it — the layer above is proved by
+    /// `a_fixed_reservation_is_not_republished_every_frame`, and going through it
+    /// would assert nothing about the guard.
+    #[test]
+    fn a_constant_reservation_on_an_unmeasured_dock_is_not_deferred() {
+        let mut surface = Recorder::default();
+        publish_exclusive_zone(&mut surface, &side_dock().exclusive_zone(48u32), None);
+        assert_eq!(surface.exclusive_zones, vec![48]);
     }
 }
 

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -1193,6 +1193,33 @@ mod tests {
         assert_eq!(left, 48 + 20);
     }
 
+    /// A corner anchor names one edge of each axis, so neither axis is the one
+    /// the reservation follows and `Auto` reserves nothing — the layer-shell
+    /// spec has no answer for it either.
+    ///
+    /// It is worth pinning because it is a premise elsewhere: the dock fixtures
+    /// that watch the deferral guard in `publish_exclusive_zone` are anchored
+    /// `LEFT | TOP | BOTTOM` rather than `TOP | LEFT` precisely so that their
+    /// assertions do not hold for this reason instead of the intended one.
+    #[test]
+    fn a_corner_or_full_anchor_has_no_axis_to_follow_and_reserves_nothing() {
+        let margin = Margin::all(10);
+        assert_eq!(
+            ExclusiveZone::Auto.resolve(Anchor::TOP | Anchor::LEFT, margin, 48, 600),
+            0
+        );
+        assert_eq!(
+            ExclusiveZone::Auto.resolve(
+                Anchor::TOP | Anchor::LEFT | Anchor::RIGHT | Anchor::BOTTOM,
+                margin,
+                48,
+                600
+            ),
+            0,
+            "and so does a surface pinned to all four"
+        );
+    }
+
     /// The other policies are numbers, and never consult anything.
     #[test]
     fn the_other_zone_policies_ignore_the_surface() {


### PR DESCRIPTION
## What changed

The guard at the top of `publish_exclusive_zone` now has a sensor. It holds back
an `Auto` reservation until a content axis has been measured, and the case it
prevents is not a small one: a surface declared
`width(content()).anchor(TOP | LEFT | RIGHT)` is stretched, so the 1920 the
compositor confirmed is a number imposed on an axis that was never the
surface's. Re-anchor it into a side dock and that number becomes a reservation
for the whole output, pushing every other window off the monitor until the
measure lands.

Deleting the guard whole left the entire suite green. No production code
changes here — the guard is right, nothing watched it.

Closes #270.

## What proves it

Three tests in `src/lib.rs`'s recorder module, one per condition of the guard,
and one in `src/surface.rs` for the premise they rest on.

Each of the guard's three conditions was forced to `true` and to `false`, and
the guard deleted outright, each time running the full `cargo test
--all-features --lib`:

| mutation | fails |
| --- | --- |
| `== Auto` → `true` | `a_constant_reservation_on_an_unmeasured_dock_is_not_deferred` |
| `== Auto` → `false` | `a_dock_whose_width_is_unmeasured_reserves_nothing_rather_than_the_whole_output` |
| `measured.is_none()` → `true` | `the_dock_reserves_the_measured_width_not_the_confirmed_one` |
| `measured.is_none()` → `false` | the unmeasured-dock test |
| `needs_content_measure` → `true` | the two pre-existing `bar()` tests |
| `needs_content_measure` → `false` | the unmeasured-dock test |
| **the guard deleted** | the unmeasured-dock test, **and nothing else** |

That last row is the issue's headline answered directly. `follow_axis`'s `None`
arm was mutated the same way and kills only the new `surface.rs` test.

Worth naming: `needs_content_measure → true` is killed by the *pre-existing*
tests, not by anything added here. That direction was already watched; what was
missing was the content-axis side.

**The acceptance criterion was wrong in two places, and this does not follow it
literally.** Both corrections are recorded on #270 itself, because the issue
outlives this pull request:

1. It names `anchor(TOP | LEFT)` and calls it a side dock. That is a *corner*:
   `follow_axis` returns `None`, `Auto` resolves to 0 whatever the width, and
   case 1 would have passed for a reason having nothing to do with the guard
   while case 2 failed outright. A dock that follows its width is
   `LEFT | TOP | BOTTOM`.
2. It says deleting `needs_content_measure` "publishes `SurfaceExtent::initial()`'s
   1px". Removing a conjunct makes the guard fire *more* often, so it publishes
   nothing. Publishing a wrong number is what a conjunct forced *false* does.

Because the corner behaviour is now load-bearing — it is why the fixture is
spelled the way it is — it gets its own test. That crosses #270's "not the
exclusive-zone arithmetic" non-goal by one test, deliberately: `follow_axis`'s
`None` arm had nothing watching it, and a fixture whose rationale is only prose
is the shallow-assertion trap this issue exists to close.

Harness: clippy `--all-targets --all-features -D warnings`, `cargo test
--all-features` (25 binaries, 587 lib tests), 9 goldens on lavapipe,
`cargo check --tests` with the default features, `cargo doc --all-features` with
`-D warnings`, and the headless tests under `GUIDO_GPU_REQUIRED=1`. Two commits,
each green alone.

## What the review found

`/simplify` found five, all applied. The one that mattered came from two agents
independently: the guard's rationale was now written out three times — its own
comment, and two test docs that paraphrased it almost sentence for sentence —
with nothing checking that the three agree. The tests now point at the guard and
say only what they pin. The others were a `Recorder { configured: Some(..),
..Default::default() }` repeated four times, folded into one `confirmed(w, h)`;
a test name that said "measured" twice where it should name what it
distinguishes; and half a sentence saying why one test reaches a layer lower
than its neighbours.

One `/simplify` finding was **not** applied: hoisting `side_dock()` to file
scope so `mod exclusive_zone_resync_tests` could share it. Those two docks are
not the same surface — the older one fixes `height: 32` because it feeds
`resolve` directly, this one leaves the height alone because the guard never
reads it. Sharing would either parameterise the fixture into noise or change
what the older test asserts.

The `reviewer` then read the two commits and **re-ran every mutation claim
itself** rather than taking them on trust. **Zero blocking findings.**

One worth answering: the deviation from the acceptance criterion was written
down in the fixture's doc comment and the commit body, but nowhere a reader of
#270 would meet it. Acted on — #270 now carries both corrections as a comment,
and they are above as well.

Two notes, both acted on: the `surface.rs` test crosses a stated non-goal and
the pull request should say why (it does, above), and the test name said
"corner" while the body also asserts the all-four-edges case (renamed to
`a_corner_or_full_anchor_has_no_axis_to_follow_and_reserves_nothing`).

## What was checked by hand

Nothing on a compositor, and nothing needed: no production code changed, so
there is no behaviour to observe that the harness cannot. What was done by hand
is the mutation matrix in the table above — seven mutants for the guard plus two
for `follow_axis`, each a full lib-suite run — because that *is* the change's
subject, and `cargo test` passing proves nothing about a test whose whole
purpose is to fail when something is removed.

## Left undone

**#279 — a surface can stop asking the compositor for a size and every test
stays green.** #270's non-goals named `send_size`'s half of this story and said
it "belongs here" if it turned out to be reachable. It was worth checking rather
than assuming, so I checked: deleting `surface.set_size(ask_w, ask_h)` from
`send_size` leaves all 587 lib tests and all 5 headless tests green, the latter
with an adapter and `GUIDO_GPU_REQUIRED=1`. The hole is real and now measured.

It is not in this pull request for the reason #270 gave, which turned out to be
right: `send_size` is reached only from `SetAnchor` and `SetSize`, both of which
need a `SurfaceHandle` and so a `SurfaceId` that `Headless` keeps private. It
cannot be driven by a host alone, and closing it is a fork — a unit test that
builds a real `ManagedSurface`, or an accessor on `Headless` that would unlock
the rest of #275 too. That belongs in its own change, and the review for this
one has already run.

Also recorded there: `Headless::sizes_asked()` is public and **no test calls
it** — built in #277, never connected to an assertion.
