### PR TITLE
TEMPORARY: proving the golden job runs the headless tests (do not merge)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,9 +74,12 @@ jobs:
     name: Golden images
     runs-on: ubuntu-latest
     env:
-      # Without an adapter the golden tests skip themselves, which would report
-      # green here for the one reason that matters. In CI a skip is a failure.
+      # Without an adapter every test that needs one skips itself, which would
+      # report green here for the one reason that matters. In CI a skip is a
+      # failure. Two names for the one idea, because the goldens got theirs
+      # first and the rest of the suite got another later — see #286.
       GUIDO_GOLDEN_REQUIRED: "1"
+      GUIDO_GPU_REQUIRED: "1"
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -108,17 +111,19 @@ jobs:
           echo "Using $icd"
       - name: Report the rasterizer
         run: vulkaninfo --summary | head -n 40
-      - name: Run golden image tests
-        run: cargo test --all-features --test golden_images
-      # The unit tests that need an adapter live in the lib, and the `test` job
-      # has no ICD — so they skip there and report green. This is the job that
-      # has one. `--lib` runs the whole set, which is cheap, and
-      # `GUIDO_GPU_REQUIRED` makes a skip a failure here for the same reason
-      # `GUIDO_GOLDEN_REQUIRED` does above it.
-      - name: Run the unit tests that need a GPU
-        env:
-          GUIDO_GPU_REQUIRED: 1
-        run: cargo test --all-features --lib
+      # Everything, rather than the targets somebody remembered. This job used
+      # to name them one at a time — the goldens, then the lib — and two test
+      # files that need an adapter were never in the list: `headless_app`, which
+      # is the entire application harness, and `text_at_angles`. Both skipped
+      # themselves in every run since they were written, and reported green.
+      #
+      # `--tests` is the lib's unit tests and every integration target, and not
+      # the sixty examples: a plain `cargo test` builds those too, which is the
+      # 18 GB the mutants job below documents avoiding. Nothing has to be added
+      # here when a target is added, which is the property the old list did not
+      # have.
+      - name: Run every test, against a rasterizer
+        run: cargo test --all-features --tests
       - name: Upload the pixels that moved
         if: failure()
         uses: actions/upload-artifact@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,8 +98,11 @@ cargo test --test golden_images
 Install it with `vulkan-swrast` on Arch, `mesa-vulkan-drivers` on Debian and
 Ubuntu. On any other adapter those tests skip themselves — a golden holds only
 against the rasterizer it was blessed on — so `cargo test --all-features` is
-green on a machine with a GPU and the pixels are checked by the job that points
-at lavapipe. In that job a skip is a failure.
+green on a machine with a GPU, and everything that needs an adapter is run by
+the job that points at lavapipe. **In that job a skip is a failure**, and it
+runs the whole suite rather than the targets somebody remembered to list: two
+files that need an adapter were once not on that list, and skipped green in
+every run for months.
 
 ## What proves what
 

--- a/tests/headless_app.rs
+++ b/tests/headless_app.rs
@@ -127,8 +127,8 @@ fn a_bar_reserving_automatically_declares_its_height_when_it_is_created() {
 
     assert_eq!(
         app.exclusive_zones_asked(),
-        [50],
-        "once, at creation, and the frames after it say nothing"
+        [51],
+        "DELIBERATELY BROKEN: proving the golden job runs this file"
     );
 }
 


### PR DESCRIPTION
Throwaway. #283's acceptance asks for the fix to be confirmed by breaking a headless test and watching the job go red, not by reading the workflow. One assertion in `tests/headless_app.rs` is deliberately wrong on top of the real change.

Expected: **Golden images** red, and `Test` green — because the `test` job has no adapter, which is the whole point.

Closed as soon as it has reported.