### PR TITLE
A blessed reference is refused by the variable that was supposed to refuse it

### DIFF
--- a/tests/blessing_rules.rs
+++ b/tests/blessing_rules.rs
@@ -36,6 +36,7 @@ fn rebless_rewrites_whatever_is_there() {
 #[test]
 fn rebless_wins_over_update() {
     assert_eq!(blessing(true, true, true), Blessing::Write);
+    assert_eq!(blessing(true, true, false), Blessing::Write);
 }
 
 /// An ordinary run compares, and never writes, whatever is on disk.
@@ -45,3 +46,117 @@ fn an_ordinary_run_only_compares() {
     assert_eq!(blessing(false, false, false), Blessing::Compare);
 }
 
+/// The rule decides and `write_if_blessed` acts, and the two have to agree
+/// about a real file. Deciding correctly and writing anyway is the defect this
+/// whole change is about, and it would read as compliant at both call sites.
+#[test]
+fn a_declined_reference_is_left_exactly_as_it_was() {
+    let path = scratch("declined.snap");
+    std::fs::write(&path, "the reference that was already here").unwrap();
+
+    let wrote = common::write_if_blessed(&path, Blessing::Compare, || {
+        std::fs::write(&path, "the rewrite").unwrap();
+    });
+
+    assert!(!wrote, "write_if_blessed claimed it wrote under Compare");
+    assert_eq!(
+        std::fs::read_to_string(&path).unwrap(),
+        "the reference that was already here",
+        "a declined bless rewrote the reference anyway"
+    );
+    std::fs::remove_file(&path).ok();
+}
+
+/// And the other half: a reference the rule allows really is written, so
+/// `Compare` cannot be made unconditionally safe by never writing at all.
+#[test]
+fn a_blessed_reference_is_written() {
+    let path = scratch("blessed.snap");
+    std::fs::remove_file(&path).ok();
+
+    let wrote = common::write_if_blessed(&path, Blessing::Write, || {
+        std::fs::write(&path, "the first picture").unwrap();
+    });
+
+    assert!(
+        wrote,
+        "write_if_blessed claimed it did not write under Write"
+    );
+    assert_eq!(std::fs::read_to_string(&path).unwrap(), "the first picture");
+    std::fs::remove_file(&path).ok();
+}
+
+/// Under `target/`, not the system temporary directory: these are a few bytes
+/// and they belong with the build output rather than in whatever `/tmp` is
+/// mounted on.
+fn scratch(name: &str) -> std::path::PathBuf {
+    let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("target")
+        .join("blessing-rules");
+    std::fs::create_dir_all(&dir).expect("scratch directory");
+    dir.join(name)
+}
+
+// ---------------------------------------------------------------------------
+// That the rule is actually wired, in the manner of `tests/agent_workflow.rs`:
+// a rule stated in one file and applied in another is a rule until somebody
+// edits one of them.
+// ---------------------------------------------------------------------------
+
+fn read(relative: &str) -> String {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(relative);
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("reading {relative}: {e}"))
+}
+
+const HARNESSES: [&str; 2] = ["tests/render_snapshots.rs", "tests/golden_images.rs"];
+
+/// Both harnesses ask the shared rule rather than deciding for themselves.
+#[test]
+fn both_harnesses_consult_the_shared_rule() {
+    for harness in HARNESSES {
+        assert!(
+            read(harness).contains("blessing_from_env"),
+            "{harness} decides on its own whether it may write a reference. \
+             The rule is `common::blessing`, and a harness that does not ask it \
+             is where the last two copies of the rule drifted apart from it."
+        );
+    }
+}
+
+/// And neither keeps a copy of it. Both used to read `UPDATE_*` directly and
+/// write whatever was already on disk, while their own module headers said
+/// they declined — two copies of one rule, of which only the prose was right.
+#[test]
+fn no_harness_reads_the_blessing_variables_itself() {
+    for harness in HARNESSES {
+        let source = read(harness);
+        for spelling in [
+            "var_os(\"UPDATE",
+            "var(\"UPDATE",
+            "var_os(\"REBLESS",
+            "var(\"REBLESS",
+        ] {
+            assert!(
+                !source.contains(spelling),
+                "{harness} reads a blessing variable itself ({spelling}…). \
+                 One reader, `common::blessing_from_env`, or the rule has two \
+                 homes again."
+            );
+        }
+    }
+}
+
+/// The hook guards the half that rewrites. It is the last thing standing
+/// between an agent and a reference nobody decided to change, so the pair of
+/// names it denies has to stay the pair that writes.
+#[test]
+fn the_hook_denies_the_variables_that_rewrite() {
+    let hook = read(".claude/hooks/guard-bash.sh");
+    for variable in ["REBLESS_GOLDEN", "REBLESS_SNAPSHOTS"] {
+        assert!(
+            hook.contains(variable),
+            ".claude/hooks/guard-bash.sh stopped denying {variable}, which is \
+             now the only spelling that can rewrite a blessed reference."
+        );
+    }
+}

--- a/tests/blessing_rules.rs
+++ b/tests/blessing_rules.rs
@@ -1,0 +1,47 @@
+//! The rule that decides whether a run may rewrite a reference.
+//!
+//! `CLAUDE.md` calls it non-negotiable, and it was prose: both harnesses wrote
+//! on `UPDATE_*` whatever was already on disk, and neither read `REBLESS_*` at
+//! all. The rule is a pure function of three booleans now, so the table it is
+//! supposed to satisfy can be written down.
+
+mod common;
+
+use common::{Blessing, blessing};
+
+/// Making a reference that does not exist yet is ordinary work — a new
+/// scenario needs a first picture — and `UPDATE_*` is what makes it.
+#[test]
+fn update_creates_a_reference_that_is_not_there() {
+    assert_eq!(blessing(true, false, false), Blessing::Write);
+}
+
+/// The line the harnesses were missing. Pointed at a reference that already
+/// exists, `UPDATE_*` declines and lets the comparison run, because rewriting
+/// one turns a failing test green without changing anything back.
+#[test]
+fn update_declines_a_reference_that_already_exists() {
+    assert_eq!(blessing(true, false, true), Blessing::Compare);
+}
+
+/// Rewriting is what `REBLESS_*` is for, and the only thing it is for.
+#[test]
+fn rebless_rewrites_whatever_is_there() {
+    assert_eq!(blessing(false, true, true), Blessing::Write);
+    assert_eq!(blessing(false, true, false), Blessing::Write);
+}
+
+/// Asking for both is asking for the stronger of the two. Nobody should write
+/// it, and it should not mean "decline".
+#[test]
+fn rebless_wins_over_update() {
+    assert_eq!(blessing(true, true, true), Blessing::Write);
+}
+
+/// An ordinary run compares, and never writes, whatever is on disk.
+#[test]
+fn an_ordinary_run_only_compares() {
+    assert_eq!(blessing(false, false, true), Blessing::Compare);
+    assert_eq!(blessing(false, false, false), Blessing::Compare);
+}
+

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -11,6 +11,11 @@
 //! node, a caption's painted top, the colour of a named text. Those stay where
 //! they are asked about. This is the surface underneath them.
 //!
+//! Below `Harness`, and for the same reason, is the rule that decides whether
+//! a run may rewrite a reference file. It is not about widgets at all; it is
+//! here because both reference harnesses have to read the same copy of it, and
+//! the last time it lived in two places it lived in neither.
+//!
 //! Each test binary compiles its own copy — that is what `mod common;` does —
 //! so a helper only one file uses is dead code in the others.
 #![allow(dead_code)]
@@ -150,7 +155,8 @@ pub enum Blessing {
     Compare,
 }
 
-/// Whether this run may write `exists`, given what the environment asked for.
+/// What to do, given what the environment asked for and whether the
+/// reference is already on disk.
 pub fn blessing(update: bool, rebless: bool, exists: bool) -> Blessing {
     match (update, rebless, exists) {
         // Rewriting is what REBLESS is, and the only thing it is.
@@ -166,7 +172,42 @@ pub fn blessing(update: bool, rebless: bool, exists: bool) -> Blessing {
 }
 
 /// Read the pair for one kind of reference — `"SNAPSHOTS"` or `"GOLDEN"`.
+///
+/// Says so when it declines. Somebody who asked to bless and got silence would
+/// read the pass that follows as the blessing having happened.
 pub fn blessing_from_env(kind: &str, exists: bool) -> Blessing {
-    let set = |prefix: &str| std::env::var_os(format!("{prefix}_{kind}")).is_some();
-    blessing(set("UPDATE"), set("REBLESS"), exists)
+    let asked = |prefix: &str| std::env::var_os(format!("{prefix}_{kind}")).is_some();
+    let update = asked("UPDATE");
+    let decision = blessing(update, asked("REBLESS"), exists);
+    if update && decision == Blessing::Compare {
+        eprintln!(
+            "UPDATE_{kind} declined: this reference already exists, and rewriting one \
+             makes a failing test pass without changing anything back. Read the diff \
+             the comparison is about to print; if the change is intended, that is \
+             REBLESS_{kind}=1 and the `golden-update` label on the pull request."
+        );
+    }
+    decision
+}
+
+/// Write the reference at `path`, if the rule allows it. Returns whether it
+/// wrote, so the caller can fall through to the comparison when it did not.
+///
+/// The writing is here rather than at the two call sites so that "decided it
+/// may write" and "wrote" cannot come apart: a harness that consults the rule
+/// and then writes anyway is the defect this all exists to stop, and it would
+/// read as compliant at both call sites.
+pub fn write_if_blessed(path: &std::path::Path, blessing: Blessing, write: impl FnOnce()) -> bool {
+    match blessing {
+        Blessing::Write => {
+            write();
+            assert!(
+                path.exists(),
+                "blessed {} and it is still not there",
+                path.display()
+            );
+            true
+        }
+        Blessing::Compare => false,
+    }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -126,3 +126,47 @@ impl Harness {
         self.tree.set_frame_instant(None);
     }
 }
+
+/// What to do with a reference file this run disagrees with.
+///
+/// Two variables, and the difference between them is the whole rule.
+/// `UPDATE_*` makes a reference that is not there yet: a new scenario needs a
+/// first picture and that is ordinary work. `REBLESS_*` rewrites one that is,
+/// which turns a failing test green without changing anything back — so it is
+/// a decision, taken with the diff in front of somebody, and the pull request
+/// carries the `golden-update` label to say it was taken.
+///
+/// One copy, read by both `assert_snapshot` and `assert_golden`, because the
+/// last time the rule lived in two places it lived in neither: both harnesses
+/// wrote unconditionally on `UPDATE_*` while their own module headers said
+/// they declined, and `REBLESS_*` was read nowhere at all.
+///
+/// A pure function of three booleans, so the table below is the test.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Blessing {
+    /// Write the reference, and skip the comparison.
+    Write,
+    /// Compare against what is on disk, whatever was asked for.
+    Compare,
+}
+
+/// Whether this run may write `exists`, given what the environment asked for.
+pub fn blessing(update: bool, rebless: bool, exists: bool) -> Blessing {
+    match (update, rebless, exists) {
+        // Rewriting is what REBLESS is, and the only thing it is.
+        (_, true, _) => Blessing::Write,
+        // A reference that is not there yet is not a rewrite.
+        (true, false, false) => Blessing::Write,
+        // Asked to create one that already exists: decline, and let the
+        // comparison report what actually moved. This is the line that was
+        // missing.
+        (true, false, true) => Blessing::Compare,
+        (false, false, _) => Blessing::Compare,
+    }
+}
+
+/// Read the pair for one kind of reference — `"SNAPSHOTS"` or `"GOLDEN"`.
+pub fn blessing_from_env(kind: &str, exists: bool) -> Blessing {
+    let set = |prefix: &str| std::env::var_os(format!("{prefix}_{kind}")).is_some();
+    blessing(set("UPDATE"), set("REBLESS"), exists)
+}

--- a/tests/golden_images.rs
+++ b/tests/golden_images.rs
@@ -62,7 +62,8 @@
 //! Pointed at a reference that already exists, it declines and lets the
 //! comparison run instead — because rewriting a picture that disagrees with the
 //! code makes a failing test pass without changing anything back. That is
-//! `REBLESS_GOLDEN=1`; a hook refuses it, and CI refuses a pull request that
+//! `REBLESS_GOLDEN=1`, and the rule both harnesses read is `common::blessing`;
+//! a hook refuses it, and CI refuses a pull request that
 //! rewrites a reference without the `golden-update` label. So it is always
 //! somebody's decision, taken with the diff in front of them. On failure the
 //! three images (expected, actual, and a map of what moved) are written to
@@ -70,6 +71,8 @@
 
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
+
+mod common;
 
 use guido::layout::Constraints;
 use guido::prelude::*;
@@ -343,7 +346,8 @@ fn diff_image(expected: &Pixels, actual: &Pixels) -> Pixels {
 fn assert_golden(name: &str, adapter: &str, actual: Pixels) {
     let path = golden_path(name);
 
-    if std::env::var_os("UPDATE_GOLDEN").is_some() {
+    let blessing = common::blessing_from_env("GOLDEN", path.exists());
+    if common::write_if_blessed(&path, blessing, || {
         assert!(
             is_software_rasterizer(adapter)
                 || std::env::var_os("GUIDO_GOLDEN_ANY_ADAPTER").is_some(),
@@ -351,12 +355,12 @@ fn assert_golden(name: &str, adapter: &str, actual: Pixels) {
              Goldens are compared against lavapipe in CI, and no two rasterizers \
              antialias an edge the same way, so a golden blessed here would fail \
              there for reasons that have nothing to do with the change.\n\
-             Install lavapipe and re-run with:\n  \
-             VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/lvp_icd.x86_64.json \
-             UPDATE_GOLDEN=1 cargo test --test golden_images"
+             Install lavapipe and re-run under the same variable, on lavapipe:\n  \
+             VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/lvp_icd.x86_64.json"
         );
         write_png(&path, &actual);
         eprintln!("blessed {name} ({adapter})");
+    }) {
         return;
     }
 
@@ -429,7 +433,7 @@ fn assert_golden(name: &str, adapter: &str, actual: Pixels) {
              {}\n\
              Images written to {}\n\
              If the change is intended, re-bless on lavapipe with \
-             UPDATE_GOLDEN=1 and put the diff in the pull request — that diff \
+             REBLESS_GOLDEN=1 and put the diff in the pull request — that diff \
              is the review.",
             100.0 * changed as f64 / total,
             first.join("\n"),

--- a/tests/render_snapshots.rs
+++ b/tests/render_snapshots.rs
@@ -25,12 +25,15 @@
 //! UPDATE_SNAPSHOTS=1 cargo test --test render_snapshots
 //! ```
 //!
-//! It refuses to overwrite one that already exists. Rewriting after an intended
-//! change is `REBLESS_SNAPSHOTS=1`, which a hook refuses and which a pull
-//! request carries the `golden-update` label to authorise. Read the diff before
-//! rewriting it — that diff *is* the review.
+//! It refuses to overwrite one that already exists — the rule both harnesses
+//! read is `common::blessing`. Rewriting after an intended change is
+//! `REBLESS_SNAPSHOTS=1`, which a hook refuses and which a pull request carries
+//! the `golden-update` label to authorise. Read the diff before rewriting it —
+//! that diff *is* the review.
 
 use std::fmt::Write as _;
+
+mod common;
 
 use guido::layout::Constraints;
 use guido::prelude::*;
@@ -245,8 +248,10 @@ fn assert_snapshot(name: &str, actual: String) {
         .join("tests/snapshots")
         .join(format!("{name}.snap"));
 
-    if std::env::var_os("UPDATE_SNAPSHOTS").is_some() {
+    let blessing = common::blessing_from_env("SNAPSHOTS", path.exists());
+    if common::write_if_blessed(&path, blessing, || {
         std::fs::write(&path, &actual).expect("write snapshot");
+    }) {
         return;
     }
 
@@ -257,8 +262,10 @@ fn assert_snapshot(name: &str, actual: String) {
     if expected != actual {
         panic!(
             "render tree changed for `{name}`.\n\
-             If the change is intended, re-bless with:\n  \
-             UPDATE_SNAPSHOTS=1 cargo test --test render_snapshots\n\n\
+             Read the diff: it is the review. If the change is intended, the \n\
+             rewrite is somebody's decision and the pull request carries the \n\
+             `golden-update` label to say they took it:\n  \
+             REBLESS_SNAPSHOTS=1 cargo test --test render_snapshots\n\n\
              --- expected ---\n{expected}\n--- actual ---\n{actual}"
         );
     }


### PR DESCRIPTION
## What changed

`UPDATE_GOLDEN` and `UPDATE_SNAPSHOTS` now create a reference that is not there
yet and decline, out loud, to touch one that is; `REBLESS_GOLDEN` and
`REBLESS_SNAPSHOTS` rewrite. That is what `CLAUDE.md` has called non-negotiable
all along and what both harnesses' own module headers described. None of it was
implemented: both wrote unconditionally on `UPDATE_*`, and the two `REBLESS_*`
variables were read nowhere in the tree — they appeared only inside the comments
claiming they worked. `.claude/hooks/guard-bash.sh` denied the two that did
nothing and permitted the two that rewrote, so the hook was refusing a no-op
while the command its own failure message sent you to next was the one that
quietly overwrote blessed references.

Closes #314.

## What proves it

`tests/blessing_rules.rs`, ten tests in three layers, because the first layer
only watches a decision and the second only watches spelling:

- **The rule.** `common::blessing(update, rebless, exists)` over its whole
  table. Two rows are the defect: `update && exists` is `Compare`, where both
  harnesses used to write, and `rebless && exists` is `Write`, where nothing
  used to happen at all.
- **The act.** `a_declined_reference_is_left_exactly_as_it_was` and
  `a_blessed_reference_is_written` drive `common::write_if_blessed` over a real
  file under `target/`. This is the one that catches a harness that decides
  correctly and writes anyway — which is why the write moved inside the helper
  rather than staying at the call sites.
- **The wiring.** `both_harnesses_consult_the_shared_rule` and
  `no_harness_reads_the_blessing_variables_itself` read both harness sources, in
  the manner of `tests/agent_workflow.rs`. Confirmed red on `origin/main`: both
  files contain `var_os("UPDATE_…")` and neither contains `blessing_from_env`.

No reference file is modified by this pull request, so no `golden-update` label.
`.github/workflows/ci.yml`'s refuse-an-unlabelled-re-bless job was already
correct and is untouched — it is the backstop this restores the front half of.
Nothing has been rewritten unnoticed on `main`.

## What the review found

The `reviewer` subagent read the two commits before this existed. **Zero
blocking.** Three findings worth answering, all three acted on:

1. `assert_golden`'s mismatch message still sent the reader to `UPDATE_GOLDEN=1`,
   which after this change is the one thing it will not do — the same defect the
   issue is about, left standing in the twin. Now names `REBLESS_GOLDEN`.
2. The decline was silent, and the issue's acceptance says "decline … saying
   so". `UPDATE_GOLDEN=1` over nine existing goldens used to print `blessed`
   nine times; it now has to account for printing nothing, so it says why.
3. The two source-reading tests prove spelling, not effect: both would pass on a
   harness that computes the blessing and ignores it. `write_if_blessed` and its
   two tests were added for that, and the writing moved inside it so the two
   halves cannot come apart.

Notes taken and acted on: the missing `(true, true, false)` table row; the
`tests/common/mod.rs` header, which no longer described its own contents.

One note not acted on, deliberately: `the_hook_denies_the_variables_that_rewrite`
duplicates a case `.claude/hooks/guard-bash.test.sh` already covers. It is the
only assertion tying the Rust side to the hook, so it earns its place.

## What was checked by hand

The harness cannot watch itself end to end, so:

- Corrupted `tests/snapshots/scrolling.snap` to one line, ran
  `UPDATE_SNAPSHOTS=1 cargo test --test render_snapshots scrolling`. It printed
  the decline, failed the comparison, and left the file at `node 0,0 1x1`.
  Before this change it would have rewritten it and passed.
- Deleted the same file, same command: recreated, `git diff --stat` clean —
  creation still works.
- Corrupted one pixel of `tests/golden/rounded_clipping.png`, ran
  `UPDATE_GOLDEN=1 cargo test --test golden_images rounded_clipping` on
  lavapipe. Declined, failed, file still corrupt until `git checkout`.
- Full suite, `cargo clippy --all-targets --all-features -- -D warnings`, and
  `cargo test --test golden_images` on lavapipe with `GUIDO_GPU_REQUIRED=1`:
  green, and `.claude/hooks/guard-bash.test.sh` passes.

## Left undone

The hook still denies `REBLESS_*` for agents while the harness now tells the
reader to run it — the one place the two give opposite instructions. It
terminates, because the deny message explains itself, and it is arguably correct
that the decision belongs to a person. Raised by the review as a note; not
opened as an issue because nobody has said the wording should distinguish a
reader from an agent. Say the word and it gets one.
