### PR TITLE
A headless application holds as many surfaces as the loop will carry

### DIFF
--- a/.claude/skills/wayland/SKILL.md
+++ b/.claude/skills/wayland/SKILL.md
@@ -45,17 +45,25 @@ Multiple surfaces share one reactive state and one renderer.
 `tests/headless_app.rs` drives the real loop — `iterate`, the function
 `App::run` calls — with a `guido::testing::Headless` standing where the
 compositor would be: a recorder implementing `Platform` and `Surface` that
-answers for one surface and keeps what it was asked. So a surface configuring, a
-frame opening, input routing, layout, paint, and *what the surface asks the
-compositor for* all have a sensor. It needs the `testing` feature and a GPU
-adapter.
+answers for as many surfaces as the loop will carry and keeps what each was
+asked. So a surface configuring, a frame opening, input routing, layout, paint,
+*what the surface asks the compositor for*, a second surface, `spawn_surface`
+and `close` at runtime, and the order a popup chain is torn down in all have a
+sensor. It needs the `testing` feature and a GPU adapter.
 
 What has none: what goes out on the wire, and what a compositor does with it.
 The recorder proves guido asks for an exclusive zone of 50; it cannot prove niri
-reserves 50. And it drives one static surface, so **dynamic spawn and close,
-popups, the session lock and output hotplug are still verified by running an
-example and looking** — they type-check against the same trait and nothing
-exercises them.
+reserves 50. And it is the recorder's own answer to
+`popup_descendants_bottom_up` that the teardown test walks — what is proved is
+that the *loop* asks in that order, not that `src/platform/popups.rs` computes
+it right.
+
+Still verified by running an example and looking: **the session lock, output
+hotplug, and grab conflicts between popups**. They type-check against the same
+trait and need no redesign, but each needs something built: the recorder leaves
+`Platform`'s four lock methods at their defaults, `outputs::sync_outputs` is
+`pub(crate)`, and the recorder discards the `PopupConfig` that says which popups
+hold a grab.
 
 When you change this layer:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,13 +125,25 @@ That last row is what is left of the hole. Until #264 it was the whole of it:
 nothing could construct an application, so everything it does with what the
 compositor says was watched by a person running an example. `Headless` closes
 that half — it drives `iterate`, the same function `App::run` drives, against a
-recorder that answers for one surface and keeps what it was asked.
+recorder that answers for every surface the loop holds and keeps what each was
+asked.
 
 What it cannot close is the half below it. The recorder is not a compositor: it
 proves guido asks for an exclusive zone of 50, never that niri does the right
-thing with one. And it answers for one static surface, so dynamic spawn and
-close, popups and the session lock are still watched by a person, even though
-they type-check against the same trait.
+thing with one.
+
+It now holds as many surfaces as the loop will carry, so a second surface, and
+`spawn_surface` and `close` at runtime, are watched too. So is the order the
+loop tears a popup chain down in — though only the loop's half of it: the
+recorder answers `popup_descendants_bottom_up` from its own map, so the Wayland
+implementation of that same rule still has no sensor (#292).
+
+The session lock, output hotplug and popup grab conflicts are the remainder.
+They need no redesign — the map was the missing part — but they do need
+machinery: the recorder answers four of `Platform`'s lock methods with the
+trait's defaults, `sync_outputs` is `pub(crate)` so no test in `tests/` can
+reach it, and the recorder throws away the `PopupConfig` that would say which
+popups hold a grab.
 
 ## What watches the harness
 

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -8,9 +8,16 @@
 //!
 //! [`Headless`] is the other caller. It holds the same tree, the same renderer
 //! and the same frame path, with a recorder where the compositor was: it answers
-//! for one surface, keeps what it was asked, and never talks to anything. A test
-//! says what the compositor said and then reads both halves — what the widgets
-//! became, and what the surface asked for.
+//! for as many surfaces as the loop will carry, keeps what each was asked, and
+//! never talks to anything. A test says what the compositor said and then reads
+//! both halves — what the widgets became, and what each surface asked for.
+//!
+//! Surfaces declared before the loop runs come from [`Headless::surface`], the
+//! way `App::add_surface` declares them. After it is running they come from
+//! guido's own `spawn_surface` and go away through `surface_handle(id).close()`,
+//! and [`Headless::step`] is what drains the command either one queues — so a
+//! test spawns a surface the way an application does, not the way a harness
+//! would let it.
 //!
 //! It is not a compositor and cannot be. What it proves is guido's half; what
 //! niri does with an exclusive zone of 50 is still a question no test here can
@@ -18,7 +25,7 @@
 
 use std::time::Instant;
 
-use crate::reactive::{self, OwnerId};
+use crate::reactive;
 use crate::renderer::{GpuContext, RenderTarget, Renderer};
 use crate::surface::{SurfaceConfig, SurfaceId};
 use crate::surface_manager::{ManagedSurface, SurfaceManager};
@@ -26,10 +33,14 @@ use crate::tree::{Tree, WidgetId};
 use crate::widgets::{Event, MouseButton, Widget};
 use crate::{Frame, LoopContext, Platform, Surface, iterate};
 
-/// The compositor's half of one surface: what it has said, and what it has been
-/// asked for.
+/// The compositor's half of one surface: what it has said, and what it has
+/// been asked for.
 #[derive(Default)]
-struct Recorder {
+struct RecordedSurface {
+    /// The surface this one hangs from, for a popup. On the surface rather than
+    /// in a map beside it, so a parent link cannot outlive its surface — which
+    /// is also where `WaylandState` keeps it.
+    parent: Option<SurfaceId>,
     width: u32,
     height: u32,
     scale: f32,
@@ -41,68 +52,138 @@ struct Recorder {
     frame_callbacks: u32,
 }
 
-/// The one surface a `Headless` has, borrowed for a frame.
-struct RecordedSurface<'a>(&'a mut Recorder);
+/// The compositor's half of a *connection*: every surface it holds, and the
+/// order it was told to build and tear them down in.
+///
+/// Lists rather than counts, because the order is what is asserted.
+#[derive(Default)]
+struct Recorder {
+    surfaces: rustc_hash::FxHashMap<SurfaceId, RecordedSurface>,
+    created: Vec<SurfaceId>,
+    destroyed: Vec<SurfaceId>,
+}
 
-impl Surface for RecordedSurface<'_> {
+impl Recorder {
+    fn get(&self, id: SurfaceId) -> &RecordedSurface {
+        self.surfaces.get(&id).unwrap_or_else(|| missing(id))
+    }
+
+    fn get_mut(&mut self, id: SurfaceId) -> &mut RecordedSurface {
+        self.surfaces.get_mut(&id).unwrap_or_else(|| missing(id))
+    }
+}
+
+/// The two ways to name a surface that is not there, said once.
+fn missing(id: SurfaceId) -> ! {
+    panic!("surface {id:?} was never declared, or has been closed")
+}
+
+impl Surface for &mut RecordedSurface {
     fn open_frame(&mut self) -> Option<Frame> {
-        if !self.0.configured {
+        if !self.configured {
             return None;
         }
         Some(Frame {
-            events: std::mem::take(&mut self.0.events),
-            scale_factor: self.0.scale,
-            width: self.0.width,
-            height: self.0.height,
+            events: std::mem::take(&mut self.events),
+            scale_factor: self.scale,
+            width: self.width,
+            height: self.height,
             // Never pending: a driver that had to wait for a callback nobody
             // sends would step once and stop.
             frame_callback_pending: false,
-            force_render_surface: !self.0.first_frame_presented,
+            force_render_surface: !self.first_frame_presented,
         })
     }
 
     fn configured_size(&self) -> Option<(u32, u32)> {
-        self.0.configured.then_some((self.0.width, self.0.height))
+        self.configured.then_some((self.width, self.height))
     }
 
     fn scale_factor(&self) -> Option<f32> {
-        self.0.configured.then_some(self.0.scale)
+        self.configured.then_some(self.scale)
     }
 
     fn set_size(&mut self, width: u32, height: u32) {
-        self.0.sizes_asked.push((width, height));
+        self.sizes_asked.push((width, height));
     }
 
     fn set_exclusive_zone(&mut self, zone: i32) {
-        self.0.exclusive_zones.push(zone);
+        self.exclusive_zones.push(zone);
     }
 
     fn request_frame_callback(&mut self) {
-        self.0.frame_callbacks += 1;
+        self.frame_callbacks += 1;
     }
 
     fn mark_frame_callback_pending(&mut self) {
-        self.0.first_frame_presented = true;
+        self.first_frame_presented = true;
     }
 }
 
 impl Platform for Recorder {
-    type Surface<'a> = RecordedSurface<'a>;
+    type Surface<'a> = &'a mut RecordedSurface;
 
-    fn surface(&mut self, _id: SurfaceId) -> Option<RecordedSurface<'_>> {
-        Some(RecordedSurface(self))
+    fn surface(&mut self, id: SurfaceId) -> Option<&mut RecordedSurface> {
+        self.surfaces.get_mut(&id)
     }
 
-    /// A texture, where a compositor would hand out a swapchain. The one place
-    /// the two implementations differ by doing rather than by recording — and
-    /// the reason a surface can be *born* without a compositor rather than only
-    /// driven after somebody else built it one.
-    fn create_surface(&mut self, _id: SurfaceId, config: &crate::surface::SurfaceConfig) {
+    fn create_surface(&mut self, id: SurfaceId, config: &crate::surface::SurfaceConfig) {
         // The same function the layer-shell path uses, so what a surface says
         // at birth cannot differ between the two.
         let declared = crate::surface::initial_declaration(config);
-        self.sizes_asked.push(declared.asked);
-        self.exclusive_zones.push(declared.exclusive_zone);
+        self.created.push(id);
+        self.surfaces.insert(
+            id,
+            RecordedSurface {
+                scale: 1.0,
+                sizes_asked: vec![declared.asked],
+                exclusive_zones: vec![declared.exclusive_zone],
+                ..Default::default()
+            },
+        );
+    }
+
+    /// A popup is a surface that knows what it hangs from. The size is the
+    /// compositor's answer, so it arrives configured — a real one would wait a
+    /// round trip, and nothing here is waiting for anything.
+    fn create_popup(
+        &mut self,
+        id: SurfaceId,
+        parent: SurfaceId,
+        _config: &crate::surface::PopupConfig,
+        size: (u32, u32),
+    ) -> bool {
+        self.created.push(id);
+        self.surfaces.insert(
+            id,
+            RecordedSurface {
+                parent: Some(parent),
+                width: size.0,
+                height: size.1,
+                scale: 1.0,
+                configured: true,
+                ..Default::default()
+            },
+        );
+        true
+    }
+
+    fn destroy_surface(&mut self, id: SurfaceId) {
+        self.destroyed.push(id);
+        self.surfaces.remove(&id);
+    }
+
+    /// Deepest first, which is the order the protocol demands and the order the
+    /// loop is supposed to close them in.
+    fn popup_descendants_bottom_up(&self, root: SurfaceId) -> Vec<SurfaceId> {
+        let mut out = Vec::new();
+        for (&child, surface) in &self.surfaces {
+            if surface.parent == Some(root) {
+                out.extend(self.popup_descendants_bottom_up(child));
+                out.push(child);
+            }
+        }
+        out
     }
 
     fn create_render_target(
@@ -117,15 +198,13 @@ impl Platform for Recorder {
     }
 }
 
-/// One application, one surface, stepped by hand.
+/// One application and its surfaces, stepped by hand.
 pub struct Headless {
     gpu: &'static GpuContext,
     tree: Tree,
     renderer: Option<Renderer>,
     surfaces: SurfaceManager,
-    id: Option<SurfaceId>,
     host: Recorder,
-    owner: Option<OwnerId>,
     layout_roots: rustc_hash::FxHashMap<WidgetId, Vec<WidgetId>>,
 }
 
@@ -157,27 +236,22 @@ impl Headless {
             tree: Tree::new(),
             renderer: None,
             surfaces: SurfaceManager::new(),
-            id: None,
-            host: Recorder {
-                scale: 1.0,
-                ..Default::default()
-            },
-            owner: None,
+            host: Recorder::default(),
             layout_roots: rustc_hash::FxHashMap::default(),
         })
     }
 
-    /// Declare the surface, as `App::add_surface` does. One only, for now.
-    pub fn surface<W, F>(&mut self, config: SurfaceConfig, widget_fn: F)
+    /// Declare a surface before the loop runs, as `App::add_surface` does.
+    ///
+    /// The id it returns is what `spawn_popup` wants for a parent, and what
+    /// every accessor here is asked about.
+    pub fn surface<W, F>(&mut self, config: SurfaceConfig, widget_fn: F) -> SurfaceId
     where
         W: Widget + 'static,
         F: FnOnce() -> W,
     {
         let (widget, owner) = reactive::with_owner(|| Box::new(widget_fn()) as Box<dyn Widget>);
-        self.owner = Some(owner);
-
         let id = SurfaceId::next();
-        self.id = Some(id);
 
         // Through the trait, not beside it: a fixed-size bar declares its
         // reservation once, at birth, and if the driver wrote that number down
@@ -190,31 +264,35 @@ impl Headless {
             owner,
             &mut self.tree,
         ));
+        id
     }
 
-    /// Say what the compositor confirmed. Until this is called there is no size
-    /// to draw at, and [`step`](Self::step) does nothing — which is what an
-    /// unconfigured surface does in the real loop.
-    pub fn configure(&mut self, width: u32, height: u32, scale: f32) {
-        self.host.width = width;
-        self.host.height = height;
-        self.host.scale = scale;
-        self.host.configured = true;
+    /// Say what the compositor confirmed for one surface. Until this is called
+    /// there is no size to draw at and [`step`](Self::step) does nothing for it
+    /// — which is what an unconfigured surface does in the real loop.
+    pub fn configure(&mut self, id: SurfaceId, width: u32, height: u32, scale: f32) {
+        let surface = self.host.get_mut(id);
+        surface.width = width;
+        surface.height = height;
+        surface.scale = scale;
+        surface.configured = true;
     }
 
-    /// Queue a press and a release at a point, in logical coordinates.
+    /// Queue a press and a release at a point on one surface, in logical
+    /// coordinates.
     ///
     /// They are delivered by the next [`step`](Self::step), because that is when
     /// the frame that carries them opens — the same order the compositor's own
     /// events arrive in.
-    pub fn click(&mut self, x: f32, y: f32) {
-        self.click_at(x, y, Instant::now());
+    pub fn click(&mut self, id: SurfaceId, x: f32, y: f32) {
+        self.click_at(id, x, y, Instant::now());
     }
 
     /// [`click`](Self::click), at a moment you name — so a gesture can be
     /// played through the application at the speed it is meant to have.
-    pub fn click_at(&mut self, x: f32, y: f32, now: Instant) {
-        self.host.events.push((
+    pub fn click_at(&mut self, id: SurfaceId, x: f32, y: f32, now: Instant) {
+        let surface = self.host.get_mut(id);
+        surface.events.push((
             now,
             Event::MouseDown {
                 x,
@@ -222,7 +300,7 @@ impl Headless {
                 button: MouseButton::Left,
             },
         ));
-        self.host.events.push((
+        surface.events.push((
             now,
             Event::MouseUp {
                 x,
@@ -234,85 +312,90 @@ impl Headless {
 
     /// One frame: open it, route what is queued, measure, paint, present.
     ///
+    /// Returns why the loop ended, or `None` if it did not: closing the last
+    /// surface is `Some(ExitReason::Quit)`. Nothing here stops a test stepping
+    /// again afterwards, and nothing good comes of it — the real loop returns.
+    ///
     /// The moment is the caller's, so an animation can be walked through
     /// without sleeping.
-    pub fn step(&mut self) {
-        self.step_at(Instant::now());
+    pub fn step(&mut self) -> Option<crate::ExitReason> {
+        self.step_at(Instant::now())
     }
 
     /// [`step`](Self::step), at a moment you name.
-    pub fn step_at(&mut self, at: Instant) {
+    pub fn step_at(&mut self, at: Instant) -> Option<crate::ExitReason> {
         let ctx = LoopContext {
             wayland_state: &mut self.host,
             surface_manager: &mut self.surfaces,
             gpu_context: self.gpu,
             renderer: &mut self.renderer,
         };
-        iterate(ctx, &mut self.tree, &mut self.layout_roots, Some(at));
+        iterate(ctx, &mut self.tree, &mut self.layout_roots, Some(at))
     }
 
-    fn root(&self) -> WidgetId {
+    fn root(&self, id: SurfaceId) -> WidgetId {
         self.surfaces
-            .get(self.id.expect("no surface"))
-            .expect("no surface")
+            .get(id)
+            .unwrap_or_else(|| missing(id))
             .widget_id
     }
 
-    fn target(&self) -> &RenderTarget {
+    fn target(&self, id: SurfaceId) -> &RenderTarget {
         self.surfaces
-            .get(self.id.expect("no surface"))
+            .get(id)
             .and_then(|s| s.wgpu_surface.as_ref())
             .expect("no target; step once after configuring")
     }
 
-    /// The size the root widget was measured at, in logical pixels.
-    pub fn root_size(&self) -> (f32, f32) {
-        let bounds = self.tree.get_bounds(self.root()).unwrap_or_default();
+    /// The size a surface's root widget was measured at, in logical pixels.
+    pub fn root_size(&self, id: SurfaceId) -> (f32, f32) {
+        let bounds = self.tree.get_bounds(self.root(id)).unwrap_or_default();
         (bounds.width, bounds.height)
     }
 
-    /// The size of the buffer the last frame was drawn into, in physical
-    /// pixels — the logical size times the scale the compositor confirmed.
-    pub fn physical_size(&self) -> (u32, u32) {
-        let target = self.target();
+    /// The size of the buffer a surface's last frame was drawn into, in
+    /// physical pixels — the logical size times the scale the compositor
+    /// confirmed.
+    pub fn physical_size(&self, id: SurfaceId) -> (u32, u32) {
+        let target = self.target(id);
         (target.width(), target.height())
     }
 
-    /// The screen space this surface last asked the compositor to reserve.
-    pub fn exclusive_zone_asked(&self) -> Option<i32> {
-        self.host.exclusive_zones.last().copied()
-    }
-
-    /// Every reservation this surface has asked for, oldest first. A frame that
+    /// Every reservation a surface has asked for, oldest first. A frame that
     /// republishes one it already sent is not the same as one that says nothing,
     /// and only a list can tell them apart.
-    pub fn exclusive_zones_asked(&self) -> &[i32] {
-        &self.host.exclusive_zones
+    pub fn exclusive_zones_asked(&self, id: SurfaceId) -> &[i32] {
+        &self.host.get(id).exclusive_zones
     }
 
-    /// The sizes this surface has asked for, oldest first.
-    pub fn sizes_asked(&self) -> &[(u32, u32)] {
-        &self.host.sizes_asked
+    /// The sizes a surface has asked for, oldest first.
+    pub fn sizes_asked(&self, id: SurfaceId) -> &[(u32, u32)] {
+        &self.host.get(id).sizes_asked
     }
 
-    /// How many frames have been presented and had their callback re-armed.
-    pub fn frames_presented(&self) -> u32 {
-        self.host.frame_callbacks
+    /// How many frames a surface has presented and had its callback re-armed.
+    pub fn frames_presented(&self, id: SurfaceId) -> u32 {
+        self.host.get(id).frame_callbacks
     }
 
-    /// The colour at one pixel of the last frame, in physical coordinates.
-    pub fn read_pixel(&self, x: u32, y: u32) -> [u8; 4] {
-        match self.target() {
+    /// Every surface the compositor was told to build, oldest first — including
+    /// the ones an application spawned at runtime, and popups.
+    pub fn surfaces_created(&self) -> &[SurfaceId] {
+        &self.host.created
+    }
+
+    /// Every surface the compositor was told to tear down, in the order it was
+    /// told.
+    pub fn surfaces_destroyed(&self) -> &[SurfaceId] {
+        &self.host.destroyed
+    }
+
+    /// The colour at one pixel of a surface's last frame, in physical
+    /// coordinates.
+    pub fn read_pixel(&self, id: SurfaceId, x: u32, y: u32) -> [u8; 4] {
+        match self.target(id) {
             RenderTarget::Offscreen(offscreen) => offscreen.read_pixel(x, y),
             RenderTarget::Swapchain(_) => panic!("a headless surface has no swapchain"),
-        }
-    }
-}
-
-impl Drop for Headless {
-    fn drop(&mut self) {
-        if let Some(owner) = self.owner.take() {
-            reactive::dispose_owner_now(owner);
         }
     }
 }

--- a/tests/headless_app.rs
+++ b/tests/headless_app.rs
@@ -219,3 +219,104 @@ fn the_frame_that_was_drawn_can_be_read_back() {
     assert_eq!(app.read_pixel(surface, 1, 1), [64, 128, 191, 255]);
     assert_eq!(app.read_pixel(surface, 98, 30), [64, 128, 191, 255]);
 }
+
+/// A widget that fills its surface and holds one whose height is a signal —
+/// the shape a test needs to watch a write reach more than one surface.
+fn filling(height: RwSignal<f32>) -> Container {
+    container()
+        .width(fill())
+        .height(fill())
+        .child(container().height(height))
+}
+
+/// Two surfaces at once, which is what the loop is for: one `SurfaceManager`,
+/// one tree, one renderer, and a signal that does not know how many surfaces
+/// are reading it.
+///
+/// Each is configured at its own size and lays out at it — the driver keeping a
+/// map rather than one id is the whole of what makes this expressible.
+#[test]
+fn two_surfaces_lay_out_at_their_own_sizes_and_one_signal_reaches_both() {
+    let Some(mut app) = headless() else { return };
+    let height = create_signal(20.0);
+
+    let top = app.surface(fixed_bar(), move || filling(height));
+    let bottom = app.surface(fixed_bar(), move || filling(height));
+
+    app.configure(top, 200, 50, 1.0);
+    app.configure(bottom, 300, 40, 1.0);
+    app.step();
+
+    assert_eq!(app.root_size(top), (200.0, 50.0));
+    assert_eq!(app.root_size(bottom), (300.0, 40.0), "each at its own size");
+
+    let before = (app.frames_presented(top), app.frames_presented(bottom));
+    height.set(35.0);
+    app.step();
+
+    assert_eq!(
+        (app.frames_presented(top), app.frames_presented(bottom)),
+        (before.0 + 1, before.1 + 1),
+        "one write, and both surfaces drew again"
+    );
+}
+
+/// `spawn_surface` is guido's own API, not the harness's: a test asks for a
+/// surface exactly as an application does, and the step that follows is the
+/// loop draining the command it queued.
+#[test]
+fn a_surface_spawned_at_runtime_reaches_the_compositor_and_the_last_close_ends_the_loop() {
+    let Some(mut app) = headless() else { return };
+    let first = app.surface(content_bar(), measuring_24);
+    app.configure(first, 200, 24, 1.0);
+    app.step();
+
+    assert_eq!(app.surfaces_created(), [first]);
+
+    let second = spawn_surface(content_bar(), measuring_24);
+    app.step();
+
+    assert_eq!(
+        app.surfaces_created(),
+        [first, second.id()],
+        "the command reached `Platform::create_surface`"
+    );
+    second.close();
+    assert_eq!(app.step(), None, "one surface left, so the loop runs on");
+    assert_eq!(app.surfaces_destroyed(), [second.id()]);
+
+    surface_handle(first).close();
+    assert_eq!(
+        app.step(),
+        Some(ExitReason::Quit),
+        "nothing left to draw on, so the loop ends"
+    );
+}
+
+/// A popup is torn down before the surface it hangs from, deepest first.
+///
+/// Getting this wrong is not a cosmetic bug: destroying a popup that still has
+/// a live child raises `not_the_topmost_popup` and the compositor kills the
+/// connection. Until now that ordering was a comment in `process_surface_commands`
+/// and an example somebody ran.
+#[test]
+fn a_popup_is_destroyed_before_the_surface_it_hangs_from() {
+    let Some(mut app) = headless() else { return };
+    let parent = app.surface(content_bar(), measuring_24);
+    app.configure(parent, 200, 24, 1.0);
+    app.step();
+
+    let popup = spawn_popup(parent, PopupConfig::new(80).height(40), measuring_24);
+    app.step();
+
+    assert_eq!(app.surfaces_created(), [parent, popup.id()]);
+
+    surface_handle(parent).close();
+    app.step();
+
+    assert_eq!(
+        app.surfaces_destroyed(),
+        [popup.id(), parent],
+        "the child goes first, or the compositor kills the connection"
+    );
+}

--- a/tests/headless_app.rs
+++ b/tests/headless_app.rs
@@ -26,6 +26,15 @@ fn bar(clicks: RwSignal<u32>) -> Container {
     )
 }
 
+/// A bar of a fixed height, on an anchor that hands the width to the
+/// compositor. Four tests share it; the two that reserve chain
+/// `.exclusive_zone(ExclusiveZone::Auto)` onto it.
+fn fixed_bar() -> SurfaceConfig {
+    SurfaceConfig::new()
+        .height(50)
+        .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
+}
+
 /// A surface whose height is whatever it holds, on an anchor that hands the
 /// width to the compositor. Two tests share it, and the only thing that differs
 /// between them is the height it is then configured at.
@@ -59,23 +68,19 @@ fn headless() -> Option<Headless> {
 fn a_configured_surface_lays_out_at_the_size_it_was_given() {
     let Some(mut app) = headless() else { return };
     let clicks = create_signal(0u32);
-    app.surface(
-        SurfaceConfig::new()
-            .height(50)
-            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
-            .exclusive_zone(ExclusiveZone::Auto),
-        move || bar(clicks),
-    );
-    app.configure(200, 50, 2.0);
+    let surface = app.surface(fixed_bar().exclusive_zone(ExclusiveZone::Auto), move || {
+        bar(clicks)
+    });
+    app.configure(surface, 200, 50, 2.0);
     app.step();
 
     assert_eq!(
-        app.root_size(),
+        app.root_size(surface),
         (200.0, 50.0),
         "logical, what layout measures"
     );
     assert_eq!(
-        app.physical_size(),
+        app.physical_size(surface),
         (400, 100),
         "physical, what the buffer is: the scale the compositor confirmed"
     );
@@ -86,20 +91,15 @@ fn a_configured_surface_lays_out_at_the_size_it_was_given() {
 fn a_click_inside_runs_the_handler_and_one_outside_does_not() {
     let Some(mut app) = headless() else { return };
     let clicks = create_signal(0u32);
-    app.surface(
-        SurfaceConfig::new()
-            .height(50)
-            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT),
-        move || bar(clicks),
-    );
-    app.configure(200, 50, 2.0);
+    let surface = app.surface(fixed_bar(), move || bar(clicks));
+    app.configure(surface, 200, 50, 2.0);
     app.step();
 
-    app.click(10.0, 10.0);
+    app.click(surface, 10.0, 10.0);
     app.step();
     assert_eq!(clicks.get(), 1, "a click inside the child");
 
-    app.click(150.0, 40.0);
+    app.click(surface, 150.0, 40.0);
     app.step();
     assert_eq!(clicks.get(), 1, "a click outside it changes nothing");
 }
@@ -115,18 +115,14 @@ fn a_click_inside_runs_the_handler_and_one_outside_does_not() {
 fn a_bar_reserving_automatically_declares_its_height_when_it_is_created() {
     let Some(mut app) = headless() else { return };
     let clicks = create_signal(0u32);
-    app.surface(
-        SurfaceConfig::new()
-            .height(50)
-            .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
-            .exclusive_zone(ExclusiveZone::Auto),
-        move || bar(clicks),
-    );
-    app.configure(200, 50, 2.0);
+    let surface = app.surface(fixed_bar().exclusive_zone(ExclusiveZone::Auto), move || {
+        bar(clicks)
+    });
+    app.configure(surface, 200, 50, 2.0);
     app.step();
 
     assert_eq!(
-        app.exclusive_zones_asked(),
+        app.exclusive_zones_asked(surface),
         [50],
         "once, at creation, and the frames after it say nothing"
     );
@@ -143,24 +139,24 @@ fn a_bar_reserving_automatically_declares_its_height_when_it_is_created() {
 #[test]
 fn a_content_sized_surface_reserves_only_once_a_frame_has_measured_it() {
     let Some(mut app) = headless() else { return };
-    app.surface(content_bar(), measuring_24);
+    let bar = app.surface(content_bar(), measuring_24);
 
     assert_eq!(
-        app.exclusive_zones_asked(),
+        app.exclusive_zones_asked(bar),
         [1],
         "born reserving the placeholder, which is wrong until a frame has run"
     );
 
-    app.configure(200, 24, 1.0);
+    app.configure(bar, 200, 24, 1.0);
     app.step();
 
     assert_eq!(
-        app.exclusive_zones_asked(),
+        app.exclusive_zones_asked(bar),
         [1, 24],
         "the frame measured the content and the reservation followed"
     );
     assert_eq!(
-        app.sizes_asked(),
+        app.sizes_asked(bar),
         [(0, 1)],
         "and it asked for no new size, having measured back the one it has: the \
          resize is conditional where the resync is not. This is the only thing \
@@ -180,19 +176,19 @@ fn a_content_sized_surface_reserves_only_once_a_frame_has_measured_it() {
 #[test]
 fn a_surface_configured_taller_than_its_content_asks_to_shrink_to_it() {
     let Some(mut app) = headless() else { return };
-    app.surface(content_bar(), measuring_24);
+    let bar = app.surface(content_bar(), measuring_24);
 
     assert_eq!(
-        app.sizes_asked(),
+        app.sizes_asked(bar),
         [(0, 1)],
         "born asking for the placeholder, having measured nothing"
     );
 
-    app.configure(200, 50, 1.0);
+    app.configure(bar, 200, 50, 1.0);
     app.step();
 
     assert_eq!(
-        app.sizes_asked(),
+        app.sizes_asked(bar),
         [(0, 1), (0, 24)],
         "the frame measured 24 against a surface configured at 50, and said so"
     );
@@ -210,16 +206,16 @@ fn a_surface_configured_taller_than_its_content_asks_to_shrink_to_it() {
 #[test]
 fn the_frame_that_was_drawn_can_be_read_back() {
     let Some(mut app) = headless() else { return };
-    app.surface(
+    let surface = app.surface(
         SurfaceConfig::new()
             .height(32)
             .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
             .background_color(Color::rgb(0.25, 0.5, 0.75)),
         container,
     );
-    app.configure(100, 32, 1.0);
+    app.configure(surface, 100, 32, 1.0);
     app.step();
 
-    assert_eq!(app.read_pixel(1, 1), [64, 128, 191, 255]);
-    assert_eq!(app.read_pixel(98, 30), [64, 128, 191, 255]);
+    assert_eq!(app.read_pixel(surface, 1, 1), [64, 128, 191, 255]);
+    assert_eq!(app.read_pixel(surface, 98, 30), [64, 128, 191, 255]);
 }


### PR DESCRIPTION
## What changed

`guido::testing::Headless` held **one** surface — `id: Option<SurfaceId>`, and
every accessor read it — where the loop it drives holds a map. So a second
surface, a surface that appears at runtime, and a popup were things the harness
could not say, even though `iterate`, `process_surface_commands` and every
`Platform` method above them are generic and were already carrying them.

The recorder is now a connection rather than a surface: surfaces keyed by id,
plus the order it was told to build and tear them down in.

Closes #275.

## What proves it

Three tests in `tests/headless_app.rs`, and each dies to a **production** line —
verified by removing that line and running the file on lavapipe:

| remove from `src/lib.rs` | fails |
| --- | --- |
| `wayland_state.create_surface(id, &config)` in the `Create` arm | the spawn test |
| the `surface_manager.is_empty()` → `request_exit()` block | the spawn test, at `Some(ExitReason::Quit)` |
| the `popup_descendants_bottom_up` loop in the `Close` arm | the popup test |
| `.take(1)` on the surfaces `iterate` lays out | the two-surface test |

That last row is the `reviewer`'s, not mine — it went looking for whether the
two-surface case was a harness demo or watched something real, and found the
line. The whole file is 9 green, and the matrix was run again after `/simplify`
touched the tests.

**What the popup test does not prove, stated because it is tempting to claim
otherwise:** it proves the *loop* asks in the right order. The recorder answers
`popup_descendants_bottom_up` from its own map, so `src/platform/popups.rs`'s
independent walk of the same rule is exactly as unwatched as before. That is
**#292**, which also records that the two implementations disagree on sibling
order — so unifying them changes production behaviour that nothing here can
referee.

## Two deliberate deviations from the acceptance

**#275 asked for `Headless::spawn(config, widget)` and `close(id)`. Neither
exists here.** The issue's own Observed section says the defect is that
`SurfaceCommand::{Create, Close}` → `Platform::create_surface` *has no caller*;
a harness twin would have been a second caller, and the test would then prove
the harness. The tests call guido's own `spawn_surface`, `spawn_popup` and
`SurfaceHandle::close`, and `step()` drains what they queue — the exact path the
issue named. Every assertion the acceptance asks for is present.

**Every accessor takes a `SurfaceId`**, which churned all five pre-existing
tests. `App::add_surface` already returns one and an application already threads
it through `spawn_popup` and `surface_handle`, so the harness now reads like the
API it stands in for. The alternative — no-argument accessors meaning "the one
surface" — would be silently wrong in exactly the tests worth writing, since the
interesting ones hold two.

`step()` also returns `Option<ExitReason>` where it returned `()`, which is how
a test sees the loop end.

## What the review found

`/simplify` ran as three readings and produced most of the shape:

- **The parent link moved onto the surface**, where `WaylandState` keeps it,
  instead of a parallel map that had to be kept in sync by hand.
- **`RecordedSurfaceRef` was deleted** — with per-surface state its own struct,
  `impl Surface for &mut RecordedSurface` works, removing a wrapper type and
  twelve `self.0.`.
- `born` inlined, a **dead `exclusive_zone_asked` accessor removed** (no caller
  anywhere), file-level test fixtures replacing inline closures, and a config
  literal that had been written four times folded into one.
- **Four places of prose the change made false**, including the module doc, the
  `Headless` doc, the `wayland` skill — the file an agent reads *before*
  touching this layer — and a sentence I had written in `AGENTS.md` an hour
  earlier that already overclaimed.

The `reviewer` then re-ran every mutation itself, found the fourth, and checked
that `SURFACE_COMMANDS` being `thread_local!` means the tests cannot contaminate
each other — the obvious way this design goes wrong. **Zero blocking findings.**

Two worth answering, both acted on:

1. **`AGENTS.md` still overclaimed.** I wrote that the session lock and hotplug
   "need no machinery the driver does not already have". False: a lock test
   needs four `Platform` methods the recorder leaves at their defaults, and a
   hotplug test cannot reach `outputs::sync_outputs` at all because it is
   `pub(crate)`. It now says *no redesign*, and names what is missing.
2. **The first commit did not compile the test suite** — the accessor change
   landed in it and the call sites in the next. Split at the right line: the
   five existing tests are rewritten in the first commit, the three new ones
   added in the second. I checked both build and pass alone.

Notes: sibling popups come back in hash-map order, which nothing depends on
today and is recorded on #292; and running the file with `--nocapture` prints
six copies of a pre-existing `signal read with no reactive scope` warning from
`src/outputs.rs`, which the new tests made audible rather than caused.

## What was checked by hand

Nothing on a compositor, and none is owed: `src/platform/` is untouched. The
mutation matrix above is the hand work.

## Left undone

**#292** — the teardown order that keeps a compositor from killing the
connection is computed twice, and this change watches only the copy in the
harness. Filed with the sibling-order disagreement that makes unifying them a
behaviour change rather than a dedup.

**The remainder of #275's own list**, now named precisely in `AGENTS.md` rather
than waved at: the session lock, output hotplug and popup grab conflicts. They
need no redesign — the map was the missing part — but each needs something
built, and the three things are now written down where the next person will meet
them.
