### PR TITLE
The scrollbar handle answers where it is painted, on the frame a wheel scroll asks for

### DIFF
--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -1419,13 +1419,6 @@ impl Widget for Container {
             }
         }
 
-        // Keep the origin the Tree holds for the handle in step with the offset,
-        // for the events forwarded to the handle widget. What is *drawn* no
-        // longer depends on this pass having run — see `scrollbar_handle_origin`.
-        if self.scroll_axis != ScrollAxis::None {
-            self.update_scrollbar_handle_positions(tree, id);
-        }
-
         // Advance scrollbar scale animations (for hover expansion effect)
         // Must be done here since scroll/hover is paint-only and layout may not run
         if self.advance_scrollbar_scale_animations_internal(id, now) {

--- a/src/widgets/container/scrollable.rs
+++ b/src/widgets/container/scrollable.rs
@@ -309,69 +309,6 @@ impl Container {
         animating
     }
 
-    /// Write the handle's origin into the `Tree` for the current scroll offset.
-    ///
-    /// Not for the paint, which derives the position itself
-    /// (`scrollbar_handle_origin`): this is for the handle *widget*, which is a
-    /// `Container` of its own and hit-tests the events forwarded to it —
-    /// `MouseDown` at the start of a drag, the synthetic `MouseEnter` — against
-    /// the bounds the `Tree` holds for it. Layout writes that origin too.
-    ///
-    /// It does not cover the paint-only paths, and does not claim to: the one
-    /// caller is `advance_animations`, which runs for a `JobType::Animation`
-    /// job alone, so after a wheel scroll or a click on the track this origin
-    /// is stale until something asks for an animation frame. Pressing the
-    /// handle still starts the drag — that is decided from the derived rect —
-    /// but the handle's own pressed and hover colours miss it until then.
-    /// One answer for both readers is #244.
-    pub(super) fn update_scrollbar_handle_positions(&mut self, tree: &mut Tree, id: WidgetId) {
-        if self.scroll_axis == ScrollAxis::None
-            || self.scroll().scrollbar_visibility == ScrollbarVisibility::Hidden
-        {
-            return;
-        }
-
-        let sd = self.scroll();
-        let needs_vertical = sd.scroll_state.needs_vertical_scrollbar();
-        let needs_horizontal = sd.scroll_state.needs_horizontal_scrollbar();
-
-        // Get bounds from Tree (single source of truth)
-        let bounds = tree.get_bounds(id).unwrap_or_default();
-        // Use local bounds (0,0 origin) for scrollbar positioning.
-        // Scrollbars are positioned relative to container origin.
-        let local_bounds = Rect::new(0.0, 0.0, bounds.width, bounds.height);
-
-        // Update vertical scrollbar handle position
-        if self.scroll_axis.allows_vertical()
-            && needs_vertical
-            && let Some(handle_id) = self.scroll().v_scrollbar_handle_id
-        {
-            let sd = self.scroll();
-            let handle_rect = sd.scroll_state.scrollbar_handle_rect(
-                ScrollbarAxis::Vertical,
-                local_bounds,
-                &sd.scrollbar_config,
-                needs_horizontal,
-            );
-            tree.set_origin(handle_id, handle_rect.x, handle_rect.y);
-        }
-
-        // Update horizontal scrollbar handle position
-        if self.scroll_axis.allows_horizontal()
-            && needs_horizontal
-            && let Some(handle_id) = self.scroll().h_scrollbar_handle_id
-        {
-            let sd = self.scroll();
-            let handle_rect = sd.scroll_state.scrollbar_handle_rect(
-                ScrollbarAxis::Horizontal,
-                local_bounds,
-                &sd.scrollbar_config,
-                needs_vertical,
-            );
-            tree.set_origin(handle_id, handle_rect.x, handle_rect.y);
-        }
-    }
-
     /// Where the handle belongs for the offset the container holds right now.
     ///
     /// Layout gives the handle its size and writes an origin into the `Tree`;
@@ -524,7 +461,18 @@ impl Container {
     /// it appears. Undoing that scale here is what `Container::event` does with
     /// its own transform before hit testing — and without it the width a hover
     /// adds is drawn and answers nothing: no pressed colour, and no ripple.
-    fn forward_to_handle(&self, tree: &mut Tree, axis: ScrollbarAxis, event: &Event) {
+    ///
+    /// The other is the offset. The handle hit-tests against the origin the
+    /// `Tree` holds for it, which layout writes and the offset then moves
+    /// without layout — scrolling is paint-only. So the origin is brought up to
+    /// the offset here, from the same `scrollbar_handle_origin` the paint draws
+    /// from, which is what leaves one answer to where the handle is rather than
+    /// two that drift. It used to be written on animation frames instead, and a
+    /// wheel scroll asks for a plain `Paint`: the drag still began, because the
+    /// scroller decides that from the derived rect, and only the feedback went
+    /// missing — the pressed colour and the ripple, on a handle sitting visibly
+    /// under the pointer.
+    fn forward_to_handle(&self, tree: &mut Tree, id: WidgetId, axis: ScrollbarAxis, event: &Event) {
         let sd = self.scroll();
         let handle_id = match axis {
             ScrollbarAxis::Vertical => sd.v_scrollbar_handle_id,
@@ -533,6 +481,9 @@ impl Container {
         let Some(handle_id) = handle_id else {
             return;
         };
+
+        let (origin_x, origin_y) = self.scrollbar_handle_origin(tree, id, axis);
+        tree.set_origin(handle_id, origin_x, origin_y);
 
         let scale = match axis {
             ScrollbarAxis::Vertical => sd.v_scrollbar_scale_anim.as_ref(),
@@ -687,13 +638,13 @@ impl Container {
             Event::MouseUp { button, .. } if *button == MouseButton::Left => {
                 if self.scroll().scroll_state.scrollbar_dragging {
                     self.scroll_mut().scroll_state.scrollbar_dragging = false;
-                    self.forward_to_handle(tree, ScrollbarAxis::Vertical, event);
+                    self.forward_to_handle(tree, id, ScrollbarAxis::Vertical, event);
                     request_job(id, JobRequest::Paint);
                     return Some(EventResponse::Handled);
                 }
                 if self.scroll().scroll_state.h_scrollbar_dragging {
                     self.scroll_mut().scroll_state.h_scrollbar_dragging = false;
-                    self.forward_to_handle(tree, ScrollbarAxis::Horizontal, event);
+                    self.forward_to_handle(tree, id, ScrollbarAxis::Horizontal, event);
                     request_job(id, JobRequest::Paint);
                     return Some(EventResponse::Handled);
                 }
@@ -712,8 +663,8 @@ impl Container {
                 sd.scroll_state.h_scrollbar_dragging = false;
 
                 if had_hover {
-                    self.forward_to_handle(tree, ScrollbarAxis::Vertical, event);
-                    self.forward_to_handle(tree, ScrollbarAxis::Horizontal, event);
+                    self.forward_to_handle(tree, id, ScrollbarAxis::Vertical, event);
+                    self.forward_to_handle(tree, id, ScrollbarAxis::Horizontal, event);
                 }
                 if had_hover || had_drag {
                     request_job(id, JobRequest::Paint);
@@ -763,7 +714,7 @@ impl Container {
             sd.scroll_state.set_drag_start(axis, pos, offset);
 
             // Forward event to handle container for pressed state
-            self.forward_to_handle(tree, axis, event);
+            self.forward_to_handle(tree, id, axis, event);
 
             request_job(id, JobRequest::Paint);
             return Some(EventResponse::Handled);
@@ -858,7 +809,7 @@ impl Container {
     fn update_scrollbar_hover(
         &mut self,
         tree: &mut Tree,
-        _id: WidgetId,
+        id: WidgetId,
         bounds: Rect,
         axis: ScrollbarAxis,
         x: f32,
@@ -907,9 +858,9 @@ impl Container {
                 x: handle_rect.x + handle_rect.width / 2.0,
                 y: handle_rect.y + handle_rect.height / 2.0,
             };
-            self.forward_to_handle(tree, axis, &enter);
+            self.forward_to_handle(tree, id, axis, &enter);
         } else if !is_hovered && was_hovered {
-            self.forward_to_handle(tree, axis, &Event::MouseLeave);
+            self.forward_to_handle(tree, id, axis, &Event::MouseLeave);
         }
 
         needs_repaint

--- a/tests/scrollbar_handle_tracking.rs
+++ b/tests/scrollbar_handle_tracking.rs
@@ -733,3 +733,74 @@ fn releasing_on_the_widened_handle_finishes_the_ripple_rather_than_abandoning_it
         "the disc is still at {leaving} against {held} held: the release never reached the handle"
     );
 }
+
+/// The handle takes the hover colour where it is painted, on the frame a wheel
+/// scroll asks for.
+///
+/// The handle widget hit-tests against the origin the `Tree` holds for it, and
+/// that origin is written where it is read — in `forward_to_handle`, from the
+/// same derivation the paint draws from.
+///
+/// It was written on animation frames instead, and `advance_animations` runs
+/// for a `JobType::Animation` job alone: a wheel scroll asks for a plain
+/// `Paint`, so after one the stored origin was wherever the last layout had
+/// left it, and the pointer met a handle that was no longer there.
+///
+/// Deliberately no animation pass anywhere here: running one would have
+/// repositioned the handle and hidden exactly that.
+#[test]
+fn the_handle_takes_the_hover_colour_where_it_is_painted_after_a_wheel_scroll() {
+    let mut h = H::vertical();
+    let resting = h.handle_fill_alpha();
+
+    h.wheel(120.0);
+
+    let painted = h.handle_pos();
+    h.dispatch(Event::MouseMove {
+        x: VIEWPORT - BAR_WIDTH / 2.0 - TRACK_START,
+        y: painted + V_HANDLE / 2.0,
+    });
+
+    let hovered = h.handle_fill_alpha();
+    assert!(
+        hovered > resting,
+        "the handle painted at {painted} is filled at {hovered}, the same as its resting \
+         {resting}: the pointer went to where the handle used to be"
+    );
+}
+
+/// And answers a press there, which is the other half of the same origin.
+///
+/// The press is asserted against the *hover* colour rather than the resting
+/// one, because the pointer has to be on the handle to press it: a press that
+/// registered as nothing more than a hover would satisfy "brighter than rest",
+/// and it is the pressed colour the issue asks for.
+///
+/// The drag begins either way — the scroller decides that from the derived rect
+/// — so it is the feedback this watches, the pressed colour and the ripple.
+#[test]
+fn the_handle_is_pressable_where_it_is_painted_after_a_wheel_scroll() {
+    let mut h = H::vertical();
+    h.wheel(120.0);
+
+    let painted = h.handle_pos();
+    let (x, y) = (
+        VIEWPORT - BAR_WIDTH / 2.0 - TRACK_START,
+        painted + V_HANDLE / 2.0,
+    );
+    h.dispatch(Event::MouseMove { x, y });
+    let hovered = h.handle_fill_alpha();
+
+    h.dispatch(Event::MouseDown {
+        x,
+        y,
+        button: MouseButton::Left,
+    });
+
+    let pressed = h.handle_fill_alpha();
+    assert!(
+        pressed > hovered,
+        "the handle painted at {painted} is filled at {pressed} against {hovered} hovered: \
+         the press went to where the handle used to be"
+    );
+}

--- a/tests/scrollbar_handle_tracking.rs
+++ b/tests/scrollbar_handle_tracking.rs
@@ -804,3 +804,52 @@ fn the_handle_is_pressable_where_it_is_painted_after_a_wheel_scroll() {
          the press went to where the handle used to be"
     );
 }
+
+/// The hover follows the pointer across the handle and stops at its edge,
+/// without leaving the scroller at all.
+///
+/// The pointer leaving the scroller outright is the other case, and it is a
+/// `MouseLeave` the compositor sends. These are ordinary `MouseMove`s:
+/// `update_scrollbar_hover` decides the transitions itself and synthesises an
+/// enter and a leave for the handle, and the branch that sends the leave is one
+/// `!` and one `&&` away from firing at the wrong moment — never, or on every
+/// move while the pointer is still on the handle. `cargo mutants` found both,
+/// with nothing objecting, so both moments are asserted here: the second move
+/// that must change nothing, and the one that must put the colour back.
+#[test]
+fn the_hover_follows_the_pointer_across_the_handle_and_stops_at_its_edge() {
+    let mut h = H::vertical();
+    let x = VIEWPORT - BAR_WIDTH / 2.0 - TRACK_START;
+    let resting = h.handle_fill_alpha();
+
+    h.dispatch(Event::MouseMove {
+        x,
+        y: TRACK_START + V_HANDLE / 4.0,
+    });
+    let hovered = h.handle_fill_alpha();
+    assert!(hovered > resting, "the handle never lit up");
+
+    // Still on the handle, further down it.
+    h.dispatch(Event::MouseMove {
+        x,
+        y: TRACK_START + V_HANDLE * 3.0 / 4.0,
+    });
+    let still = h.handle_fill_alpha();
+    assert!(
+        (still - hovered).abs() < 0.001,
+        "the handle dimmed to {still} from {hovered} while the pointer was still on it"
+    );
+
+    // Down the track, past the foot of the handle, and still inside the scroller.
+    h.dispatch(Event::MouseMove {
+        x,
+        y: TRACK_START + V_HANDLE + 20.0,
+    });
+
+    let after = h.handle_fill_alpha();
+    assert!(
+        (after - resting).abs() < 0.001,
+        "the handle is still filled at {after} against {resting} at rest: the pointer moved \
+         off it and the hover stayed"
+    );
+}


### PR DESCRIPTION
## What changed

Two answers to "where is the scrollbar handle" have been living side by side: the origin the `Tree` holds for the handle widget, and `ScrollState::scrollbar_handle_rect`, derived from the offset. #201 made the *paint* derive its own, so what is drawn has been right on every path since; this is the other half. The stored origin was written by layout and by `update_scrollbar_handle_positions`, whose one caller was `advance_animations` — a `JobType::Animation` job alone. A wheel scroll and a click on the track both ask for a plain `Paint`, so after either the stored origin was wherever the last layout had left it, while the handle was drawn where the offset says.

That origin has exactly one reader — `forward_to_handle`, directly for the unscale pivot and through the handle's own `Container::event` — so the write goes there, from `scrollbar_handle_origin`, the same derivation the paint draws from. `update_scrollbar_handle_positions` goes with it: a second derivation of the handle rect, a guard its remaining caller had already made unreachable, and seventeen lines of comment about when it happened to run. One answer, written immediately before it is read, on the events that read it rather than on whichever frames pass through an animation pass.

Closes #244.

## What proves it

Two cases in `tests/scrollbar_handle_tracking.rs`, both red against `origin/main`'s `src/` and green with this — checked by `git checkout origin/main -- src` and re-running:

- `the_handle_is_pressable_where_it_is_painted_after_a_wheel_scroll` — the acceptance criterion: wheel-scroll, press the centre of the *painted* handle, paint with no animation pass, assert the fill. Before: `filled at 0.3, the same as its resting 0.3` — the issue's own table, to the digit.
- `the_handle_takes_the_hover_colour_where_it_is_painted_after_a_wheel_scroll` — the issue's Expected says "pressing *or hovering*", and the hover half travels a different path: `update_scrollbar_hover` derives its own rect and synthesises a `MouseEnter`, so it can regress on its own.

The press is asserted against the *hover* colour rather than the resting one. The pointer has to be on the handle to press it, so a press that registered as nothing more than a hover would satisfy "brighter than rest" — measured, that is 0.5 against the 0.6 the criterion asks for.

No animation pass anywhere in either case, deliberately: running one would reposition the handle and hide exactly the defect. No golden or snapshot moved, and none should have — #201 already settled what is drawn, and this changes only where an event lands.

Full suite green (25 binaries), `golden_images` green on lavapipe, clippy clean with `-D warnings`.

**On scope.** The issue's "The shape" section proposes one call to `update_scrollbar_handle_positions` at the top of `handle_scrollbar_event`, calling that "the cheap version" of collapsing the two answers. This does the collapse instead: the cheap form keeps the second derivation alive and pays for it on every event that reaches a scrollable container, measured at +15ns for a pointer merely passing over one, against a handful of events this way. Net −18 lines, one file, no new type, trait or ownership rule.

## What the review found

The `reviewer` subagent ran over the commit, before the pull request existed: **zero blocking findings.** It confirmed the acceptance criterion by running it, confirmed the "one reader" claim by reading every consumer of the stored origin, and confirmed the deleted guards were unreachable from the single remaining call site.

Both of its findings are acted on rather than answered here: the missing hover case, and an assertion loose enough that a hover would have satisfied it. Both are in the commit.

Its notes: the "it used to be written on animation frames" paragraph exists in the commit body, the `forward_to_handle` doc and the test docs — the commit body is where the history belongs, and the doc comments lead with what is true now. And `set_origin` is now reached from event dispatch, where every other caller is layout; it expands the damage rect for the vacated and occupied rects, which is correct here — the handle genuinely moved, and every forwarding site requests a `Paint` anyway.

One thing it suspected and I checked rather than assumed: the `set_origin` must stay above the `unscaled` computation, which reads `tree.get_bounds(handle_id)` for the untransform pivot. It does, and the doc comment says why it is there.

## What was checked by hand

`cargo run --example scroll_example` on niri, by the maintainer. Wheel-scroll first, then press the handle where it now sits: it takes the pressed colour and ripples, where before the drag began with no feedback at all.

## Left undone

Nothing. `forward_to_handle` is not called for the `MouseMove`s during a drag, so the stored origin is not refreshed for the length of one — that is the invariant working rather than a gap, since the only reader is the write's own call site.