### PR TITLE
One device for the whole test binary, where there were one per test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,3 +132,10 @@ opt-level = 3
 opt-level = 3
 [profile.dev.package.image]
 opt-level = 3
+# naga is the WGSL front end, run on every shader module and every pipeline a
+# `Renderer` builds — which is once per surface, and once per headless test.
+# Measured on lavapipe: `Renderer::new` costs 133ms with naga at opt-level 0 and
+# 76ms at 3. The price is naga's own codegen, 29s to 34s on a cold build, paid
+# once per build rather than once per surface.
+[profile.dev.package.naga]
+opt-level = 3

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2593,6 +2593,27 @@ mod a_frame_is_a_description_not_a_connection {
     }
 }
 
+/// What a missing GPU adapter means to a test: skip, unless
+/// `GUIDO_GPU_REQUIRED` says a skip is a failure.
+///
+/// A test that needs an adapter and silently passes without one reports green
+/// for the single reason that matters, so the job pointed at lavapipe sets that
+/// variable and a skip becomes a failure there. Written once because the
+/// variable's name and the message are the contract that job depends on.
+#[cfg(test)]
+fn or_skip<T>(made: Option<T>) -> Option<T> {
+    match made {
+        Some(made) => Some(made),
+        None if std::env::var_os("GUIDO_GPU_REQUIRED").is_some() => {
+            panic!("GUIDO_GPU_REQUIRED is set and no GPU adapter was found")
+        }
+        None => {
+            eprintln!("no GPU adapter; skipping");
+            None
+        }
+    }
+}
+
 /// A surface the manager owns, for the tests that need one rather than a
 /// recorder alone — `send_size` reads its config, and a frame needs somewhere to
 /// land.
@@ -2926,19 +2947,6 @@ mod a_frame_lands_where_the_surface_points {
         }
     }
 
-    fn gpu() -> Option<GpuContext> {
-        match GpuContext::try_new() {
-            Some(gpu) => Some(gpu),
-            None if std::env::var_os("GUIDO_GPU_REQUIRED").is_some() => {
-                panic!("GUIDO_GPU_REQUIRED is set and no GPU adapter was found")
-            }
-            None => {
-                eprintln!("no GPU adapter; skipping");
-                None
-            }
-        }
-    }
-
     /// A target smaller than its frame is made to fit, and then reports that it
     /// fits.
     ///
@@ -2947,7 +2955,9 @@ mod a_frame_lands_where_the_surface_points {
     /// them, repainting the entire tree for ever.
     #[test]
     fn a_target_the_wrong_size_is_resized_once_and_not_again() {
-        let Some(gpu) = gpu() else { return };
+        let Some(gpu) = or_skip(GpuContext::try_new()) else {
+            return;
+        };
 
         let mut tree = Tree::new();
         let mut surface = managed_surface(SurfaceConfig::new(), &mut tree);

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -119,7 +119,7 @@ impl Platform for Recorder {
 
 /// One application, one surface, stepped by hand.
 pub struct Headless {
-    gpu: GpuContext,
+    gpu: &'static GpuContext,
     tree: Tree,
     renderer: Option<Renderer>,
     surfaces: SurfaceManager,
@@ -129,12 +129,31 @@ pub struct Headless {
     layout_roots: rustc_hash::FxHashMap<WidgetId, Vec<WidgetId>>,
 }
 
+/// One device for the whole test binary.
+///
+/// An instance, an adapter request and a queue, and every application in a
+/// process can share one set. It outlives them all because a `wgpu::Device` is
+/// cheapest when nothing has to decide when to stop holding it, and a test
+/// binary ends soon enough for that to be the whole of the lifetime question.
+///
+/// One device is not most of what starting an application costs. Measured on
+/// lavapipe: 48ms here, against 76ms to build the `Renderer` that every
+/// application needs one of anyway. So this is a fifth off a test binary, not an
+/// order of magnitude.
+///
+/// The absence of an adapter is cached too: without that, a machine with no GPU
+/// re-discovers it once per test, which is the slow way to skip.
+fn shared_device() -> Option<&'static GpuContext> {
+    static GPU: std::sync::OnceLock<Option<GpuContext>> = std::sync::OnceLock::new();
+    GPU.get_or_init(GpuContext::try_new).as_ref()
+}
+
 impl Headless {
     /// `None` where there is no GPU adapter at all — a frame has to land
     /// somewhere, and the somewhere is a texture this allocates.
     pub fn new() -> Option<Self> {
         Some(Self {
-            gpu: GpuContext::try_new()?,
+            gpu: shared_device()?,
             tree: Tree::new(),
             renderer: None,
             surfaces: SurfaceManager::new(),
@@ -226,7 +245,7 @@ impl Headless {
         let ctx = LoopContext {
             wayland_state: &mut self.host,
             surface_manager: &mut self.surfaces,
-            gpu_context: &self.gpu,
+            gpu_context: self.gpu,
             renderer: &mut self.renderer,
         };
         iterate(ctx, &mut self.tree, &mut self.layout_roots, Some(at));
@@ -295,5 +314,31 @@ impl Drop for Headless {
         if let Some(owner) = self.owner.take() {
             reactive::dispose_owner_now(owner);
         }
+    }
+}
+
+#[cfg(test)]
+mod one_device_for_the_binary {
+    use super::*;
+
+    /// Two applications in one process are handed the same context, so the
+    /// second pays nothing for an adapter. Without it #275's list of scenarios
+    /// is a list of Vulkan devices.
+    ///
+    /// The identity is not observable through [`Headless`]'s public surface,
+    /// which is why this is a unit test rather than one in
+    /// `tests/headless_app.rs`: an accessor added so a test could look would
+    /// outlive the test.
+    #[test]
+    fn two_applications_are_handed_the_same_device() {
+        let Some(first) = crate::or_skip(Headless::new()) else {
+            return;
+        };
+        let second = Headless::new().expect("the first one had an adapter");
+
+        assert!(
+            std::ptr::eq(first.gpu, second.gpu),
+            "a second application built a context of its own"
+        );
     }
 }


### PR DESCRIPTION
## What changed

`Headless::new` built its own `GpuContext` — an instance, an adapter request and
a queue — so the six tests in `tests/headless_app.rs` built six devices, while
the nine goldens beside them have shared one since they were written. Now a
`OnceLock` in the harness hands out one per process, and `Headless` holds a
`&'static` rather than owning one. The absence of an adapter is cached with it:
without that, a machine with no GPU re-discovers it once per test, which is the
slow way to skip.

Two other things came out of the readings and are here because they are the same
subject measured properly:

- **`naga` was missing from the dev-profile opt-level overrides.** It is the
  WGSL front end, run on every shader module and pipeline a `Renderer` builds,
  and the list two dozen lines above it already optimizes tiny-skia, cosmic-text,
  rustybuzz, fontdb and five others for exactly this reason. Two lines, no code.
- **The "skip unless `GUIDO_GPU_REQUIRED`" rule is written once.** It stood in
  two copies with the same panic string, and this change was about to add a
  third.

Closes #281.

## What proves it

`src/testing.rs`'s `two_applications_are_handed_the_same_device`. It is a unit
test rather than one in `tests/headless_app.rs` because device identity is not
observable through `Headless`'s public surface, and an accessor added so a test
could look would outlive the test.

Confirmed failing by reverting **only** the sharing and keeping the rest of the
diff: it fails with "a second application built a context of its own".

And the measurements, three runs each, lavapipe, dev profile:

| `tests/headless_app.rs`, 6 tests | before | one device | + naga |
| --- | --- | --- | --- |
| single-threaded | 1030 ms | 856 ms | **553 ms** |
| default threads | 343 ms | 239 ms | **167 ms** |

Per phase, measured directly rather than inferred:

| | naga at 0 | naga at 3 |
| --- | --- | --- |
| `GpuContext::try_new` | 58.5 ms | 47.6 ms |
| `Renderer::new` | 132.9 ms | 76.3 ms |

**#281's premise was wrong and I corrected it on the issue before writing any of
this.** It attributed the whole 182ms of a headless test to the device; the
device is about 35ms of it, and the win from sharing is a fifth rather than the
order of magnitude the issue implied. What holds exactly as written is the
scaling argument — the seventh test no longer pays for an adapter, and #275 is a
list of scenarios to add.

The other half of the naga trade, which the review asked for and I had not
measured: **its own codegen, 29s to 34s on a cold build.** Five seconds once per
build, against 57ms once per surface and once per headless test.

Harness: clippy `--all-targets --all-features -D warnings`, `cargo test
--all-features` (25 binaries, 590 lib tests), 9 goldens on lavapipe, `cargo check
--tests` with the default features, `cargo check --no-default-features`, `cargo
doc --all-features` with `-D warnings`, and both suites under
`GUIDO_GPU_REQUIRED=1`. Three commits, each green alone.

## What the review found

`/simplify` found twelve across four readings. Three mattered:

1. **A `clippy::needless_borrow` that would have failed CI.** Changing the field
   to `&'static GpuContext` left `gpu_context: &self.gpu` compiling only through
   deref coercion. `-D warnings` rejects it. I had run the tests and not clippy;
   the reading found it before CI did.
2. **The `naga` lever itself**, from the efficiency reading, verified
   independently before being believed — and it is a larger win than this
   issue's own subject.
3. **A doc comment stating a number the measurement did not support** — "some
   170ms" for a device, which was the aggregate saving reported as the
   per-instance cost. Both prose numbers in the diff are now measured figures,
   which is what the phase table above is for.

The `reviewer` read the three commits, ran the test itself on lavapipe and
reproduced the 553/167 numbers. **Zero blocking findings.**

Two worth answering, both acted on, and both the same mistake: a share inferred
rather than measured. The `Cargo.toml` comment claimed naga was "three quarters"
of building a `Renderer` (it is 43%), and it contradicted `shared_device`'s doc.
And the naga change carried only the side of the trade that improved. Both
corrected with the tables above — which is the rule I had just written a
correction on #281 to enforce, and then broke twice in the same diff.

Notes: nothing tests `or_skip`'s panic branch (equally true of the two copies it
replaces, and setting env in a test is `unsafe` under edition 2024); sharing a
device means a wgpu error in one test now reaches its neighbours, a trade the
goldens already accept.

## What CI's mutation job reported, and why it is #283

It came back red with **3 mutants, 3 missed**, all in `src/testing.rs`:
`shared_device` to `None`, `shared_device` to a leaked default, and
`Headless::step_at` to `()`. That job reports and does not block, but the number
was worth understanding rather than waving past.

I ran the two that matter locally, on lavapipe:

| mutant | without `GUIDO_GPU_REQUIRED` | with it |
| --- | --- | --- |
| `shared_device` → `None` | **0 tests fail** | 2 lib + 7 headless fail |
| `step_at` → `()` | — | **6 of 6 headless fail** |

An application whose `step` does nothing is as complete a break as this file
has, and it survives a run that treats a skip as a pass. Both mutants are alive
in CI for one reason: no adapter, so everything skips. That is #283 measured
rather than argued, and the evidence is recorded there.

## What was checked by hand

No compositor: no production behaviour changed. The measurements above are the
hand work — six timed runs of a test binary in three configurations, plus the
per-phase timing, plus two cold builds for the compile-time side.

## Left undone

**#283 — the headless tests have never met an adapter in CI, and skip green in
every run.** The `test` job runs them without an ICD; the `golden` job has
lavapipe and names only `--test golden_images` and `--lib`. So the harness #264
built, and everything #279 and #282 added to it, is watched by nothing but a
developer's machine. Found by the `reviewer` here and confirmed against
`.github/workflows/ci.yml`. **This is the most serious thing this pull request
turned up and it is not in it**, because it is a different subject and the review
had already run — but it should be next.

**#284** — `tests/text_at_angles.rs` still builds two devices in one binary, and
`tests/golden_images.rs` keeps its own `OnceLock`. Sharing them means making this
one public, which would make both files require `--features testing`. That is a
fork worth stating rather than guessing, and #284 records why
`GpuContext::shared()` on the core type was weighed and rejected here.

**Not filed**: `Renderer::new` is now the whole marginal cost of a headless test
at 76ms, of which the readings put roughly 30ms in two `FontSystem::new` calls
scanning every font on the machine. Unifying them is a refactor of who owns what,
not a cleanup, and I have not measured the alternative — so it is named here and
nowhere else until somebody has.

