### PR TITLE
One rule decides the order a popup tree comes down in, grabs included

### DIFF
--- a/.claude/skills/wayland/SKILL.md
+++ b/.claude/skills/wayland/SKILL.md
@@ -59,12 +59,10 @@ implementations answer `popup_descendants_bottom_up` from one
 compositor is given. What `src/platform/popups.rs` still answers alone is which
 surfaces are popups and whose children they are.
 
-Still verified by running an example and looking: **the session lock, output
-hotplug, and grab conflicts between popups**. They type-check against the same
-trait and need no redesign, but each needs something built: the recorder leaves
-`Platform`'s four lock methods at their defaults, `outputs::sync_outputs` is
-`pub(crate)`, and the recorder discards the `PopupConfig` that says which popups
-hold a grab.
+Still verified by running an example and looking: **the session lock and output
+hotplug**. They type-check against the same trait and need no redesign, but each
+needs something built: the recorder leaves `Platform`'s four lock methods at
+their defaults, and `outputs::sync_outputs` is `pub(crate)`.
 
 When you change this layer:
 

--- a/.claude/skills/wayland/SKILL.md
+++ b/.claude/skills/wayland/SKILL.md
@@ -53,10 +53,11 @@ sensor. It needs the `testing` feature and a GPU adapter.
 
 What has none: what goes out on the wire, and what a compositor does with it.
 The recorder proves guido asks for an exclusive zone of 50; it cannot prove niri
-reserves 50. And it is the recorder's own answer to
-`popup_descendants_bottom_up` that the teardown test walks — what is proved is
-that the *loop* asks in that order, not that `src/platform/popups.rs` computes
-it right.
+reserves 50. The teardown order is no longer in that half — both `Platform`
+implementations answer `popup_descendants_bottom_up` from one
+`descendants_bottom_up`, so the order the test walks is the order the
+compositor is given. What `src/platform/popups.rs` still answers alone is which
+surfaces are popups and whose children they are.
 
 Still verified by running an example and looking: **the session lock, output
 hotplug, and grab conflicts between popups**. They type-check against the same

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,17 +147,14 @@ loop tears a popup chain down in, and this one is watched all the way now: both
 order by the same code. What `src/platform/popups.rs` still keeps to itself is
 six lines saying which surfaces are popups and whose children they are.
 
-The grab-conflict teardown is the exception, and a live one: two chains are
-still concatenated in whatever order the surfaces were stored in, and nothing
-can referee it because the recorder discards the `PopupConfig` that says which
-popups hold a grab (#300).
+The grab-conflict teardown is watched too, now that the recorder keeps the
+`grab` flag it used to throw away: a new grab that cannot nest under the live
+chain brings that chain down, and a test says in which order.
 
-The session lock, output hotplug and popup grab conflicts are the remainder.
-They need no redesign — the map was the missing part — but they do need
-machinery: the recorder answers four of `Platform`'s lock methods with the
-trait's defaults, `sync_outputs` is `pub(crate)` so no test in `tests/` can
-reach it, and the recorder throws away the `PopupConfig` that would say which
-popups hold a grab.
+The session lock and output hotplug are the remainder. They need no redesign —
+the map was the missing part — but they do need machinery: the recorder answers
+four of `Platform`'s lock methods with the trait's defaults, and `sync_outputs`
+is `pub(crate)` so no test in `tests/` can reach it.
 
 ## What watches the harness
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,9 +141,16 @@ thing with one.
 
 It now holds as many surfaces as the loop will carry, so a second surface, and
 `spawn_surface` and `close` at runtime, are watched too. So is the order the
-loop tears a popup chain down in — though only the loop's half of it: the
-recorder answers `popup_descendants_bottom_up` from its own map, so the Wayland
-implementation of that same rule still has no sensor (#292).
+loop tears a popup chain down in, and this one is watched all the way now: both
+`Platform` implementations answer `popup_descendants_bottom_up` from one
+`descendants_bottom_up`, so the recorder and the compositor are given the same
+order by the same code. What `src/platform/popups.rs` still keeps to itself is
+six lines saying which surfaces are popups and whose children they are.
+
+The grab-conflict teardown is the exception, and a live one: two chains are
+still concatenated in whatever order the surfaces were stored in, and nothing
+can referee it because the recorder discards the `PopupConfig` that says which
+popups hold a grab (#300).
 
 The session lock, output hotplug and popup grab conflicts are the remainder.
 They need no redesign — the map was the missing part — but they do need

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -861,6 +861,145 @@ pub(crate) trait Surface {
     }
 }
 
+/// The order a popup tree must be destroyed in: every descendant of `root`,
+/// deepest and newest first.
+///
+/// `edges` is the whole live popup forest as `(popup, its parent)` pairs, in
+/// any order; only the ones reachable from `root` come back, and `root` itself
+/// does not — the caller destroys that after, or is a surface rather than a
+/// popup.
+///
+/// **What the protocol requires** is that a popup outlive none of its children:
+/// `xdg_popup.destroy` on one that is not the topmost raises
+/// `not_the_topmost_popup` and the compositor drops the connection, and
+/// xdg-shell defines that for a chain — *"Nested popups must be destroyed in
+/// the reverse order they were created in, e.g. the only popup you are allowed
+/// to destroy at all times is the topmost one."* Between two popups on the same
+/// parent it says nothing, and this does not pretend otherwise.
+///
+/// **What is chosen** is that siblings come back newest first, and the way both
+/// are had at once is a sort rather than a walk. A [`SurfaceId`] is a counter
+/// that only goes up, so descending id puts every child before its parent for
+/// free — a popup cannot be created on a parent that does not exist — and
+/// orders siblings by age on the same pass. The reason to decide it at all is
+/// that the alternative was three answers: a frontier reversed, a recursion,
+/// and a hash iteration, disagreeing on the case the protocol leaves open, with
+/// no way to tell which a compositor had been given.
+///
+/// Callers may depend on the order, and both `Platform` implementations do —
+/// that is the point of it being here rather than in either of them.
+/// topmost first.
+///
+/// `edges` is the whole live popup forest as `(popup, its parent)` pairs, in
+/// any order; only the ones reachable from `root` come back, and `root` itself
+/// does not — the caller destroys that after, or is a surface rather than a
+/// popup.
+///
+/// **The order is decided, not incidental.** xdg-shell keeps live popups in a
+/// stack and `xdg_popup.destroy` must take the topmost one; taking any other
+/// raises `not_the_topmost_popup`, and the compositor drops the connection. The
+/// stack is creation order, and a [`SurfaceId`] is a counter that only goes up,
+/// so **descending id is the stack** — which is why this sorts rather than
+/// walks. Depth needs no separate rule: a popup cannot be created on a parent
+/// that does not exist, so a child's id always exceeds its parent's and comes
+/// out first for free.
+///
+/// Callers may depend on that order, and the two `Platform` implementations do:
+/// it is the same sequence on both, where a tree walk left it to whatever order
+/// the surfaces happened to be stored in. Siblings were the visible half of
+/// that — a frontier reversed, a recursion and a hash iteration are three
+/// answers — but the old walks could also emit a popup while a *newer* sibling
+/// was still live, which is the error above rather than a matter of taste.
+pub(crate) fn descendants_bottom_up(
+    root: SurfaceId,
+    edges: impl Iterator<Item = (SurfaceId, SurfaceId)>,
+) -> Vec<SurfaceId> {
+    let edges: Vec<(SurfaceId, SurfaceId)> = edges.collect();
+    let mut out: Vec<SurfaceId> = Vec::new();
+    let mut frontier = vec![root];
+
+    while let Some(current) = frontier.pop() {
+        for (popup, parent) in &edges {
+            if *parent == current {
+                out.push(*popup);
+                frontier.push(*popup);
+            }
+        }
+    }
+
+    out.sort_unstable_by_key(|id| std::cmp::Reverse(id.raw()));
+    out
+}
+
+#[cfg(test)]
+mod teardown_order {
+    use super::descendants_bottom_up;
+    use crate::surface::SurfaceId;
+
+    /// Ids in the order they would have been created.
+    fn ids(n: usize) -> Vec<SurfaceId> {
+        (0..n).map(|_| SurfaceId::next()).collect()
+    }
+
+    #[test]
+    fn a_chain_comes_back_deepest_first() {
+        let s = ids(4);
+        let edges = vec![(s[1], s[0]), (s[2], s[1]), (s[3], s[2])];
+        assert_eq!(
+            descendants_bottom_up(s[0], edges.into_iter()),
+            vec![s[3], s[2], s[1]]
+        );
+    }
+
+    /// The case the walks disagreed on: two popups on one parent, one of them
+    /// carrying a chain of its own. The newest goes first even though it is the
+    /// shallowest, because it is the one on top of the stack.
+    #[test]
+    fn siblings_come_back_newest_first() {
+        let s = ids(4);
+        // s[0] ── s[1] ── s[2]
+        //     └── s[3]
+        let edges = vec![(s[1], s[0]), (s[2], s[1]), (s[3], s[0])];
+        assert_eq!(
+            descendants_bottom_up(s[0], edges.into_iter()),
+            vec![s[3], s[2], s[1]]
+        );
+    }
+
+    /// Edges arrive in whatever order the surfaces happen to be stored in, and
+    /// the answer may not depend on it — which is the whole point of sorting
+    /// rather than walking.
+    #[test]
+    fn the_order_the_edges_arrive_in_does_not_matter() {
+        let s = ids(4);
+        let edges = [(s[1], s[0]), (s[2], s[1]), (s[3], s[0])];
+        let want = vec![s[3], s[2], s[1]];
+
+        let mut shuffled = edges;
+        shuffled.reverse();
+        assert_eq!(descendants_bottom_up(s[0], shuffled.into_iter()), want);
+        assert_eq!(
+            descendants_bottom_up(s[0], [edges[1], edges[2], edges[0]].into_iter()),
+            want
+        );
+    }
+
+    /// Another surface's popups are not this surface's to destroy.
+    #[test]
+    fn only_what_hangs_from_the_root_comes_back() {
+        let s = ids(4);
+        let edges = vec![(s[1], s[0]), (s[3], s[2])];
+        assert_eq!(descendants_bottom_up(s[0], edges.into_iter()), vec![s[1]]);
+    }
+
+    #[test]
+    fn a_surface_with_no_popups_has_nothing_to_tear_down() {
+        let s = ids(2);
+        let edges = vec![(s[1], s[0])];
+        assert!(descendants_bottom_up(s[1], edges.into_iter()).is_empty());
+    }
+}
+
 /// Whatever the application is running on.
 ///
 /// The thin half: it hands out surfaces and answers for the things that belong
@@ -915,7 +1054,7 @@ pub(crate) trait Platform {
         Vec::new()
     }
 
-    /// A popup's descendants, deepest first — the order they must close in.
+    /// A popup's descendants, in the order [`descendants_bottom_up`] decides.
     fn popup_descendants_bottom_up(&self, root: SurfaceId) -> Vec<SurfaceId> {
         let _ = root;
         Vec::new()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -931,9 +931,56 @@ pub(crate) fn descendants_bottom_up(
     out
 }
 
+/// The grabbing popups a new grab under `new_parent` cannot coexist with, in
+/// teardown order.
+///
+/// xdg-shell allows one grab chain at a time and requires a new grab to nest
+/// under the current holder: *"The parent of a grabbing popup must either be an
+/// xdg_toplevel surface or another xdg_popup with an explicit grab."* So a grab
+/// requested anywhere else means the live chain comes down first, and it comes
+/// down in [`descendants_bottom_up`]'s order like any other — these are the same
+/// `xdg_popup.destroy` requests, and the same `not_the_topmost_popup` waiting
+/// behind them.
+///
+/// `popups` is the live popup forest as `(popup, its parent, whether it holds a
+/// grab)`. Anything on `new_parent`'s own ancestry is spared, that being exactly
+/// the chain a new grab is allowed to nest under.
+pub(crate) fn conflicting_grabs(
+    new_parent: SurfaceId,
+    popups: impl Iterator<Item = (SurfaceId, SurfaceId, bool)>,
+) -> Vec<SurfaceId> {
+    let popups: Vec<(SurfaceId, SurfaceId, bool)> = popups.collect();
+
+    // What a new grab under `new_parent` may legally nest on.
+    let mut ancestors = vec![new_parent];
+    let mut current = new_parent;
+    while let Some((_, parent, _)) = popups.iter().find(|(popup, _, _)| *popup == current) {
+        ancestors.push(*parent);
+        current = *parent;
+    }
+
+    let mut out: Vec<SurfaceId> = Vec::new();
+    for (popup, _, holds_grab) in &popups {
+        if *holds_grab && !ancestors.contains(popup) {
+            out.push(*popup);
+            out.extend(descendants_bottom_up(
+                *popup,
+                popups.iter().map(|(popup, parent, _)| (*popup, *parent)),
+            ));
+        }
+    }
+
+    // One sort for the whole answer rather than per chain: the rule that orders
+    // a chain orders two of them against each other just as well, and the
+    // alternative was concatenating chains in whatever order they were stored.
+    out.sort_unstable_by_key(|id| std::cmp::Reverse(id.raw()));
+    out.dedup();
+    out
+}
+
 #[cfg(test)]
 mod teardown_order {
-    use super::descendants_bottom_up;
+    use super::{conflicting_grabs, descendants_bottom_up};
     use crate::surface::SurfaceId;
 
     /// Ids in the order they would have been created.
@@ -990,6 +1037,49 @@ mod teardown_order {
         let s = ids(4);
         let edges = vec![(s[1], s[0]), (s[3], s[2])];
         assert_eq!(descendants_bottom_up(s[0], edges.into_iter()), vec![s[1]]);
+    }
+
+    /// A grab chain spares its own ancestry and takes everything else, in the
+    /// order everything else comes down in.
+    #[test]
+    fn a_new_grab_takes_the_chain_it_cannot_nest_under() {
+        let s = ids(4);
+        // bar s[0] ── menu s[1] (grab) ── submenu s[2] (grab)
+        let popups = vec![(s[1], s[0], true), (s[2], s[1], true)];
+        assert_eq!(
+            conflicting_grabs(s[0], popups.clone().into_iter()),
+            vec![s[2], s[1]],
+            "a grab on the bar itself cannot nest under the menu"
+        );
+        assert_eq!(
+            conflicting_grabs(s[2], popups.into_iter()),
+            Vec::new(),
+            "a grab under the current holder nests, and takes nothing down"
+        );
+    }
+
+    /// Two chains are ordered against each other by the same rule that orders
+    /// one, rather than by which was looked at first.
+    #[test]
+    fn two_grab_chains_come_down_newest_first() {
+        let s = ids(5);
+        // s[0] ── s[1] (grab) ── s[2] (grab)
+        // s[3] ── s[4] (grab)
+        let popups = vec![(s[1], s[0], true), (s[2], s[1], true), (s[4], s[3], true)];
+        let mut reversed = popups.clone();
+        reversed.reverse();
+        let want = vec![s[4], s[2], s[1]];
+        assert_eq!(conflicting_grabs(s[3], popups.into_iter()), want);
+        assert_eq!(conflicting_grabs(s[3], reversed.into_iter()), want);
+    }
+
+    /// A popup without a grab is nobody's conflict, and neither are its
+    /// children — only a grab chain has to go.
+    #[test]
+    fn a_popup_holding_no_grab_is_left_alone() {
+        let s = ids(3);
+        let popups = vec![(s[1], s[0], false), (s[2], s[1], false)];
+        assert_eq!(conflicting_grabs(s[0], popups.into_iter()), Vec::new());
     }
 
     #[test]

--- a/src/platform/popups.rs
+++ b/src/platform/popups.rs
@@ -196,52 +196,20 @@ impl WaylandState {
         )
     }
 
-    /// Grabbing popups that would make a new grab on `new_parent` illegal:
-    /// xdg-shell requires a new grab to nest under the current grab holder,
-    /// so any live grabbing popup that is not `new_parent` itself (or one
-    /// of its ancestors) must be destroyed before the new popup is created.
+    /// Grabbing popups that would make a new grab on `new_parent` illegal.
     ///
-    /// Each chain comes back in [`crate::descendants_bottom_up`]'s order, but
-    /// the chains are concatenated in whatever order the surfaces were stored
-    /// in — so two independent grab chains interleave arbitrarily. Nothing can
-    /// referee that today: the recorder discards the `PopupConfig` that says
-    /// which popups hold a grab, so this path has no sensor at all. #300.
+    /// The rule is [`crate::conflicting_grabs`]'s; this only says which surfaces
+    /// are popups, whose children they are, and which of them hold a grab.
     pub(crate) fn conflicting_grab_popups(&self, new_parent: SurfaceId) -> Vec<SurfaceId> {
-        // Ancestor chain of the new popup (surfaces a nested grab may sit on)
-        let mut ancestors = vec![new_parent];
-        let mut current = new_parent;
-        while let Some(state) = self.surfaces.get(&current) {
-            match &state.role {
-                SurfaceRole::Popup { parent, .. } => {
-                    ancestors.push(*parent);
-                    current = *parent;
-                }
-                _ => break,
-            }
-        }
-
-        let mut conflicts: Vec<SurfaceId> = self
-            .surfaces
-            .iter()
-            .filter(|(id, state)| {
-                matches!(&state.role, SurfaceRole::Popup { config, .. } if config.grab)
-                    && !ancestors.contains(id)
-            })
-            .map(|(id, _)| *id)
-            .collect();
-        // Close whole chains children-first: append descendants and dedup
-        let mut ordered = Vec::new();
-        for id in conflicts.drain(..) {
-            for d in self.popup_descendants_bottom_up(id) {
-                if !ordered.contains(&d) {
-                    ordered.push(d);
-                }
-            }
-            if !ordered.contains(&id) {
-                ordered.push(id);
-            }
-        }
-        ordered
+        crate::conflicting_grabs(
+            new_parent,
+            self.surfaces
+                .iter()
+                .filter_map(|(id, state)| match &state.role {
+                    SurfaceRole::Popup { parent, config, .. } => Some((*id, *parent, config.grab)),
+                    _ => None,
+                }),
+        )
     }
 
     /// For auto-height popups: the width to measure content at.

--- a/src/platform/popups.rs
+++ b/src/platform/popups.rs
@@ -180,31 +180,32 @@ impl WaylandState {
         true
     }
 
-    /// Live popup descendants of `root`, deepest first — the order the
-    /// protocol demands for teardown (a popup must be destroyed before its
-    /// parent, or the compositor raises `not_the_topmost_popup`).
+    /// Live popup descendants of `root`, in teardown order.
+    ///
+    /// The rule is [`crate::descendants_bottom_up`]'s; this only says which
+    /// surfaces are popups and whose children they are.
     pub(crate) fn popup_descendants_bottom_up(&self, root: SurfaceId) -> Vec<SurfaceId> {
-        let mut out = Vec::new();
-        let mut frontier = vec![root];
-        while let Some(current) = frontier.pop() {
-            for (id, state) in &self.surfaces {
-                if let SurfaceRole::Popup { parent, .. } = &state.role
-                    && *parent == current
-                {
-                    out.push(*id);
-                    frontier.push(*id);
-                }
-            }
-        }
-        out.reverse(); // deepest first
-        out
+        crate::descendants_bottom_up(
+            root,
+            self.surfaces
+                .iter()
+                .filter_map(|(id, state)| match &state.role {
+                    SurfaceRole::Popup { parent, .. } => Some((*id, *parent)),
+                    _ => None,
+                }),
+        )
     }
 
     /// Grabbing popups that would make a new grab on `new_parent` illegal:
     /// xdg-shell requires a new grab to nest under the current grab holder,
     /// so any live grabbing popup that is not `new_parent` itself (or one
     /// of its ancestors) must be destroyed before the new popup is created.
-    /// Returned deepest-chain-first, ready for ordered teardown.
+    ///
+    /// Each chain comes back in [`crate::descendants_bottom_up`]'s order, but
+    /// the chains are concatenated in whatever order the surfaces were stored
+    /// in — so two independent grab chains interleave arbitrarily. Nothing can
+    /// referee that today: the recorder discards the `PopupConfig` that says
+    /// which popups hold a grab, so this path has no sensor at all. #300.
     pub(crate) fn conflicting_grab_popups(&self, new_parent: SurfaceId) -> Vec<SurfaceId> {
         // Ancestor chain of the new popup (surfaces a nested grab may sit on)
         let mut ancestors = vec![new_parent];

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -45,6 +45,9 @@ use crate::reactive::global::GlobalSignal;
 use crate::widgets::{Color, Rect, Widget};
 
 /// Unique identifier for each surface in the application.
+///
+/// Ids come from one counter that only goes up, so a larger id was handed out
+/// later. [`raw`](SurfaceId::raw) is how to ask.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct SurfaceId(u64);
 
@@ -55,7 +58,10 @@ impl SurfaceId {
         SurfaceId(COUNTER.fetch_add(1, Ordering::Relaxed))
     }
 
-    /// Get the raw ID value (for debugging/logging).
+    /// The counter value behind the id.
+    ///
+    /// Useful for logging, and load-bearing in one place: `descendants_bottom_up`
+    /// sorts popups by it, a larger value meaning a later surface.
     pub fn raw(&self) -> u64 {
         self.0
     }

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -173,17 +173,15 @@ impl Platform for Recorder {
         self.surfaces.remove(&id);
     }
 
-    /// Deepest first, which is the order the protocol demands and the order the
-    /// loop is supposed to close them in.
+    /// The same rule the Wayland platform answers with — the recorder's job is
+    /// to know who hangs from whom, not to have an opinion about the order.
     fn popup_descendants_bottom_up(&self, root: SurfaceId) -> Vec<SurfaceId> {
-        let mut out = Vec::new();
-        for (&child, surface) in &self.surfaces {
-            if surface.parent == Some(root) {
-                out.extend(self.popup_descendants_bottom_up(child));
-                out.push(child);
-            }
-        }
-        out
+        crate::descendants_bottom_up(
+            root,
+            self.surfaces
+                .iter()
+                .filter_map(|(id, surface)| surface.parent.map(|parent| (*id, parent))),
+        )
     }
 
     fn create_render_target(

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -41,6 +41,10 @@ struct RecordedSurface {
     /// in a map beside it, so a parent link cannot outlive its surface — which
     /// is also where `WaylandState` keeps it.
     parent: Option<SurfaceId>,
+    /// Whether this popup took an explicit grab. Kept because
+    /// `conflicting_grab_popups` cannot be answered without it, and a recorder
+    /// that throws it away leaves that path with no sensor at all.
+    grab: bool,
     width: u32,
     height: u32,
     scale: f32,
@@ -150,7 +154,7 @@ impl Platform for Recorder {
         &mut self,
         id: SurfaceId,
         parent: SurfaceId,
-        _config: &crate::surface::PopupConfig,
+        config: &crate::surface::PopupConfig,
         size: (u32, u32),
     ) -> bool {
         self.created.push(id);
@@ -158,6 +162,7 @@ impl Platform for Recorder {
             id,
             RecordedSurface {
                 parent: Some(parent),
+                grab: config.grab,
                 width: size.0,
                 height: size.1,
                 scale: 1.0,
@@ -181,6 +186,17 @@ impl Platform for Recorder {
             self.surfaces
                 .iter()
                 .filter_map(|(id, surface)| surface.parent.map(|parent| (*id, parent))),
+        )
+    }
+
+    /// Likewise: which popups hold a grab is the recorder's to know, what to do
+    /// about it is not.
+    fn conflicting_grab_popups(&self, new_parent: SurfaceId) -> Vec<SurfaceId> {
+        crate::conflicting_grabs(
+            new_parent,
+            self.surfaces.iter().filter_map(|(id, surface)| {
+                surface.parent.map(|parent| (*id, parent, surface.grab))
+            }),
         )
     }
 

--- a/tests/headless_app.rs
+++ b/tests/headless_app.rs
@@ -371,3 +371,47 @@ fn a_branching_popup_tree_comes_down_newest_first() {
          branch, then its root, then the surface they all hang from"
     );
 }
+
+/// A new grab closes the grab chain it cannot nest under, deepest first.
+///
+/// xdg-shell lets one grab chain exist at a time and a new grab must nest under
+/// the current holder. Opening one somewhere else means tearing the old chain
+/// down first, and in the same order as any other teardown — the compositor
+/// applies `not_the_topmost_popup` to these destroys like the rest.
+///
+/// This path had no sensor at all: the recorder used to discard the
+/// `PopupConfig` it was handed, so it could not say which popups held a grab
+/// and answered `conflicting_grab_popups` with the trait's empty default.
+#[test]
+fn a_new_grab_tears_down_the_chain_it_cannot_nest_under() {
+    let Some(mut app) = headless() else { return };
+    let bar = app.surface(content_bar(), measuring_24);
+    app.configure(bar, 200, 24, 1.0);
+    app.step();
+
+    let menu = spawn_popup(bar, PopupConfig::new(80).height(40).grab(), measuring_24);
+    app.step();
+    let submenu = spawn_popup(
+        menu.id(),
+        PopupConfig::new(60).height(30).grab(),
+        measuring_24,
+    );
+    app.step();
+    assert_eq!(app.surfaces_created(), [bar, menu.id(), submenu.id()]);
+
+    // A second menu on the bar itself: it cannot nest under the chain above, so
+    // that chain has to go before this one opens.
+    let other = spawn_popup(bar, PopupConfig::new(80).height(40).grab(), measuring_24);
+    app.step();
+
+    assert_eq!(
+        app.surfaces_destroyed(),
+        [submenu.id(), menu.id()],
+        "the chain comes down deepest first, before the new grab opens"
+    );
+    assert_eq!(
+        app.surfaces_created(),
+        [bar, menu.id(), submenu.id(), other.id()],
+        "and the new grab did open"
+    );
+}

--- a/tests/headless_app.rs
+++ b/tests/headless_app.rs
@@ -299,6 +299,10 @@ fn a_surface_spawned_at_runtime_reaches_the_compositor_and_the_last_close_ends_t
 /// a live child raises `not_the_topmost_popup` and the compositor kills the
 /// connection. Until now that ordering was a comment in `process_surface_commands`
 /// and an example somebody ran.
+///
+/// Two popups deep rather than one, so that the order is something a list can
+/// get wrong: with a single popup every rule agrees, and this case could not
+/// tell a teardown order from its reverse.
 #[test]
 fn a_popup_is_destroyed_before_the_surface_it_hangs_from() {
     let Some(mut app) = headless() else { return };
@@ -308,15 +312,62 @@ fn a_popup_is_destroyed_before_the_surface_it_hangs_from() {
 
     let popup = spawn_popup(parent, PopupConfig::new(80).height(40), measuring_24);
     app.step();
+    let nested = spawn_popup(popup.id(), PopupConfig::new(60).height(30), measuring_24);
+    app.step();
 
-    assert_eq!(app.surfaces_created(), [parent, popup.id()]);
+    assert_eq!(app.surfaces_created(), [parent, popup.id(), nested.id()]);
 
     surface_handle(parent).close();
     app.step();
 
     assert_eq!(
         app.surfaces_destroyed(),
-        [popup.id(), parent],
+        [nested.id(), popup.id(), parent],
         "the child goes first, or the compositor kills the connection"
+    );
+}
+
+/// A branching popup tree comes down topmost first, and "topmost" is a decided
+/// order rather than whatever a map iterated.
+///
+/// xdg-shell keeps the live popups in a stack and a client must destroy them
+/// from the top down; the one raised last is the one on top. A `SurfaceId` is a
+/// monotonic counter, so descending id *is* that stack, and it gives
+/// child-before-parent for free — a popup cannot be created on a parent that
+/// does not exist yet.
+///
+/// The chain in `a_popup_is_destroyed_before_the_surface_it_hangs_from` has one
+/// child at every level, so every order agrees on it. This one branches, which
+/// is where they stop agreeing: a frontier reversed, a recursion, and a hash
+/// iteration are three different answers, and only one of them is the stack.
+#[test]
+fn a_branching_popup_tree_comes_down_newest_first() {
+    let Some(mut app) = headless() else { return };
+    let parent = app.surface(content_bar(), measuring_24);
+    app.configure(parent, 200, 24, 1.0);
+    app.step();
+
+    let first = spawn_popup(parent, PopupConfig::new(80).height(40), measuring_24);
+    app.step();
+    let nested = spawn_popup(first.id(), PopupConfig::new(60).height(30), measuring_24);
+    app.step();
+    // A sibling of `first`, raised after the whole of `first`'s own chain.
+    let last = spawn_popup(parent, PopupConfig::new(80).height(40), measuring_24);
+    app.step();
+
+    assert_eq!(
+        app.surfaces_created(),
+        [parent, first.id(), nested.id(), last.id()],
+        "the four surfaces exist, in the order they were asked for"
+    );
+
+    surface_handle(parent).close();
+    app.step();
+
+    assert_eq!(
+        app.surfaces_destroyed(),
+        [last.id(), nested.id(), first.id(), parent],
+        "the stack comes down from the top: the newest popup, then the deepest \
+         branch, then its root, then the surface they all hang from"
     );
 }


### PR DESCRIPTION
## What changed

A popup must be destroyed before its children are gone, or the compositor raises `not_the_topmost_popup` and drops the connection — and that order was computed twice: a frontier walk reversed in `src/platform/popups.rs`, a recursion over a hash map in `src/testing.rs`. Both were `Platform::popup_descendants_bottom_up`, both carried the same sentence about the error, and only one of them was a real connection away from it.

There is now one `descendants_bottom_up`, beside the `Platform` trait rather than in either implementation, because it is the obligation both of them sign: `testing.rs`, whose whole point is that it never talks to anything, should not reach into the file that imports sctk to find out what order to close popups in. It sorts rather than walks — a `SurfaceId` is a counter that only goes up, so descending id puts every child before its parent for free and orders siblings by age on the same pass.

The second commit does the same for the grab-conflict teardown, which was #292's stated non-goal. That was left out because nothing could referee a change to it: the recorder threw away the `PopupConfig` it was handed, so it could not say which popups held a grab and answered with the trait's empty default. One `bool` on `RecordedSurface` was the whole of what was missing.

Closes #292. Closes #300.

## What proves it

- Eight unit tests beside the rules (`mod teardown_order` in `src/lib.rs`): a chain, siblings, shuffled edges, a forest where only one root's popups come back, a surface with no popups, a grab chain a new grab cannot nest under, one it can, two chains against each other, and a popup holding no grab.
- `a_popup_is_destroyed_before_the_surface_it_hangs_from` gains a second popup. This is the acceptance's second bullet and it did not hold as written: with one popup the list has a single element, so the case could not tell a teardown order from its reverse, and both mutations passed it. At two levels, deleting the sort fails it.
- `a_branching_popup_tree_comes_down_newest_first` is the case the old walks disagreed on.
- `a_new_grab_tears_down_the_chain_it_cannot_nest_under` is the first test ever to reach `conflicting_grab_popups`. It fails without the recorder change, because nothing is destroyed at all.

**The branching test passed before the change**, which is worth saying plainly: the recorder's hash order happened to coincide with the decided order for those ids. That is the hazard the issue's comment predicted — "the first test with two sibling popups would bake a hash iteration order into an assertion" — so the red was established by mutation instead, and the test's value is that it pins the decision so hash luck cannot drift.

Full suite green (25 binaries), `golden_images` green on lavapipe, clippy clean, `cargo doc` clean with `-D warnings`, `documentation_references` green.

**On the protocol claim.** An earlier draft justified sibling order by asserting xdg-shell keeps all live popups in one creation-ordered stack. It does not say that. `xdg_popup.destroy` says only that a non-topmost popup is an error, and the ordering rule is stated for *nested* popups: *"Nested popups must be destroyed in the reverse order they were created in."* Between two popups on the same parent the protocol is silent, so all three old orders were legal — what was wrong is that nothing decided which one a compositor got. The doc separates the requirement (child-first) from the choice (newest-first among siblings).

**On the grab ordering, honestly.** The old code concatenated one descendants-block per conflicting popup in map order. Within a single chain that is correct however the map iterated, because each block expands to its own descendants first — I checked both orders by hand. Across two chains it is not, but whether two independent grab chains can coexist through the loop's own logic is doubtful, since this function is what prevents it. So the ordering half is defensive, and the sensor half is the real gain. The commit says so rather than claiming a bug it cannot demonstrate.

## What the review found

The `reviewer` subagent ran over the first commit before this pull request existed: **zero blocking findings.** Its three worth-answering items are all acted on:

1. I had inserted the new function *between* the `Platform` trait's doc comment and the trait, so the trait lost its doc and the function gained two paragraphs about something else. Moved.
2. The protocol overclaim above — it checked my doc against the xdg-shell xml and was right. Reworded, and the commit message with it.
3. `AGENTS.md` and `.claude/skills/wayland/SKILL.md` both described this divergence as open and cited #292. Neither was in the diff, and `documentation_references` cannot see a sentence going false around identifiers that still exist. Both now say what is actually left — and the second commit updated them again, since grab conflicts are no longer in the run-an-example-and-look column.

`/simplify` before it caught a `cargo doc` failure that would have gone red in CI — a public `SurfaceId` doc linking to a `pub(crate)` function — and pointed out that the `PartialOrd, Ord` derive I had added was unnecessary, `raw()` being already public. Both fixed before the commit. `cargo doc` is not in `/implement`'s harness list; it is in mine now.

The second commit has not been read by anything that did not write it.

## What was checked by hand

`examples/popup_example.rs` on niri, by the maintainer, twice — the second time after review edits moved the function, since the first run was of a different binary. Four paths, the ones where a wrong order kills the application rather than drawing something odd: open the popup and dismiss it with an outside click; open the nested "Settings ▸" popup; dismiss the pair with one outside click; close the parent while the child is still open. All four work, the application survives, and the popups disappear cleanly.

**The grab-conflict path has no by-hand route in this example, and that is the point of the second commit.** The bar has one button, so while a grabbing popup is open, clicking it is an outside click: the compositor dismisses the grab and consumes the click, and a second grab is never requested. A person cannot reach `conflicting_grab_popups` here at all — which is why it needed a sensor rather than another manual pass. The headless test requests the second grab directly.

## Left undone

Nothing. #300 was filed for the grab-conflict path and is closed by the second commit rather than left for later.