### PR TITLE
A press reaches the whole scrollbar handle, on both axes, and the ripple starts under the finger

### DIFF
--- a/src/widgets/container/interaction.rs
+++ b/src/widgets/container/interaction.rs
@@ -41,7 +41,7 @@ impl HitContext {
     }
 
     /// The same, for a point that has already had the transform undone.
-    fn rebase(&self, x: f32, y: f32) -> (f32, f32) {
+    pub(super) fn rebase(&self, x: f32, y: f32) -> (f32, f32) {
         (x - self.bounds.x, y - self.bounds.y)
     }
 }

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -1617,7 +1617,7 @@ impl Widget for Container {
             _ => Cow::Borrowed(event),
         };
 
-        if let Some(response) = self.handle_scrollbar_event(tree, id, hit.bounds, &local_event) {
+        if let Some(response) = self.handle_scrollbar_event(tree, id, &hit, &local_event) {
             return response;
         }
 

--- a/src/widgets/container/scrollable.rs
+++ b/src/widgets/container/scrollable.rs
@@ -1,5 +1,7 @@
 //! Scrollable container functionality.
 
+use std::borrow::Cow;
+
 use crate::animation::{SpringConfig, Transition};
 use crate::jobs::{JobRequest, RequiredJob, request_job};
 use crate::layout::Constraints;
@@ -10,6 +12,7 @@ use crate::widgets::widget::{Event, EventResponse, MouseButton, Rect, ScrollSour
 
 use super::Container;
 use super::animations::AnimationState;
+use super::interaction::HitContext;
 use crate::widgets::state_layer::Stateful;
 
 impl Container {
@@ -532,12 +535,22 @@ impl Container {
         }
     }
 
-    /// Handle scrollbar-related events, returns EventResponse if handled
+    /// Handle scrollbar-related events, returns EventResponse if handled.
+    ///
+    /// Everything below works in the scroller's own space, because that is the
+    /// space the scrollbars live in: their rects are derived from local bounds
+    /// (see `layout_scrollbar_containers`), and the origins the `Tree` holds
+    /// for the track and handle widgets are written from the same derivation.
+    /// The event arrives in the scroller's *parent's* space, like `hit.bounds`,
+    /// so it is rebased once here rather than at each of the places that
+    /// forwards it on — which is how a handle came to answer for a strip beside
+    /// itself, and to ripple that far from the finger, on every scroller not
+    /// sitting at its parent's origin.
     pub(super) fn handle_scrollbar_event(
         &mut self,
         tree: &mut Tree,
         id: WidgetId,
-        bounds: Rect,
+        hit: &HitContext,
         event: &Event,
     ) -> Option<EventResponse> {
         if self.scroll_axis == ScrollAxis::None
@@ -545,6 +558,16 @@ impl Container {
         {
             return None;
         }
+
+        let local: Cow<'_, Event> = match event.coords() {
+            Some((x, y)) => {
+                let (local_x, local_y) = hit.rebase(x, y);
+                Cow::Owned(event.with_coords(local_x, local_y))
+            }
+            None => Cow::Borrowed(event),
+        };
+        let event = local.as_ref();
+        let bounds = Rect::new(0.0, 0.0, hit.bounds.width, hit.bounds.height);
 
         match event {
             Event::MouseDown { x, y, button } if *button == MouseButton::Left => {
@@ -640,9 +663,7 @@ impl Container {
                 if self.scroll().scroll_state.scrollbar_dragging {
                     self.scroll_mut().scroll_state.scrollbar_dragging = false;
                     if let Some(handle_id) = self.scroll().v_scrollbar_handle_id {
-                        tree.with_widget_mut(handle_id, |widget, widget_id, tree| {
-                            widget.event(tree, widget_id, event);
-                        });
+                        forward_to_handle(tree, handle_id, event);
                     }
                     request_job(id, JobRequest::Paint);
                     return Some(EventResponse::Handled);
@@ -650,9 +671,7 @@ impl Container {
                 if self.scroll().scroll_state.h_scrollbar_dragging {
                     self.scroll_mut().scroll_state.h_scrollbar_dragging = false;
                     if let Some(handle_id) = self.scroll().h_scrollbar_handle_id {
-                        tree.with_widget_mut(handle_id, |widget, widget_id, tree| {
-                            widget.event(tree, widget_id, event);
-                        });
+                        forward_to_handle(tree, handle_id, event);
                     }
                     request_job(id, JobRequest::Paint);
                     return Some(EventResponse::Handled);
@@ -675,14 +694,10 @@ impl Container {
 
                 if had_hover {
                     if let Some(handle_id) = v_handle {
-                        tree.with_widget_mut(handle_id, |widget, widget_id, tree| {
-                            widget.event(tree, widget_id, event);
-                        });
+                        forward_to_handle(tree, handle_id, event);
                     }
                     if let Some(handle_id) = h_handle {
-                        tree.with_widget_mut(handle_id, |widget, widget_id, tree| {
-                            widget.event(tree, widget_id, event);
-                        });
+                        forward_to_handle(tree, handle_id, event);
                     }
                 }
                 if had_hover || had_drag {
@@ -738,9 +753,7 @@ impl Container {
                 ScrollbarAxis::Horizontal => sd.h_scrollbar_handle_id,
             };
             if let Some(handle_id) = handle_id {
-                tree.with_widget_mut(handle_id, |widget, widget_id, tree| {
-                    widget.event(tree, widget_id, event);
-                });
+                forward_to_handle(tree, handle_id, event);
             }
 
             request_job(id, JobRequest::Paint);
@@ -874,33 +887,25 @@ impl Container {
             needs_repaint = true;
         }
 
-        // Send synthetic MouseEnter/MouseLeave events to handle container when hover state changes.
-        // We can't forward raw MouseMove events because the Container's bounds check would fail
-        // (coordinates are in parent space, not local to the handle widget).
+        // A synthetic enter and leave rather than the move itself: hover is
+        // decided above against the widened hit area, and the handle deciding
+        // it again against its own narrow rect would disagree with the
+        // scrollbar that just widened for the pointer.
         let handle_id = match axis {
             ScrollbarAxis::Vertical => sd.v_scrollbar_handle_id,
             ScrollbarAxis::Horizontal => sd.h_scrollbar_handle_id,
         };
         if let Some(handle_id) = handle_id {
             if is_hovered && !was_hovered {
-                // Transitioning to hovered state - send coordinates at handle center
-                let center_x = handle_rect.x + handle_rect.width / 2.0;
-                let center_y = handle_rect.y + handle_rect.height / 2.0;
-                tree.with_widget_mut(handle_id, |widget, widget_id, tree| {
-                    widget.event(
-                        tree,
-                        widget_id,
-                        &Event::MouseEnter {
-                            x: center_x,
-                            y: center_y,
-                        },
-                    );
-                });
+                // The centre of the handle: a point it holds whatever part of
+                // the widened area the pointer is actually over.
+                let enter = Event::MouseEnter {
+                    x: handle_rect.x + handle_rect.width / 2.0,
+                    y: handle_rect.y + handle_rect.height / 2.0,
+                };
+                forward_to_handle(tree, handle_id, &enter);
             } else if !is_hovered && was_hovered {
-                // Transitioning away from hovered state
-                tree.with_widget_mut(handle_id, |widget, widget_id, tree| {
-                    widget.event(tree, widget_id, &Event::MouseLeave);
-                });
+                forward_to_handle(tree, handle_id, &Event::MouseLeave);
             }
         }
 
@@ -958,6 +963,17 @@ impl Container {
 
         old_x != sd.scroll_state.offset_x || old_y != sd.scroll_state.offset_y
     }
+}
+
+/// Hand an event to the handle widget.
+///
+/// The handle is a `Container` of its own, hit-testing against the bounds the
+/// `Tree` holds for it, so the event has to be in the scroller's space —
+/// which, inside `handle_scrollbar_event`, it already is.
+fn forward_to_handle(tree: &mut Tree, handle_id: WidgetId, event: &Event) {
+    tree.with_widget_mut(handle_id, |handle, id, tree| {
+        handle.event(tree, id, event);
+    });
 }
 
 /// The handle's interactive rect: its extent along the scroll axis, widened

--- a/src/widgets/container/scrollable.rs
+++ b/src/widgets/container/scrollable.rs
@@ -12,7 +12,9 @@ use crate::widgets::widget::{Event, EventResponse, MouseButton, Rect, ScrollSour
 
 use super::Container;
 use super::animations::AnimationState;
-use super::interaction::HitContext;
+use super::interaction::{HitContext, untransform_point};
+use crate::pivot::Pivot;
+use crate::transform::Transform;
 use crate::widgets::state_layer::Stateful;
 
 impl Container {
@@ -416,8 +418,6 @@ impl Container {
         id: WidgetId,
         ctx: &mut PaintContext,
     ) {
-        use crate::transform::Transform;
-
         let sd = self.scroll();
 
         if sd.scrollbar_visibility == ScrollbarVisibility::Hidden {
@@ -440,9 +440,6 @@ impl Container {
 
         // Vertical scrollbar
         if self.scroll_axis.allows_vertical() && sd.scroll_state.needs_vertical_scrollbar() {
-            // Vertical scrollbar scales horizontally (expands width on hover)
-            let scale_transform = Transform::scale_xy(v_scale, 1.0);
-
             if let Some(track_id) = sd.v_scrollbar_track_id
                 && let Some(track_bounds) = tree.get_bounds(track_id)
             {
@@ -450,16 +447,12 @@ impl Container {
                 let track_local = Rect::new(0.0, 0.0, track_bounds.width, track_bounds.height);
 
                 let mut track_ctx = ctx.add_child(track_id.as_u64(), track_local);
-                // Scale from right edge (transform origin at right center)
-                // First translate to position, then apply scale centered at right edge
-                let position = Transform::translate(track_bounds.x, track_bounds.y);
-                let scale_origin_x = track_bounds.width;
-                let scale_origin_y = track_bounds.height / 2.0;
-                let combined = position
-                    .then(&Transform::translate(scale_origin_x, scale_origin_y))
-                    .then(&scale_transform)
-                    .then(&Transform::translate(-scale_origin_x, -scale_origin_y));
-                track_ctx.set_transform(combined);
+                track_ctx.set_transform(scrollbar_paint_transform(
+                    ScrollbarAxis::Vertical,
+                    v_scale,
+                    (track_bounds.x, track_bounds.y),
+                    track_local,
+                ));
                 tree.with_widget(track_id, |widget| {
                     widget.paint(tree, track_id, &mut track_ctx);
                 });
@@ -470,17 +463,12 @@ impl Container {
                 let handle_local = Rect::new(0.0, 0.0, handle_bounds.width, handle_bounds.height);
 
                 let mut handle_ctx = ctx.add_child(handle_id.as_u64(), handle_local);
-                // Scale from right edge (transform origin at right center)
-                let (handle_x, handle_y) =
-                    self.scrollbar_handle_origin(tree, id, ScrollbarAxis::Vertical);
-                let position = Transform::translate(handle_x, handle_y);
-                let scale_origin_x = handle_bounds.width;
-                let scale_origin_y = handle_bounds.height / 2.0;
-                let combined = position
-                    .then(&Transform::translate(scale_origin_x, scale_origin_y))
-                    .then(&scale_transform)
-                    .then(&Transform::translate(-scale_origin_x, -scale_origin_y));
-                handle_ctx.set_transform(combined);
+                handle_ctx.set_transform(scrollbar_paint_transform(
+                    ScrollbarAxis::Vertical,
+                    v_scale,
+                    self.scrollbar_handle_origin(tree, id, ScrollbarAxis::Vertical),
+                    handle_local,
+                ));
                 tree.with_widget(handle_id, |widget| {
                     widget.paint(tree, handle_id, &mut handle_ctx);
                 });
@@ -489,24 +477,18 @@ impl Container {
 
         // Horizontal scrollbar
         if self.scroll_axis.allows_horizontal() && sd.scroll_state.needs_horizontal_scrollbar() {
-            // Horizontal scrollbar scales vertically (expands height on hover)
-            let scale_transform = Transform::scale_xy(1.0, h_scale);
-
             if let Some(track_id) = sd.h_scrollbar_track_id
                 && let Some(track_bounds) = tree.get_bounds(track_id)
             {
                 let track_local = Rect::new(0.0, 0.0, track_bounds.width, track_bounds.height);
 
                 let mut track_ctx = ctx.add_child(track_id.as_u64(), track_local);
-                // Scale from bottom edge (transform origin at bottom center)
-                let position = Transform::translate(track_bounds.x, track_bounds.y);
-                let scale_origin_x = track_bounds.width / 2.0;
-                let scale_origin_y = track_bounds.height;
-                let combined = position
-                    .then(&Transform::translate(scale_origin_x, scale_origin_y))
-                    .then(&scale_transform)
-                    .then(&Transform::translate(-scale_origin_x, -scale_origin_y));
-                track_ctx.set_transform(combined);
+                track_ctx.set_transform(scrollbar_paint_transform(
+                    ScrollbarAxis::Horizontal,
+                    h_scale,
+                    (track_bounds.x, track_bounds.y),
+                    track_local,
+                ));
                 tree.with_widget(track_id, |widget| {
                     widget.paint(tree, track_id, &mut track_ctx);
                 });
@@ -517,22 +499,65 @@ impl Container {
                 let handle_local = Rect::new(0.0, 0.0, handle_bounds.width, handle_bounds.height);
 
                 let mut handle_ctx = ctx.add_child(handle_id.as_u64(), handle_local);
-                // Scale from bottom edge (transform origin at bottom center)
-                let (handle_x, handle_y) =
-                    self.scrollbar_handle_origin(tree, id, ScrollbarAxis::Horizontal);
-                let position = Transform::translate(handle_x, handle_y);
-                let scale_origin_x = handle_bounds.width / 2.0;
-                let scale_origin_y = handle_bounds.height;
-                let combined = position
-                    .then(&Transform::translate(scale_origin_x, scale_origin_y))
-                    .then(&scale_transform)
-                    .then(&Transform::translate(-scale_origin_x, -scale_origin_y));
-                handle_ctx.set_transform(combined);
+                handle_ctx.set_transform(scrollbar_paint_transform(
+                    ScrollbarAxis::Horizontal,
+                    h_scale,
+                    self.scrollbar_handle_origin(tree, id, ScrollbarAxis::Horizontal),
+                    handle_local,
+                ));
                 tree.with_widget(handle_id, |widget| {
                     widget.paint(tree, handle_id, &mut handle_ctx);
                 });
             }
         }
+    }
+
+    /// Hand an event to the handle widget of `axis`, in the space that widget
+    /// hit-tests in.
+    ///
+    /// Two things stand between the event and the handle. The event has already
+    /// been rebased into the scroller's space by `handle_scrollbar_event`, which
+    /// is the space the handle's own bounds are in. What is left is the
+    /// widening: the handle is drawn scaled about its outer edge by *this*
+    /// container's paint (`scrollbar_paint_transform`) rather than by a scale
+    /// declared on the handle, so its bounds stay the resting strip however wide
+    /// it appears. Undoing that scale here is what `Container::event` does with
+    /// its own transform before hit testing — and without it the width a hover
+    /// adds is drawn and answers nothing: no pressed colour, and no ripple.
+    fn forward_to_handle(&self, tree: &mut Tree, axis: ScrollbarAxis, event: &Event) {
+        let sd = self.scroll();
+        let handle_id = match axis {
+            ScrollbarAxis::Vertical => sd.v_scrollbar_handle_id,
+            ScrollbarAxis::Horizontal => sd.h_scrollbar_handle_id,
+        };
+        let Some(handle_id) = handle_id else {
+            return;
+        };
+
+        let scale = match axis {
+            ScrollbarAxis::Vertical => sd.v_scrollbar_scale_anim.as_ref(),
+            ScrollbarAxis::Horizontal => sd.h_scrollbar_scale_anim.as_ref(),
+        }
+        .map(|anim| *anim.current())
+        .unwrap_or(1.0);
+
+        let unscaled: Cow<'_, Event> = match (event.coords(), tree.get_bounds(handle_id)) {
+            (Some((x, y)), Some(bounds)) => {
+                let (local_x, local_y) = untransform_point(
+                    &scrollbar_scale_transform(axis, scale),
+                    scrollbar_scale_pivot(axis),
+                    bounds,
+                    x,
+                    y,
+                );
+                Cow::Owned(event.with_coords(local_x, local_y))
+            }
+            _ => Cow::Borrowed(event),
+        };
+
+        tree.with_widget_mut(handle_id, |handle, id, tree| {
+            handle.event(tree, id, &unscaled);
+        });
     }
 
     /// Handle scrollbar-related events, returns EventResponse if handled.
@@ -662,17 +687,13 @@ impl Container {
             Event::MouseUp { button, .. } if *button == MouseButton::Left => {
                 if self.scroll().scroll_state.scrollbar_dragging {
                     self.scroll_mut().scroll_state.scrollbar_dragging = false;
-                    if let Some(handle_id) = self.scroll().v_scrollbar_handle_id {
-                        forward_to_handle(tree, handle_id, event);
-                    }
+                    self.forward_to_handle(tree, ScrollbarAxis::Vertical, event);
                     request_job(id, JobRequest::Paint);
                     return Some(EventResponse::Handled);
                 }
                 if self.scroll().scroll_state.h_scrollbar_dragging {
                     self.scroll_mut().scroll_state.h_scrollbar_dragging = false;
-                    if let Some(handle_id) = self.scroll().h_scrollbar_handle_id {
-                        forward_to_handle(tree, handle_id, event);
-                    }
+                    self.forward_to_handle(tree, ScrollbarAxis::Horizontal, event);
                     request_job(id, JobRequest::Paint);
                     return Some(EventResponse::Handled);
                 }
@@ -689,16 +710,10 @@ impl Container {
                 sd.scroll_state.h_scrollbar_hovered = false;
                 sd.scroll_state.scrollbar_dragging = false;
                 sd.scroll_state.h_scrollbar_dragging = false;
-                let v_handle = sd.v_scrollbar_handle_id;
-                let h_handle = sd.h_scrollbar_handle_id;
 
                 if had_hover {
-                    if let Some(handle_id) = v_handle {
-                        forward_to_handle(tree, handle_id, event);
-                    }
-                    if let Some(handle_id) = h_handle {
-                        forward_to_handle(tree, handle_id, event);
-                    }
+                    self.forward_to_handle(tree, ScrollbarAxis::Vertical, event);
+                    self.forward_to_handle(tree, ScrollbarAxis::Horizontal, event);
                 }
                 if had_hover || had_drag {
                     request_job(id, JobRequest::Paint);
@@ -748,13 +763,7 @@ impl Container {
             sd.scroll_state.set_drag_start(axis, pos, offset);
 
             // Forward event to handle container for pressed state
-            let handle_id = match axis {
-                ScrollbarAxis::Vertical => sd.v_scrollbar_handle_id,
-                ScrollbarAxis::Horizontal => sd.h_scrollbar_handle_id,
-            };
-            if let Some(handle_id) = handle_id {
-                forward_to_handle(tree, handle_id, event);
-            }
+            self.forward_to_handle(tree, axis, event);
 
             request_job(id, JobRequest::Paint);
             return Some(EventResponse::Handled);
@@ -891,22 +900,16 @@ impl Container {
         // decided above against the widened hit area, and the handle deciding
         // it again against its own narrow rect would disagree with the
         // scrollbar that just widened for the pointer.
-        let handle_id = match axis {
-            ScrollbarAxis::Vertical => sd.v_scrollbar_handle_id,
-            ScrollbarAxis::Horizontal => sd.h_scrollbar_handle_id,
-        };
-        if let Some(handle_id) = handle_id {
-            if is_hovered && !was_hovered {
-                // The centre of the handle: a point it holds whatever part of
-                // the widened area the pointer is actually over.
-                let enter = Event::MouseEnter {
-                    x: handle_rect.x + handle_rect.width / 2.0,
-                    y: handle_rect.y + handle_rect.height / 2.0,
-                };
-                forward_to_handle(tree, handle_id, &enter);
-            } else if !is_hovered && was_hovered {
-                forward_to_handle(tree, handle_id, &Event::MouseLeave);
-            }
+        if is_hovered && !was_hovered {
+            // The centre of the handle: a point it holds whatever part of the
+            // widened area the pointer is actually over.
+            let enter = Event::MouseEnter {
+                x: handle_rect.x + handle_rect.width / 2.0,
+                y: handle_rect.y + handle_rect.height / 2.0,
+            };
+            self.forward_to_handle(tree, axis, &enter);
+        } else if !is_hovered && was_hovered {
+            self.forward_to_handle(tree, axis, &Event::MouseLeave);
         }
 
         needs_repaint
@@ -965,15 +968,41 @@ impl Container {
     }
 }
 
-/// Hand an event to the handle widget.
+/// Where a scrollbar's hover widening turns about: a vertical bar grows
+/// leftwards from its right edge, a horizontal one upwards from its bottom.
+fn scrollbar_scale_pivot(axis: ScrollbarAxis) -> Pivot {
+    match axis {
+        ScrollbarAxis::Vertical => Pivot::RIGHT,
+        ScrollbarAxis::Horizontal => Pivot::BOTTOM,
+    }
+}
+
+/// The widening itself: across the axis the bar runs along, never along it.
+fn scrollbar_scale_transform(axis: ScrollbarAxis, scale: f32) -> Transform {
+    match axis {
+        ScrollbarAxis::Vertical => Transform::scale_xy(scale, 1.0),
+        ScrollbarAxis::Horizontal => Transform::scale_xy(1.0, scale),
+    }
+}
+
+/// The transform a scrollbar container is painted with: where it sits, and the
+/// widening turned about its outer edge.
 ///
-/// The handle is a `Container` of its own, hit-testing against the bounds the
-/// `Tree` holds for it, so the event has to be in the scroller's space —
-/// which, inside `handle_scrollbar_event`, it already is.
-fn forward_to_handle(tree: &mut Tree, handle_id: WidgetId, event: &Event) {
-    tree.with_widget_mut(handle_id, |handle, id, tree| {
-        handle.event(tree, id, event);
-    });
+/// The scale is applied here rather than declared on the track and handle, so
+/// their own bounds stay the resting strip however wide they are drawn. What
+/// undoes it is `Container::forward_to_handle`, about the same point — which is
+/// the only reason the width a hover adds can answer a press at all.
+fn scrollbar_paint_transform(
+    axis: ScrollbarAxis,
+    scale: f32,
+    position: (f32, f32),
+    local: Rect,
+) -> Transform {
+    let (pivot_x, pivot_y) = scrollbar_scale_pivot(axis).resolve(local);
+    Transform::translate(position.0, position.1)
+        .then(&Transform::translate(pivot_x, pivot_y))
+        .then(&scrollbar_scale_transform(axis, scale))
+        .then(&Transform::translate(-pivot_x, -pivot_y))
 }
 
 /// The handle's interactive rect: its extent along the scroll axis, widened

--- a/tests/scrollbar_handle_tracking.rs
+++ b/tests/scrollbar_handle_tracking.rs
@@ -38,6 +38,7 @@ const V_HANDLE: f32 = 60.4938;
 
 /// A horizontal scroller: 200x80 over 888px of content — 10 columns of 80,
 /// spaced 8, padded 8.
+const H_VIEWPORT: f32 = 80.0;
 const H_CONTENT: f32 = 888.0;
 const H_HANDLE: f32 = 44.1441;
 
@@ -98,11 +99,19 @@ impl H {
         h
     }
 
+    /// The horizontal scroller, moved off its parent's origin the same way
+    /// `vertical_inset` moves the vertical one.
+    fn horizontal_inset() -> Self {
+        let mut h = Self::horizontal();
+        h.tree.set_origin(h.root, INSET, INSET);
+        h
+    }
+
     fn horizontal() -> Self {
         Self::new(
             container()
                 .width(VIEWPORT)
-                .height(80.0)
+                .height(H_VIEWPORT)
                 .scrollable(ScrollAxis::Horizontal)
                 .child(
                     container()
@@ -110,7 +119,7 @@ impl H {
                         .padding(8.0)
                         .children((0..10).map(|_| container().width(80.0).height(24.0))),
                 ),
-            80.0,
+            H_VIEWPORT,
             true,
         )
     }
@@ -190,11 +199,17 @@ impl H {
     /// The ripple this frame draws on the scrollbar handle, in the handle's own
     /// coordinates, if it draws one.
     fn handle_ripple(&mut self) -> Option<(f32, f32)> {
+        self.handle_ripple_disc().map(|(center, _)| center)
+    }
+
+    /// The same, with how opaque the disc is — which is what says whether it is
+    /// held, completing or abandoned.
+    fn handle_ripple_disc(&mut self) -> Option<((f32, f32), f32)> {
         self.handle_node()
             .overlay_commands
             .iter()
             .find_map(|cmd| match &**cmd {
-                DrawCommand::Circle { center, .. } => Some(*center),
+                DrawCommand::Circle { center, color, .. } => Some((*center, color.a)),
                 _ => None,
             })
     }
@@ -512,5 +527,113 @@ fn the_width_a_hover_adds_to_the_handle_answers_a_press_too() {
         cx < BAR_WIDTH / 2.0,
         "pressed the handle's left edge and the ripple started at {cx}, \
          past the middle of a {BAR_WIDTH}-wide handle"
+    );
+}
+
+/// The horizontal handle answers a press off-origin too.
+///
+/// The forwarding is shared between the axes, but the geometry either side of
+/// it is not: the rects come from a different branch of
+/// `scrollbar_handle_rect`, and the widening turns about the bottom edge rather
+/// than the right one. The file's own opening argument applies — either axis
+/// can lose it on its own.
+#[test]
+fn the_horizontal_handle_ripples_from_where_it_landed_too() {
+    let handle_x = INSET + TRACK_START;
+    let handle_y = INSET + H_VIEWPORT - BAR_WIDTH - TRACK_START;
+
+    for (qx, qy) in [(0.25, 0.25), (0.75, 0.75)] {
+        let (local_x, local_y) = (H_HANDLE * qx, BAR_WIDTH * qy);
+        let mut h = H::horizontal_inset();
+
+        let pressed = Instant::now();
+        h.dispatch_at(
+            Event::MouseDown {
+                x: handle_x + local_x,
+                y: handle_y + local_y,
+                button: MouseButton::Left,
+            },
+            pressed,
+        );
+        h.frame(pressed + Duration::from_millis(16));
+
+        let (cx, cy) = h
+            .handle_ripple()
+            .unwrap_or_else(|| panic!("the press at quadrant ({qx}, {qy}) started no ripple"));
+        assert!(
+            (cx - local_x).abs() < 2.0 && (cy - local_y).abs() < 2.0,
+            "quadrant ({qx}, {qy}): ripple at ({cx}, {cy}), pressed at ({local_x}, {local_y})"
+        );
+    }
+}
+
+/// A release on the handle finishes the ripple rather than abandoning it —
+/// including on the width the hover added.
+///
+/// The `MouseUp` that ends a drag is forwarded like the `MouseDown` that began
+/// it, and the handle decides from its coordinates which of three things
+/// happened. Each leaves the disc in a different state a frame later, which is
+/// why the assertion is on the opacity and not on the disc being there:
+///
+/// - released inside — the expansion completes, fading over `FADE_OUT`, so the
+///   disc is still drawn and dimmer than it was.
+/// - released elsewhere — abandoned, fading over `CANCEL_FADE`, five times
+///   quicker, and gone by the time this looks.
+/// - never arrived — no exit begins at all, and the disc sits at full strength
+///   for ever. Only "dimmer, and still there" excludes both of the others.
+///
+/// Hovered, and pressed on the widening, because that is the only state in
+/// which the release has anything to undo: at rest the scale is 1 and dropping
+/// it changes nothing.
+#[test]
+fn releasing_on_the_widened_handle_finishes_the_ripple_rather_than_abandoning_it() {
+    let mut h = H::vertical_inset();
+    let y = INSET + TRACK_START + V_HANDLE / 2.0;
+    let hovered = Instant::now();
+    h.dispatch(Event::MouseMove {
+        x: INSET + VIEWPORT - BAR_WIDTH / 2.0 - TRACK_START,
+        y,
+    });
+    for step in 1..=8 {
+        h.frame(hovered + Duration::from_millis(16 * step));
+    }
+
+    let (left, _) = h
+        .handle_node()
+        .local_transform
+        .transform_point(0.0, V_HANDLE / 2.0);
+    let x = INSET + left + 1.0;
+
+    let pressed = hovered + Duration::from_millis(200);
+    h.dispatch_at(
+        Event::MouseDown {
+            x,
+            y,
+            button: MouseButton::Left,
+        },
+        pressed,
+    );
+    // Past FADE_IN, so the disc is at its full strength and the fade below is
+    // the only thing that can have dimmed it.
+    let released = pressed + Duration::from_millis(100);
+    h.frame(released);
+    let (_, held) = h.handle_ripple_disc().expect("the press started no ripple");
+
+    h.dispatch_at(
+        Event::MouseUp {
+            x,
+            y,
+            button: MouseButton::Left,
+        },
+        released,
+    );
+    h.frame(released + Duration::from_millis(150));
+
+    let (_, leaving) = h
+        .handle_ripple_disc()
+        .expect("the disc was gone 150ms after the release: it was abandoned, not completed");
+    assert!(
+        leaving < held,
+        "the disc is still at {leaving} against {held} held: the release never reached the handle"
     );
 }

--- a/tests/scrollbar_handle_tracking.rs
+++ b/tests/scrollbar_handle_tracking.rs
@@ -10,9 +10,12 @@
 //! Both axes, because both are drawn from the same derivation and either can
 //! lose it on its own.
 
+use std::rc::Rc;
+use std::time::{Duration, Instant};
+
 use guido::layout::{Constraints, Flex};
 use guido::prelude::*;
-use guido::renderer::{PaintContext, RenderNode};
+use guido::renderer::{DrawCommand, PaintContext, RenderNode};
 use guido::tree::{Tree, WidgetId};
 
 /// The scrollbar sits 2px in from the edges of the container along its axis,
@@ -21,6 +24,7 @@ use guido::tree::{Tree, WidgetId};
 const VIEWPORT: f32 = 200.0;
 const TRACK_START: f32 = 2.0;
 const TRACK_LENGTH: f32 = 196.0;
+const BAR_WIDTH: f32 = 6.0;
 
 /// A vertical scroller: 200x200 over 648px of content — 20 rows of 24, spaced
 /// 8, padded 8. The handle is `viewport / content * track` long.
@@ -31,6 +35,15 @@ const V_HANDLE: f32 = 60.4938;
 /// spaced 8, padded 8.
 const H_CONTENT: f32 = 888.0;
 const H_HANDLE: f32 = 44.1441;
+
+/// How far `H::vertical_inset` holds the scroller off its parent's origin.
+///
+/// The cases above lay the scroller out at (0, 0), where its own coordinate
+/// space and its parent's are the same one — and the scrollbars are laid out
+/// from the scroller's *local* bounds while the events reaching it are in its
+/// parent's. At the origin those two agree by accident, so an offset is what
+/// makes the difference between them visible.
+const INSET: f32 = 20.0;
 
 /// Where the handle belongs for a given offset: the same proportion
 /// `ScrollState::scrollbar_handle_rect` computes, written out so the test says
@@ -64,6 +77,20 @@ impl H {
             VIEWPORT,
             false,
         )
+    }
+
+    /// The same scroller, moved `INSET` off its parent's origin — the ordinary
+    /// case, and the one where the scroller's own coordinate space is not the
+    /// space the events reaching it are in.
+    ///
+    /// Moved rather than wrapped: the `Tree` holds a widget's origin apart from
+    /// its cached size, so setting it after layout is the whole of what a
+    /// parent would have done to it, without a second widget standing between
+    /// the scroller and every reader below.
+    fn vertical_inset() -> Self {
+        let mut h = Self::vertical();
+        h.tree.set_origin(h.root, INSET, INSET);
+        h
     }
 
     fn horizontal() -> Self {
@@ -115,13 +142,65 @@ impl H {
         node
     }
 
-    /// The painted position of the scrollbar handle, along the axis it travels.
+    /// The same, at a named instant, so that the frame after it can be placed a
+    /// known distance later.
+    fn dispatch_at(&mut self, event: Event, at: Instant) {
+        self.tree.set_event_instant(Some(at));
+        self.dispatch(event);
+        self.tree.set_event_instant(None);
+    }
+
+    /// One animation frame, at `at`.
+    ///
+    /// The loop gives every widget that asked for one its own `Animation` job,
+    /// so a ripple living on the scrollbar handle advances even though nothing
+    /// above it is animating. Advancing the whole subtree is that queue's
+    /// stand-in: no test here can name the handle, which the scroller owns
+    /// privately.
+    fn frame(&mut self, at: Instant) {
+        self.tree.set_frame_instant(Some(at));
+        for id in self.tree.collect_subtree_post_order(self.root) {
+            self.tree
+                .with_widget_mut(id, |w, id, t| w.advance_animations(t, id));
+        }
+        self.tree.set_frame_instant(None);
+    }
+
+    /// The opacity the scrollbar handle is filled with this frame.
+    ///
+    /// The three states the handle declares differ only in the alpha of a white
+    /// fill — resting, hovered, pressed — so that is what says which one it is
+    /// in.
+    fn handle_fill_alpha(&mut self) -> f32 {
+        self.handle_node()
+            .commands
+            .iter()
+            .find_map(|cmd| match &**cmd {
+                DrawCommand::RoundedRect { color, .. } => Some(color.a),
+                _ => None,
+            })
+            .expect("the handle fills itself")
+    }
+
+    /// The ripple this frame draws on the scrollbar handle, in the handle's own
+    /// coordinates, if it draws one.
+    fn handle_ripple(&mut self) -> Option<(f32, f32)> {
+        self.handle_node()
+            .overlay_commands
+            .iter()
+            .find_map(|cmd| match &**cmd {
+                DrawCommand::Circle { center, .. } => Some(*center),
+                _ => None,
+            })
+    }
+
+    /// The scrollbar handle's painted node.
     ///
     /// `paint_scrollbar_containers` draws the track and then the handle, after
     /// the content, so the scroller's children are content, track, handle. The
     /// handle's extent is asserted so that a change to that order fails here
     /// loudly rather than by silently measuring the wrong node.
-    fn handle_pos(&mut self) -> f32 {
+    fn handle_node(&mut self) -> Rc<RenderNode> {
         let horizontal = self.horizontal;
         let expect_extent = if horizontal { H_HANDLE } else { V_HANDLE };
 
@@ -131,7 +210,7 @@ impl H {
             3,
             "expected content, track and handle under the scroller"
         );
-        let handle = &node.children[2];
+        let handle = Rc::clone(&node.children[2]);
         let extent = if horizontal {
             handle.bounds.width
         } else {
@@ -143,8 +222,13 @@ impl H {
             handle.bounds.width,
             handle.bounds.height
         );
+        handle
+    }
 
-        if horizontal {
+    /// The painted position of the scrollbar handle, along the axis it travels.
+    fn handle_pos(&mut self) -> f32 {
+        let handle = self.handle_node();
+        if self.horizontal {
             handle.local_transform.tx()
         } else {
             handle.local_transform.ty()
@@ -298,5 +382,75 @@ fn pressing_the_painted_handle_starts_a_drag_rather_than_jumping_the_track() {
         near(after, 120.0),
         "pressing the painted handle at y={painted_centre} moved the content to {after}: \
          the paint and the hit test disagree about where the handle is"
+    );
+}
+
+/// A press has to reach the whole handle, and the disc it starts has to grow
+/// from where it landed — wherever the scroller itself sits.
+///
+/// The handle is a `Container` of its own and the scroller forwards the press
+/// to it. Forwarding it unchanged hands a point in the scroller's parent space
+/// to a widget laid out in the scroller's own, and the two differ by exactly
+/// the scroller's origin: off the surface origin the handle answers for a strip
+/// beside itself, so part of it — or all of it — takes no press at all, and
+/// where one does land the ripple starts that far from the finger.
+///
+/// Four quadrants, because a shift shows up as a fraction of the handle
+/// answering rather than none of it, which is how #261 was seen by hand.
+#[test]
+fn a_press_anywhere_on_the_handle_ripples_from_where_it_landed() {
+    let handle_x = INSET + VIEWPORT - BAR_WIDTH - TRACK_START;
+    let handle_y = INSET + TRACK_START;
+
+    for (qx, qy) in [(0.25, 0.25), (0.75, 0.25), (0.25, 0.75), (0.75, 0.75)] {
+        let (local_x, local_y) = (BAR_WIDTH * qx, V_HANDLE * qy);
+        let mut h = H::vertical_inset();
+
+        let pressed = Instant::now();
+        h.dispatch_at(
+            Event::MouseDown {
+                x: handle_x + local_x,
+                y: handle_y + local_y,
+                button: MouseButton::Left,
+            },
+            pressed,
+        );
+        h.frame(pressed + Duration::from_millis(16));
+
+        let (cx, cy) = h
+            .handle_ripple()
+            .unwrap_or_else(|| panic!("the press at quadrant ({qx}, {qy}) started no ripple"));
+
+        // The disc settles from the press point onto the handle's centre as it
+        // grows, so one frame's worth of that drift is expected and a whole
+        // scroller origin's worth is the defect.
+        assert!(
+            (cx - local_x).abs() < 2.0 && (cy - local_y).abs() < 2.0,
+            "quadrant ({qx}, {qy}): ripple at ({cx}, {cy}), pressed at ({local_x}, {local_y})"
+        );
+    }
+}
+
+/// The hover colour reaches the handle wherever the scroller sits.
+///
+/// The scroller decides hover itself, against the widened hit area, and then
+/// tells the handle with a synthetic `MouseEnter` at the handle's centre. That
+/// point is in the scroller's space like everything else the scroller
+/// computes, and the handle answers in its own — so the enter has the same
+/// origin to shed as the press does.
+#[test]
+fn hovering_the_handle_colours_it_wherever_the_scroller_sits() {
+    let mut h = H::vertical_inset();
+    let resting = h.handle_fill_alpha();
+
+    h.dispatch(Event::MouseMove {
+        x: INSET + VIEWPORT - BAR_WIDTH / 2.0 - TRACK_START,
+        y: INSET + TRACK_START + V_HANDLE / 2.0,
+    });
+
+    let hovered = h.handle_fill_alpha();
+    assert!(
+        hovered > resting,
+        "the handle is filled at {hovered} hovered and {resting} at rest: the enter never landed"
     );
 }

--- a/tests/scrollbar_handle_tracking.rs
+++ b/tests/scrollbar_handle_tracking.rs
@@ -1,11 +1,16 @@
-//! The scrollbar handle is drawn where the offset says it is.
+//! The scrollbar handle is drawn where the offset says it is, and answers a
+//! press wherever it is drawn.
 //!
 //! Scrolling is paint-only, and the loop runs `advance_animations` for a
 //! `JobType::Animation` job alone. A wheel scroll and a click on the track both
-//! request a plain `Paint`, so every case here dispatches an event and paints
-//! with no animation pass in between — which is what the loop actually does for
-//! them. Running one here would mask the defect: it repositions the handle, and
-//! the test would pass without the fix.
+//! request a plain `Paint`, so the cases that ask *where the handle is* dispatch
+//! an event and paint with no animation pass in between — which is what the loop
+//! actually does for them. Running one there would mask the defect: it
+//! repositions the handle, and the test would pass without the fix.
+//!
+//! The cases that ask *what the handle answers* run one, because they have to:
+//! a ripple is drawn only once it has grown, and it grows in an animation pass.
+//! They read what the paint says rather than assuming the frame they are on.
 //!
 //! Both axes, because both are drawn from the same derivation and either can
 //! lose it on its own.
@@ -452,5 +457,60 @@ fn hovering_the_handle_colours_it_wherever_the_scroller_sits() {
     assert!(
         hovered > resting,
         "the handle is filled at {hovered} hovered and {resting} at rest: the enter never landed"
+    );
+}
+
+/// A hovered handle is drawn wider than it is laid out, and the part that only
+/// the hover adds has to answer a press like the rest of it.
+///
+/// The widening is a scale the *scroller* applies at paint time — about the
+/// handle's outer edge, and never stored on the handle — so the handle's own
+/// bounds stay its resting strip however wide it is drawn. A press on the half
+/// that only exists while hovered therefore reached a widget that had no idea
+/// it was there.
+///
+/// Where the pixels are is read off the paint rather than assumed, so the case
+/// does not depend on the spring having settled by any particular frame.
+#[test]
+fn the_width_a_hover_adds_to_the_handle_answers_a_press_too() {
+    let mut h = H::vertical_inset();
+    let hovered = Instant::now();
+    h.dispatch(Event::MouseMove {
+        x: INSET + VIEWPORT - BAR_WIDTH / 2.0 - TRACK_START,
+        y: INSET + TRACK_START + V_HANDLE / 2.0,
+    });
+    for step in 1..=8 {
+        h.frame(hovered + Duration::from_millis(16 * step));
+    }
+
+    // The handle's painted edges, in the scroller's space: its own transform
+    // carries the hover scale, so the left edge is where the widening reaches.
+    let painted = h.handle_node().local_transform;
+    let (left, _) = painted.transform_point(0.0, V_HANDLE / 2.0);
+    let (right, _) = painted.transform_point(BAR_WIDTH, V_HANDLE / 2.0);
+    assert!(
+        right - left > BAR_WIDTH + 0.5,
+        "the hover widened the handle to {} from {BAR_WIDTH}: nothing was added to press on",
+        right - left
+    );
+
+    let pressed = hovered + Duration::from_millis(200);
+    h.dispatch_at(
+        Event::MouseDown {
+            x: INSET + left + 1.0,
+            y: INSET + TRACK_START + V_HANDLE / 2.0,
+            button: MouseButton::Left,
+        },
+        pressed,
+    );
+    h.frame(pressed + Duration::from_millis(16));
+
+    let (cx, _) = h
+        .handle_ripple()
+        .expect("a press on the widened edge started no ripple");
+    assert!(
+        cx < BAR_WIDTH / 2.0,
+        "pressed the handle's left edge and the ripple started at {cx}, \
+         past the middle of a {BAR_WIDTH}-wide handle"
     );
 }

--- a/tests/scrollbar_handle_tracking.rs
+++ b/tests/scrollbar_handle_tracking.rs
@@ -530,6 +530,30 @@ fn the_width_a_hover_adds_to_the_handle_answers_a_press_too() {
     );
 }
 
+/// The horizontal handle takes the hover colour too.
+///
+/// The pair to the case above, and between them they are what #260 asked for:
+/// that scrollbar answered neither a hover nor a press on a compositor, and
+/// both halves of it were this — a scroller nowhere near its parent's origin,
+/// and a bar whose mismatch is in y where the vertical one's is in x, which is
+/// why one of them still answered in part and this one not at all.
+#[test]
+fn hovering_the_horizontal_handle_colours_it_too() {
+    let mut h = H::horizontal_inset();
+    let resting = h.handle_fill_alpha();
+
+    h.dispatch(Event::MouseMove {
+        x: INSET + TRACK_START + H_HANDLE / 2.0,
+        y: INSET + H_VIEWPORT - BAR_WIDTH / 2.0 - TRACK_START,
+    });
+
+    let hovered = h.handle_fill_alpha();
+    assert!(
+        hovered > resting,
+        "the handle is filled at {hovered} hovered and {resting} at rest: the enter never landed"
+    );
+}
+
 /// The horizontal handle answers a press off-origin too.
 ///
 /// The forwarding is shared between the axes, but the geometry either side of

--- a/tests/scrollbar_handle_tracking.rs
+++ b/tests/scrollbar_handle_tracking.rs
@@ -591,6 +591,78 @@ fn the_horizontal_handle_ripples_from_where_it_landed_too() {
     }
 }
 
+/// The widening grows inward, from the edge the bar sits against.
+///
+/// Which point the scale turns about is the one thing the paint and the hit
+/// test have to agree on, and they agree by asking the same function — so a
+/// wrong answer moves both together and every press case here still passes.
+/// `cargo mutants` says as much: replacing `scrollbar_scale_pivot` with
+/// `Default::default()`, which is the centre, survived them all.
+///
+/// What it cannot survive is a question about the pixels. A vertical bar sits
+/// against the right edge of its scroller, so that is the edge that must not
+/// move: widening about the centre would push the bar out over the container's
+/// own boundary, half of it into the margin.
+#[test]
+fn the_hover_widens_the_handle_inward_and_leaves_its_outer_edge_alone() {
+    let mut h = H::vertical_inset();
+    let edges = |h: &mut H| {
+        let painted = h.handle_node().local_transform;
+        (
+            painted.transform_point(0.0, V_HANDLE / 2.0).0,
+            painted.transform_point(BAR_WIDTH, V_HANDLE / 2.0).0,
+        )
+    };
+    let (resting_left, resting_right) = edges(&mut h);
+
+    let hovered = Instant::now();
+    h.dispatch(Event::MouseMove {
+        x: INSET + VIEWPORT - BAR_WIDTH / 2.0 - TRACK_START,
+        y: INSET + TRACK_START + V_HANDLE / 2.0,
+    });
+    for step in 1..=8 {
+        h.frame(hovered + Duration::from_millis(16 * step));
+    }
+    let (left, right) = edges(&mut h);
+
+    assert!(
+        (right - resting_right).abs() < 0.01,
+        "the outer edge moved from {resting_right} to {right}: the bar is widening over the \
+         container's boundary rather than into it"
+    );
+    assert!(
+        left < resting_left - 0.5,
+        "the inner edge is at {left} against {resting_left} at rest: nothing widened"
+    );
+}
+
+/// The pointer leaving the scroller takes the handle's hover with it.
+///
+/// `handle_scrollbar_event`'s `MouseLeave` arm is the only thing that clears
+/// it: a pointer that leaves the whole scroller sends no `MouseMove` on its way
+/// out, so without this the bar stays lit and widened after the pointer has
+/// gone. `cargo mutants` found the arm deletable with nothing objecting.
+#[test]
+fn leaving_the_scroller_takes_the_handles_hover_with_it() {
+    let mut h = H::vertical_inset();
+    let resting = h.handle_fill_alpha();
+
+    h.dispatch(Event::MouseMove {
+        x: INSET + VIEWPORT - BAR_WIDTH / 2.0 - TRACK_START,
+        y: INSET + TRACK_START + V_HANDLE / 2.0,
+    });
+    assert!(h.handle_fill_alpha() > resting, "the handle never lit up");
+
+    h.dispatch(Event::MouseLeave);
+
+    let after = h.handle_fill_alpha();
+    assert!(
+        (after - resting).abs() < 0.001,
+        "the handle is still filled at {after} against {resting} at rest: the pointer left and \
+         the hover stayed"
+    );
+}
+
 /// A release on the handle finishes the ripple rather than abandoning it —
 /// including on the width the hover added.
 ///


### PR DESCRIPTION
## What changed

A scrollbar handle now answers a hover and a press everywhere it is drawn, on either axis, and the ripple grows from the point pressed. Two independent causes stood between those facts.

First, `handle_scrollbar_event` took the scroller's bounds in its *parent's* space and passed them, with the event, to every rect derivation below it — while the scrollbars themselves are laid out from local bounds, as `layout_scrollbar_containers`, `update_scrollbar_handle_positions` and `scrollbar_handle_origin` each say out loud. The event is now rebased once, where it enters, and everything below it is in the one space the rest of the file already assumed.

Second, the hover widening is a scale this container applies when it *paints* the track and handle — about the right edge of a vertical bar, the bottom of a horizontal one — and never declared on either of them, so the handle's own bounds stayed the resting six pixels of a hovered ten. That scale is now undone before the event is forwarded, about the same point the paint turns it about, which is the order `Container::event` already uses on its own transform. The four paint sites that each composed a translate, a scale and two more translates by hand now name their axis and share one function with the hit test.

Four commits: those two, then the forwarding paths they changed and left unwatched, then #260.

Closes #261. Closes #260. Closes #297.

## What proves it

Seven cases in `tests/scrollbar_handle_tracking.rs`, each red before the commit that answers it and green after — checked by restoring `origin/main`'s `src/` under the new tests:

- `a_press_anywhere_on_the_handle_ripples_from_where_it_landed` — #261's acceptance criterion: a `MouseDown` at each of the four quadrants of the handle adds a `DrawCommand::Circle` to the handle's overlay, with its centre within a pixel or two of the press. Before, on a scroller off its parent's origin, no quadrant rippled at all.
- `hovering_the_handle_colours_it_wherever_the_scroller_sits` — the synthetic `MouseEnter` that carries the hover colour missed the same way, so the handle's fill never changed.
- `the_width_a_hover_adds_to_the_handle_answers_a_press_too` — hovers, reads the painted edges off the handle's own transform rather than assuming the spring has settled, and presses a pixel inside the left one. No ripple before, one after.
- `the_horizontal_handle_ripples_from_where_it_landed_too` and `hovering_the_horizontal_handle_colours_it_too` — #260's acceptance criterion, both halves.
- `releasing_on_the_widened_handle_finishes_the_ripple_rather_than_abandoning_it` — the `MouseUp` that ends a drag. Asserted on how bright the disc is rather than on whether one is drawn, because three outcomes have to be told apart and only one is absent: completed fades over `FADE_OUT` and is still there, abandoned over `CANCEL_FADE` and is gone, and a release that never arrived begins no exit at all and stays at full strength for ever.

The harness gained a scroller held off its parent's origin, which is what makes the two spaces differ; at (0, 0) they agree by accident, which is where every case in the file used to put it. It is *moved* rather than wrapped — the `Tree` holds a widget's origin apart from its cached size — so nothing that already existed in the file changed shape.

Two cases were checked by mutation rather than by the before/after alone, because their first drafts passed against a broken build: dropping the unscale for a `MouseUp` makes the release case report the disc gone, and not forwarding the `MouseUp` at all makes it report the disc undimmed.

Full suite green (25 binaries), `golden_images` green on lavapipe, clippy clean with `-D warnings`. No golden moved, and none should have: this changes where an event lands, not what a pixel is. #261 conditioned a golden on its own hypothesis — that the hit test and the paint disagreed about a scale *pivot* — and that hypothesis is refuted below.

**On #261's reading.** It offered a hypothesis "to be confirmed rather than believed": that `Container::event`'s `HitContext` and `Ripple::center` disagreed about the handle's scale pivot. Measured, they do not — the handle Container declares no transform of its own, so `animated_transform` is the identity there and `untransform_point` is a no-op. The first cause was a coordinate space, not a transform. The second cause *is* the scale, but not a pivot disagreement: paint and hit test agreed about the pivot and the hit test simply did not know a scale existed.

**On #260.** Filed as its own defect — the horizontal handle answered nothing while the vertical one answered in part — and it is the same cause. The scroller's space and its parent's differ in x and y at once, and the two bars sit on different edges, so the vertical bar's mismatch falls across its narrow width where enough overlap survived to answer in part, and the horizontal bar's across its height where none did. On `origin/main`'s `src`: a horizontal scroller at the origin takes the hover colour (0.3 → 0.5), one moved off it does not (0.3 → 0.3). Confirmed by hand on niri as well.

**On #297.** Filed by me as a follow-up to this branch and closed here instead, which is where it belonged: those are paths this change touched. Writing the tests corrected what it claimed. `MouseLeave` carries no coordinates at all — `Event::coords` answers `None`, so `forward_to_handle` passes it through untouched and neither fix reaches it; there was never anything there to watch. And the release only exercises the *unscale*, not the rebase, and only while the handle is hovered, since the rebase happens above the forwarding and a resting scale of 1 undoes to itself.

## What the review found

The `reviewer` subagent ran over the first commit, before the pull request existed: **zero blocking findings.**

Its one finding worth answering was that #261's symptom was only half gone — that the widened part of a hovered handle still took no press, at smaller magnitude, and the issue would reopen after the next run of `scroll_example`. It was right, and independently so: the maintainer found the same thing by hand at the same time. That is the second commit. Its note that the `MouseUp` and `MouseLeave` paths had no test is the third.

Its remaining notes: the file's module doc no longer described every case, since the ripple ones must run an animation pass — updated. A press mid-track can still miss the handle after a wheel scroll, because the handle's `Tree` origin is stale until an animation frame — that is #244, pre-existing and untouched here.

The review predates the last three commits, which therefore have not been read by anything that did not write them.

## What was checked by hand

`cargo run --example scroll_example` on niri, by the maintainer, before and after.

- Before: pressing the vertical handle answered only in part, and the left side of it — the width the hover adds — was not clickable at all. The horizontal handle answered nothing.
- After: the vertical handle presses and ripples across its whole painted width. The horizontal one widens on hover, changes colour, and ripples on a press.

## Left undone

- **#244**, untouched — after a wheel scroll the handle's `Tree` origin is stale until an animation frame, so a press mid-track can still miss it. The cases here all press at offset 0, which is why they do not meet it.