### PR TITLE
A value says how it moves, and the seventeen setters that said it for the value are gone

### DIFF
--- a/.claude/skills/widgets/SKILL.md
+++ b/.claude/skills/widgets/SKILL.md
@@ -15,7 +15,16 @@ Reactive: `background`, `gradient`, `backdrop_blur`, `overflow`, `corners`,
 `padding`, `visible`, `elevation`.
 
 Structural: `layout`, `child`, `children`, `scrollable`, `scrollbar`,
-`scrollbar_visibility`, `control`, `animate_*`, the event handlers.
+`scrollbar_visibility`, `control`, the event handlers — and the *motion* a
+value is declared with, which is the next section.
+
+An animatable property takes `impl IntoAnimated<T, M>` instead, which is
+everything `IntoSignal` accepts plus a value carrying its own motion:
+`background`, `corners`, `padding`, `border` (each half), `elevation`, `width`,
+`height`, `translate`, `rotate`, `scale`. The others keep plain `IntoSignal`,
+and so does every setter on `StateStyle` — a state layer supplies a value for a
+property somebody else declared, so a timing there is a compile error rather
+than a value quietly ignored.
 
 A new property lands on one side of that line. If it changes what a pixel looks
 like, it is reactive.
@@ -127,3 +136,40 @@ container().corners(Corners::superellipse(12.0, 1.5))
    changes pixels — see the `visual-verification` skill.
 4. Update `docs/` where the pattern is described, and the book chapter that
    teaches it — see the `book` skill.
+
+## The motion rides with the value
+
+`.transition(..)` and `.timeline(..)` hang off `IntoSignal` itself, so they are
+available on everything a property setter already accepts, and each returns an
+`Animated<T>`:
+
+```rust
+container()
+    .background(theme.surface.transition(200.0))
+    .width((move || if open.get() { 520.0 } else { 120.0 }).transition(SpringConfig::SNAPPY))
+    .rotate(0.0.timeline(shake(), rejections))
+```
+
+A bare number is milliseconds, eased out — the one place the animation
+vocabulary has two defaults, because `Transition::default()` is a spring and
+has no duration for a number to attach to.
+
+Three rules the shape depends on, in order of how easily they are broken:
+
+- **A declaration is the whole property.** Restating one replaces the value
+  *and* the motion, so `.background(x.transition(200.0)).background(y)` leaves
+  no animation behind. There are never two declarations for one property to
+  reconcile.
+- **`Animated<T>` is not an `IntoSignal`.** That is what makes a timing on a
+  state-layer override a compile error. Adding an `IntoSignal` impl for it
+  would put the rule back into prose.
+- **`timeline` needs `T: Animatable`.** That is what keeps a timeline off a
+  property whose declared type is not the type it animates — `width` and
+  `height` declare a `Length` and move an `f32` — so `width(w.timeline(..))`
+  does not compile rather than compiling and playing nothing.
+
+A new animatable property adds its name to four lists that nothing keeps in
+step: `ContainerAnims`'s fields, `start_timeline!` and the `advance_anim!`
+block in `advance_animations`, and the drift block in
+`resync_animation_targets`. Miss one and the property silently never plays or
+never wakes.

--- a/book/src/animations/README.md
+++ b/book/src/animations/README.md
@@ -1,35 +1,67 @@
 # Animations
 
-Guido supports smooth animations for property changes using both duration-based transitions and spring physics.
+A value in guido can say how it moves. Declare a property with a motion and it
+eases to each new value instead of jumping there; declare it with a timeline and
+it plays a sequence whenever a trigger fires.
 
 ![Animation Example](../images/animation_example.png)
 
-## Overview
+## The motion rides with the value
 
-Animations in Guido work by:
-1. Declaring which properties can animate
-2. Specifying a transition type (duration or spring)
-3. Letting the framework interpolate between values
+There is no separate declaration naming a property and saying how it animates.
+The timing is part of what the property was *set to*, so it cannot name a
+property that was never set and cannot disagree with the property it decorates:
 
 ```rust
 # extern crate guido;
 # use guido::prelude::*;
 # fn main() {
 container()
-    .background(Color::rgb(0.3, 0.5, 0.8))
-    .animate_background(Transition::new(200.0, TimingFunction::EaseOut))
+    .background(Color::rgb(0.3, 0.5, 0.8).transition(200.0))
     .when_hovered(|s| s.lighter(0.15))
 # ;
 # }
 ```
 
-When the hover state changes, the background animates smoothly over 200ms.
+When the hover state changes, the background animates over 200ms. The state
+layer supplies the *value*; the property carries the motion — see
+[State Layers](../interactivity/state-layer.md).
+
+A bare number is a duration in milliseconds, eased out. Where the curve matters,
+name it:
+
+```rust
+# extern crate guido;
+# use guido::prelude::*;
+# fn main() {
+# let c = Color::WHITE;
+container().background(c.transition(Transition::new(200.0, TimingFunction::EaseInOut)))
+# ;
+# }
+```
+
+`.transition(..)` and `.timeline(..)` hang off everything a property setter
+already accepts — a value, a signal, or a closure. The parentheses around a
+closure are Rust's rule for calling a method on a closure literal, not a second
+API:
+
+```rust
+# extern crate guido;
+# use guido::prelude::*;
+# fn main() {
+# let open = create_signal(false);
+container()
+    .width((move || if open.get() { 520.0 } else { 120.0 }).transition(200.0))
+# ;
+# }
+```
 
 ## In This Section
 
 - [Transitions](transitions.md) - Duration-based animations
 - [Timing Functions](timing.md) - Easing curves for natural motion
 - [Spring Physics](springs.md) - Physics-based animations
+- [Keyframes](keyframes.md) - Sequences played on a trigger
 - [Animatable Properties](properties.md) - What can be animated
 
 ## Two Types of Animation
@@ -77,14 +109,18 @@ Good for:
 # extern crate guido;
 # use guido::prelude::*;
 # fn main() {
-# container()
-// Duration-based
-.animate_background(Transition::new(200.0, TimingFunction::EaseOut))
-.animate_border_width(Transition::new(150.0, TimingFunction::EaseInOut))
-
-// Spring-based
-.animate_scale(Transition::spring(SpringConfig::BOUNCY))
-.animate_width(Transition::spring(SpringConfig::GENTLE))
+# let c = Color::WHITE;
+container()
+    // Milliseconds, eased out
+    .background(c.transition(200.0))
+    // A curve by name
+    .border(
+        1.0.transition(Transition::new(150.0, TimingFunction::EaseInOut)),
+        c.transition(150.0),
+    )
+    // Spring physics
+    .scale(1.0.transition(SpringConfig::BOUNCY))
+    .width(200.0.transition(Transition::spring(SpringConfig::GENTLE)))
 # ;
 # }
 ```

--- a/book/src/animations/keyframes.md
+++ b/book/src/animations/keyframes.md
@@ -6,7 +6,8 @@ change looks like, and none of what a sequence looks like — a shake, a flash, 
 bounce, anything that has to pass through somewhere on its way and end where it
 started.
 
-A timeline is the other shape. It has no target: it plays.
+A timeline is the other shape. It has no target: it plays. Declare it with
+`.timeline(..)`, on the value the property rests at between plays:
 
 ```rust
 # extern crate guido;
@@ -14,7 +15,7 @@ A timeline is the other shape. It has no target: it plays.
 # fn main() {
 # let rejections = create_signal(0);
 container()
-    .keyframes_rotate(
+    .rotate(0.0.timeline(
         Keyframes::new(320.0)
             .at(0.0, 0.0)
             .at(0.15, 2.0)
@@ -22,10 +23,55 @@ container()
             .at(0.65, 0.9)
             .at(1.0, 0.0),
         rejections,
-    )
+    ))
 # ;
 # }
 ```
+
+It reaches every animatable property, not only the transform components — a
+`Keyframes<Color>` on a background is a flash:
+
+```rust
+# extern crate guido;
+# use guido::prelude::*;
+# fn main() {
+# let errors = create_signal(0);
+# let surface = Color::rgb(0.15, 0.15, 0.2);
+container()
+    .background(surface.timeline(
+        Keyframes::new(240.0)
+            .at(0.0, surface)
+            .at(0.3, Color::rgb(0.8, 0.2, 0.2))
+            .at(1.0, surface),
+        errors,
+    ))
+# ;
+# }
+```
+
+## The resting value
+
+The value `.timeline(..)` is called on is what the property *is* whenever
+nothing is playing. A shake returns to where it began, which makes it look
+redundant — but a sequence that ends somewhere else snaps back to it, and a
+sequence resting on a live signal has nowhere else to put its expression:
+
+```rust
+# extern crate guido;
+# use guido::prelude::*;
+# fn main() {
+# let rejections = create_signal(0);
+# let spin = create_signal(0u32);
+# let shake = || Keyframes::new(320.0).at(0.0, 0.0).at(0.5, 2.0).at(1.0, 0.0);
+// A glyph that spins on one signal, and shakes on another.
+container()
+    .rotate((move || spin.get() as f32 * 90.0).timeline(shake(), rejections))
+# ;
+# }
+```
+
+A timeline is for something that happens and is over. A change that should
+persist is a transition.
 
 ## What plays it
 
@@ -81,8 +127,8 @@ at the same time without the two meeting at all:
 # let shake = move || {};
 container()
     .when_hovered(|s| s.scale(1.03))
-    .animate_scale(Transition::spring(SpringConfig::SNAPPY))
-    .keyframes_rotate(shake(), rejections)
+    .scale(Scale::NONE.transition(Transition::spring(SpringConfig::SNAPPY)))
+    .rotate(0.0.timeline(shake(), rejections))
 # ;
 # }
 ```
@@ -101,21 +147,20 @@ component:
 # let shake = move || {};
 container()
     .when_hovered(|s| s.rotate(3.0))
-    .animate_rotate(Transition::spring(SpringConfig::SNAPPY))
-    .keyframes_rotate(shake(), rejections)
+    .rotate(0.0.timeline(shake(), rejections))
 # ;
 # }
 ```
 
 Here the hover tilt is still declared while the shake runs; it simply is not
-being drawn. When the sequence ends the property is handed back **through its
-declared transition**, from wherever the sequence left it — so a pointer that
-arrived mid-shake gets its spring, rather than the card jumping to the tilted
-angle on the sequence's last frame. A callback on that transition fires as it
-normally would, for the same reason.
+being drawn. When the sequence ends the property is handed back from wherever
+the sequence left it, rather than the card jumping to the tilted angle on the
+sequence's last frame.
 
-The builders do not care which order you write them in: declaring a transition
-after a sequence keeps the sequence, and the other way round too.
+A property carries one motion: a value is declared either with a transition or
+with a timeline, and a second declaration of the same property replaces the
+whole thing — the value included. Where a card wants both a spring and a
+sequence, they go on two components, as in the example above.
 
 ## What a segment cannot be eased with
 

--- a/book/src/animations/properties.md
+++ b/book/src/animations/properties.md
@@ -1,18 +1,16 @@
 # Animatable Properties
 
-This page lists all container properties that can be animated.
+Every property on this page takes a motion the same way: `.transition(..)` or
+`.timeline(..)` on the value it is being set to.
 
 ## Background
-
-Animate background color changes:
 
 ```rust
 # extern crate guido;
 # use guido::prelude::*;
 # fn main() {
 container()
-    .background(Color::rgb(0.2, 0.2, 0.3))
-    .animate_background(Transition::new(200.0, TimingFunction::EaseOut))
+    .background(Color::rgb(0.2, 0.2, 0.3).transition(200.0))
     .when_hovered(|s| s.lighter(0.1))
 # ;
 # }
@@ -22,17 +20,16 @@ Works with:
 - Solid colors
 - State layer overrides (lighter, darker, explicit)
 
-## Border Width
+## Border
 
-Animate border thickness:
+A border is declared as a pair, and each half carries its own timing:
 
 ```rust
 # extern crate guido;
 # use guido::prelude::*;
 # fn main() {
 container()
-    .border(1.0, Color::rgb(0.3, 0.3, 0.4))
-    .animate_border_width(Transition::new(150.0, TimingFunction::EaseOut))
+    .border(1.0.transition(150.0), Color::rgb(0.3, 0.3, 0.4))
     // A border is declared as a pair, so the layer restates the colour it is
     // not changing — otherwise the width eases while the colour jumps.
     .when_hovered(|s| s.border(2.0, Color::rgb(0.3, 0.3, 0.4)))
@@ -40,45 +37,51 @@ container()
 # }
 ```
 
-## Border Color
-
-Animate border color:
+The mirror image, where only the colour moves:
 
 ```rust
 # extern crate guido;
 # use guido::prelude::*;
 # fn main() {
 container()
-    .border(2.0, Color::rgb(0.3, 0.3, 0.4))
-    .animate_border_color(Transition::new(150.0, TimingFunction::EaseOut))
-    // The mirror image: the width is restated so only the colour moves.
+    .border(2.0, Color::rgb(0.3, 0.3, 0.4).transition(150.0))
     .when_hovered(|s| s.border(2.0, Color::rgb(0.5, 0.7, 1.0)))
+# ;
+# }
+```
+
+Or both at once, on curves of their own — a width that springs while its colour
+eases is what one call could never express:
+
+```rust
+# extern crate guido;
+# use guido::prelude::*;
+# fn main() {
+container()
+    .border(
+        2.0.transition(Transition::spring(SpringConfig::BOUNCY)),
+        Color::rgb(0.3, 0.3, 0.4).transition(300.0),
+    )
 # ;
 # }
 ```
 
 ## Transform
 
-Animate translation, rotation, and scale:
+Translation, rotation and scale each animate on their own curve. There is no
+call that animates the three together, and declaring one says nothing about the
+other two:
 
 ```rust
 # extern crate guido;
 # use guido::prelude::*;
 # fn main() {
 container()
-    .animate_scale(Transition::new(300.0, TimingFunction::EaseOut))
+    .scale(Scale::NONE.transition(Transition::new(300.0, TimingFunction::EaseOut)))
     .when_pressed(|s| s.scale(0.98))
 # ;
 # }
 ```
-
-Works with:
-- Rotate
-- Scale
-- Translate
-
-Each on its own curve — there is no call that animates the three together, and
-declaring one says nothing about the other two.
 
 Spring animations are especially good for transforms:
 
@@ -87,14 +90,12 @@ Spring animations are especially good for transforms:
 # use guido::prelude::*;
 # fn main() {
 # container()
-.animate_scale(Transition::spring(SpringConfig::BOUNCY))
+.scale(Scale::NONE.transition(Transition::spring(SpringConfig::BOUNCY)))
 # ;
 # }
 ```
 
-## Width
-
-Animate width changes:
+## Width and Height
 
 ```rust
 # extern crate guido;
@@ -103,23 +104,44 @@ Animate width changes:
 let expanded = create_signal(false);
 
 container()
-    .width(move || if expanded.get() { 400.0 } else { 200.0 })
-    .animate_width(Transition::spring(SpringConfig::DEFAULT))
+    .width(
+        (move || if expanded.get() { 400.0 } else { 200.0 })
+            .transition(Transition::spring(SpringConfig::DEFAULT)),
+    )
 # ;
 # }
 ```
 
-## Elevation
+A size follows the content it holds as well as the length declared here, so the
+animation is over the resolved extent. These are the one pair that cannot carry
+a timeline: they declare a `Length`, which is not an animatable value in itself.
 
-Animate shadow depth:
+## Corners and Padding
+
+```rust
+# extern crate guido;
+# use guido::prelude::*;
+# fn main() {
+# let open = create_signal(false);
+container()
+    .corners((move || if open.get() { 30.0 } else { 6.0 }).transition(250.0))
+    .padding(8.0.transition(200.0))
+# ;
+# }
+```
+
+A corner transition that crosses zero curvature changes family in one frame:
+below zero a corner is concave and a different formula draws it. Within a family
+it is continuous.
+
+## Elevation
 
 ```rust
 # extern crate guido;
 # use guido::prelude::*;
 # fn main() {
 container()
-    .elevation(2.0)
-    .animate_elevation(Transition::new(200.0, TimingFunction::EaseOut))
+    .elevation(2.0.transition(200.0))
     .when_hovered(|s| s.elevation(6.0))
 # ;
 # }
@@ -154,23 +176,17 @@ say the same thing.
 
 ## Multiple Animations
 
-Combine animations on a single container:
+Each property carries its own, where it is declared:
 
 ```rust
 # extern crate guido;
 # use guido::prelude::*;
 # fn main() {
 container()
-    .background(Color::rgb(0.2, 0.2, 0.3))
-    .border(1.0, Color::rgb(0.3, 0.3, 0.4))
-    .elevation(2.0)
-
-    // Animate all
-    .animate_background(Transition::new(200.0, TimingFunction::EaseOut))
-    .animate_border_width(Transition::new(150.0, TimingFunction::EaseOut))
-    .animate_border_color(Transition::new(150.0, TimingFunction::EaseOut))
-    .animate_elevation(Transition::new(250.0, TimingFunction::EaseOut))
-    .animate_scale(Transition::spring(SpringConfig::GENTLE))
+    .background(Color::rgb(0.2, 0.2, 0.3).transition(200.0))
+    .border(1.0.transition(150.0), Color::rgb(0.3, 0.3, 0.4).transition(150.0))
+    .elevation(2.0.transition(250.0))
+    .scale(Scale::NONE.transition(Transition::spring(SpringConfig::GENTLE)))
 
     .when_hovered(|s| s
         .lighter(0.1)
@@ -187,16 +203,18 @@ container()
 
 ## Complete Reference
 
-| Property | Method | Recommended Transition |
-|----------|--------|----------------------|
-| Background | `animate_background()` | Duration, EaseOut |
-| Border Width | `animate_border_width()` | Duration, EaseOut |
-| Border Color | `animate_border_color()` | Duration, EaseOut |
-| Translate | `animate_translate()` | Spring or Duration |
-| Rotate | `animate_rotate()` | Spring or Duration |
-| Scale | `animate_scale()` | Spring or Duration |
-| Width | `animate_width()` | Spring |
-| Elevation | `animate_elevation()` | Duration, EaseOut |
+| Property | Declared on | Recommended Transition |
+|----------|-------------|----------------------|
+| Background | `background(..)` | Duration, EaseOut |
+| Border width | `border(width, _)` | Duration, EaseOut |
+| Border colour | `border(_, colour)` | Duration, EaseOut |
+| Corners | `corners(..)` | Duration |
+| Padding | `padding(..)` | Duration |
+| Translate | `translate(..)` | Spring or Duration |
+| Rotate | `rotate(..)` | Spring or Duration |
+| Scale | `scale(..)` | Spring or Duration |
+| Width, height | `width(..)`, `height(..)` | Spring |
+| Elevation | `elevation(..)` | Duration, EaseOut |
 
 ## Best Practices
 
@@ -208,8 +226,7 @@ container()
 # fn main() {
 # container()
 // Same duration for border width and color
-.animate_border_width(Transition::new(150.0, TimingFunction::EaseOut))
-.animate_border_color(Transition::new(150.0, TimingFunction::EaseOut))
+.border(1.0.transition(150.0), Color::WHITE.transition(150.0))
 # ;
 # }
 ```
@@ -222,11 +239,11 @@ container()
 # fn main() {
 # container()
 // Spring for size/position changes
-.animate_width(Transition::spring(SpringConfig::DEFAULT))
-.animate_scale(Transition::spring(SpringConfig::BOUNCY))
+.width(200.0.transition(Transition::spring(SpringConfig::DEFAULT)))
+.scale(Scale::NONE.transition(Transition::spring(SpringConfig::BOUNCY)))
 
 // Duration for visual changes
-.animate_background(Transition::new(200.0, TimingFunction::EaseOut))
+.background(Color::WHITE.transition(200.0))
 # ;
 # }
 ```
@@ -240,14 +257,11 @@ container()
 ## API Reference
 
 ```rust,ignore
-impl Container {
-    pub fn animate_background(self, transition: Transition) -> Self;
-    pub fn animate_border_width(self, transition: Transition) -> Self;
-    pub fn animate_border_color(self, transition: Transition) -> Self;
-    pub fn animate_translate(self, transition: Transition) -> Self;
-    pub fn animate_rotate(self, transition: Transition) -> Self;
-    pub fn animate_scale(self, transition: Transition) -> Self;
-    pub fn animate_width(self, transition: Transition) -> Self;
-    pub fn animate_elevation(self, transition: Transition) -> Self;
+/// On everything a property setter accepts — a value, a signal, a closure.
+pub trait Animate<T, M>: IntoSignal<T, M> + Sized {
+    fn transition(self, transition: impl Into<TransitionConfig>) -> Animated<T>;
+    fn timeline<M2>(self, keyframes: Keyframes<T>, plays: impl IntoSignal<u32, M2>) -> Animated<T>
+    where
+        T: Animatable;
 }
 ```

--- a/book/src/animations/springs.md
+++ b/book/src/animations/springs.md
@@ -83,8 +83,10 @@ Springs excel at:
 let expanded = create_signal(false);
 
 container()
-    .width(move || if expanded.get() { 600.0 } else { 50.0 })
-    .animate_width(Transition::spring(SpringConfig::DEFAULT))
+    .width(
+        (move || if expanded.get() { 600.0 } else { 50.0 })
+            .transition(Transition::spring(SpringConfig::DEFAULT)),
+    )
     .on_click(move || expanded.update(|e| *e = !*e))
 # ;
 # }
@@ -116,8 +118,7 @@ let scale_factor = create_signal(1.0f32);
 let is_scaled = create_signal(false);
 
 container()
-    .scale(scale_factor)
-    .animate_scale(Transition::spring(SpringConfig::BOUNCY))
+    .scale(scale_factor.transition(Transition::spring(SpringConfig::BOUNCY)))
     .on_click(move || {
         is_scaled.update(|s| *s = !*s);
         let target = if is_scaled.get() { 1.3 } else { 1.0 };
@@ -136,8 +137,10 @@ container()
 let expanded = create_signal(false);
 
 container()
-    .width(move || at_least(if expanded.get() { 400.0 } else { 200.0 }))
-    .animate_width(Transition::spring(SpringConfig::GENTLE))
+    .width(
+        (move || at_least(if expanded.get() { 400.0 } else { 200.0 }))
+            .transition(Transition::spring(SpringConfig::GENTLE)),
+    )
     .on_click(move || expanded.update(|e| *e = !*e))
 # ;
 # }
@@ -152,8 +155,7 @@ container()
 let rotation = create_signal(0.0f32);
 
 container()
-    .rotate(rotation)
-    .animate_rotate(Transition::spring(SpringConfig::DEFAULT))
+    .rotate(rotation.transition(Transition::spring(SpringConfig::DEFAULT)))
     .on_click(move || rotation.update(|r| *r += 90.0))
 # ;
 # }
@@ -169,12 +171,12 @@ Use different transition types for different properties:
 # fn main() {
 container()
     // Spring for physical properties
-    .animate_rotate(Transition::spring(SpringConfig::BOUNCY))
-    .animate_width(Transition::spring(SpringConfig::GENTLE))
+    .rotate(0.0.transition(Transition::spring(SpringConfig::BOUNCY)))
+    .width(200.0.transition(Transition::spring(SpringConfig::GENTLE)))
 
     // Duration for color properties
-    .animate_background(Transition::new(200.0, TimingFunction::EaseOut))
-    .animate_border_color(Transition::new(150.0, TimingFunction::EaseOut))
+    .background(Color::WHITE.transition(Transition::new(200.0, TimingFunction::EaseOut)))
+    .border(1.0, Color::WHITE.transition(Transition::new(150.0, TimingFunction::EaseOut)))
 # ;
 # }
 ```
@@ -187,15 +189,15 @@ fn spring_button() -> Container {
 
     container()
         .padding(20.0)
-        .background(Color::rgb(0.3, 0.5, 0.8))
+        // Duration for color - smooth transition
+        .background(Color::rgb(0.3, 0.5, 0.8).transition(200.0))
         .corners(12.0)
-        .scale(move || if pressed.get() { 1.1 } else { 1.0 })
 
         // Spring for scale - bouncy feedback
-        .animate_scale(Transition::spring(SpringConfig::BOUNCY))
-
-        // Duration for color - smooth transition
-        .animate_background(Transition::new(200.0, TimingFunction::EaseOut))
+        .scale(
+            (move || if pressed.get() { 1.1 } else { 1.0 })
+                .transition(Transition::spring(SpringConfig::BOUNCY)),
+        )
 
         .when_hovered(|s| s.lighter(0.1))
         .on_click(move || {
@@ -222,8 +224,7 @@ so a button shakes itself:
 ```rust,ignore
 fn nudge(angle: RwSignal<f32>) -> Container {
     container()
-        .rotate(move || angle.get())
-        .animate_rotate(Transition::spring(SpringConfig::BOUNCY))
+        .rotate((move || angle.get()).transition(Transition::spring(SpringConfig::BOUNCY)))
         .on_mouse_down(move |_, _| angle.set(2.0))
         .on_mouse_up(move |_, _| angle.set(0.0))
         .child(text("shake me"))

--- a/book/src/animations/timing.md
+++ b/book/src/animations/timing.md
@@ -83,8 +83,9 @@ Use `EaseOut` - immediate response, smooth finish:
 # extern crate guido;
 # use guido::prelude::*;
 # fn main() {
+# let c = Color::WHITE;
 # container()
-.animate_background(Transition::new(200.0, TimingFunction::EaseOut))
+.background(c.transition(Transition::new(200.0, TimingFunction::EaseOut)))
 # ;
 # }
 ```
@@ -98,7 +99,7 @@ Use `EaseInOut` - smooth start and stop:
 # use guido::prelude::*;
 # fn main() {
 # container()
-.animate_width(Transition::new(300.0, TimingFunction::EaseInOut))
+.width(200.0.transition(Transition::new(300.0, TimingFunction::EaseInOut)))
 # ;
 # }
 ```
@@ -138,7 +139,7 @@ Transition::new(200.0, TimingFunction::EaseIn)
 # use guido::prelude::*;
 # fn main() {
 container()
-    .animate_background(Transition::new(200.0, TimingFunction::EaseOut))
+    .background(Color::rgb(0.3, 0.5, 0.8).transition(Transition::new(200.0, TimingFunction::EaseOut)))
     .when_hovered(|s| s.lighter(0.1))
 # ;
 # }
@@ -153,8 +154,10 @@ container()
 let expanded = create_signal(false);
 
 container()
-    .width(move || if expanded.get() { 400.0 } else { 200.0 })
-    .animate_width(Transition::new(300.0, TimingFunction::EaseInOut))
+    .width(
+        (move || if expanded.get() { 400.0 } else { 200.0 })
+            .transition(Transition::new(300.0, TimingFunction::EaseInOut)),
+    )
     .on_click(move || expanded.update(|e| *e = !*e))
 # ;
 # }
@@ -167,7 +170,7 @@ container()
 # use guido::prelude::*;
 # fn main() {
 container()
-    .animate_scale(Transition::new(300.0, TimingFunction::EaseOut))
+    .scale(Scale::NONE.transition(Transition::new(300.0, TimingFunction::EaseOut)))
     .when_pressed(|s| s.scale(0.98))
 # ;
 # }
@@ -181,12 +184,13 @@ For physical motion (bouncing, overshooting), use spring animations:
 # extern crate guido;
 # use guido::prelude::*;
 # fn main() {
+# let c = Color::WHITE;
 # container()
 // Spring for bouncy physical motion
-.animate_scale(Transition::spring(SpringConfig::BOUNCY))
+.scale(Scale::NONE.transition(Transition::spring(SpringConfig::BOUNCY)))
 
 // Duration for smooth UI transitions
-.animate_background(Transition::new(200.0, TimingFunction::EaseOut))
+.background(c.transition(Transition::new(200.0, TimingFunction::EaseOut)))
 # ;
 # }
 ```

--- a/book/src/animations/transitions.md
+++ b/book/src/animations/transitions.md
@@ -1,22 +1,26 @@
 # Transitions
 
-Duration-based transitions animate properties over a fixed time with an easing curve.
+A transition eases a property to each new value over a fixed time, with an
+easing curve. It is declared on the value itself, with `.transition(..)`.
 
-## Creating Transitions
+## Declaring one
 
 ```rust,ignore
 # extern crate guido;
 # use guido::prelude::*;
 # fn main() {
+# let value = Color::WHITE;
 # let timing = TimingFunction::EaseOut;
-# let duration_ms = 200u64;
-Transition::new(duration_ms, timing)
+# let duration_ms = 200.0;
+value.transition(Transition::new(duration_ms, timing))
 # ;
 # }
 ```
 
 - `duration_ms` - Animation duration in milliseconds
 - `timing` - Easing curve for the animation
+
+A bare number is the short form: `.transition(200.0)` is 200ms eased out.
 
 ## Examples
 
@@ -27,8 +31,7 @@ Transition::new(duration_ms, timing)
 # use guido::prelude::*;
 # fn main() {
 container()
-    .background(Color::rgb(0.3, 0.5, 0.8))
-    .animate_background(Transition::new(200.0, TimingFunction::EaseOut))
+    .background(Color::rgb(0.3, 0.5, 0.8).transition(200.0))
     .when_hovered(|s| s.lighter(0.15))
 # ;
 # }
@@ -36,14 +39,18 @@ container()
 
 ### Border Animation
 
+A border is declared as a pair and each half carries its own timing, so the
+width can spring while the colour eases:
+
 ```rust
 # extern crate guido;
 # use guido::prelude::*;
 # fn main() {
 container()
-    .border(1.0, Color::rgb(0.3, 0.3, 0.4))
-    .animate_border_width(Transition::new(150.0, TimingFunction::EaseOut))
-    .animate_border_color(Transition::new(150.0, TimingFunction::EaseOut))
+    .border(
+        1.0.transition(150.0),
+        Color::rgb(0.3, 0.3, 0.4).transition(150.0),
+    )
     .when_hovered(|s| s.border(2.0, Color::rgb(0.5, 0.5, 0.6)))
 # ;
 # }
@@ -56,11 +63,14 @@ container()
 # use guido::prelude::*;
 # fn main() {
 container()
-    .animate_scale(Transition::new(300.0, TimingFunction::EaseOut))
+    .scale(Scale::NONE.transition(Transition::new(300.0, TimingFunction::EaseOut)))
     .when_pressed(|s| s.scale(0.98))
 # ;
 # }
 ```
+
+The resting value is what the property is when no state layer overrides it —
+here `Scale::NONE`, the size the press shrinks away from.
 
 ## Duration Guidelines
 
@@ -73,25 +83,29 @@ container()
 
 ## Combining with State Layers
 
-Transitions work seamlessly with state layers:
+A state layer supplies a value for a property somebody else declared, and
+carries no timing of its own. The property eases whatever supplies its value:
 
 ```rust
 # extern crate guido;
 # use guido::prelude::*;
 # fn main() {
 container()
-    .background(Color::rgb(0.2, 0.2, 0.3))
-    .elevation(2.0)
+    .background(Color::rgb(0.2, 0.2, 0.3).transition(200.0))
+    .elevation(2.0.transition(200.0))
 
-    // Animate multiple properties
-    .animate_background(Transition::new(200.0, TimingFunction::EaseOut))
-    .animate_elevation(Transition::new(200.0, TimingFunction::EaseOut))
-
-    // State changes trigger animations
+    // State changes trigger the animations declared above
     .when_hovered(|s| s.lighter(0.1).elevation(4.0))
     .when_pressed(|s| s.darker(0.05).elevation(1.0))
 # ;
 # }
+```
+
+Writing a timing on the override does not compile — it would be a declaration
+that is legal and does nothing:
+
+```rust,ignore
+.when_hovered(|s| s.background(HOT.transition(900.0)))   // error
 ```
 
 ## Complete Example
@@ -100,16 +114,13 @@ container()
 fn animated_card() -> Container {
     container()
         .padding(20.0)
-        .background(Color::rgb(0.15, 0.15, 0.2))
+        .background(Color::rgb(0.15, 0.15, 0.2).transition(200.0))
         .corners(12.0)
-        .border(1.0, Color::rgb(0.25, 0.25, 0.3))
-        .elevation(4.0)
-
-        // Animations
-        .animate_background(Transition::new(200.0, TimingFunction::EaseOut))
-        .animate_border_width(Transition::new(150.0, TimingFunction::EaseOut))
-        .animate_border_color(Transition::new(150.0, TimingFunction::EaseOut))
-        .animate_elevation(Transition::new(250.0, TimingFunction::EaseOut))
+        .border(
+            1.0.transition(150.0),
+            Color::rgb(0.25, 0.25, 0.3).transition(150.0),
+        )
+        .elevation(4.0.transition(250.0))
 
         // State layers
         .when_hovered(|s| s
@@ -129,7 +140,10 @@ fn animated_card() -> Container {
 ## API Reference
 
 ```text
-/// Create a duration-based transition
+/// Ease to each new value this holds
+value.transition(transition: impl Into<TransitionConfig>) -> Animated<T>;
+
+/// A bare number is milliseconds, eased out
 Transition::new(duration_ms: f32, timing: TimingFunction) -> Transition;
 
 /// Create a spring-based transition

--- a/book/src/building-ui/borders.md
+++ b/book/src/building-ui/borders.md
@@ -154,16 +154,18 @@ container()
 
 ## Animated Borders
 
-Borders can animate on state changes:
+A border is declared as a pair and each half carries its own timing, so the
+width and the colour can move on curves of their own:
 
 ```rust
 # extern crate guido;
 # use guido::prelude::*;
 # fn main() {
 container()
-    .border(1.0, Color::rgb(0.3, 0.3, 0.4))
-    .animate_border_width(Transition::new(150.0, TimingFunction::EaseOut))
-    .animate_border_color(Transition::new(150.0, TimingFunction::EaseOut))
+    .border(
+        1.0.transition(150.0),
+        Color::rgb(0.3, 0.3, 0.4).transition(150.0),
+    )
     .when_hovered(|s| s.border(2.0, Color::rgb(0.5, 0.5, 0.6)))
     .when_pressed(|s| s.border(3.0, Color::rgb(0.7, 0.7, 0.8)))
 # ;
@@ -214,9 +216,10 @@ fn card_with_border() -> Container {
         .background(Color::rgb(0.12, 0.12, 0.16))
         .corners(Corners::squircle(12.0))
         
-        .border(1.0, Color::rgb(0.2, 0.2, 0.25))
-        .animate_border_width(Transition::new(150.0, TimingFunction::EaseOut))
-        .animate_border_color(Transition::new(150.0, TimingFunction::EaseOut))
+        .border(
+            1.0.transition(150.0),
+            Color::rgb(0.2, 0.2, 0.25).transition(150.0),
+        )
         .when_hovered(|s| s
             .border(2.0, Color::rgb(0.4, 0.6, 0.9))
             .lighter(0.03)

--- a/book/src/building-ui/elevation.md
+++ b/book/src/building-ui/elevation.md
@@ -53,8 +53,7 @@ Smooth elevation transitions:
 # use guido::prelude::*;
 # fn main() {
 container()
-    .elevation(2.0)
-    .animate_elevation(Transition::new(200.0, TimingFunction::EaseOut))
+    .elevation(2.0.transition(Transition::new(200.0, TimingFunction::EaseOut)))
     .when_hovered(|s| s.elevation(6.0))
 # ;
 # }
@@ -83,11 +82,9 @@ fn elevated_card() -> Container {
     container()
         .width(200.0)
         .padding(20.0)
-        .background(Color::rgb(0.15, 0.15, 0.2))
+        .background(Color::rgb(0.15, 0.15, 0.2).transition(150.0))
         .corners(12.0)
-        .elevation(4.0)
-        .animate_background(Transition::new(150.0, TimingFunction::EaseOut))
-        .animate_elevation(Transition::new(200.0, TimingFunction::EaseOut))
+        .elevation(4.0.transition(200.0))
         .when_hovered(|s| s.elevation(8.0).lighter(0.05))
         .when_pressed(|s| s.elevation(2.0).darker(0.05))
         .layout(Flex::column().spacing(8.0))

--- a/book/src/building-ui/styling.md
+++ b/book/src/building-ui/styling.md
@@ -219,10 +219,11 @@ is what lets one signal switch the effect on and off rather than forcing the
 caller to rebuild the widget in a Rust branch.
 
 **What is not reactive** is structural: `.layout(..)`, `.scrollable(..)`,
-`.scrollbar(..)`, `.scrollbar_visibility(..)`, `.control()`, and the
-`.animate_*()` declarations. These say
-what kind of thing the container *is*; change one and you are describing a
-different widget, so declare it in the closure that builds the widget instead.
+`.scrollbar(..)`, `.scrollbar_visibility(..)`, `.control()`, and the motion a
+value is declared with — `.transition(..)` and `.timeline(..)`. These say what
+kind of thing the container *is*; change one and you are describing a different
+widget, so declare it in the closure that builds the widget instead. The
+*value* a motion decorates is as reactive as any other.
 
 ## Complete Example
 

--- a/book/src/building-ui/styling.md
+++ b/book/src/building-ui/styling.md
@@ -233,8 +233,9 @@ fn styled_card(title: &str, content: &str) -> Container {
         .width(300.0)
         .padding(20.0)
 
-        // Background and corners
-        .background(Color::rgb(0.15, 0.15, 0.2))
+        // Background and corners — the background eases, so the hover below
+        // arrives over 200ms rather than in one frame
+        .background(Color::rgb(0.15, 0.15, 0.2).transition(200.0))
         .corners(Corners::squircle(12.0))
         
 
@@ -247,8 +248,7 @@ fn styled_card(title: &str, content: &str) -> Container {
         // Layout
         .layout(Flex::column().spacing(12.0))
 
-        // State layers
-        .animate_background(Transition::new(200.0, TimingFunction::EaseOut))
+        // State layers — they supply values; the motion was declared above
         .when_hovered(|s| s.lighter(0.05).elevation(6.0))
 
         // Children

--- a/book/src/concepts/container.md
+++ b/book/src/concepts/container.md
@@ -188,15 +188,16 @@ See [Transforms](../transforms/README.md) for details.
 
 ## Animations
 
-Animate property changes:
+The motion rides with the value: declare a property with a transition and it
+eases to each new value instead of jumping there.
 
 ```rust
 # extern crate guido;
 # use guido::prelude::*;
 # fn main() {
 container()
-    .animate_background(Transition::new(200.0, TimingFunction::EaseOut))
-    .animate_scale(Transition::spring(SpringConfig::BOUNCY))
+    .background(Color::rgb(0.3, 0.5, 0.8).transition(200.0))
+    .scale(Scale::NONE.transition(Transition::spring(SpringConfig::BOUNCY)))
 # ;
 # }
 ```
@@ -296,13 +297,9 @@ fn create_button(label: &str, on_click: impl Fn() + 'static) -> Container {
         .padding(16.0)
 
         // Styling
-        .background(Color::rgb(0.3, 0.5, 0.8))
+        .background(Color::rgb(0.3, 0.5, 0.8).transition(200.0))
         .corners(8.0)
-        .border(1.0, Color::rgb(0.4, 0.6, 0.9))
-
-        // Animations
-        .animate_background(Transition::new(200.0, TimingFunction::EaseOut))
-        .animate_border_width(Transition::new(150.0, TimingFunction::EaseOut))
+        .border(1.0.transition(150.0), Color::rgb(0.4, 0.6, 0.9))
 
         // State layers
         .when_hovered(|s| s.lighter(0.1).border(2.0, Color::rgb(0.5, 0.7, 1.0)))
@@ -365,10 +362,9 @@ fn create_button(label: &str, on_click: impl Fn() + 'static) -> Container {
 - `.pivot(origin)` - Pivot point
 
 ### Animations
-- `.animate_background(transition)` - Animate background
-- `.animate_translate(transition)` / `.animate_rotate(..)` / `.animate_scale(..)`
-- `.animate_border_width(transition)` - Animate border width
-- `.animate_border_color(transition)` - Animate border color
+Declared on the value, not beside it:
+- `value.transition(ms)` - ease to each new value
+- `value.timeline(keyframes, plays)` - play a sequence on a trigger
 
 ### Visibility
 - `.visible(condition)` - Show or hide the container (accepts static, signal, or closure)

--- a/book/src/interactivity/state-layer.md
+++ b/book/src/interactivity/state-layer.md
@@ -135,19 +135,27 @@ Chain multiple overrides in a single state:
 
 ## With Animations
 
-Add transitions for smooth state changes:
+The motion belongs to the property, declared once beside its base value. A
+layer supplies a value for a property somebody else owns, and carries no timing
+of its own — so a hover eases under whatever the base declared:
 
 ```rust
 # extern crate guido;
 # use guido::prelude::*;
 # fn main() {
 container()
-    .background(Color::rgb(0.3, 0.5, 0.8))
-    .animate_background(Transition::new(200.0, TimingFunction::EaseOut))
+    .background(Color::rgb(0.3, 0.5, 0.8).transition(200.0))
     .when_hovered(|s| s.lighter(0.15))
     .when_pressed(|s| s.darker(0.1))
 # ;
 # }
+```
+
+Writing a timing on the override does not compile. It would be a declaration
+that is legal and does nothing:
+
+```rust,ignore
+.when_hovered(|s| s.background(HOT.transition(900.0)))   // error
 ```
 
 ## Complete Example
@@ -156,14 +164,11 @@ container()
 fn interactive_button(label: &str) -> Container {
     container()
         .padding(16.0)
-        .background(Color::rgb(0.3, 0.5, 0.8))
+        // Each property carries its own motion
+        .background(Color::rgb(0.3, 0.5, 0.8).transition(200.0))
         .corners(8.0)
-        .border(1.0, Color::rgb(0.4, 0.6, 0.9))
-
-        // Animations
-        .animate_background(Transition::new(200.0, TimingFunction::EaseOut))
-        .animate_border_width(Transition::new(150.0, TimingFunction::EaseOut))
-        .animate_scale(Transition::spring(SpringConfig::GENTLE))
+        .border(1.0.transition(150.0), Color::rgb(0.4, 0.6, 0.9))
+        .scale(Scale::NONE.transition(Transition::spring(SpringConfig::GENTLE)))
 
         // State layers
         .when_hovered(|s| s

--- a/book/src/interactivity/states.md
+++ b/book/src/interactivity/states.md
@@ -395,10 +395,9 @@ Add transitions for smooth state changes:
 # use guido::prelude::*;
 # fn main() {
 container()
-    .background(Color::rgb(0.3, 0.5, 0.8))
-    .animate_background(Transition::new(200.0, TimingFunction::EaseOut))
-    .animate_border_width(Transition::new(150.0, TimingFunction::EaseOut))
-    .animate_scale(Transition::spring(SpringConfig::GENTLE))
+    .background(Color::rgb(0.3, 0.5, 0.8).transition(200.0))
+    .border(1.0.transition(150.0), Color::WHITE)
+    .scale(Scale::NONE.transition(Transition::spring(SpringConfig::GENTLE)))
     .when_hovered(|s| s.lighter(0.1).border(2.0, Color::WHITE))
     .when_pressed(|s| s.darker(0.1).scale(0.98))
 # ;
@@ -453,8 +452,7 @@ container()
     .padding(16.0)
     .background(Color::rgb(0.15, 0.15, 0.2))
     .corners(8.0)
-    .elevation(2.0)
-    .animate_elevation(Transition::new(200.0, TimingFunction::EaseOut))
+    .elevation(2.0.transition(200.0))
     .when_hovered(|s| s.elevation(6.0).lighter(0.03))
     .when_pressed(|s| s.elevation(1.0))
     .children([...])

--- a/book/src/transforms/animated.md
+++ b/book/src/transforms/animated.md
@@ -2,7 +2,10 @@
 
 Animate transform changes with smooth transitions.
 
-## Enabling Animation
+## Declaring one
+
+The timing rides with the value: `.transition(..)` on whatever the component is
+being set to, so a component cannot be animated without being set.
 
 ```rust
 # extern crate guido;
@@ -10,8 +13,7 @@ Animate transform changes with smooth transitions.
 # fn main() {
 # let rotation_signal = create_signal(0.0f32);
 container()
-    .rotate(rotation_signal)
-    .animate_rotate(Transition::new(300.0, TimingFunction::EaseOut))
+    .rotate(rotation_signal.transition(Transition::new(300.0, TimingFunction::EaseOut)))
 # ;
 # }
 ```
@@ -29,8 +31,7 @@ Standard easing curve transitions:
 # let rotation = create_signal(0.0f32);
 // Smooth ease-out rotation
 container()
-    .rotate(rotation)
-    .animate_rotate(Transition::new(300.0, TimingFunction::EaseOut))
+    .rotate(rotation.transition(Transition::new(300.0, TimingFunction::EaseOut)))
     .on_click(move || rotation.update(|r| *r += 45.0))
 # ;
 # }
@@ -46,8 +47,7 @@ Physics simulation for bouncy, natural motion:
 # fn main() {
 # let scale_signal = create_signal(1.0f32);
 container()
-    .scale(scale_signal)
-    .animate_scale(Transition::spring(SpringConfig::BOUNCY))
+    .scale(scale_signal.transition(Transition::spring(SpringConfig::BOUNCY)))
 # ;
 # }
 ```
@@ -73,8 +73,7 @@ container()
     .height(80.0)
     .background(Color::rgb(0.3, 0.6, 0.8))
     .corners(8.0)
-    .rotate(rotation)
-    .animate_rotate(Transition::new(300.0, TimingFunction::EaseOut))
+    .rotate(rotation.transition(Transition::new(300.0, TimingFunction::EaseOut)))
     .when_hovered(|s| s.lighter(0.1))
     .when_pressed(|s| s.ripple())
     .on_click(move || rotation.update(|r| *r += 45.0))
@@ -92,8 +91,7 @@ let scale_factor = create_signal(1.0f32);
 let is_scaled = create_signal(false);
 
 container()
-    .scale(scale_factor)
-    .animate_scale(Transition::spring(SpringConfig::BOUNCY))
+    .scale(scale_factor.transition(Transition::spring(SpringConfig::BOUNCY)))
     .on_click(move || {
         is_scaled.update(|s| *s = !*s);
         let target = if is_scaled.get() { 1.3 } else { 1.0 };
@@ -110,7 +108,7 @@ container()
 # use guido::prelude::*;
 # fn main() {
 container()
-    .animate_scale(Transition::spring(SpringConfig::GENTLE))
+    .scale(Scale::NONE.transition(Transition::spring(SpringConfig::GENTLE)))
     .when_pressed(|s| s.scale(0.98))
 # ;
 # }
@@ -125,8 +123,10 @@ container()
 let offset_x = create_signal(0.0f32);
 
 container()
-    .translate(move || (offset_x.get(), 0.0))
-    .animate_translate(Transition::new(400.0, TimingFunction::EaseInOut))
+    .translate(
+        (move || (offset_x.get(), 0.0))
+            .transition(Transition::new(400.0, TimingFunction::EaseInOut)),
+    )
     .on_scroll(move |_, dy, _| {
         offset_x.update(|x| *x += dy * 10.0);
     })
@@ -164,8 +164,7 @@ fn animated_transforms_demo() -> impl Widget {
                 .height(80.0)
                 .background(Color::rgb(0.3, 0.5, 0.8))
                 .corners(8.0)
-                .rotate(rotation)
-                .animate_rotate(Transition::new(300.0, TimingFunction::EaseOut))
+                .rotate(rotation.transition(Transition::new(300.0, TimingFunction::EaseOut)))
                 .when_hovered(|s| s.lighter(0.1))
                 .when_pressed(|s| s.ripple())
                 .on_click(move || rotation.update(|r| *r += 45.0))
@@ -178,8 +177,7 @@ fn animated_transforms_demo() -> impl Widget {
                 .height(80.0)
                 .background(Color::rgb(0.3, 0.8, 0.4))
                 .corners(8.0)
-                .scale(scale)
-                .animate_scale(Transition::spring(SpringConfig::BOUNCY))
+                .scale(scale.transition(Transition::spring(SpringConfig::BOUNCY)))
                 .when_hovered(|s| s.lighter(0.1))
                 .when_pressed(|s| s.ripple())
                 .on_click(move || {
@@ -195,15 +193,11 @@ fn animated_transforms_demo() -> impl Widget {
 ## API Reference
 
 ```rust,ignore
+// The three components each take a value that may carry its own motion.
 impl Container {
-    pub fn animate_translate(self, transition: Transition) -> Self;
-    pub fn animate_rotate(self, transition: Transition) -> Self;
-    pub fn animate_scale(self, transition: Transition) -> Self;
-
-    // Each has an enter form, animating in from a value on first layout
-    pub fn animate_translate_from(self, from: impl Into<Translate>, t: Transition) -> Self;
-    pub fn animate_rotate_from(self, from: impl IntoF32, t: Transition) -> Self;
-    pub fn animate_scale_from(self, from: impl Into<Scale>, t: Transition) -> Self;
+    pub fn translate<M>(self, t: impl IntoAnimated<Translate, M>) -> Self;
+    pub fn rotate<M>(self, degrees: impl IntoAnimated<f32, M>) -> Self;
+    pub fn scale<M>(self, factor: impl IntoAnimated<Scale, M>) -> Self;
 }
 
 // Duration-based

--- a/book/src/transforms/nested.md
+++ b/book/src/transforms/nested.md
@@ -195,13 +195,11 @@ Deep nesting with many transforms is fine for typical UIs. The transform matrice
 # fn main() {
 // Group animation
 container()
-    .rotate(group_rotation)
-    .animate_rotate(Transition::new(300.0, TimingFunction::EaseOut))
+    .rotate(group_rotation.transition(Transition::new(300.0, TimingFunction::EaseOut)))
     .children([
         // Individual children can have their own animations
         container()
-            .scale(child_scale)
-            .animate_scale(Transition::spring(SpringConfig::BOUNCY))
+            .scale(child_scale.transition(Transition::spring(SpringConfig::BOUNCY)))
             .child(...),
     ])
 # ;

--- a/book/src/transforms/origins.md
+++ b/book/src/transforms/origins.md
@@ -174,9 +174,8 @@ fn create_rotating_box(origin: Pivot, label: &'static str) -> Container {
                 .height(60.0)
                 .background(Color::rgb(0.3, 0.5, 0.8))
                 .corners(8.0)
-                .rotate(rotation)
+                .rotate(rotation.transition(Transition::new(300.0, TimingFunction::EaseOut)))
                 .pivot(origin)
-                .animate_rotate(Transition::new(300.0, TimingFunction::EaseOut))
                 .when_hovered(|s| s.lighter(0.1))
                 .on_click(move || rotation.update(|r| *r += 45.0)),
             container().child(text(label).font_size(12.0).color(Color::WHITE)),

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -495,12 +495,21 @@ See [STATE_LAYER.md](./STATE_LAYER.md) for full documentation.
 
 Duration-based and spring-based animations:
 
+The timing rides with the value, so a property cannot be animated without
+being set and the two cannot disagree about which property they mean:
+
 ```rust
+// A bare number is milliseconds
+.background(theme.surface.transition(200.0))
+
 // Duration with easing
-.animate_background(Transition::new(200.0, TimingFunction::EaseOut))
+.background(theme.surface.transition(Transition::new(200.0, TimingFunction::EaseOut)))
 
 // Spring physics
-.animate_scale(Transition::spring(SpringConfig::BOUNCY))
+.scale(open.transition(Transition::spring(SpringConfig::BOUNCY)))
+
+// A sequence played on a trigger, resting on the declared value between plays
+.rotate(0.0.timeline(shake, rejections))
 ```
 
 ## Performance Considerations

--- a/docs/STATE_LAYER.md
+++ b/docs/STATE_LAYER.md
@@ -199,21 +199,31 @@ is its own ripple and they overlap; up to four are alive at a time.
 
 ## Animations
 
-State transitions can be animated using the `animate_*` methods:
+The motion belongs to the *property*, declared once beside its base value. A
+state layer supplies a value for a property somebody else owns, so it carries no
+timing of its own — and a hover eases under whatever the base declared:
 
 ```rust
 container()
-    .background(Color::rgb(0.3, 0.6, 0.4))
-    .animate_background(Transition::new(200.0, TimingFunction::EaseOut))
+    .background(Color::rgb(0.3, 0.6, 0.4).transition(200.0))
     .when_hovered(|s| s.lighter(0.15))
     .when_pressed(|s| s.darker(0.1))
 ```
 
-Available animation methods:
-- `animate_background(Transition)` - Animate background color changes
-- `animate_border_width(Transition)` - Animate border width changes
-- `animate_border_color(Transition)` - Animate border color changes
-- `animate_translate(Transition)` / `animate_rotate(..)` / `animate_scale(..)`
+Declaring a timing on the override is a compile error rather than a value
+quietly ignored, because [`Animated`] is deliberately not an [`IntoSignal`]:
+
+```rust
+// does not compile
+.when_hovered(|s| s.background(HOT.transition(900.0)))
+```
+
+Every animatable property takes a motion the same way — `background`, `border`
+(each half separately), `corners`, `padding`, `elevation`, `width`, `height`,
+`translate`, `rotate` and `scale`.
+
+[`Animated`]: ../src/animation/animated.rs
+[`IntoSignal`]: ../src/reactive/into_signal.rs
 
 ### Transition Types
 
@@ -233,15 +243,12 @@ Transition::spring(SpringConfig::GENTLE)
 fn create_button(label: &str) -> Container {
     container()
         .padding(16.0)
-        .background(Color::rgb(0.3, 0.5, 0.8))
+        .background(Color::rgb(0.3, 0.5, 0.8).transition(200.0))
         .corners(8.0)
-        .border(1.0, Color::rgb(0.4, 0.6, 0.9))
-        
+        .border(1.0.transition(150.0), Color::rgb(0.4, 0.6, 0.9))
+
         // The label follows the state too, not just the box
         .control()   // the text below declares .when_hovered(|s| s.color(Color::rgb(0.95, 0.98, 1.0)))
-        // Animations
-        .animate_background(Transition::new(200.0, TimingFunction::EaseOut))
-        .animate_border_width(Transition::new(150.0, TimingFunction::EaseOut))
         // State overrides
         .when_hovered(|s| s.lighter(0.1).border(2.0, Color::rgb(0.5, 0.7, 1.0)))
         .when_pressed(|s| s.ripple().darker(0.05).scale(0.98))

--- a/docs/STYLING.md
+++ b/docs/STYLING.md
@@ -95,9 +95,7 @@ const FIELD_BORDER: f32 = 1.5;
 
 ```rust
 container()
-    .border(1.0, Color::rgb(0.3, 0.3, 0.4))
-    .animate_border_width(Transition::new(150.0, TimingFunction::EaseOut))
-    .animate_border_color(Transition::new(150.0, TimingFunction::EaseOut))
+    .border(1.0.transition(150.0), Color::rgb(0.3, 0.3, 0.4).transition(150.0))
     .when_hovered(|s| s.border(2.0, Color::rgb(0.5, 0.5, 0.6)))
 ```
 
@@ -220,10 +218,11 @@ is what lets one signal switch the effect on and off rather than forcing the
 caller to rebuild the widget in a Rust branch.
 
 **What is not reactive** is structural: `.layout(..)`, `.scrollable(..)`,
-`.scrollbar(..)`, `.scrollbar_visibility(..)`, `.control()`, and the
-`.animate_*()` declarations. These say
-what kind of thing the container *is*; change one and you are describing a
-different widget, so declare it in the closure that builds the widget instead.
+`.scrollbar(..)`, `.scrollbar_visibility(..)`, `.control()`, and the motion a
+value is declared with — `.transition(..)` and `.timeline(..)`. These say what
+kind of thing the container *is*; change one and you are describing a different
+widget, so declare it in the closure that builds the widget instead. The
+*value* a motion decorates is as reactive as any other.
 
 ## Text Styling
 
@@ -333,8 +332,9 @@ fn styled_card(title: &str, content: &str) -> Container {
         // Size and padding
         .width(300.0)
         .padding(20.0)
-        // Background and corners
-        .background(Color::rgb(0.15, 0.15, 0.2))
+        // Background and corners — the background eases, so the hover below
+        // arrives over 200ms rather than in one frame
+        .background(Color::rgb(0.15, 0.15, 0.2).transition(200.0))
         .corners(Corners::squircle(12.0))
         
         // Border
@@ -343,8 +343,7 @@ fn styled_card(title: &str, content: &str) -> Container {
         .elevation(4.0)
         // Layout
         .layout(Flex::column().spacing(12.0))
-        // State layers
-        .animate_background(Transition::new(200.0, TimingFunction::EaseOut))
+        // State layers — they supply values; the motion is declared above
         .when_hovered(|s| s.lighter(0.05).elevation(6.0))
         // Children
         .children([

--- a/docs/TRANSFORMS.md
+++ b/docs/TRANSFORMS.md
@@ -113,8 +113,7 @@ Animate transform changes with transitions:
 let rotation = create_signal(0.0f32);
 
 container()
-    .rotate(rotation)
-    .animate_rotate(Transition::new(300.0, TimingFunction::EaseOut))
+    .rotate(rotation.transition(Transition::new(300.0, TimingFunction::EaseOut)))
     .on_click(move || rotation.update(|r| *r += 45.0))
 ```
 
@@ -124,8 +123,7 @@ For physics-based animation:
 
 ```rust
 container()
-    .scale(scale_signal)
-    .animate_scale(Transition::spring(SpringConfig::BOUNCY))
+    .scale(scale_signal.transition(Transition::spring(SpringConfig::BOUNCY)))
 ```
 
 ## Nested Transforms
@@ -200,12 +198,9 @@ impl Transform {
 
 ```rust
 impl Container {
-    pub fn translate<M>(self, t: impl IntoSignal<Translate, M>) -> Self;
-    pub fn rotate<M>(self, degrees: impl IntoSignal<f32, M>) -> Self;
-    pub fn scale<M>(self, factor: impl IntoSignal<Scale, M>) -> Self;
+    pub fn translate<M>(self, t: impl IntoAnimated<Translate, M>) -> Self;
+    pub fn rotate<M>(self, degrees: impl IntoAnimated<f32, M>) -> Self;
+    pub fn scale<M>(self, factor: impl IntoAnimated<Scale, M>) -> Self;
     pub fn pivot<M>(self, pivot: impl IntoSignal<Pivot, M>) -> Self;
-    pub fn animate_translate(self, transition: impl Into<TransitionConfig>) -> Self;
-    pub fn animate_rotate(self, transition: impl Into<TransitionConfig>) -> Self;
-    pub fn animate_scale(self, transition: impl Into<TransitionConfig>) -> Self;
 }
 ```

--- a/examples/animation_example.rs
+++ b/examples/animation_example.rs
@@ -52,12 +52,11 @@ fn main() {
 
 fn card(title: &str, hint: impl Into<String>, body: Container) -> Container {
     container()
-        .background(CARD)
+        .background(CARD.transition(Transition::new(150.0, TimingFunction::EaseOut)))
         .corners(12.0)
         .padding(12.0)
         .layout(Flex::column().spacing(7.0))
         .when_hovered(|s| s.lighter(0.04))
-        .animate_background(Transition::new(150.0, TimingFunction::EaseOut))
         .children([
             text(title.to_string())
                 .font_size(14.0)
@@ -93,8 +92,10 @@ fn width_card() -> Container {
         track(
             36.0,
             container()
-                .width(move || if wide.get() { WIDE } else { NARROW })
-                .animate_width(Transition::spring(SpringConfig::DEFAULT))
+                .width(
+                    (move || if wide.get() { WIDE } else { NARROW })
+                        .transition(Transition::spring(SpringConfig::DEFAULT)),
+                )
                 .height(fill())
                 .background(INK)
                 .corners(6.0),
@@ -111,8 +112,7 @@ fn colour_card() -> Container {
             .width(280.0)
             .height(48.0)
             .corners(8.0)
-            .background(Color::rgb(0.22, 0.20, 0.30))
-            .animate_background(transition)
+            .background(Color::rgb(0.22, 0.20, 0.30).transition(transition))
             .when_hovered(|s| s.background(HOT))
     };
 
@@ -138,19 +138,25 @@ fn corner_and_size_card() -> Container {
         track(
             56.0,
             container()
-                .width(move || if open.get() { 520.0 } else { 120.0 })
-                .animate_width(Transition::spring(SpringConfig::SNAPPY))
+                .width(
+                    (move || if open.get() { 520.0 } else { 120.0 })
+                        .transition(Transition::spring(SpringConfig::SNAPPY)),
+                )
                 .height(fill())
-                .background(move || {
-                    if open.get() {
-                        Color::rgb(0.25, 0.55, 0.40)
-                    } else {
-                        Color::rgb(0.25, 0.30, 0.45)
-                    }
-                })
-                .animate_background(Transition::new(200.0, TimingFunction::EaseOut))
-                .corners(move || if open.get() { 30.0 } else { 6.0 })
-                .animate_corners(Transition::new(250.0, TimingFunction::EaseInOut)),
+                .background(
+                    (move || {
+                        if open.get() {
+                            Color::rgb(0.25, 0.55, 0.40)
+                        } else {
+                            Color::rgb(0.25, 0.30, 0.45)
+                        }
+                    })
+                    .transition(200.0),
+                )
+                .corners(
+                    (move || if open.get() { 30.0 } else { 6.0 })
+                        .transition(Transition::new(250.0, TimingFunction::EaseInOut)),
+                ),
         )
         .on_click(move || open.update(|o| *o = !*o)),
     )
@@ -170,11 +176,10 @@ fn border_card() -> Container {
             .background(Color::rgb(0.13, 0.13, 0.18))
             .corners(10.0)
             .border(
-                move || if thick.get() { 14.0 } else { 2.0 },
-                Color::rgb(0.40, 0.50, 0.70),
+                (move || if thick.get() { 14.0 } else { 2.0 })
+                    .transition(Transition::spring(SpringConfig::BOUNCY)),
+                Color::rgb(0.40, 0.50, 0.70).transition(300.0),
             )
-            .animate_border_width(Transition::spring(SpringConfig::BOUNCY))
-            .animate_border_color(Transition::new(300.0, TimingFunction::EaseOut))
             // A border is declared as a pair, so the hover restates the width —
             // and restates it as the same signal, or hovering would pin it and
             // the click would have nothing left to spring. Each half of a state

--- a/examples/at_most_animation.rs
+++ b/examples/at_most_animation.rs
@@ -1,7 +1,7 @@
 //! Does attaching a size animation change how a capped container lays out?
 //!
 //! Each row below is the SAME container twice: on the left as written, on the
-//! right with `.animate_width(...)` added and nothing else. The animation never
+//! right with a transition on its declared width and nothing else. The animation never
 //! runs — there is no signal to move it — so the two ought to be identical.
 //!
 //! Run it on a build with the fix and the pairs match. Run it on one without
@@ -29,20 +29,19 @@ fn heading(s: &str) -> Text {
 
 /// The cap, drawn as an outline so overflowing content is visible against it.
 fn capped(animated: bool, body: impl Widget + 'static) -> Container {
-    let c = container()
-        .width(at_most(CAP))
-        .border(1.0, Color::rgb(0.45, 0.5, 0.65))
+    let width = at_most(CAP);
+    let c = if animated {
+        container().width(width.transition(Transition::new(200, TimingFunction::EaseOut)))
+    } else {
+        container().width(width)
+    };
+    c.border(1.0, Color::rgb(0.45, 0.5, 0.65))
         .corners(4.0)
         .padding(6.0)
         // Visible, not Hidden: clipping would conceal exactly what we are here
         // to look at.
         .overflow(Overflow::Visible)
-        .child(body);
-    if animated {
-        c.animate_width(Transition::new(200, TimingFunction::EaseOut))
-    } else {
-        c
-    }
+        .child(body)
 }
 
 /// One case, shown twice, with its measured size printed underneath.
@@ -75,7 +74,7 @@ fn pair(title: &str, build: impl Fn(bool) -> Container + 'static) -> Container {
             container()
                 .layout(Flex::row().spacing(24.0))
                 .child(side("come scritto", build(false), plain_ref))
-                .child(side("+ .animate_width()", build(true), anim_ref)),
+                .child(side("+ .transition()", build(true), anim_ref)),
         )
 }
 

--- a/examples/keyframes_example.rs
+++ b/examples/keyframes_example.rs
@@ -51,7 +51,7 @@ fn card(label: &'static str, plays: RwSignal<u32>) -> Container {
         )
         // Declared, animated, and quietly stood aside while a sequence runs.
         .when_hovered(|s| s.scale(1.03))
-        .animate_scale(Transition::spring(SpringConfig::SNAPPY))
+        .scale(Scale::NONE.transition(Transition::spring(SpringConfig::SNAPPY)))
         .on_click(move || plays.update(|p| *p += 1))
         .child(text(label).color(Color::WHITE).font_size(16.0))
 }
@@ -65,8 +65,8 @@ fn main() {
         let view = container()
             .padding(24.0)
             .layout(Flex::row().spacing(20.0))
-            .child(card("shake", plays).keyframes_rotate(shake(), plays))
-            .child(card("nod", plays).keyframes_translate(nod(), plays));
+            .child(card("shake", plays).rotate(0.0.timeline(shake(), plays)))
+            .child(card("nod", plays).translate(Translate::NONE.timeline(nod(), plays)));
 
         app.add_surface(
             SurfaceConfig::new()

--- a/examples/spring_momentum.rs
+++ b/examples/spring_momentum.rs
@@ -90,9 +90,10 @@ fn turn_around() -> Container {
         "Hover the strip, then leave it while the dot is still travelling. It \
          should reverse without pausing at the point you left it.",
         track(
-            dot(INK)
-                .translate(move || (if out.get() { 760.0 } else { 0.0 }, 0.0))
-                .animate_translate(Transition::spring(SpringConfig::GENTLE)),
+            dot(INK).translate(
+                (move || (if out.get() { 760.0 } else { 0.0 }, 0.0))
+                    .transition(Transition::spring(SpringConfig::GENTLE)),
+            ),
         )
         .control()
         .on_hover(move |hovered| out.set(hovered)),
@@ -109,9 +110,10 @@ fn past_the_overshoot() -> Container {
          the dot has shot past the end and is settling back — it should carry \
          on the way it was going, not lurch forward first.",
         track(
-            dot(HOT)
-                .translate(move || (if out.get() { 700.0 } else { 0.0 }, 0.0))
-                .animate_translate(Transition::spring(SpringConfig::BOUNCY)),
+            dot(HOT).translate(
+                (move || (if out.get() { 700.0 } else { 0.0 }, 0.0))
+                    .transition(Transition::spring(SpringConfig::BOUNCY)),
+            ),
         )
         .control()
         .on_hover(move |hovered| out.set(hovered)),
@@ -129,10 +131,14 @@ fn own_channel() -> Container {
          because the two are separate properties with a spring each.",
         track(
             dot(INK)
-                .translate(move || Translate::new(if out.get() { 700.0 } else { 0.0 }, 0.0))
-                .animate_translate(Transition::spring(SpringConfig::GENTLE))
-                .scale(move || if big.get() { 1.6 } else { 1.0 })
-                .animate_scale(Transition::spring(SpringConfig::GENTLE)),
+                .translate(
+                    (move || Translate::new(if out.get() { 700.0 } else { 0.0 }, 0.0))
+                        .transition(Transition::spring(SpringConfig::GENTLE)),
+                )
+                .scale(
+                    (move || if big.get() { 1.6 } else { 1.0 })
+                        .transition(Transition::spring(SpringConfig::GENTLE)),
+                ),
         )
         .control()
         .on_hover(move |hovered| out.set(hovered))
@@ -149,9 +155,10 @@ fn from_rest() -> Container {
         "Hover and wait for the dot to come to a complete stop at the far end, \
          then leave. It should ease away, not start with a kick.",
         track(
-            dot(INK)
-                .translate(move || (if out.get() { 760.0 } else { 0.0 }, 0.0))
-                .animate_translate(Transition::spring(SpringConfig::SNAPPY)),
+            dot(INK).translate(
+                (move || (if out.get() { 760.0 } else { 0.0 }, 0.0))
+                    .transition(Transition::spring(SpringConfig::SNAPPY)),
+            ),
         )
         .control()
         .on_hover(move |hovered| out.set(hovered)),
@@ -172,8 +179,7 @@ fn shake() -> Container {
             .background(HOT)
             .corners(8.0)
             .padding(10.0)
-            .rotate(move || angle.get())
-            .animate_rotate(Transition::spring(SpringConfig::BOUNCY))
+            .rotate((move || angle.get()).transition(Transition::spring(SpringConfig::BOUNCY)))
             .on_mouse_down(move |_, _| angle.set(6.0))
             .on_mouse_up(move |_, _| angle.set(0.0))
             .child(

--- a/examples/state_layer_example.rs
+++ b/examples/state_layer_example.rs
@@ -55,11 +55,12 @@ fn main() {
 fn create_lighter_button() -> Container {
     container()
         .padding(16.0)
-        .background(Color::rgb(0.2, 0.2, 0.3))
+        .background(
+            Color::rgb(0.2, 0.2, 0.3).transition(Transition::new(200.0, TimingFunction::EaseOut)),
+        )
         .corners(8.0)
         .control()
         .when_hovered(|s| s.lighter(0.1))
-        .animate_background(Transition::new(200.0, TimingFunction::EaseOut))
         // The hover belongs to the box and the colour to the glyphs: the
         // label brightens with the background because `control()` joins them.
         .child(
@@ -95,9 +96,10 @@ fn create_transform_button() -> Container {
 fn create_animated_button() -> Container {
     container()
         .padding(16.0)
-        .background(Color::rgb(0.3, 0.6, 0.4))
+        .background(
+            Color::rgb(0.3, 0.6, 0.4).transition(Transition::new(200.0, TimingFunction::EaseOut)),
+        )
         .corners(8.0)
-        .animate_background(Transition::new(200.0, TimingFunction::EaseOut))
         .when_hovered(|s| s.lighter(0.15))
         .when_pressed(|s| s.darker(0.1))
         .child(text("Animated transitions").color(Color::WHITE))
@@ -109,9 +111,10 @@ fn create_border_button() -> Container {
         .padding(16.0)
         .background(Color::rgb(0.15, 0.15, 0.2))
         .corners(8.0)
-        .border(1.0, Color::rgb(0.3, 0.3, 0.4))
-        .animate_border_width(Transition::new(150.0, TimingFunction::EaseOut))
-        .animate_border_color(Transition::new(150.0, TimingFunction::EaseOut))
+        .border(
+            1.0.transition(Transition::new(150.0, TimingFunction::EaseOut)),
+            Color::rgb(0.3, 0.3, 0.4).transition(Transition::new(150.0, TimingFunction::EaseOut)),
+        )
         .when_hovered(|s| s.border(2.0, Color::rgb(0.5, 0.5, 0.6)))
         .when_pressed(|s| s.border(3.0, Color::rgb(0.7, 0.7, 0.8)))
         .child(text("Border changes").color(Color::rgb(0.8, 0.8, 0.85)))

--- a/examples/surface_runtime.rs
+++ b/examples/surface_runtime.rs
@@ -239,8 +239,10 @@ fn main() {
                         // `content()` surface has something whose size moves.
                         let grown = container()
                             .width(120.0)
-                            .height(move || if tall.get() { 150.0 } else { 50.0 })
-                            .animate_height(Transition::new(400.0, TimingFunction::EaseOut))
+                            .height(
+                                (move || if tall.get() { 150.0 } else { 50.0 })
+                                    .transition(Transition::new(400.0, TimingFunction::EaseOut)),
+                            )
                             .background(Color::rgb(0.30, 0.45, 0.35))
                             .corners(6.0)
                             .into_any();

--- a/examples/transform_example.rs
+++ b/examples/transform_example.rs
@@ -54,8 +54,10 @@ fn main() {
                             .height(60.0)
                             .background(Color::rgb(0.3, 0.6, 0.8))
                             .corners(8.0)
-                            .rotate(move || rotation.get())
-                            .animate_rotate(Transition::new(300.0, TimingFunction::EaseOut))
+                            .rotate(
+                                (move || rotation.get())
+                                    .transition(Transition::new(300.0, TimingFunction::EaseOut)),
+                            )
                             .when_hovered(|s| s.lighter(0.1))
                             .when_pressed(|s| s.ripple())
                             .on_click(move || {
@@ -78,8 +80,10 @@ fn main() {
                             .height(60.0)
                             .background(Color::rgb(0.3, 0.8, 0.4))
                             .corners(8.0)
-                            .scale(move || scale_factor.get())
-                            .animate_scale(Transition::spring(SpringConfig::BOUNCY))
+                            .scale(
+                                (move || scale_factor.get())
+                                    .transition(Transition::spring(SpringConfig::BOUNCY)),
+                            )
                             .when_hovered(|s| s.lighter(0.1))
                             .when_pressed(|s| s.ripple())
                             .on_click(move || {

--- a/src/animation/animated.rs
+++ b/src/animation/animated.rs
@@ -1,0 +1,193 @@
+//! How a value moves, carried by the value itself.
+//!
+//! Every property that survives to paint takes a signal as readily as a value.
+//! This is that sentence extended to time: the *how* rides with the *what*, so
+//! a timing cannot name a property it does not decorate and cannot be declared
+//! for a property that was never set.
+//!
+//! Two verbs, on everything a property setter already accepts — a value, a
+//! closure, a signal:
+//!
+//! ```ignore
+//! container()
+//!     .background(theme.surface.transition(200.0))
+//!     .width((move || if open.get() { 520.0 } else { 120.0 }).transition(SpringConfig::SNAPPY))
+//!     .rotate(0.0.timeline(shake(), rejections))
+//! ```
+//!
+//! [`Animated`] is deliberately **not** an [`IntoSignal`]. A state layer
+//! supplies values for a property somebody else declared, so it has no timing
+//! to give — and because the two traits are separate, saying otherwise is a
+//! compile error rather than a value quietly ignored:
+//!
+//! ```ignore
+//! .when_hovered(|s| s.background(HOT.transition(900.0)))   // does not compile
+//! ```
+
+use crate::reactive::{IntoSignal, Signal};
+
+use super::{Animatable, Keyframes, TransitionConfig};
+
+/// A value, and how it moves when it changes.
+///
+/// Built by [`Animate::transition`] or [`Animate::timeline`] on anything that
+/// can already be a property, and accepted wherever a `Container` setter
+/// declares an animatable property.
+pub struct Animated<T> {
+    signal: Signal<T>,
+    /// Boxed and absent by default, for the reason `AnimationState` boxes its
+    /// `Timeline`: every animatable setter routes through here, and almost
+    /// every call declares no motion at all. A `Motion` owns a `Keyframes` and
+    /// a `TransitionConfig` with two callback slots, so inline it would make
+    /// `container().background(RED)` construct, move and drop a hundred and
+    /// more bytes to say "nothing".
+    motion: Option<Box<Motion<T>>>,
+}
+
+impl<T> Animated<T> {
+    /// The value and its motion, taken apart by the setter that installs them.
+    pub(crate) fn into_parts(self) -> (Signal<T>, Option<Box<Motion<T>>>) {
+        (self.signal, self.motion)
+    }
+
+    /// The value and the timing it eases with, for a property whose declared
+    /// type is not the type it animates: a width and a height say how the box
+    /// is sized with a `Length` and move an `f32`.
+    ///
+    /// A timeline cannot cross that gap, and cannot be written across it
+    /// either — [`Animate::timeline`] requires `T: Animatable` and
+    /// [`Keyframes`] has no other constructor, so a `Keyframes<Length>` does
+    /// not exist. That bound is what makes this a narrowing rather than a
+    /// value quietly dropped, and relaxing it would have to bring a spelling
+    /// for a timeline on a size with it.
+    pub(crate) fn into_eased(self) -> (Signal<T>, Option<TransitionConfig>) {
+        let ease = match self.motion.map(|motion| *motion) {
+            Some(Motion::Ease(config)) => Some(config),
+            // Unreachable for every `T` that reaches here; see above.
+            Some(Motion::Play { .. }) | None => None,
+        };
+        (self.signal, ease)
+    }
+}
+
+/// The two ways a value can move. An implementation detail: `motion` already
+/// means a pointer event here and scrolling calls its own `momentum`, so a
+/// public name about easing would sit between two unrelated meanings.
+pub(crate) enum Motion<T> {
+    /// Ease to each new value instead of jumping to it.
+    Ease(TransitionConfig),
+    /// Play a sequence whenever the trigger changes, and rest on the declared
+    /// value in between.
+    Play {
+        keyframes: Keyframes<T>,
+        plays: Signal<u32>,
+    },
+}
+
+/// The two verbs, on everything [`IntoSignal`] accepts.
+///
+/// There is no separate spelling for closures: the parentheses in
+/// `(move || …).transition(..)` are Rust's rule for calling a method on a
+/// closure literal, not a second API. The marker generic `M` is the same one
+/// `IntoSignal` carries, and for the same reason — a blanket impl over `T` and
+/// one over `FnMut() -> T` would overlap without it.
+pub trait Animate<T: Clone + 'static, M>: IntoSignal<T, M> + Sized {
+    /// Ease to each new value this holds, instead of jumping to it.
+    ///
+    /// A bare number is milliseconds; a [`Transition`](super::Transition) or a
+    /// [`SpringConfig`](super::SpringConfig) says which curve.
+    ///
+    /// ```ignore
+    /// container().background(theme.surface.transition(200.0))
+    /// container().width(w.transition(Transition::spring(SpringConfig::SNAPPY)))
+    /// ```
+    fn transition(self, transition: impl Into<TransitionConfig>) -> Animated<T> {
+        Animated {
+            signal: self.into_signal(),
+            motion: Some(Box::new(Motion::Ease(transition.into()))),
+        }
+    }
+
+    /// Play `keyframes` whenever `plays` changes, resting on this value in
+    /// between.
+    ///
+    /// The trigger is a count and not a flag on purpose: a second refusal has
+    /// to shake as loudly as the first, and a signal that stays equal notifies
+    /// nobody. The count it starts at is whatever it holds when the widget is
+    /// built, so nothing plays on the first frame.
+    ///
+    /// The resting value is required because it is what the property *is*
+    /// whenever nothing is playing — a shake returns to where it began and
+    /// makes it look redundant, but a sequence that ends somewhere else snaps
+    /// back to it, and a sequence resting on a live signal has nowhere else to
+    /// put its expression:
+    ///
+    /// ```ignore
+    /// container().rotate(0.0.timeline(shake(), rejections))
+    /// container().rotate((move || spin.get() * STEP).timeline(shake(), rejections))
+    /// ```
+    ///
+    /// A timeline is for something that happens and is over. A change that
+    /// should persist is a [`transition`](Self::transition).
+    ///
+    /// The `T: Animatable` bound is load-bearing beyond the `Keyframes` it
+    /// names: it is what keeps a timeline off a property whose declared type
+    /// is not the type it animates. A width and a height say how the box is
+    /// sized with a `Length` and move an `f32`, and a `Length` is not
+    /// animatable — so `width(w.timeline(..))` does not compile, rather than
+    /// compiling and playing nothing.
+    fn timeline<M2>(self, keyframes: Keyframes<T>, plays: impl IntoSignal<u32, M2>) -> Animated<T>
+    where
+        T: Animatable,
+    {
+        Animated {
+            signal: self.into_signal(),
+            motion: Some(Box::new(Motion::Play {
+                keyframes,
+                plays: plays.into_signal(),
+            })),
+        }
+    }
+}
+
+impl<T: Clone + 'static, M, S: IntoSignal<T, M>> Animate<T, M> for S {}
+
+#[doc(hidden)]
+pub struct AnimatedMarker;
+
+/// The marker for a value arriving with no motion, wrapping the one
+/// [`IntoSignal`] picked for it.
+///
+/// A wrapper rather than `M` passed straight through, because coherence
+/// reasons about what *could* be implemented, not only what is: a downstream
+/// crate is allowed to write `IntoSignal<Their, AnimatedMarker> for
+/// Animated<Their>`, which would make a blanket `IntoAnimated<T, M>` overlap
+/// the impl below. Two marker types that cannot unify close that off by
+/// construction.
+#[doc(hidden)]
+pub struct Plain<M>(std::marker::PhantomData<M>);
+
+/// What an animatable property setter takes: everything [`IntoSignal`]
+/// accepts, plus a value that carries its own motion.
+///
+/// The wider bound is what keeps the rule at compile time. `StateStyle`'s
+/// setters keep plain `IntoSignal`, so a timing declared on an override — a
+/// value for a property somebody else owns — does not compile.
+pub trait IntoAnimated<T: Clone + 'static, M> {
+    fn into_animated(self) -> Animated<T>;
+}
+
+impl<T: Clone + 'static, M, S: IntoSignal<T, M>> IntoAnimated<T, Plain<M>> for S {
+    fn into_animated(self) -> Animated<T> {
+        Animated {
+            signal: self.into_signal(),
+            motion: None,
+        }
+    }
+}
+
+impl<T: Clone + 'static> IntoAnimated<T, AnimatedMarker> for Animated<T> {
+    fn into_animated(self) -> Animated<T> {
+        self
+    }
+}

--- a/src/animation/animated.rs
+++ b/src/animation/animated.rs
@@ -63,8 +63,15 @@ impl<T> Animated<T> {
     pub(crate) fn into_eased(self) -> (Signal<T>, Option<TransitionConfig>) {
         let ease = match self.motion.map(|motion| *motion) {
             Some(Motion::Ease(config)) => Some(config),
-            // Unreachable for every `T` that reaches here; see above.
-            Some(Motion::Play { .. }) | None => None,
+            None => None,
+            // Loud rather than `None`, because the thing that makes this
+            // unreachable is a bound three types away: silently dropping a
+            // timeline here is the defect this whole shape exists to remove,
+            // and the day somebody relaxes that bound is the day this has to
+            // say so.
+            Some(Motion::Play { .. }) => {
+                unreachable!("a timeline needs T: Animatable, which this T is not")
+            }
         };
         (self.signal, ease)
     }

--- a/src/animation/keyframes.rs
+++ b/src/animation/keyframes.rs
@@ -11,22 +11,25 @@
 //! settled on, where an animation outranks a normal declaration for as long as
 //! it runs and hands the property back afterwards.
 //!
+//! It is declared where the value is, with
+//! [`timeline`](crate::animation::Animate::timeline), on whatever the property
+//! rests at between plays:
+//!
 //! ```ignore
-//! container()
-//!     .keyframes_rotate(
-//!         Keyframes::new(320.0)
-//!             .at(0.0, 0.0)
-//!             .at(0.2, 1.5)
-//!             .at(0.5, -1.0)
-//!             .at(0.8, 0.4)
-//!             .at(1.0, 0.0),
-//!         rejections,
-//!     )
+//! container().rotate(0.0.timeline(
+//!     Keyframes::new(320.0)
+//!         .at(0.0, 0.0)
+//!         .at(0.2, 1.5)
+//!         .at(0.5, -1.0)
+//!         .at(0.8, 0.4)
+//!         .at(1.0, 0.0),
+//!     rejections,
+//! ))
 //! ```
 //!
-//! A timeline belongs to the one component it moves: `keyframes_rotate` for a
-//! shake, `keyframes_translate` for a nod, `keyframes_scale` for a pulse. A
-//! hover that scales is untouched by a sequence that rotates.
+//! A timeline belongs to the one property it moves — a rotation for a shake, a
+//! translation for a nod, a background for a flash — so a hover that scales is
+//! untouched by a sequence that rotates.
 //!
 //! # What the offsets mean
 //!

--- a/src/animation/mod.rs
+++ b/src/animation/mod.rs
@@ -1,10 +1,13 @@
 mod animatable;
+mod animated;
 mod keyframes;
 mod spring;
 mod timing;
 
 pub(crate) use animatable::carry_velocity;
 pub use animatable::{Animatable, Channels};
+pub(crate) use animated::Motion;
+pub use animated::{Animate, Animated, AnimatedMarker, IntoAnimated, Plain};
 pub use keyframes::Keyframes;
 pub use spring::{SpringConfig, SpringState};
 pub use timing::{CustomCurve, TimingFunction};
@@ -118,5 +121,45 @@ impl From<Transition> for TransitionConfig {
             forward: t,
             reverse: None,
         }
+    }
+}
+
+/// A bare number is a duration in milliseconds, the way
+/// [`Keyframes::new`](Keyframes::new) already takes one:
+/// `.background(theme.surface.transition(200.0))`.
+///
+/// The curve it implies is [`EaseOut`](TimingFunction::EaseOut), and *not*
+/// [`Transition::default`]'s spring — a spring has no duration for the number
+/// to attach to. So the animation vocabulary has two defaults, deliberately:
+/// a transition asked for by name springs, and one asked for by duration eases
+/// out. `EaseOut` is what this codebase and its documentation reach for when
+/// they name a curve at all, by better than two to one.
+impl From<f32> for TransitionConfig {
+    fn from(duration_ms: f32) -> Self {
+        Transition::new(duration_ms, TimingFunction::EaseOut).into()
+    }
+}
+
+/// The same, written without a decimal point — `.transition(200)`, matching
+/// [`Transition::new`], which takes its duration through
+/// [`IntoF32`](crate::layout::IntoF32) for exactly this reason.
+///
+/// Two impls and not `IntoF32`'s four: a blanket one would collide with
+/// [`From<Transition>`], and adding `f64` would make the bare `200.0` above
+/// ambiguous — an unsuffixed float literal has to have exactly one impl to
+/// land on. `f32` and `i32` are what a literal defaults to, which is the whole
+/// of what this shorthand is for; a runtime `f64` says
+/// `Transition::new(ms, ..)`.
+impl From<i32> for TransitionConfig {
+    fn from(duration_ms: i32) -> Self {
+        Transition::new(duration_ms, TimingFunction::EaseOut).into()
+    }
+}
+
+/// A spring named on its own: `.transition(SpringConfig::SNAPPY)`, which is
+/// what `Transition::spring(SpringConfig::SNAPPY)` says at greater length.
+impl From<SpringConfig> for TransitionConfig {
+    fn from(config: SpringConfig) -> Self {
+        Transition::spring(config).into()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,7 +157,8 @@ pub fn quit_app() {
 /// re-exported here.
 pub mod prelude {
     pub use crate::animation::{
-        Keyframes, SpringConfig, TimingFunction, Transition, TransitionConfig,
+        Animate, Animated, IntoAnimated, Keyframes, SpringConfig, TimingFunction, Transition,
+        TransitionConfig,
     };
     pub use crate::backdrop::{BackdropBlur, BackdropSources};
     pub use crate::compositor::{CompositorEffects, compositor_effects};

--- a/src/widgets/container/anim_bridge.rs
+++ b/src/widgets/container/anim_bridge.rs
@@ -109,7 +109,7 @@ impl Container {
     /// value its signal actually holds, not the one captured at construction.
     ///
     /// See the module docs for why this cannot wait for the first paint.
-    pub(super) fn seed_animations(&mut self, id: WidgetId, now: std::time::Instant) {
+    pub(super) fn seed_animations(&mut self, id: WidgetId) {
         // Written out one by one: each property animates a different type, so
         // there is no single accessor to loop over.
         let anims = self.anims.as_ref();
@@ -163,34 +163,15 @@ impl Container {
         let Some(ref mut anims) = self.anims else {
             return;
         };
-        if let (Some(anim), Some(target)) = (&mut anims.background, bg_target) {
-            anim.set_immediate(target);
-        }
-        if let (Some(anim), Some(target)) = (&mut anims.corners, cr_target) {
-            anim.set_immediate(target);
-        }
-        if let (Some(anim), Some(target)) = (&mut anims.elevation, el_target) {
-            anim.set_immediate(target);
-        }
-        if let (Some(anim), Some(target)) = (&mut anims.border_color, bc_target) {
-            anim.set_immediate(target);
-        }
-        // An enter transition animates in from the declared value instead of
-        // snapping to the target. Written three times rather than looped:
-        // each component animates a different type.
-        let mut entered = false;
-        if let (Some(anim), Some(target)) = (&mut anims.translate, tr_target) {
-            entered |= seed_or_enter(anim, target, now);
-        }
-        if let (Some(anim), Some(target)) = (&mut anims.rotate, ro_target) {
-            entered |= seed_or_enter(anim, target, now);
-        }
-        if let (Some(anim), Some(target)) = (&mut anims.scale, sc_target) {
-            entered |= seed_or_enter(anim, target, now);
-        }
-        if entered {
-            request_job(id, JobRequest::Animation(RequiredJob::Paint));
-        }
+        // One line per property rather than a loop: each animates a
+        // different type, so there is nothing to iterate over.
+        seed(&mut anims.background, bg_target);
+        seed(&mut anims.corners, cr_target);
+        seed(&mut anims.elevation, el_target);
+        seed(&mut anims.border_color, bc_target);
+        seed(&mut anims.translate, tr_target);
+        seed(&mut anims.rotate, ro_target);
+        seed(&mut anims.scale, sc_target);
     }
 
     /// Every paint: re-read the animated targets under tracking, and ask for an
@@ -209,6 +190,10 @@ impl Container {
             // An animation still in its initial state has no target to drift
             // from — seed_animations has not run for it yet.
             let moved = |initial: bool, same: bool| !initial && !same;
+            // Each property answers twice: has its target drifted, and has its
+            // timeline been asked to play. Both reads are the subscription, so
+            // every one runs whatever the last one answered — which is why
+            // these are `|=` statements and not a `||` chain.
             let mut drift = false;
 
             if let Some(a) = &anims.padding {
@@ -216,65 +201,64 @@ impl Container {
                     a.is_initial(),
                     *a.target() == self.padding.get_or(Padding::default()),
                 );
+                drift |= a.wants_play();
             }
             if let Some(a) = &anims.border_width {
                 drift |= moved(
                     a.is_initial(),
                     *a.target() == self.effective_border_width_target(id),
                 );
+                drift |= a.wants_play();
             }
             if let Some(a) = &anims.background {
                 drift |= moved(
                     a.is_initial(),
                     *a.target() == self.effective_background_target(id),
                 );
+                drift |= a.wants_play();
             }
             if let Some(a) = &anims.corners {
                 drift |= moved(
                     a.is_initial(),
                     *a.target() == self.effective_corners_target(id),
                 );
+                drift |= a.wants_play();
             }
             if let Some(a) = &anims.elevation {
                 drift |= moved(
                     a.is_initial(),
                     *a.target() == self.effective_elevation_target(id),
                 );
+                drift |= a.wants_play();
             }
             if let Some(a) = &anims.border_color {
                 drift |= moved(
                     a.is_initial(),
                     *a.target() == self.effective_border_color_target(id),
                 );
+                drift |= a.wants_play();
             }
             if let Some(a) = &anims.translate {
                 drift |= moved(
                     a.is_initial(),
                     *a.target() == self.effective_translate_target(id),
                 );
+                drift |= a.wants_play();
             }
             if let Some(a) = &anims.rotate {
                 drift |= moved(
                     a.is_initial(),
                     *a.target() == self.effective_rotate_target(id),
                 );
+                drift |= a.wants_play();
             }
             if let Some(a) = &anims.scale {
                 drift |= moved(
                     a.is_initial(),
                     *a.target() == self.effective_scale_target(id),
                 );
+                drift |= a.wants_play();
             }
-            // The timeline's trigger, read here for the same reason as the
-            // targets: reading it is the subscription, so a container that
-            // plays on a signal is woken by it. Asking and committing are the
-            // same comparison in the same place — see `take_play`.
-            // Three statements and not `||`, for the same reason the targets
-            // above are: reading is the subscription, so all three have to be
-            // read whatever the first one answers.
-            drift |= anims.translate.as_ref().is_some_and(|a| a.wants_play());
-            drift |= anims.rotate.as_ref().is_some_and(|a| a.wants_play());
-            drift |= anims.scale.as_ref().is_some_and(|a| a.wants_play());
             drift
         });
 
@@ -284,21 +268,12 @@ impl Container {
     }
 }
 
-/// Start one component at its seeded target, or begin its enter transition.
-/// Returns whether an enter was begun, which is what needs a paint job.
-fn seed_or_enter<T: crate::animation::Animatable>(
-    anim: &mut AnimationState<T>,
-    target: T,
-    now: std::time::Instant,
-) -> bool {
-    match anim.take_enter_from() {
-        Some(enter) => {
-            anim.begin_from(enter, target, now);
-            true
-        }
-        None => {
-            anim.set_immediate(target);
-            false
-        }
+/// Start one animated property at the target just read for it.
+///
+/// Written as a call per property rather than a loop, because each animates a
+/// different type and there is no single accessor to iterate.
+fn seed<T: crate::animation::Animatable>(slot: &mut Option<AnimationState<T>>, target: Option<T>) {
+    if let (Some(anim), Some(target)) = (slot, target) {
+        anim.set_immediate(target);
     }
 }

--- a/src/widgets/container/animations.rs
+++ b/src/widgets/container/animations.rs
@@ -592,12 +592,12 @@ mod tests {
     }
     use crate::animation::TimingFunction;
 
-    /// Step a running sequence to `ms` into its run.
     /// A trigger nothing ever writes to: these tests call `play` directly.
     fn never_played() -> Signal<u32> {
         crate::reactive::create_stored(0)
     }
 
+    /// Step a running sequence to `ms` into its run.
     fn play_at<T: Animatable>(anim: &mut AnimationState<T>, ms: u64) {
         let started = anim
             .timeline

--- a/src/widgets/container/animations.rs
+++ b/src/widgets/container/animations.rs
@@ -21,7 +21,7 @@ struct Timeline<T> {
     /// events and a signal that stays equal notifies nobody. Reading it and
     /// committing to it live in one place, so the pass that subscribes and the
     /// pass that plays cannot disagree about what has been seen.
-    trigger: Option<Signal<u32>>,
+    trigger: Signal<u32>,
     last_play: u32,
 }
 
@@ -75,13 +75,9 @@ pub struct AnimationState<T: Animatable> {
     initialized: bool,
     /// Previous value for change detection
     prev_value: Option<T>,
-    /// Pending enter value: consumed at first layout to start an enter
-    /// animation instead of snapping to the target
-    enter_from: Option<T>,
     /// A sequence to play on demand, and what plays it. Boxed and absent by
-    /// default: `ContainerAnims` holds eleven of these states and only three
-    /// can carry a sequence — `keyframes_translate`, `keyframes_rotate` and
-    /// `keyframes_scale` — so the rest pay a pointer rather than the struct.
+    /// default: most declared properties ease to a target and never carry one,
+    /// so they pay a pointer rather than the struct.
     timeline: Option<Box<Timeline<T>>>,
 }
 
@@ -108,7 +104,6 @@ impl<T: Animatable> AnimationState<T> {
             spring_state,
             initialized: false, // Not yet initialized with real content-based value
             prev_value: None,
-            enter_from: None,
             timeline: None,
         }
     }
@@ -331,54 +326,19 @@ impl<T: Animatable> AnimationState<T> {
             || (self.spring_state.is_some() && self.progress < 0.99)
     }
 
-    /// Give this property a sequence to play, keeping whatever already plays
-    /// it.
-    pub(crate) fn set_timeline(&mut self, keyframes: Keyframes<T>) {
-        match &mut self.timeline {
-            Some(timeline) => timeline.keyframes = keyframes,
-            None => {
-                self.timeline = Some(Box::new(Timeline {
-                    keyframes,
-                    playing: None,
-                    trigger: None,
-                    last_play: 0,
-                }))
-            }
-        }
-    }
-
-    /// Give it the signal that plays it. Ignored without a sequence, which
-    /// cannot happen through the builders.
-    pub(crate) fn set_play_trigger(&mut self, trigger: Signal<u32>) {
-        if let Some(timeline) = &mut self.timeline {
-            timeline.last_play = trigger.get_untracked();
-            timeline.trigger = Some(trigger);
-        }
-    }
-
-    /// Carry what a caller declared over from the state this one replaces.
+    /// Give this property a sequence and the signal that plays it.
     ///
-    /// The builders each construct a fresh `AnimationState`, so without this
-    /// the order `keyframes_*`, `animate_*` and `animate_*_from` were written
-    /// in would decide what survived — silently, since a trigger would go on
-    /// firing against a state that had nothing to play and an enter would
-    /// simply never run.
-    ///
-    /// Both fields, not just the sequence. Carrying one and dropping the other
-    /// is the same defect this exists to fix, and it was open on `enter_from`
-    /// for as long as this took only the timeline: writing
-    /// `animate_scale_from(0.9, ..)` before `animate_scale(..)` lost the enter.
-    ///
-    /// An `enter_from` already on `self` wins — it came from the builder being
-    /// written now, and the later declaration is the one a caller means.
-    pub(crate) fn adopt_declarations_of(&mut self, previous: Option<Self>) {
-        let Some(previous) = previous else { return };
-        if let Some(timeline) = previous.timeline {
-            self.timeline = Some(timeline);
-        }
-        if self.enter_from.is_none() {
-            self.enter_from = previous.enter_from;
-        }
+    /// One declaration per property, so this replaces rather than merges:
+    /// a motion arrives with the value it moves, and a second `.rotate(..)`
+    /// restates the whole property.
+    pub(crate) fn with_timeline(mut self, keyframes: Keyframes<T>, plays: Signal<u32>) -> Self {
+        self.timeline = Some(Box::new(Timeline {
+            keyframes,
+            playing: None,
+            last_play: plays.get_untracked(),
+            trigger: plays,
+        }));
+        self
     }
 
     /// Whether the trigger has moved since the sequence last played.
@@ -388,8 +348,7 @@ impl<T: Animatable> AnimationState<T> {
     pub(crate) fn wants_play(&self) -> bool {
         self.timeline
             .as_ref()
-            .and_then(|t| t.trigger.map(|signal| signal.get() != t.last_play))
-            .unwrap_or(false)
+            .is_some_and(|t| t.trigger.get() != t.last_play)
     }
 
     /// The same question, answered once: `true` hands over the play and marks
@@ -398,10 +357,7 @@ impl<T: Animatable> AnimationState<T> {
         let Some(timeline) = &mut self.timeline else {
             return false;
         };
-        let Some(trigger) = timeline.trigger else {
-            return false;
-        };
-        let now = trigger.get();
+        let now = timeline.trigger.get();
         if now == timeline.last_play {
             return false;
         }
@@ -465,32 +421,6 @@ impl<T: Animatable> AnimationState<T> {
     /// Get target value
     pub fn target(&self) -> &T {
         &self.target
-    }
-
-    /// Take the pending enter value, if any (consumed at first layout).
-    pub(crate) fn take_enter_from(&mut self) -> Option<T> {
-        self.enter_from.take()
-    }
-
-    /// Store an enter value: the first layout starts an animation from it
-    /// to the effective target instead of snapping (see
-    /// `Container::animate_scale_from`).
-    pub(crate) fn with_enter_from(mut self, from: T) -> Self {
-        self.enter_from = Some(from);
-        self
-    }
-
-    /// Begin animating from an explicit value (enter transitions): the
-    /// widget appears mid-animation instead of snapping to its target.
-    pub(crate) fn begin_from(&mut self, from: T, target: T, now: Instant) {
-        self.current = from;
-        self.start = from;
-        self.initialized = true;
-        // Reuse animate_to for direction selection and spring setup; it
-        // starts from `current`, which is now the enter value
-        let t = target;
-        self.target = from; // force the retarget below to fire
-        self.animate_to(t, now);
     }
 
     /// Set value immediately without animation (for initialization)
@@ -663,6 +593,11 @@ mod tests {
     use crate::animation::TimingFunction;
 
     /// Step a running sequence to `ms` into its run.
+    /// A trigger nothing ever writes to: these tests call `play` directly.
+    fn never_played() -> Signal<u32> {
+        crate::reactive::create_stored(0)
+    }
+
     fn play_at<T: Animatable>(anim: &mut AnimationState<T>, ms: u64) {
         let started = anim
             .timeline
@@ -681,7 +616,10 @@ mod tests {
 
         let mut anim = AnimationState::new(0.0_f32, Transition::new(0.0, TimingFunction::Linear));
         anim.set_immediate(0.0);
-        anim.set_timeline(Keyframes::new(60.0).at(0.0, 0.0).at(0.5, 10.0).at(1.0, 0.0));
+        anim = anim.with_timeline(
+            Keyframes::new(60.0).at(0.0, 0.0).at(0.5, 10.0).at(1.0, 0.0),
+            never_played(),
+        );
 
         anim.play(Instant::now());
         assert!(anim.is_animating(), "a playing timeline is an animation");
@@ -709,7 +647,10 @@ mod tests {
 
         let mut anim = AnimationState::new(0.0_f32, Transition::new(0.0, TimingFunction::Linear));
         anim.set_immediate(0.0);
-        anim.set_timeline(Keyframes::new(80.0).at(0.0, 0.0).at(1.0, 8.0));
+        anim = anim.with_timeline(
+            Keyframes::new(80.0).at(0.0, 0.0).at(1.0, 8.0),
+            never_played(),
+        );
 
         anim.play(Instant::now());
         play_at(&mut anim, 60);
@@ -736,7 +677,10 @@ mod tests {
 
         let mut anim = AnimationState::new(0.0_f32, Transition::new(200.0, TimingFunction::Linear));
         anim.set_immediate(0.0);
-        anim.set_timeline(Keyframes::new(60.0).at(0.0, 0.0).at(1.0, 10.0));
+        anim = anim.with_timeline(
+            Keyframes::new(60.0).at(0.0, 0.0).at(1.0, 10.0),
+            never_played(),
+        );
 
         anim.play(Instant::now());
         play_at(&mut anim, 30);
@@ -773,7 +717,10 @@ mod tests {
 
         let mut anim = AnimationState::new(0.0_f32, transition);
         anim.set_immediate(0.0);
-        anim.set_timeline(Keyframes::new(60.0).at(0.0, 0.0).at(1.0, 5.0));
+        anim = anim.with_timeline(
+            Keyframes::new(60.0).at(0.0, 0.0).at(1.0, 5.0),
+            never_played(),
+        );
 
         anim.animate_to(1.0, Instant::now());
         anim.play(Instant::now());
@@ -807,8 +754,7 @@ mod tests {
 
         let plays = create_signal(0_u32);
         let mut anim = AnimationState::new(0.0_f32, Transition::new(0.0, TimingFunction::Linear));
-        anim.set_timeline(Keyframes::new(40.0).at(0.0, 0.0).at(1.0, 1.0));
-        anim.set_play_trigger(plays.into());
+        anim = anim.with_timeline(Keyframes::new(40.0).at(0.0, 0.0).at(1.0, 1.0), plays.into());
 
         assert!(!anim.wants_play(), "nothing has happened yet");
 

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -1381,6 +1381,62 @@ fn a_transition_on_the_value_is_what_makes_that_value_ease() {
     );
 }
 
+/// A declaration is the whole property, so restating one with a plain value
+/// takes its motion away with it.
+///
+/// This is what makes `adopt_declarations_of` unnecessary — there are never
+/// two declarations for one property to reconcile, only the one written last.
+/// Left unwritten, the animation would outlive the declaration that asked for
+/// it, which is the shape of the defect this whole change removes: a timing
+/// still governing a property nobody declared it on.
+#[test]
+fn restating_a_property_plainly_takes_its_motion_with_it() {
+    let color = create_signal(Color::BLACK);
+    let mut h = H::new(
+        container()
+            .layout(Flex::row())
+            .child(
+                box_of(20.0, 20.0)
+                    .background(color.transition(Transition::new(200.0, TimingFunction::Linear))),
+            )
+            // The same declaration, restated without one.
+            .child(
+                box_of(20.0, 20.0)
+                    .background(color.transition(Transition::new(200.0, TimingFunction::Linear)))
+                    .background(color),
+            ),
+    );
+    h.fit(200.0, 200.0);
+    h.paint();
+
+    color.set(Color::WHITE);
+    let t0 = std::time::Instant::now();
+    frame_at(&mut h, t0, 200.0, 200.0);
+    frame_at(
+        &mut h,
+        t0 + std::time::Duration::from_millis(100),
+        200.0,
+        200.0,
+    );
+
+    let painted: Vec<Color> = h
+        .paint()
+        .children
+        .iter()
+        .map(|child| rects(child).first().expect("a background").1)
+        .collect();
+    assert!(
+        painted[0].r < 0.95,
+        "the transition it was declared with still holds, got {:?}",
+        painted[0]
+    );
+    assert_eq!(
+        painted[1],
+        Color::WHITE,
+        "and the one restated plainly has no transition left to hold it back"
+    );
+}
+
 /// And on a padding, which is the one newly-timeline-capable property on the
 /// *layout* path rather than the paint path — so it is where "a sequence
 /// speaks for its property while it plays" has to hold against

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -14,7 +14,7 @@
 use rustc_hash::FxHashSet;
 
 use super::*;
-use crate::animation::{SpringConfig, TimingFunction, Transition};
+use crate::animation::{Animate, Keyframes, SpringConfig, TimingFunction, Transition};
 use crate::backdrop::BackdropSources;
 use crate::jobs::{self, JobType};
 use crate::layout::{Constraints, Flex, at_least, at_most, fill, fraction};
@@ -377,11 +377,11 @@ fn at_most_bounds_children_with_or_without_a_size_animation() {
 
     for animated in [false, true] {
         let inner = container().width(fill()).height(5.0);
-        let outer = container().width(at_most(60.0));
         let outer = if animated {
-            outer.animate_width(Transition::new(200, TimingFunction::EaseOut))
+            container()
+                .width(at_most(60.0).transition(Transition::new(200, TimingFunction::EaseOut)))
         } else {
-            outer
+            container().width(at_most(60.0))
         };
 
         let mut h = H::new(outer.child(inner));
@@ -414,8 +414,7 @@ fn a_size_animation_does_not_change_how_content_wraps() {
 
     let mut animated = H::new(
         container()
-            .width(at_most(100.0))
-            .animate_width(Transition::new(200, TimingFunction::EaseOut))
+            .width(at_most(100.0).transition(Transition::new(200, TimingFunction::EaseOut)))
             .child(text(sentence)),
     );
     let animated_size = animated.fit(500.0, 500.0);
@@ -819,10 +818,11 @@ fn advancing_animations_does_not_report_a_missing_scope() {
             .width(50.0)
             .height(50.0)
             .background(Color::RED)
-            .border(move || if wide.get() { 6.0 } else { 2.0 }, Color::BLUE)
-            .corners(move || if wide.get() { 20.0 } else { 4.0 })
-            .animate_border_width(t())
-            .animate_corners(t()),
+            .border(
+                (move || if wide.get() { 6.0 } else { 2.0 }).transition(t()),
+                Color::BLUE,
+            )
+            .corners((move || if wide.get() { 20.0 } else { 4.0 }).transition(t())),
     );
     h.fit(200.0, 200.0);
     h.paint();
@@ -863,8 +863,10 @@ fn advancing_animations_does_not_report_a_missing_scope() {
 #[test]
 fn a_border_width_animation_counts_as_movable_by_a_state_layer() {
     let animated = container()
-        .border(2.0, Color::BLUE)
-        .animate_border_width(Transition::spring(SpringConfig::BOUNCY))
+        .border(
+            2.0.transition(Transition::spring(SpringConfig::BOUNCY)),
+            Color::BLUE,
+        )
         .when_hovered(|s| s.border(14.0, Color::BLUE));
     assert!(
         animated.has_animated_state_properties(),
@@ -888,21 +890,21 @@ fn a_state_layer_moving_an_animated_transform_counts_as_movable() {
 
     assert!(
         container()
-            .animate_translate(t())
+            .translate(Translate::NONE.transition(t()))
             .when_hovered(|s| s.translate(Translate::new(0.0, -2.0)))
             .has_animated_state_properties(),
         "hovering moves the translate, so it needs an Animation job"
     );
     assert!(
         container()
-            .animate_rotate(t())
+            .rotate(0.0.transition(t()))
             .when_hovered(|s| s.rotate(2.0))
             .has_animated_state_properties(),
         "and a rotate"
     );
     assert!(
         container()
-            .animate_scale(t())
+            .scale(Scale::NONE.transition(t()))
             .when_pressed(|s| s.scale(0.98))
             .has_animated_state_properties(),
         "and a scale — the layer on every button there is"
@@ -931,20 +933,26 @@ fn each_animated_transform_component_is_a_signal_animated_prop() {
 
     assert!(
         container()
-            .animate_translate(t())
+            .translate(Translate::NONE.transition(t()))
             .has_signal_animated_props(),
         "a translate animation mirrors a signal, so it re-syncs at paint"
     );
     assert!(
-        container().animate_rotate(t()).has_signal_animated_props(),
+        container()
+            .rotate(0.0.transition(t()))
+            .has_signal_animated_props(),
         "and a rotate"
     );
     assert!(
-        container().animate_scale(t()).has_signal_animated_props(),
+        container()
+            .scale(Scale::NONE.transition(t()))
+            .has_signal_animated_props(),
         "and a scale"
     );
     assert!(
-        !container().animate_width(t()).has_signal_animated_props(),
+        !container()
+            .width(0.0.transition(t()))
+            .has_signal_animated_props(),
         "a width follows the content it measured, and is retargeted at layout"
     );
 }
@@ -1090,8 +1098,7 @@ fn a_linear_animation_is_halfway_at_half_its_duration() {
     let mut h = H::new(
         container()
             .height(10.0)
-            .width(w)
-            .animate_width(Transition::new(100.0, TimingFunction::Linear)),
+            .width(w.transition(Transition::new(100.0, TimingFunction::Linear))),
     );
     h.fit(400.0, 400.0);
 
@@ -1142,8 +1149,7 @@ fn a_ripple_and_a_transition_are_asked_about_the_same_moment() {
     let mut h = H::new(
         container()
             .height(100.0)
-            .width(w)
-            .animate_width(Transition::new(100.0, TimingFunction::Linear))
+            .width(w.transition(Transition::new(100.0, TimingFunction::Linear)))
             .when_pressed(|s| s.ripple())
             .on_click(|| {}),
     );
@@ -1321,6 +1327,104 @@ fn a_hover_layer_reaches_the_text() {
 }
 
 // ---------------------------------------------------------------------------
+// The motion rides with the value
+// ---------------------------------------------------------------------------
+
+/// Two boxes differing in one thing only — whether the colour they are handed
+/// carries a transition — and one write to the one signal both read.
+///
+/// This is the whole shape of the change in a single assertion: the timing is
+/// not a second declaration naming a property, it is part of what the property
+/// was set to, so the two containers can disagree about how they move while
+/// agreeing about what they show.
+#[test]
+fn a_transition_on_the_value_is_what_makes_that_value_ease() {
+    let color = create_signal(Color::BLACK);
+    let mut h = H::new(
+        container()
+            .layout(Flex::row())
+            .child(box_of(20.0, 20.0).background(color))
+            .child(
+                box_of(20.0, 20.0)
+                    .background(color.transition(Transition::new(200.0, TimingFunction::Linear))),
+            ),
+    );
+    h.fit(200.0, 200.0);
+    h.paint();
+
+    color.set(Color::WHITE);
+    let t0 = std::time::Instant::now();
+    frame_at(&mut h, t0, 200.0, 200.0);
+    frame_at(
+        &mut h,
+        t0 + std::time::Duration::from_millis(100),
+        200.0,
+        200.0,
+    );
+
+    // The two boxes' backgrounds, in the order they were declared.
+    let painted: Vec<Color> = h
+        .paint()
+        .children
+        .iter()
+        .map(|child| rects(child).first().expect("a background").1)
+        .collect();
+    assert_eq!(
+        painted[0],
+        Color::WHITE,
+        "a value declared with no motion is at its new value on the next paint"
+    );
+    assert!(
+        painted[1].r > 0.05 && painted[1].r < 0.95,
+        "and one declared with a transition is still on its way, got {:?}",
+        painted[1]
+    );
+}
+
+/// A timeline is no longer transform-only: `Keyframes<T>` was always generic
+/// and only the setters were not, so a background can flash where before it
+/// could only be eased to.
+#[test]
+fn a_timeline_plays_on_a_background() {
+    let plays = create_signal(0u32);
+    let rest = Color::BLACK;
+    let mut h = H::new(
+        box_of(50.0, 50.0).background(
+            rest.timeline(
+                Keyframes::new(200.0)
+                    .at(0.0, rest)
+                    .at(0.5, Color::RED)
+                    .at(1.0, rest),
+                plays,
+            ),
+        ),
+    );
+    h.fit(200.0, 200.0);
+    h.paint();
+    assert_eq!(
+        rects(&h.paint())[0].1,
+        rest,
+        "nothing plays until the trigger moves"
+    );
+
+    plays.set(1);
+    let t0 = std::time::Instant::now();
+    frame_at(&mut h, t0, 200.0, 200.0);
+    frame_at(
+        &mut h,
+        t0 + std::time::Duration::from_millis(100),
+        200.0,
+        200.0,
+    );
+
+    let flashed = rects(&h.paint())[0].1;
+    assert!(
+        flashed.r > 0.5,
+        "the sequence has to reach the pixels, got {flashed:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Keyframes
 // ---------------------------------------------------------------------------
 
@@ -1330,13 +1434,11 @@ fn a_hover_layer_reaches_the_text() {
 /// somebody else asked for.
 #[test]
 fn a_container_wakes_when_its_timeline_is_asked_to_play() {
-    use crate::animation::Keyframes;
-
     let plays = create_signal(0u32);
-    let mut h = H::new(box_of(50.0, 50.0).keyframes_rotate(
+    let mut h = H::new(box_of(50.0, 50.0).rotate(0.0.timeline(
         Keyframes::new(200.0).at(0.0, 0.0).at(0.5, 2.0).at(1.0, 0.0),
         plays,
-    ));
+    )));
     h.fit(100.0, 100.0);
     h.paint();
 
@@ -1368,17 +1470,17 @@ fn played_transform(h: &mut H) -> Transform {
 /// only question that matters: did the property move?
 #[test]
 fn a_played_sequence_actually_moves_the_transform() {
-    use crate::animation::Keyframes;
-
     let plays = create_signal(0u32);
     let mut h = H::new(
         container().layout(Flex::row()).child(
-            box_of(50.0, 50.0).keyframes_rotate(
-                Keyframes::new(200.0)
-                    .at(0.0, 0.0)
-                    .at(0.5, 20.0)
-                    .at(1.0, 0.0),
-                plays,
+            box_of(50.0, 50.0).rotate(
+                0.0.timeline(
+                    Keyframes::new(200.0)
+                        .at(0.0, 0.0)
+                        .at(0.5, 20.0)
+                        .at(1.0, 0.0),
+                    plays,
+                ),
             ),
         ),
     );
@@ -1394,67 +1496,6 @@ fn a_played_sequence_actually_moves_the_transform() {
     );
 }
 
-/// So does an enter, for the same reason and by the same route: whichever of
-/// the two builders is written second builds a fresh state, and one that took
-/// the sequence but not the enter left half the defect standing.
-#[test]
-fn declaring_a_transition_after_an_enter_does_not_lose_it() {
-    let entering = box_of(50.0, 50.0)
-        .scale(Scale::NONE)
-        .animate_scale_from(0.5, Transition::new(200.0, TimingFunction::EaseOut))
-        // Written after, which used to decide whether the enter existed.
-        .animate_scale(Transition::new(200.0, TimingFunction::EaseOut));
-
-    let mut h = H::new(container().layout(Flex::row()).child(entering));
-    h.fit(200.0, 200.0);
-    h.paint();
-    pump(&mut h);
-    h.fit(200.0, 200.0);
-    let painted = h.paint().children[0].local_transform;
-
-    assert_ne!(
-        painted,
-        Transform::IDENTITY,
-        "the enter has to start from the value it was given, not snap to the target"
-    );
-}
-
-/// And it survives the transition being declared after it.
-///
-/// `animate_rotate` builds a fresh `AnimationState`, so the sequence used
-/// to be thrown away by whichever builder came second — with the trigger
-/// still firing, the job still queued and nothing at all to show for it.
-#[test]
-fn declaring_a_transition_after_a_sequence_does_not_lose_it() {
-    use crate::animation::Keyframes;
-
-    let plays = create_signal(0u32);
-    let mut h = H::new(
-        container().layout(Flex::row()).child(
-            box_of(50.0, 50.0)
-                .keyframes_rotate(
-                    Keyframes::new(200.0)
-                        .at(0.0, 0.0)
-                        .at(0.5, 20.0)
-                        .at(1.0, 0.0),
-                    plays,
-                )
-                // Written after, which used to decide the whole thing.
-                .animate_rotate(Transition::new(100.0, TimingFunction::EaseOut)),
-        ),
-    );
-    h.fit(200.0, 200.0);
-    h.paint();
-
-    plays.set(1);
-    assert_ne!(
-        played_transform(&mut h),
-        Transform::IDENTITY,
-        "the order the two builders were written in must not decide whether \
-         the sequence exists"
-    );
-}
-
 /// A translate that animates has to arrive where its signal points.
 ///
 /// The one component with no such test until now, and four separate lists name
@@ -1467,8 +1508,7 @@ fn an_animated_translate_reaches_the_paint() {
     let mut h = H::new(
         container().layout(Flex::row()).child(
             box_of(50.0, 50.0)
-                .translate(offset)
-                .animate_translate(Transition::new(600.0, TimingFunction::Linear)),
+                .translate(offset.transition(Transition::new(600.0, TimingFunction::Linear))),
         ),
     );
     h.fit(200.0, 200.0);
@@ -1527,15 +1567,16 @@ fn a_translate_target_behind_an_untaken_branch_is_picked_up_by_the_resync() {
     let offset = create_signal(0.0f32);
     let mut h = H::new(
         container().layout(Flex::row()).child(
-            box_of(50.0, 50.0)
-                .translate(move || {
+            box_of(50.0, 50.0).translate(
+                (move || {
                     if armed.get() {
                         Translate::new(offset.get(), 0.0)
                     } else {
                         Translate::NONE
                     }
                 })
-                .animate_translate(Transition::new(80.0, TimingFunction::Linear)),
+                .transition(Transition::new(80.0, TimingFunction::Linear)),
+            ),
         ),
     );
     h.fit(200.0, 200.0);
@@ -1556,41 +1597,9 @@ fn a_translate_target_behind_an_untaken_branch_is_picked_up_by_the_resync() {
     );
 }
 
-/// An enter animates in from the value it was handed instead of snapping to
-/// the target — for a translate, which `seed_animations` reaches through a
-/// third list, after the one that decides it is initial and the one that
-/// computes its target.
-#[test]
-fn an_entering_translate_starts_from_where_it_was_told() {
-    let entering = box_of(50.0, 50.0)
-        .translate(Translate::NONE)
-        .animate_translate_from(
-            Translate::new(0.0, -20.0),
-            Transition::new(200.0, TimingFunction::EaseOut),
-        );
-
-    let mut h = H::new(container().layout(Flex::row()).child(entering));
-    h.fit(200.0, 200.0);
-    h.paint();
-    pump(&mut h);
-    h.fit(200.0, 200.0);
-    let painted = h.paint().children[0].local_transform;
-
-    assert_eq!(
-        painted.tx(),
-        0.0,
-        "the enter was declared on one axis and has to stay on it"
-    );
-    assert!(
-        painted.ty() < -1.0,
-        "it has to start up where it was told, not snap to the target, got {}",
-        painted.ty()
-    );
-}
-
 /// The other two timelines, which `advance_animations` starts and
 /// `resync_animation_targets` wakes from lists that name each component once.
-/// Only `keyframes_rotate` was played by anything before this.
+/// Only a rotation was played by anything before this.
 ///
 /// Neither sequence passes through the value that composes to the identity —
 /// the displacement stays out at 10 and the pulse never comes back below 1.1 —
@@ -1602,17 +1611,17 @@ fn an_entering_translate_starts_from_where_it_was_told() {
 /// each assertion is against.
 #[test]
 fn a_translate_sequence_and_a_scale_sequence_move_the_transform() {
-    use crate::animation::Keyframes;
-
     let plays = create_signal(0u32);
     let mut h = H::new(
         container().layout(Flex::row()).child(
-            box_of(50.0, 50.0).keyframes_translate(
-                Keyframes::new(200.0)
-                    .at(0.0, Translate::new(10.0, 0.0))
-                    .at(0.5, Translate::new(30.0, 0.0))
-                    .at(1.0, Translate::new(10.0, 0.0)),
-                plays,
+            box_of(50.0, 50.0).translate(
+                Translate::NONE.timeline(
+                    Keyframes::new(200.0)
+                        .at(0.0, Translate::new(10.0, 0.0))
+                        .at(0.5, Translate::new(30.0, 0.0))
+                        .at(1.0, Translate::new(10.0, 0.0)),
+                    plays,
+                ),
             ),
         ),
     );
@@ -1629,12 +1638,14 @@ fn a_translate_sequence_and_a_scale_sequence_move_the_transform() {
     let plays = create_signal(0u32);
     let mut h = H::new(
         container().layout(Flex::row()).child(
-            box_of(50.0, 50.0).keyframes_scale(
-                Keyframes::new(200.0)
-                    .at(0.0, Scale::uniform(1.1))
-                    .at(0.5, Scale::uniform(1.4))
-                    .at(1.0, Scale::uniform(1.1)),
-                plays,
+            box_of(50.0, 50.0).scale(
+                Scale::NONE.timeline(
+                    Keyframes::new(200.0)
+                        .at(0.0, Scale::uniform(1.1))
+                        .at(0.5, Scale::uniform(1.4))
+                        .at(1.0, Scale::uniform(1.1)),
+                    plays,
+                ),
             ),
         ),
     );
@@ -2046,9 +2057,8 @@ fn elevation_animates_towards_its_state_layer() {
             .width(40.0)
             .height(40.0)
             .background(Color::RED)
-            .elevation(0.0)
-            .when_hovered(|s| s.elevation(8.0))
-            .animate_elevation(Transition::new(80.0, TimingFunction::Linear)),
+            .elevation(0.0.transition(Transition::new(80.0, TimingFunction::Linear)))
+            .when_hovered(|s| s.elevation(8.0)),
     );
     h.fit(100.0, 100.0);
     h.paint();
@@ -2339,9 +2349,8 @@ fn the_damage_reach_covers_the_elevation_a_hover_can_reach() {
             .width(40.0)
             .height(40.0)
             .background(Color::RED)
-            .elevation(0.0)
-            .when_hovered(|s| s.elevation(8.0))
-            .animate_elevation(Transition::new(80.0, TimingFunction::Linear)),
+            .elevation(0.0.transition(Transition::new(80.0, TimingFunction::Linear)))
+            .when_hovered(|s| s.elevation(8.0)),
     );
     h.fit(100.0, 100.0);
 
@@ -2363,22 +2372,20 @@ fn the_damage_reach_covers_the_elevation_a_hover_can_reach() {
 /// artefact the reach exists to prevent, moved to the moment it is most visible.
 #[test]
 fn the_damage_reach_allows_for_a_spring_overshooting() {
-    let bouncy = |c: Container| {
-        c.width(40.0)
+    let bouncy = |transition: Transition| {
+        container()
+            .width(40.0)
             .height(40.0)
             .background(Color::RED)
-            .elevation(0.0)
+            .elevation(0.0.transition(transition))
             .when_hovered(|s| s.elevation(8.0))
     };
 
-    let mut eased = H::new(
-        bouncy(container()).animate_elevation(Transition::new(80.0, TimingFunction::Linear)),
-    );
+    let mut eased = H::new(bouncy(Transition::new(80.0, TimingFunction::Linear)));
     eased.fit(100.0, 100.0);
     let without_bounce = eased.tree.paint_overflow(eased.root);
 
-    let mut sprung =
-        H::new(bouncy(container()).animate_elevation(Transition::spring(SpringConfig::BOUNCY)));
+    let mut sprung = H::new(bouncy(Transition::spring(SpringConfig::BOUNCY)));
     sprung.fit(100.0, 100.0);
     let with_bounce = sprung.tree.paint_overflow(sprung.root);
 
@@ -2426,8 +2433,10 @@ fn a_falling_elevation_animates_down_instead_of_snapping() {
                 .width(40.0)
                 .height(40.0)
                 .background(Color::RED)
-                .elevation(move || level.get())
-                .animate_elevation(Transition::new(ramp_ms, TimingFunction::Linear)),
+                .elevation(
+                    (move || level.get())
+                        .transition(Transition::new(ramp_ms, TimingFunction::Linear)),
+                ),
         );
         (h, level)
     };
@@ -2485,9 +2494,8 @@ fn hover_flicker_cannot_push_a_shadow_outside_its_damage_rect() {
             // Small enough that the shadow is still growing with the number:
             // past ~12 the blur and the offset are both capped, so a clamp
             // there would have nothing to show for itself.
-            .elevation(0.0)
-            .when_hovered(|s| s.elevation(2.0))
-            .animate_elevation(Transition::spring(pumpable)),
+            .elevation(0.0.transition(Transition::spring(pumpable)))
+            .when_hovered(|s| s.elevation(2.0)),
     );
     h.fit(100.0, 100.0);
     h.paint();

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -1381,6 +1381,38 @@ fn a_transition_on_the_value_is_what_makes_that_value_ease() {
     );
 }
 
+/// A container that declares no motion carries no animation box.
+///
+/// `ContainerAnims` holds eleven `AnimationState`s and is boxed precisely so
+/// that the overwhelming majority of containers — every one that only sets a
+/// background — do not pay for it. Writing the absence of a motion is a real
+/// write, so it has to skip the container that has nothing to write it into,
+/// and nothing else can see the difference: the pixels are identical either
+/// way, which is why this asks the field directly.
+#[test]
+fn declaring_no_motion_allocates_no_animation_box() {
+    assert!(
+        container().background(Color::RED).anims.is_none(),
+        "a plain declaration must not allocate the animation box"
+    );
+    assert!(
+        container()
+            .background(Color::RED.transition(200.0))
+            .anims
+            .is_some(),
+        "and one that declares a motion has somewhere to keep it"
+    );
+    assert!(
+        container()
+            .background(Color::RED.transition(200.0))
+            .background(Color::BLUE)
+            .anims
+            .as_ref()
+            .is_some_and(|a| a.background.is_none()),
+        "restating it plainly empties the slot rather than the box"
+    );
+}
+
 /// A declaration is the whole property, so restating one with a plain value
 /// takes its motion away with it.
 ///

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -1381,6 +1381,52 @@ fn a_transition_on_the_value_is_what_makes_that_value_ease() {
     );
 }
 
+/// And on a padding, which is the one newly-timeline-capable property on the
+/// *layout* path rather than the paint path — so it is where "a sequence
+/// speaks for its property while it plays" has to hold against
+/// `update_size_targets` recomputing the declared value at every layout.
+///
+/// Asserted on the box the padding sizes rather than on a colour: a padding is
+/// not drawn, it is the space a container takes around what it holds.
+#[test]
+fn a_timeline_plays_on_a_padding() {
+    let plays = create_signal(0u32);
+    let rest = Padding::all(0.0);
+    let mut h = H::new(
+        container()
+            .padding(
+                rest.timeline(
+                    Keyframes::new(200.0)
+                        .at(0.0, rest)
+                        .at(0.5, Padding::all(20.0))
+                        .at(1.0, rest),
+                    plays,
+                ),
+            )
+            .child(box_of(20.0, 20.0)),
+    );
+    let at_rest = h.fit(200.0, 200.0);
+    h.paint();
+    assert_eq!(at_rest.width, 20.0, "nothing plays until the trigger moves");
+
+    plays.set(1);
+    let t0 = std::time::Instant::now();
+    frame_at(&mut h, t0, 200.0, 200.0);
+    h.tree
+        .set_frame_instant(Some(t0 + std::time::Duration::from_millis(100)));
+    pump(&mut h);
+    let played = h.fit(200.0, 200.0);
+    h.tree.set_frame_instant(None);
+
+    assert!(
+        played.width > at_rest.width + 5.0,
+        "the sequence has to reach the layout the padding sizes, got {} \
+         against {} at rest",
+        played.width,
+        at_rest.width
+    );
+}
+
 /// A timeline is no longer transform-only: `Keyframes<T>` was always generic
 /// and only the setters were not, so a background can flash where before it
 /// could only be eased to.

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -23,10 +23,10 @@ use std::cell::Cell;
 use std::rc::Rc;
 
 use crate::advance_anim;
-use crate::animation::TransitionConfig;
+use crate::animation::{Animatable, IntoAnimated, Motion};
 use crate::backdrop::BackdropBlur;
 use crate::jobs::{JobRequest, JobType, RequiredJob, request_job};
-use crate::layout::{Constraints, Flex, IntoF32, Layout, Length, Size};
+use crate::layout::{Constraints, Flex, Layout, Length, Size};
 use crate::pivot::Pivot;
 use crate::reactive::{
     IntoSignal, OptionSignalExt, RwSignal, Signal, create_signal, focus_path, with_signal_tracking,
@@ -202,8 +202,8 @@ pub(super) struct TransformProps {
     pub(super) pivot: Option<Signal<Pivot>>,
 }
 
-/// Boxed animation states. Only allocated when `.transition()` or
-/// `.animate_*()` is called, saving ~400 bytes per non-animated Container.
+/// Boxed animation states. Only allocated when a declared value arrives
+/// carrying a motion, saving ~400 bytes per non-animated Container.
 #[derive(Default)]
 pub(super) struct ContainerAnims {
     pub(super) width: Option<AnimationState<f32>>,
@@ -501,11 +501,6 @@ impl Container {
         self.scroll_data.get_or_insert_with(Box::default)
     }
 
-    /// Get or create animation states box
-    fn anims_mut(&mut self) -> &mut ContainerAnims {
-        self.anims.get_or_insert_with(Box::default)
-    }
-
     /// Get or create the transform components.
     fn transform_mut(&mut self) -> &mut TransformProps {
         self.transform.get_or_insert_with(Box::default)
@@ -573,8 +568,9 @@ impl Container {
     /// - `padding([1.0, 2.0, 3.0, 4.0])` — `[top, right, bottom, left]` (CSS 4-value)
     /// - `padding(Padding::all(8.0).with_top(20.0))` — builder pattern
     /// - `padding(signal)` or `padding(move || ...)` — reactive
-    pub fn padding<M>(mut self, value: impl IntoSignal<Padding, M>) -> Self {
-        self.padding = Some(value.into_signal());
+    /// - `padding(8.0.transition(200.0))` — eased instead of jumped to
+    pub fn padding<M>(mut self, value: impl IntoAnimated<Padding, M>) -> Self {
+        self.padding = Some(declare(&mut self.anims, value, |a| &mut a.padding));
         self
     }
 
@@ -588,9 +584,11 @@ impl Container {
     /// ```ignore
     /// container().background(Color::rgb(0.2, 0.2, 0.3))
     /// container().background(Color::rgba(0.0, 0.0, 0.0, 0.5))  // 50% transparent black
+    /// container().background(theme.surface.transition(200.0))  // eased
+    /// container().background(theme.surface.timeline(flash(), errors))
     /// ```
-    pub fn background<M>(mut self, color: impl IntoSignal<Color, M>) -> Self {
-        self.background = Some(color.into_signal());
+    pub fn background<M>(mut self, color: impl IntoAnimated<Color, M>) -> Self {
+        self.background = Some(declare(&mut self.anims, color, |a| &mut a.background));
         self
     }
 
@@ -615,8 +613,14 @@ impl Container {
     /// The shape reaches everything: the box, its border and shadow, the blur
     /// behind it, the clip its children are cut to, and the region that
     /// answers a click.
-    pub fn corners<M>(mut self, corners: impl IntoSignal<crate::widgets::Corners, M>) -> Self {
-        self.corners = Some(corners.into_signal());
+    ///
+    /// A shape that eases carries its own timing —
+    /// `corners(8.0.transition(250.0))`. A transition that crosses zero
+    /// curvature changes family in one frame: below zero a corner is concave,
+    /// and the formula that draws it (and the one that answers a click) is a
+    /// different one. Within a family it is continuous.
+    pub fn corners<M>(mut self, corners: impl IntoAnimated<crate::widgets::Corners, M>) -> Self {
+        self.corners = Some(declare(&mut self.anims, corners, |a| &mut a.corners));
         self
     }
 
@@ -671,13 +675,24 @@ impl Container {
     ///
     /// A width repeated across layers is a constant in your own code — there is
     /// deliberately no way to leave half a border unsaid.
+    ///
+    /// Each half carries its own timing, which is what the pair wanted: the
+    /// two channels are different types and a border can spring open while its
+    /// colour eases.
+    ///
+    /// ```ignore
+    /// container().border(
+    ///     (move || if thick.get() { 14.0 } else { 2.0 }).transition(SpringConfig::BOUNCY),
+    ///     Color::rgb(0.40, 0.50, 0.70).transition(300.0),
+    /// )
+    /// ```
     pub fn border<M1, M2>(
         mut self,
-        width: impl IntoSignal<f32, M1>,
-        color: impl IntoSignal<Color, M2>,
+        width: impl IntoAnimated<f32, M1>,
+        color: impl IntoAnimated<Color, M2>,
     ) -> Self {
-        self.border_width = Some(width.into_signal());
-        self.border_color = Some(color.into_signal());
+        self.border_width = Some(declare(&mut self.anims, width, |a| &mut a.border_width));
+        self.border_color = Some(declare(&mut self.anims, color, |a| &mut a.border_color));
         self
     }
 
@@ -701,14 +716,19 @@ impl Container {
     }
 
     /// Set the width of the container.
-    pub fn width<M>(mut self, width: impl IntoSignal<Length, M>) -> Self {
-        self.width = Some(width.into_signal());
+    ///
+    /// `width(w.transition(200.0))` grows and shrinks over time instead of
+    /// jumping. A size follows the content it holds as well as the length
+    /// declared here, so the animation is over the resolved extent.
+    pub fn width<M>(mut self, width: impl IntoAnimated<Length, M>) -> Self {
+        self.width = Some(declare_size(&mut self.anims, width, |a| &mut a.width));
         self
     }
 
-    /// Set the height of the container.
-    pub fn height<M>(mut self, height: impl IntoSignal<Length, M>) -> Self {
-        self.height = Some(height.into_signal());
+    /// Set the height of the container. Eases the same way
+    /// [`width`](Self::width) does.
+    pub fn height<M>(mut self, height: impl IntoAnimated<Length, M>) -> Self {
+        self.height = Some(declare_size(&mut self.anims, height, |a| &mut a.height));
         self
     }
 
@@ -833,8 +853,10 @@ impl Container {
         self
     }
 
-    pub fn elevation<M>(mut self, level: impl IntoSignal<f32, M>) -> Self {
-        self.elevation = Some(level.into_signal());
+    /// The Material lift, as a shadow. `elevation(8.0.transition(120.0))`
+    /// raises and drops it in motion rather than as a jump.
+    pub fn elevation<M>(mut self, level: impl IntoAnimated<f32, M>) -> Self {
+        self.elevation = Some(declare(&mut self.anims, level, |a| &mut a.elevation));
         self
     }
 
@@ -843,12 +865,19 @@ impl Container {
     /// Paint-only, like the other two: the space the layout gave it does not
     /// move, so nothing around it shifts.
     ///
+    /// The three components move independently: each carries its own timing,
+    /// so a card can spring into place while its rotation eases. Declaring one
+    /// says nothing about the other two.
+    ///
     /// ```ignore
     /// container().translate((20.0, 10.0))
     /// container().translate(move || Translate::new(offset.get(), 0.0))
+    /// container().translate(target.transition(SpringConfig::SNAPPY))
+    /// container().translate(Translate::NONE.timeline(nod(), refusals))
     /// ```
-    pub fn translate<M>(mut self, t: impl IntoSignal<Translate, M>) -> Self {
-        self.transform_mut().translate = Some(t.into_signal());
+    pub fn translate<M>(mut self, t: impl IntoAnimated<Translate, M>) -> Self {
+        let signal = declare(&mut self.anims, t, |a| &mut a.translate);
+        self.transform_mut().translate = Some(signal);
         self
     }
 
@@ -862,9 +891,24 @@ impl Container {
     /// ```ignore
     /// container().rotate(45.0)
     /// container().rotate(move || heading.get())
+    /// container().rotate(0.0.timeline(shake(), rejections))
     /// ```
-    pub fn rotate<M>(mut self, degrees: impl IntoSignal<f32, M>) -> Self {
-        self.transform_mut().rotate = Some(degrees.into_signal());
+    ///
+    /// An eased angle is interpolated as the number it is, so a turn to 360°
+    /// is a full revolution. Nothing takes a shorter way round on the
+    /// container's behalf: an angle that arrives already wrapped — from
+    /// `atan2`, say — wraps the animation with it, and unwrapping it is the
+    /// caller's to do because only the caller knows which way was meant.
+    ///
+    /// A declared `.reverse()` follows the *number*, not the turn, because the
+    /// angle is an `f32` and `f32::is_reverse` means decreasing. So a tilt from
+    /// `0.0` to `-8.0` takes the reverse curve going out and the forward one
+    /// coming home. Where that matters, declare the rest angle as the larger
+    /// number — `8.0` out and `0.0` home — or leave the reverse undeclared and
+    /// use one curve both ways.
+    pub fn rotate<M>(mut self, degrees: impl IntoAnimated<f32, M>) -> Self {
+        let signal = declare(&mut self.anims, degrees, |a| &mut a.rotate);
+        self.transform_mut().rotate = Some(signal);
         self
     }
 
@@ -876,9 +920,12 @@ impl Container {
     /// ```ignore
     /// container().scale(1.5)
     /// container().scale((2.0, 0.5))
+    /// container().scale(open_size.transition(SpringConfig::SNAPPY))
+    /// container().scale(Scale::NONE.timeline(pulse(), beats))
     /// ```
-    pub fn scale<M>(mut self, factor: impl IntoSignal<Scale, M>) -> Self {
-        self.transform_mut().scale = Some(factor.into_signal());
+    pub fn scale<M>(mut self, factor: impl IntoAnimated<Scale, M>) -> Self {
+        let signal = declare(&mut self.anims, factor, |a| &mut a.scale);
+        self.transform_mut().scale = Some(signal);
         self
     }
 
@@ -886,274 +933,6 @@ impl Container {
     /// grows from. The centre of the container by default.
     pub fn pivot<M>(mut self, origin: impl IntoSignal<Pivot, M>) -> Self {
         self.transform_mut().pivot = Some(origin.into_signal());
-        self
-    }
-
-    /// Enable animation for width changes
-    pub fn animate_width(mut self, transition: impl Into<TransitionConfig>) -> Self {
-        let initial = self
-            .width
-            .as_ref()
-            .map(|w| {
-                // Builder time, before the widget exists: a snapshot by nature
-                let len = w.get_untracked();
-                len.exact.or(len.min).unwrap_or(0.0)
-            })
-            .unwrap_or(0.0);
-        self.anims_mut().width = Some(AnimationState::new(initial, transition));
-        self
-    }
-
-    /// Enable animation for height changes
-    pub fn animate_height(mut self, transition: impl Into<TransitionConfig>) -> Self {
-        let initial = self
-            .height
-            .as_ref()
-            .map(|h| {
-                let len = h.get_untracked();
-                len.exact.or(len.min).unwrap_or(0.0)
-            })
-            .unwrap_or(0.0);
-        self.anims_mut().height = Some(AnimationState::new(initial, transition));
-        self
-    }
-
-    /// Enable animation for background color changes
-    pub fn animate_background(mut self, transition: impl Into<TransitionConfig>) -> Self {
-        let initial = self.background.get_or_untracked(Color::TRANSPARENT);
-        self.anims_mut().background = Some(AnimationState::new(initial, transition));
-        self
-    }
-
-    /// Ease the corner *shape* — the four radii and the curvature — instead
-    /// of snapping to it.
-    ///
-    /// A transition that crosses zero curvature changes family in one frame:
-    /// below zero a corner is concave, and the formula that draws it (and the
-    /// one that answers a click) is a different one. Within a family it is
-    /// continuous.
-    pub fn animate_corners(mut self, transition: impl Into<TransitionConfig>) -> Self {
-        let initial = self
-            .corners
-            .get_or_untracked(crate::widgets::Corners::SQUARE);
-        self.anims_mut().corners = Some(AnimationState::new(initial, transition));
-        self
-    }
-
-    /// Enable animation for padding changes
-    pub fn animate_padding(mut self, transition: impl Into<TransitionConfig>) -> Self {
-        let initial = self.padding.get_or_untracked(Padding::default());
-        self.anims_mut().padding = Some(AnimationState::new(initial, transition));
-        self
-    }
-
-    /// Enable animation for border width changes.
-    ///
-    /// Width and colour keep separate `animate_*` declarations even though the
-    /// border is *declared* as a pair: these name an animatable channel, not a
-    /// way to state a value, and the two channels are different types with
-    /// their own curves. `examples/animation_example.rs` springs the width while
-    /// easing the colour, which one call could not express.
-    pub fn animate_border_width(mut self, transition: impl Into<TransitionConfig>) -> Self {
-        let initial = self.border_width.get_or_untracked(0.0);
-        self.anims_mut().border_width = Some(AnimationState::new(initial, transition));
-        self
-    }
-
-    /// Enable animation for border colour changes. See
-    /// [`animate_border_width`](Self::animate_border_width) for why the two
-    /// halves have their own declarations.
-    pub fn animate_border_color(mut self, transition: impl Into<TransitionConfig>) -> Self {
-        let initial = self.border_color.get_or_untracked(Color::TRANSPARENT);
-        self.anims_mut().border_color = Some(AnimationState::new(initial, transition));
-        self
-    }
-
-    /// Animate elevation changes — the Material lift on hover, in motion
-    /// rather than as a jump.
-    pub fn animate_elevation(mut self, transition: impl Into<TransitionConfig>) -> Self {
-        let initial = self.elevation.get_or_untracked(0.0);
-        self.anims_mut().elevation = Some(AnimationState::new(initial, transition));
-        self
-    }
-
-    /// Ease `translate` changes instead of snapping to them.
-    ///
-    /// The three components animate independently: each has its own curve, so
-    /// a card can spring into place while its rotation eases. Declaring one
-    /// says nothing about the other two.
-    pub fn animate_translate(mut self, transition: impl Into<TransitionConfig>) -> Self {
-        let initial = self.translate_signal().get_or_untracked(Translate::NONE);
-        // Whatever sequence is already here comes along: a fresh state would
-        // throw it away, and the order the two builders were written in would
-        // decide whether it exists — silently, with the trigger still firing.
-        let previous = self.anims_mut().translate.take();
-        let mut anim = AnimationState::new(initial, transition);
-        anim.adopt_declarations_of(previous);
-        self.anims_mut().translate = Some(anim);
-        self
-    }
-
-    /// Ease `rotate` changes instead of snapping to them.
-    ///
-    /// The angle is interpolated as the number it is, so a turn to 360° is a
-    /// full revolution and a turn to 720° is two. Nothing takes a shorter way
-    /// round on the container's behalf: an angle that arrives already wrapped
-    /// — from `atan2`, say — wraps the animation with it, and unwrapping it is
-    /// the caller's to do because only the caller knows which way was meant.
-    ///
-    /// A declared `.reverse()` follows the *number*, not the turn, because the
-    /// angle is an `f32` and `f32::is_reverse` means decreasing. So a tilt from
-    /// `0.0` to `-8.0` takes the reverse curve going out and the forward one
-    /// coming home. Where that matters, declare the rest angle as the larger
-    /// number — `8.0` out and `0.0` home — or leave the reverse undeclared and
-    /// use one curve both ways.
-    pub fn animate_rotate(mut self, transition: impl Into<TransitionConfig>) -> Self {
-        let initial = self.rotate_signal().get_or_untracked(0.0);
-        let previous = self.anims_mut().rotate.take();
-        let mut anim = AnimationState::new(initial, transition);
-        anim.adopt_declarations_of(previous);
-        self.anims_mut().rotate = Some(anim);
-        self
-    }
-
-    /// Ease `scale` changes instead of snapping to them.
-    pub fn animate_scale(mut self, transition: impl Into<TransitionConfig>) -> Self {
-        let initial = self.scale_signal().get_or_untracked(Scale::NONE);
-        let previous = self.anims_mut().scale.take();
-        let mut anim = AnimationState::new(initial, transition);
-        anim.adopt_declarations_of(previous);
-        self.anims_mut().scale = Some(anim);
-        self
-    }
-
-    /// Play a sequence of displacements whenever `plays` changes.
-    ///
-    /// The other animations here move *towards* a value; this one has none. It
-    /// plays, and while it plays it replaces whatever `translate` declares,
-    /// handing the property back when it ends — the rule CSS gives an
-    /// animation over a normal declaration.
-    ///
-    /// The trigger is a count and not a flag on purpose: a second refusal has
-    /// to shake as loudly as the first, and a signal that stays equal notifies
-    /// nobody. The count it starts at is whatever it holds when the container
-    /// is built, so nothing plays on the first frame.
-    pub fn keyframes_translate<M>(
-        mut self,
-        keyframes: crate::animation::Keyframes<Translate>,
-        plays: impl IntoSignal<u32, M>,
-    ) -> Self {
-        let initial = self.translate_signal().get_or_untracked(Translate::NONE);
-        let anim = self
-            .anims_mut()
-            .translate
-            .get_or_insert_with(|| AnimationState::new(initial, instant_transition()));
-        anim.set_timeline(keyframes);
-        anim.set_play_trigger(plays.into_signal());
-        self
-    }
-
-    /// Play a sequence of angles whenever `plays` changes — a shake, a wobble,
-    /// a turn that comes back. See
-    /// [`keyframes_translate`](Self::keyframes_translate) for what a timeline
-    /// is and why the trigger counts.
-    ///
-    /// ```ignore
-    /// container().keyframes_rotate(
-    ///     Keyframes::new(320.0)
-    ///         .at(0.0, 0.0)
-    ///         .at(0.2, 1.5)
-    ///         .at(0.5, -1.0)
-    ///         .at(1.0, 0.0),
-    ///     rejections,
-    /// )
-    /// ```
-    pub fn keyframes_rotate<M>(
-        mut self,
-        keyframes: crate::animation::Keyframes<f32>,
-        plays: impl IntoSignal<u32, M>,
-    ) -> Self {
-        let initial = self.rotate_signal().get_or_untracked(0.0);
-        let anim = self
-            .anims_mut()
-            .rotate
-            .get_or_insert_with(|| AnimationState::new(initial, instant_transition()));
-        anim.set_timeline(keyframes);
-        anim.set_play_trigger(plays.into_signal());
-        self
-    }
-
-    /// Play a sequence of scales whenever `plays` changes — a pulse, a bounce.
-    /// See [`keyframes_translate`](Self::keyframes_translate).
-    pub fn keyframes_scale<M>(
-        mut self,
-        keyframes: crate::animation::Keyframes<Scale>,
-        plays: impl IntoSignal<u32, M>,
-    ) -> Self {
-        let initial = self.scale_signal().get_or_untracked(Scale::NONE);
-        let anim = self
-            .anims_mut()
-            .scale
-            .get_or_insert_with(|| AnimationState::new(initial, instant_transition()));
-        anim.set_timeline(keyframes);
-        anim.set_play_trigger(plays.into_signal());
-        self
-    }
-
-    /// Animate `translate` with an ENTER transition: on first layout it
-    /// animates from `enter_from` to its effective value, so the widget
-    /// appears mid-animation — no signal flip, no timer.
-    pub fn animate_translate_from(
-        mut self,
-        enter_from: impl Into<Translate>,
-        transition: impl Into<TransitionConfig>,
-    ) -> Self {
-        let initial = self.translate_signal().get_or_untracked(Translate::NONE);
-        let previous = self.anims_mut().translate.take();
-        let mut anim = AnimationState::new(initial, transition).with_enter_from(enter_from.into());
-        anim.adopt_declarations_of(previous);
-        self.anims_mut().translate = Some(anim);
-        self
-    }
-
-    /// Animate `rotate` with an ENTER transition. See
-    /// [`animate_translate_from`](Self::animate_translate_from).
-    ///
-    /// `IntoF32` rather than `Into<f32>` so that `animate_rotate_from(45, ..)`
-    /// works, the way `animate_scale_from(2, ..)` does through `From<i32> for
-    /// Scale`: there is no `From<i32> for f32`, and an angle written as a bare
-    /// integer is the ordinary case.
-    pub fn animate_rotate_from(
-        mut self,
-        enter_from: impl IntoF32,
-        transition: impl Into<TransitionConfig>,
-    ) -> Self {
-        let enter_from = enter_from.into_f32();
-        let initial = self.rotate_signal().get_or_untracked(0.0);
-        let previous = self.anims_mut().rotate.take();
-        let mut anim = AnimationState::new(initial, transition).with_enter_from(enter_from);
-        anim.adopt_declarations_of(previous);
-        self.anims_mut().rotate = Some(anim);
-        self
-    }
-
-    /// Animate `scale` with an ENTER transition: a menu that scales open
-    /// declares it directly, and `open` can simply start true.
-    ///
-    /// ```ignore
-    /// .scale(move || if open.get() { Scale::NONE } else { Scale::uniform(0.9) })
-    /// .animate_scale_from(0.9, Transition::spring(SpringConfig::SNAPPY))
-    /// ```
-    pub fn animate_scale_from(
-        mut self,
-        enter_from: impl Into<Scale>,
-        transition: impl Into<TransitionConfig>,
-    ) -> Self {
-        let initial = self.scale_signal().get_or_untracked(Scale::NONE);
-        let previous = self.anims_mut().scale.take();
-        let mut anim = AnimationState::new(initial, transition).with_enter_from(enter_from.into());
-        anim.adopt_declarations_of(previous);
-        self.anims_mut().scale = Some(anim);
         self
     }
 
@@ -1311,6 +1090,36 @@ impl Widget for Container {
             });
             let anims = self.anims.as_mut().unwrap();
 
+            // A trigger that has moved starts the sequence, before the frame
+            // that will show its first value. The read is a snapshot: the
+            // subscription belongs to `resync_animation_targets`, which asks
+            // the same question inside its tracking scope.
+            macro_rules! start_timeline {
+                ($field:ident) => {
+                    if let Some(anim) = anims.$field.as_mut()
+                        && anim.take_play()
+                    {
+                        anim.play(now);
+                    }
+                };
+            }
+            // Every property that can carry one, not the three transform
+            // components a timeline used to be limited to. Width and height
+            // are the only pair left out, and they are left out by
+            // construction: they declare a `Length`, and `Keyframes<Length>`
+            // has no constructor.
+            crate::reactive::diagnostics::snapshot_zone(|| {
+                start_timeline!(padding);
+                start_timeline!(border_width);
+                start_timeline!(background);
+                start_timeline!(corners);
+                start_timeline!(elevation);
+                start_timeline!(border_color);
+                start_timeline!(translate);
+                start_timeline!(rotate);
+                start_timeline!(scale);
+            });
+
             // Layout-affecting animations: width, height, padding
             advance_anim!(anims, width, id, any_animating, now, layout);
             advance_anim!(anims, height, id, any_animating, now, layout);
@@ -1363,22 +1172,6 @@ impl Widget for Container {
                 now,
                 paint
             );
-            // A trigger that has moved starts the sequence, before the frame
-            // that will show its first value. The read is a snapshot: the
-            // subscription belongs to `resync_animation_targets`, which asks
-            // the same question inside its tracking scope.
-            macro_rules! start_timeline {
-                ($field:ident) => {
-                    if let Some(anim) = anims.$field.as_mut()
-                        && crate::reactive::diagnostics::snapshot_zone(|| anim.take_play())
-                    {
-                        anim.play(now);
-                    }
-                };
-            }
-            start_timeline!(translate);
-            start_timeline!(rotate);
-            start_timeline!(scale);
             advance_anim!(
                 anims,
                 translate,
@@ -1552,7 +1345,7 @@ impl Widget for Container {
         }
 
         self.update_size_targets(tree, id, &lengths, content_size);
-        self.seed_animations(id, tree.frame_instant());
+        self.seed_animations(id);
 
         let size = self.resolve_size(&lengths, constraints, content_size);
 
@@ -1882,6 +1675,53 @@ impl Widget for Container {
     }
 }
 
+/// Declare an animatable property: keep the value's signal, and install
+/// whatever motion arrived with it.
+///
+/// The animation is seeded from the signal's value at builder time. For every
+/// property but padding and border width that seed is replaced at the first
+/// layout by `seed_animations`, which reads the signal rather than this
+/// snapshot; those two are read there only for their subscription, so their
+/// seed survives into the first advance.
+fn declare<T: Animatable, M>(
+    anims: &mut Option<Box<ContainerAnims>>,
+    value: impl IntoAnimated<T, M>,
+    slot: impl FnOnce(&mut ContainerAnims) -> &mut Option<AnimationState<T>>,
+) -> Signal<T> {
+    let (signal, motion) = value.into_animated().into_parts();
+    if let Some(motion) = motion {
+        let seed = signal.get_untracked();
+        *slot(anims.get_or_insert_with(Box::default)) = Some(match *motion {
+            Motion::Ease(config) => AnimationState::new(seed, config),
+            Motion::Play { keyframes, plays } => {
+                AnimationState::new(seed, instant_transition()).with_timeline(keyframes, plays)
+            }
+        });
+    }
+    signal
+}
+
+/// The same for a width or a height, the one pair whose declared type is not
+/// the type it animates — see [`Animated::into_eased`], which is where that
+/// narrowing is argued.
+///
+/// The seed is where the *first frame* starts, so it reads the declared length
+/// alone. `update_size_targets` recomputes the target from the measured
+/// content at every layout after that, which is why the two formulas differ.
+fn declare_size<M>(
+    anims: &mut Option<Box<ContainerAnims>>,
+    value: impl IntoAnimated<Length, M>,
+    slot: impl FnOnce(&mut ContainerAnims) -> &mut Option<AnimationState<f32>>,
+) -> Signal<Length> {
+    let (signal, ease) = value.into_animated().into_eased();
+    if let Some(config) = ease {
+        let length = signal.get_untracked();
+        let seed = length.exact.or(length.min).unwrap_or(0.0);
+        *slot(anims.get_or_insert_with(Box::default)) = Some(AnimationState::new(seed, config));
+    }
+    signal
+}
+
 pub fn container() -> Container {
     Container::new()
 }
@@ -1889,7 +1729,7 @@ pub fn container() -> Container {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::animation::{TimingFunction, Transition};
+    use crate::animation::{Animate, TimingFunction, Transition};
     use crate::jobs::{self, Job};
     use crate::layout::Constraints;
     use crate::reactive::create_signal;
@@ -1907,15 +1747,16 @@ mod tests {
     #[test]
     fn write_between_first_layout_and_first_paint_starts_animation() {
         let open = create_signal(false);
-        let widget = container()
-            .scale(move || {
+        let widget = container().scale(
+            (move || {
                 if open.get() {
                     Scale::NONE
                 } else {
                     Scale::new(1.0, 0.0)
                 }
             })
-            .animate_scale(Transition::new(200, TimingFunction::EaseOut));
+            .transition(Transition::new(200, TimingFunction::EaseOut)),
+        );
 
         let mut tree = Tree::new();
         let id = tree.register(Box::new(widget));
@@ -1956,56 +1797,15 @@ mod tests {
         );
     }
 
-    /// An enter transition starts animating at first layout — the widget
-    /// appears mid-animation, no signal flip or timer needed.
-    #[test]
-    fn enter_transition_starts_animating_at_first_layout() {
-        use crate::animation::TimingFunction;
-
-        let collapsed = Scale::new(1.0, 0.0);
-        let entering = container()
-            .scale(Scale::NONE)
-            .animate_scale_from(collapsed, Transition::new(200, TimingFunction::EaseOut));
-        let plain = container()
-            .scale(Scale::NONE)
-            .animate_scale(Transition::new(200, TimingFunction::EaseOut));
-
-        let mut tree = Tree::new();
-        let entering_id = tree.register(Box::new(entering));
-        let plain_id = tree.register(Box::new(plain));
-        let c = Constraints::new(0.0, 0.0, 100.0, 100.0);
-        for id in [entering_id, plain_id] {
-            tree.with_widget_mut(id, |w, id, tree| {
-                w.layout(tree, id, c);
-            });
-        }
-
-        let entering_animating = tree
-            .with_widget_mut(entering_id, |w, id, tree| w.advance_animations(tree, id))
-            .unwrap();
-        let plain_animating = tree
-            .with_widget_mut(plain_id, |w, id, tree| w.advance_animations(tree, id))
-            .unwrap();
-        assert!(
-            entering_animating,
-            "enter transition must be in flight right after the first layout"
-        );
-        assert!(
-            !plain_animating,
-            "a plain animation initializes settled at its target"
-        );
-    }
-
     /// Content-sized surfaces measure under the measure-final flag: layout
     /// must report animation TARGETS, not in-flight values, so a growth
     /// animation resizes the surface once instead of once per frame.
     #[test]
     fn measure_final_reads_animation_targets() {
         let height_sig = create_signal(100.0_f32);
-        let widget = container()
-            .width(50.0)
-            .height(move || height_sig.get())
-            .animate_height(Transition::new(200, TimingFunction::EaseOut));
+        let widget = container().width(50.0).height(
+            (move || height_sig.get()).transition(Transition::new(200, TimingFunction::EaseOut)),
+        );
 
         let mut tree = Tree::new();
         let id = tree.register(Box::new(widget));
@@ -2051,8 +1851,7 @@ mod tests {
     fn padding_write_after_first_layout_schedules_animation() {
         let pad = create_signal(4.0_f32);
         let widget = container()
-            .padding(move || pad.get())
-            .animate_padding(Transition::new(200, TimingFunction::EaseOut));
+            .padding((move || pad.get()).transition(Transition::new(200, TimingFunction::EaseOut)));
 
         let mut tree = Tree::new();
         let id = tree.register(Box::new(widget));

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -1678,6 +1678,12 @@ impl Widget for Container {
 /// Declare an animatable property: keep the value's signal, and install
 /// whatever motion arrived with it.
 ///
+/// A declaration is the whole property, so the last one wins outright — value
+/// *and* motion. Restating a property with a plain value takes its animation
+/// away, which is what makes `adopt_declarations_of` unnecessary: there are
+/// never two declarations for one property to reconcile, only the one written
+/// last.
+///
 /// The animation is seeded from the signal's value at builder time. For every
 /// property but padding and border width that seed is replaced at the first
 /// layout by `seed_animations`, which reads the signal rather than this
@@ -1689,16 +1695,34 @@ fn declare<T: Animatable, M>(
     slot: impl FnOnce(&mut ContainerAnims) -> &mut Option<AnimationState<T>>,
 ) -> Signal<T> {
     let (signal, motion) = value.into_animated().into_parts();
-    if let Some(motion) = motion {
+    let installed = motion.map(|motion| {
         let seed = signal.get_untracked();
-        *slot(anims.get_or_insert_with(Box::default)) = Some(match *motion {
+        match *motion {
             Motion::Ease(config) => AnimationState::new(seed, config),
             Motion::Play { keyframes, plays } => {
                 AnimationState::new(seed, instant_transition()).with_timeline(keyframes, plays)
             }
-        });
-    }
+        }
+    });
+    write_slot(anims, slot, installed);
     signal
+}
+
+/// Put an animation, or the absence of one, where the property keeps it.
+///
+/// Nothing into a container that has no animation box is the overwhelmingly
+/// common case — every plain `background(RED)` — so it must not be the thing
+/// that allocates one.
+fn write_slot<T: Animatable>(
+    anims: &mut Option<Box<ContainerAnims>>,
+    slot: impl FnOnce(&mut ContainerAnims) -> &mut Option<AnimationState<T>>,
+    installed: Option<AnimationState<T>>,
+) {
+    match anims.as_deref_mut() {
+        Some(anims) => *slot(anims) = installed,
+        None if installed.is_some() => *slot(anims.get_or_insert_with(Box::default)) = installed,
+        None => {}
+    }
 }
 
 /// The same for a width or a height, the one pair whose declared type is not
@@ -1714,11 +1738,11 @@ fn declare_size<M>(
     slot: impl FnOnce(&mut ContainerAnims) -> &mut Option<AnimationState<f32>>,
 ) -> Signal<Length> {
     let (signal, ease) = value.into_animated().into_eased();
-    if let Some(config) = ease {
+    let installed = ease.map(|config| {
         let length = signal.get_untracked();
-        let seed = length.exact.or(length.min).unwrap_or(0.0);
-        *slot(anims.get_or_insert_with(Box::default)) = Some(AnimationState::new(seed, config));
-    }
+        AnimationState::new(length.exact.or(length.min).unwrap_or(0.0), config)
+    });
+    write_slot(anims, slot, installed);
     signal
 }
 

--- a/src/widgets/diagnostic_audit.rs
+++ b/src/widgets/diagnostic_audit.rs
@@ -19,7 +19,7 @@
 
 #![cfg(debug_assertions)]
 
-use crate::animation::{TimingFunction, Transition};
+use crate::animation::{Animate, TimingFunction, Transition};
 use crate::layout::{Constraints, Flex};
 use crate::reactive::create_signal;
 use crate::reactive::diagnostics::report_count;
@@ -127,18 +127,24 @@ fn a_fully_reactive_container_is_quiet() {
 
     let widget = container()
         .layout(Flex::row().spacing(move || n.get()))
-        .padding(move || n.get())
-        .background(move || if flag.get() { Color::RED } else { Color::BLUE })
-        .border(move || n.get() + 1.0, Color::WHITE)
-        .corners(move || crate::widgets::Corners::superellipse(n.get() + 4.0, n.get() + 1.0))
-        .elevation(move || n.get())
-        .width(move || n.get() + 100.0)
-        .height(move || n.get() + 100.0)
+        .padding((move || n.get()).transition(t()))
+        .background((move || if flag.get() { Color::RED } else { Color::BLUE }).transition(t()))
+        .border(
+            (move || n.get() + 1.0).transition(t()),
+            Color::WHITE.transition(t()),
+        )
+        .corners(
+            (move || crate::widgets::Corners::superellipse(n.get() + 4.0, n.get() + 1.0))
+                .transition(t()),
+        )
+        .elevation((move || n.get()).transition(t()))
+        .width((move || n.get() + 100.0).transition(t()))
+        .height((move || n.get() + 100.0).transition(t()))
         .visible(move || !flag.get())
         // All three, not just the one: each reaches its target through its
         // own signal and its own converting derivation, so a tracking
         // regression in `translate` or `scale` would leave this green.
-        .rotate(move || n.get())
+        .rotate((move || n.get()).transition(t()))
         .translate(move || (n.get(), 0.0))
         .scale(move || n.get())
         .gradient(move || {
@@ -155,15 +161,6 @@ fn a_fully_reactive_container_is_quiet() {
                 Overflow::Visible
             }
         })
-        .animate_background(t())
-        .animate_border_width(t())
-        .animate_border_color(t())
-        .animate_corners(t())
-        .animate_elevation(t())
-        .animate_padding(t())
-        .animate_width(t())
-        .animate_height(t())
-        .animate_rotate(t())
         .when_hovered(|s| s.lighter(0.1))
         .when_pressed(|s| s.ripple())
         .when_focused(|s| s.border(2.0, Color::WHITE))

--- a/src/widgets/state_layer.rs
+++ b/src/widgets/state_layer.rs
@@ -167,6 +167,30 @@ impl StateStyle {
     }
 
     /// Set an explicit background color for this state.
+    ///
+    /// A value, and nothing about time. The motion belongs to the property,
+    /// declared once beside its base value, and a state layer *overrides* a
+    /// property somebody else owns — so a hover already eases under whatever
+    /// the base declared:
+    ///
+    /// ```ignore
+    /// container()
+    ///     .background(base.transition(200.0))    // the property eases
+    ///     .when_hovered(|s| s.background(HOT.transition(900.0)))   // the override changes the value
+    /// ```
+    ///
+    /// Declaring a timing here is a compile error rather than a value quietly
+    /// ignored, which is the whole reason [`Animated`](crate::animation::Animated)
+    /// is not an [`IntoSignal`]:
+    ///
+    /// ```compile_fail
+    /// use guido::prelude::*;
+    ///
+    /// const HOT: Color = Color::rgb(0.9, 0.3, 0.2);
+    /// let _ = container()
+    ///     .background(Color::BLACK)
+    ///     .when_hovered(|s| s.background(HOT.transition(900.0)));
+    /// ```
     pub fn background<M>(mut self, color: impl IntoSignal<Color, M>) -> Self {
         self.background = Some(BackgroundOverride::Exact(color.into_signal()));
         self

--- a/tests/animation_api.rs
+++ b/tests/animation_api.rs
@@ -1,0 +1,71 @@
+//! A timing is never a declaration of its own.
+//!
+//! The seventeen `animate_*` and `keyframes_*` builders that `Container` used
+//! to carry each named a property and said how it moved, two lines away from
+//! where the property's value was set. Nothing checked that the two agreed,
+//! and nothing stopped a timing being declared for a property that was never
+//! set at all. They are gone: a motion now rides with the value, so there is
+//! no way to spell one without naming what it moves.
+//!
+//! This reads the source the way `documentation_references.rs` does, because
+//! the property being asserted is the *absence* of an API — nothing can call
+//! what is not there, so no ordinary test can watch for its return.
+
+use std::path::{Path, PathBuf};
+
+/// `AnimationState::animate_to` retargets a running animation from inside the
+/// advance loop. It is not a builder and names no property: the value it is
+/// given is the one it moves to.
+const NOT_A_DECLARATION: &[&str] = &["animate_to"];
+
+fn rust_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            rust_files(&path, out);
+        } else if path.extension().is_some_and(|e| e == "rs") {
+            out.push(path);
+        }
+    }
+}
+
+/// The name a `pub fn` line declares, if the line declares one.
+fn public_fn_name(line: &str) -> Option<&str> {
+    let rest = line.trim().strip_prefix("pub fn ")?;
+    let end = rest.find(|c: char| !c.is_alphanumeric() && c != '_')?;
+    Some(&rest[..end])
+}
+
+#[test]
+fn no_public_builder_declares_a_timing_beside_its_property() {
+    let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut files = Vec::new();
+    rust_files(&src, &mut files);
+
+    let mut found: Vec<String> = Vec::new();
+    for file in &files {
+        let text = std::fs::read_to_string(file).expect("a source file this crate owns");
+        for line in text.lines() {
+            let Some(name) = public_fn_name(line) else {
+                continue;
+            };
+            if (name.starts_with("animate_") || name.starts_with("keyframes_"))
+                && !NOT_A_DECLARATION.contains(&name)
+            {
+                let shown = file.strip_prefix(&src).unwrap_or(file).display();
+                found.push(format!("{shown}: {name}"));
+            }
+        }
+    }
+    found.sort();
+
+    assert!(
+        found.is_empty(),
+        "a motion rides with the value it moves, so no builder names a \
+         property and a timing apart. Found:\n  {}",
+        found.join("\n  ")
+    );
+}

--- a/tests/animation_api.rs
+++ b/tests/animation_api.rs
@@ -13,10 +13,12 @@
 
 use std::path::{Path, PathBuf};
 
-/// `AnimationState::animate_to` retargets a running animation from inside the
-/// advance loop. It is not a builder and names no property: the value it is
-/// given is the one it moves to.
-const NOT_A_DECLARATION: &[&str] = &["animate_to"];
+/// The one `pub fn animate_*` that is not a declaration, named with the file it
+/// lives in so that the exemption does not quietly cover a second one
+/// somewhere else: `AnimationState::animate_to` retargets a running animation
+/// from inside the advance loop, and the value it is given is the one it moves
+/// to.
+const NOT_A_DECLARATION: &[(&str, &str)] = &[("widgets/container/animations.rs", "animate_to")];
 
 fn rust_files(dir: &Path, out: &mut Vec<PathBuf>) {
     let Ok(entries) = std::fs::read_dir(dir) else {
@@ -52,12 +54,18 @@ fn no_public_builder_declares_a_timing_beside_its_property() {
             let Some(name) = public_fn_name(line) else {
                 continue;
             };
-            if (name.starts_with("animate_") || name.starts_with("keyframes_"))
-                && !NOT_A_DECLARATION.contains(&name)
-            {
-                let shown = file.strip_prefix(&src).unwrap_or(file).display();
-                found.push(format!("{shown}: {name}"));
+            if !name.starts_with("animate_") && !name.starts_with("keyframes_") {
+                continue;
             }
+            let shown = file
+                .strip_prefix(&src)
+                .unwrap_or(file)
+                .display()
+                .to_string();
+            if NOT_A_DECLARATION.contains(&(shown.as_str(), name)) {
+                continue;
+            }
+            found.push(format!("{shown}: {name}"));
         }
     }
     found.sort();


### PR DESCRIPTION
## What changed

`Container` no longer carries seventeen setters that name a property and a
timing two lines away from where the property's value was set. A motion now
rides with the value: `.background(theme.surface.transition(200.0))`,
`.rotate(0.0.timeline(shake(), rejections))`. `.transition(..)` and
`.timeline(..)` hang off `IntoSignal`, so a value, a closure and a signal all
take them, and the animatable setters take a wider `IntoAnimated` bound.
`Animated<T>` is deliberately **not** an `IntoSignal`, which is what makes a
timing on a state-layer override a compile error rather than a value quietly
ignored — a layer supplies a value for a property somebody else declared, so it
has no timing to give. A timeline is no longer transform-only: `Keyframes<T>`
was always generic and only the setters were not, so a background can flash
where before it could only be eased to. A bare number is milliseconds, eased
out — `Transition::default()` is a spring and has no duration for the number to
attach to, so the shorthand names `EaseOut`, the curve this codebase reaches
for by better than two to one. Closes #215.

## What proves it

Six tests that could not be written before, each confirmed red before the
change and green after:

- `characterization::a_transition_on_the_value_is_what_makes_that_value_ease` —
  two boxes differing in nothing but whether the colour they are handed carries
  a transition, on one write to the one signal both read. One is at the new
  value on the next paint; the other is still on its way.
- `characterization::a_timeline_plays_on_a_background` — a `Keyframes<Color>`
  played by a trigger, asserted on the painted colour across frames. Red until
  `advance_animations` started a sequence on more than the three transform
  components.
- `characterization::a_timeline_plays_on_a_padding` — the same for the one
  newly-capable property on the *layout* path, where a sequence meets
  `update_size_targets` recomputing the declared value every layout. Red
  without `start_timeline!(padding)`.
- `characterization::restating_a_property_plainly_takes_its_motion_with_it` —
  `.background(c.transition(..)).background(c)` leaves no animation behind. Red
  before the last commit, which is where that stopped being only a claim.
- `StateStyle::background`'s `compile_fail` doctest — `when_hovered(|s|
  s.background(HOT.transition(900.0)))`. Confirmed it fails *because of* the
  timing: with `.transition(900.0)` removed the snippet compiles and the
  doctest reports "test did not panic as expected".
- `tests/animation_api.rs`, which asserts the absence — nothing can call a
  builder that is not there, so it reads `src/` the way
  `documentation_references.rs` does. Red on `main` with all seventeen names
  listed.

Goldens: run here against lavapipe, 9 passed, none moved. Expected — the change
is to the declaration surface, not the renderer; what a container paints once
an animation reaches a value is untouched, and the render-tree and
characterization tests are what watch the values getting there.

`cargo test --all-features`, `clippy --all-targets --all-features -D warnings`,
`mdbook test`, `mdbook build` and `cargo doc -D warnings` all green.

## What the review found

The `reviewer` subagent ran over the commits before this pull request existed.
**Zero blocking.** Six findings worth answering, all acted on:

- *Six of the nine newly-timeline-capable properties have no test.*
  `a_timeline_plays_on_a_padding` covers the one that could plausibly behave
  differently — the only one on the layout path. The other five sit on the same
  paint path as `background`, which is covered.
- *`into_eased` silently dropped a timeline behind a comment asserting it could
  not happen.* That arm panics now. What makes it unreachable is a bound three
  types away (`timeline` needs `T: Animatable`; a `Length` is not one), and a
  silent `None` there is the very defect this shape removes.
- *`declare` did not clear the animation when a property was restated plainly*,
  so the sentence that justified deleting `adopt_declarations_of` — and the
  same sentence in the book — was not the behaviour. Fixed in 4de8893, with the
  test above.
- *The book's twin of the "what is not reactive" paragraph was left stale.*
  `docs/STYLING.md` was rewritten and `book/src/building-ui/styling.md` was
  not; `documentation_references.rs` cannot see it because `animate_*` has a
  star in it and does not parse as an identifier. Both say the same thing now.
- *`.claude/skills/widgets/SKILL.md` still taught `impl IntoSignal<T, M>` as
  the bound every painted property takes, and listed `animate_*` as
  structural.* It is the file the next agent reads before adding a property
  setter, so a wrong bound there reproduces itself. It now carries the
  `IntoAnimated` bound, the three rules the shape depends on, and the four
  lists a new animatable property has to join.
- *The goldens were not verified in the reviewer's environment* — it had no
  lavapipe. Run here; see above.

Notes not acted on: `tests/animation_api.rs` duplicates a directory walker from
`documentation_references.rs`, which the two test binaries cannot share without
a `tests/common/` this repo does not have; and `Plain<M>`, the `#[doc(hidden)]`
marker wrapper, appears in the headline of a wrong-type error — unavoidable
given the coherence constraint it exists for, and the useful line follows it.

Two things about shape the review raised and I am answering rather than
changing. The first commit is 34 files: the API change, its call sites, the
examples and the documentation cannot be split without a red intermediate —
`documentation_references.rs` fails the moment the setters go and the book still
names them. Both of the first two commits are green in isolation; I checked.
And `tests/animation_api.rs` landed in the commit after the change rather than
before it — it was written and confirmed red first, against `main`, which is
what the rule is for; the commit order is what keeps each commit green.

**The mutation job reports nine survivors, and eight of them are the shape this
change inherited.** The ninth was `write_slot`'s guard — replaceable with
`true`, with every test still passing, because the only difference is that a
container declaring no motion allocates the animation box anyway. Closed with a
test that asks the field, since no pixel can see it. The other eight are the
per-property `drift |=` accumulators in `resync_animation_targets`, which stand
exactly as they did before this change: a mutated one is invisible because the
Animation job reaches the container by a second route as well, through the
subscription paint establishes. Nine tests for a redundant path is not the
trade. Per `AGENTS.md` that job reports and does not block.

## What was checked by hand

Nothing. The harness covers all of it: this change alters how a timing is
declared, not what the compositor is asked for, and no Wayland protocol
behaviour is touched.

## Left undone

**Enter transitions.** `animate_translate_from`, `animate_rotate_from` and
`animate_scale_from` are removed with no replacement. They were a different
idea wearing the same prefix — a one-shot at birth with a start value, not
"ease to the new value" — and they were transform-only, which is the complaint
#215 opens with. #303 tracks bringing them back as one mechanism that works for
every animatable property.

**A property carries one motion.** A value is declared either with a
transition or with a timeline; a second declaration of the same property
replaces the whole thing, value and motion. That was the point — it is what
lets `adopt_declarations_of` go — but it means a timeline and a resting
transition on the *same* component can no longer be combined. In practice they
go on two components, which is what `examples/keyframes_example.rs` already
did.

**The four parallel per-property lists** — `ContainerAnims`'s fields,
`start_timeline!`, the drift block in `resync_animation_targets`, and the
`advance_anim!` block — went from naming three transform components to naming
nine properties. Nothing enforces that they agree, so a tenth animatable
property added later gets no timeline and no wake unless its author finds all
four. The `widgets` skill now says so; collapsing them needs a macro over the
field list, which is a refactor of the advance loop and explicitly a non-goal
of #215.

**`.transition(..)` is offered on types no setter accepts.** `Animate` is
blanket-implemented over every `IntoSignal`, so `some_bool.transition(200.0)`
compiles and produces a value with nowhere to go; the error lands on the setter
rather than on the call that was wrong. Narrowing the bound to `Animatable` is
what `width` and `height` rule out, since they declare a `Length`. It is the
same deliberate gap #302 leaves for `text(..).color(x.transition(..))`, and it
is noise rather than a wrong result, so it stays as it is.