### PR TITLE
The job says what it does, and what it does is everything

### DIFF
--- a/.claude/skills/visual-verification/SKILL.md
+++ b/.claude/skills/visual-verification/SKILL.md
@@ -44,7 +44,8 @@ corner tangent points. Blessing on anything else is refused by the test.
 On any other adapter they skip themselves, which is why `cargo test` on a
 machine with a GPU does not drown in failures that are not regressions. Set
 `GUIDO_GOLDEN_ANY_ADAPTER=1` to run them anyway and look. CI sets
-`GUIDO_GOLDEN_REQUIRED=1` in the golden job, where a skip is a failure.
+`GUIDO_GOLDEN_REQUIRED=1` in the job that points at lavapipe, where a skip is a
+failure.
 
 ### Reading a failure
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,12 +70,22 @@ jobs:
       - name: Build the tests with the default features
         run: cargo check --tests
 
+  # Keyed `golden` because the goldens are why this job has a rasterizer, and
+  # named for what it does because it runs the whole suite.
+  #
+  # This string and the `main` ruleset's required status check are one edit
+  # apart: change either and change both, or every pull request waits on a
+  # check that can no longer appear, which is #288. The ruleset is invisible
+  # from here — `repos/.../branches/main/protection` answers 404 and reads as
+  # "nothing is required"; it is `repos/.../rules/branches/main` that answers.
+  #
+  # The order is not the intuitive one. Adding the new name *beside* the old
+  # blocks just as hard, because a required check that never reports stays
+  # pending for ever: the old name has to come out of the ruleset first, then
+  # the rename merges, then the new name goes in. Removing the coupling
+  # altogether is #290.
   golden:
-    # The name is narrower than what this job does — it runs the whole suite
-    # now, so a failure in `signal_fields` reports under it. Renaming it is a
-    # one-word change here and a change to the repository's ruleset, which
-    # requires this exact string as a status check: #289.
-    name: Golden images
+    name: Everything, on a rasterizer
     runs-on: ubuntu-latest
     env:
       # Without an adapter every test that needs one skips itself, which would


### PR DESCRIPTION
## What changed

Since #283 this job runs `cargo test --all-features --tests` — the lib's unit
tests and every integration target — and it was still called `Golden images`. A
failure in `signal_fields` reported under that name, sending whoever read it to
`target/golden-failures/` to find nothing.

It is now **`Everything, on a rasterizer`**. The skill said "the golden job",
which matched the old display name and now matches nothing a reader would find
in the checks list; it says what `AGENTS.md` says instead.

Closes #289.

## ⚠️ This cannot be merged on the usual reflex

The `main` ruleset requires a status check named exactly `Golden images`.
Renaming the job deletes that check, so **merging this while the ruleset is
unchanged blocks it**, green checks and all — which is #288, arrived at from the
other side.

Three edits, in this order, and no other order is safe:

1. `Golden images` comes **out** of the ruleset's required checks.
2. This merges.
3. `Everything, on a rasterizer` goes **in**.

The intuitive sequence — add the new name beside the old, merge, drop the old —
blocks just as hard, because a required check that never reports stays pending
for ever. That correction is recorded on #289 and, because that issue closes
with this, in the comment above the job as well.

**Steps 1 and 3 have not been made.** They are repository settings rather than
files, so they are not in this diff and cannot be reviewed by merging it; I am
asking before touching them. Between 1 and 2 the rasterizer job runs and is
green but is not *required* to be — one merge wide, watched by whoever does it.

## What proves it

Nothing automated, and my first statement of why was wrong.

I claimed the divergence is between a file and a setting no test can read. The
`reviewer` checked rather than accepting it, and
`GET /repos/{owner}/{repo}/rules/branches/main` returns the required contexts
with an ordinary read token — no admin, no ruleset id. So a check *is* writable;
it would be a new CI gate, which is #290's subject and the maintainer's call, and
it is now recorded there as a third option that issue did not weigh. The honest
narrower claim is that nothing in **this repository's harness** can read a
repository setting.

So the proof is by hand and in two halves: this pull request merging with
`mergeStateStatus` not `BLOCKED` — green alone is exactly what looked fine on
#288 — and the ruleset read back afterwards, because between steps 1 and 3
"renamed" and "quietly unguarded" look identical from outside.

The harness ran green regardless: clippy `--all-targets --all-features -D
warnings`, the whole suite on lavapipe with both variables, `cargo fmt --check`,
and `agent_workflow` and `documentation_references` for the prose.

## What the review found

`/simplify` ran as two readings rather than four: on a seven-line YAML diff,
separate efficiency and reuse passes had nothing to look at. Worth noting the
`reviewer` agreed for a better reason than mine — the reading that would have
been dropped is the one that found the stale sentence in the skill.

It rejected my first name. **`Tests, against a rasterizer`** shares a prefix with
the job called `Test`: the two sort adjacent in the checks list, one `s` apart, in
a string that gets typed by hand into repository settings — where a mismatch does
not error, it sits at "Expected" for ever. It also made the `mutants` job's "the
examples are compiled by the Test job" ambiguous, and that sentence is the whole
argument for `--lib --tests` there. It cut a clause from my comment that was
still arguing against the old name, and found the skill's stale reference.

The `reviewer` verified the comment's factual claims by running them rather than
reading them, and grepped the tree for surviving references to the old name.
**Zero blocking findings.**

Three worth answering, all acted on: the sequence correction lived only in a
comment on an issue about to close, and is now in the workflow comment where the
next person renaming a required job will meet it; my "there cannot be a test"
claim was too strong, narrowed above and the endpoint recorded on #290; and the
merge precondition, which is the section at the top of this body.

One note taken: the comment stated as fact that the ruleset names this string,
which is false until step 3. It states the invariant instead — the two are one
edit apart.

## What was checked by hand

The ruleset, read live: it still requires `Golden images`, and
`branches/main/protection` still answers `404 Branch not protected`, which is why
this was invisible. Nothing on a compositor — no library code changed.

## Left undone

**#290** — five job names live in repository settings and nothing checks they
still match the workflow. Filed as its own issue rather than left in a comment on
#289, because that issue closes here and a follow-up recorded only in a closing
thread is written down and lost in one motion. It carries the four concrete
objections to the aggregating gate as prior art — chiefly that it trades #288's
loud failure for a quiet one, since GitHub counts a skipped required check as
success — and now the third option above. Labelled `needs-design`: what gates
merges is not mine to change.
