### PR TITLE
A surface that stops asking the compositor for a size is noticed

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2624,6 +2624,7 @@ mod a_second_host_can_answer_for_a_compositor {
     struct Recorder {
         configured: Option<(u32, u32)>,
         exclusive_zones: Vec<i32>,
+        sizes_asked: Vec<(u32, u32)>,
     }
 
     impl Surface for Recorder {
@@ -2637,6 +2638,10 @@ mod a_second_host_can_answer_for_a_compositor {
 
         fn set_exclusive_zone(&mut self, zone: i32) {
             self.exclusive_zones.push(zone);
+        }
+
+        fn set_size(&mut self, width: u32, height: u32) {
+            self.sizes_asked.push((width, height));
         }
     }
 
@@ -2723,6 +2728,43 @@ mod a_second_host_can_answer_for_a_compositor {
         let mut surface = confirmed(1920, 1080);
         resync_exclusive_zone(&mut surface, &side_dock(), Some((240, 1080)));
         assert_eq!(surface.exclusive_zones, vec![240]);
+    }
+
+    /// What a bar asks for: the height it declared, and whatever
+    /// `surface::honour_owned_axes` leaves of the width, which for both
+    /// horizontal edges is nothing.
+    #[test]
+    fn a_bar_asks_for_its_own_height_and_leaves_the_stretched_width_to_the_compositor() {
+        let mut tree = Tree::new();
+        let managed = managed_surface(bar(), &mut tree);
+        let mut surface = confirmed(1920, 32);
+
+        let (needs_measure, root) = send_size(&managed, &mut surface);
+
+        assert_eq!(surface.sizes_asked, vec![(0, 32)]);
+        assert!(!needs_measure, "two fixed axes have nothing to measure");
+        assert_eq!(
+            root, managed.widget_id,
+            "and the layout job names this root"
+        );
+    }
+
+    /// A `content()` axis has no number of its own, so it asks for the one the
+    /// compositor confirmed — not the 1px placeholder, which is what it would
+    /// fall back to if `send_size` stopped reading the live size.
+    #[test]
+    fn a_dock_asks_for_the_width_it_was_confirmed_at_rather_than_the_placeholder() {
+        let mut tree = Tree::new();
+        let managed = managed_surface(side_dock(), &mut tree);
+        let mut surface = confirmed(240, 1080);
+
+        let (needs_measure, _) = send_size(&managed, &mut surface);
+
+        assert_eq!(surface.sizes_asked, vec![(240, 0)]);
+        assert!(
+            needs_measure,
+            "and the width is still the surface's own, so it is still waiting on a measure"
+        );
     }
 
     /// A constant on the same unmeasured surface goes out at once: the guard is

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2593,6 +2593,20 @@ mod a_frame_is_a_description_not_a_connection {
     }
 }
 
+/// A surface the manager owns, for the tests that need one rather than a
+/// recorder alone — `send_size` reads its config, and a frame needs somewhere to
+/// land.
+///
+/// The widget is the smallest there is: none of these lay anything out, it only
+/// has to be registered so the tree can name it. The tree is the caller's
+/// because [`ManagedSurface::new`] registers into it and some callers go on to
+/// use it.
+#[cfg(test)]
+fn managed_surface(config: SurfaceConfig, tree: &mut Tree) -> ManagedSurface {
+    let (widget, owner) = with_owner(|| Box::new(widgets::container()) as Box<dyn Widget>);
+    ManagedSurface::new(SurfaceId::next(), config, widget, owner, tree)
+}
+
 /// The frame path asks a compositor for things, and this is the asking written
 /// down. `WaylandState` is one answer to it; a recorder that keeps what it was
 /// asked is another, and having two is the whole point — one implementation is
@@ -2826,7 +2840,6 @@ mod a_frame_lands_where_the_surface_points {
     use super::*;
     use crate::renderer::{GpuContext, RenderTarget};
     use crate::surface::SurfaceConfig;
-    use crate::widgets::container;
 
     const W: u32 = 100;
     const H: u32 = 32;
@@ -2895,14 +2908,7 @@ mod a_frame_lands_where_the_surface_points {
         let Some(gpu) = gpu() else { return };
 
         let mut tree = Tree::new();
-        let (widget, owner) = reactive::with_owner(|| Box::new(container()) as Box<dyn Widget>);
-        let mut surface = surface_manager::ManagedSurface::new(
-            SurfaceId::next(),
-            SurfaceConfig::new(),
-            widget,
-            owner,
-            &mut tree,
-        );
+        let mut surface = managed_surface(SurfaceConfig::new(), &mut tree);
         surface.wgpu_surface = Some(RenderTarget::offscreen(&gpu, 8, 8));
         let mut renderer = Renderer::new(
             gpu.device.clone(),

--- a/tests/headless_app.rs
+++ b/tests/headless_app.rs
@@ -26,6 +26,20 @@ fn bar(clicks: RwSignal<u32>) -> Container {
     )
 }
 
+/// A surface whose height is whatever it holds, on an anchor that hands the
+/// width to the compositor. Two tests share it, and the only thing that differs
+/// between them is the height it is then configured at.
+fn content_bar() -> SurfaceConfig {
+    SurfaceConfig::new()
+        .height(content())
+        .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+        .exclusive_zone(ExclusiveZone::Auto)
+}
+
+fn measuring_24() -> Container {
+    container().height(24.0).child(container().height(24.0))
+}
+
 fn headless() -> Option<Headless> {
     match Headless::new() {
         Some(app) => Some(app),
@@ -129,13 +143,7 @@ fn a_bar_reserving_automatically_declares_its_height_when_it_is_created() {
 #[test]
 fn a_content_sized_surface_reserves_only_once_a_frame_has_measured_it() {
     let Some(mut app) = headless() else { return };
-    app.surface(
-        SurfaceConfig::new()
-            .height(content())
-            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
-            .exclusive_zone(ExclusiveZone::Auto),
-        || container().height(24.0).child(container().height(24.0)),
-    );
+    app.surface(content_bar(), measuring_24);
 
     assert_eq!(
         app.exclusive_zones_asked(),
@@ -150,6 +158,43 @@ fn a_content_sized_surface_reserves_only_once_a_frame_has_measured_it() {
         app.exclusive_zones_asked(),
         [1, 24],
         "the frame measured the content and the reservation followed"
+    );
+    assert_eq!(
+        app.sizes_asked(),
+        [(0, 1)],
+        "and it asked for no new size, having measured back the one it has: the \
+         resize is conditional where the resync is not. This is the only thing \
+         watching that condition's false arm — see \
+         a_surface_configured_taller_than_its_content_asks_to_shrink_to_it for \
+         the true one"
+    );
+}
+
+/// The other half of what a frame tells the compositor: not only what to
+/// reserve, but what size to be.
+///
+/// A surface configured taller than its content measures asks to shrink, and
+/// the request goes out from inside the measure pass — the one place the
+/// measured number is known before the compositor knows it. The width stays 0
+/// throughout, for the reason `surface::honour_owned_axes` gives.
+#[test]
+fn a_surface_configured_taller_than_its_content_asks_to_shrink_to_it() {
+    let Some(mut app) = headless() else { return };
+    app.surface(content_bar(), measuring_24);
+
+    assert_eq!(
+        app.sizes_asked(),
+        [(0, 1)],
+        "born asking for the placeholder, having measured nothing"
+    );
+
+    app.configure(200, 50, 1.0);
+    app.step();
+
+    assert_eq!(
+        app.sizes_asked(),
+        [(0, 1), (0, 24)],
+        "the frame measured 24 against a surface configured at 50, and said so"
     );
 }
 


### PR DESCRIPTION
## What changed

Nothing in production. `send_size` could drop its `set_size` call entirely and
the whole suite stayed green — 587 lib tests and the five headless ones, the
latter with an adapter and a skip counted as a failure. A surface that never
asks the compositor for a size was indistinguishable from one that does.

What was watched was the arithmetic: `surface::resize_request` has seven call
sites in tests and they are thorough. What nothing watched was the four lines
around it — that the live size comes from `configured_size()`, that the answer
reaches `set_size`, and that `needs_measure` is handed back to the caller that
queues the layout job.

Closes #279.

## What proves it

The two `set_size` call sites are watched where each one's inputs live, which is
why this lands at two levels rather than one.

**`send_size`** is reached only from `SurfaceCommand::SetAnchor` and `SetSize`,
both of which need a `SurfaceHandle` and so a `SurfaceId` that `Headless` keeps
to itself. Two unit tests against the recorder: a bar asks for its declared
height and nothing for the stretched width, and a dock asks for the width it was
*confirmed at* rather than the 1px placeholder it would fall back to if the live
size stopped being read.

**The measure pass** has no such seam — its `resizing` compares the measurement
against a frame that only exists once one has opened — so it is watched through
the real loop, in `tests/headless_app.rs`.

Every claim above was checked by mutation, each run over the full
`cargo test --all-features --lib` *and* the headless tests with an adapter and
`GUIDO_GPU_REQUIRED=1`:

| mutation | fails |
| --- | --- |
| `send_size` drops `set_size` | both new unit tests |
| `send_size` reads `None` for the live size | the dock unit test |
| the measure pass drops `set_size` | `a_surface_configured_taller_than_its_content_asks_to_shrink_to_it` |
| `resizing` forced `true` | `a_content_sized_surface_reserves_only_once_a_frame_has_measured_it` |
| `resizing` forced `false` | the shrink test |

**`Headless::sizes_asked()` had been recording since #277 and read by nothing.**
Both halves of that pair now assert against it, which is the clause of #279's
acceptance that was easiest to satisfy on paper and leave undone.

One assertion went onto a *pre-existing* test rather than the new one, and that
was measured rather than chosen: the false arm of `if resizing` needs a step
where the measure runs and the size does not move, and the only place that
happens is the content test that already configures at the height it measures. I
wrote it in the new test first — `configure(200, 24)` then `step()` after the
shrink — and the `resizing → true` mutant survived, because no layout job is
queued there and the measure pass never runs. The assertion says in its own
failure message that it is the only thing watching that arm.

Harness: clippy `--all-targets --all-features -D warnings`, `cargo test
--all-features` (25 binaries, 589 lib tests), 9 goldens on lavapipe,
`cargo check --tests` with the default features, `cargo check
--no-default-features`, `cargo doc --all-features` with `-D warnings`, and both
the lib and headless suites under `GUIDO_GPU_REQUIRED=1`. Two commits, each
green alone.

## What the review found

#279 named two routes and said choosing between them was the decision: unit
tests with a real `ManagedSurface`, or a new public accessor on `Headless`
letting tests issue surface commands. **Route 1**, because route 2 grows the
harness's public API and is #275's subject — taking it here as a side effect of
covering four wiring lines would pre-empt that issue — and because headless tests
return silently without an adapter, so the acceptance criterion would then hold
only on adapter machines. The `reviewer` was asked explicitly whether that
needed the maintainer and said it did not: one `#[cfg(test)]` fixture, no public
API.

`/simplify` found eleven across four readings, of which the substantial ones
were: a protocol rule (`honour_owned_axes`'s "zero means you decide") paraphrased
into two more places, making five copies of one sentence with nothing checking
they agree; a doc paragraph that was changelog rather than documentation and
would have aged into a lie the moment it merged; the content-surface fixture
copied byte for byte between two tests so that the one meaningful difference
between them — the configured height — was buried in eight identical lines; and
a `ManagedSurface` construction already spelled inline in a sibling module of
the same file, now one fixture used by all three call sites, which is the first
commit here.

Two `/simplify` findings were **not** applied:

- Merging the new headless test into its neighbour, saving 182ms and one Vulkan
  device. The two claims are different — configured *equals* content asks for
  nothing, configured *exceeds* it asks to shrink — and each deserves a name
  somebody can grep for. The real lever is a shared `GpuContext` behind a
  `OnceLock`, which `tests/golden_images.rs` already does and `Headless` does
  not; that is **#281**, because #275 will add many more of these.
- Dropping the `&mut Tree` parameter from the fixture. Two of its three callers
  do not need the tree afterwards, but the third does, and sharing one fixture
  across all three is worth one line of prologue.

The `reviewer` then read the two commits and **re-ran all five mutations itself**
rather than taking the table on trust. **Zero blocking findings.**

One worth answering, acted on: I had inserted the fixture between
`mod a_second_host_can_answer_for_a_compositor`'s doc comment and the `mod`
itself, so the paragraph explaining *why there are two `Surface` implementations*
became the head of a fixture that has nothing to do with seams — and the module
was left undocumented. Nothing catches this: the item is `#[cfg(test)]`, so
rustdoc never sees it. Fixed, and folded into the commit that caused it.

Three notes. The added assertion names the other test in prose and nothing
checks that name survives a rename — true, and cheaper than the alternatives.
The fixture spelled three paths in full that are imported at the crate root —
shortened, except `container`, which is not. And `assert_eq!(root,
managed.widget_id)` kills no mutant the others do not; kept, because it is the
only statement of what the second half of that return value is for.

## What was checked by hand

No compositor and none needed: no production code changed. What was done by hand
is the mutation table above — five mutants, each a full lib run plus the headless
suite on lavapipe — because `cargo test` passing says nothing about a test whose
whole purpose is to fail when something is removed.

## Left undone

**#281** — every `Headless` builds its own `GpuContext`, so each headless test
costs a full Vulkan instance, adapter request and device: 182ms measured, against
a 5ms process baseline. `tests/golden_images.rs` already shares one through a
`OnceLock`. This is what makes adding headless scenarios expensive, and #275 is
about adding a lot of them.

**Not filed, recorded here and in #275's territory:** nothing watches that
`SetAnchor` and `SetSize` call `send_size` at all, nor that `needs_measure`
reaches `jobs::request_job`. The unit tests stop at the function boundary by
construction — that is the same wall #275 describes, and closing it is the
accessor this pull request declined to add.
