### PR TITLE
A press nobody claimed takes the keyboard with it

### DIFF
--- a/book/src/building-ui/text-input.md
+++ b/book/src/building-ui/text-input.md
@@ -164,6 +164,48 @@ whichever was laid out last.
 The offer is made once. A relayout does not ask again, so a resize or a scale
 change cannot drag focus back from wherever the user has since put it.
 
+## Losing Focus
+
+A press that no widget claimed takes the keyboard off the field. Clicking the
+surface behind it, or a decorative panel, or empty space in a row: nothing there
+wanted the press, so there is nothing left for the focus to belong to, and the
+caret stops.
+
+A press that something *did* claim leaves the focus alone. A container with an
+`on_click`, `on_mouse_down` or `on_mouse_up` claims the left presses that land
+on it, so a toolbar button that acts on the field it sits beside does not blur
+it, and neither does the field's own scrollbar. The other two buttons are
+claimed by the handlers that name them, `on_right_click` and `on_middle_click`:
+a container with only an `on_click` does not claim a right press, and a right
+press it did not claim is a press on nothing like any other.
+
+A press inside the focused field is always the field's, whichever button it
+was.
+
+The box drawn around a field is the third case, and it is the one worth knowing:
+a container that declares `when_focused` and currently holds that focus keeps
+presses inside itself. Clicking its padding, its border, the space beside the
+caret, is clicking the field it draws.
+
+```rust
+# extern crate guido;
+# use guido::prelude::*;
+# fn main() {
+# let value = create_signal(String::new());
+container()
+    .padding(8.0)
+    .border(1.0, Color::rgb(0.3, 0.3, 0.4))
+    // Lights up for the focus, and keeps it: a click on the padding is a
+    // click on the field.
+    .when_focused(|s| s.border(2.0, Color::rgb(0.4, 0.8, 1.0)))
+    .child(text_input(value))
+# ;
+# }
+```
+
+The focus also leaves when the whole surface does — the compositor moving the
+keyboard elsewhere — and when the field is taken out of the tree.
+
 ## Placeholder
 
 What the field says while it is empty:

--- a/book/src/interactivity/states.md
+++ b/book/src/interactivity/states.md
@@ -315,6 +315,13 @@ row. What the nested control changes is only who a descendant asks.
 pointer over its own bounds. It is never pressed: being pressed means being
 activated, and it has nothing to activate.
 
+**`when_focused` also keeps the focus.** A press that no widget claimed takes
+the keyboard off whatever held it, and a container declaring `when_focused`
+while that focus is inside it claims presses on itself. A box that says it
+lights up for a field has said the box is part of the field, so clicking its
+padding does not blur what it draws. See
+[Losing Focus](../building-ui/text-input.md#losing-focus).
+
 ## Which Layer Wins
 
 Layers are resolved in reverse declaration order, one property at a time: the

--- a/docs/STATE_LAYER.md
+++ b/docs/STATE_LAYER.md
@@ -39,6 +39,18 @@ container()
     .child(text_input(value))
 ```
 
+The declaration carries a second meaning, and it is load-bearing rather than
+decorative. `dispatch_events` takes the focus off a `MouseDown` that came back
+`Ignored` from the root the focus path ends at — a press nobody claimed is a
+press on nothing. A container declaring `when_focused` while that focus is
+inside it therefore claims presses on itself (`handle_own_event`), so the
+padding and the border of the box above belong to the field it draws rather than
+blurring it.
+
+The coupling is deliberate and is the whole of the mechanism: there is no
+separate `.keeps_focus()`, and the box that lights up for a focus is the box
+that holds on to it.
+
 ### App-Declared States
 
 The first three states are noticed by the container. The fourth is a condition the app already holds, so it needs no propagation — the container just reads the signal:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -633,9 +633,18 @@ fn dispatch_events(
         // and each has its own moment.
         tree.set_event_instant(Some(*at));
         reactive::diagnostics::snapshot_zone(|| {
-            tree.with_widget_mut(root, |widget, id, tree| {
-                widget.event(tree, id, event);
-            });
+            let response =
+                tree.with_widget_mut(root, |widget, id, tree| widget.event(tree, id, event));
+
+            // A press nobody claimed is a press on nothing, and the keyboard
+            // goes with it. This is the only place that can tell: a widget is
+            // handed the presses that miss it, but never learns whether one of
+            // them turned out to be somebody else's.
+            if matches!(event, widgets::Event::MouseDown { .. })
+                && response != Some(widgets::EventResponse::Handled)
+            {
+                reactive::focus::release_focus_under(root);
+            }
         });
     }
     tree.set_event_instant(None);
@@ -2770,6 +2779,257 @@ mod dispatch_declares_the_moment {
             after > happened,
             "the moment has to be cleared when the dispatch ends, got {after:?} \
              for an event from an hour ago"
+        );
+    }
+}
+
+/// Where a press stops being the focused field's business.
+///
+/// Focus used to leave only with the whole surface: `Event::FocusOut` comes
+/// from `wl_keyboard.leave` and nothing else, so a press that landed anywhere
+/// else in the same surface left the caret blinking in a field the user had
+/// walked away from. The dispatcher is the only place that can see the
+/// difference, because it is the only place that learns whether *anything*
+/// claimed the press.
+#[cfg(test)]
+mod a_press_nothing_claimed_takes_the_focus_with_it {
+    use super::*;
+    use crate::layout::{Constraints, Flex};
+    use crate::reactive::create_signal;
+    use crate::reactive::owner::create_root_owner;
+    use crate::widget_ref::{WidgetRef, create_widget_ref, update_widget_refs};
+    use crate::widgets::state_layer::Stateful;
+    use crate::widgets::widget::{Event, MouseButton};
+    use crate::widgets::{Widget, container, text_input};
+
+    /// A surface: one root, laid out at 200x100, driven through the dispatcher
+    /// the loop drives. Two of them share a `Tree`, because the application
+    /// holds every surface's root in one.
+    struct Screen {
+        tree: Tree,
+        root: WidgetId,
+    }
+
+    impl Screen {
+        fn new(widget: impl Widget + 'static) -> Self {
+            let mut tree = Tree::new();
+            let root = Self::lay_out(&mut tree, widget);
+            Self { tree, root }
+        }
+
+        /// A second surface beside the first, in the tree they share.
+        fn add(&mut self, widget: impl Widget + 'static) -> WidgetId {
+            Self::lay_out(&mut self.tree, widget)
+        }
+
+        fn lay_out(tree: &mut Tree, widget: impl Widget + 'static) -> WidgetId {
+            let root = tree.register(Box::new(widget));
+            tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
+            tree.set_origin(root, 0.0, 0.0);
+            tree.with_widget_mut(root, |w, id, t| {
+                w.layout(t, id, Constraints::new(0.0, 0.0, 200.0, 100.0))
+            });
+            // The handles resolve once their widgets have been laid out, which
+            // is the order the loop runs them in.
+            update_widget_refs(tree);
+            root
+        }
+
+        /// A left press on this screen's own surface.
+        fn press(&mut self, x: f32, y: f32) {
+            let root = self.root;
+            self.press_button(root, x, y, MouseButton::Left);
+        }
+
+        fn press_button(&mut self, root: WidgetId, x: f32, y: f32, button: MouseButton) {
+            let events = [(std::time::Instant::now(), Event::mouse_down(x, y, button))];
+            dispatch_events(&events, root, &mut self.tree, &Default::default());
+        }
+    }
+
+    /// A handle for the field, in a fresh owner: the ref and the signal behind
+    /// it are made before the tree that will come to hold them.
+    fn a_field() -> WidgetRef {
+        create_root_owner();
+        create_widget_ref()
+    }
+
+    /// A field on a surface with nothing else on it, with the keyboard already
+    /// in it. The press that put it there is the same in four of the tests
+    /// below, and it is the half of the rule that already worked.
+    fn a_focused_field() -> (Screen, WidgetRef) {
+        let field = a_field();
+        let mut screen = Screen::new(
+            container()
+                .width(200.0)
+                .height(100.0)
+                .child(text_input(create_signal(String::new())).widget_ref(field)),
+        );
+
+        screen.press(100.0, 8.0);
+        assert!(field.is_focused(), "a press inside the field focuses it");
+        (screen, field)
+    }
+
+    /// The press that lands on the background is claimed by nobody, and there
+    /// is nothing left for the focus to belong to.
+    #[test]
+    fn a_press_on_the_background_takes_the_keyboard_off_the_field() {
+        let (mut screen, field) = a_focused_field();
+
+        screen.press(100.0, 80.0);
+        assert!(
+            !field.is_focused(),
+            "a press on the background is a press on nothing, and takes the \
+             keyboard with it"
+        );
+    }
+
+    /// The press the field itself claimed. Nothing to do with the rule, and
+    /// everything to do with it not firing on the gesture that grants focus.
+    #[test]
+    fn a_press_inside_the_field_keeps_it() {
+        let (mut screen, field) = a_focused_field();
+
+        screen.press(40.0, 8.0);
+        assert!(
+            field.is_focused(),
+            "a second press inside the field moves the caret, it does not \
+             surrender the keyboard"
+        );
+    }
+
+    /// `TextInput` takes the focus on a middle press as readily as a left one
+    /// (the primary-selection paste), so a middle press has to be able to take
+    /// it away.
+    #[test]
+    fn a_middle_press_on_the_background_takes_the_keyboard_too() {
+        let (mut screen, field) = a_focused_field();
+        let root = screen.root;
+
+        screen.press_button(root, 100.0, 80.0, MouseButton::Middle);
+        assert!(
+            !field.is_focused(),
+            "the button that can take the focus can give it back"
+        );
+    }
+
+    /// The arms that grant focus are guarded on left and middle, so a right
+    /// press inside the field falls past all of them. Read as "nobody claimed
+    /// it" that is a press on nothing — and it landed on the caret.
+    #[test]
+    fn a_right_press_inside_the_field_keeps_it() {
+        let (mut screen, field) = a_focused_field();
+        let root = screen.root;
+
+        screen.press_button(root, 100.0, 8.0, MouseButton::Right);
+        assert!(
+            field.is_focused(),
+            "a press inside the field is the field's, whatever the button"
+        );
+    }
+
+    /// The other half of the box's claim: it holds presses because it holds
+    /// *this* focus, not because it once declared it would light up for one.
+    /// Without the second half every `when_focused` box in an application
+    /// swallows every press inside it.
+    #[test]
+    fn a_when_focused_box_holding_no_focus_claims_nothing() {
+        let field = a_field();
+        let mut screen = Screen::new(
+            container()
+                .width(200.0)
+                .height(100.0)
+                .layout(Flex::column())
+                .child(
+                    container()
+                        .padding(8.0)
+                        .when_focused(|s| s.border(2.0, crate::widgets::Color::WHITE))
+                        .child(text_input(create_signal(String::new())).widget_ref(field)),
+                )
+                .child(
+                    container()
+                        .width(200.0)
+                        .height(40.0)
+                        .when_focused(|s| s.border(2.0, crate::widgets::Color::WHITE)),
+                ),
+        );
+
+        screen.press(100.0, 12.0);
+        assert!(field.is_focused(), "the press reached the field");
+
+        screen.press(100.0, 50.0);
+        assert!(
+            !field.is_focused(),
+            "a box that declares when_focused while the focus is elsewhere has              claimed nothing, and the press is still a press on nothing"
+        );
+    }
+
+    /// Focus is one signal for the whole application while one `Tree` holds
+    /// every surface's root. A press on the bar must not blur the field on the
+    /// popup: the focus path ends at the root that owns it, and that is not
+    /// this one.
+    #[test]
+    fn a_press_in_one_surface_does_not_blur_a_field_focused_in_another() {
+        let (mut screen, field) = a_focused_field();
+        let other = screen.add(container().width(200.0).height(100.0));
+
+        screen.press_button(other, 100.0, 80.0, MouseButton::Left);
+        assert!(
+            field.is_focused(),
+            "a press on another surface says nothing about where this one's \
+             keyboard is"
+        );
+    }
+
+    /// The box drawn around a field is the field, as far as the user is
+    /// concerned: it lights up when the focus is inside it, and clicking its
+    /// padding is clicking the thing it draws.
+    #[test]
+    fn a_press_on_the_padding_of_a_when_focused_box_keeps_it() {
+        let field = a_field();
+        let mut screen = Screen::new(
+            container().width(200.0).height(100.0).child(
+                container()
+                    .padding(8.0)
+                    .when_focused(|s| s.border(2.0, crate::widgets::Color::WHITE))
+                    .child(text_input(create_signal(String::new())).widget_ref(field)),
+            ),
+        );
+
+        screen.press(100.0, 12.0);
+        assert!(field.is_focused(), "the press reached the field");
+
+        screen.press(4.0, 4.0);
+        assert!(
+            field.is_focused(),
+            "the padding of the box that lights up for this focus belongs to it"
+        );
+    }
+
+    /// A toolbar button acting on the field, spelled the way every button is
+    /// spelled: it has an `on_click`, so it claims the press, so the press is
+    /// not a press on nothing.
+    #[test]
+    fn a_press_a_button_claimed_keeps_it() {
+        let field = a_field();
+        let mut screen = Screen::new(
+            container()
+                .width(200.0)
+                .height(100.0)
+                .layout(Flex::column())
+                .child(text_input(create_signal(String::new())).widget_ref(field))
+                .child(container().width(200.0).height(40.0).on_click(|| {})),
+        );
+
+        screen.press(100.0, 8.0);
+        assert!(field.is_focused(), "the press reached the field");
+
+        screen.press(100.0, 40.0);
+        assert!(
+            field.is_focused(),
+            "a widget that claimed the press said the press was its own; the \
+             focus is not up for grabs"
         );
     }
 }

--- a/src/reactive/focus.rs
+++ b/src/reactive/focus.rs
@@ -59,6 +59,19 @@ impl FocusPath {
         self.chain.contains(&id)
     }
 
+    /// The root the focused widget sits under, if anything is focused.
+    ///
+    /// The chain was walked to a widget with no parent when the focus moved,
+    /// and the only widgets without one are surface roots — so the last link
+    /// already names the surface the keyboard is on.
+    /// [`Tree::surface_root_of`](crate::tree::Tree::surface_root_of) answers
+    /// the same question by walking live parents; this one is here because the
+    /// answer is already in hand, and the walk is what the path exists to have
+    /// done once.
+    pub(crate) fn root(&self) -> Option<WidgetId> {
+        self.chain.last().copied()
+    }
+
     pub fn is_empty(&self) -> bool {
         self.chain.is_empty()
     }
@@ -182,9 +195,31 @@ pub fn release_focus(id: WidgetId) {
 /// A stored path has no such self-correction — the ancestors would keep
 /// answering "the focus is inside me" for a widget that no longer exists.
 pub(crate) fn release_focus_if_within(id: WidgetId) {
-    let path = focus().get_untracked();
-    if path.contains(id) {
+    if focus_within(id) {
         focus().set(FocusPath::default());
+    }
+}
+
+/// Whether the focus is on `id` or inside it, without subscribing.
+///
+/// The tracked spelling of the same question is `focus_path().contains(id)`,
+/// and it is the right one for anything resolving a style: it wants to be woken
+/// when the answer changes. This one is for the event path, which reads to
+/// decide and is already running because something happened — subscribing there
+/// would open a subscription from inside an event handler.
+pub(crate) fn focus_within(id: WidgetId) -> bool {
+    focus().with_untracked(|path| path.contains(id))
+}
+
+/// Drop the focus if it belongs to the surface rooted at `root`.
+///
+/// Focus is one signal for the whole application while one `Tree` holds every
+/// surface's root, so "nothing here claimed that press" speaks only for the
+/// surface the press landed on. The focus path ends at the root of whichever
+/// surface owns the keyboard, and that is the whole test.
+pub(crate) fn release_focus_under(root: WidgetId) {
+    if focus().with_untracked(|path| path.root() == Some(root)) {
+        clear_focus();
     }
 }
 

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -688,6 +688,44 @@ fn a_click_inside_the_bounds_fires_on_click() {
     assert_eq!(clicks.get(), 1, "a click outside must not fire");
 }
 
+/// The other two buttons, which fire on the press rather than on a matched
+/// release: there is no drag to complete, so there is nothing to wait for.
+///
+/// Nothing tested these at all until a mutant said so — killing the guard that
+/// separates them from the left button left the whole suite green, which is the
+/// same as saying the two handlers could stop firing and nobody would hear.
+#[test]
+fn the_right_and_middle_buttons_fire_the_handlers_that_name_them() {
+    let right = std::rc::Rc::new(std::cell::Cell::new(0));
+    let middle = std::rc::Rc::new(std::cell::Cell::new(0));
+    let (r, m) = (right.clone(), middle.clone());
+    let mut h = H::new(
+        container()
+            .width(50.0)
+            .height(20.0)
+            .on_right_click(move || r.set(r.get() + 1))
+            .on_middle_click(move || m.set(m.get() + 1)),
+    );
+    h.fit(500.0, 500.0);
+
+    h.send(Event::mouse_down(25.0, 10.0, MouseButton::Right));
+    assert_eq!((right.get(), middle.get()), (1, 0), "a right press");
+
+    h.send(Event::mouse_down(25.0, 10.0, MouseButton::Middle));
+    assert_eq!((right.get(), middle.get()), (1, 1), "a middle press");
+
+    // The left button is neither of them, and reaches neither handler.
+    h.send(Event::mouse_down(25.0, 10.0, MouseButton::Left));
+    assert_eq!(
+        (right.get(), middle.get()),
+        (1, 1),
+        "a left press belongs to on_click, and must not reach either"
+    );
+
+    h.send(Event::mouse_down(200.0, 10.0, MouseButton::Right));
+    assert_eq!(right.get(), 1, "a right press outside must not fire");
+}
+
 /// Hit testing follows the rounded shape, not its bounding box.
 #[test]
 fn a_corner_radius_excludes_the_corner() {

--- a/src/widgets/container/interaction.rs
+++ b/src/widgets/container/interaction.rs
@@ -18,6 +18,7 @@
 use std::time::Instant;
 
 use super::*;
+use crate::reactive::focus::focus_within;
 
 /// The geometry an event is resolved against: where the container ended up,
 /// what shape it is, and the transform standing between the two.
@@ -209,16 +210,23 @@ impl Container {
         local: &Event,
         now: Instant,
     ) -> EventResponse {
+        // One question for a press, asked once and answered up to twice: by the
+        // arm that handles it, and by the focus claim at the end of the
+        // function. `contains` runs the corner SDF, and a press inside the
+        // shape is exactly the case that would run it twice.
+        let pressed_inside =
+            matches!(local, Event::MouseDown { .. }) && hit.contains(local.coords());
+
         match local {
             // Hover was tracked before the children ran. Returning Ignored
             // here is deliberate: a hover change must not stop sibling
             // containers from tracking their own.
             Event::MouseEnter { .. } | Event::MouseMove { .. } => {}
 
-            Event::MouseDown { at, button } if *button != MouseButton::Left => {
-                if hit.contains(*at)
-                    && let Some(ref ix) = self.interaction
-                {
+            // Claiming a press here is not only about the callback: the focus
+            // claim at the end of the function reads the same `pressed_inside`.
+            Event::MouseDown { button, .. } if *button != MouseButton::Left => {
+                if pressed_inside && let Some(ref ix) = self.interaction {
                     let callback = match button {
                         MouseButton::Right => ix.on_right_click.as_ref(),
                         MouseButton::Middle => ix.on_middle_click.as_ref(),
@@ -232,7 +240,7 @@ impl Container {
             }
 
             Event::MouseDown { at, button } => {
-                if hit.contains(*at)
+                if pressed_inside
                     && let Some(at) = at
                     && *button == MouseButton::Left
                     && let Some(ref mut ix) = self.interaction
@@ -411,6 +419,24 @@ impl Container {
             Event::KeyUp { .. } | Event::FocusIn | Event::FocusOut => {}
         }
 
+        // A press inside the box that lights up for this focus is a press on
+        // the field the box draws — its padding, its border, the gap beside
+        // the caret. The dispatcher takes the focus off a press nobody
+        // claimed, so claiming it here is how the box says the keyboard is
+        // still its own.
+        if pressed_inside && self.holds_the_focus_it_draws(id) {
+            return EventResponse::Handled;
+        }
+
         EventResponse::Ignored
+    }
+
+    /// Whether this container declares `when_focused` and the focus is
+    /// currently inside it.
+    fn holds_the_focus_it_draws(&self, id: WidgetId) -> bool {
+        self.interaction
+            .as_ref()
+            .is_some_and(|ix| ix.declares(|w| matches!(w, StateWhen::Focused)))
+            && focus_within(id)
     }
 }

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -354,7 +354,11 @@ impl InteractionState {
         match when {
             StateWhen::Hovered => self.flags.get().contains(InteractionFlags::HOVERED),
             StateWhen::Pressed => self.flags.get().contains(InteractionFlags::PRESSED),
-            StateWhen::Focused => Container::has_child_focus(id),
+            // The path, rather than a walk of this container's descendants:
+            // the same question has to be answerable from a `create_derived`
+            // closure, which has no tree, and that is where a container
+            // resolves the text colour it publishes below it.
+            StateWhen::Focused => focus_path().contains(id),
             StateWhen::When(condition) => condition.get(),
         }
     }

--- a/src/widgets/container/style.rs
+++ b/src/widgets/container/style.rs
@@ -22,19 +22,6 @@ use super::*;
 
 impl Container {
     // -----------------------------------------------------------------------
-    // Focus, as seen by the focused state layer
-    // -----------------------------------------------------------------------
-
-    /// Whether the focused widget is this container or one of its descendants.
-    ///
-    /// Asks the focus path rather than walking the tree, so it can be called
-    /// from a `create_derived` closure — which has no tree, and is where a
-    /// container resolves the text colour it publishes to its descendants.
-    pub(super) fn has_child_focus(id: WidgetId) -> bool {
-        focus_path().contains(id)
-    }
-
-    // -----------------------------------------------------------------------
     // State layer: base value plus the override of the active state
     // -----------------------------------------------------------------------
 

--- a/src/widgets/text_input.rs
+++ b/src/widgets/text_input.rs
@@ -1361,6 +1361,16 @@ impl Widget for TextInput {
                 request_job(id, JobRequest::Paint);
                 return EventResponse::Handled;
             }
+            // A press inside a field that holds the keyboard is the field's,
+            // whatever the button pressed. The dispatcher takes the focus off a
+            // press nobody claimed, and the arms above claim only left and
+            // middle — so a right press on the caret used to blur the very
+            // field it landed on.
+            Event::MouseDown { at: Some(at), .. }
+                if has_focus(id) && bounds.contains(at.x, at.y) =>
+            {
+                return EventResponse::Handled;
+            }
             Event::KeyDown { key, modifiers } if has_focus(id) => {
                 let response = self.handle_key(key, modifiers.ctrl, modifiers.shift, edit);
                 if response == EventResponse::Handled {

--- a/tests/headless_app.rs
+++ b/tests/headless_app.rs
@@ -415,3 +415,40 @@ fn a_new_grab_tears_down_the_chain_it_cannot_nest_under() {
         "and the new grab did open"
     );
 }
+
+/// A bar with one field on it and nothing else: the shape #206 was filed
+/// against, less the second field it did not need.
+fn bar_with_a_field(field: WidgetRef, value: RwSignal<String>) -> Container {
+    container()
+        .width(fill())
+        .height(fill())
+        .child(text_input(value).widget_ref(field))
+}
+
+/// A press nobody claimed takes the keyboard with it. The decision is the
+/// dispatcher's, and the unit tests beside it pin the decision; this is the
+/// loop actually taking it — a surface configured, a frame open, and a press
+/// routed the way the compositor's would be.
+#[test]
+fn a_click_outside_the_field_takes_the_keyboard_off_it() {
+    let Some(mut app) = headless() else { return };
+    let field = create_widget_ref();
+    let value = create_signal(String::new());
+    let surface = app.surface(fixed_bar(), move || bar_with_a_field(field, value));
+    app.configure(surface, 200, 50, 1.0);
+    app.step();
+
+    app.click(surface, 100.0, 8.0);
+    app.step();
+    assert!(
+        field.is_focused(),
+        "a click into the field takes the keyboard"
+    );
+
+    app.click(surface, 100.0, 40.0);
+    app.step();
+    assert!(
+        !field.is_focused(),
+        "and a click on the bar behind it gives it back"
+    );
+}


### PR DESCRIPTION
## What changed

Clicking outside a focused text input now takes the keyboard off it. `dispatch_events` is the one place that learns whether *anything* claimed an event, so a `MouseDown` that comes back `Ignored` from the root the focus path ends at is a press on nothing, and the focus goes with it — any button, and touch for free, since a tap arrives as a synthesised `MouseDown`. Three things keep that from being a nuisance: a press inside the focused field is the field's whatever the button; every handler that claims its button claims the press; and a container declaring `when_focused` while it holds that focus claims presses inside itself, so the padding and border of the box drawn around a field belong to the field. That last one is `when_focused` acquiring a second meaning, which is what #206 decided instead of a new `.keeps_focus()`.

Closes #206

## What proves it

Eight tests in a new `a_press_nothing_claimed_takes_the_focus_with_it` module in `src/lib.rs`, driving the real `dispatch_events` over a hand-built tree — no adapter needed. The two that fail without the change are `a_press_on_the_background_takes_the_keyboard_off_the_field` and `a_middle_press_on_the_background_takes_the_keyboard_too`; I confirmed the red before writing the fix, and confirmed it again for each half separately afterwards:

| disable | what goes red |
| --- | --- |
| the clear in `dispatch_events` | the two background-press tests, and the headless one |
| `focus_within` in `holds_the_focus_it_draws` | `a_press_on_the_padding_of_a_when_focused_box_keeps_it` |
| `focus_within` forced true | `a_when_focused_box_holding_no_focus_claims_nothing` |
| the new `TextInput` press arm | `a_right_press_inside_the_field_keeps_it` |

And `a_click_outside_the_field_takes_the_keyboard_off_it` in `tests/headless_app.rs`, which proves the loop takes the decision rather than the dispatcher taking it in isolation — surface configured, frame open, press routed the way the compositor's would be. Also confirmed red without the change.

No golden and no snapshot moved, and none was re-blessed. Nothing enters the paint path: the `when_focused` border going out is the existing styling path reacting to the existing signal. Full suite green on lavapipe with `GUIDO_GPU_REQUIRED=1`, so `headless_app` ran rather than skipped.

## What the review found

**One blocking finding, and it was real.** A **right** press *inside* the focused field blurred it: `TextInput`'s press arms are guarded on `Left` and `Middle`, so a right press fell through to `Ignored` and the dispatcher read it as a press on nothing — on the field it had landed on. That is the "came back `Ignored`" proxy failing to stand in for the focus region #206's **Expected** actually names ("the focused widget's own bounds, plus..."), not the decision being re-litigated. Fixed by `TextInput` claiming any press inside its bounds while it holds the focus, with `a_right_press_inside_the_field_keeps_it` pinning it.

Three worth answering, all acted on:

- **Half the container rule was unwatched.** Forcing `focus_within(id)` to `true` left the whole suite green — so nothing said a `when_focused` box must hold *this* focus to claim a press. `a_when_focused_box_holding_no_focus_claims_nothing` is that test.
- **The first commit did not build clean alone**: it added `FocusPath::root` and `release_focus_under` with no caller, so `-D warnings` failed on it and a bisect landing there would fail for an unrelated reason. Folded into the commit with its caller; both commits now lint clean standalone, which I checked by checking each out.
- **The book overstated what claims a press** — "everything with an `on_click`" is true for the left button only. Corrected to say which handler claims which button, since prose that names an API is followed rather than read sceptically.

Two notes, both filed rather than dropped: #308 and #309 below.

The `/simplify` pass ran first and its edits are inside the commits: `with_untracked` instead of cloning the path to answer a boolean, one `hit.contains` per press instead of one per arm, a shared fixture across the tests, and `Container::has_child_focus` deleted — a one-use alias that would have left `container` with two names for one question.

## What was checked by hand

`cargo run --example text_input_example` on niri. The maintainer clicked into a field and then clicked outside it: the focus goes away — the blue `when_focused` border drops back to the plain 1px one and the caret stops. That is the gesture the issue was filed about, on a real compositor.

I captured the surface at rest myself but did not drive the clicks; synthetic input is not how interaction is proved here.

## Left undone

- **#308 — a box that keeps the focus should not also swallow the press.** The claim is spoken on the event-propagation channel, so a `when_focused` box holding the focus short-circuits an outer clickable ancestor's `on_click` for that press. This cost was named and accepted in #206's **Decided** section; #308 is the deeper spelling — carry "declares `when_focused`" into the tree as a per-widget bit and let `dispatch_events` resolve the whole region itself, so `Handled` goes back to meaning only "consumed". Labelled `needs-design`, since it adds a bit to the tree.
- **#309 — the focus path is a snapshot, and nothing says what may not move under it.** `FocusPath::root()` reads a chain computed when the focus arrived; a live focused widget reparented under a different root would name the old one and silently stop blurring. Nothing reparents a live widget today, so there is no failing test to write — which is why it is an issue and not a change here. The staleness is `FocusPath`'s from the start; this change only gave it a second reader.
