### PR TITLE
A collapsed subtree has no position, and every hit test below it says so

### DIFF
--- a/book/src/architecture/events.md
+++ b/book/src/architecture/events.md
@@ -161,10 +161,15 @@ container()
 ```
 
 The event still *travels*. A press given up and a hover cleared are things only
-a delivered event can do, so a button inside a menu that collapses mid-press
-hears the release and lets the press go — it simply has nowhere to have been
-released. A key or a focus change is untouched, having never had a position to
-lose.
+a delivered event can do, so a container inside a menu that collapses mid-press
+hears the release and drops its own pressed state — the state layer stops
+painting, the ripple is cancelled. What it does *not* do is call `on_click` or
+`on_mouse_up`: those say where the release landed, and it landed nowhere. An
+application pairing `on_mouse_down` with `on_mouse_up` to track a press of its
+own should expect the down without the up, and clear on the same signal that
+collapsed the box.
+
+A key or a focus change is untouched, having never had a position to lose.
 
 ## Event Handlers
 

--- a/book/src/architecture/events.md
+++ b/book/src/architecture/events.md
@@ -18,8 +18,8 @@ Wayland → Platform → App → Widget Tree
 ### Mouse Movement
 
 ```text
-Event::MouseMove { x, y };
-Event::MouseEnter;
+Event::MouseMove { at };
+Event::MouseEnter { at };
 Event::MouseLeave
 ```
 
@@ -28,8 +28,8 @@ Tracked for hover states. The platform layer determines which widget the cursor 
 ### Mouse Buttons
 
 ```text
-Event::MouseDown { x, y, button };
-Event::MouseUp { x, y, button }
+Event::MouseDown { at, button };
+Event::MouseUp { at, button }
 ```
 
 Used for click detection and pressed states.
@@ -37,11 +37,11 @@ Used for click detection and pressed states.
 ### Scrolling
 
 ```text
-Event::Scroll { x, y, delta_x, delta_y, source };
-Event::ScrollEnd { x, y }
+Event::Scroll { at, delta_x, delta_y, source };
+Event::ScrollEnd { at }
 ```
 
-- `x`, `y` - Pointer position
+- `at` - Pointer position, or `None`: see [Where an event is](#where-an-event-is)
 - `delta_x` - Horizontal scroll amount, in pixels
 - `delta_y` - Vertical scroll amount, in pixels
 - `source` - `Wheel`, `Finger` or `Continuous`
@@ -125,14 +125,46 @@ dist <= 0.0  // Inside if distance is negative
 
 ### With Transforms
 
-Inverse transform applied to test point:
+The transform is undone before the point is compared against the laid-out
+bounds — and a transform that has collapsed the widget onto a line has no
+inverse to undo it with:
 
 ```rust,ignore
-fn contains_transformed(&self, x: f32, y: f32) -> bool {
-    let (local_x, local_y) = self.transform.inverse().transform_point(x, y);
-    self.bounds.contains(local_x, local_y)
+fn contains(&self, at: Option<Point>) -> bool {
+    // `untransform_point` answers None where the transform has no inverse,
+    // and `contains_at` answers false for a point that is not there.
+    self.bounds.contains_at(untransform_point(&self.transform, at))
 }
 ```
+
+## Where an event is
+
+A pointer event carries `at: Option<Point>`, and the `None` is the interesting
+half. It means one of two things, and a consumer wants the same answer from
+both: a keyboard or focus event never had a position, and a pointer event that
+descended into a subtree scaled to nothing has *lost* the one it had.
+
+`scale(0.0)` squashes the plane onto a line. The map stops being one-to-one —
+every point in the box lands on top of every other — so there is no inverse,
+and no coordinate that could stand for "nowhere": every number is somewhere,
+and a descendant that rotates or mirrors would carry a far-away sentinel back
+into the visible half-plane.
+
+So the position is simply absent, and every bounds test below answers no:
+
+```rust,ignore
+container()
+    .width(80.0)
+    .height(40.0)
+    .scale(Scale::new(1.0, 0.0))   // collapsed: takes no click, hover or scroll
+    .on_click(|| unreachable!())
+```
+
+The event still *travels*. A press given up and a hover cleared are things only
+a delivered event can do, so a button inside a menu that collapses mid-press
+hears the release and lets the press go — it simply has nowhere to have been
+released. A key or a focus change is untouched, having never had a position to
+lose.
 
 ## Event Handlers
 
@@ -172,12 +204,12 @@ The state layer system uses events internally:
 ```rust,ignore
 fn event(&mut self, tree: &mut Tree, id: WidgetId, event: &Event) -> EventResponse {
     match event {
-        Event::MouseEnter => {
+        Event::MouseEnter { .. } => {
             self.flags.update(|f| f.insert(InteractionFlags::HOVERED));
         }
-        Event::MouseDown { x, y, .. } => {
+        Event::MouseDown { at: Some(at), .. } => {
             self.flags.update(|f| f.insert(InteractionFlags::PRESSED));
-            self.ripple.start(*x, *y, Instant::now());
+            self.ripple.start(at.x, at.y, Instant::now());
         }
         // ...
     }
@@ -211,7 +243,7 @@ The platform layer receives Wayland protocol events:
 fn pointer_motion(x: f32, y: f32) {
     self.cursor_x = x;
     self.cursor_y = y;
-    self.dispatch(Event::MouseMove { x, y });
+    self.dispatch(Event::MouseMove { at: Some(Point::new(x, y)) });
 }
 
 fn pointer_button(button: u32, state: ButtonState) {

--- a/book/src/architecture/overview.md
+++ b/book/src/architecture/overview.md
@@ -101,7 +101,7 @@ container().translate((x, y));
 container().rotate(deg);
 container().scale(s);
 t1.then(&t2);  // Composition
-t.inverse()   // Inversion
+t.inverse()   // Inversion, or None where it collapsed
 ```
 
 ### `pivot.rs` - Pivot Points

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -247,7 +247,7 @@ container().scale((sx, sy))     // Non-uniform scale
 // What they compose into. `Transform` is not in `guido::prelude`; a widget
 // written outside the crate reaches it through `guido::widget_prelude`:
 t1.then(&t2)                    // Compose transforms
-t.inverse()                     // Invert transform
+t.inverse()                     // Invert, or None where it collapsed
 t.center_at(cx, cy)             // Apply around point
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,9 +191,9 @@ pub mod prelude {
         AnyWidget, Border, Color, Container, ContentFit, Control, CornerRadii, Corners, Event,
         EventResponse, FontFamily, FontWeight, GradientDirection, Image, ImageSource, InputStyle,
         InputStyled, IntoChildren, IntoClickHandler, Key, LinearGradient, Modifiers, MouseButton,
-        Overflow, Padding, Rect, ScrollAxis, ScrollSource, ScrollbarBuilder, ScrollbarVisibility,
-        Selection, StateStyle, Stateful, Text, TextInput, TextShadow, TextStroke, TextStyle,
-        TextStyled, Widget, container, image, keyed, text, text_input,
+        Overflow, Padding, Point, Rect, ScrollAxis, ScrollSource, ScrollbarBuilder,
+        ScrollbarVisibility, Selection, StateStyle, Stateful, Text, TextInput, TextShadow,
+        TextStroke, TextStyle, TextStyled, Widget, container, image, keyed, text, text_input,
     };
     pub use crate::{
         App, ExitReason, SignalFields, component, default_font_family, load_font, quit_app,
@@ -2748,7 +2748,12 @@ mod dispatch_declares_the_moment {
         // An hour ago: no clock this process could read would answer with it,
         // so the widget can only have got it from the event.
         let happened = std::time::Instant::now() - std::time::Duration::from_secs(3600);
-        let events = [(happened, Event::MouseMove { x: 10.0, y: 10.0 })];
+        let events = [(
+            happened,
+            Event::MouseMove {
+                at: Some(crate::widgets::Point::new(10.0, 10.0)),
+            },
+        )];
 
         dispatch_events(&events, root, &mut tree, &Default::default());
 

--- a/src/platform/input.rs
+++ b/src/platform/input.rs
@@ -44,13 +44,8 @@ const SCROLL_PIXELS_PER_LINE: f32 = 40.0;
 /// costs a full event-dispatch walk of the widget tree. The coalesced one keeps
 /// the newest instant: it stands for where the pointer is now, not for where it
 /// was when the run began.
-fn push_move(events: &mut Vec<(Instant, Event)>, at: Instant, x: f32, y: f32) {
-    let moved = (
-        at,
-        Event::MouseMove {
-            at: Some(Point::new(x, y)),
-        },
-    );
+fn push_move(events: &mut Vec<(Instant, Event)>, at: Instant, pointer: Point) {
+    let moved = (at, Event::MouseMove { at: Some(pointer) });
     if let Some(last @ (_, Event::MouseMove { .. })) = events.last_mut() {
         *last = moved;
     } else {
@@ -60,11 +55,11 @@ fn push_move(events: &mut Vec<(Instant, Event)>, at: Instant, x: f32, y: f32) {
 
 /// The finger is gone: release the synthesized press, and clear hover, because
 /// unlike a real pointer nothing hovers after a lift.
-fn push_release(events: &mut Vec<(Instant, Event)>, at: Instant, x: f32, y: f32) {
+fn push_release(events: &mut Vec<(Instant, Event)>, at: Instant, pointer: Point) {
     events.push((
         at,
         Event::MouseUp {
-            at: Some(Point::new(x, y)),
+            at: Some(pointer),
             button: MouseButton::Left,
         },
     ));
@@ -147,8 +142,11 @@ impl EventClock {
 pub struct InputState {
     // Pointer
     pub(super) pointer: Option<wl_pointer::WlPointer>,
-    pub(super) pointer_x: f32,
-    pub(super) pointer_y: f32,
+    /// Where the pointer is. One field rather than two coordinates, because
+    /// every use of it is a [`Point`] — an `Event` carries an `Option<Point>`,
+    /// and re-pairing two floats at each construction site is how one of them
+    /// comes to be the wrong one.
+    pub(super) pointer_at: Point,
     pub(super) pointer_over_surface: bool,
     pub(super) pointer_enter_serial: u32,
 
@@ -192,8 +190,7 @@ impl InputState {
     ) -> Self {
         Self {
             pointer: None,
-            pointer_x: 0.0,
-            pointer_y: 0.0,
+            pointer_at: Point::new(0.0, 0.0),
             pointer_over_surface: false,
             pointer_enter_serial: 0,
             touch: None,
@@ -374,19 +371,12 @@ impl TouchHandler for WaylandState {
         if self.input.primary_finger.is_none() {
             self.input.primary_finger = Some(id);
             if let Some(surface_state) = self.surfaces.get_mut(&surface_id) {
-                surface_state.pending_events.push((
-                    at,
-                    Event::MouseMove {
-                        at: Some(Point::new(x, y)),
-                    },
-                ));
-                surface_state.pending_events.push((
-                    at,
-                    Event::MouseDown {
-                        at: Some(Point::new(x, y)),
-                        button: MouseButton::Left,
-                    },
-                ));
+                surface_state
+                    .pending_events
+                    .push((at, Event::mouse_move(x, y)));
+                surface_state
+                    .pending_events
+                    .push((at, Event::mouse_down(x, y, MouseButton::Left)));
             }
         }
     }
@@ -407,7 +397,7 @@ impl TouchHandler for WaylandState {
         if self.input.primary_finger == Some(id) {
             self.input.primary_finger = None;
             if let Some(surface_state) = self.surfaces.get_mut(&surface_id) {
-                push_release(&mut surface_state.pending_events, at, x, y);
+                push_release(&mut surface_state.pending_events, at, Point::new(x, y));
             }
         }
     }
@@ -433,7 +423,7 @@ impl TouchHandler for WaylandState {
         if self.input.primary_finger == Some(id)
             && let Some(surface_state) = self.surfaces.get_mut(&surface_id)
         {
-            push_move(&mut surface_state.pending_events, at, x, y);
+            push_move(&mut surface_state.pending_events, at, Point::new(x, y));
         }
     }
 
@@ -467,7 +457,7 @@ impl TouchHandler for WaylandState {
         {
             // The compositor is telling us the gesture is not ours any more.
             let at = untimed();
-            push_release(&mut surface_state.pending_events, at, x, y);
+            push_release(&mut surface_state.pending_events, at, Point::new(x, y));
         }
         self.input.touch_fingers.clear();
     }
@@ -511,8 +501,8 @@ impl PointerHandler for WaylandState {
                     self.input.pointer_over_surface = true;
                     self.input.pointer_enter_serial = serial;
                     self.input.latest_input_serial = serial;
-                    self.input.pointer_x = event.position.0 as f32;
-                    self.input.pointer_y = event.position.1 as f32;
+                    self.input.pointer_at =
+                        Point::new(event.position.0 as f32, event.position.1 as f32);
 
                     // Track which surface has pointer focus
                     self.current_pointer_surface = surface_id;
@@ -521,13 +511,13 @@ impl PointerHandler for WaylandState {
                         events.push((
                             at,
                             Event::MouseEnter {
-                                at: Some(Point::new(self.input.pointer_x, self.input.pointer_y)),
+                                at: Some(self.input.pointer_at),
                             },
                         ));
                         events.push((
                             at,
                             Event::MouseMove {
-                                at: Some(Point::new(self.input.pointer_x, self.input.pointer_y)),
+                                at: Some(self.input.pointer_at),
                             },
                         ));
                     }
@@ -547,10 +537,10 @@ impl PointerHandler for WaylandState {
                     }
                 }
                 PointerEventKind::Motion { .. } => {
-                    self.input.pointer_x = event.position.0 as f32;
-                    self.input.pointer_y = event.position.1 as f32;
+                    self.input.pointer_at =
+                        Point::new(event.position.0 as f32, event.position.1 as f32);
                     if let Some(events) = target_events {
-                        push_move(events, at, self.input.pointer_x, self.input.pointer_y);
+                        push_move(events, at, self.input.pointer_at);
                     }
                 }
                 PointerEventKind::Press { button, serial, .. } => {
@@ -561,7 +551,7 @@ impl PointerHandler for WaylandState {
                         events.push((
                             at,
                             Event::MouseDown {
-                                at: Some(Point::new(self.input.pointer_x, self.input.pointer_y)),
+                                at: Some(self.input.pointer_at),
                                 button: mouse_button,
                             },
                         ));
@@ -574,7 +564,7 @@ impl PointerHandler for WaylandState {
                         events.push((
                             at,
                             Event::MouseUp {
-                                at: Some(Point::new(self.input.pointer_x, self.input.pointer_y)),
+                                at: Some(self.input.pointer_at),
                                 button: mouse_button,
                             },
                         ));
@@ -593,8 +583,7 @@ impl PointerHandler for WaylandState {
                             source,
                             &horizontal,
                             &vertical,
-                            self.input.pointer_x,
-                            self.input.pointer_y,
+                            self.input.pointer_at,
                         );
                     }
                 }
@@ -614,8 +603,7 @@ fn translate_axis(
     source: Option<wl_pointer::AxisSource>,
     horizontal: &AxisScroll,
     vertical: &AxisScroll,
-    x: f32,
-    y: f32,
+    pointer: Point,
 ) {
     let scroll_source = match source {
         Some(wl_pointer::AxisSource::Wheel) => ScrollSource::Wheel,
@@ -654,7 +642,7 @@ fn translate_axis(
         events.push((
             at,
             Event::Scroll {
-                at: Some(Point::new(x, y)),
+                at: Some(pointer),
                 delta_x,
                 delta_y,
                 source: scroll_source,
@@ -662,12 +650,7 @@ fn translate_axis(
         ));
     }
     if horizontal.stop || vertical.stop {
-        events.push((
-            at,
-            Event::ScrollEnd {
-                at: Some(Point::new(x, y)),
-            },
-        ));
+        events.push((at, Event::ScrollEnd { at: Some(pointer) }));
     }
 }
 
@@ -1030,8 +1013,7 @@ mod tests {
             source,
             &horizontal,
             &vertical,
-            PX,
-            PY,
+            Point::new(PX, PY),
         );
         events.into_iter().map(|(_, event)| event).collect()
     }

--- a/src/platform/input.rs
+++ b/src/platform/input.rs
@@ -33,7 +33,7 @@ use smithay_client_toolkit::reexports::protocols::wp::cursor_shape::v1::client::
 use super::wayland::WaylandState;
 use crate::reactive::CursorIcon;
 use crate::surface::SurfaceId;
-use crate::widgets::{Event, Key, Modifiers, MouseButton, ScrollSource};
+use crate::widgets::{Event, Key, Modifiers, MouseButton, Point, ScrollSource};
 
 /// Pixels per line for discrete scroll (mouse wheel)
 const SCROLL_PIXELS_PER_LINE: f32 = 40.0;
@@ -45,10 +45,16 @@ const SCROLL_PIXELS_PER_LINE: f32 = 40.0;
 /// the newest instant: it stands for where the pointer is now, not for where it
 /// was when the run began.
 fn push_move(events: &mut Vec<(Instant, Event)>, at: Instant, x: f32, y: f32) {
+    let moved = (
+        at,
+        Event::MouseMove {
+            at: Some(Point::new(x, y)),
+        },
+    );
     if let Some(last @ (_, Event::MouseMove { .. })) = events.last_mut() {
-        *last = (at, Event::MouseMove { x, y });
+        *last = moved;
     } else {
-        events.push((at, Event::MouseMove { x, y }));
+        events.push(moved);
     }
 }
 
@@ -58,8 +64,7 @@ fn push_release(events: &mut Vec<(Instant, Event)>, at: Instant, x: f32, y: f32)
     events.push((
         at,
         Event::MouseUp {
-            x,
-            y,
+            at: Some(Point::new(x, y)),
             button: MouseButton::Left,
         },
     ));
@@ -369,14 +374,16 @@ impl TouchHandler for WaylandState {
         if self.input.primary_finger.is_none() {
             self.input.primary_finger = Some(id);
             if let Some(surface_state) = self.surfaces.get_mut(&surface_id) {
-                surface_state
-                    .pending_events
-                    .push((at, Event::MouseMove { x, y }));
+                surface_state.pending_events.push((
+                    at,
+                    Event::MouseMove {
+                        at: Some(Point::new(x, y)),
+                    },
+                ));
                 surface_state.pending_events.push((
                     at,
                     Event::MouseDown {
-                        x,
-                        y,
+                        at: Some(Point::new(x, y)),
                         button: MouseButton::Left,
                     },
                 ));
@@ -514,15 +521,13 @@ impl PointerHandler for WaylandState {
                         events.push((
                             at,
                             Event::MouseEnter {
-                                x: self.input.pointer_x,
-                                y: self.input.pointer_y,
+                                at: Some(Point::new(self.input.pointer_x, self.input.pointer_y)),
                             },
                         ));
                         events.push((
                             at,
                             Event::MouseMove {
-                                x: self.input.pointer_x,
-                                y: self.input.pointer_y,
+                                at: Some(Point::new(self.input.pointer_x, self.input.pointer_y)),
                             },
                         ));
                     }
@@ -556,8 +561,7 @@ impl PointerHandler for WaylandState {
                         events.push((
                             at,
                             Event::MouseDown {
-                                x: self.input.pointer_x,
-                                y: self.input.pointer_y,
+                                at: Some(Point::new(self.input.pointer_x, self.input.pointer_y)),
                                 button: mouse_button,
                             },
                         ));
@@ -570,8 +574,7 @@ impl PointerHandler for WaylandState {
                         events.push((
                             at,
                             Event::MouseUp {
-                                x: self.input.pointer_x,
-                                y: self.input.pointer_y,
+                                at: Some(Point::new(self.input.pointer_x, self.input.pointer_y)),
                                 button: mouse_button,
                             },
                         ));
@@ -651,8 +654,7 @@ fn translate_axis(
         events.push((
             at,
             Event::Scroll {
-                x,
-                y,
+                at: Some(Point::new(x, y)),
                 delta_x,
                 delta_y,
                 source: scroll_source,
@@ -660,7 +662,12 @@ fn translate_axis(
         ));
     }
     if horizontal.stop || vertical.stop {
-        events.push((at, Event::ScrollEnd { x, y }));
+        events.push((
+            at,
+            Event::ScrollEnd {
+                at: Some(Point::new(x, y)),
+            },
+        ));
     }
 }
 
@@ -1061,10 +1068,14 @@ mod tests {
     fn a_stop_with_no_delta_is_an_end_and_nothing_else() {
         let events = axis(Some(wl_pointer::AxisSource::Finger), nothing(), stopped());
         assert_eq!(events.len(), 1, "one event, got {events:?}");
-        let Event::ScrollEnd { x, y } = events[0] else {
+        let Event::ScrollEnd { at } = events[0] else {
             panic!("a stop is a ScrollEnd, got {:?}", events[0]);
         };
-        assert_eq!((x, y), (PX, PY), "and it carries the pointer, not a delta");
+        assert_eq!(
+            at,
+            Some(Point::new(PX, PY)),
+            "and it carries the pointer, not a delta"
+        );
 
         // Either axis alone says it: a vertical gesture ends on the vertical
         // axis, a horizontal one on the horizontal.
@@ -1126,8 +1137,7 @@ mod tests {
         let events = axis(Some(wl_pointer::AxisSource::Finger), nothing(), finger(7.5));
         let [
             Event::Scroll {
-                x,
-                y,
+                at,
                 delta_y,
                 source,
                 ..
@@ -1138,9 +1148,9 @@ mod tests {
         };
         assert_eq!(*delta_y, 7.5, "pixels pass through");
         assert_eq!(*source, ScrollSource::Finger);
-        // Where the scroll happened, not how far it went: `hit.contains(x, y)`
+        // Where the scroll happened, not how far it went: `hit.contains(at)`
         // in `interaction.rs` is what decides whose scroll this is.
-        assert_eq!((*x, *y), (PX, PY), "and it carries the pointer");
+        assert_eq!(*at, Some(Point::new(PX, PY)), "and it carries the pointer");
     }
 
     /// The last message of a flick carries both: the final movement and the

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -30,7 +30,7 @@ use crate::renderer::{GpuContext, RenderTarget, Renderer};
 use crate::surface::{SurfaceConfig, SurfaceId};
 use crate::surface_manager::{ManagedSurface, SurfaceManager};
 use crate::tree::{Tree, WidgetId};
-use crate::widgets::{Event, MouseButton, Point, Widget};
+use crate::widgets::{Event, MouseButton, Widget};
 use crate::{Frame, LoopContext, Platform, Surface, iterate};
 
 /// The compositor's half of one surface: what it has said, and what it has
@@ -306,20 +306,12 @@ impl Headless {
     /// played through the application at the speed it is meant to have.
     pub fn click_at(&mut self, id: SurfaceId, x: f32, y: f32, now: Instant) {
         let surface = self.host.get_mut(id);
-        surface.events.push((
-            now,
-            Event::MouseDown {
-                at: Some(Point::new(x, y)),
-                button: MouseButton::Left,
-            },
-        ));
-        surface.events.push((
-            now,
-            Event::MouseUp {
-                at: Some(Point::new(x, y)),
-                button: MouseButton::Left,
-            },
-        ));
+        surface
+            .events
+            .push((now, Event::mouse_down(x, y, MouseButton::Left)));
+        surface
+            .events
+            .push((now, Event::mouse_up(x, y, MouseButton::Left)));
     }
 
     /// One frame: open it, route what is queued, measure, paint, present.

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -30,7 +30,7 @@ use crate::renderer::{GpuContext, RenderTarget, Renderer};
 use crate::surface::{SurfaceConfig, SurfaceId};
 use crate::surface_manager::{ManagedSurface, SurfaceManager};
 use crate::tree::{Tree, WidgetId};
-use crate::widgets::{Event, MouseButton, Widget};
+use crate::widgets::{Event, MouseButton, Point, Widget};
 use crate::{Frame, LoopContext, Platform, Surface, iterate};
 
 /// The compositor's half of one surface: what it has said, and what it has
@@ -309,16 +309,14 @@ impl Headless {
         surface.events.push((
             now,
             Event::MouseDown {
-                x,
-                y,
+                at: Some(Point::new(x, y)),
                 button: MouseButton::Left,
             },
         ));
         surface.events.push((
             now,
             Event::MouseUp {
-                x,
-                y,
+                at: Some(Point::new(x, y)),
                 button: MouseButton::Left,
             },
         ));

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -350,24 +350,32 @@ impl Transform {
         }
     }
 
-    /// Compute the inverse of this transform.
+    /// Compute the inverse of this transform, or `None` where there is none.
     ///
-    /// Returns the identity for degenerate (zero-determinant) transforms.
-    pub fn inverse(&self) -> Transform {
+    /// A scale of zero on either axis squashes the plane onto a line or a
+    /// point, and the map stops being one-to-one: every point in the box lands
+    /// on top of every other, so "which point did this come from" has
+    /// infinitely many answers and the arithmetic divides by zero.
+    ///
+    /// This used to answer the identity there, on the grounds that it was the
+    /// least wrong finite answer. It was not: the caller that undoes a
+    /// transform before hit testing read it as "nothing to undo" and compared
+    /// the point against the *uncollapsed* bounds, so an invisible subtree
+    /// answered for the whole area it covers when it is open. Saying `None`
+    /// hands the caller a decision instead of a wrong number — which is how
+    /// Qt spells it too, where `inverted` sets an `invertible` flag beside the
+    /// identity it returns.
+    pub fn inverse(&self) -> Option<Transform> {
         let [a, b, tx, c, d, ty] = self.data;
 
         let det = a * d - b * c;
-
-        // Degenerate: the transform has collapsed the plane onto a line or a
-        // point and cannot be undone, so the identity is the least wrong
-        // answer available. What that costs the hit test is #227.
         if det.abs() < DEGENERATE {
-            return Self::IDENTITY;
+            return None;
         }
 
         let inv_det = 1.0 / det;
 
-        Transform {
+        Some(Transform {
             data: [
                 d * inv_det,
                 -b * inv_det,
@@ -376,7 +384,7 @@ impl Transform {
                 a * inv_det,
                 (c * tx - a * ty) * inv_det,
             ],
-        }
+        })
     }
 
     /// Transform a 2D point by this transform
@@ -543,7 +551,7 @@ mod tests {
     #[test]
     fn test_inverse_translate() {
         let t = Transform::translate(10.0, 20.0);
-        let inv = t.inverse();
+        let inv = t.inverse().expect("invertible");
         let composed = t.then(&inv);
 
         // Should be identity
@@ -555,7 +563,7 @@ mod tests {
     #[test]
     fn test_inverse_rotate() {
         let t = Transform::rotate_degrees(45.0);
-        let inv = t.inverse();
+        let inv = t.inverse().expect("invertible");
         let composed = t.then(&inv);
 
         let (x, y) = composed.transform_point(3.0, 4.0);
@@ -566,7 +574,7 @@ mod tests {
     #[test]
     fn test_inverse_scale() {
         let t = Transform::scale(2.0);
-        let inv = t.inverse();
+        let inv = t.inverse().expect("invertible");
         let composed = t.then(&inv);
 
         let (x, y) = composed.transform_point(3.0, 4.0);
@@ -805,12 +813,18 @@ mod tests {
         assert!(approx_eq(y1, y2));
     }
 
+    /// A collapsed transform has no inverse, and says so rather than handing
+    /// back the identity — which the hit test read as "nothing to undo", so an
+    /// invisible subtree answered for the area it covers when it is open.
     #[test]
-    fn test_inverse_degenerate() {
-        // Zero scale has zero determinant - should return identity
-        let t = Transform::scale(0.0);
-        let inv = t.inverse();
-        assert!(inv.is_identity());
+    fn a_collapsed_transform_has_no_inverse() {
+        assert!(Transform::scale(0.0).inverse().is_none());
+        assert!(Transform::scale_xy(1.0, 0.0).inverse().is_none());
+        assert!(Transform::scale_xy(0.0, 1.0).inverse().is_none());
+
+        // Small is not collapsed: the map is still one-to-one, so undoing it
+        // is a division by something rather than by nothing.
+        assert!(Transform::scale_xy(1.0, 0.001).inverse().is_some());
     }
 
     #[test]

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -661,13 +661,11 @@ fn a_zero_area_container_skips_its_children() {
 fn click_at(x: f32, y: f32) -> [Event; 2] {
     [
         Event::MouseDown {
-            x,
-            y,
+            at: Some(Point::new(x, y)),
             button: MouseButton::Left,
         },
         Event::MouseUp {
-            x,
-            y,
+            at: Some(Point::new(x, y)),
             button: MouseButton::Left,
         },
     ]
@@ -733,10 +731,14 @@ fn hover_tracks_entering_and_leaving() {
     );
     h.fit(500.0, 500.0);
 
-    h.send(Event::MouseMove { x: 25.0, y: 10.0 });
+    h.send(Event::MouseMove {
+        at: Some(Point::new(25.0, 10.0)),
+    });
     assert!(state.get());
 
-    h.send(Event::MouseMove { x: 300.0, y: 10.0 });
+    h.send(Event::MouseMove {
+        at: Some(Point::new(300.0, 10.0)),
+    });
     assert!(!state.get());
 }
 
@@ -780,8 +782,7 @@ fn scroll_reaches_the_callback_inside_the_bounds() {
     h.fit(500.0, 500.0);
 
     h.send(Event::Scroll {
-        x: 25.0,
-        y: 10.0,
+        at: Some(Point::new(25.0, 10.0)),
         delta_x: 0.0,
         delta_y: 12.0,
         source: crate::widgets::widget::ScrollSource::Wheel,
@@ -1156,8 +1157,7 @@ fn a_ripple_and_a_transition_are_asked_about_the_same_moment() {
     h.fit(400.0, 400.0);
 
     h.send(Event::MouseDown {
-        x: 10.0,
-        y: 50.0,
+        at: Some(Point::new(10.0, 50.0)),
         button: MouseButton::Left,
     });
     w.set(120.0);
@@ -1235,8 +1235,7 @@ fn a_press_held_for_a_named_time_has_grown_by_a_named_amount() {
         &mut h,
         t0,
         Event::MouseDown {
-            x: 50.0,
-            y: 50.0,
+            at: Some(Point::new(50.0, 50.0)),
             button: MouseButton::Left,
         },
     );
@@ -1300,7 +1299,9 @@ fn painted_text_color(h: &mut H) -> Color {
 
 fn set_hover(h: &mut H, inside: bool) {
     let (x, y) = if inside { (5.0, 5.0) } else { (-50.0, -50.0) };
-    h.send(Event::MouseMove { x, y });
+    h.send(Event::MouseMove {
+        at: Some(Point::new(x, y)),
+    });
 }
 
 /// The failure this guards against is cache-shaped and silent: the container
@@ -2038,8 +2039,7 @@ fn a_layer_silent_on_a_property_does_not_shadow_the_one_below_it() {
 
     set_hover(&mut h, true);
     h.send(Event::MouseDown {
-        x: 5.0,
-        y: 5.0,
+        at: Some(Point::new(5.0, 5.0)),
         button: MouseButton::Left,
     });
     assert_eq!(rects(&h.paint())[0].1, Color::RED);
@@ -2842,8 +2842,7 @@ fn scrolling_a_frosted_card_away_withdraws_its_blur() {
     );
 
     h.send(Event::Scroll {
-        x: 20.0,
-        y: 15.0,
+        at: Some(Point::new(20.0, 15.0)),
         delta_x: 0.0,
         delta_y: 600.0,
         source: ScrollSource::Wheel,

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -660,14 +660,8 @@ fn a_zero_area_container_skips_its_children() {
 
 fn click_at(x: f32, y: f32) -> [Event; 2] {
     [
-        Event::MouseDown {
-            at: Some(Point::new(x, y)),
-            button: MouseButton::Left,
-        },
-        Event::MouseUp {
-            at: Some(Point::new(x, y)),
-            button: MouseButton::Left,
-        },
+        Event::mouse_down(x, y, MouseButton::Left),
+        Event::mouse_up(x, y, MouseButton::Left),
     ]
 }
 
@@ -731,14 +725,10 @@ fn hover_tracks_entering_and_leaving() {
     );
     h.fit(500.0, 500.0);
 
-    h.send(Event::MouseMove {
-        at: Some(Point::new(25.0, 10.0)),
-    });
+    h.send(Event::mouse_move(25.0, 10.0));
     assert!(state.get());
 
-    h.send(Event::MouseMove {
-        at: Some(Point::new(300.0, 10.0)),
-    });
+    h.send(Event::mouse_move(300.0, 10.0));
     assert!(!state.get());
 }
 
@@ -781,12 +771,13 @@ fn scroll_reaches_the_callback_inside_the_bounds() {
     );
     h.fit(500.0, 500.0);
 
-    h.send(Event::Scroll {
-        at: Some(Point::new(25.0, 10.0)),
-        delta_x: 0.0,
-        delta_y: 12.0,
-        source: crate::widgets::widget::ScrollSource::Wheel,
-    });
+    h.send(Event::scroll(
+        25.0,
+        10.0,
+        0.0,
+        12.0,
+        crate::widgets::widget::ScrollSource::Wheel,
+    ));
     assert_eq!(deltas.get(), 12.0);
 }
 
@@ -1156,10 +1147,7 @@ fn a_ripple_and_a_transition_are_asked_about_the_same_moment() {
     );
     h.fit(400.0, 400.0);
 
-    h.send(Event::MouseDown {
-        at: Some(Point::new(10.0, 50.0)),
-        button: MouseButton::Left,
-    });
+    h.send(Event::mouse_down(10.0, 50.0, MouseButton::Left));
     w.set(120.0);
 
     // After the press, because a ripple begins at the instant its event
@@ -1231,14 +1219,7 @@ fn a_press_held_for_a_named_time_has_grown_by_a_named_amount() {
     // clock instead of from the event, the disc would be a minute old by the
     // first frame and there would be nothing left to draw.
     let t0 = std::time::Instant::now() - std::time::Duration::from_secs(60);
-    send_at(
-        &mut h,
-        t0,
-        Event::MouseDown {
-            at: Some(Point::new(50.0, 50.0)),
-            button: MouseButton::Left,
-        },
-    );
+    send_at(&mut h, t0, Event::mouse_down(50.0, 50.0, MouseButton::Left));
 
     // A frame later, because the press and the frame are now genuinely the same
     // instant: at t0 exactly nothing has elapsed and the disc has no opacity to
@@ -1299,9 +1280,7 @@ fn painted_text_color(h: &mut H) -> Color {
 
 fn set_hover(h: &mut H, inside: bool) {
     let (x, y) = if inside { (5.0, 5.0) } else { (-50.0, -50.0) };
-    h.send(Event::MouseMove {
-        at: Some(Point::new(x, y)),
-    });
+    h.send(Event::mouse_move(x, y));
 }
 
 /// The failure this guards against is cache-shaped and silent: the container
@@ -2038,10 +2017,7 @@ fn a_layer_silent_on_a_property_does_not_shadow_the_one_below_it() {
     h.fit(100.0, 100.0);
 
     set_hover(&mut h, true);
-    h.send(Event::MouseDown {
-        at: Some(Point::new(5.0, 5.0)),
-        button: MouseButton::Left,
-    });
+    h.send(Event::mouse_down(5.0, 5.0, MouseButton::Left));
     assert_eq!(rects(&h.paint())[0].1, Color::RED);
 }
 
@@ -2841,12 +2817,7 @@ fn scrolling_a_frosted_card_away_withdraws_its_blur() {
         "visible at the top of the scroll"
     );
 
-    h.send(Event::Scroll {
-        at: Some(Point::new(20.0, 15.0)),
-        delta_x: 0.0,
-        delta_y: 600.0,
-        source: ScrollSource::Wheel,
-    });
+    h.send(Event::scroll(20.0, 15.0, 0.0, 600.0, ScrollSource::Wheel));
     // Two frames: the first repaints the scroller and settles the flags, the
     // second is where a clean card is culled — or never offered at all.
     h.frame(40.0, 30.0);

--- a/src/widgets/container/interaction.rs
+++ b/src/widgets/container/interaction.rs
@@ -155,9 +155,7 @@ impl Container {
                 // with no position is not one of those: there is nowhere to
                 // report, so the callback is not called and the hover below
                 // simply falls.
-                // Asked once: `contains_shape` evaluates the corner
-                // superellipse, which is three `powf`s for a squircle, and
-                // this is the coalesced-pointer-move path.
+                // One question, asked once and answered twice below.
                 let inside = hit.contains(*at);
 
                 if let Some(ref callback) = ix.on_pointer_move

--- a/src/widgets/container/interaction.rs
+++ b/src/widgets/container/interaction.rs
@@ -125,6 +125,21 @@ impl Container {
         };
 
         match event {
+            // An enter with no position is an enter into nothing, so it is
+            // the falling edge rather than the rising one. The platform only
+            // ever sends a positioned one (`input.rs`), but a container that
+            // collapses is what takes the position away on the way down, and
+            // the move that would otherwise clear the hover is a whole event
+            // later.
+            Event::MouseEnter { at: None } if ix.is_hovered() => {
+                ix.set_flag(InteractionFlags::HOVERED, false);
+                if ix.declares(|w| matches!(w, StateWhen::Hovered)) {
+                    request_repaint(id);
+                }
+                if let Some(ref callback) = ix.on_hover {
+                    callback(false);
+                }
+            }
             Event::MouseEnter { at } if hit.contains(*at) && !ix.is_hovered() => {
                 ix.set_flag(InteractionFlags::HOVERED, true);
                 if ix.declares(|w| matches!(w, StateWhen::Hovered)) {

--- a/src/widgets/container/interaction.rs
+++ b/src/widgets/container/interaction.rs
@@ -31,60 +31,57 @@ pub(super) struct HitContext {
 impl HitContext {
     /// Whether a point falls inside the container's *shape* — its bounds
     /// narrowed by the corner radius, not the bounding box.
-    pub(super) fn contains(&self, x: f32, y: f32) -> bool {
-        self.bounds.contains_shape(x, y, self.corners)
+    ///
+    /// An event with no position is inside nothing. That is the whole of
+    /// #227: a container collapsed to a line has no inverse to undo, so the
+    /// point that reaches it is `None`, and every bounds test below it answers
+    /// no without any of them having to know why.
+    #[inline]
+    pub(super) fn contains(&self, at: Option<Point>) -> bool {
+        self.bounds.contains_shape_at(at, self.corners)
     }
 
-    /// A surface-space point expressed relative to the container's own origin.
-    pub(super) fn local(&self, x: f32, y: f32) -> (f32, f32) {
-        local_point(&self.transform, self.pivot, self.bounds, x, y)
+    /// A surface-space point expressed relative to the container's own origin
+    /// — the space ripples and pointer callbacks work in.
+    pub(super) fn local(&self, at: Point) -> Option<Point> {
+        Some(
+            untransform_point(&self.transform, self.pivot, self.bounds, at)?
+                .offset(-self.bounds.x, -self.bounds.y),
+        )
     }
 
     /// The same, for a point that has already had the transform undone.
-    pub(super) fn rebase(&self, x: f32, y: f32) -> (f32, f32) {
-        (x - self.bounds.x, y - self.bounds.y)
+    pub(super) fn rebase(&self, at: Point) -> Point {
+        at.offset(-self.bounds.x, -self.bounds.y)
     }
 }
 
-/// Map a point from surface space into the container's untransformed space.
+/// Map a point from surface space into the container's untransformed space,
+/// or `None` where the container occupies no space to be pointed at.
 ///
 /// A container's own transform is applied around its origin at paint time, so
 /// hit testing has to undo it before comparing against the laid-out bounds.
 /// An identity transform returns the point unchanged.
 ///
-/// A transform that has collapsed the container onto a line or a point cannot
-/// be undone, and the point comes back unchanged — so an invisible subtree
-/// answers for the whole area it occupies when it is open. That is #227, and
-/// it is older than the components API: it needs the *event* to be able to say
-/// it has no position, which no coordinate can say on its behalf.
+/// A transform that has collapsed the container onto a line or a point has no
+/// inverse, and there is no coordinate that means "nowhere" — every number is
+/// somewhere, and a descendant that rotates or mirrors would carry a far-away
+/// sentinel back into the visible half-plane. So the absence is the answer.
 pub(super) fn untransform_point(
     transform: &Transform,
     origin: Pivot,
     bounds: Rect,
-    x: f32,
-    y: f32,
-) -> (f32, f32) {
+    at: Point,
+) -> Option<Point> {
     if transform.is_identity() {
-        return (x, y);
+        return Some(at);
     }
     let (origin_x, origin_y) = origin.resolve(bounds);
-    transform
+    let (ux, uy) = transform
         .center_at(origin_x, origin_y)
-        .inverse()
-        .transform_point(x, y)
-}
-
-/// [`untransform_point`] expressed relative to the container's own origin —
-/// the space ripples and pointer callbacks work in.
-pub(super) fn local_point(
-    transform: &Transform,
-    origin: Pivot,
-    bounds: Rect,
-    x: f32,
-    y: f32,
-) -> (f32, f32) {
-    let (ux, uy) = untransform_point(transform, origin, bounds, x, y);
-    (ux - bounds.x, uy - bounds.y)
+        .inverse()?
+        .transform_point(at.x, at.y);
+    Some(Point::new(ux, uy))
 }
 
 impl Container {
@@ -111,7 +108,7 @@ impl Container {
         id: WidgetId,
         hit: &HitContext,
         event: &Event,
-        at: Instant,
+        now: Instant,
     ) {
         let has_animated = self.has_animated_state_properties();
         // Read before the mutable borrow: cancelling a ripple below needs it.
@@ -128,7 +125,7 @@ impl Container {
         };
 
         match event {
-            Event::MouseEnter { x, y } if hit.contains(*x, *y) && !ix.is_hovered() => {
+            Event::MouseEnter { at } if hit.contains(*at) && !ix.is_hovered() => {
                 ix.set_flag(InteractionFlags::HOVERED, true);
                 if ix.declares(|w| matches!(w, StateWhen::Hovered)) {
                     request_repaint(id);
@@ -137,18 +134,27 @@ impl Container {
                     callback(true);
                 }
             }
-            Event::MouseMove { x, y } => {
+            Event::MouseMove { at } => {
                 // A pressed container keeps receiving moves that leave it —
-                // that implicit capture is what makes dragging work.
+                // that implicit capture is what makes dragging work. A move
+                // with no position is not one of those: there is nowhere to
+                // report, so the callback is not called and the hover below
+                // simply falls.
+                // Asked once: `contains_shape` evaluates the corner
+                // superellipse, which is three `powf`s for a squircle, and
+                // this is the coalesced-pointer-move path.
+                let inside = hit.contains(*at);
+
                 if let Some(ref callback) = ix.on_pointer_move
-                    && (hit.contains(*x, *y) || ix.is_pressed())
+                    && (inside || ix.is_pressed())
+                    && let Some(at) = at
                 {
-                    let (lx, ly) = hit.rebase(*x, *y);
-                    callback(lx, ly);
+                    let local = hit.rebase(*at);
+                    callback(local.x, local.y);
                 }
 
                 let was_hovered = ix.is_hovered();
-                ix.set_flag(InteractionFlags::HOVERED, hit.contains(*x, *y));
+                ix.set_flag(InteractionFlags::HOVERED, inside);
 
                 // Dragging off the container abandons the press. Only leaving
                 // the whole surface used to say so, which left a ripple
@@ -159,7 +165,7 @@ impl Container {
                     && ix.ripple.is_active()
                     && let Some(ref config) = ripple_config
                 {
-                    ix.ripple.cancel(config, at);
+                    ix.ripple.cancel(config, now);
                     request_job(id, JobRequest::Animation(RequiredJob::Paint));
                 }
 
@@ -188,7 +194,7 @@ impl Container {
         hit: &HitContext,
         event: &Event,
         local: &Event,
-        at: Instant,
+        now: Instant,
     ) -> EventResponse {
         match local {
             // Hover was tracked before the children ran. Returning Ignored
@@ -196,8 +202,8 @@ impl Container {
             // containers from tracking their own.
             Event::MouseEnter { .. } | Event::MouseMove { .. } => {}
 
-            Event::MouseDown { x, y, button } if *button != MouseButton::Left => {
-                if hit.contains(*x, *y)
+            Event::MouseDown { at, button } if *button != MouseButton::Left => {
+                if hit.contains(*at)
                     && let Some(ref ix) = self.interaction
                 {
                     let callback = match button {
@@ -212,8 +218,9 @@ impl Container {
                 }
             }
 
-            Event::MouseDown { x, y, button } => {
-                if hit.contains(*x, *y)
+            Event::MouseDown { at, button } => {
+                if hit.contains(*at)
+                    && let Some(at) = at
                     && *button == MouseButton::Left
                     && let Some(ref mut ix) = self.interaction
                 {
@@ -225,9 +232,13 @@ impl Container {
                         .iter()
                         .any(|(w, s)| matches!(w, StateWhen::Pressed) && s.ripple.is_some());
                     if has_ripple {
-                        let (screen_x, screen_y) = event.coords().unwrap_or((*x, *y));
-                        let (local_x, local_y) = hit.local(screen_x, screen_y);
-                        ix.ripple.start(local_x, local_y, at);
+                        // The ripple starts under the finger, so it wants the
+                        // point as the surface gave it, not the one already
+                        // rebased for this container.
+                        let on_screen = event.coords().unwrap_or(*at);
+                        if let Some(local) = hit.local(on_screen) {
+                            ix.ripple.start(local.x, local.y, now);
+                        }
                         request_job(id, JobRequest::Animation(RequiredJob::Paint));
                     }
 
@@ -237,8 +248,8 @@ impl Container {
                     if let Some(ref ix) = self.interaction
                         && let Some(ref callback) = ix.on_mouse_down
                     {
-                        let (lx, ly) = hit.rebase(*x, *y);
-                        callback(lx, ly);
+                        let local = hit.rebase(*at);
+                        callback(local.x, local.y);
                         return EventResponse::Handled;
                     }
                     // A press is claimed even without a down handler, so the
@@ -251,7 +262,7 @@ impl Container {
                 }
             }
 
-            Event::MouseUp { x, y, button } => {
+            Event::MouseUp { at, button } => {
                 if let Some(ref mut ix) = self.interaction
                     && ix.is_pressed()
                     && *button == MouseButton::Left
@@ -266,10 +277,10 @@ impl Container {
                     if ix.ripple.is_active()
                         && let Some(config) = ix.ripple_config()
                     {
-                        if hit.contains(*x, *y) {
-                            ix.ripple.release(&config, at);
+                        if hit.contains(*at) {
+                            ix.ripple.release(&config, now);
                         } else {
-                            ix.ripple.cancel(&config, at);
+                            ix.ripple.cancel(&config, now);
                         }
                         request_job(id, JobRequest::Animation(RequiredJob::Paint));
                     }
@@ -279,17 +290,18 @@ impl Container {
                     }
 
                     let mut handled = false;
-                    if let Some(ref ix) = self.interaction
+                    if let Some(at) = at
+                        && let Some(ref ix) = self.interaction
                         && let Some(ref callback) = ix.on_mouse_up
                     {
-                        let (lx, ly) = hit.rebase(*x, *y);
-                        callback(lx, ly);
+                        let local = hit.rebase(*at);
+                        callback(local.x, local.y);
                         handled = true;
                     }
                     // A click is a release *inside* the shape; a release that
                     // wandered off only ends the press.
                     if let Some(ref ix) = self.interaction
-                        && hit.contains(*x, *y)
+                        && hit.contains(*at)
                         && let Some(ref callback) = ix.on_click
                     {
                         callback();
@@ -319,7 +331,7 @@ impl Container {
                     if ix.ripple.is_active()
                         && let Some(config) = ix.ripple_config()
                     {
-                        ix.ripple.cancel(&config, at);
+                        ix.ripple.cancel(&config, now);
                         request_job(id, JobRequest::Animation(RequiredJob::Paint));
                     }
 
@@ -332,17 +344,16 @@ impl Container {
             }
 
             Event::Scroll {
-                x,
-                y,
+                at,
                 delta_x,
                 delta_y,
                 source,
             } => {
-                if hit.contains(*x, *y) {
+                if hit.contains(*at) {
                     // Our own scrolling consumes the event first; the callback
                     // only sees what scrolling did not take.
                     if self.scroll_axis != ScrollAxis::None
-                        && self.apply_scroll(*delta_x, *delta_y, *source, at)
+                        && self.apply_scroll(*delta_x, *delta_y, *source, now)
                     {
                         // A paint, and only a paint. A sample means the finger
                         // is still down, so there is no momentum for an
@@ -373,10 +384,10 @@ impl Container {
             // The finger lifted. Momentum starts here or not at all — and it
             // starts now, on the event, rather than becoming due for whatever
             // frame happens along next.
-            Event::ScrollEnd { x, y } => {
-                if self.scroll_axis != ScrollAxis::None && hit.contains(*x, *y) {
+            Event::ScrollEnd { at } => {
+                if self.scroll_axis != ScrollAxis::None && hit.contains(*at) {
                     let sd = self.scroll_mut();
-                    sd.scroll_state.end_gesture(at);
+                    sd.scroll_state.end_gesture(now);
                     if sd.scroll_state.should_apply_momentum() {
                         request_job(id, JobRequest::Animation(RequiredJob::Paint));
                     }

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -1437,7 +1437,7 @@ impl Widget for Container {
         let skip_child_dispatch = clips_children
             && local_event
                 .coords()
-                .is_some_and(|at| !hit.bounds.contains_at(Some(at)));
+                .is_some_and(|at| !hit.bounds.contains(at.x, at.y));
 
         if !skip_child_dispatch {
             for &child_id in self.children_source.get() {

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -47,7 +47,7 @@ use super::state_layer::{
     Moves, RippleConfig, StateStyle, StateWhen, Stateful, resolve_background,
 };
 use super::widget::{
-    Color, Event, EventResponse, Key, LayoutHints, Modifiers, MouseButton, Padding, Rect,
+    Color, Event, EventResponse, Key, LayoutHints, Modifiers, MouseButton, Padding, Point, Rect,
     ScrollSource, Widget,
 };
 
@@ -1393,13 +1393,15 @@ impl Widget for Container {
             pivot: self.pivot_signal().get_or(Pivot::CENTER),
         };
 
-        // Undo our own transform before hit testing against the laid-out bounds
+        // Undo our own transform before hit testing against the laid-out
+        // bounds. A transform collapsed to a line has no inverse, and the
+        // event goes on without a position rather than with the wrong one —
+        // it still has to arrive, because a press given up and a hover
+        // cleared are things only a delivered event can do.
         let local_event: Cow<'_, Event> = match event.coords() {
-            Some((x, y)) if !hit.transform.is_identity() => {
-                let (local_x, local_y) =
-                    untransform_point(&hit.transform, hit.pivot, hit.bounds, x, y);
-                Cow::Owned(event.with_coords(local_x, local_y))
-            }
+            Some(at) if !hit.transform.is_identity() => Cow::Owned(
+                event.with_coords(untransform_point(&hit.transform, hit.pivot, hit.bounds, at)),
+            ),
             _ => Cow::Borrowed(event),
         };
 
@@ -1413,14 +1415,13 @@ impl Widget for Container {
         // Children are positioned relative to our origin (and to the scroll
         // offset, when we scroll), so their events have to be too.
         let child_event: Cow<'_, Event> = match local_event.coords() {
-            Some((x, y)) => {
-                let (mut cx, mut cy) = (x - hit.bounds.x, y - hit.bounds.y);
+            Some(at) => {
+                let mut child_at = hit.rebase(at);
                 if self.scroll_axis != ScrollAxis::None {
                     let sd = self.scroll();
-                    cx += sd.scroll_state.offset_x;
-                    cy += sd.scroll_state.offset_y;
+                    child_at = child_at.offset(sd.scroll_state.offset_x, sd.scroll_state.offset_y);
                 }
-                Cow::Owned(local_event.with_coords(cx, cy))
+                Cow::Owned(local_event.with_coords(Some(child_at)))
             }
             None => local_event.clone(),
         };
@@ -1430,10 +1431,13 @@ impl Widget for Container {
         // below it (a collapsed submenu used to do exactly that).
         let clips_children = self.overflow_resolved.get() == Overflow::Hidden
             || self.scroll_axis != ScrollAxis::None;
+        // An event with no position falls outside nothing, so the children
+        // are still asked — and still answer no, because their own bounds
+        // test is given the same absence.
         let skip_child_dispatch = clips_children
             && local_event
                 .coords()
-                .is_some_and(|(x, y)| !hit.bounds.contains(x, y));
+                .is_some_and(|at| !hit.bounds.contains_at(Some(at)));
 
         if !skip_child_dispatch {
             for &child_id in self.children_source.get() {

--- a/src/widgets/container/scrollable.rs
+++ b/src/widgets/container/scrollable.rs
@@ -8,7 +8,7 @@ use crate::layout::Constraints;
 use crate::renderer::PaintContext;
 use crate::tree::{Tree, WidgetId};
 use crate::widgets::scroll::{ScrollAxis, ScrollbarAxis, ScrollbarVisibility};
-use crate::widgets::widget::{Event, EventResponse, MouseButton, Rect, ScrollSource};
+use crate::widgets::widget::{Event, EventResponse, MouseButton, Point, Rect, ScrollSource};
 
 use super::Container;
 use super::animations::AnimationState;
@@ -493,16 +493,12 @@ impl Container {
         .unwrap_or(1.0);
 
         let unscaled: Cow<'_, Event> = match (event.coords(), tree.get_bounds(handle_id)) {
-            (Some((x, y)), Some(bounds)) => {
-                let (local_x, local_y) = untransform_point(
-                    &scrollbar_scale_transform(axis, scale),
-                    scrollbar_scale_pivot(axis),
-                    bounds,
-                    x,
-                    y,
-                );
-                Cow::Owned(event.with_coords(local_x, local_y))
-            }
+            (Some(at), Some(bounds)) => Cow::Owned(event.with_coords(untransform_point(
+                &scrollbar_scale_transform(axis, scale),
+                scrollbar_scale_pivot(axis),
+                bounds,
+                at,
+            ))),
             _ => Cow::Borrowed(event),
         };
 
@@ -536,17 +532,17 @@ impl Container {
         }
 
         let local: Cow<'_, Event> = match event.coords() {
-            Some((x, y)) => {
-                let (local_x, local_y) = hit.rebase(x, y);
-                Cow::Owned(event.with_coords(local_x, local_y))
-            }
+            Some(at) => Cow::Owned(event.with_coords(Some(hit.rebase(at)))),
             None => Cow::Borrowed(event),
         };
         let event = local.as_ref();
         let bounds = Rect::new(0.0, 0.0, hit.bounds.width, hit.bounds.height);
 
         match event {
-            Event::MouseDown { x, y, button } if *button == MouseButton::Left => {
+            Event::MouseDown {
+                at: Some(at),
+                button,
+            } if *button == MouseButton::Left => {
                 // Check vertical scrollbar
                 if self.scroll_axis.allows_vertical()
                     && self.scroll().scroll_state.needs_vertical_scrollbar()
@@ -555,8 +551,8 @@ impl Container {
                         id,
                         bounds,
                         ScrollbarAxis::Vertical,
-                        *x,
-                        *y,
+                        at.x,
+                        at.y,
                         event,
                     )
                 {
@@ -571,8 +567,8 @@ impl Container {
                         id,
                         bounds,
                         ScrollbarAxis::Horizontal,
-                        *x,
-                        *y,
+                        at.x,
+                        at.y,
                         event,
                     )
                 {
@@ -580,23 +576,31 @@ impl Container {
                 }
             }
 
-            Event::MouseMove { x, y } => {
+            // Matched whether or not it has a position. A move with no
+            // position cannot say where a drag has got to, and must not be
+            // read as one that says zero — so the drag keeps what it had and
+            // ends on the release, which needs no position at all. The hover
+            // below is the other half, and wants the opposite: over nothing
+            // is not hovered.
+            Event::MouseMove { at } => {
                 // Handle dragging
-                if self.scroll().scroll_state.scrollbar_dragging {
-                    return Some(self.handle_scrollbar_drag(
-                        id,
-                        bounds,
-                        ScrollbarAxis::Vertical,
-                        *y,
-                    ));
-                }
-                if self.scroll().scroll_state.h_scrollbar_dragging {
-                    return Some(self.handle_scrollbar_drag(
-                        id,
-                        bounds,
-                        ScrollbarAxis::Horizontal,
-                        *x,
-                    ));
+                if let Some(at) = at {
+                    if self.scroll().scroll_state.scrollbar_dragging {
+                        return Some(self.handle_scrollbar_drag(
+                            id,
+                            bounds,
+                            ScrollbarAxis::Vertical,
+                            at.y,
+                        ));
+                    }
+                    if self.scroll().scroll_state.h_scrollbar_dragging {
+                        return Some(self.handle_scrollbar_drag(
+                            id,
+                            bounds,
+                            ScrollbarAxis::Horizontal,
+                            at.x,
+                        ));
+                    }
                 }
 
                 // Update hover states
@@ -610,8 +614,7 @@ impl Container {
                         id,
                         bounds,
                         ScrollbarAxis::Vertical,
-                        *x,
-                        *y,
+                        *at,
                         event,
                     );
                 }
@@ -624,8 +627,7 @@ impl Container {
                         id,
                         bounds,
                         ScrollbarAxis::Horizontal,
-                        *x,
-                        *y,
+                        *at,
                         event,
                     );
                 }
@@ -812,8 +814,7 @@ impl Container {
         id: WidgetId,
         bounds: Rect,
         axis: ScrollbarAxis,
-        x: f32,
-        y: f32,
+        at: Option<Point>,
         _event: &Event,
     ) -> bool {
         let sd = self.scroll();
@@ -831,8 +832,8 @@ impl Container {
         let handle_hit = widen_across_axis(axis, handle_rect, hit_area);
 
         let mut needs_repaint = false;
-        let is_track_hovered = hit_area.contains(x, y);
-        let is_hovered = handle_hit.contains(x, y);
+        let is_track_hovered = hit_area.contains_at(at);
+        let is_hovered = handle_hit.contains_at(at);
 
         // Update track and handle hover state in one borrow
         let sd = self.scroll_mut();
@@ -855,8 +856,10 @@ impl Container {
             // The centre of the handle: a point it holds whatever part of the
             // widened area the pointer is actually over.
             let enter = Event::MouseEnter {
-                x: handle_rect.x + handle_rect.width / 2.0,
-                y: handle_rect.y + handle_rect.height / 2.0,
+                at: Some(Point::new(
+                    handle_rect.x + handle_rect.width / 2.0,
+                    handle_rect.y + handle_rect.height / 2.0,
+                )),
             };
             self.forward_to_handle(tree, id, axis, &enter);
         } else if !is_hovered && was_hovered {

--- a/src/widgets/container/scrollable.rs
+++ b/src/widgets/container/scrollable.rs
@@ -855,12 +855,10 @@ impl Container {
         if is_hovered && !was_hovered {
             // The centre of the handle: a point it holds whatever part of the
             // widened area the pointer is actually over.
-            let enter = Event::MouseEnter {
-                at: Some(Point::new(
-                    handle_rect.x + handle_rect.width / 2.0,
-                    handle_rect.y + handle_rect.height / 2.0,
-                )),
-            };
+            let enter = Event::mouse_enter(
+                handle_rect.x + handle_rect.width / 2.0,
+                handle_rect.y + handle_rect.height / 2.0,
+            );
             self.forward_to_handle(tree, id, axis, &enter);
         } else if !is_hovered && was_hovered {
             self.forward_to_handle(tree, id, axis, &Event::MouseLeave);

--- a/src/widgets/diagnostic_audit.rs
+++ b/src/widgets/diagnostic_audit.rs
@@ -25,7 +25,7 @@ use crate::reactive::create_signal;
 use crate::reactive::diagnostics::report_count;
 use crate::renderer::{PaintContext, RenderNode};
 use crate::tree::Tree;
-use crate::widgets::widget::{Event, Key, Modifiers, MouseButton, Point, ScrollSource};
+use crate::widgets::widget::{Event, Key, Modifiers, MouseButton, ScrollSource};
 use crate::widgets::{Color, ImageSource, LinearGradient, Overflow, ScrollAxis};
 use crate::widgets::{
     InputStyled, Stateful, TextStyled, Widget, container, image, text, text_input,
@@ -66,26 +66,11 @@ fn diagnostics_from_full_lifecycle(widget: impl Widget + 'static) -> u64 {
     // meaningful against the call sites the library actually uses.
     crate::reactive::diagnostics::snapshot_zone(|| {
         for event in [
-            Event::MouseEnter {
-                at: Some(Point::new(10.0, 10.0)),
-            },
-            Event::MouseMove {
-                at: Some(Point::new(10.0, 10.0)),
-            },
-            Event::MouseDown {
-                at: Some(Point::new(10.0, 10.0)),
-                button: MouseButton::Left,
-            },
-            Event::MouseUp {
-                at: Some(Point::new(10.0, 10.0)),
-                button: MouseButton::Left,
-            },
-            Event::Scroll {
-                at: Some(Point::new(10.0, 10.0)),
-                delta_x: 0.0,
-                delta_y: 10.0,
-                source: ScrollSource::Wheel,
-            },
+            Event::mouse_enter(10.0, 10.0),
+            Event::mouse_move(10.0, 10.0),
+            Event::mouse_down(10.0, 10.0, MouseButton::Left),
+            Event::mouse_up(10.0, 10.0, MouseButton::Left),
+            Event::scroll(10.0, 10.0, 0.0, 10.0, ScrollSource::Wheel),
             Event::KeyDown {
                 key: Key::Char('a'),
                 modifiers: Modifiers::default(),

--- a/src/widgets/diagnostic_audit.rs
+++ b/src/widgets/diagnostic_audit.rs
@@ -25,7 +25,7 @@ use crate::reactive::create_signal;
 use crate::reactive::diagnostics::report_count;
 use crate::renderer::{PaintContext, RenderNode};
 use crate::tree::Tree;
-use crate::widgets::widget::{Event, Key, Modifiers, MouseButton, ScrollSource};
+use crate::widgets::widget::{Event, Key, Modifiers, MouseButton, Point, ScrollSource};
 use crate::widgets::{Color, ImageSource, LinearGradient, Overflow, ScrollAxis};
 use crate::widgets::{
     InputStyled, Stateful, TextStyled, Widget, container, image, text, text_input,
@@ -66,21 +66,22 @@ fn diagnostics_from_full_lifecycle(widget: impl Widget + 'static) -> u64 {
     // meaningful against the call sites the library actually uses.
     crate::reactive::diagnostics::snapshot_zone(|| {
         for event in [
-            Event::MouseEnter { x: 10.0, y: 10.0 },
-            Event::MouseMove { x: 10.0, y: 10.0 },
+            Event::MouseEnter {
+                at: Some(Point::new(10.0, 10.0)),
+            },
+            Event::MouseMove {
+                at: Some(Point::new(10.0, 10.0)),
+            },
             Event::MouseDown {
-                x: 10.0,
-                y: 10.0,
+                at: Some(Point::new(10.0, 10.0)),
                 button: MouseButton::Left,
             },
             Event::MouseUp {
-                x: 10.0,
-                y: 10.0,
+                at: Some(Point::new(10.0, 10.0)),
                 button: MouseButton::Left,
             },
             Event::Scroll {
-                x: 10.0,
-                y: 10.0,
+                at: Some(Point::new(10.0, 10.0)),
                 delta_x: 0.0,
                 delta_y: 10.0,
                 source: ScrollSource::Wheel,

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -39,7 +39,7 @@ pub use text_input::{Selection, TextInput, text_input};
 pub use text_style::{TextShadow, TextStroke, TextStyle, TextStyled};
 pub use widget::{
     AnyWidget, Color, Event, EventResponse, Key, LayoutHints, Modifiers, MouseButton, Padding,
-    Rect, ScrollSource, Widget,
+    Point, Rect, ScrollSource, Widget,
 };
 
 // IntoVal<Padding> impls for closures returning numeric types

--- a/src/widgets/paint_children.rs
+++ b/src/widgets/paint_children.rs
@@ -154,10 +154,10 @@ fn reuse_cached(
         // Moved: shallow header clone (children and commands stay Rc-shared),
         // with the user transform extracted and recomposed at the new position.
         let mut reused = (**cached).clone();
-        let user_part = cached
-            .parent_position
-            .inverse()
-            .then(&cached.local_transform);
+        // A position is a pure translation, so undoing it is negating it —
+        // no determinant, no inverse, and nothing to unwrap.
+        let pos = &cached.parent_position;
+        let user_part = Transform::translate(-pos.tx(), -pos.ty()).then(&cached.local_transform);
         reused.local_transform = child_position.then(&user_part);
         reused.parent_position = child_position;
         reused.bounds = child_local;

--- a/src/widgets/text.rs
+++ b/src/widgets/text.rs
@@ -288,9 +288,11 @@ impl Widget for Text {
         }
 
         let inside = match event {
-            Event::MouseMove { x, y } | Event::MouseEnter { x, y } => tree
+            // A pointer with no position is over nothing — the same answer a
+            // `MouseLeave` gives, and `contains_at` is where that is decided.
+            Event::MouseMove { at } | Event::MouseEnter { at } => tree
                 .get_bounds(id)
-                .is_some_and(|bounds| bounds.contains(*x, *y)),
+                .is_some_and(|bounds| bounds.contains_at(*at)),
             Event::MouseLeave => false,
             _ => return EventResponse::Ignored,
         };

--- a/src/widgets/text_input.rs
+++ b/src/widgets/text_input.rs
@@ -1403,6 +1403,55 @@ mod tests {
     use crate::jobs::{clear_pending_jobs, clear_scheduled_jobs, next_deadline, queued_job_types};
     use crate::layout::Constraints;
     use crate::reactive::create_signal;
+    use crate::widgets::widget::Point;
+
+    /// A move with no position says nothing about where a drag has got to.
+    ///
+    /// A pointer event that has descended into a subtree collapsed to nothing
+    /// arrives without a position (#227), and the arm that extends a selection
+    /// has to leave it alone rather than read the absence as an origin — which
+    /// is what an earlier attempt's far-away sentinel did, putting the cursor
+    /// at index 0 for as long as the box was closed.
+    ///
+    /// A guard rather than a fix: the shape that ships already holds this,
+    /// because the drag branch asks for a position before it moves anything.
+    /// What it guards against is somebody restoring the unwrap — the `None`
+    /// arriving here is indistinguishable from a click at the origin the
+    /// moment it is given a default.
+    #[test]
+    fn a_move_with_no_position_leaves_the_selection_where_it_was() {
+        let mut tree = crate::tree::Tree::new();
+        // An id with no bounds: the drag branch does not consult them — that
+        // is what lets a selection continue past the edge of the field — so
+        // the empty rect is exactly the right stand-in here.
+        let id = tree.register(Box::new(crate::widgets::container()));
+
+        let text = create_signal(String::from("hello world"));
+        let mut input = text_input(text);
+        input.selection = Selection {
+            anchor: 2,
+            cursor: 7,
+        };
+        input.is_dragging = true;
+
+        let moved_to = Event::MouseMove {
+            at: Some(Point::new(60.0, 5.0)),
+        };
+        Widget::event(&mut input, &mut tree, id, &moved_to);
+        let dragged = input.selection.cursor;
+        assert_ne!(
+            dragged, 7,
+            "a positioned move has to extend the selection, or this test is \
+             asserting against a drag that was never running"
+        );
+
+        Widget::event(&mut input, &mut tree, id, &Event::MouseMove { at: None });
+        assert_eq!(
+            (input.selection.anchor, input.selection.cursor),
+            (2, dragged),
+            "and one with no position leaves it exactly where it was"
+        );
+    }
 
     /// Two keystrokes inside the window are one undo, and two outside it are
     /// two — which is what `HISTORY_COALESCE_MS` promises and nothing could

--- a/src/widgets/text_input.rs
+++ b/src/widgets/text_input.rs
@@ -1289,16 +1289,17 @@ impl Widget for TextInput {
         let bounds = tree.get_bounds(id).unwrap_or_default();
 
         match event {
-            Event::MouseDown { x, y, button }
-                if bounds.contains(*x, *y) && *button == MouseButton::Left =>
-            {
+            Event::MouseDown {
+                at: Some(at),
+                button,
+            } if bounds.contains(at.x, at.y) && *button == MouseButton::Left => {
                 // Focus, then repaint to show the caret where the click landed.
                 // The blink schedules its own next wake from `paint`.
                 request_focus(tree, id);
                 request_job(id, JobRequest::Paint);
 
                 // Set cursor position
-                let char_index = self.char_index_at_x(*x, bounds);
+                let char_index = self.char_index_at_x(at.x, bounds);
                 self.selection = Selection::new(char_index);
                 self.is_dragging = true;
                 self.reset_cursor_blink(edit.at);
@@ -1306,8 +1307,13 @@ impl Widget for TextInput {
 
                 return EventResponse::Handled;
             }
-            Event::MouseMove { x, y, .. } => {
-                let in_bounds = bounds.contains(*x, *y);
+            // Matched whether or not it has a position, because the two
+            // halves want different answers: a move with no position is over
+            // nothing, so the hover below has to fall — but it says nothing
+            // about where a selection has got to, so the drag keeps what it
+            // had rather than being dragged to the start of the line.
+            Event::MouseMove { at } => {
+                let in_bounds = bounds.contains_at(*at);
 
                 // Update hover state and cursor
                 if in_bounds && !self.is_hovered {
@@ -1320,9 +1326,11 @@ impl Widget for TextInput {
                     set_cursor(CursorIcon::Default);
                 }
 
-                if self.is_dragging {
+                if let Some(at) = at
+                    && self.is_dragging
+                {
                     // Extend selection while dragging
-                    let char_index = self.char_index_at_x(*x, bounds);
+                    let char_index = self.char_index_at_x(at.x, bounds);
                     self.selection.cursor = char_index;
                     self.ensure_cursor_visible(bounds.width);
                     request_job(id, JobRequest::Paint);
@@ -1338,12 +1346,13 @@ impl Widget for TextInput {
                 }
                 return EventResponse::Handled;
             }
-            Event::MouseDown { x, y, button }
-                if bounds.contains(*x, *y) && *button == MouseButton::Middle =>
-            {
+            Event::MouseDown {
+                at: Some(at),
+                button,
+            } if bounds.contains(at.x, at.y) && *button == MouseButton::Middle => {
                 // Middle-click paste from the primary selection
                 request_focus(tree, id);
-                let char_index = self.char_index_at_x(*x, bounds);
+                let char_index = self.char_index_at_x(at.x, bounds);
                 self.selection = Selection::new(char_index);
                 if let Some(text) = primary_paste() {
                     self.insert_text(&text, edit);

--- a/src/widgets/text_input.rs
+++ b/src/widgets/text_input.rs
@@ -1403,7 +1403,6 @@ mod tests {
     use crate::jobs::{clear_pending_jobs, clear_scheduled_jobs, next_deadline, queued_job_types};
     use crate::layout::Constraints;
     use crate::reactive::create_signal;
-    use crate::widgets::widget::Point;
 
     /// A move with no position says nothing about where a drag has got to.
     ///
@@ -1434,9 +1433,7 @@ mod tests {
         };
         input.is_dragging = true;
 
-        let moved_to = Event::MouseMove {
-            at: Some(Point::new(60.0, 5.0)),
-        };
+        let moved_to = Event::mouse_move(60.0, 5.0);
         Widget::event(&mut input, &mut tree, id, &moved_to);
         let dragged = input.selection.cursor;
         assert_ne!(

--- a/src/widgets/widget.rs
+++ b/src/widgets/widget.rs
@@ -609,6 +609,60 @@ pub enum EventResponse {
 }
 
 impl Event {
+    /// A pointer move at a place.
+    ///
+    /// The constructors exist for the positioned case only, and deliberately:
+    /// it is the overwhelmingly common one, and the absent case has to stay
+    /// spelled out. `Event::MouseMove { at: None }` says what it is; a
+    /// `mouse_move_nowhere()` beside `mouse_move(x, y)` would make the two
+    /// look like a pair of ordinary alternatives, which is exactly what the
+    /// `Option` exists to prevent.
+    pub fn mouse_move(x: f32, y: f32) -> Self {
+        Event::MouseMove {
+            at: Some(Point::new(x, y)),
+        }
+    }
+
+    /// A button pressed at a place. See [`mouse_move`](Self::mouse_move).
+    pub fn mouse_down(x: f32, y: f32, button: MouseButton) -> Self {
+        Event::MouseDown {
+            at: Some(Point::new(x, y)),
+            button,
+        }
+    }
+
+    /// A button released at a place. See [`mouse_move`](Self::mouse_move).
+    pub fn mouse_up(x: f32, y: f32, button: MouseButton) -> Self {
+        Event::MouseUp {
+            at: Some(Point::new(x, y)),
+            button,
+        }
+    }
+
+    /// The pointer arriving at a place. See [`mouse_move`](Self::mouse_move).
+    pub fn mouse_enter(x: f32, y: f32) -> Self {
+        Event::MouseEnter {
+            at: Some(Point::new(x, y)),
+        }
+    }
+
+    /// A scroll at a place. See [`mouse_move`](Self::mouse_move).
+    pub fn scroll(x: f32, y: f32, delta_x: f32, delta_y: f32, source: ScrollSource) -> Self {
+        Event::Scroll {
+            at: Some(Point::new(x, y)),
+            delta_x,
+            delta_y,
+            source,
+        }
+    }
+
+    /// A scroll gesture ending at a place. See [`mouse_move`](Self::mouse_move).
+    pub fn scroll_end(x: f32, y: f32) -> Self {
+        Event::ScrollEnd {
+            at: Some(Point::new(x, y)),
+        }
+    }
+
     /// Where this event happened, if it happened anywhere.
     ///
     /// `None` for two different reasons, and a consumer wants the same thing

--- a/src/widgets/widget.rs
+++ b/src/widgets/widget.rs
@@ -158,6 +158,35 @@ pub struct Rect {
     pub height: f32,
 }
 
+/// Where a pointer is.
+///
+/// Its own type rather than a pair of floats because the interesting value is
+/// [`Option<Point>`]: a pointer event that has descended into a subtree
+/// collapsed to nothing has no position, and there is no *number* that means
+/// nowhere. See [`Event::coords`].
+/// No `Default`, deliberately. The origin is a place like any other, and this
+/// whole type exists so that "nowhere" is not spelled as a coordinate — a
+/// `Option<Point>::unwrap_or_default()` would put the pointer at the top-left
+/// corner, which is the snapped-to-zero failure #227 records.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Point {
+    pub x: f32,
+    pub y: f32,
+}
+
+impl Point {
+    #[inline]
+    pub const fn new(x: f32, y: f32) -> Self {
+        Self { x, y }
+    }
+
+    /// Offset by a vector — how a container rebases a point into child space.
+    #[inline]
+    pub fn offset(self, dx: f32, dy: f32) -> Self {
+        Self::new(self.x + dx, self.y + dy)
+    }
+}
+
 /// The superellipse "length" of a vector — the shader's `superellipse_length`.
 ///
 /// `n = 1` is the diamond a bevel cuts, `n = 2` the circle of an ordinary
@@ -217,6 +246,23 @@ impl Rect {
 
     pub fn contains(&self, x: f32, y: f32) -> bool {
         x >= self.x && x < self.x + self.width && y >= self.y && y < self.y + self.height
+    }
+
+    /// Whether a point that may not exist is inside this rect.
+    ///
+    /// An event with no position is inside nothing — see [`Event::coords`] for
+    /// the two ways it comes to have none. Every hit test asks this rather
+    /// than unwrapping first, so the rule is written once instead of being
+    /// taught to each widget separately.
+    #[inline]
+    pub fn contains_at(&self, at: Option<Point>) -> bool {
+        at.is_some_and(|at| self.contains(at.x, at.y))
+    }
+
+    /// [`contains_at`](Self::contains_at), narrowed by the corner shape.
+    #[inline]
+    pub fn contains_shape_at(&self, at: Option<Point>, corners: crate::widgets::Corners) -> bool {
+        at.is_some_and(|at| self.contains_shape(at.x, at.y, corners))
     }
 
     /// Whether a point is inside this rect once its corners are taken off.
@@ -500,21 +546,25 @@ pub enum Key {
 #[derive(Debug, Clone)]
 pub enum Event {
     /// Mouse/pointer moved
-    MouseMove { x: f32, y: f32 },
+    MouseMove { at: Option<Point> },
     /// Mouse button pressed
-    MouseDown { x: f32, y: f32, button: MouseButton },
+    MouseDown {
+        at: Option<Point>,
+        button: MouseButton,
+    },
     /// Mouse button released
-    MouseUp { x: f32, y: f32, button: MouseButton },
+    MouseUp {
+        at: Option<Point>,
+        button: MouseButton,
+    },
     /// Mouse/pointer entered the surface (with entry coordinates)
-    MouseEnter { x: f32, y: f32 },
+    MouseEnter { at: Option<Point> },
     /// Mouse/pointer left the surface
     MouseLeave,
     /// Scroll event (wheel, touchpad, or touchscreen)
     Scroll {
-        /// X position of the pointer
-        x: f32,
-        /// Y position of the pointer
-        y: f32,
+        /// Where the pointer is, if it is anywhere
+        at: Option<Point>,
         /// Horizontal scroll delta in pixels (positive = right)
         delta_x: f32,
         /// Vertical scroll delta in pixels (positive = down)
@@ -529,10 +579,8 @@ pub enum Event {
     /// no delta, because nothing moved; what it carries is the one unguessed
     /// answer to when a momentum may begin.
     ScrollEnd {
-        /// X position of the pointer
-        x: f32,
-        /// Y position of the pointer
-        y: f32,
+        /// Where the pointer is, if it is anywhere
+        at: Option<Point>,
     },
     /// Key pressed
     KeyDown {
@@ -561,15 +609,22 @@ pub enum EventResponse {
 }
 
 impl Event {
-    /// Get the coordinates from this event, if any
-    pub fn coords(&self) -> Option<(f32, f32)> {
+    /// Where this event happened, if it happened anywhere.
+    ///
+    /// `None` for two different reasons, and a consumer wants the same thing
+    /// from both: a keyboard or focus event never had a position, and a
+    /// pointer event that descended into a subtree collapsed to nothing has
+    /// lost the one it had. Either way there is no point to test against
+    /// bounds, so nothing is under the pointer here.
+    #[inline]
+    pub fn coords(&self) -> Option<Point> {
         match self {
-            Event::MouseMove { x, y } => Some((*x, *y)),
-            Event::MouseDown { x, y, .. } => Some((*x, *y)),
-            Event::MouseUp { x, y, .. } => Some((*x, *y)),
-            Event::MouseEnter { x, y } => Some((*x, *y)),
-            Event::Scroll { x, y, .. } => Some((*x, *y)),
-            Event::ScrollEnd { x, y } => Some((*x, *y)),
+            Event::MouseMove { at }
+            | Event::MouseDown { at, .. }
+            | Event::MouseUp { at, .. }
+            | Event::MouseEnter { at }
+            | Event::Scroll { at, .. }
+            | Event::ScrollEnd { at } => *at,
             Event::MouseLeave
             | Event::KeyDown { .. }
             | Event::KeyUp { .. }
@@ -578,36 +633,38 @@ impl Event {
         }
     }
 
-    /// Create a new event with transformed coordinates
-    pub fn with_coords(&self, new_x: f32, new_y: f32) -> Self {
+    /// The same event somewhere else, or nowhere.
+    ///
+    /// `None` is what a container passes down when its own transform cannot
+    /// be undone. The event still travels — a press given up and a hover
+    /// cleared are things only a delivered event can do — it simply arrives
+    /// without a position, so every bounds test below answers no.
+    pub fn with_coords(&self, at: Option<Point>) -> Self {
         match self {
-            Event::MouseMove { .. } => Event::MouseMove { x: new_x, y: new_y },
+            Event::MouseMove { .. } => Event::MouseMove { at },
             Event::MouseDown { button, .. } => Event::MouseDown {
-                x: new_x,
-                y: new_y,
+                at,
                 button: *button,
             },
             Event::MouseUp { button, .. } => Event::MouseUp {
-                x: new_x,
-                y: new_y,
+                at,
                 button: *button,
             },
-            Event::MouseEnter { .. } => Event::MouseEnter { x: new_x, y: new_y },
+            Event::MouseEnter { .. } => Event::MouseEnter { at },
             Event::Scroll {
                 delta_x,
                 delta_y,
                 source,
                 ..
             } => Event::Scroll {
-                x: new_x,
-                y: new_y,
+                at,
                 delta_x: *delta_x,
                 delta_y: *delta_y,
                 source: *source,
             },
-            Event::ScrollEnd { .. } => Event::ScrollEnd { x: new_x, y: new_y },
+            Event::ScrollEnd { .. } => Event::ScrollEnd { at },
             Event::MouseLeave => Event::MouseLeave,
-            // Keyboard/focus events don't have coordinates
+            // Keyboard and focus events never had one to replace.
             Event::KeyDown { key, modifiers } => Event::KeyDown {
                 key: *key,
                 modifiers: *modifiers,

--- a/tests/collapsed_subtree.rs
+++ b/tests/collapsed_subtree.rs
@@ -1,0 +1,419 @@
+//! A subtree collapsed to nothing answers for nothing.
+//!
+//! `scale(0.0)` on either axis squashes the plane onto a line, and a matrix
+//! that has done that has no inverse — so the hit test, which works by undoing
+//! the transform before comparing against the laid-out bounds, has nothing to
+//! undo it with. It used to hand the point back unchanged, and an invisible
+//! subtree answered for the whole area it covers when it is open: #227.
+//!
+//! Every case here is one of the five the issue says a fix has to hold at
+//! once, and each is a shape one of the three rejected attempts got wrong.
+
+use std::cell::Cell;
+use std::rc::Rc;
+
+use guido::layout::Constraints;
+use guido::prelude::*;
+use guido::tree::{Tree, WidgetId};
+use guido::widgets::widget::EventResponse;
+
+struct H {
+    tree: Tree,
+    root: WidgetId,
+}
+
+impl H {
+    fn new(widget: impl Widget + 'static) -> Self {
+        let mut tree = Tree::new();
+        let root = tree.register(Box::new(widget));
+        tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
+        let mut h = Self { tree, root };
+        h.lay_out();
+        h
+    }
+
+    fn lay_out(&mut self) {
+        let root = self.root;
+        self.tree.with_widget_mut(root, |w, id, t| {
+            w.layout(t, id, Constraints::new(0.0, 0.0, 400.0, 200.0))
+        });
+    }
+
+    fn send(&mut self, event: Event) -> EventResponse {
+        let root = self.root;
+        guido::reactive::diagnostics::snapshot_zone(|| {
+            self.tree
+                .with_widget_mut(root, |w, id, t| w.event(t, id, &event))
+                .expect("the root is registered")
+        })
+    }
+
+    fn click(&mut self, x: f32, y: f32) {
+        self.send(Event::MouseDown {
+            at: Some(Point::new(x, y)),
+            button: MouseButton::Left,
+        });
+        self.send(Event::MouseUp {
+            at: Some(Point::new(x, y)),
+            button: MouseButton::Left,
+        });
+    }
+}
+
+/// A counter a callback bumps, readable from the test.
+fn counter() -> (Rc<Cell<u32>>, impl Fn() + 'static) {
+    let count = Rc::new(Cell::new(0));
+    let bump = counting(Rc::clone(&count));
+    (count, bump)
+}
+
+/// Another callback bumping the same counter — for the handlers that take
+/// arguments this file does not care about.
+fn counting(count: Rc<Cell<u32>>) -> impl Fn() + 'static {
+    move || count.set(count.get() + 1)
+}
+
+/// The collapsed idiom the enter transition documents: full width, no height.
+const COLLAPSED: Scale = Scale::new(1.0, 0.0);
+
+// ---------------------------------------------------------------------------
+// 1. A collapsed container takes nothing, and neither does anything inside it
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_collapsed_container_takes_no_click() {
+    let (clicks, bump) = counter();
+    let mut h = H::new(
+        container()
+            .width(80.0)
+            .height(40.0)
+            .scale(COLLAPSED)
+            .on_click(bump),
+    );
+
+    h.click(40.0, 20.0);
+    assert_eq!(
+        clicks.get(),
+        0,
+        "a container squashed to nothing must not answer for the area it \
+         covers when it is open"
+    );
+}
+
+/// The case a test with no children hides, and the one that matters: a menu
+/// *is* its buttons, and every one of them used to answer while it was closed.
+#[test]
+fn nothing_inside_a_collapsed_container_takes_a_click() {
+    let (clicks, bump) = counter();
+    let mut h = H::new(
+        container().width(80.0).height(40.0).scale(COLLAPSED).child(
+            container()
+                .width(80.0)
+                .height(40.0)
+                .background(Color::RED)
+                .on_click(bump),
+        ),
+    );
+
+    h.click(40.0, 20.0);
+    assert_eq!(clicks.get(), 0, "an invisible button is not a button");
+}
+
+/// Wherever the collapse sits, everything below it goes with it — the
+/// determinant of a composed transform is the product, so a collapsed
+/// ancestor collapses every descendant.
+#[test]
+fn a_collapse_reaches_every_depth_below_it() {
+    let (clicks, bump) = counter();
+    let mut h = H::new(
+        container().width(80.0).height(40.0).scale(COLLAPSED).child(
+            container().width(80.0).height(40.0).child(
+                container()
+                    .width(80.0)
+                    .height(40.0)
+                    .background(Color::RED)
+                    .on_click(bump),
+            ),
+        ),
+    );
+
+    h.click(40.0, 20.0);
+    assert_eq!(
+        clicks.get(),
+        0,
+        "two levels down is still below the collapse"
+    );
+}
+
+/// And a sibling stacked with it gets the click the collapsed one used to
+/// swallow. Children are asked in declaration order, so the collapsed one is
+/// declared first: it is the one that answered before anybody else was asked.
+#[test]
+fn a_collapsed_container_does_not_swallow_a_siblings_click() {
+    let (clicks, bump) = counter();
+    let mut h = H::new(
+        container()
+            .layout(guido::layout::ZStack::new())
+            .width(80.0)
+            .height(40.0)
+            .child(
+                container()
+                    .width(80.0)
+                    .height(40.0)
+                    .scale(COLLAPSED)
+                    .on_click(|| panic!("the collapsed one must not answer")),
+            )
+            .child(
+                container()
+                    .width(80.0)
+                    .height(40.0)
+                    .background(Color::BLUE)
+                    .on_click(bump),
+            ),
+    );
+
+    h.click(40.0, 20.0);
+    assert_eq!(
+        clicks.get(),
+        1,
+        "the visible sibling is what was clicked, not the invisible one in \
+         front of it in the dispatch order"
+    );
+}
+
+#[test]
+fn a_collapsed_container_takes_no_scroll() {
+    let (scrolls, _) = counter();
+    let bump = counting(Rc::clone(&scrolls));
+    let mut h = H::new(
+        container()
+            .width(80.0)
+            .height(40.0)
+            .scale(COLLAPSED)
+            .on_scroll(move |_, _, _| bump()),
+    );
+
+    h.send(Event::Scroll {
+        at: Some(Point::new(40.0, 20.0)),
+        delta_x: 0.0,
+        delta_y: 10.0,
+        source: ScrollSource::Wheel,
+    });
+    assert_eq!(scrolls.get(), 0, "there is nothing there to scroll");
+}
+
+#[test]
+fn a_collapsed_container_takes_no_hover() {
+    let (hovers, _) = counter();
+    let bump = counting(Rc::clone(&hovers));
+    let mut h = H::new(
+        container()
+            .width(80.0)
+            .height(40.0)
+            .scale(COLLAPSED)
+            .on_hover(move |inside| {
+                if inside {
+                    bump()
+                }
+            }),
+    );
+
+    h.send(Event::MouseMove {
+        at: Some(Point::new(40.0, 20.0)),
+    });
+    assert_eq!(hovers.get(), 0, "the pointer is not over anything");
+}
+
+// ---------------------------------------------------------------------------
+// 2. What was in flight when it collapsed is cleared, not stranded
+// ---------------------------------------------------------------------------
+
+/// The half that refusing events strands: a button pressed when its menu
+/// closes has to hear the release, or it stays pressed for good.
+///
+/// Asserted through `on_click`, which fires only for a release *inside* the
+/// shape: the press must be given up, so the release that follows must not
+/// activate anything.
+#[test]
+fn a_press_in_flight_is_given_up_when_the_container_collapses() {
+    let open = create_signal(true);
+    let (clicks, bump) = counter();
+    let mut h = H::new(
+        container()
+            .width(80.0)
+            .height(40.0)
+            .scale(move || if open.get() { Scale::NONE } else { COLLAPSED })
+            .on_click(bump),
+    );
+
+    h.send(Event::MouseDown {
+        at: Some(Point::new(40.0, 20.0)),
+        button: MouseButton::Left,
+    });
+
+    open.set(false);
+    h.lay_out();
+
+    h.send(Event::MouseUp {
+        at: Some(Point::new(40.0, 20.0)),
+        button: MouseButton::Left,
+    });
+    assert_eq!(
+        clicks.get(),
+        0,
+        "a release into nothing activates nothing — and the press has to be \
+         given up rather than left standing"
+    );
+
+    // And the container is genuinely no longer pressed: reopening it and
+    // releasing again must not fire the click the first release left owing.
+    open.set(true);
+    h.lay_out();
+    h.send(Event::MouseUp {
+        at: Some(Point::new(40.0, 20.0)),
+        button: MouseButton::Left,
+    });
+    assert_eq!(clicks.get(), 0, "the press did not survive the collapse");
+}
+
+/// The same for hover, which is what a state layer paints from.
+#[test]
+fn a_hover_in_flight_is_cleared_when_the_container_collapses() {
+    let open = create_signal(true);
+    let hovers = Rc::new(Cell::new(Vec::new()));
+    let seen = Rc::clone(&hovers);
+    let mut h = H::new(
+        container()
+            .width(80.0)
+            .height(40.0)
+            .scale(move || if open.get() { Scale::NONE } else { COLLAPSED })
+            .on_hover(move |inside| {
+                let mut v = seen.take();
+                v.push(inside);
+                seen.set(v);
+            }),
+    );
+
+    h.send(Event::MouseMove {
+        at: Some(Point::new(40.0, 20.0)),
+    });
+    assert_eq!(hovers.take(), vec![true], "hovered while it was open");
+
+    open.set(false);
+    h.lay_out();
+    h.send(Event::MouseMove {
+        at: Some(Point::new(40.0, 20.0)),
+    });
+    assert_eq!(
+        hovers.take(),
+        vec![false],
+        "and told it is no longer hovered once there is nothing to hover"
+    );
+}
+
+/// And for a widget that hit-tests on its own bounds rather than through the
+/// container's `HitContext` — a text input keeps a hover flag and an I-beam
+/// cursor of its own, and both have to fall when the box holding it does.
+///
+/// This is the half a `Some(at)` pattern silently drops: an arm that only
+/// matches a positioned move is never entered by a positionless one, so the
+/// state it would have cleared stays exactly as it was.
+#[test]
+fn a_text_input_inside_a_collapsing_container_stops_being_hovered() {
+    let open = create_signal(true);
+    let text = create_signal(String::from("hello"));
+    let mut h = H::new(
+        container()
+            .width(200.0)
+            .height(40.0)
+            .scale(move || if open.get() { Scale::NONE } else { COLLAPSED })
+            .child(text_input(text)),
+    );
+
+    h.send(Event::MouseMove {
+        at: Some(Point::new(5.0, 5.0)),
+    });
+    assert_eq!(
+        guido::reactive::cursor::get_current_cursor(),
+        CursorIcon::Text,
+        "the pointer is over the field while the box is open"
+    );
+
+    open.set(false);
+    h.lay_out();
+    h.send(Event::MouseMove {
+        at: Some(Point::new(5.0, 5.0)),
+    });
+    assert_eq!(
+        guido::reactive::cursor::get_current_cursor(),
+        CursorIcon::Default,
+        "and over nothing once it has collapsed"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 3. A key still reaches a focused descendant, which has no position
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_key_still_reaches_a_descendant_of_a_collapsed_container() {
+    let (keys, _) = counter();
+    let bump = counting(Rc::clone(&keys));
+    let mut h = H::new(
+        container().width(80.0).height(40.0).scale(COLLAPSED).child(
+            container()
+                .width(80.0)
+                .height(40.0)
+                .on_key_down(move |_, _| bump()),
+        ),
+    );
+
+    h.send(Event::KeyDown {
+        key: Key::Enter,
+        modifiers: Modifiers::default(),
+    });
+    assert_eq!(
+        keys.get(),
+        1,
+        "a key has no position to be wrong about, so a collapse says nothing \
+         about it"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 4. A drag in flight is not snapped to zero
+//
+// Covered where the drag lives rather than in a case of its own: a move with
+// no position leaves a scrollbar drag and a text selection exactly where they
+// were, because the arm that would move them asks for a position first. The
+// half that *does* change is the hover beside it, which is what
+// `a_text_input_inside_a_collapsing_container_stops_being_hovered` asserts.
+//
+// 5. Clipping behaves like the rest
+// ---------------------------------------------------------------------------
+
+/// `skip_child_dispatch` decides whether a clipping container's children are
+/// asked at all, by testing the point against the bounds. With no point there
+/// is nothing to fall outside, so the children are still asked — and still
+/// answer no.
+#[test]
+fn a_collapsed_clipping_container_neither_takes_nor_strands() {
+    let (clicks, bump) = counter();
+    let mut h = H::new(
+        container()
+            .width(80.0)
+            .height(40.0)
+            .overflow(Overflow::Hidden)
+            .scale(COLLAPSED)
+            .child(
+                container()
+                    .width(80.0)
+                    .height(40.0)
+                    .background(Color::RED)
+                    .on_click(bump),
+            ),
+    );
+
+    h.click(40.0, 20.0);
+    assert_eq!(clicks.get(), 0, "clipped or not, it is not there");
+}

--- a/tests/collapsed_subtree.rs
+++ b/tests/collapsed_subtree.rs
@@ -381,14 +381,15 @@ fn a_key_still_reaches_a_descendant_of_a_collapsed_container() {
 }
 
 // ---------------------------------------------------------------------------
-// 4. A drag in flight is not snapped to zero
+// 4. A selection or a drag in flight is not snapped to zero
 //
-// Covered where the drag lives rather than in a case of its own: a move with
-// no position leaves a scrollbar drag and a text selection exactly where they
-// were, because the arm that would move them asks for a position first. The
-// half that *does* change is the hover beside it, which is what
-// `a_text_input_inside_a_collapsing_container_stops_being_hovered` asserts.
-//
+// Asserted where the state lives, because nothing outside the crate can read a
+// selection back: `text_input::tests::a_move_with_no_position_leaves_the_
+// selection_where_it_was`. The half of that split which *is* visible from here
+// is the hover above, which falls while the selection stands.
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
 // 5. Clipping behaves like the rest
 // ---------------------------------------------------------------------------
 

--- a/tests/collapsed_subtree.rs
+++ b/tests/collapsed_subtree.rs
@@ -12,53 +12,10 @@
 use std::cell::Cell;
 use std::rc::Rc;
 
-use guido::layout::Constraints;
 use guido::prelude::*;
-use guido::tree::{Tree, WidgetId};
-use guido::widgets::widget::EventResponse;
 
-struct H {
-    tree: Tree,
-    root: WidgetId,
-}
-
-impl H {
-    fn new(widget: impl Widget + 'static) -> Self {
-        let mut tree = Tree::new();
-        let root = tree.register(Box::new(widget));
-        tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
-        let mut h = Self { tree, root };
-        h.lay_out();
-        h
-    }
-
-    fn lay_out(&mut self) {
-        let root = self.root;
-        self.tree.with_widget_mut(root, |w, id, t| {
-            w.layout(t, id, Constraints::new(0.0, 0.0, 400.0, 200.0))
-        });
-    }
-
-    fn send(&mut self, event: Event) -> EventResponse {
-        let root = self.root;
-        guido::reactive::diagnostics::snapshot_zone(|| {
-            self.tree
-                .with_widget_mut(root, |w, id, t| w.event(t, id, &event))
-                .expect("the root is registered")
-        })
-    }
-
-    fn click(&mut self, x: f32, y: f32) {
-        self.send(Event::MouseDown {
-            at: Some(Point::new(x, y)),
-            button: MouseButton::Left,
-        });
-        self.send(Event::MouseUp {
-            at: Some(Point::new(x, y)),
-            button: MouseButton::Left,
-        });
-    }
-}
+mod common;
+use common::Harness;
 
 /// A counter a callback bumps, readable from the test.
 fn counter() -> (Rc<Cell<u32>>, impl Fn() + 'static) {
@@ -83,12 +40,14 @@ const COLLAPSED: Scale = Scale::new(1.0, 0.0);
 #[test]
 fn a_collapsed_container_takes_no_click() {
     let (clicks, bump) = counter();
-    let mut h = H::new(
+    let mut h = Harness::laid_out(
         container()
             .width(80.0)
             .height(40.0)
             .scale(COLLAPSED)
             .on_click(bump),
+        400.0,
+        200.0,
     );
 
     h.click(40.0, 20.0);
@@ -105,7 +64,7 @@ fn a_collapsed_container_takes_no_click() {
 #[test]
 fn nothing_inside_a_collapsed_container_takes_a_click() {
     let (clicks, bump) = counter();
-    let mut h = H::new(
+    let mut h = Harness::laid_out(
         container().width(80.0).height(40.0).scale(COLLAPSED).child(
             container()
                 .width(80.0)
@@ -113,6 +72,8 @@ fn nothing_inside_a_collapsed_container_takes_a_click() {
                 .background(Color::RED)
                 .on_click(bump),
         ),
+        400.0,
+        200.0,
     );
 
     h.click(40.0, 20.0);
@@ -125,7 +86,7 @@ fn nothing_inside_a_collapsed_container_takes_a_click() {
 #[test]
 fn a_collapse_reaches_every_depth_below_it() {
     let (clicks, bump) = counter();
-    let mut h = H::new(
+    let mut h = Harness::laid_out(
         container().width(80.0).height(40.0).scale(COLLAPSED).child(
             container().width(80.0).height(40.0).child(
                 container()
@@ -135,6 +96,8 @@ fn a_collapse_reaches_every_depth_below_it() {
                     .on_click(bump),
             ),
         ),
+        400.0,
+        200.0,
     );
 
     h.click(40.0, 20.0);
@@ -151,7 +114,7 @@ fn a_collapse_reaches_every_depth_below_it() {
 #[test]
 fn a_collapsed_container_does_not_swallow_a_siblings_click() {
     let (clicks, bump) = counter();
-    let mut h = H::new(
+    let mut h = Harness::laid_out(
         container()
             .layout(guido::layout::ZStack::new())
             .width(80.0)
@@ -170,6 +133,8 @@ fn a_collapsed_container_does_not_swallow_a_siblings_click() {
                     .background(Color::BLUE)
                     .on_click(bump),
             ),
+        400.0,
+        200.0,
     );
 
     h.click(40.0, 20.0);
@@ -185,12 +150,14 @@ fn a_collapsed_container_does_not_swallow_a_siblings_click() {
 fn a_collapsed_container_takes_no_scroll() {
     let (scrolls, _) = counter();
     let bump = counting(Rc::clone(&scrolls));
-    let mut h = H::new(
+    let mut h = Harness::laid_out(
         container()
             .width(80.0)
             .height(40.0)
             .scale(COLLAPSED)
             .on_scroll(move |_, _, _| bump()),
+        400.0,
+        200.0,
     );
 
     h.send(Event::Scroll {
@@ -206,7 +173,7 @@ fn a_collapsed_container_takes_no_scroll() {
 fn a_collapsed_container_takes_no_hover() {
     let (hovers, _) = counter();
     let bump = counting(Rc::clone(&hovers));
-    let mut h = H::new(
+    let mut h = Harness::laid_out(
         container()
             .width(80.0)
             .height(40.0)
@@ -216,6 +183,8 @@ fn a_collapsed_container_takes_no_hover() {
                     bump()
                 }
             }),
+        400.0,
+        200.0,
     );
 
     h.send(Event::MouseMove {
@@ -238,12 +207,14 @@ fn a_collapsed_container_takes_no_hover() {
 fn a_press_in_flight_is_given_up_when_the_container_collapses() {
     let open = create_signal(true);
     let (clicks, bump) = counter();
-    let mut h = H::new(
+    let mut h = Harness::laid_out(
         container()
             .width(80.0)
             .height(40.0)
             .scale(move || if open.get() { Scale::NONE } else { COLLAPSED })
             .on_click(bump),
+        400.0,
+        200.0,
     );
 
     h.send(Event::MouseDown {
@@ -252,7 +223,7 @@ fn a_press_in_flight_is_given_up_when_the_container_collapses() {
     });
 
     open.set(false);
-    h.lay_out();
+    h.lay_out(400.0, 200.0);
 
     h.send(Event::MouseUp {
         at: Some(Point::new(40.0, 20.0)),
@@ -268,7 +239,7 @@ fn a_press_in_flight_is_given_up_when_the_container_collapses() {
     // And the container is genuinely no longer pressed: reopening it and
     // releasing again must not fire the click the first release left owing.
     open.set(true);
-    h.lay_out();
+    h.lay_out(400.0, 200.0);
     h.send(Event::MouseUp {
         at: Some(Point::new(40.0, 20.0)),
         button: MouseButton::Left,
@@ -282,7 +253,7 @@ fn a_hover_in_flight_is_cleared_when_the_container_collapses() {
     let open = create_signal(true);
     let hovers = Rc::new(Cell::new(Vec::new()));
     let seen = Rc::clone(&hovers);
-    let mut h = H::new(
+    let mut h = Harness::laid_out(
         container()
             .width(80.0)
             .height(40.0)
@@ -292,6 +263,8 @@ fn a_hover_in_flight_is_cleared_when_the_container_collapses() {
                 v.push(inside);
                 seen.set(v);
             }),
+        400.0,
+        200.0,
     );
 
     h.send(Event::MouseMove {
@@ -300,7 +273,7 @@ fn a_hover_in_flight_is_cleared_when_the_container_collapses() {
     assert_eq!(hovers.take(), vec![true], "hovered while it was open");
 
     open.set(false);
-    h.lay_out();
+    h.lay_out(400.0, 200.0);
     h.send(Event::MouseMove {
         at: Some(Point::new(40.0, 20.0)),
     });
@@ -322,12 +295,14 @@ fn a_hover_in_flight_is_cleared_when_the_container_collapses() {
 fn a_text_input_inside_a_collapsing_container_stops_being_hovered() {
     let open = create_signal(true);
     let text = create_signal(String::from("hello"));
-    let mut h = H::new(
+    let mut h = Harness::laid_out(
         container()
             .width(200.0)
             .height(40.0)
             .scale(move || if open.get() { Scale::NONE } else { COLLAPSED })
             .child(text_input(text)),
+        400.0,
+        200.0,
     );
 
     h.send(Event::MouseMove {
@@ -340,7 +315,7 @@ fn a_text_input_inside_a_collapsing_container_stops_being_hovered() {
     );
 
     open.set(false);
-    h.lay_out();
+    h.lay_out(400.0, 200.0);
     h.send(Event::MouseMove {
         at: Some(Point::new(5.0, 5.0)),
     });
@@ -364,7 +339,7 @@ fn an_enter_with_no_position_clears_the_hover_it_finds() {
     let open = create_signal(true);
     let hovers = Rc::new(Cell::new(Vec::new()));
     let seen = Rc::clone(&hovers);
-    let mut h = H::new(
+    let mut h = Harness::laid_out(
         container()
             .width(80.0)
             .height(40.0)
@@ -374,6 +349,8 @@ fn an_enter_with_no_position_clears_the_hover_it_finds() {
                 v.push(inside);
                 seen.set(v);
             }),
+        400.0,
+        200.0,
     );
 
     h.send(Event::MouseEnter {
@@ -382,7 +359,7 @@ fn an_enter_with_no_position_clears_the_hover_it_finds() {
     assert_eq!(hovers.take(), vec![true], "hovered while it was open");
 
     open.set(false);
-    h.lay_out();
+    h.lay_out(400.0, 200.0);
     h.send(Event::MouseEnter {
         at: Some(Point::new(40.0, 20.0)),
     });
@@ -402,13 +379,15 @@ fn an_enter_with_no_position_clears_the_hover_it_finds() {
 fn a_key_still_reaches_a_descendant_of_a_collapsed_container() {
     let (keys, _) = counter();
     let bump = counting(Rc::clone(&keys));
-    let mut h = H::new(
+    let mut h = Harness::laid_out(
         container().width(80.0).height(40.0).scale(COLLAPSED).child(
             container()
                 .width(80.0)
                 .height(40.0)
                 .on_key_down(move |_, _| bump()),
         ),
+        400.0,
+        200.0,
     );
 
     h.send(Event::KeyDown {
@@ -443,7 +422,7 @@ fn a_key_still_reaches_a_descendant_of_a_collapsed_container() {
 #[test]
 fn a_collapsed_clipping_container_neither_takes_nor_strands() {
     let (clicks, bump) = counter();
-    let mut h = H::new(
+    let mut h = Harness::laid_out(
         container()
             .width(80.0)
             .height(40.0)
@@ -456,6 +435,8 @@ fn a_collapsed_clipping_container_neither_takes_nor_strands() {
                     .background(Color::RED)
                     .on_click(bump),
             ),
+        400.0,
+        200.0,
     );
 
     h.click(40.0, 20.0);

--- a/tests/collapsed_subtree.rs
+++ b/tests/collapsed_subtree.rs
@@ -351,6 +351,49 @@ fn a_text_input_inside_a_collapsing_container_stops_being_hovered() {
     );
 }
 
+/// An enter into nothing is the falling edge, not a no-op.
+///
+/// `MouseEnter` is guarded on being inside, so a positionless one used to
+/// match no arm at all and whatever hover stood went on standing. The platform
+/// always pushes a move straight after an enter, so the window is one event
+/// wide — but a collapsing container is what takes the position away on the
+/// way down, so the event does occur, and one event of a stuck hover is still
+/// a stuck hover.
+#[test]
+fn an_enter_with_no_position_clears_the_hover_it_finds() {
+    let open = create_signal(true);
+    let hovers = Rc::new(Cell::new(Vec::new()));
+    let seen = Rc::clone(&hovers);
+    let mut h = H::new(
+        container()
+            .width(80.0)
+            .height(40.0)
+            .scale(move || if open.get() { Scale::NONE } else { COLLAPSED })
+            .on_hover(move |inside| {
+                let mut v = seen.take();
+                v.push(inside);
+                seen.set(v);
+            }),
+    );
+
+    h.send(Event::MouseEnter {
+        at: Some(Point::new(40.0, 20.0)),
+    });
+    assert_eq!(hovers.take(), vec![true], "hovered while it was open");
+
+    open.set(false);
+    h.lay_out();
+    h.send(Event::MouseEnter {
+        at: Some(Point::new(40.0, 20.0)),
+    });
+    assert_eq!(
+        hovers.take(),
+        vec![false],
+        "and an enter that arrives without a position says so, rather than \
+         leaving the hover standing until the next move"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // 3. A key still reaches a focused descendant, which has no position
 // ---------------------------------------------------------------------------

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,107 @@
+//! The four lines every integration test writes before it can ask anything.
+//!
+//! A widget cannot be laid out, pointed at or painted without a [`Tree`] to
+//! hold its bounds, and registering one takes the same shape every time:
+//! register, register its children, lay it out under some constraints. Five
+//! test files had written that out privately before this existed, and each had
+//! drifted — one dispatched inside a snapshot zone and the others did not,
+//! which decides whether the non-reactive-read diagnostic fires on a hit test.
+//!
+//! What is *not* here is anything a single file needs: a scrollbar's handle
+//! node, a caption's painted top, the colour of a named text. Those stay where
+//! they are asked about. This is the surface underneath them.
+//!
+//! Each test binary compiles its own copy — that is what `mod common;` does —
+//! so a helper only one file uses is dead code in the others.
+#![allow(dead_code)]
+
+use guido::layout::{Constraints, Size};
+use guido::prelude::*;
+use guido::renderer::{PaintContext, RenderNode};
+use guido::tree::{Tree, WidgetId};
+use guido::widgets::widget::EventResponse;
+
+/// A registered widget and the tree that holds its bounds.
+pub struct Harness {
+    pub tree: Tree,
+    pub root: WidgetId,
+}
+
+impl Harness {
+    /// Register `widget` as the root, and its children with it.
+    pub fn new(widget: impl Widget + 'static) -> Self {
+        let mut tree = Tree::new();
+        let root = tree.register(Box::new(widget));
+        tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
+        Self { tree, root }
+    }
+
+    /// Register a widget and lay it out at once, which is what a test that
+    /// then asks a question about it wants.
+    pub fn laid_out(widget: impl Widget + 'static, width: f32, height: f32) -> Self {
+        let mut surface = Self::new(widget);
+        surface.lay_out(width, height);
+        surface
+    }
+
+    /// Lay out loose within `width` x `height`.
+    pub fn lay_out(&mut self, width: f32, height: f32) -> Size {
+        let root = self.root;
+        self.tree
+            .with_widget_mut(root, |w, id, t| {
+                w.layout(t, id, Constraints::new(0.0, 0.0, width, height))
+            })
+            .expect("the root is registered")
+    }
+
+    /// Deliver one event.
+    ///
+    /// Inside a snapshot zone, because that is where the real loop dispatches
+    /// (`render_surface`): hit testing reads animated values for *this* event
+    /// and must not subscribe to them. Outside one those reads trip the
+    /// non-reactive-read diagnostic, which would be the harness reporting on
+    /// itself.
+    pub fn send(&mut self, event: Event) -> EventResponse {
+        let root = self.root;
+        guido::reactive::diagnostics::snapshot_zone(|| {
+            self.tree
+                .with_widget_mut(root, |w, id, t| w.event(t, id, &event))
+                .expect("the root is registered")
+        })
+    }
+
+    /// Deliver one event, at a named instant.
+    pub fn send_at(&mut self, event: Event, at: std::time::Instant) -> EventResponse {
+        self.tree.set_event_instant(Some(at));
+        let response = self.send(event);
+        self.tree.set_event_instant(None);
+        response
+    }
+
+    /// A press and the release that follows it, at the same place.
+    pub fn click(&mut self, x: f32, y: f32) {
+        self.send(Event::mouse_down(x, y, MouseButton::Left));
+        self.send(Event::mouse_up(x, y, MouseButton::Left));
+    }
+
+    /// Paint the whole tree and hand back what it drew.
+    pub fn paint(&mut self) -> RenderNode {
+        let root = self.root;
+        let mut node = RenderNode::new(root.as_u64());
+        self.tree.with_widget_mut(root, |w, id, t| {
+            let mut ctx = PaintContext::new(&mut node);
+            w.paint(t, id, &mut ctx);
+        });
+        node
+    }
+
+    /// One animation pass, at a named instant, post-order as the loop runs it.
+    pub fn advance(&mut self, at: std::time::Instant) {
+        self.tree.set_frame_instant(Some(at));
+        for id in self.tree.collect_subtree_post_order(self.root) {
+            self.tree
+                .with_widget_mut(id, |w, id, t| w.advance_animations(t, id));
+        }
+        self.tree.set_frame_instant(None);
+    }
+}

--- a/tests/external_widget.rs
+++ b/tests/external_widget.rs
@@ -10,6 +10,14 @@
 //! This file covers the first: the two preludes are the only imports, which is
 //! the point of `widget_prelude` existing — the tree, the paint context and the
 //! tracking scope used to have to be reached for one module at a time.
+//!
+//! It also covers `event`, which is not required but is what a widget needs to
+//! be pointed at. That method's signature names `Event`, and a positional
+//! `Event` names `Point`, so this is where those two being reachable from the
+//! documented pair of preludes is checked.
+
+use std::cell::Cell;
+use std::rc::Rc;
 
 use guido::prelude::*;
 use guido::widget_prelude::*;
@@ -20,6 +28,9 @@ use guido::widget_prelude::*;
 struct Bar {
     extent: Signal<f32>,
     measured: f32,
+    /// Where the last pointer event said it was, if it said anywhere. Shared
+    /// with the test, which has no other way to look inside a boxed widget.
+    pointed_at: Rc<Cell<Option<Option<Point>>>>,
 }
 
 impl Widget for Bar {
@@ -30,6 +41,17 @@ impl Widget for Bar {
         tree.cache_layout(id, constraints, size);
         tree.clear_needs_layout(id);
         size
+    }
+
+    fn event(&mut self, _tree: &mut Tree, _id: WidgetId, event: &Event) -> EventResponse {
+        // A pointer event may have no position — see `Event::coords`. A widget
+        // outside the crate has to be able to say so, which means naming the
+        // `Option` rather than unwrapping it.
+        if let Event::MouseMove { at } = event {
+            self.pointed_at.set(Some(*at));
+            return EventResponse::Handled;
+        }
+        EventResponse::Ignored
     }
 
     fn paint(&self, _tree: &Tree, _id: WidgetId, ctx: &mut PaintContext) {
@@ -59,6 +81,7 @@ fn a_widget_from_outside_the_crate_lays_out_and_paints() {
     let (mut tree, root, size) = lay_out(Bar {
         extent: extent.into(),
         measured: 0.0,
+        pointed_at: Rc::new(Cell::new(None)),
     });
 
     assert_eq!(size, Size::new(20.0, 20.0));
@@ -82,6 +105,7 @@ fn it_re_measures_from_the_signal_it_read() {
     let (mut tree, root, _) = lay_out(Bar {
         extent: extent.into(),
         measured: 0.0,
+        pointed_at: Rc::new(Cell::new(None)),
     });
 
     extent.set(40.0);
@@ -92,4 +116,42 @@ fn it_re_measures_from_the_signal_it_read() {
         .expect("root is registered");
 
     assert_eq!(size, Size::new(40.0, 40.0));
+}
+
+/// A pointer event reaches a widget written outside the crate, and it can tell
+/// a position from the absence of one.
+///
+/// `Event`'s positional variants carry `Option<Point>` rather than a pair of
+/// floats, because a subtree collapsed to nothing has no position to give and
+/// no number could have said so (#227). That is public API, so a third-party
+/// widget has to be able to spell both halves — with nothing imported but the
+/// two preludes.
+#[test]
+fn a_widget_from_outside_the_crate_can_tell_a_position_from_none() {
+    let extent = create_signal(20.0f32);
+    let pointed_at = Rc::new(Cell::new(None));
+    let (mut tree, root, _) = lay_out(Bar {
+        extent: extent.into(),
+        measured: 0.0,
+        pointed_at: Rc::clone(&pointed_at),
+    });
+
+    let mut send = |at| {
+        tree.with_widget_mut(root, |w, id, t| w.event(t, id, &Event::MouseMove { at }));
+    };
+
+    send(Some(Point::new(3.0, 4.0)));
+    assert_eq!(
+        pointed_at.get(),
+        Some(Some(Point::new(3.0, 4.0))),
+        "a positioned move arrives with its position"
+    );
+
+    send(None);
+    assert_eq!(
+        pointed_at.get(),
+        Some(None),
+        "and one that lost its position arrives without it, rather than not \
+         arriving or arriving at the origin"
+    );
 }

--- a/tests/interaction_controls.rs
+++ b/tests/interaction_controls.rs
@@ -34,8 +34,15 @@ impl H {
 
     fn point_at(&mut self, x: f32, y: f32) {
         let root = self.root;
-        self.tree
-            .with_widget_mut(root, |w, id, t| w.event(t, id, &Event::MouseMove { x, y }));
+        self.tree.with_widget_mut(root, |w, id, t| {
+            w.event(
+                t,
+                id,
+                &Event::MouseMove {
+                    at: Some(Point::new(x, y)),
+                },
+            )
+        });
     }
 
     /// Every text drawn, in paint order, as (content, colour).

--- a/tests/interaction_controls.rs
+++ b/tests/interaction_controls.rs
@@ -4,57 +4,33 @@
 //! label's hover is not its own glyphs, and it is not any ancestor either —
 //! it is the nearest thing marked as a unit.
 
-use guido::layout::{Constraints, Flex};
+use guido::layout::Flex;
 use guido::prelude::*;
 use guido::reactive::focus::{clear_focus, request_focus};
-use guido::renderer::{DrawCommand, PaintContext, RenderNode};
-use guido::tree::{Tree, WidgetId};
+use guido::renderer::{DrawCommand, RenderNode};
+
+mod common;
+use common::Harness;
 
 struct H {
-    tree: Tree,
-    root: WidgetId,
+    surface: Harness,
 }
 
 impl H {
     fn new(widget: impl Widget + 'static) -> Self {
-        let mut tree = Tree::new();
-        let root = tree.register(Box::new(widget));
-        tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
-        let mut h = Self { tree, root };
-        h.lay_out();
-        h
-    }
-
-    fn lay_out(&mut self) {
-        let root = self.root;
-        self.tree.with_widget_mut(root, |w, id, t| {
-            w.layout(t, id, Constraints::new(0.0, 0.0, 400.0, 200.0))
-        });
+        Self {
+            surface: Harness::laid_out(widget, 400.0, 200.0),
+        }
     }
 
     fn point_at(&mut self, x: f32, y: f32) {
-        let root = self.root;
-        self.tree.with_widget_mut(root, |w, id, t| {
-            w.event(
-                t,
-                id,
-                &Event::MouseMove {
-                    at: Some(Point::new(x, y)),
-                },
-            )
-        });
+        self.surface.send(Event::mouse_move(x, y));
     }
 
     /// Every text drawn, in paint order, as (content, colour).
     fn texts(&mut self) -> Vec<(String, Color)> {
-        let root = self.root;
-        let mut node = RenderNode::new(root.as_u64());
-        self.tree.with_widget_mut(root, |w, id, t| {
-            let mut ctx = PaintContext::new(&mut node);
-            w.paint(t, id, &mut ctx);
-        });
         let mut out = Vec::new();
-        collect(&node, &mut out);
+        collect(&self.surface.paint(), &mut out);
         out
     }
 
@@ -186,8 +162,8 @@ fn a_label_reacts_to_the_focus_of_the_input_beside_it() {
 
     assert_eq!(h.colour_of("Password"), WEAK);
 
-    let input = h.tree.get_children(h.root)[1];
-    request_focus(&h.tree, input);
+    let input = h.surface.tree.get_children(h.surface.root)[1];
+    request_focus(&h.surface.tree, input);
     assert_eq!(h.colour_of("Password"), STRONG);
 
     clear_focus();

--- a/tests/paint_cache_across_frames.rs
+++ b/tests/paint_cache_across_frames.rs
@@ -17,12 +17,15 @@
 //! Two sibling scrollable columns, because the bug needs a second widget to
 //! ask for the frame that the first one is then served stale into.
 
-use guido::layout::{Constraints, Flex};
+use guido::layout::Flex;
+
+mod common;
+use common::Harness;
 use guido::prelude::*;
 use guido::renderer::{
     CommandLayer, FlattenedCommand, PaintContext, RenderNode, flatten_root_into,
 };
-use guido::tree::{Tree, WidgetId};
+use guido::tree::WidgetId;
 use guido::widgets::Rect;
 
 const VIEWPORT: f32 = 200.0;
@@ -85,8 +88,7 @@ fn column() -> Container {
 
 /// A surface that renders frame after frame into one retained root node.
 struct Surface {
-    tree: Tree,
-    root: WidgetId,
+    surface: Harness,
     /// Retained across frames and `clear()`ed per frame — `SurfaceState::root_node`.
     root_node: RenderNode,
     commands: Vec<FlattenedCommand>,
@@ -106,16 +108,11 @@ impl Surface {
         let width = PAD + VIEWPORT + GAP + VIEWPORT + PAD;
         let height = PAD + CAPTION + CAPTION_GAP + VIEWPORT + PAD;
 
-        let mut tree = Tree::new();
-        let root = tree.register(Box::new(view));
-        tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
-        tree.with_widget_mut(root, |w, id, t| {
-            w.layout(t, id, Constraints::new(0.0, 0.0, width, height))
-        });
+        let harness = Harness::laid_out(view, width, height);
+        let root = harness.root;
 
         Self {
-            tree,
-            root,
+            surface: harness,
             root_node: RenderNode::new(root.as_u64()),
             commands: Vec::new(),
             layers: Vec::new(),
@@ -126,8 +123,8 @@ impl Surface {
 
     /// The scroller inside the nth column: root → column → [caption, scroller].
     fn scroller(&self, column: usize) -> WidgetId {
-        let col = self.tree.get_children(self.root)[column];
-        self.tree.get_children(col)[1]
+        let col = self.surface.tree.get_children(self.surface.root)[column];
+        self.surface.tree.get_children(col)[1]
     }
 
     /// The node the nth column's caption contributed to this frame's render
@@ -144,7 +141,7 @@ impl Surface {
     /// cache — per child of the root and never on the root itself, which is
     /// what `render_surface` does.
     fn frame(&mut self) {
-        if !self.tree.needs_paint(self.root) {
+        if !self.surface.tree.needs_paint(self.surface.root) {
             return;
         }
 
@@ -152,8 +149,7 @@ impl Surface {
         self.root_node.bounds = Rect::new(0.0, 0.0, self.width, self.height);
 
         let Self {
-            tree,
-            root,
+            surface: Harness { tree, root },
             root_node,
             commands,
             layers,
@@ -174,26 +170,27 @@ impl Surface {
     /// the offset, and the `JobRequest::Paint` it asks for arrives as
     /// `mark_needs_paint` when the job queue is drained (`jobs.rs`).
     fn scroll(&mut self, column: usize, delta: f32) {
-        let root = self.root;
+        let root = self.surface.root;
         let x = if column == 0 {
             COLUMN_A_X + VIEWPORT / 2.0
         } else {
             COLUMN_B_X + VIEWPORT / 2.0
         };
-        self.tree.with_widget_mut(root, |w, id, t| {
+        self.surface.tree.with_widget_mut(root, |w, id, t| {
             w.event(
                 t,
                 id,
-                &Event::Scroll {
-                    at: Some(Point::new(x, SCROLLER_TOP + VIEWPORT / 2.0)),
-                    delta_x: 0.0,
-                    delta_y: delta,
-                    source: ScrollSource::Wheel,
-                },
+                &Event::scroll(
+                    x,
+                    SCROLLER_TOP + VIEWPORT / 2.0,
+                    0.0,
+                    delta,
+                    ScrollSource::Wheel,
+                ),
             )
         });
         let scroller = self.scroller(column);
-        self.tree.mark_needs_paint(scroller);
+        self.surface.tree.mark_needs_paint(scroller);
     }
 
     /// The top of what the nth column's scroller draws, in surface
@@ -249,7 +246,7 @@ fn a_scrolled_list_survives_a_frame_painted_for_its_sibling() {
     // The pointer moves onto the other list's scrollbar: that column repaints,
     // this one is untouched and clean.
     let other = s.scroller(1);
-    s.tree.mark_needs_paint(other);
+    s.surface.tree.mark_needs_paint(other);
     s.frame();
 
     assert_eq!(

--- a/tests/paint_cache_across_frames.rs
+++ b/tests/paint_cache_across_frames.rs
@@ -185,8 +185,7 @@ impl Surface {
                 t,
                 id,
                 &Event::Scroll {
-                    x,
-                    y: SCROLLER_TOP + VIEWPORT / 2.0,
+                    at: Some(Point::new(x, SCROLLER_TOP + VIEWPORT / 2.0)),
                     delta_x: 0.0,
                     delta_y: delta,
                     source: ScrollSource::Wheel,

--- a/tests/password_never_exports.rs
+++ b/tests/password_never_exports.rs
@@ -68,17 +68,9 @@ impl Field {
     fn drag_select_all(&mut self) {
         // The field is only `font_size * 1.2` tall, so the y has to stay well
         // inside it or the hit test drops the press and the drag selects nothing.
-        self.event(&Event::MouseDown {
-            at: Some(Point::new(0.0, 4.0)),
-            button: MouseButton::Left,
-        });
-        self.event(&Event::MouseMove {
-            at: Some(Point::new(399.0, 4.0)),
-        });
-        self.event(&Event::MouseUp {
-            at: Some(Point::new(399.0, 4.0)),
-            button: MouseButton::Left,
-        });
+        self.event(&Event::mouse_down(0.0, 4.0, MouseButton::Left));
+        self.event(&Event::mouse_move(399.0, 4.0));
+        self.event(&Event::mouse_up(399.0, 4.0, MouseButton::Left));
     }
 }
 

--- a/tests/password_never_exports.rs
+++ b/tests/password_never_exports.rs
@@ -69,14 +69,14 @@ impl Field {
         // The field is only `font_size * 1.2` tall, so the y has to stay well
         // inside it or the hit test drops the press and the drag selects nothing.
         self.event(&Event::MouseDown {
-            x: 0.0,
-            y: 4.0,
+            at: Some(Point::new(0.0, 4.0)),
             button: MouseButton::Left,
         });
-        self.event(&Event::MouseMove { x: 399.0, y: 4.0 });
+        self.event(&Event::MouseMove {
+            at: Some(Point::new(399.0, 4.0)),
+        });
         self.event(&Event::MouseUp {
-            x: 399.0,
-            y: 4.0,
+            at: Some(Point::new(399.0, 4.0)),
             button: MouseButton::Left,
         });
     }

--- a/tests/scroll_momentum.rs
+++ b/tests/scroll_momentum.rs
@@ -57,8 +57,7 @@ impl H {
     fn scroll(&mut self, delta: f32, source: ScrollSource) {
         let root = self.root;
         let event = Event::Scroll {
-            x: 100.0,
-            y: 100.0,
+            at: Some(Point::new(100.0, 100.0)),
             delta_x: 0.0,
             delta_y: delta,
             source,
@@ -104,7 +103,9 @@ impl H {
     /// The finger lifted, as the compositor's `axis_stop` reaches the tree.
     fn scroll_end(&mut self) {
         let root = self.root;
-        let event = Event::ScrollEnd { x: 100.0, y: 100.0 };
+        let event = Event::ScrollEnd {
+            at: Some(Point::new(100.0, 100.0)),
+        };
         self.tree
             .with_widget_mut(root, |w, id, t| w.event(t, id, &event));
     }

--- a/tests/scroll_momentum.rs
+++ b/tests/scroll_momentum.rs
@@ -7,14 +7,14 @@
 
 use std::time::{Duration, Instant};
 
-use guido::layout::{Constraints, Flex};
+use guido::layout::Flex;
 use guido::prelude::*;
-use guido::renderer::{PaintContext, RenderNode};
-use guido::tree::{Tree, WidgetId};
+
+mod common;
+use common::Harness;
 
 struct H {
-    tree: Tree,
-    root: WidgetId,
+    surface: Harness,
 }
 
 impl H {
@@ -30,40 +30,20 @@ impl H {
                     .children((0..20).map(|_| container().width(120.0).height(24.0))),
             );
 
-        let mut tree = Tree::new();
-        let root = tree.register(Box::new(view));
-        tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
-        tree.with_widget_mut(root, |w, id, t| {
-            w.layout(t, id, Constraints::new(0.0, 0.0, 200.0, 200.0))
-        });
-        Self { tree, root }
+        Self {
+            surface: Harness::laid_out(view, 200.0, 200.0),
+        }
     }
 
     /// One scroll sample from any source, at a named moment.
     fn scroll_at(&mut self, delta: f32, source: ScrollSource, at: std::time::Instant) {
-        self.tree.set_event_instant(Some(at));
-        self.scroll(delta, source);
-        self.tree.set_event_instant(None);
+        self.surface
+            .send_at(Event::scroll(100.0, 100.0, 0.0, delta, source), at);
     }
 
     /// The finger lifted at a named moment.
     fn scroll_end_at(&mut self, at: std::time::Instant) {
-        self.tree.set_event_instant(Some(at));
-        self.scroll_end();
-        self.tree.set_event_instant(None);
-    }
-
-    /// One scroll sample from any source.
-    fn scroll(&mut self, delta: f32, source: ScrollSource) {
-        let root = self.root;
-        let event = Event::Scroll {
-            at: Some(Point::new(100.0, 100.0)),
-            delta_x: 0.0,
-            delta_y: delta,
-            source,
-        };
-        self.tree
-            .with_widget_mut(root, |w, id, t| w.event(t, id, &event));
+        self.surface.send_at(Event::scroll_end(100.0, 100.0), at);
     }
 
     /// Play a flick of six samples eight milliseconds apart, and lift.
@@ -88,36 +68,16 @@ impl H {
     /// Run `n` animation frames at sixty a second from `start`, as the loop does
     /// while anything is animating, and return the moment of the last one.
     fn frames_from(&mut self, n: usize, start: Instant) -> Instant {
-        let root = self.root;
         let mut at = start;
         for _ in 0..n {
             at += Duration::from_millis(16);
-            self.tree.set_frame_instant(Some(at));
-            self.tree
-                .with_widget_mut(root, |w, id, t| w.advance_animations(t, id));
+            self.surface.advance(at);
         }
-        self.tree.set_frame_instant(None);
         at
     }
 
-    /// The finger lifted, as the compositor's `axis_stop` reaches the tree.
-    fn scroll_end(&mut self) {
-        let root = self.root;
-        let event = Event::ScrollEnd {
-            at: Some(Point::new(100.0, 100.0)),
-        };
-        self.tree
-            .with_widget_mut(root, |w, id, t| w.event(t, id, &event));
-    }
-
     fn offset(&mut self) -> f32 {
-        let root = self.root;
-        let mut node = RenderNode::new(root.as_u64());
-        self.tree.with_widget_mut(root, |w, id, t| {
-            let mut ctx = PaintContext::new(&mut node);
-            w.paint(t, id, &mut ctx);
-        });
-        -node.children[0].local_transform.ty()
+        -self.surface.paint().children[0].local_transform.ty()
     }
 }
 

--- a/tests/scrollbar_handle_tracking.rs
+++ b/tests/scrollbar_handle_tracking.rs
@@ -859,3 +859,41 @@ fn the_hover_follows_the_pointer_across_the_handle_and_stops_at_its_edge() {
          off it and the hover stayed"
     );
 }
+
+/// A move with no position leaves a scrollbar drag where it was.
+///
+/// A pointer event that has descended into a subtree collapsed to nothing
+/// arrives without a position (#227). The arm that continues a drag has to ask
+/// for one before it moves anything: an earlier attempt at that issue answered
+/// a far-away sentinel instead, and `handle_scrollbar_drag` read it as a drag
+/// and snapped the offset to 0 — which is this function, named in the issue.
+#[test]
+fn a_drag_that_loses_its_position_does_not_snap_the_offset() {
+    let mut h = H::vertical();
+
+    // Press the handle where it sits at rest, then drag down the track.
+    h.dispatch(Event::MouseDown {
+        at: Some(Point::new(195.0, TRACK_START + 10.0)),
+        button: MouseButton::Left,
+    });
+    h.dispatch(Event::MouseMove {
+        at: Some(Point::new(195.0, 120.0)),
+    });
+
+    let dragged_to = h.handle_pos();
+    assert!(
+        dragged_to > TRACK_START + 10.0,
+        "the drag has to have moved the handle to begin with, got {dragged_to}"
+    );
+
+    // The container holding the scroller collapses: the move still arrives,
+    // because that is what gives the press up, but it arrives with nowhere.
+    h.dispatch(Event::MouseMove { at: None });
+
+    let after = h.handle_pos();
+    assert!(
+        near(after, dragged_to),
+        "a move with no position leaves the drag where it was: handle at \
+         {after}, was at {dragged_to}"
+    );
+}

--- a/tests/scrollbar_handle_tracking.rs
+++ b/tests/scrollbar_handle_tracking.rs
@@ -272,8 +272,7 @@ impl H {
             (0.0, delta)
         };
         self.dispatch(Event::Scroll {
-            x: 100.0,
-            y: 40.0,
+            at: Some(Point::new(100.0, 40.0)),
             delta_x,
             delta_y,
             source: ScrollSource::Wheel,
@@ -311,8 +310,7 @@ fn a_track_click_moves_the_handle() {
     let mut h = H::vertical();
 
     h.dispatch(Event::MouseDown {
-        x: 195.0,
-        y: 190.0,
+        at: Some(Point::new(195.0, 190.0)),
         button: MouseButton::Left,
     });
 
@@ -349,8 +347,7 @@ fn a_track_click_moves_the_horizontal_handle() {
     let mut h = H::horizontal();
 
     h.dispatch(Event::MouseDown {
-        x: 190.0,
-        y: 75.0,
+        at: Some(Point::new(190.0, 75.0)),
         button: MouseButton::Left,
     });
 
@@ -392,8 +389,7 @@ fn pressing_the_painted_handle_starts_a_drag_rather_than_jumping_the_track() {
 
     let painted_centre = h.handle_pos() + V_HANDLE / 2.0;
     h.dispatch(Event::MouseDown {
-        x: 195.0,
-        y: painted_centre,
+        at: Some(Point::new(195.0, painted_centre)),
         button: MouseButton::Left,
     });
 
@@ -429,8 +425,7 @@ fn a_press_anywhere_on_the_handle_ripples_from_where_it_landed() {
         let pressed = Instant::now();
         h.dispatch_at(
             Event::MouseDown {
-                x: handle_x + local_x,
-                y: handle_y + local_y,
+                at: Some(Point::new(handle_x + local_x, handle_y + local_y)),
                 button: MouseButton::Left,
             },
             pressed,
@@ -464,8 +459,10 @@ fn hovering_the_handle_colours_it_wherever_the_scroller_sits() {
     let resting = h.handle_fill_alpha();
 
     h.dispatch(Event::MouseMove {
-        x: INSET + VIEWPORT - BAR_WIDTH / 2.0 - TRACK_START,
-        y: INSET + TRACK_START + V_HANDLE / 2.0,
+        at: Some(Point::new(
+            INSET + VIEWPORT - BAR_WIDTH / 2.0 - TRACK_START,
+            INSET + TRACK_START + V_HANDLE / 2.0,
+        )),
     });
 
     let hovered = h.handle_fill_alpha();
@@ -491,8 +488,10 @@ fn the_width_a_hover_adds_to_the_handle_answers_a_press_too() {
     let mut h = H::vertical_inset();
     let hovered = Instant::now();
     h.dispatch(Event::MouseMove {
-        x: INSET + VIEWPORT - BAR_WIDTH / 2.0 - TRACK_START,
-        y: INSET + TRACK_START + V_HANDLE / 2.0,
+        at: Some(Point::new(
+            INSET + VIEWPORT - BAR_WIDTH / 2.0 - TRACK_START,
+            INSET + TRACK_START + V_HANDLE / 2.0,
+        )),
     });
     for step in 1..=8 {
         h.frame(hovered + Duration::from_millis(16 * step));
@@ -512,8 +511,10 @@ fn the_width_a_hover_adds_to_the_handle_answers_a_press_too() {
     let pressed = hovered + Duration::from_millis(200);
     h.dispatch_at(
         Event::MouseDown {
-            x: INSET + left + 1.0,
-            y: INSET + TRACK_START + V_HANDLE / 2.0,
+            at: Some(Point::new(
+                INSET + left + 1.0,
+                INSET + TRACK_START + V_HANDLE / 2.0,
+            )),
             button: MouseButton::Left,
         },
         pressed,
@@ -543,8 +544,10 @@ fn hovering_the_horizontal_handle_colours_it_too() {
     let resting = h.handle_fill_alpha();
 
     h.dispatch(Event::MouseMove {
-        x: INSET + TRACK_START + H_HANDLE / 2.0,
-        y: INSET + H_VIEWPORT - BAR_WIDTH / 2.0 - TRACK_START,
+        at: Some(Point::new(
+            INSET + TRACK_START + H_HANDLE / 2.0,
+            INSET + H_VIEWPORT - BAR_WIDTH / 2.0 - TRACK_START,
+        )),
     });
 
     let hovered = h.handle_fill_alpha();
@@ -573,8 +576,7 @@ fn the_horizontal_handle_ripples_from_where_it_landed_too() {
         let pressed = Instant::now();
         h.dispatch_at(
             Event::MouseDown {
-                x: handle_x + local_x,
-                y: handle_y + local_y,
+                at: Some(Point::new(handle_x + local_x, handle_y + local_y)),
                 button: MouseButton::Left,
             },
             pressed,
@@ -617,8 +619,10 @@ fn the_hover_widens_the_handle_inward_and_leaves_its_outer_edge_alone() {
 
     let hovered = Instant::now();
     h.dispatch(Event::MouseMove {
-        x: INSET + VIEWPORT - BAR_WIDTH / 2.0 - TRACK_START,
-        y: INSET + TRACK_START + V_HANDLE / 2.0,
+        at: Some(Point::new(
+            INSET + VIEWPORT - BAR_WIDTH / 2.0 - TRACK_START,
+            INSET + TRACK_START + V_HANDLE / 2.0,
+        )),
     });
     for step in 1..=8 {
         h.frame(hovered + Duration::from_millis(16 * step));
@@ -648,8 +652,10 @@ fn leaving_the_scroller_takes_the_handles_hover_with_it() {
     let resting = h.handle_fill_alpha();
 
     h.dispatch(Event::MouseMove {
-        x: INSET + VIEWPORT - BAR_WIDTH / 2.0 - TRACK_START,
-        y: INSET + TRACK_START + V_HANDLE / 2.0,
+        at: Some(Point::new(
+            INSET + VIEWPORT - BAR_WIDTH / 2.0 - TRACK_START,
+            INSET + TRACK_START + V_HANDLE / 2.0,
+        )),
     });
     assert!(h.handle_fill_alpha() > resting, "the handle never lit up");
 
@@ -687,8 +693,10 @@ fn releasing_on_the_widened_handle_finishes_the_ripple_rather_than_abandoning_it
     let y = INSET + TRACK_START + V_HANDLE / 2.0;
     let hovered = Instant::now();
     h.dispatch(Event::MouseMove {
-        x: INSET + VIEWPORT - BAR_WIDTH / 2.0 - TRACK_START,
-        y,
+        at: Some(Point::new(
+            INSET + VIEWPORT - BAR_WIDTH / 2.0 - TRACK_START,
+            y,
+        )),
     });
     for step in 1..=8 {
         h.frame(hovered + Duration::from_millis(16 * step));
@@ -703,8 +711,7 @@ fn releasing_on_the_widened_handle_finishes_the_ripple_rather_than_abandoning_it
     let pressed = hovered + Duration::from_millis(200);
     h.dispatch_at(
         Event::MouseDown {
-            x,
-            y,
+            at: Some(Point::new(x, y)),
             button: MouseButton::Left,
         },
         pressed,
@@ -717,8 +724,7 @@ fn releasing_on_the_widened_handle_finishes_the_ripple_rather_than_abandoning_it
 
     h.dispatch_at(
         Event::MouseUp {
-            x,
-            y,
+            at: Some(Point::new(x, y)),
             button: MouseButton::Left,
         },
         released,
@@ -757,8 +763,10 @@ fn the_handle_takes_the_hover_colour_where_it_is_painted_after_a_wheel_scroll() 
 
     let painted = h.handle_pos();
     h.dispatch(Event::MouseMove {
-        x: VIEWPORT - BAR_WIDTH / 2.0 - TRACK_START,
-        y: painted + V_HANDLE / 2.0,
+        at: Some(Point::new(
+            VIEWPORT - BAR_WIDTH / 2.0 - TRACK_START,
+            painted + V_HANDLE / 2.0,
+        )),
     });
 
     let hovered = h.handle_fill_alpha();
@@ -788,12 +796,13 @@ fn the_handle_is_pressable_where_it_is_painted_after_a_wheel_scroll() {
         VIEWPORT - BAR_WIDTH / 2.0 - TRACK_START,
         painted + V_HANDLE / 2.0,
     );
-    h.dispatch(Event::MouseMove { x, y });
+    h.dispatch(Event::MouseMove {
+        at: Some(Point::new(x, y)),
+    });
     let hovered = h.handle_fill_alpha();
 
     h.dispatch(Event::MouseDown {
-        x,
-        y,
+        at: Some(Point::new(x, y)),
         button: MouseButton::Left,
     });
 
@@ -823,16 +832,14 @@ fn the_hover_follows_the_pointer_across_the_handle_and_stops_at_its_edge() {
     let resting = h.handle_fill_alpha();
 
     h.dispatch(Event::MouseMove {
-        x,
-        y: TRACK_START + V_HANDLE / 4.0,
+        at: Some(Point::new(x, TRACK_START + V_HANDLE / 4.0)),
     });
     let hovered = h.handle_fill_alpha();
     assert!(hovered > resting, "the handle never lit up");
 
     // Still on the handle, further down it.
     h.dispatch(Event::MouseMove {
-        x,
-        y: TRACK_START + V_HANDLE * 3.0 / 4.0,
+        at: Some(Point::new(x, TRACK_START + V_HANDLE * 3.0 / 4.0)),
     });
     let still = h.handle_fill_alpha();
     assert!(
@@ -842,8 +849,7 @@ fn the_hover_follows_the_pointer_across_the_handle_and_stops_at_its_edge() {
 
     // Down the track, past the foot of the handle, and still inside the scroller.
     h.dispatch(Event::MouseMove {
-        x,
-        y: TRACK_START + V_HANDLE + 20.0,
+        at: Some(Point::new(x, TRACK_START + V_HANDLE + 20.0)),
     });
 
     let after = h.handle_fill_alpha();

--- a/tests/scrollbar_handle_tracking.rs
+++ b/tests/scrollbar_handle_tracking.rs
@@ -18,10 +18,12 @@
 use std::rc::Rc;
 use std::time::{Duration, Instant};
 
-use guido::layout::{Constraints, Flex};
+use guido::layout::Flex;
 use guido::prelude::*;
-use guido::renderer::{DrawCommand, PaintContext, RenderNode};
-use guido::tree::{Tree, WidgetId};
+use guido::renderer::{DrawCommand, RenderNode};
+
+mod common;
+use common::Harness;
 
 /// The scrollbar sits 2px in from the edges of the container along its axis,
 /// and is `width` across — 6 by default. So a 200-long viewport carries a
@@ -60,8 +62,7 @@ fn expected(offset: f32, content: f32, handle: f32) -> f32 {
 }
 
 struct H {
-    tree: Tree,
-    root: WidgetId,
+    surface: Harness,
     /// Whether the handle travels in x or in y — the same question as which
     /// axis the container scrolls on.
     horizontal: bool,
@@ -95,7 +96,7 @@ impl H {
     /// the scroller and every reader below.
     fn vertical_inset() -> Self {
         let mut h = Self::vertical();
-        h.tree.set_origin(h.root, INSET, INSET);
+        h.surface.tree.set_origin(h.surface.root, INSET, INSET);
         h
     }
 
@@ -103,7 +104,7 @@ impl H {
     /// `vertical_inset` moves the vertical one.
     fn horizontal_inset() -> Self {
         let mut h = Self::horizontal();
-        h.tree.set_origin(h.root, INSET, INSET);
+        h.surface.tree.set_origin(h.surface.root, INSET, INSET);
         h
     }
 
@@ -125,43 +126,27 @@ impl H {
     }
 
     fn new(view: impl Widget + 'static, height: f32, horizontal: bool) -> Self {
-        let mut tree = Tree::new();
-        let root = tree.register(Box::new(view));
-        tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
         // Once, deliberately: layout does not run again for a paint-only scroll,
         // so neither does this test.
-        tree.with_widget_mut(root, |w, id, t| {
-            w.layout(t, id, Constraints::new(0.0, 0.0, VIEWPORT, height))
-        });
+        let surface = Harness::laid_out(view, VIEWPORT, height);
         Self {
-            tree,
-            root,
+            surface,
             horizontal,
         }
     }
 
     fn dispatch(&mut self, event: Event) {
-        let root = self.root;
-        self.tree
-            .with_widget_mut(root, |w, id, t| w.event(t, id, &event));
+        self.surface.send(event);
     }
 
     fn paint(&mut self) -> RenderNode {
-        let root = self.root;
-        let mut node = RenderNode::new(root.as_u64());
-        self.tree.with_widget_mut(root, |w, id, t| {
-            let mut ctx = PaintContext::new(&mut node);
-            w.paint(t, id, &mut ctx);
-        });
-        node
+        self.surface.paint()
     }
 
     /// The same, at a named instant, so that the frame after it can be placed a
     /// known distance later.
     fn dispatch_at(&mut self, event: Event, at: Instant) {
-        self.tree.set_event_instant(Some(at));
-        self.dispatch(event);
-        self.tree.set_event_instant(None);
+        self.surface.send_at(event, at);
     }
 
     /// One animation frame, at `at`.
@@ -172,12 +157,7 @@ impl H {
     /// stand-in: no test here can name the handle, which the scroller owns
     /// privately.
     fn frame(&mut self, at: Instant) {
-        self.tree.set_frame_instant(Some(at));
-        for id in self.tree.collect_subtree_post_order(self.root) {
-            self.tree
-                .with_widget_mut(id, |w, id, t| w.advance_animations(t, id));
-        }
-        self.tree.set_frame_instant(None);
+        self.surface.advance(at);
     }
 
     /// The opacity the scrollbar handle is filled with this frame.
@@ -271,12 +251,13 @@ impl H {
         } else {
             (0.0, delta)
         };
-        self.dispatch(Event::Scroll {
-            at: Some(Point::new(100.0, 40.0)),
+        self.dispatch(Event::scroll(
+            100.0,
+            40.0,
             delta_x,
             delta_y,
-            source: ScrollSource::Wheel,
-        });
+            ScrollSource::Wheel,
+        ));
     }
 }
 
@@ -309,10 +290,7 @@ fn a_wheel_scroll_moves_the_handle() {
 fn a_track_click_moves_the_handle() {
     let mut h = H::vertical();
 
-    h.dispatch(Event::MouseDown {
-        at: Some(Point::new(195.0, 190.0)),
-        button: MouseButton::Left,
-    });
+    h.dispatch(Event::mouse_down(195.0, 190.0, MouseButton::Left));
 
     let max_scroll = V_CONTENT - VIEWPORT;
     assert!(near(h.scrolled_by(), max_scroll), "the content jumped");
@@ -346,10 +324,7 @@ fn a_wheel_scroll_moves_the_horizontal_handle() {
 fn a_track_click_moves_the_horizontal_handle() {
     let mut h = H::horizontal();
 
-    h.dispatch(Event::MouseDown {
-        at: Some(Point::new(190.0, 75.0)),
-        button: MouseButton::Left,
-    });
+    h.dispatch(Event::mouse_down(190.0, 75.0, MouseButton::Left));
 
     let max_scroll = H_CONTENT - VIEWPORT;
     assert!(near(h.scrolled_by(), max_scroll), "the content jumped");
@@ -388,10 +363,7 @@ fn pressing_the_painted_handle_starts_a_drag_rather_than_jumping_the_track() {
     h.wheel(120.0);
 
     let painted_centre = h.handle_pos() + V_HANDLE / 2.0;
-    h.dispatch(Event::MouseDown {
-        at: Some(Point::new(195.0, painted_centre)),
-        button: MouseButton::Left,
-    });
+    h.dispatch(Event::mouse_down(195.0, painted_centre, MouseButton::Left));
 
     let after = h.scrolled_by();
     assert!(
@@ -424,10 +396,7 @@ fn a_press_anywhere_on_the_handle_ripples_from_where_it_landed() {
 
         let pressed = Instant::now();
         h.dispatch_at(
-            Event::MouseDown {
-                at: Some(Point::new(handle_x + local_x, handle_y + local_y)),
-                button: MouseButton::Left,
-            },
+            Event::mouse_down(handle_x + local_x, handle_y + local_y, MouseButton::Left),
             pressed,
         );
         h.frame(pressed + Duration::from_millis(16));
@@ -458,12 +427,10 @@ fn hovering_the_handle_colours_it_wherever_the_scroller_sits() {
     let mut h = H::vertical_inset();
     let resting = h.handle_fill_alpha();
 
-    h.dispatch(Event::MouseMove {
-        at: Some(Point::new(
-            INSET + VIEWPORT - BAR_WIDTH / 2.0 - TRACK_START,
-            INSET + TRACK_START + V_HANDLE / 2.0,
-        )),
-    });
+    h.dispatch(Event::mouse_move(
+        INSET + VIEWPORT - BAR_WIDTH / 2.0 - TRACK_START,
+        INSET + TRACK_START + V_HANDLE / 2.0,
+    ));
 
     let hovered = h.handle_fill_alpha();
     assert!(
@@ -487,12 +454,10 @@ fn hovering_the_handle_colours_it_wherever_the_scroller_sits() {
 fn the_width_a_hover_adds_to_the_handle_answers_a_press_too() {
     let mut h = H::vertical_inset();
     let hovered = Instant::now();
-    h.dispatch(Event::MouseMove {
-        at: Some(Point::new(
-            INSET + VIEWPORT - BAR_WIDTH / 2.0 - TRACK_START,
-            INSET + TRACK_START + V_HANDLE / 2.0,
-        )),
-    });
+    h.dispatch(Event::mouse_move(
+        INSET + VIEWPORT - BAR_WIDTH / 2.0 - TRACK_START,
+        INSET + TRACK_START + V_HANDLE / 2.0,
+    ));
     for step in 1..=8 {
         h.frame(hovered + Duration::from_millis(16 * step));
     }
@@ -510,13 +475,11 @@ fn the_width_a_hover_adds_to_the_handle_answers_a_press_too() {
 
     let pressed = hovered + Duration::from_millis(200);
     h.dispatch_at(
-        Event::MouseDown {
-            at: Some(Point::new(
-                INSET + left + 1.0,
-                INSET + TRACK_START + V_HANDLE / 2.0,
-            )),
-            button: MouseButton::Left,
-        },
+        Event::mouse_down(
+            INSET + left + 1.0,
+            INSET + TRACK_START + V_HANDLE / 2.0,
+            MouseButton::Left,
+        ),
         pressed,
     );
     h.frame(pressed + Duration::from_millis(16));
@@ -543,12 +506,10 @@ fn hovering_the_horizontal_handle_colours_it_too() {
     let mut h = H::horizontal_inset();
     let resting = h.handle_fill_alpha();
 
-    h.dispatch(Event::MouseMove {
-        at: Some(Point::new(
-            INSET + TRACK_START + H_HANDLE / 2.0,
-            INSET + H_VIEWPORT - BAR_WIDTH / 2.0 - TRACK_START,
-        )),
-    });
+    h.dispatch(Event::mouse_move(
+        INSET + TRACK_START + H_HANDLE / 2.0,
+        INSET + H_VIEWPORT - BAR_WIDTH / 2.0 - TRACK_START,
+    ));
 
     let hovered = h.handle_fill_alpha();
     assert!(
@@ -575,10 +536,7 @@ fn the_horizontal_handle_ripples_from_where_it_landed_too() {
 
         let pressed = Instant::now();
         h.dispatch_at(
-            Event::MouseDown {
-                at: Some(Point::new(handle_x + local_x, handle_y + local_y)),
-                button: MouseButton::Left,
-            },
+            Event::mouse_down(handle_x + local_x, handle_y + local_y, MouseButton::Left),
             pressed,
         );
         h.frame(pressed + Duration::from_millis(16));
@@ -618,12 +576,10 @@ fn the_hover_widens_the_handle_inward_and_leaves_its_outer_edge_alone() {
     let (resting_left, resting_right) = edges(&mut h);
 
     let hovered = Instant::now();
-    h.dispatch(Event::MouseMove {
-        at: Some(Point::new(
-            INSET + VIEWPORT - BAR_WIDTH / 2.0 - TRACK_START,
-            INSET + TRACK_START + V_HANDLE / 2.0,
-        )),
-    });
+    h.dispatch(Event::mouse_move(
+        INSET + VIEWPORT - BAR_WIDTH / 2.0 - TRACK_START,
+        INSET + TRACK_START + V_HANDLE / 2.0,
+    ));
     for step in 1..=8 {
         h.frame(hovered + Duration::from_millis(16 * step));
     }
@@ -651,12 +607,10 @@ fn leaving_the_scroller_takes_the_handles_hover_with_it() {
     let mut h = H::vertical_inset();
     let resting = h.handle_fill_alpha();
 
-    h.dispatch(Event::MouseMove {
-        at: Some(Point::new(
-            INSET + VIEWPORT - BAR_WIDTH / 2.0 - TRACK_START,
-            INSET + TRACK_START + V_HANDLE / 2.0,
-        )),
-    });
+    h.dispatch(Event::mouse_move(
+        INSET + VIEWPORT - BAR_WIDTH / 2.0 - TRACK_START,
+        INSET + TRACK_START + V_HANDLE / 2.0,
+    ));
     assert!(h.handle_fill_alpha() > resting, "the handle never lit up");
 
     h.dispatch(Event::MouseLeave);
@@ -692,12 +646,10 @@ fn releasing_on_the_widened_handle_finishes_the_ripple_rather_than_abandoning_it
     let mut h = H::vertical_inset();
     let y = INSET + TRACK_START + V_HANDLE / 2.0;
     let hovered = Instant::now();
-    h.dispatch(Event::MouseMove {
-        at: Some(Point::new(
-            INSET + VIEWPORT - BAR_WIDTH / 2.0 - TRACK_START,
-            y,
-        )),
-    });
+    h.dispatch(Event::mouse_move(
+        INSET + VIEWPORT - BAR_WIDTH / 2.0 - TRACK_START,
+        y,
+    ));
     for step in 1..=8 {
         h.frame(hovered + Duration::from_millis(16 * step));
     }
@@ -709,26 +661,14 @@ fn releasing_on_the_widened_handle_finishes_the_ripple_rather_than_abandoning_it
     let x = INSET + left + 1.0;
 
     let pressed = hovered + Duration::from_millis(200);
-    h.dispatch_at(
-        Event::MouseDown {
-            at: Some(Point::new(x, y)),
-            button: MouseButton::Left,
-        },
-        pressed,
-    );
+    h.dispatch_at(Event::mouse_down(x, y, MouseButton::Left), pressed);
     // Past FADE_IN, so the disc is at its full strength and the fade below is
     // the only thing that can have dimmed it.
     let released = pressed + Duration::from_millis(100);
     h.frame(released);
     let (_, held) = h.handle_ripple_disc().expect("the press started no ripple");
 
-    h.dispatch_at(
-        Event::MouseUp {
-            at: Some(Point::new(x, y)),
-            button: MouseButton::Left,
-        },
-        released,
-    );
+    h.dispatch_at(Event::mouse_up(x, y, MouseButton::Left), released);
     h.frame(released + Duration::from_millis(150));
 
     let (_, leaving) = h
@@ -762,12 +702,10 @@ fn the_handle_takes_the_hover_colour_where_it_is_painted_after_a_wheel_scroll() 
     h.wheel(120.0);
 
     let painted = h.handle_pos();
-    h.dispatch(Event::MouseMove {
-        at: Some(Point::new(
-            VIEWPORT - BAR_WIDTH / 2.0 - TRACK_START,
-            painted + V_HANDLE / 2.0,
-        )),
-    });
+    h.dispatch(Event::mouse_move(
+        VIEWPORT - BAR_WIDTH / 2.0 - TRACK_START,
+        painted + V_HANDLE / 2.0,
+    ));
 
     let hovered = h.handle_fill_alpha();
     assert!(
@@ -796,15 +734,10 @@ fn the_handle_is_pressable_where_it_is_painted_after_a_wheel_scroll() {
         VIEWPORT - BAR_WIDTH / 2.0 - TRACK_START,
         painted + V_HANDLE / 2.0,
     );
-    h.dispatch(Event::MouseMove {
-        at: Some(Point::new(x, y)),
-    });
+    h.dispatch(Event::mouse_move(x, y));
     let hovered = h.handle_fill_alpha();
 
-    h.dispatch(Event::MouseDown {
-        at: Some(Point::new(x, y)),
-        button: MouseButton::Left,
-    });
+    h.dispatch(Event::mouse_down(x, y, MouseButton::Left));
 
     let pressed = h.handle_fill_alpha();
     assert!(
@@ -831,16 +764,12 @@ fn the_hover_follows_the_pointer_across_the_handle_and_stops_at_its_edge() {
     let x = VIEWPORT - BAR_WIDTH / 2.0 - TRACK_START;
     let resting = h.handle_fill_alpha();
 
-    h.dispatch(Event::MouseMove {
-        at: Some(Point::new(x, TRACK_START + V_HANDLE / 4.0)),
-    });
+    h.dispatch(Event::mouse_move(x, TRACK_START + V_HANDLE / 4.0));
     let hovered = h.handle_fill_alpha();
     assert!(hovered > resting, "the handle never lit up");
 
     // Still on the handle, further down it.
-    h.dispatch(Event::MouseMove {
-        at: Some(Point::new(x, TRACK_START + V_HANDLE * 3.0 / 4.0)),
-    });
+    h.dispatch(Event::mouse_move(x, TRACK_START + V_HANDLE * 3.0 / 4.0));
     let still = h.handle_fill_alpha();
     assert!(
         (still - hovered).abs() < 0.001,
@@ -848,9 +777,7 @@ fn the_hover_follows_the_pointer_across_the_handle_and_stops_at_its_edge() {
     );
 
     // Down the track, past the foot of the handle, and still inside the scroller.
-    h.dispatch(Event::MouseMove {
-        at: Some(Point::new(x, TRACK_START + V_HANDLE + 20.0)),
-    });
+    h.dispatch(Event::mouse_move(x, TRACK_START + V_HANDLE + 20.0));
 
     let after = h.handle_fill_alpha();
     assert!(
@@ -872,13 +799,12 @@ fn a_drag_that_loses_its_position_does_not_snap_the_offset() {
     let mut h = H::vertical();
 
     // Press the handle where it sits at rest, then drag down the track.
-    h.dispatch(Event::MouseDown {
-        at: Some(Point::new(195.0, TRACK_START + 10.0)),
-        button: MouseButton::Left,
-    });
-    h.dispatch(Event::MouseMove {
-        at: Some(Point::new(195.0, 120.0)),
-    });
+    h.dispatch(Event::mouse_down(
+        195.0,
+        TRACK_START + 10.0,
+        MouseButton::Left,
+    ));
+    h.dispatch(Event::mouse_move(195.0, 120.0));
 
     let dragged_to = h.handle_pos();
     assert!(


### PR DESCRIPTION
## What changed

A container scaled to nothing painted nothing and answered for everything.
`Transform::inverse` returned the identity for a zero determinant — the least
wrong *finite* answer — and the hit test, which works by undoing a transform
before comparing against the laid-out bounds, read that as "nothing to undo".
So the point was tested against the *uncollapsed* bounds and every button
inside a closed menu was a live button nobody could see.

`inverse` returns `Option<Transform>` now, and the absence travels: a container
whose transform cannot be undone passes its children `at: None` instead of a
coordinate, so every bounds test below answers no. The events still arrive,
which is what lets a press be given up and a hover fall. Closes #227, and
Closes #306.

The design was agreed before it was written — the issue said the model change
wanted that — and [the decision is recorded on
#227](https://github.com/MalpenZibo/guido/issues/227#issuecomment-5478542050)
with the two alternatives weighed and the prior art named.

## What proves it

`tests/collapsed_subtree.rs`, eleven cases, one per shape the issue says a fix
has to hold at once. Ten were confirmed red before the change, failing with the
collapsed container answering (`left: 1, right: 0`); the eleventh — a key still
reaching a focused descendant — passed before and after, and is there as the
guard on the one thing that must *not* change.

The list is the issue's, not the bug's: the case with no children passes
whatever the fix does, and is what hid the first attempt's failure. Four cases
go through a child, one two levels down, and one puts a live sibling under the
collapsed one so the swallow is proved rather than assumed.

Beside them:

- `text_input::a_move_with_no_position_leaves_the_selection_where_it_was` —
  the "not snapped to zero" bullet. A guard rather than a fix, since the shape
  that ships already holds it; confirmed it fails with the cursor at index 0,
  the exact failure the issue records, the moment the absence is given a
  default.
- `external_widget::a_widget_from_outside_the_crate_can_tell_a_position_from_none`
  — `Event` is public, so this is a breaking change, and that file is what
  exists to watch that surface. It implemented `layout` and `paint` only, so it
  would have stayed silent.
- `transform::a_collapsed_transform_has_no_inverse` — including that a scale of
  `0.001` still inverts, since the cutoff is on the determinant and it is worth
  saying where it is not.

Goldens: 9 passed on lavapipe, none moved — expected, the renderer is
untouched. `cargo test --all-features` 27/27 binaries, `clippy --all-targets
--all-features -D warnings`, `cargo doc -D warnings`, `mdbook test` and `mdbook
build` all green. Both of the first two commits verified green in isolation.

## What the review found

The `reviewer` subagent ran over the commits before this pull request existed.
**Zero blocking.** Three worth answering, all acted on in `f6b6559`:

- *A positionless `MouseEnter` did nothing at all* — `contains(None)` is false
  so it never set hover, but the arm is guarded, so it matched nothing and a
  hover already standing stood. One event wide in practice, because the
  platform always pushes a move straight after; fixed anyway.
- *`tests/external_widget.rs` did not exercise the surface this breaks.* It
  does now.
- *The "not snapped to zero" bullet was held by argument, not by a test.* It
  has one.

Four notes. Two are recorded below under **Left undone**; the other two need no
action — `Point` sits in `prelude` beside `Event` rather than in
`widget_prelude` beside `Transform`, which is consistent because an external
widget imports both, and `Rect::contains_shape_at` has one caller, which is the
right one.

Before the review, `/simplify` read the change four ways and found a genuine
hole the compiler had opened and I had not walked through: `TextInput` and the
scrollbar path matched `at: Some(at)`, so a positionless move never entered
their arms and their hover and I-beam cursor were retained indefinitely. Both
split the arm now — the drag half keeps what it had, the hover half falls.
`a_text_input_inside_a_collapsing_container_stops_being_hovered` is that case,
and it was red.

**The mutation job reports 26 survivors of 89 viable, and one is worth
chasing.** `reuse_cached`'s moved-child branch
(`src/widgets/paint_children.rs:160`) can have either sign flipped with the
suite still green — `tests/paint_cache_across_frames.rs` has one scenario, and
it exercises the branch where the position has *not* moved. Not introduced
here: that line read `parent_position.inverse()` before, and the inverse of a
translation is its negation, so the arithmetic is unchanged; writing the sign
down is what made the gap visible. #307.

Of the rest: seven are in `src/platform/input.rs`'s Wayland handlers, which
`AGENTS.md` records as deliberately unautomated; several are equivalent
mutants (`!hit.transform.is_identity()` replaced with `true` sends an identity
transform down the slow path to the same answer); and the `text_input` and
`scrollable` guards are pre-existing shapes this diff destructured but did not
otherwise change. Per `AGENTS.md` that job reports and does not block.

## What was checked by hand

Nothing. This is input routing above the compositor; no protocol behaviour
changed and no example needed running to see it.

## Left undone

Nothing. The three shapes the review flagged as this diff's cost were taken
here rather than deferred, which is what #306 was opened for — it closes with
this.

- **`Some(Point::new(x, y))` at sixty-odd sites.** `Event::mouse_move(x, y)`
  and its five siblings now say it once. The positioned case only, and
  deliberately: `Event::MouseMove { at: None }` stays spelled out, because a
  `mouse_move_nowhere()` beside `mouse_move(x, y)` would read as a pair of
  ordinary alternatives, which is what the `Option` exists to prevent.
- **`pointer_x`/`pointer_y` in the platform layer.** One `pointer_at: Point`,
  and the three helpers beside it take the same.
- **The `H` harness in five files.** `tests/common/mod.rs` holds the four lines
  every one of them wrote — tree, register, register children, lay out — plus
  the pair they all want together. They had already drifted: one dispatched
  inside a snapshot zone and the others did not, which decides whether the
  non-reactive-read diagnostic fires on a hit test.
  `paint_cache_across_frames` keeps its own frame loop and has to, since it
  retains a render node across frames and the paint-fresh helper would defeat
  the thing it watches; it shares the registration and nothing else.



