### PR TITLE
A cached child that moved is drawn where it moved to, and something says so

### DIFF
--- a/tests/paint_cache_across_frames.rs
+++ b/tests/paint_cache_across_frames.rs
@@ -27,6 +27,7 @@ use guido::renderer::{
 };
 use guido::tree::WidgetId;
 use guido::widgets::Rect;
+use std::rc::Rc;
 
 const VIEWPORT: f32 = 200.0;
 /// The row's padding, and the column's own padding around its rows.
@@ -86,6 +87,15 @@ fn column() -> Container {
         )
 }
 
+/// The two scrolling columns, side by side.
+fn two_columns() -> Container {
+    container()
+        .layout(Flex::row().spacing(GAP))
+        .padding(PAD)
+        .child(column())
+        .child(column())
+}
+
 /// A surface that renders frame after frame into one retained root node.
 struct Surface {
     surface: Harness,
@@ -98,16 +108,7 @@ struct Surface {
 }
 
 impl Surface {
-    fn new() -> Self {
-        let view = container()
-            .layout(Flex::row().spacing(GAP))
-            .padding(PAD)
-            .child(column())
-            .child(column());
-
-        let width = PAD + VIEWPORT + GAP + VIEWPORT + PAD;
-        let height = PAD + CAPTION + CAPTION_GAP + VIEWPORT + PAD;
-
+    fn new(view: impl Widget + 'static, width: f32, height: f32) -> Self {
         let harness = Harness::laid_out(view, width, height);
         let root = harness.root;
 
@@ -133,8 +134,8 @@ impl Surface {
     /// allocation* frame after frame, where one that repaints is a new node
     /// each time. Comparing the tree against the cache would not tell those
     /// apart: `cache_paint_results` stores whatever was painted.
-    fn caption_node(&self, column: usize) -> std::rc::Rc<RenderNode> {
-        std::rc::Rc::clone(&self.root_node.children[column].children[0])
+    fn caption_node(&self, column: usize) -> Rc<RenderNode> {
+        Rc::clone(&self.root_node.children[column].children[0])
     }
 
     /// One frame: the skip gate, paint into the retained root, flatten, then
@@ -225,7 +226,11 @@ impl Surface {
 /// so `reuse_cached` serves that entry, content and scrollbar handle together.
 #[test]
 fn a_scrolled_list_survives_a_frame_painted_for_its_sibling() {
-    let mut s = Surface::new();
+    let mut s = Surface::new(
+        two_columns(),
+        PAD + VIEWPORT + GAP + VIEWPORT + PAD,
+        PAD + CAPTION + CAPTION_GAP + VIEWPORT + PAD,
+    );
 
     s.frame();
     let caption = s.caption_node(0);
@@ -260,7 +265,7 @@ fn a_scrolled_list_survives_a_frame_painted_for_its_sibling() {
         "the second list was never scrolled"
     );
     assert!(
-        std::rc::Rc::ptr_eq(&caption, &s.caption_node(0)),
+        Rc::ptr_eq(&caption, &s.caption_node(0)),
         "the caption was repainted rather than served from the paint cache — \
          a harness that stops reaching `reuse_cached` goes green however \
          broken the cache is"

--- a/tests/paint_cache_across_frames.rs
+++ b/tests/paint_cache_across_frames.rs
@@ -14,8 +14,11 @@
 //! quietly stopped reaching `reuse_cached` would go green for the wrong
 //! reason and take the only test of this path with it.
 //!
-//! Two sibling scrollable columns, because the bug needs a second widget to
-//! ask for the frame that the first one is then served stale into.
+//! Two scenarios, one per branch of `reuse_cached`. Two sibling scrollable
+//! columns, because a child served at an unchanged position needs a second
+//! widget to ask for the frame the first one is then served stale into; and a
+//! row whose first box grows, because a child served at a *changed* one needs
+//! something to move it while leaving it clean.
 
 use guido::layout::Flex;
 
@@ -23,7 +26,7 @@ mod common;
 use common::Harness;
 use guido::prelude::*;
 use guido::renderer::{
-    CommandLayer, FlattenedCommand, PaintContext, RenderNode, flatten_root_into,
+    CommandLayer, DrawCommand, FlattenedCommand, PaintContext, RenderNode, flatten_root_into,
 };
 use guido::tree::WidgetId;
 use guido::widgets::Rect;
@@ -53,6 +56,22 @@ const SCROLL: f32 = 120.0;
 const SCROLLER_TOP: f32 = PAD + CAPTION + CAPTION_GAP;
 const COLUMN_A_X: f32 = PAD;
 const COLUMN_B_X: f32 = PAD + VIEWPORT + GAP;
+
+// The second scenario's two boxes. One takes its width from a signal; the
+// other sits behind it in the row and never changes, so growing the first is
+// the whole of what moves the second.
+const BOX_HEIGHT: f32 = 30.0;
+/// What the grower is declared at, and what it grows to.
+const GROWER_WIDTH: f32 = 40.0;
+const GROWN_WIDTH: f32 = 90.0;
+const PUSHED_WIDTH: f32 = 50.0;
+/// The pushed box's fill, which is how its command is picked out of the frame.
+const PUSHED_FILL: Color = Color::rgb(0.9, 0.4, 0.1);
+/// A transform of the box's own, so that the branch under test has a user part
+/// to recompose and not only a position to strip. Without one `user_part` works
+/// out to the identity, and the recomposition could be dropped entirely with
+/// this test still green.
+const PUSHED_NUDGE: (f32, f32) = (5.0, 3.0);
 
 /// A caption and a vertical scroller over `ROWS` rows — one column of
 /// `examples/scroll_example.rs`.
@@ -94,6 +113,31 @@ fn two_columns() -> Container {
         .padding(PAD)
         .child(column())
         .child(column())
+}
+
+/// A row of two boxes: one whose width `grower` decides, and one behind it.
+///
+/// The grower's height comes from a child rather than from `.height()`, and
+/// that is load-bearing. A container with a fixed width *and* a fixed height is
+/// a relayout boundary (`is_relayout_boundary_for`), and marking a boundary
+/// stops there — so a grower declared both ways would resize inside itself and
+/// never move the box behind it, which is the whole scenario.
+fn pushed_row(grower: RwSignal<f32>) -> Container {
+    container()
+        .layout(Flex::row().spacing(GAP))
+        .padding(PAD)
+        .child(
+            container()
+                .width(grower)
+                .child(container().height(BOX_HEIGHT)),
+        )
+        .child(
+            container()
+                .width(PUSHED_WIDTH)
+                .height(BOX_HEIGHT)
+                .translate(PUSHED_NUDGE)
+                .background(PUSHED_FILL),
+        )
 }
 
 /// A surface that renders frame after frame into one retained root node.
@@ -165,6 +209,34 @@ impl Surface {
             guido::cache_paint_results(tree, child);
         }
         tree.clear_needs_paint(*root);
+    }
+
+    /// The command the box filled with `fill` contributed to the last frame:
+    /// the `Rc` itself, and where it landed in surface coordinates.
+    ///
+    /// One lookup for both, because they are assertions about the same box and
+    /// two schemes could drift onto two boxes. The `Rc` is `caption_node`'s
+    /// identity argument one level down: the moved branch of `reuse_cached`
+    /// rebuilds the node header, so the node cannot answer here — but the
+    /// commands stay shared through it and through flatten, so they can.
+    fn box_drawn(&self, fill: Color) -> (Rc<DrawCommand>, (f32, f32)) {
+        let mut matches = self.commands.iter().filter_map(|cmd| match &*cmd.command {
+            DrawCommand::RoundedRect { rect, color, .. } if *color == fill => Some((
+                Rc::clone(&cmd.command),
+                (
+                    cmd.world_transform.tx() + rect.x,
+                    cmd.world_transform.ty() + rect.y,
+                ),
+            )),
+            _ => None,
+        });
+        let found = matches.next().expect("the box contributed a command");
+        assert!(
+            matches.next().is_none(),
+            "the fill names more than one box, so neither what this returns \
+             nor what is asserted of it is about the box the test means"
+        );
+        found
     }
 
     /// Scroll the nth column's list, the way the loop does it: the event moves
@@ -269,5 +341,75 @@ fn a_scrolled_list_survives_a_frame_painted_for_its_sibling() {
         "the caption was repainted rather than served from the paint cache — \
          a harness that stops reaching `reuse_cached` goes green however \
          broken the cache is"
+    );
+}
+
+/// The other branch of `reuse_cached`: a child served from the paint cache
+/// whose position changed since it was painted.
+///
+/// The box behind the grower never becomes dirty — its constraints do not
+/// change when the grower widens, so its own layout early-returns and it keeps
+/// its cache entry — but the row hands it a new origin. `set_origin` says so in
+/// as many words: a widget that moves is not repainted, the parent re-emits it
+/// at the new offset, and re-parenting the cached node is how. That
+/// re-parenting strips the old position out of the cached transform and
+/// recomposes the box's own transform at the new one. Both halves are
+/// unwatched without this: the two negations that strip the position can each
+/// be dropped with the rest of the suite still green, and so can the
+/// recomposition, which is why the box carries a transform of its own.
+#[test]
+fn a_cached_child_is_drawn_where_it_moved_to() {
+    let grower = create_signal(GROWER_WIDTH);
+    let mut s = Surface::new(
+        pushed_row(grower),
+        PAD + GROWN_WIDTH + GAP + PUSHED_WIDTH + PAD,
+        PAD + BOX_HEIGHT + PAD,
+    );
+
+    s.frame();
+    let (painted, at_rest) = s.box_drawn(PUSHED_FILL);
+    assert_eq!(
+        at_rest,
+        (
+            PAD + GROWER_WIDTH + GAP + PUSHED_NUDGE.0,
+            PAD + PUSHED_NUDGE.1
+        ),
+        "the box starts behind the grower at its declared width, nudged by its \
+         own transform"
+    );
+
+    grower.set(GROWN_WIDTH);
+    // The relayout a Layout job produces: `process_jobs` marks the widget the
+    // signal woke and lays out from the relayout boundary that marking names.
+    let grower_id = s.surface.tree.get_children(s.surface.root)[0];
+    let boundary = s
+        .surface
+        .tree
+        .mark_needs_layout(grower_id)
+        .expect("the grower is registered and was not already dirty");
+    s.surface.lay_out(s.width, s.height);
+    assert_eq!(
+        boundary, s.surface.root,
+        "the grower is its own relayout boundary, so nothing outside it would \
+         have moved in the running loop either"
+    );
+    s.frame();
+
+    let (reused, moved_to) = s.box_drawn(PUSHED_FILL);
+    assert_eq!(
+        moved_to,
+        (
+            PAD + GROWN_WIDTH + GAP + PUSHED_NUDGE.0,
+            PAD + PUSHED_NUDGE.1
+        ),
+        "the box did not land at its new position plus its own transform — \
+         the cached transform either kept a position that should have been \
+         stripped out or lost the user part that should have been kept"
+    );
+    assert!(
+        Rc::ptr_eq(&painted, &reused),
+        "the box was repainted rather than re-parented out of the paint \
+         cache — the moved branch of `reuse_cached` was never reached, so \
+         this test would go green however broken it is"
     );
 }


### PR DESCRIPTION
## What changed

`reuse_cached` (`src/widgets/paint_children.rs`) has two branches, and only one had a scenario. The unchanged-position branch is covered by this file's two scrolling columns; the *moved* branch — the one that strips the old position out of a cached child's transform and recomposes the child's own transform at the new position — was covered by nothing. `tests/paint_cache_across_frames.rs` gains a second scenario for it: a row of two boxes whose first one grows, pushing the second sideways while leaving it clean and cached. Test-only; no `src/` file is touched. Closes #307.

## What proves it

`a_cached_child_is_drawn_where_it_moved_to`, in `tests/paint_cache_across_frames.rs`. Four ways to break the branch, each applied by hand and each failing the test:

| broken how | box lands at | expected |
| --- | --- | --- |
| first `-` deleted from `Transform::translate(-pos.tx(), -pos.ty())` | `(247, 11)` | `(119, 11)` |
| second `-` deleted | `(119, 27)` | `(119, 11)` |
| `reused.local_transform = child_position` — user part dropped | `(114, 8)` | `(119, 11)` |
| moved branch bypassed entirely | — | `Rc::ptr_eq` guard fires |

The first two are the survivors #307 was opened for (`src/widgets/paint_children.rs:160:46` and `:160:57`). The third came out of the review, below. The existing scrolling test stays green under all of them, which is the issue's claim that it never reached this branch.

The scenario is faithful to the running loop rather than convenient: `.width(signal)` subscribes the container's own id with `JobType::Layout`, and `process_jobs` turns that into `tree.mark_needs_layout(id)`, which is exactly what the test does. The grower takes its height from a child rather than from `.height()`, because a container with a fixed width *and* a fixed height is a relayout boundary and a boundary that grows moves nothing outside itself; the test asserts the boundary is the root, so a scenario that stopped being the one the loop produces would say so rather than pass.

`cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all-features` (27 targets), and `cargo test --test golden_images` on lavapipe (9/9, none skipped) are all green. No golden or snapshot moved, and none should have — nothing that draws changed.

## What the review found

**Zero blocking findings.**

One finding worth answering, and it was acted on rather than declined: line 161 of `paint_children.rs` recomposes the child's *user* transform, and with no transform on the pushed box `user_part` computed to the identity — so `reused.local_transform = child_position` would have passed the test as first written. The box now carries a `.translate((5, 3))` of its own, which is the third row of the table above. The reviewer's related note — that `box_drawn` adds `world_transform.tx() + rect.x` and so is sound only while every transform on the path is a pure translation — still holds with a translate and is noted in **Left undone**.

Notes taken and not acted on: `Surface` still carries the scrolling scenario's vocabulary (`scroller`, `caption_node`, `scroll`, `drawn_top`) alongside the generic frame loop, so those methods are meaningful only for a surface built from `two_columns()`. Splitting them behind a newtype is a bigger restructure than a two-scenario file earns, and misuse is an immediate index panic in a new test rather than a silent pass. Worth revisiting if a third scenario arrives.

The `/simplify` pass ran before the commits and its edits are inside them: one lookup scheme instead of two for the pushed box (it was found by index for one assertion and by fill for the other, which would have compared two different widgets if `pushed_row` ever gained a child), `find_map` in place of a double match with an `unreachable!` arm, and `relayout_after` inlined at its one call site so its reasoning sits with the assertion that guards it.

## What was checked by hand

Nothing beyond the mutants in the table — the four were applied by editing `src/widgets/paint_children.rs`, running the test, and restoring the file. This change touches no Wayland surface and no shader, so there is nothing here the harness cannot see.

## Left undone

- `box_drawn` composes a drawn point as `world_transform.tx() + rect.x`, which is the box's corner only while every transform on its path is a pure translation. True of both scenarios today, including the new `.translate`. A scenario that rotates or scales a cached child would need it to compose rather than add. Not filed: it is a property of a helper in this file, it would be found the moment such a scenario is written, and `FlattenedCommand::world_rounded_rect` already exists as the answer.
- The other survivors from the run on #305 are #307's own non-goals and stay out of scope. Most are in `src/platform/input.rs`, which `AGENTS.md` records as deliberately unautomated.

Closes #307