### PR TITLE
The job with a rasterizer runs every test, not the ones on a list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,12 +71,19 @@ jobs:
         run: cargo check --tests
 
   golden:
+    # The name is narrower than what this job does — it runs the whole suite
+    # now, so a failure in `signal_fields` reports under it. Renaming it is a
+    # one-word change here and a change to the repository's ruleset, which
+    # requires this exact string as a status check: #289.
     name: Golden images
     runs-on: ubuntu-latest
     env:
-      # Without an adapter the golden tests skip themselves, which would report
-      # green here for the one reason that matters. In CI a skip is a failure.
+      # Without an adapter every test that needs one skips itself, which would
+      # report green here for the one reason that matters. In CI a skip is a
+      # failure. Two names for the one idea, because the goldens got theirs
+      # first and the rest of the suite got another later — see #286.
       GUIDO_GOLDEN_REQUIRED: "1"
+      GUIDO_GPU_REQUIRED: "1"
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -108,17 +115,19 @@ jobs:
           echo "Using $icd"
       - name: Report the rasterizer
         run: vulkaninfo --summary | head -n 40
-      - name: Run golden image tests
-        run: cargo test --all-features --test golden_images
-      # The unit tests that need an adapter live in the lib, and the `test` job
-      # has no ICD — so they skip there and report green. This is the job that
-      # has one. `--lib` runs the whole set, which is cheap, and
-      # `GUIDO_GPU_REQUIRED` makes a skip a failure here for the same reason
-      # `GUIDO_GOLDEN_REQUIRED` does above it.
-      - name: Run the unit tests that need a GPU
-        env:
-          GUIDO_GPU_REQUIRED: 1
-        run: cargo test --all-features --lib
+      # Everything, rather than the targets somebody remembered. This job used
+      # to name them one at a time — the goldens, then the lib — and two test
+      # files that need an adapter were never in the list: `headless_app`, which
+      # is the entire application harness, and `text_at_angles`. Both skipped
+      # themselves in every run since they were written, and reported green.
+      #
+      # `--tests` is the lib's unit tests and every integration target, and not
+      # the sixty examples: a plain `cargo test` builds those too, which is the
+      # 18 GB the mutants job below documents avoiding. Nothing has to be added
+      # here when a target is added, which is the property the old list did not
+      # have.
+      - name: Run every test, against a rasterizer
+        run: cargo test --all-features --tests
       - name: Upload the pixels that moved
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -55,7 +55,9 @@ jobs:
               cargo fmt --all
               cargo clippy --all-targets --all-features -- -D warnings
               cargo test --all-features
-              GUIDO_GOLDEN_REQUIRED=1 cargo test --test golden_images
+              GUIDO_GOLDEN_REQUIRED=1 GUIDO_GPU_REQUIRED=1 \
+                cargo test --all-features --tests
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GUIDO_GOLDEN_REQUIRED: "1"
+          GUIDO_GPU_REQUIRED: "1"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,8 +98,11 @@ cargo test --test golden_images
 Install it with `vulkan-swrast` on Arch, `mesa-vulkan-drivers` on Debian and
 Ubuntu. On any other adapter those tests skip themselves — a golden holds only
 against the rasterizer it was blessed on — so `cargo test --all-features` is
-green on a machine with a GPU and the pixels are checked by the job that points
-at lavapipe. In that job a skip is a failure.
+green on a machine with a GPU, and everything that needs an adapter is run by
+the job that points at lavapipe. **In that job a skip is a failure**, and it
+runs the whole suite rather than the targets somebody remembered to list: two
+files that need an adapter were once not on that list, and skipped green in
+every run for months.
 
 ## What proves what
 


### PR DESCRIPTION
## What changed

The job with the rasterizer named its targets one at a time — the goldens, then
the lib — and two files that need an adapter were never on that list.
`tests/headless_app.rs` is the whole application harness, six tests driving the
real loop with a recorder where the compositor would be. `tests/text_at_angles.rs`
renders text and counts glyph pixels. Both return early without a Vulkan adapter
rather than failing, which is right on a laptop and wrong in the one job built to
catch it. **They had skipped green in every run since they were written.**

The list is gone rather than corrected: `cargo test --all-features --tests`, one
step, and `GUIDO_GPU_REQUIRED` moved up to the job's `env:` beside
`GUIDO_GOLDEN_REQUIRED`. Nothing has to be added here when a target is added.

`claude.yml` handed an agent the same list in a prompt, so an agent following the
contract to the letter would have run the pixels and skipped the harness — on a
runner with lavapipe installed for it.

The job's name is untouched, and that is a correction: I renamed it, CI went
fully green, and **the merge was refused** — the repository's ruleset requires a
status check with exactly the string `Golden images`, so renaming the job deleted
a check every pull request waits for. I had checked
`branches/main/protection`, which answers `404 Branch not protected`, and read
that as "nothing is required"; the requirement lives under `rulesets`, a
different endpoint. The name is back, with a comment saying why, and the rename
is **#289** — it needs the workflow and the ruleset changed in one motion, in a
sequence that never leaves an open pull request waiting for a check that cannot
appear.

Closes #283.

## What proves it

Not the workflow read back to itself. #283 asks for the fix to be confirmed by
breaking a headless test and watching the job go red, so that is what was done:
**a throwaway branch and draft pull request (#287)**, one assertion in
`tests/headless_app.rs` deliberately wrong on top of this change.

| job | result |
| --- | --- |
| `Test` (no ICD) | **green** — it ran the broken test and the test skipped |
| the rasterizer job | **red** on `a_bar_reserving_automatically_declares_its_height_when_it_is_created` |

The same broken test passing in one job and failing in the other is this issue
and its fix in a single run. What that job's log shows it ran, with real counts
rather than skips: lib **590**, `golden_images` **9**, `headless_app` **5 passed 1
failed**, `text_at_angles` **2**. #287 is closed and its branch deleted.

Locally on lavapipe with both variables set, the whole suite is green in 3s and
`--tests` builds 24 targets and **zero** examples — a plain `cargo test` builds
the sixty, which is the 18 GB the mutants job documents avoiding.

**On the wall clock #283 asked for**: the rasterizer job has historically run in
46, 54, 64, 81 and 89 seconds, and the proof run took 58. The added tests are
about 3 seconds of runtime; the job now also links 21 more test binaries in its
own cache, and I did not isolate that cost. It is inside the existing variance,
which is the honest thing to say rather than quoting a delta the numbers do not
support.

Harness: clippy `--all-targets --all-features -D warnings`, the whole suite on
lavapipe with both variables, `cargo test --all-features` (25 binaries with the
doc tests), `cargo check --tests`, `cargo check --no-default-features`, `cargo doc
--all-features -D warnings`, and `agent_workflow` and `documentation_references`
for the `AGENTS.md` edit.

## What the review found

**The first version of this change was thrown away, and that is the interesting
part.** I had written `tests/ci_runs_what_needs_an_adapter.rs` — 161 lines that
parsed the workflow YAML and asserted every adapter-needing target was named in
the job — plus two steps naming the two missing targets.

`/simplify`'s **altitude** reading argued that was one level too low: the
omission should be made unrepresentable rather than watched, and
`cargo test --all-features --tests` does that. It measured what I had not — that
`--tests` excludes the examples, and that the job has 168 seconds of slack
against the `Test` job it runs in parallel with.

Its **simplification** reading then proved one of my two tests **could not
fail**: to be true of both env-var spellings it accepted either, and the job sets
`GUIDO_GOLDEN_REQUIRED` job-wide, so the assertion held for every step regardless
of what the step said. A tautology that read as coverage — which is the same
failure this issue is about, one level up. It also found that my YAML block
splitter silently never saw the last job in the file.

I verified all of it myself before believing it, deleted the file, and rewrote
the change as one step.

Its **reuse** reading found I had put `GUIDO_GPU_REQUIRED` on two steps when the
job already had an `env:` block; **efficiency** found the diff clean and
corrected a premise of mine (the directory scan was not in a loop).

The `reviewer` then read the commits and ran the suite itself. **Zero blocking
findings.** It judged deleting the sensor right, and for a reason worth keeping:
what the test had left to assert was that the YAML says `--tests`, which is a
restatement of the file it reads and passes whether or not any test met an
adapter.

Two worth answering, both closed above: the acceptance needed CI evidence rather
than a local run (#287), and my cost claim measured runtime and not the build.

Notes acted on: the job's name, and `claude.yml`. One note is recorded rather
than fixed — see below.

**On process**: `/simplify` ran on the *first* shape and its readings produced
this one. The resulting diff did not go back through it; it is a step, a name and
a prompt line, and the `reviewer` is the independent read of it.

## What was checked by hand

The CI run above, which is the only place this change can be checked. Nothing on
a compositor: no library code changed.

## Left undone

**#286, widened** — `--tests` guarantees a binary *runs*, not that its skip is
*fatal*. A new adapter-needing test that forgets to copy a guard will still skip
green. There are three hand-copied guards, and `or_skip`, the one that would
serve everybody, is `#[cfg(test)]` and so unreachable from `tests/`. The issue
already covered the two variable names; it now covers the guard as well, and
notes that where a shared one lives is the same fork #284 describes.

**#278** — the mutation job has neither an adapter nor either variable, so the
three missed mutants in `src/testing.rs` that are the evidence on #283 will keep
reporting missed. This change does not fix that, and the evidence should not read
as though it did.

