### PR TITLE
The visible window belongs to whoever has the rect, not to whoever scrolls

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -554,7 +554,7 @@ The paint system tracks which widgets need repainting:
   subsequent frames, a clean child whose position didn't change is reused via `Rc::clone`
   (zero copies); if it moved, only the node header is cloned (children and commands stay
   shared) with the position recomposed from the decomposed parent/user transforms.
-- **Partial propagation**: a node whose children were culled (`partial`) poisons its
+- **Partial propagation**: a node that did not paint all of itself (`partial`) poisons its
   ancestors in the cache walk — incomplete paints are never cached, so reuse can never
   resurrect a subtree with missing children. Refusing to cache is only half of it: a
   partial paint also *drops* the entry the last complete one left, because the widget

--- a/docs/RENDERER.md
+++ b/docs/RENDERER.md
@@ -31,7 +31,7 @@ pub struct RenderNode {
     pub clip: Option<ClipRegion>,            // Clips this node and children
     pub overlay_clip: Option<ClipRegion>,    // Clips only overlay commands
     pub repainted: Cell<bool>,               // true = freshly painted this frame
-    pub partial: bool,                       // Some children were culled (do not cache)
+    pub partial: bool,                       // Some children were not painted (do not cache)
     pub cached_flatten: RefCell<Option<Rc<CachedFlatten>>>, // Cached flatten output
 }
 ```
@@ -49,7 +49,8 @@ to the same node that sits in the frame's render tree:
   cached nodes are shared: `repainted` is cleared once the node's output has
   been cached, and flatten writes `cached_flatten` through a `&RenderNode`.
 - `partial` propagates to ancestors during the cache walk: a subtree that
-  embeds a partially-painted node (culled children) is never cached, so a
+  embeds a partially-painted node — children narrowed away by the visible
+  window, or culled one at a time beneath it — is never cached, so a
   later cache reuse cannot resurrect an incomplete paint. It also invalidates:
   `Tree::clear_cached_paint` drops whatever the last complete paint left, which
   is a picture of the widget as it no longer is — a list that scrolls culls

--- a/src/render_stats.rs
+++ b/src/render_stats.rs
@@ -62,9 +62,12 @@ pub struct StatsSnapshot {
     pub flatten_timing: PhaseTiming,
     pub gpu_render_timing: PhaseTiming,
     pub cache_paint_timing: PhaseTiming,
-    // Scroll
-    pub scroll_children_total: u64,
-    pub scroll_children_iterated: u64,
+    // The paint window: children offered to it, children it let through, and
+    // the ones it could not narrow because nothing ordered them.
+    pub window_children_total: u64,
+    pub window_children_iterated: u64,
+    pub window_declined_children: u64,
+    pub window_declined_containers: u64,
 }
 
 /// Zero-cost timing macro. Wraps a block with `Instant::now()` / `.elapsed()`
@@ -166,9 +169,11 @@ mod inner {
         flatten_phase: PhaseAccum,
         gpu_render_phase: PhaseAccum,
         cache_paint_phase: PhaseAccum,
-        // Scroll
-        scroll_children_total: u64,
-        scroll_children_iterated: u64,
+        // Paint window
+        window_children_total: u64,
+        window_children_iterated: u64,
+        window_declined_children: u64,
+        window_declined_containers: u64,
         // Report timing
         last_print: Instant,
     }
@@ -195,8 +200,10 @@ mod inner {
                 flatten_phase: PhaseAccum::new(),
                 gpu_render_phase: PhaseAccum::new(),
                 cache_paint_phase: PhaseAccum::new(),
-                scroll_children_total: 0,
-                scroll_children_iterated: 0,
+                window_children_total: 0,
+                window_children_iterated: 0,
+                window_declined_children: 0,
+                window_declined_containers: 0,
                 last_print: Instant::now(),
             }
         }
@@ -221,8 +228,10 @@ mod inner {
             self.flatten_phase.reset();
             self.gpu_render_phase.reset();
             self.cache_paint_phase.reset();
-            self.scroll_children_total = 0;
-            self.scroll_children_iterated = 0;
+            self.window_children_total = 0;
+            self.window_children_iterated = 0;
+            self.window_declined_children = 0;
+            self.window_declined_containers = 0;
             self.last_print = Instant::now();
         }
     }
@@ -323,13 +332,28 @@ mod inner {
         });
     }
 
-    /// Record scroll paint iteration stats.
+    /// Record a container that narrowed its children to the visible rect.
     #[inline]
-    pub fn record_scroll_paint_range(total_children: u64, iterated: u64) {
+    pub fn record_paint_window(total_children: u64, iterated: u64) {
         STATS.with(|s| {
             let mut stats = s.borrow_mut();
-            stats.scroll_children_total += total_children;
-            stats.scroll_children_iterated += iterated;
+            stats.window_children_total += total_children;
+            stats.window_children_iterated += iterated;
+        });
+    }
+
+    /// Record a container that had a rect to narrow to and could not: its
+    /// children are ordered along no axis, so every one of them is examined.
+    ///
+    /// This is the number worth watching. A container in this state looks
+    /// healthy from the outside — it draws the right thing — and pays for the
+    /// whole of its list on every frame that repaints it.
+    #[inline]
+    pub fn record_paint_window_declined(total_children: u64) {
+        STATS.with(|s| {
+            let mut stats = s.borrow_mut();
+            stats.window_declined_children += total_children;
+            stats.window_declined_containers += 1;
         });
     }
 
@@ -357,8 +381,10 @@ mod inner {
                 flatten_timing: stats.flatten_phase.to_timing(),
                 gpu_render_timing: stats.gpu_render_phase.to_timing(),
                 cache_paint_timing: stats.cache_paint_phase.to_timing(),
-                scroll_children_total: stats.scroll_children_total,
-                scroll_children_iterated: stats.scroll_children_iterated,
+                window_children_total: stats.window_children_total,
+                window_children_iterated: stats.window_children_iterated,
+                window_declined_children: stats.window_declined_children,
+                window_declined_containers: stats.window_declined_containers,
             }
         })
     }
@@ -458,11 +484,14 @@ mod inner {
                     ct.avg_us, ct.min_us, ct.max_us,
                 );
 
-                // Scroll stats (only if scroll activity occurred)
-                if stats.scroll_children_total > 0 {
+                // The paint window, and what it could not narrow.
+                if stats.window_children_total > 0 || stats.window_declined_children > 0 {
                     eprintln!(
-                        "  scroll: total_children={} iterated={}",
-                        stats.scroll_children_total, stats.scroll_children_iterated
+                        "  window: offered={} narrowed_to={} | declined={} children in {} containers",
+                        stats.window_children_total,
+                        stats.window_children_iterated,
+                        stats.window_declined_children,
+                        stats.window_declined_containers
                     );
                 }
 
@@ -529,7 +558,11 @@ pub fn record_phase_duration(_phase: Phase, _duration: std::time::Duration) {}
 
 #[cfg(not(feature = "render-stats"))]
 #[inline(always)]
-pub fn record_scroll_paint_range(_total_children: u64, _iterated: u64) {}
+pub fn record_paint_window(_total_children: u64, _iterated: u64) {}
+
+#[cfg(not(feature = "render-stats"))]
+#[inline(always)]
+pub fn record_paint_window_declined(_total_children: u64) {}
 
 #[cfg(not(feature = "render-stats"))]
 #[inline(always)]
@@ -738,12 +771,25 @@ mod tests {
     }
 
     #[test]
-    fn test_scroll_paint_range() {
+    fn test_paint_window() {
         setup();
-        record_scroll_paint_range(10000, 52);
-        record_scroll_paint_range(10000, 48);
+        record_paint_window(10000, 52);
+        record_paint_window(10000, 48);
         let s = get_stats();
-        assert_eq!(s.scroll_children_total, 20000);
-        assert_eq!(s.scroll_children_iterated, 100);
+        assert_eq!(s.window_children_total, 20000);
+        assert_eq!(s.window_children_iterated, 100);
+    }
+
+    /// A container that could not narrow is counted apart from one whose
+    /// window happened to cover everything. Both used to read as a window.
+    #[test]
+    fn test_paint_window_declined() {
+        setup();
+        record_paint_window(10000, 10000);
+        record_paint_window_declined(10000);
+        let s = get_stats();
+        assert_eq!(s.window_children_iterated, 10000);
+        assert_eq!(s.window_declined_children, 10000);
+        assert_eq!(s.window_declined_containers, 1);
     }
 }

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -26,7 +26,7 @@ use crate::advance_anim;
 use crate::animation::{Animatable, IntoAnimated, Motion};
 use crate::backdrop::BackdropBlur;
 use crate::jobs::{JobRequest, JobType, RequiredJob, request_job};
-use crate::layout::{Constraints, Flex, Layout, Length, Size};
+use crate::layout::{Axis, Constraints, Flex, Layout, Length, Size};
 use crate::pivot::Pivot;
 use crate::reactive::{
     IntoSignal, OptionSignalExt, RwSignal, Signal, create_signal, focus_path, with_signal_tracking,
@@ -456,6 +456,20 @@ pub struct Container {
     // Scroll configuration
     pub(super) scroll_axis: ScrollAxis,
     pub(super) scroll_data: Option<Box<ScrollData>>,
+
+    /// The axis the last layout left the children ordered along, if any.
+    ///
+    /// `paint` narrows the children to a cull rect with a binary search, and a
+    /// binary search needs a partitioned slice. Which axis partitions them —
+    /// and whether any does — is a property of what the layout *did*, not of
+    /// what the container was declared with: a `Flex::row()` under a vertical
+    /// scroller orders its children along x, and a layout free to put them
+    /// anywhere orders them along neither.
+    ///
+    /// So it is measured once per layout, where the walk over the children is
+    /// already happening and is off the frame path, rather than asked of
+    /// `Layout` at every paint.
+    pub(super) children_sorted_along: Option<Axis>,
 }
 
 impl Container {
@@ -485,6 +499,7 @@ impl Container {
             anims: None,
             scroll_axis: ScrollAxis::None,
             scroll_data: None,
+            children_sorted_along: None,
         }
     }
 
@@ -1339,6 +1354,8 @@ impl Widget for Container {
             tree.set_baseline(id, child_y + child_baseline);
         }
 
+        self.children_sorted_along = sorted_axis(tree, children);
+
         if self.scroll_axis != ScrollAxis::None {
             let sd = self.scroll_mut();
             sd.scroll_state.content_width = content_size.width + padding.horizontal_total();
@@ -1577,56 +1594,7 @@ impl Widget for Container {
             return;
         }
 
-        // Draw children - each gets its own node with position transform.
-        //
-        // For scrollable containers with a single-axis layout, use binary search
-        // to find the visible range (O(log n)) instead of iterating all children (O(n)).
         let all_children = self.children_source.get();
-
-        let visible_children: &[WidgetId] = if is_scrollable {
-            let sd = self.scroll();
-            match self.scroll_axis {
-                ScrollAxis::Vertical => {
-                    let vp_top = sd.scroll_state.offset_y;
-                    let vp_bottom = vp_top + local_bounds.height;
-                    let first = all_children.partition_point(|&cid| {
-                        tree.get_bounds(cid)
-                            .is_some_and(|b| b.y + b.height <= vp_top)
-                    });
-                    let last = all_children.partition_point(|&cid| {
-                        tree.get_bounds(cid).is_some_and(|b| b.y < vp_bottom)
-                    });
-                    let start = first.saturating_sub(1);
-                    let end = (last + 1).min(all_children.len());
-                    crate::render_stats::record_scroll_paint_range(
-                        all_children.len() as u64,
-                        (end - start) as u64,
-                    );
-                    &all_children[start..end]
-                }
-                ScrollAxis::Horizontal => {
-                    let vp_left = sd.scroll_state.offset_x;
-                    let vp_right = vp_left + local_bounds.width;
-                    let first = all_children.partition_point(|&cid| {
-                        tree.get_bounds(cid)
-                            .is_some_and(|b| b.x + b.width <= vp_left)
-                    });
-                    let last = all_children.partition_point(|&cid| {
-                        tree.get_bounds(cid).is_some_and(|b| b.x < vp_right)
-                    });
-                    let start = first.saturating_sub(1);
-                    let end = (last + 1).min(all_children.len());
-                    crate::render_stats::record_scroll_paint_range(
-                        all_children.len() as u64,
-                        (end - start) as u64,
-                    );
-                    &all_children[start..end]
-                }
-                _ => all_children, // Both/None: fall back to full iteration
-            }
-        } else {
-            all_children
-        };
 
         let scroll_offset = if is_scrollable {
             let sd = self.scroll();
@@ -1637,10 +1605,11 @@ impl Widget for Container {
         paint_children(
             tree,
             ctx,
-            visible_children,
+            all_children,
             &ChildPaintOptions {
                 scroll_offset,
                 cull_rect: effective_cull_rect,
+                children_sorted_along: self.children_sorted_along,
                 // A scroller's cull rect moves under its content, so a
                 // partially visible child has to repaint for its own children
                 // to be culled against the current rect.
@@ -1681,6 +1650,53 @@ impl Widget for Container {
             }
         }
     }
+}
+
+/// The axis `children` came out ordered along, if any.
+///
+/// Ordered means what the binary search in `paint` needs: consecutive children
+/// that do not overlap on that axis, so both of the predicates it searches with
+/// partition the slice. Anything less and `partition_point` answers about
+/// whichever child it happened to probe rather than about the viewport, and a
+/// child sitting in plain view is dropped.
+///
+/// Non-overlap also settles which axis to answer when a layout orders its
+/// children along both: a column's children overlap horizontally and a row's
+/// overlap vertically, so each rules the other axis out and the answer is the
+/// one that narrows.
+///
+/// Bails on the first pair that overlaps on both, so a layout that stacks its
+/// children costs two of them and a list costs the pass that earns it.
+fn sorted_axis(tree: &Tree, children: &[WidgetId]) -> Option<Axis> {
+    // No children are ordered along nothing in particular, and answering an
+    // axis for them would be a claim about nothing.
+    if children.is_empty() {
+        return None;
+    }
+    let (mut vertical, mut horizontal) = (true, true);
+    let (mut bottom, mut right) = (f32::NEG_INFINITY, f32::NEG_INFINITY);
+
+    for &child in children {
+        // A child the tree cannot answer for is a child the search cannot
+        // place, and one unplaceable child unpartitions the whole slice.
+        let bounds = tree.get_bounds(child)?;
+        let (top, next_bottom) = bounds.span(Axis::Vertical);
+        let (left, next_right) = bounds.span(Axis::Horizontal);
+        vertical &= top >= bottom;
+        horizontal &= left >= right;
+        if !vertical && !horizontal {
+            return None;
+        }
+        (bottom, right) = (next_bottom, next_right);
+    }
+
+    // The loop returns on the first pair that overlaps on both, so reaching
+    // here means at least one axis survived.
+    Some(if vertical {
+        Axis::Vertical
+    } else {
+        Axis::Horizontal
+    })
 }
 
 /// Declare an animatable property: keep the value's signal, and install

--- a/src/widgets/paint_children.rs
+++ b/src/widgets/paint_children.rs
@@ -9,6 +9,13 @@
 //!
 //! The invariants it upholds:
 //!
+//! - The children are narrowed to the cull rect twice over, and the two are
+//!   not alternatives. A binary search takes the slice down to the ones the
+//!   rect can reach, which is the only bound that holds on a first paint;
+//!   the per-child test below then drops what the search let through and the
+//!   cache says is clean. The search needs the children ordered along an
+//!   axis and says nothing when they are not, which is why the cheaper test
+//!   still runs underneath it.
 //! - A culled child makes the parent's paint **partial**, and a partial paint
 //!   is never cached — otherwise reusing it later would permanently hide the
 //!   children this pass skipped. It also invalidates whatever the last
@@ -20,6 +27,7 @@
 //!   path; falling through to a full paint if it ever does keeps a missed
 //!   invalidation from showing stale content stretched to the wrong box.
 
+use crate::layout::Axis;
 use crate::renderer::PaintContext;
 use crate::transform::Transform;
 use crate::tree::{Tree, WidgetId};
@@ -39,6 +47,11 @@ pub(crate) struct ChildPaintOptions {
     /// rect moves under the content; a parent that merely inherits its own
     /// parent's cull rect does not.
     pub cache_requires_full_visibility: bool,
+    /// The axis the parent's last layout left these children ordered along, if
+    /// it left them ordered along one. Without it the children are painted
+    /// whole, however small the cull rect: a binary search over a slice that
+    /// is not partitioned answers about whichever child it probed.
+    pub children_sorted_along: Option<Axis>,
 }
 
 impl Default for ChildPaintOptions {
@@ -47,8 +60,65 @@ impl Default for ChildPaintOptions {
             scroll_offset: (0.0, 0.0),
             cull_rect: None,
             cache_requires_full_visibility: false,
+            children_sorted_along: None,
         }
     }
+}
+
+/// The children the cull rect can reach, found by binary search.
+///
+/// This is what bounds the work unconditionally. The per-child test in
+/// `paint_children` only drops children the paint cache calls clean, so on a
+/// first paint — and after anything that dirties the subtree — it drops
+/// nothing and every child is painted in full. A list of ten thousand rows
+/// costs ten thousand paints unless the slice is narrowed first.
+///
+/// Marks the paint partial when it does narrow, for the same reason the
+/// per-child cull does: a node that did not paint all of itself must not be
+/// cached as though it had, or the rect moves on and the cache serves the
+/// children it skipped.
+fn visible_window<'a>(
+    tree: &Tree,
+    children: &'a [WidgetId],
+    ctx: &mut PaintContext,
+    opts: &ChildPaintOptions,
+) -> &'a [WidgetId] {
+    // One child cannot be narrowed to fewer than one, and none cannot be
+    // narrowed at all. Before the counting, not after: a scroller's subtree is
+    // mostly single-child wrappers and childless leaves, and counting those as
+    // windows that could not narrow would bury the one container that matters
+    // under every box below it.
+    if children.len() < 2 {
+        return children;
+    }
+    let (Some(cull), Some(axis)) = (opts.cull_rect, opts.children_sorted_along) else {
+        if opts.cull_rect.is_some() {
+            // A rect to narrow to and nothing to narrow with. This is the case
+            // that silently costs a list its virtualization, and it used to
+            // report a window of one child out of one.
+            crate::render_stats::record_paint_window_declined(children.len() as u64);
+        }
+        return children;
+    };
+
+    let (near, far) = cull.span(axis);
+    let span = |cid: WidgetId| tree.get_bounds(cid).map(|b| b.span(axis));
+    let first = children.partition_point(|&cid| span(cid).is_some_and(|(_, f)| f <= near));
+    // From `first`, so `last` cannot come out below it however degenerate the
+    // rect is, and the slice below is well formed by construction.
+    let last =
+        first + children[first..].partition_point(|&cid| span(cid).is_some_and(|(n, _)| n < far));
+
+    // One either side, because these are laid-out bounds and a child draws
+    // where its own transform puts it. One child of slack is a margin, not a
+    // bound: a translate larger than a child clips against the rect anyway,
+    // which is its own defect and older than this window.
+    let window = &children[first.saturating_sub(1)..(last + 1).min(children.len())];
+    crate::render_stats::record_paint_window(children.len() as u64, window.len() as u64);
+    if window.len() < children.len() {
+        ctx.mark_partial();
+    }
+    window
 }
 
 /// Paint `children` into `ctx`, culling and reusing cached paint where possible.
@@ -59,6 +129,7 @@ pub(crate) fn paint_children(
     opts: &ChildPaintOptions,
 ) {
     let (offset_x, offset_y) = opts.scroll_offset;
+    let children = visible_window(tree, children, ctx, opts);
 
     for &child_id in children {
         // Child bounds come from the tree in the parent's local coordinates

--- a/src/widgets/widget.rs
+++ b/src/widgets/widget.rs
@@ -1,4 +1,4 @@
-use crate::layout::{Constraints, Size};
+use crate::layout::{Axis, Constraints, Size};
 use crate::renderer::PaintContext;
 use crate::tree::{Tree, WidgetId};
 
@@ -208,6 +208,17 @@ impl Rect {
             y,
             width,
             height,
+        }
+    }
+
+    /// The interval this rect covers on one axis, near edge first.
+    ///
+    /// What a search along an axis compares against, and what deciding
+    /// whether two rects follow one another along it comes down to.
+    pub(crate) fn span(&self, axis: Axis) -> (f32, f32) {
+        match axis {
+            Axis::Horizontal => (self.x, self.x + self.width),
+            Axis::Vertical => (self.y, self.y + self.height),
         }
     }
 

--- a/tests/scroll_virtualization.rs
+++ b/tests/scroll_virtualization.rs
@@ -1,0 +1,211 @@
+//! What reaches paint inside a scroller, and what does not.
+//!
+//! `paint_children` narrows a parent's children to the ones the cull rect can
+//! reach, with a binary search over their bounds. That window is the only
+//! thing that bounds the work unconditionally: the per-child cull beside it is
+//! guarded by `!tree.needs_paint(child_id)`, so on a first paint — and after
+//! anything that dirties the subtree — it drops nothing and every child is
+//! painted in full.
+//!
+//! So the window is worth asserting on directly, over a first paint, where the
+//! cull cannot stand in for it. Neither pass needs a compositor or a GPU.
+
+mod common;
+
+use common::Harness;
+use guido::prelude::*;
+use guido::widget_prelude::{Constraints, Layout, Tree, WidgetId};
+
+const ROWS: usize = 200;
+const ROW_WIDTH: f32 = 120.0;
+const ROW_HEIGHT: f32 = 24.0;
+const SPACING: f32 = 8.0;
+const VIEWPORT: f32 = 200.0;
+
+/// The rows that reached paint, counted by size so that the count means the
+/// same thing however deep they sit — which is the whole question here.
+fn painted_rows(widget: impl Widget + 'static, viewport: f32) -> usize {
+    Harness::laid_out(widget, 400.0, viewport)
+        .painted_rects()
+        .iter()
+        .filter(|r| (r.width - ROW_WIDTH).abs() < 0.01 && (r.height - ROW_HEIGHT).abs() < 0.01)
+        .count()
+}
+
+fn rows(n: usize) -> Vec<guido::widgets::Container> {
+    (0..n)
+        .map(|_| {
+            container()
+                .width(ROW_WIDTH)
+                .height(ROW_HEIGHT)
+                .background(Color::rgb(0.25, 0.25, 0.35))
+        })
+        .collect()
+}
+
+/// The rows are the same rows and the viewport is the same viewport, so the
+/// window has to reach the same number of them however deep they sit.
+///
+/// After `examples/bench_list.rs`, which is written the wrapped way — as are
+/// `examples/scroll_example.rs` and `examples/perf_stress_test.rs`.
+#[test]
+fn a_wrapped_list_paints_the_rows_an_unwrapped_one_paints() {
+    let direct = painted_rows(
+        container()
+            .width(200.0)
+            .height(VIEWPORT)
+            .scrollable(ScrollAxis::Vertical)
+            .layout(Flex::column().spacing(SPACING))
+            .children(rows(ROWS)),
+        VIEWPORT,
+    );
+
+    let wrapped = painted_rows(
+        container()
+            .width(200.0)
+            .height(VIEWPORT)
+            .scrollable(ScrollAxis::Vertical)
+            .child(
+                container()
+                    .layout(Flex::column().spacing(SPACING))
+                    .children(rows(ROWS)),
+            ),
+        VIEWPORT,
+    );
+
+    // 200 px of viewport over a 32 px pitch is seven rows, plus the one either
+    // side the window carries for a child whose transform moves what it draws.
+    assert!(
+        direct <= 12,
+        "the direct form is no longer windowed: {direct} of {ROWS} rows painted"
+    );
+    assert_eq!(
+        wrapped, direct,
+        "wrapping the rows cost the list its window: {wrapped} rows painted where the same rows \
+         as direct children paint {direct}"
+    );
+}
+
+/// A window over bounds that are not ordered along the axis it searches does
+/// not answer about the viewport. `partition_point` needs a partitioned slice,
+/// and nothing used to check that the children were one — it was inferred from
+/// `scroll_axis` alone, and a binary search over an unpartitioned slice returns
+/// whichever index it happened to land on.
+///
+/// So the container has to be able to say *no*: children ordered along neither
+/// axis are all painted, because there is no window to be had and a wrong one
+/// drops something visible.
+#[test]
+fn a_scroller_whose_children_are_ordered_along_neither_axis_paints_all_of_them() {
+    // Eight rows at one x, so every one of them is inside the viewport
+    // horizontally, at a `y` that runs 0, 400, 400 … 40 — ordered along
+    // neither axis. Two are visible in a 100 px viewport: the first, and the
+    // last. Searching that for `y < 100` lands on index 1, and the last is
+    // dropped.
+    let ys = [0.0, 400.0, 400.0, 400.0, 400.0, 400.0, 400.0, 40.0];
+
+    let painted = painted_rows(
+        container()
+            .width(200.0)
+            .height(100.0)
+            .scrollable(ScrollAxis::Vertical)
+            .layout(Scatter(ys.to_vec()))
+            .children(rows(ys.len())),
+        100.0,
+    );
+
+    assert_eq!(
+        painted,
+        ys.len(),
+        "a scroller binary-searched bounds that are not partitioned along its axis and dropped a \
+         child sitting in the viewport: {painted} of {} painted",
+        ys.len()
+    );
+}
+
+/// Stacks its children at the offsets it is given, so a test can hand a
+/// container children ordered along neither axis. `Flex` orders them along one
+/// by construction and `ZStack` puts them all at the origin, where every
+/// predicate a search asks is constant and the old code came out right by
+/// accident — neither can pose the question.
+struct Scatter(Vec<f32>);
+
+impl Layout for Scatter {
+    fn layout(
+        &mut self,
+        tree: &mut Tree,
+        children: &[WidgetId],
+        constraints: Constraints,
+        origin: (f32, f32),
+    ) -> Size {
+        let mut size = Size::zero();
+        for (&child, &y) in children.iter().zip(&self.0) {
+            let child_size = tree
+                .with_widget_mut(child, |w, id, t| w.layout(t, id, constraints))
+                .unwrap_or_default();
+            tree.set_origin(child, origin.0, origin.1 + y);
+            size.width = size.width.max(child_size.width);
+            size.height = size.height.max(y + child_size.height);
+        }
+        size
+    }
+}
+
+/// The counter has to be able to tell a container that narrowed from one that
+/// could not, because "1 offered, 1 iterated" is what the wrapped form used to
+/// report and it reads as a healthy window over a list of one.
+///
+/// Behind the feature, because that is where the counters exist at all; the
+/// lavapipe job runs the suite with every feature on.
+#[cfg(feature = "render-stats")]
+#[test]
+fn the_counter_separates_a_narrowed_window_from_one_that_could_not_narrow() {
+    use guido::render_stats::{get_stats, reset_stats};
+
+    reset_stats();
+    painted_rows(
+        container()
+            .width(200.0)
+            .height(VIEWPORT)
+            .scrollable(ScrollAxis::Vertical)
+            .layout(Flex::column().spacing(SPACING))
+            .children(rows(ROWS)),
+        VIEWPORT,
+    );
+    let narrowed = get_stats();
+    assert_eq!(
+        narrowed.window_children_total, ROWS as u64,
+        "the window was not offered the rows"
+    );
+    assert!(
+        narrowed.window_children_iterated < ROWS as u64,
+        "the window let every row through: {} of {ROWS}",
+        narrowed.window_children_iterated
+    );
+    assert_eq!(
+        narrowed.window_declined_containers, 0,
+        "a column of rows is ordered along an axis and nothing should have declined"
+    );
+
+    reset_stats();
+    painted_rows(
+        container()
+            .width(200.0)
+            .height(100.0)
+            .scrollable(ScrollAxis::Vertical)
+            .layout(Scatter(vec![
+                0.0, 400.0, 400.0, 400.0, 400.0, 400.0, 400.0, 40.0,
+            ]))
+            .children(rows(8)),
+        100.0,
+    );
+    let declined = get_stats();
+    assert_eq!(
+        declined.window_declined_containers, 1,
+        "a container that could not narrow went uncounted"
+    );
+    assert_eq!(
+        declined.window_declined_children, 8,
+        "the children it had to examine one at a time went uncounted"
+    );
+}

--- a/tests/scroll_virtualization.rs
+++ b/tests/scroll_virtualization.rs
@@ -22,6 +22,29 @@ const ROW_HEIGHT: f32 = 24.0;
 const SPACING: f32 = 8.0;
 const VIEWPORT: f32 = 200.0;
 
+/// Eight places whose `y` runs 0, 400, 400 … 40 and whose `x` runs
+/// 0, 300, 300 … 0 — ordered along neither axis, and unordered in the same
+/// shape on each of them separately. In a 100 px viewport the first and the
+/// last are visible.
+///
+/// Both coordinates carry their weight. Searching the `y` for `y < 100` lands
+/// on index 1 and drops the last row, which is what catches a wrong vertical
+/// answer; the `x` catches a wrong horizontal one, because a search for
+/// `x < 200` lands on index 1 in exactly the same way. With every row at one
+/// `x` the horizontal branch could answer anything and no row would move —
+/// which is what `cargo mutants` found by turning its `&=` into `|=` and
+/// watching nothing object.
+const SCATTERED: [(f32, f32); 8] = [
+    (0.0, 0.0),
+    (300.0, 400.0),
+    (300.0, 400.0),
+    (300.0, 400.0),
+    (300.0, 400.0),
+    (300.0, 400.0),
+    (300.0, 400.0),
+    (0.0, 40.0),
+];
+
 /// The rows that reached paint, counted by size so that the count means the
 /// same thing however deep they sit — which is the whole question here.
 fn painted_rows(widget: impl Widget + 'static, viewport: f32) -> usize {
@@ -97,38 +120,43 @@ fn a_wrapped_list_paints_the_rows_an_unwrapped_one_paints() {
 /// drops something visible.
 #[test]
 fn a_scroller_whose_children_are_ordered_along_neither_axis_paints_all_of_them() {
-    // Eight rows at one x, so every one of them is inside the viewport
-    // horizontally, at a `y` that runs 0, 400, 400 … 40 — ordered along
-    // neither axis. Two are visible in a 100 px viewport: the first, and the
-    // last. Searching that for `y < 100` lands on index 1, and the last is
-    // dropped.
-    let ys = [0.0, 400.0, 400.0, 400.0, 400.0, 400.0, 400.0, 40.0];
-
+    // Eight rows whose `y` runs 0, 400, 400 … 40 and whose `x` runs
+    // 0, 300, 300 … 0 — ordered along neither axis, and unordered in the same
+    // shape on both. Two are visible in a 100 px viewport: the first and the
+    // last.
+    //
+    // Both coordinates carry their weight. Searching the `y` for `y < 100`
+    // lands on index 1 and drops the last row, which is what this catches if
+    // the vertical answer is wrong; the `x` is what catches a wrong horizontal
+    // one, because a search for `x < 200` lands on index 1 in just the same
+    // way. With every row at one `x` the horizontal branch could answer
+    // anything and no row would move.
     let painted = painted_rows(
         container()
             .width(200.0)
             .height(100.0)
             .scrollable(ScrollAxis::Vertical)
-            .layout(Scatter(ys.to_vec()))
-            .children(rows(ys.len())),
+            .layout(Scatter(SCATTERED.to_vec()))
+            .children(rows(SCATTERED.len())),
         100.0,
     );
 
     assert_eq!(
         painted,
-        ys.len(),
+        SCATTERED.len(),
         "a scroller binary-searched bounds that are not partitioned along its axis and dropped a \
          child sitting in the viewport: {painted} of {} painted",
-        ys.len()
+        SCATTERED.len()
     );
 }
 
-/// Stacks its children at the offsets it is given, so a test can hand a
-/// container children ordered along neither axis. `Flex` orders them along one
-/// by construction and `ZStack` puts them all at the origin, where every
-/// predicate a search asks is constant and the old code came out right by
-/// accident — neither can pose the question.
-struct Scatter(Vec<f32>);
+/// Places its children exactly where it is told, so a test can hand a container
+/// children ordered along neither axis — and unordered along each of them
+/// separately, which is what watches both halves of the answer. `Flex` orders
+/// them along one axis by construction and `ZStack` puts them all at the
+/// origin, where every predicate a search asks is constant and the old code
+/// came out right by accident; neither can pose the question.
+struct Scatter(Vec<(f32, f32)>);
 
 impl Layout for Scatter {
     fn layout(
@@ -139,12 +167,12 @@ impl Layout for Scatter {
         origin: (f32, f32),
     ) -> Size {
         let mut size = Size::zero();
-        for (&child, &y) in children.iter().zip(&self.0) {
+        for (&child, &(x, y)) in children.iter().zip(&self.0) {
             let child_size = tree
                 .with_widget_mut(child, |w, id, t| w.layout(t, id, constraints))
                 .unwrap_or_default();
-            tree.set_origin(child, origin.0, origin.1 + y);
-            size.width = size.width.max(child_size.width);
+            tree.set_origin(child, origin.0 + x, origin.1 + y);
+            size.width = size.width.max(x + child_size.width);
             size.height = size.height.max(y + child_size.height);
         }
         size
@@ -193,9 +221,7 @@ fn the_counter_separates_a_narrowed_window_from_one_that_could_not_narrow() {
             .width(200.0)
             .height(100.0)
             .scrollable(ScrollAxis::Vertical)
-            .layout(Scatter(vec![
-                0.0, 400.0, 400.0, 400.0, 400.0, 400.0, 400.0, 40.0,
-            ]))
+            .layout(Scatter(SCATTERED.to_vec()))
             .children(rows(8)),
         100.0,
     );

--- a/tests/snapshots/bar_like_composition.snap
+++ b/tests/snapshots/bar_like_composition.snap
@@ -11,7 +11,7 @@ node 0,0 600x36
   node 0,0 254x1 at 166,17.5
   node 0,0 90x24 at 428,6 clip(0,0 90x24 r=6)
     draw rect 0,0 90x24 fill=#262633ff radius=6/6/6/6
-    node 0,0 200x14
+    node 0,0 200x14 partial
       node 0,0 30x14
         draw rect 0,0 30x14 fill=#00ffffff radius=0/0/0/0
       node 0,0 30x14 at 34,0
@@ -19,10 +19,6 @@ node 0,0 600x36
       node 0,0 30x14 at 68,0
         draw rect 0,0 30x14 fill=#00ffffff radius=0/0/0/0
       node 0,0 30x14 at 102,0
-        draw rect 0,0 30x14 fill=#00ffffff radius=0/0/0/0
-      node 0,0 30x14 at 136,0
-        draw rect 0,0 30x14 fill=#00ffffff radius=0/0/0/0
-      node 0,0 30x14 at 170,0
         draw rect 0,0 30x14 fill=#00ffffff radius=0/0/0/0
     node 0,0 86x6 at 2,16
       draw rect 0,0 86x6 fill=#ffffff0d radius=100/100/100/100

--- a/tests/snapshots/scrolling.snap
+++ b/tests/snapshots/scrolling.snap
@@ -1,7 +1,7 @@
 node 0,0 648x216
   node 0,0 200x200 at 8,8 clip(0,0 200x200 r=8)
     draw rect 0,0 200x200 fill=#262633ff radius=8/8/8/8
-    node 0,0 136x648
+    node 0,0 136x648 partial
       node 0,0 120x24 at 8,8
         draw rect 0,0 120x24 fill=#404059ff radius=4/4/4/4
       node 0,0 120x24 at 8,41
@@ -16,32 +16,6 @@ node 0,0 648x216
         draw rect 0,0 120x24 fill=#404059ff radius=4/4/4/4
       node 0,0 120x24 at 8,206
         draw rect 0,0 120x24 fill=#404059ff radius=4/4/4/4
-      node 0,0 120x24 at 8,239
-        draw rect 0,0 120x24 fill=#404059ff radius=4/4/4/4
-      node 0,0 120x24 at 8,272
-        draw rect 0,0 120x24 fill=#404059ff radius=4/4/4/4
-      node 0,0 120x24 at 8,305
-        draw rect 0,0 120x24 fill=#404059ff radius=4/4/4/4
-      node 0,0 120x24 at 8,338
-        draw rect 0,0 120x24 fill=#404059ff radius=4/4/4/4
-      node 0,0 120x24 at 8,371
-        draw rect 0,0 120x24 fill=#404059ff radius=4/4/4/4
-      node 0,0 120x24 at 8,404
-        draw rect 0,0 120x24 fill=#404059ff radius=4/4/4/4
-      node 0,0 120x24 at 8,437
-        draw rect 0,0 120x24 fill=#404059ff radius=4/4/4/4
-      node 0,0 120x24 at 8,470
-        draw rect 0,0 120x24 fill=#404059ff radius=4/4/4/4
-      node 0,0 120x24 at 8,503
-        draw rect 0,0 120x24 fill=#404059ff radius=4/4/4/4
-      node 0,0 120x24 at 8,536
-        draw rect 0,0 120x24 fill=#404059ff radius=4/4/4/4
-      node 0,0 120x24 at 8,569
-        draw rect 0,0 120x24 fill=#404059ff radius=4/4/4/4
-      node 0,0 120x24 at 8,602
-        draw rect 0,0 120x24 fill=#404059ff radius=4/4/4/4
-      node 0,0 120x24 at 8,635
-        draw rect 0,0 120x24 fill=#404059ff radius=4/4/4/4
     node 0,0 6x196 at 192,2
       draw rect 0,0 6x196 fill=#ffffff0d radius=100/100/100/100
     node 0,0 6x60.49 at 192,2
@@ -55,7 +29,7 @@ node 0,0 648x216
         draw rect 0,0 120x24 fill=#404059ff radius=4/4/4/4
   node 0,0 200x80 at 440,8 clip(0,0 200x80 r=0)
     draw rect 0,0 200x80 fill=#262633ff radius=0/0/0/0
-    node 0,0 888x56
+    node 0,0 888x56 partial
       node 0,0 80x40 at 8,8
         draw rect 0,0 80x40 fill=#0000ffff radius=0/0/0/0
       node 0,0 80x40 at 96,8
@@ -63,18 +37,6 @@ node 0,0 648x216
       node 0,0 80x40 at 184,8
         draw rect 0,0 80x40 fill=#0000ffff radius=0/0/0/0
       node 0,0 80x40 at 272,8
-        draw rect 0,0 80x40 fill=#0000ffff radius=0/0/0/0
-      node 0,0 80x40 at 360,8
-        draw rect 0,0 80x40 fill=#0000ffff radius=0/0/0/0
-      node 0,0 80x40 at 448,8
-        draw rect 0,0 80x40 fill=#0000ffff radius=0/0/0/0
-      node 0,0 80x40 at 536,8
-        draw rect 0,0 80x40 fill=#0000ffff radius=0/0/0/0
-      node 0,0 80x40 at 624,8
-        draw rect 0,0 80x40 fill=#0000ffff radius=0/0/0/0
-      node 0,0 80x40 at 712,8
-        draw rect 0,0 80x40 fill=#0000ffff radius=0/0/0/0
-      node 0,0 80x40 at 800,8
         draw rect 0,0 80x40 fill=#0000ffff radius=0/0/0/0
     node 0,0 196x6 at 2,72
       draw rect 0,0 196x6 fill=#ffffff0d radius=100/100/100/100


### PR DESCRIPTION
## What changed

The binary search that narrows a container's children to the ones the viewport
can reach used to run only when the container was scrollable, and took its axis
from `scroll_axis`. Wrapping the rows in a layout container — which is how all
three scrollable examples in this repo are written — left the scroller with one
child to narrow, and turned virtualization off completely with no warning and a
counter reading `1/1`.

The window was never about scrolling. It needs a rect to narrow to and children
ordered along an axis to search; a scroller supplies the first from its own
viewport and everything below it inherits one. So it moves into
`paint_children`, which already owns narrowing children to a cull rect and
belongs to no widget in particular, and it applies wherever both halves are
present — at any depth, with or without siblings.

The axis is measured, not declared. `Container::layout` records, in the pass
that just laid the children out, whether they came out non-overlapping along an
axis — which is exactly what `partition_point` needs of the slice and what
nothing had ever checked.

Closes #204.

## What proves it

**`tests/scroll_virtualization.rs`, three tests.** Confirmed red on
`origin/main` and green here — the reviewer re-checked this independently by
copying the file onto 5f2bc37.

- `a_wrapped_list_paints_the_rows_an_unwrapped_one_paints` — 200 rows in a
  200 px scroller, written both ways. **200 painted wrapped against 8 direct**
  before; equal after.
- `a_scroller_whose_children_are_ordered_along_neither_axis_paints_all_of_them`
  — this one is a **correctness** fix, not a performance one. `partition_point`
  over an unpartitioned slice returns whichever index it probed. Eight rows of
  which two are in the viewport: the old search painted the first and dropped
  the last. **2 of 8** before, 8 of 8 after.
- `the_counter_separates_a_narrowed_window_from_one_that_could_not_narrow` —
  under `--features render-stats`, over a real paint.

**Two snapshots moved, and the PR carries `golden-update`.**
`tests/snapshots/scrolling.snap`: vertical scroller 20 → 7 rows, horizontal
10 → 4, and the middle scroller whose content fits is unchanged and *not*
marked partial. `tests/snapshots/bar_like_composition.snap`: 6 → 4 swatches.
Every dropped node is outside its viewport; the three new `partial` markers are
the narrowed paints. The reviewer recomputed both by hand against the window
arithmetic and they match. The re-bless was the maintainer's decision, taken
with this diff in front of them.

No golden moved, and none should: no golden scenario holds a scroller, and the
table in `AGENTS.md` puts "what gets drawn and where" on the render-tree
snapshots.

## The measurement

`examples/perf_stress_test.rs` — 10 000 rows, already written in the wrapped
form — release with `render-stats`, the same scroll gesture both ways.
Normalised per *painted* frame, since the two runs saw different amounts of
scrolling:

| per painted frame | before | after |
| --- | --- | --- |
| children examined | **10 004** | **12** |
| paint phase, avg | **174–187 µs** | **12–16 µs** |
| paint cache hit rate | **0.1 %** | **46–52 %** |
| the window itself | `scroll: total_children=1 iterated=1` | `window: offered=10 002 narrowed_to=7.6 \| declined=0` |

Raw, one representative block each:

```
before   paint: children=530212 cached=308 painted=106 culled=529798 cache_rate=0.1%
         timing paint=174/92/505 us
         scroll: total_children=53 iterated=53          (53 painted frames)

after    paint: children=179 cached=86 painted=50 culled=43 cache_rate=48.0%
         timing paint=12/8/26 us
         window: offered=150030 narrowed_to=114 | declined=0 in 0 containers   (15 painted frames)
```

**The predicted cost did not appear.** The review flagged that
`visible_window` calls `ctx.mark_partial()` where the old scroll window never
did, so a windowing container and its ancestors become uncacheable — a cost
pointing the other way. Measured, the paint cache went **up**, 0.1 % → 48 %:
the wrapper was already partial every frame from the per-child cull, and what
the window buys the ten thousand rows underneath it dwarfs one uncacheable
node.

## What the review found

The `reviewer` subagent read the commit before this existed. **Zero blocking.**
Three worth answering, all acted on:

1. **No after-measurement.** Fixed — the table above. This is the finding that
   mattered; the numbers in the issue were taken on the old code comparing
   wrapped against a hand-restructured tree, and nothing measured this branch.
2. **Nothing exercised the counters through the paint path.** Added
   `the_counter_separates_a_narrowed_window_from_one_that_could_not_narrow`.
   Writing it found a real bug: every childless leaf under a scroller was being
   counted as a window that could not narrow, which would have buried the one
   container that matters. The nothing-to-narrow cases are now excluded before
   the counting rather than after.
3. **`ScrollAxis::Both` was a stated non-goal and no longer holds.** True, and
   flagged here rather than left for a reader to discover. The `_ => all_children`
   arm is gone, so a `Both` scroller whose children come out ordered now
   windows. It is correct — non-overlap along the searched axis is all the
   search needs, whatever the other axis does — and free.

Notes acted on: `docs/ARCHITECTURE.md` said `partial` meant "children were
culled", the twin of the `docs/RENDERER.md` line already widened; `sorted_axis`
answered `Vertical` for an empty child list, a claim about nothing; the comment
on the one-child-either-side slack implied it bounds a transform, which it does
not.

One note not acted on: the reviewer would have accepted a split into two
commits and did not object to one. I kept one — a first commit measuring an
axis nothing reads is not obviously better, and the counter rename really is
part of "the window is not about scrolling".

## What was checked by hand

`examples/perf_stress_test` on niri, before and after, driven by the
maintainer — the measurement above. The list scrolls, the rows are the right
rows, and nothing flickers or comes back at the top, which is the failure mode
`partial` exists to prevent.

## Left undone

**#316** — a cull rect is translated into a child's coordinate space by the
child's laid-out origin and never composed with the child's own transform, so a
transformed child is culled against where it *would* have been. Older than this
change and unchanged by it in steady state; what this spends is one frame, the
first, where the per-child cull had not started yet and `main` was accidentally
right. Found by the review, filed rather than fixed: it is not this change's
defect and it needs its own tests.
