### PR TITLE
A widget is culled where it draws, not where it was laid out

### DIFF
--- a/.claude/skills/widgets/SKILL.md
+++ b/.claude/skills/widgets/SKILL.md
@@ -70,6 +70,14 @@ Two methods are required, the rest default:
 - `event(&mut self, tree, id, event) -> EventResponse` — defaults to `Ignored`
 - `advance_animations`, `reconcile_children`, `layout_hints`,
   `register_children` — defaults
+- `refresh_paint_bounds` — a default too, and the one a widget that transforms
+  itself has to override: a parent narrows its children to the visible rect
+  before painting them, by their laid-out bounds, so a widget that draws
+  somewhere else says how far with `Tree::set_own_paint_reach`. Called from the
+  Paint job, which is where a reach that follows a paint-only property belongs —
+  a transform must not reflow anything. A reach that follows a layout-tracked
+  signal is published from `layout` instead, as `Text` and `TextInput` do for
+  their stroke and shadow
 
 Position and bounds live in the `Tree`, never on the widget. Writing a widget
 from outside the crate needs `guido::widget_prelude::*` alongside the ordinary

--- a/book/src/advanced/custom-widgets.md
+++ b/book/src/advanced/custom-widgets.md
@@ -34,7 +34,20 @@ application never names `Transform`: it declares `translate`, `rotate` and
 
 `Widget` has two required methods. Everything else — `event`,
 `advance_animations`, `reconcile_children`, `layout_hints`,
-`register_children` — has a default.
+`register_children`, `refresh_paint_bounds` — has a default.
+
+One of those defaults is worth knowing about if your widget draws outside the
+box it was given. A parent narrows its children to the visible region before
+painting them, and it does that by their laid-out bounds — so a widget that
+paints elsewhere, because it transforms itself or casts something past its
+edges, has to say how far. That is `refresh_paint_bounds`, which reports it with
+`Tree::set_own_paint_reach`. It runs from the paint job rather than from layout,
+so saying it never costs a reflow.
+
+Which pass you publish from follows what your reach depends on. If it moves with
+something layout already tracks — a size, a font — publish it from `layout`,
+which is what the built-in text widgets do for their stroke and shadow. If it
+moves with a paint-only property such as a transform, publish it here.
 
 ```rust,ignore
 struct Bar {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -414,6 +414,10 @@ pub trait Widget {
     /// Reconcile dynamic children. Returns true if children changed.
     fn reconcile_children(&mut self, tree: &mut Tree, id: WidgetId) -> bool { false }
 
+    /// Publish how far this widget's paint lands outside its bounds, before
+    /// anything decides whether to paint it. Called from the Paint job.
+    fn refresh_paint_bounds(&self, tree: &mut Tree, id: WidgetId) {}
+
     fn layout(&mut self, tree: &mut Tree, id: WidgetId, constraints: Constraints) -> Size;
     fn paint(&self, tree: &Tree, id: WidgetId, ctx: &mut PaintContext);
     fn event(&mut self, tree: &mut Tree, id: WidgetId, event: &Event) -> EventResponse;

--- a/src/jobs.rs
+++ b/src/jobs.rs
@@ -503,6 +503,12 @@ pub fn process_jobs(jobs: &[Job], tree: &mut Tree, layout_roots: &mut Vec<Widget
         }
     }
     for id in paint {
+        // Before the flag, and before this frame's paint: a parent decides
+        // which children to paint at the top of its own, so a widget that has
+        // moved has to have said so by now. See `Widget::refresh_paint_bounds`.
+        tree.with_widget_mut(id, |widget, wid, tree| {
+            widget.refresh_paint_bounds(tree, wid);
+        });
         tree.mark_needs_paint(id);
     }
     for id in layout {

--- a/src/renderer/flatten.rs
+++ b/src/renderer/flatten.rs
@@ -94,26 +94,7 @@ impl FlattenedCommand {
 
     /// The axis-aligned world box containing a rect of this command's own space.
     fn world_aabb(&self, rect: Rect) -> Rect {
-        let corners = [
-            self.world_transform.transform_point(rect.x, rect.y),
-            self.world_transform
-                .transform_point(rect.x + rect.width, rect.y),
-            self.world_transform
-                .transform_point(rect.x, rect.y + rect.height),
-            self.world_transform
-                .transform_point(rect.x + rect.width, rect.y + rect.height),
-        ];
-        let min_x = corners.iter().map(|c| c.0).fold(f32::INFINITY, f32::min);
-        let max_x = corners
-            .iter()
-            .map(|c| c.0)
-            .fold(f32::NEG_INFINITY, f32::max);
-        let min_y = corners.iter().map(|c| c.1).fold(f32::INFINITY, f32::min);
-        let max_y = corners
-            .iter()
-            .map(|c| c.1)
-            .fold(f32::NEG_INFINITY, f32::max);
-        Rect::new(min_x, min_y, max_x - min_x, max_y - min_y)
+        self.world_transform.map_rect(rect)
     }
 
     /// [`world_rounded_rect`](Self::world_rounded_rect), narrowed to what the
@@ -545,11 +526,11 @@ fn flatten_node(
     // Compute this node's world transform
     let (origin_x, origin_y) = node.pivot.resolve(node.bounds);
 
-    // Compose transforms: parent first, then local centered at origin
+    // Compose transforms: parent first, then local about its own pivot
     let local_centered = if node.local_transform.is_identity() {
         Transform::IDENTITY
     } else {
-        node.local_transform.center_at(origin_x, origin_y)
+        node.local_transform.about(node.pivot, node.bounds)
     };
     let world_transform = parent_world_transform.then(&local_centered);
 
@@ -790,45 +771,16 @@ fn world_bounds(cmd: &FlattenedCommand) -> Option<Rect> {
     ))
 }
 
-/// Compute axis-aligned bounding box from an array of points.
-fn aabb_from_points(points: &[(f32, f32)]) -> Rect {
-    let (min_x, max_x, min_y, max_y) = points.iter().fold(
-        (
-            f32::INFINITY,
-            f32::NEG_INFINITY,
-            f32::INFINITY,
-            f32::NEG_INFINITY,
-        ),
-        |(min_x, max_x, min_y, max_y), &(x, y)| {
-            (min_x.min(x), max_x.max(x), min_y.min(y), max_y.max(y))
-        },
-    );
-    Rect::new(min_x, min_y, max_x - min_x, max_y - min_y)
-}
-
 /// Transform a local clip region to world space (axis-aligned bounding box).
 ///
 /// When the transform includes rotation, the clip becomes the AABB of
 /// the rotated rectangle. This is a conservative approximation that
 /// ensures no clipped content is visible outside the clip region.
 fn transform_clip_to_world(clip: &ClipRegion, transform: &Transform) -> WorldClip {
-    // Transform all 4 corners and compute AABB
-    let corners = [
-        transform.transform_point(clip.rect.x, clip.rect.y),
-        transform.transform_point(clip.rect.x + clip.rect.width, clip.rect.y),
-        transform.transform_point(clip.rect.x, clip.rect.y + clip.rect.height),
-        transform.transform_point(
-            clip.rect.x + clip.rect.width,
-            clip.rect.y + clip.rect.height,
-        ),
-    ];
-
-    // Scale corner radius by transform scale
-    let scale = transform.extract_scale();
-
     WorldClip {
-        rect: aabb_from_points(&corners),
-        corner_radius: clip.corner_radius.scaled(scale),
+        rect: transform.map_rect(clip.rect),
+        // Scale corner radius by transform scale
+        corner_radius: clip.corner_radius.scaled(transform.extract_scale()),
         curvature: clip.curvature,
     }
 }

--- a/src/renderer/paint_context.rs
+++ b/src/renderer/paint_context.rs
@@ -117,15 +117,49 @@ impl<'a> PaintContext<'a> {
     pub fn apply_transform(&mut self, transform: Transform) {
         if !transform.is_identity() {
             self.node.local_transform = self.node.local_transform.then(&transform);
+            self.cull_rect_follows(transform);
         }
     }
 
     /// Apply a transform with origin by composing it with the existing transform.
     pub fn apply_transform_with_pivot(&mut self, transform: Transform, origin: Pivot) {
         if !transform.is_identity() {
-            self.node.local_transform = self.node.local_transform.then(&transform);
             self.node.pivot = origin;
+            self.apply_transform(transform);
         }
+    }
+
+    /// Move the cull rect with the transform just applied.
+    ///
+    /// The rect names the visible region in *this node's* coordinates, and a
+    /// widget that transforms itself has just changed what those coordinates
+    /// mean. Without this the rect goes on describing where the content would
+    /// have been drawn, and everything downstream that narrows children to it
+    /// — the binary-search window and the per-child cull — answers about the
+    /// wrong ones.
+    ///
+    /// The inverse, because the rect travels the other way from the content: a
+    /// subtree lifted 300px upward shows what lies 300px further down. Resolved
+    /// about the node's own pivot with `Transform::about`, the same composition
+    /// `flatten` performs, so a rotation about a corner and one about a centre
+    /// do not agree here and disagree on screen.
+    ///
+    /// A transform with no inverse — a scale of zero — collapses the content to
+    /// a point, so none of it is visible and the rect that says so is the empty
+    /// one. Dropping the rect instead would mean *nothing* is narrowed, and a
+    /// collapsed subtree is a shipped idiom here: `scale(0.0)` is how a menu
+    /// closes, and two hundred rows nobody can see would be painted on every
+    /// frame that dirtied them.
+    fn cull_rect_follows(&mut self, transform: Transform) {
+        let Some(cull) = self.cull_rect else {
+            return;
+        };
+        self.cull_rect = Some(
+            transform
+                .about(self.node.pivot, self.node.bounds)
+                .inverse()
+                .map_or(Rect::default(), |back| back.map_rect(cull)),
+        );
     }
 
     /// Set this node's transform origin.

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -387,6 +387,47 @@ impl Transform {
         })
     }
 
+    /// This transform as it acts about `pivot` within `bounds`.
+    ///
+    /// A transform is written about the origin and applied about a pivot, and
+    /// resolving the one into the other is what `flatten` does before it draws
+    /// anything. Everything that reasons about transformed geometry ahead of
+    /// the draw — where a clip lands, how far a box can move — has to resolve
+    /// it the same way, so there is one function rather than four
+    /// transcriptions agreeing by prose.
+    #[inline]
+    pub fn about(&self, pivot: crate::pivot::Pivot, bounds: crate::widgets::Rect) -> Self {
+        let (px, py) = pivot.resolve(bounds);
+        self.center_at(px, py)
+    }
+
+    /// The smallest axis-aligned rect containing `rect` once this transform
+    /// has been applied to it.
+    ///
+    /// Under rotation the image of a rect is not a rect, so this is the
+    /// enclosing box: bigger than the shape, never smaller. Everything that
+    /// asks a rect question about transformed geometry — where a clip lands,
+    /// which children a viewport can reach — wants that answer rather than an
+    /// exact one, because being too generous only costs work while being too
+    /// mean loses pixels.
+    #[inline]
+    pub fn map_rect(&self, rect: crate::widgets::Rect) -> crate::widgets::Rect {
+        let (x1, y1) = (rect.x + rect.width, rect.y + rect.height);
+        let corners = [
+            self.transform_point(rect.x, rect.y),
+            self.transform_point(x1, rect.y),
+            self.transform_point(rect.x, y1),
+            self.transform_point(x1, y1),
+        ];
+        let (mut min_x, mut min_y) = (f32::INFINITY, f32::INFINITY);
+        let (mut max_x, mut max_y) = (f32::NEG_INFINITY, f32::NEG_INFINITY);
+        for (x, y) in corners {
+            (min_x, min_y) = (min_x.min(x), min_y.min(y));
+            (max_x, max_y) = (max_x.max(x), max_y.max(y));
+        }
+        crate::widgets::Rect::new(min_x, min_y, max_x - min_x, max_y - min_y)
+    }
+
     /// Transform a 2D point by this transform
     #[inline]
     pub fn transform_point(&self, x: f32, y: f32) -> (f32, f32) {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -128,13 +128,42 @@ struct Slot {
     /// of text, if it has one. Reported by leaves during layout and read by a
     /// parent aligning on `CrossAlignment::Baseline`.
     baseline: Option<f32>,
-    /// How far this widget paints outside its own bounds, in logical pixels.
+    /// How far this widget's *own* painting lands outside its bounds — its
+    /// shadow, and where its transform can carry it. Published by the widget.
+    own_paint_reach: f32,
+
+    /// How far anything its children draw stands outside its box.
     ///
-    /// A shadow — a box's or a glyph's — lands outside the box that cast it,
-    /// and damage is computed from the bounds. Without this, repainting such a
-    /// widget tells the compositor to re-composite a rect that stops short of
-    /// the shadow, leaving the old one on screen as a fringe.
-    paint_overflow: f32,
+    /// Kept apart from `own_paint_reach` so the two can be maintained on
+    /// different schedules: the widget republishes its own on every Paint job,
+    /// which must stay cheap, while this one is a fact about a list and is
+    /// re-measured only when that list is walked anyway.
+    children_outset: f32,
+
+    /// Whether this widget clips its children to its own edges.
+    ///
+    /// A scroller's content runs far past its viewport by design, and what the
+    /// scroller paints is its own box however far the column inside it runs. So
+    /// the overhang stops here: it is not gathered into this widget, and
+    /// nothing above it hears about it either.
+    ///
+    /// Kept on the slot rather than asked of the widget because the gather runs
+    /// from `set_own_paint_reach`, which has a tree and an id and no widget —
+    /// and a one-shot clear at layout would be undone by the next descendant
+    /// whose reach moves.
+    clips_children: bool,
+
+    /// The widest reach among this widget's children.
+    ///
+    /// Cached here rather than walked at paint, because the search that reads
+    /// it is O(log n) and walking the children to feed it would be O(n) — the
+    /// cost that search exists to avoid.
+    ///
+    /// Kept true between layouts on the two schedules `gather_reach_upward`
+    /// describes: a reach that grew widens this by comparison, and one that
+    /// shrank re-measures the siblings, because the child that shrank may have
+    /// been the widest and the new answer is whatever the others say.
+    children_reach: f32,
 }
 
 /// Central tree for widget storage using arena-based sparse-set architecture.
@@ -270,7 +299,10 @@ impl Tree {
             cached_paint: None,
             control: None,
             baseline: None,
-            paint_overflow: 0.0,
+            own_paint_reach: 0.0,
+            children_outset: 0.0,
+            clips_children: false,
+            children_reach: 0.0,
         });
 
         // Update sparse map
@@ -459,18 +491,231 @@ impl Tree {
             .and_then(|idx| self.dense[idx].baseline)
     }
 
-    pub fn set_paint_overflow(&mut self, id: WidgetId, overflow: f32) {
-        if let Some(idx) = self.get_dense_index(id) {
-            self.dense[idx].paint_overflow = overflow.max(0.0);
+    /// Record how far this widget's own painting lands outside its bounds.
+    ///
+    /// Named for the half it writes, because `paint_overflow` returns the union
+    /// of that with what the children add, and a setter and getter that are not
+    /// inverses should not share a name.
+    ///
+    /// What a widget draws also includes what its descendants draw, and that
+    /// half is `children_outset`, gathered upward here when the union a parent
+    /// can see actually moves. Without it a row holding a box that a transform
+    /// carried outside it reports nothing, an ancestor narrowing by laid-out
+    /// bounds drops the row, and the visible box goes with it. Flutter and
+    /// Blink union descendant paint bounds up the tree for the same reason.
+    pub fn set_own_paint_reach(&mut self, id: WidgetId, reach: f32) {
+        let Some(idx) = self.get_dense_index(id) else {
+            return;
+        };
+        let reach = reach.max(0.0);
+        if self.dense[idx].own_paint_reach == reach {
+            return;
+        }
+        // Against the union, not against the half being written: an ancestor
+        // reads `paint_overflow`, so a widget whose children already reach
+        // further has moved nothing anyone can see, and the walk above it —
+        // whose shrink path re-measures siblings — is pure cost.
+        let before = self.paint_overflow(id);
+        self.dense[idx].own_paint_reach = reach;
+        let after = self.paint_overflow(id);
+        if before == after {
+            return;
+        }
+        self.gather_reach_upward(id, before, after > before);
+    }
+
+    /// Carry a change in a child's reach into the ancestors it affects.
+    ///
+    /// A reach that **grew** only ever widens, so each ancestor is compared and
+    /// the walk stops at the first one already wide enough — nothing above it
+    /// can be narrow either. O(depth), no walk over siblings.
+    ///
+    /// A reach that **shrank** cannot be answered by comparison: this child may
+    /// have been the widest, and the new maximum is whatever the others say. So
+    /// that path re-measures — but only where it has to. A child that was not
+    /// the maximum on either axis cannot have changed one by getting smaller,
+    /// which is the common case and the one that matters: the return leg of a
+    /// spring shrinks on *every frame*, so a fold over the siblings there would
+    /// be an O(children) walk per frame, and a staggered list of them O(n²).
+    fn gather_reach_upward(&mut self, from: WidgetId, was: f32, grew: bool) {
+        let mut child = from;
+        let mut was = was;
+        while let Some(parent) = self.get_parent(child) {
+            let Some(parent_idx) = self.get_dense_index(parent) else {
+                return;
+            };
+            let (had_outset, had_reach) = (
+                self.dense[parent_idx].children_outset,
+                self.dense[parent_idx].children_reach,
+            );
+            if self.dense[parent_idx].clips_children {
+                // The overhang stops here. The search below this widget still
+                // wants to know how far its children reach, so that is carried;
+                // what this widget paints is its own box, so nothing above it
+                // learns anything and the walk is done.
+                let (_, widest) = self.measure_children(parent);
+                self.dense[parent_idx].children_reach = widest;
+                self.dense[parent_idx].children_outset = 0.0;
+                return;
+            }
+            let (outset, widest) = if grew {
+                (
+                    had_outset.max(self.child_paint_outset(child, parent)),
+                    had_reach.max(self.paint_overflow(child)),
+                )
+            } else if was < had_reach && self.child_outset_from(was, child, parent) < had_outset {
+                // Not the widest on either axis before it shrank, so neither
+                // maximum can have moved, and nothing above can have either.
+                return;
+            } else {
+                self.measure_children(parent)
+            };
+
+            if (outset, widest) == (had_outset, had_reach) {
+                // Nothing moved here, so nothing above it moved either.
+                return;
+            }
+            // What this parent's own reach *was*, which is what the guard on
+            // the next level up needs — the child's previous `paint_overflow`,
+            // not the maximum over its siblings. The two differ wherever a
+            // node's children reach less far than they stand outside its box,
+            // which is every scroller.
+            was = self.dense[parent_idx].own_paint_reach.max(had_outset);
+            self.dense[parent_idx].children_outset = outset;
+            self.dense[parent_idx].children_reach = widest;
+            child = parent;
         }
     }
 
-    /// How far this widget's paint reaches beyond its bounds.
+    /// How far what `child` draws stands outside `parent`'s own box.
+    fn child_paint_outset(&self, child: WidgetId, parent: WidgetId) -> f32 {
+        self.child_outset_from(self.paint_overflow(child), child, parent)
+    }
+
+    /// The same, for a reach the caller names — which is how the shrink path
+    /// asks what a child's outset *was* without having kept the rect.
+    fn child_outset_from(&self, reach: f32, child: WidgetId, parent: WidgetId) -> f32 {
+        let (Some(child_box), Some(parent_box)) = (self.get_bounds(child), self.get_bounds(parent))
+        else {
+            return 0.0;
+        };
+        // A child's bounds are relative to its parent, whose own box therefore
+        // starts at the origin.
+        child_box
+            .outset(reach)
+            .outset_beyond(crate::widgets::Rect::from_size(crate::layout::Size::new(
+                parent_box.width,
+                parent_box.height,
+            )))
+    }
+
+    /// Both facts a narrowing needs about a widget's children: how far the
+    /// furthest of them stands outside the box, and the widest reach any of
+    /// them has.
+    ///
+    /// One walk and one lookup per child — the sparse-then-dense resolve is the
+    /// expensive half, and every number below comes off the slot it lands on.
+    fn measure_children(&self, id: WidgetId) -> (f32, f32) {
+        let Some(parent_box) = self
+            .get_bounds(id)
+            .map(|b| crate::widgets::Rect::from_size(crate::layout::Size::new(b.width, b.height)))
+        else {
+            return (0.0, 0.0);
+        };
+        self.get_children(id)
+            .iter()
+            .filter_map(|&child| self.get_dense_index(child))
+            .fold((0.0f32, 0.0f32), |(outset, widest), idx| {
+                let slot = &self.dense[idx];
+                // The reach counts whether or not the child has been laid out
+                // — the grow path in `gather_reach_upward` folds it
+                // unconditionally, and the two have to answer the same. Only
+                // the outset needs a box to be measured against.
+                let reach = slot.own_paint_reach.max(slot.children_outset);
+                let widest = widest.max(reach);
+                let Some(size) = slot.cached_size else {
+                    return (outset, widest);
+                };
+                let drawn = crate::widgets::Rect::new(
+                    slot.origin.0,
+                    slot.origin.1,
+                    size.width,
+                    size.height,
+                )
+                .outset(reach);
+                (
+                    outset.max(drawn.outset_beyond(parent_box)),
+                    widest.max(reach),
+                )
+            })
+    }
+
+    /// Republish both, as this widget's own layout has just measured them.
+    /// Replaces rather than grows, which is what un-sticks a reach that shrank.
+    ///
+    /// Gathers upward when the union it feeds actually moved — see the body
+    /// for why bottom-up layout is not enough on its own.
+    pub(crate) fn remeasure_children(&mut self, id: WidgetId) {
+        let (outset, widest) = self.measure_children(id);
+        let Some(idx) = self.get_dense_index(id) else {
+            return;
+        };
+        let before = self.paint_overflow(id);
+        self.dense[idx].children_outset = outset;
+        self.dense[idx].children_reach = widest;
+        let after = self.paint_overflow(id);
+        if before != after {
+            // Layout is bottom-up, so an ancestor inside the same pass will
+            // measure this for itself — but a widget with a fixed size is its
+            // own relayout boundary and the pass starts there, with no ancestor
+            // to follow. Then this is the only thing that tells them.
+            self.gather_reach_upward(id, before, after > before);
+        }
+    }
+
+    /// Record whether this widget clips its children to its own edges, and
+    /// forget any overhang already gathered into it.
+    ///
+    /// The widest *reach* is kept: the search that narrows the children still
+    /// needs it, because a child inside the clip can still draw outside its own
+    /// bounds and into view.
+    pub(crate) fn set_clips_children(&mut self, id: WidgetId, clips: bool) {
+        let Some(idx) = self.get_dense_index(id) else {
+            return;
+        };
+        self.dense[idx].clips_children = clips;
+        if clips {
+            self.dense[idx].children_outset = 0.0;
+            let (_, widest) = self.measure_children(id);
+            self.dense[idx].children_reach = widest;
+        }
+    }
+
+    /// How far the furthest of this widget's children stands outside its box.
     #[cfg(test)]
-    pub(crate) fn paint_overflow(&self, id: WidgetId) -> f32 {
+    pub(crate) fn children_outset(&self, id: WidgetId) -> f32 {
         self.get_dense_index(id)
-            .map(|idx| self.dense[idx].paint_overflow)
-            .unwrap_or(0.0)
+            .map_or(0.0, |idx| self.dense[idx].children_outset)
+    }
+
+    /// The widest reach among this widget's children.
+    pub(crate) fn children_reach(&self, id: WidgetId) -> f32 {
+        self.get_dense_index(id)
+            .map_or(0.0, |idx| self.dense[idx].children_reach)
+    }
+
+    /// How far this widget's paint reaches beyond its bounds — a shadow's
+    /// falloff, or the distance its own transform can move what it draws.
+    ///
+    /// Read by damage, so a repaint covers the shadow it moved, and by the two
+    /// narrowings in `paint_children`, so neither drops a widget that draws
+    /// somewhere other than where it was laid out.
+    pub(crate) fn paint_overflow(&self, id: WidgetId) -> f32 {
+        self.get_dense_index(id).map_or(0.0, |idx| {
+            self.dense[idx]
+                .own_paint_reach
+                .max(self.dense[idx].children_outset)
+        })
     }
 
     /// Get the children of a widget (returns a slice to avoid heap allocation).
@@ -682,16 +927,12 @@ impl Tree {
             }
         }
         // Widen by whatever this widget paints outside itself, so a shadow is
-        // re-composited along with the thing that cast it.
-        let overflow = self.dense[idx].paint_overflow;
+        // re-composited along with the thing that cast it — and so is a widget
+        // its own transform has carried off its laid-out box.
+        let overflow = self.paint_overflow(id);
         Some((
             current,
-            Rect::new(
-                x - overflow,
-                y - overflow,
-                size.width + overflow * 2.0,
-                size.height + overflow * 2.0,
-            ),
+            Rect::new(x, y, size.width, size.height).outset(overflow),
         ))
     }
 
@@ -1332,7 +1573,7 @@ mod tests {
     #[test]
     fn damage_covers_what_a_widget_paints_outside_its_bounds() {
         let (mut tree, root, a, _b) = two_children_tree();
-        tree.set_paint_overflow(a, 8.0);
+        tree.set_own_paint_reach(a, 8.0);
 
         tree.mark_needs_paint(a);
 
@@ -1347,6 +1588,251 @@ mod tests {
                     "and past its far edges, got {rect:?}"
                 );
             }
+            other => panic!("expected partial damage, got {other:?}"),
+        }
+    }
+
+    /// The widest child shrinking is the case the prune must not skip.
+    ///
+    /// The guard asks whether this child *was* the maximum and skips the
+    /// re-measure when it was not. Equality is the boundary and it belongs on
+    /// the re-measuring side: a child exactly as wide as the maximum is the one
+    /// holding it up, and nothing else knows what it falls to.
+    ///
+    /// The two children are chosen so the guard's halves disagree — one stands
+    /// furthest outside the box, the other reaches furthest — because when both
+    /// halves sit on their boundary together the second rescues the first and a
+    /// wrong comparison in either is invisible.
+    #[test]
+    fn the_widest_child_shrinking_is_not_pruned_away() {
+        let mut tree = Tree::new();
+        let root = tree.register(Box::new(MockWidget::new()));
+        // At the corner, so what it reaches lands outside the box.
+        let overhanging = tree.register(Box::new(MockWidget::new()));
+        // In the middle, so it reaches further and stands outside less.
+        let far_reaching = tree.register(Box::new(MockWidget::new()));
+        tree.set_parent(overhanging, root);
+        tree.set_parent(far_reaching, root);
+
+        let cons = Constraints::new(0.0, 0.0, 100.0, 100.0);
+        tree.cache_layout(root, cons, Size::new(100.0, 100.0));
+        tree.cache_layout(overhanging, cons, Size::new(20.0, 20.0));
+        tree.cache_layout(far_reaching, cons, Size::new(20.0, 20.0));
+        tree.set_origin(overhanging, 0.0, 0.0);
+        tree.set_origin(far_reaching, 40.0, 40.0);
+
+        tree.set_own_paint_reach(overhanging, 30.0);
+        tree.set_own_paint_reach(far_reaching, 40.0);
+        assert_eq!(
+            tree.children_reach(root),
+            40.0,
+            "the far-reaching one leads"
+        );
+        assert_eq!(tree.children_outset(root), 30.0, "the overhanging one does");
+
+        tree.set_own_paint_reach(far_reaching, 5.0);
+        assert_eq!(
+            tree.children_reach(root),
+            30.0,
+            "the parent kept the width of a child that has let go of it"
+        );
+    }
+
+    /// And a child that was never the widest costs nothing to shrink.
+    ///
+    /// This is the prune earning its place: the return leg of a spring shrinks
+    /// on every frame, so a fold over the siblings here would be an O(children)
+    /// walk per frame and a staggered list of them O(n squared).
+    #[test]
+    fn a_child_that_was_not_the_widest_leaves_the_parent_alone() {
+        let mut tree = Tree::new();
+        let root = tree.register(Box::new(MockWidget::new()));
+        let wide = tree.register(Box::new(MockWidget::new()));
+        let small = tree.register(Box::new(MockWidget::new()));
+        tree.set_parent(wide, root);
+        tree.set_parent(small, root);
+
+        let cons = Constraints::new(0.0, 0.0, 100.0, 100.0);
+        tree.cache_layout(root, cons, Size::new(100.0, 100.0));
+        tree.cache_layout(wide, cons, Size::new(20.0, 20.0));
+        tree.cache_layout(small, cons, Size::new(20.0, 20.0));
+        tree.set_origin(wide, 40.0, 40.0);
+        tree.set_origin(small, 40.0, 40.0);
+
+        tree.set_own_paint_reach(wide, 50.0);
+        tree.set_own_paint_reach(small, 10.0);
+        assert_eq!(tree.children_reach(root), 50.0);
+
+        tree.set_own_paint_reach(small, 1.0);
+        assert_eq!(
+            tree.children_reach(root),
+            50.0,
+            "the widest child still reaches 50, so the parent must not have moved"
+        );
+    }
+
+    /// But a child that leads on the *other* axis is not "not the widest".
+    ///
+    /// The guard has two halves because a parent keeps two maxima, and a child
+    /// can hold up either. One that reaches less far than its sibling can still
+    /// be the one standing furthest outside the box — it only has to sit nearer
+    /// the edge — and pruning it on the reach alone leaves the outset stale.
+    #[test]
+    fn a_child_that_leads_on_outset_alone_is_not_pruned_away() {
+        let mut tree = Tree::new();
+        let root = tree.register(Box::new(MockWidget::new()));
+        let at_the_edge = tree.register(Box::new(MockWidget::new()));
+        let in_the_middle = tree.register(Box::new(MockWidget::new()));
+        tree.set_parent(at_the_edge, root);
+        tree.set_parent(in_the_middle, root);
+
+        let cons = Constraints::new(0.0, 0.0, 100.0, 100.0);
+        tree.cache_layout(root, cons, Size::new(100.0, 100.0));
+        tree.cache_layout(at_the_edge, cons, Size::new(20.0, 20.0));
+        tree.cache_layout(in_the_middle, cons, Size::new(20.0, 20.0));
+        tree.set_origin(at_the_edge, 0.0, 0.0);
+        tree.set_origin(in_the_middle, 40.0, 40.0);
+
+        tree.set_own_paint_reach(in_the_middle, 40.0);
+        tree.set_own_paint_reach(at_the_edge, 30.0);
+        assert_eq!(
+            tree.children_reach(root),
+            40.0,
+            "the middle one reaches most"
+        );
+        assert_eq!(
+            tree.children_outset(root),
+            30.0,
+            "the edge one stands out most"
+        );
+
+        // Shrinks the one that was never the widest by reach, but was the only
+        // thing holding the outset up.
+        tree.set_own_paint_reach(at_the_edge, 1.0);
+        // Its remaining 1px of reach, and nothing of the 30 it used to hold.
+        assert_eq!(
+            tree.children_outset(root),
+            1.0,
+            "the parent kept an overhang no child has any more"
+        );
+    }
+
+    /// A re-measure that moves the union tells the ancestors too.
+    ///
+    /// Layout is bottom-up, so an ancestor inside the same pass measures this
+    /// for itself and the gather is redundant — except that a widget with a
+    /// fixed size is its own relayout boundary and the pass *starts* there,
+    /// with no ancestor to follow. Then this is the only thing that carries it.
+    ///
+    /// The case is a child growing under a parent that does not: the parent's
+    /// own reach never moves, so `set_own_paint_reach` returns early and cannot
+    /// be what tells anyone.
+    #[test]
+    fn a_re_measure_that_moves_the_union_reaches_the_ancestors() {
+        let mut tree = Tree::new();
+        let outer = tree.register(Box::new(MockWidget::new()));
+        let boundary = tree.register(Box::new(MockWidget::new()));
+        let child = tree.register(Box::new(MockWidget::new()));
+        tree.set_parent(boundary, outer);
+        tree.set_parent(child, boundary);
+
+        let cons = Constraints::new(0.0, 0.0, 100.0, 100.0);
+        tree.cache_layout(outer, cons, Size::new(100.0, 100.0));
+        tree.cache_layout(boundary, cons, Size::new(100.0, 100.0));
+        tree.cache_layout(child, cons, Size::new(100.0, 100.0));
+        tree.remeasure_children(boundary);
+        tree.remeasure_children(outer);
+        assert_eq!(tree.children_reach(outer), 0.0, "nothing hangs out yet");
+
+        // The child outgrows the box it sits in. Its own reach is still zero,
+        // so nothing publishes; only the re-measure knows.
+        tree.cache_layout(child, cons, Size::new(100.0, 400.0));
+        tree.remeasure_children(boundary);
+
+        assert_eq!(
+            tree.children_reach(outer),
+            300.0,
+            "the boundary took on 300px of overhang and its parent never heard, \
+             so the search that narrows it would drop a box that is on screen"
+        );
+    }
+
+    /// A reach that shrinks lets go all the way up, not one level.
+    ///
+    /// The shrink path prunes when the child that shrank was not the widest,
+    /// and that guard needs the child's own previous `paint_overflow`. Carrying
+    /// the parent's widest *child* instead stops the walk wherever the two
+    /// differ — which is any node whose children stand further outside it than
+    /// they themselves reach, i.e. every scroller over a longer column. The
+    /// middle box here is smaller than what it holds, so its outset and its
+    /// widest-child are different numbers and the mistake is visible.
+    #[test]
+    fn a_reach_that_shrinks_releases_every_ancestor() {
+        let mut tree = Tree::new();
+        let g = tree.register(Box::new(MockWidget::new()));
+        let p = tree.register(Box::new(MockWidget::new()));
+        let c = tree.register(Box::new(MockWidget::new()));
+        tree.set_parent(p, g);
+        tree.set_parent(c, p);
+
+        let cons = Constraints::new(0.0, 0.0, 100.0, 100.0);
+        tree.cache_layout(g, cons, Size::new(100.0, 100.0));
+        tree.cache_layout(p, cons, Size::new(100.0, 100.0));
+        tree.cache_layout(c, cons, Size::new(100.0, 500.0));
+
+        tree.set_own_paint_reach(c, 70.0);
+        let held = tree.paint_overflow(g);
+        assert!(held > 0.0, "nothing to let go of");
+
+        tree.set_own_paint_reach(c, 0.0);
+        assert!(
+            tree.paint_overflow(g) < held,
+            "the grandparent stayed at {held} after its grandchild's reach went \
+             to nothing, so the walk stopped one level short"
+        );
+    }
+
+    /// And by *its own* reach, not by whatever the surface root happens to
+    /// report.
+    ///
+    /// The test above cannot tell the two apart: its widget is a direct child
+    /// of the root, so its reach gathers straight into the root's and both
+    /// spellings give the same number. A widget sitting well inside its
+    /// ancestors — a card with room around it — is where they differ, and where
+    /// the shadow is left on screen as a fringe.
+    #[test]
+    fn damage_is_grown_by_the_widget_s_own_reach_not_the_root_s() {
+        let mut tree = Tree::new();
+        let root = tree.register(Box::new(MockWidget::new()));
+        let card = tree.register(Box::new(MockWidget::new()));
+        tree.set_parent(card, root);
+
+        let c = Constraints::new(0.0, 0.0, 200.0, 200.0);
+        tree.cache_layout(root, c, Size::new(200.0, 200.0));
+        tree.cache_layout(card, c, Size::new(40.0, 20.0));
+        tree.set_origin(card, 80.0, 80.0);
+        for id in [root, card] {
+            tree.clear_needs_paint(id);
+        }
+        let _ = tree.take_damage(root);
+
+        // Inset far enough that the shadow stays inside the root, so nothing of
+        // this reach reaches the root's own numbers.
+        tree.set_own_paint_reach(card, 20.0);
+        assert_eq!(
+            tree.paint_overflow(root),
+            0.0,
+            "the root should not have taken this on, which is what makes the \
+             distinction visible"
+        );
+
+        tree.mark_needs_paint(card);
+        match tree.take_damage(root) {
+            DamageRegion::Partial(rect) => assert!(
+                rect.x <= 60.0 && rect.y <= 60.0 && rect.width >= 80.0 && rect.height >= 60.0,
+                "the card's shadow is outside the damage rect, so it is left on \
+                 screen as a fringe: got {rect:?}"
+            ),
             other => panic!("expected partial damage, got {other:?}"),
         }
     }

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -1056,6 +1056,86 @@ fn corner_radius_invalidates_paint_only() {
     assert!(!queued.contains(&JobType::Layout), "got {queued:?}");
 }
 
+/// A transform is a paint property and moving a widget must not reflow it —
+/// not the widget, not its siblings, not the page. That has to hold even now
+/// that a parent asks how far a transform can carry a child before deciding
+/// whether to paint it: the answer is refreshed from the Paint job the same
+/// write schedules, in `refresh_paint_bounds`, and never from layout.
+///
+/// Each of the three separately, because they are declared apart and a reach
+/// read under layout tracking for one of them would be invisible in the others.
+#[test]
+fn a_transform_invalidates_paint_only() {
+    for (name, build) in [
+        (
+            "translate",
+            Box::new(|s: RwSignal<f32>| {
+                container()
+                    .width(10.0)
+                    .height(10.0)
+                    .translate(move || Translate::new(s.get(), 0.0))
+            }) as Box<dyn Fn(RwSignal<f32>) -> Container>,
+        ),
+        (
+            "rotate",
+            Box::new(|s: RwSignal<f32>| {
+                container().width(10.0).height(10.0).rotate(move || s.get())
+            }),
+        ),
+        (
+            "scale",
+            Box::new(|s: RwSignal<f32>| {
+                container()
+                    .width(10.0)
+                    .height(10.0)
+                    .scale(move || Scale::uniform(1.0 + s.get()))
+            }),
+        ),
+    ] {
+        let value = create_signal(0.0f32);
+        let mut h = H::new(build(value));
+        h.fit(500.0, 500.0);
+        h.paint();
+
+        let queued = h.jobs_from(|| value.set(30.0));
+        assert!(
+            queued.contains(&JobType::Paint),
+            "{name}: a transform must repaint, got {queued:?}"
+        );
+        assert!(
+            !queued.contains(&JobType::Layout),
+            "{name}: a transform must not reflow anything, got {queued:?}"
+        );
+    }
+}
+
+/// And the same, for a container that has a parent.
+///
+/// A child lays out inside its parent's tracking scope, so a read that does not
+/// suspend tracking registers against *the parent* — the transformed container
+/// stays quiet and its parent reflows instead. The test above cannot see it:
+/// its container is the root, where there is no outer scope to catch the read.
+#[test]
+fn a_transform_does_not_reflow_the_parent_either() {
+    let dx = create_signal(0.0f32);
+    let mut h = H::new(
+        container().layout(Flex::column()).child(
+            container()
+                .width(10.0)
+                .height(10.0)
+                .translate(move || Translate::new(dx.get(), 0.0)),
+        ),
+    );
+    h.fit(500.0, 500.0);
+    h.paint();
+
+    let queued = h.jobs_from(|| dx.set(30.0));
+    assert!(
+        !queued.contains(&JobType::Layout),
+        "a child's transform relaid out its parent, got {queued:?}"
+    );
+}
+
 #[test]
 fn visibility_invalidates_layout() {
     let shown = create_signal(true);
@@ -2700,6 +2780,181 @@ fn a_declared_elevation_change_invalidates_the_reach() {
     pump(&mut h);
     h.fit(100.0, 100.0);
     assert!(h.tree.paint_overflow(h.root) > 0.0);
+}
+
+/// A container that clips does not report the overhang it is clipping away.
+///
+/// A scroller's content runs far past its viewport by design. Counting that as
+/// "how far this widget paints outside itself" would damage a rect the size of
+/// the whole scrolled column on every frame the scroller repaints, and widen
+/// every search above it by the same. What it paints is its own box.
+#[test]
+fn a_clipping_container_does_not_carry_its_content_s_overhang() {
+    let rows: Vec<_> = (0..20)
+        .map(|_| container().width(100.0).height(50.0).background(Color::RED))
+        .collect();
+    let mut clipped = H::new(
+        container()
+            .width(100.0)
+            .height(100.0)
+            .scrollable(ScrollAxis::Vertical)
+            .layout(Flex::column())
+            .children(rows),
+    );
+    clipped.fit(400.0, 400.0);
+
+    assert_eq!(
+        clipped.tree.paint_overflow(clipped.root),
+        0.0,
+        "a scroller reported the height of everything inside it as paint that \
+         lands outside its own box"
+    );
+}
+
+/// And it keeps not carrying it, after a descendant moves.
+///
+/// The clear at layout is one write; the gather that runs whenever any
+/// descendant's reach changes writes the same field. A row with an animating
+/// transform does that every frame, so a scroller that only forgot the overhang
+/// once would have it back on the next one — with its damage rect and every
+/// search above it sized to the whole scrolled column.
+#[test]
+fn a_clipping_container_keeps_not_carrying_it_when_a_child_moves() {
+    let lift = create_signal(0.0f32);
+    let mut rows: Vec<_> = (0..20)
+        .map(|_| container().width(100.0).height(50.0).background(Color::RED))
+        .collect();
+    // The first row, so it is inside the viewport and therefore painted — a
+    // row culled on the first frame holds no paint subscription and its own
+    // write would wake nobody.
+    rows[0] = container()
+        .width(100.0)
+        .height(50.0)
+        .background(Color::BLUE)
+        .translate(move || Translate::new(0.0, -lift.get()));
+
+    let mut h = H::new(
+        container()
+            .width(100.0)
+            .height(100.0)
+            .scrollable(ScrollAxis::Vertical)
+            .layout(Flex::column())
+            .children(rows),
+    );
+    h.fit(400.0, 400.0);
+    // Painted, so the row holds the paint subscription its own write needs.
+    h.paint();
+    assert_eq!(h.tree.paint_overflow(h.root), 0.0);
+
+    // A frame of an animating row, with no layout in between.
+    lift.set(20.0);
+    pump(&mut h);
+
+    assert_eq!(
+        h.tree.paint_overflow(h.root),
+        0.0,
+        "one row moved and the scroller went back to claiming it paints the \
+         whole column outside its own box"
+    );
+}
+
+/// A 40x40 box carried off its laid-out place by `lift` — the smallest thing
+/// whose paint leaves its bounds without anything laying out.
+fn lifted_box(lift: RwSignal<f32>) -> Container {
+    container()
+        .width(40.0)
+        .height(40.0)
+        .background(Color::RED)
+        .translate(move || Translate::new(0.0, -lift.get()))
+}
+
+/// The transform's twin, and the one that proves `refresh_paint_bounds` is
+/// wired at all: the reach has to grow on a Paint job, with no layout run
+/// between the write and the answer.
+///
+/// A shadow's reach is republished by layout, so an elevation test passes
+/// whether or not the Paint-job refresh exists. A transform's is not — layout
+/// never subscribes to it — so this is the only thing standing between the hook
+/// in `process_jobs` and being deleted with the suite still green.
+#[test]
+fn a_declared_transform_change_invalidates_the_reach_without_a_layout() {
+    let lift = create_signal(0.0f32);
+    let mut h = H::new(lifted_box(lift));
+    h.fit(100.0, 100.0);
+    h.paint();
+    assert_eq!(h.tree.paint_overflow(h.root), 0.0);
+
+    lift.set(30.0);
+    let queued = jobs::queued_job_types(h.root);
+    assert!(
+        !queued.contains(&JobType::Layout),
+        "a transform asked for a layout: {queued:?}"
+    );
+
+    // No `fit` between the write and the assertion: the reach has to be current
+    // from the job alone, because the parent narrows to it in the same frame
+    // and nothing lays out in between.
+    pump(&mut h);
+    assert_eq!(
+        h.tree.paint_overflow(h.root),
+        30.0,
+        "the reach did not follow the transform through its Paint job"
+    );
+}
+
+/// A child that is its own relayout boundary moves without its parent laying
+/// out, and the reach still has to reach the parent.
+///
+/// This is what `gather_reach_upward` is for, and the only thing that asks for
+/// it: `publish_paint_reach` gathers a container's children when *it* lays out,
+/// which covers everything except the case where it does not lay out at all. A
+/// fixed width and height make the row a boundary (`is_relayout_boundary_for`),
+/// so `mark_needs_layout` stops there and the parent never re-runs.
+#[test]
+fn a_reach_that_grows_under_a_relayout_boundary_still_reaches_the_parent() {
+    let lift = create_signal(0.0f32);
+    let mut h = H::new(container().layout(Flex::column()).child(lifted_box(lift)));
+    h.fit(200.0, 200.0);
+    h.paint();
+    assert_eq!(h.tree.children_reach(h.root), 0.0);
+
+    lift.set(70.0);
+    pump(&mut h);
+
+    assert_eq!(
+        h.tree.children_reach(h.root),
+        70.0,
+        "the row moved under a relayout boundary and its parent never heard, so \
+         the search that narrows it would drop a row that is on screen"
+    );
+}
+
+/// And one that shrinks lets go again.
+///
+/// Growing upward can be answered by comparison — wider than the parent knows,
+/// so widen it — but shrinking cannot: this child may have been the widest and
+/// the new maximum is whatever the others say. Answering it by comparison alone
+/// would leave a scroller widened by a transform that has long since come to
+/// rest, for as long as it goes without laying out, and a window widened for
+/// nothing is virtualization spent for nothing.
+#[test]
+fn a_reach_that_shrinks_lets_the_parent_narrow_again() {
+    let lift = create_signal(70.0f32);
+    let mut h = H::new(container().layout(Flex::column()).child(lifted_box(lift)));
+    h.fit(200.0, 200.0);
+    h.paint();
+    assert_eq!(h.tree.children_reach(h.root), 70.0);
+
+    // No `fit`: the parent must let go without laying out, because a scroller
+    // that is not being resized never does.
+    lift.set(0.0);
+    pump(&mut h);
+
+    assert_eq!(
+        h.tree.children_reach(h.root),
+        0.0,
+        "the parent stayed widened by a transform that has come to rest"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -503,6 +503,24 @@ impl Container {
         }
     }
 
+    /// Where a transform can carry what this container draws, published for
+    /// whoever is about to decide whether to paint it.
+    ///
+    /// Read outside any tracking scope on purpose. The transform components
+    /// belong to paint, and subscribing layout to them would make
+    /// `.translate(move || ..)` reflow on every write. What keeps the answer
+    /// current instead is that the same write schedules a Paint job, and
+    /// `refresh_paint_bounds` runs from that job before this frame paints.
+    fn publish_paint_reach(&self, tree: &mut Tree, id: WidgetId, bounds: Rect) {
+        let shadow = style::elevation_to_shadow(self.elevation_reach.get()).extent();
+        // Only this container's own half. What its children add is
+        // `children_outset`, which the tree keeps for it — gathered upward as
+        // they publish, and re-measured whenever this container lays out. That
+        // split is what lets this run from a Paint job without walking
+        // anything.
+        tree.set_own_paint_reach(id, self.max_transform_reach(bounds, shadow));
+    }
+
     /// Get scroll data (panics if not scrollable — only call when scroll_axis != None)
     fn scroll(&self) -> &ScrollData {
         self.scroll_data.as_deref().expect("scroll_data not set")
@@ -1392,7 +1410,31 @@ impl Widget for Container {
         // computations of it made a frame apart.
         let reach = with_signal_tracking(id, JobType::Layout, || self.max_elevation());
         self.elevation_reach.set(reach);
-        tree.set_paint_overflow(id, style::elevation_to_shadow(reach).extent());
+        // The shadow's reach is layout's to publish — it follows the elevation,
+        // which layout already tracks. What a transform adds is not: a
+        // transform is a paint property and reading it here would make moving a
+        // widget reflow it. `refresh_paint_bounds` answers that part, in the
+        // pass before paint.
+        // The children first, so what the publish below carries upward is what
+        // was just measured rather than what stood here before this layout.
+        // Layout only: `refresh_paint_bounds` runs from a Paint job, and a walk
+        // over the children there would put an O(n) back on the frame path that
+        // the window exists to keep off it.
+        // What a scroller or an `Overflow::Hidden` box paints is bounded by its
+        // own edges, however far the content inside it runs. Counting the
+        // overhang would damage, and narrow against, a rect the size of the
+        // whole scrolled column.
+        //
+        // `lengths.overflow` rather than a fresh read: `read_box_lengths`
+        // already resolved it under this layout's tracking, so the value is in
+        // hand and the dependence is the one that makes a Hidden-to-Visible
+        // toggle re-run this.
+        let clips = self.scroll_axis != ScrollAxis::None || lengths.overflow == Overflow::Hidden;
+        tree.set_clips_children(id, clips);
+        if !clips {
+            tree.remeasure_children(id);
+        }
+        self.publish_paint_reach(tree, id, Rect::from_size(size));
 
         // Register widget ref so update_widget_refs() can refresh bounds
         if let Some(ref wr) = self.widget_ref {
@@ -1472,6 +1514,11 @@ impl Widget for Container {
         }
 
         self.handle_own_event(id, &hit, event, &local_event, at)
+    }
+
+    fn refresh_paint_bounds(&self, tree: &mut Tree, id: WidgetId) {
+        let size = tree.cached_size(id).unwrap_or_default();
+        self.publish_paint_reach(tree, id, Rect::from_size(size));
     }
 
     fn paint(&self, tree: &Tree, id: WidgetId, ctx: &mut PaintContext) {
@@ -1610,6 +1657,7 @@ impl Widget for Container {
                 scroll_offset,
                 cull_rect: effective_cull_rect,
                 children_sorted_along: self.children_sorted_along,
+                children_reach: tree.children_reach(id),
                 // A scroller's cull rect moves under its content, so a
                 // partially visible child has to repaint for its own children
                 // to be culled against the current rect.
@@ -1654,11 +1702,11 @@ impl Widget for Container {
 
 /// The axis `children` came out ordered along, if any.
 ///
-/// Ordered means what the binary search in `paint` needs: consecutive children
-/// that do not overlap on that axis, so both of the predicates it searches with
-/// partition the slice. Anything less and `partition_point` answers about
-/// whichever child it happened to probe rather than about the viewport, and a
-/// child sitting in plain view is dropped.
+/// **Ordered** means what the binary search in `paint_children` needs:
+/// consecutive children that do not overlap on that axis, so both of the
+/// predicates it searches with partition the slice. Anything less and
+/// `partition_point` answers about whichever child it happened to probe rather
+/// than about the viewport, and a child sitting in plain view is dropped.
 ///
 /// Non-overlap also settles which axis to answer when a layout orders its
 /// children along both: a column's children overlap horizontally and a row's
@@ -1666,7 +1714,7 @@ impl Widget for Container {
 /// one that narrows.
 ///
 /// Bails on the first pair that overlaps on both, so a layout that stacks its
-/// children costs two of them and a list costs the pass that earns it.
+/// children costs two of them rather than all of them.
 fn sorted_axis(tree: &Tree, children: &[WidgetId]) -> Option<Axis> {
     // No children are ordered along nothing in particular, and answering an
     // axis for them would be a claim about nothing.
@@ -1684,14 +1732,12 @@ fn sorted_axis(tree: &Tree, children: &[WidgetId]) -> Option<Axis> {
         let (left, next_right) = bounds.span(Axis::Horizontal);
         vertical &= top >= bottom;
         horizontal &= left >= right;
-        if !vertical && !horizontal {
+        if !(vertical || horizontal) {
             return None;
         }
         (bottom, right) = (next_bottom, next_right);
     }
 
-    // The loop returns on the first pair that overlaps on both, so reaching
-    // here means at least one axis survived.
     Some(if vertical {
         Axis::Vertical
     } else {

--- a/src/widgets/container/style.rs
+++ b/src/widgets/container/style.rs
@@ -161,6 +161,175 @@ impl Container {
         }
     }
 
+    /// Which of the three components anything can move — the declaration, a
+    /// state layer's override of it, or an animation holding one.
+    ///
+    /// One computation, read by `animated_transform`'s gate and by
+    /// `max_transform_reach`'s. Two copies of this drifting apart would make a
+    /// container that transforms report a reach of zero and be culled while it
+    /// is moved, which is the defect this all exists to stop.
+    pub(super) fn moving_components(&self) -> Moves {
+        let anims = self.anims.as_ref();
+        let declared = self
+            .interaction
+            .as_ref()
+            .map(|ix| ix.declares_transform)
+            .unwrap_or_default();
+        Moves {
+            translate: declared.translate
+                || self.translate_signal().is_some()
+                || anims.is_some_and(|a| a.translate.is_some()),
+            rotate: declared.rotate
+                || self.rotate_signal().is_some()
+                || anims.is_some_and(|a| a.rotate.is_some()),
+            scale: declared.scale
+                || self.scale_signal().is_some()
+                || anims.is_some_and(|a| a.scale.is_some()),
+        }
+    }
+
+    /// The furthest this container's paint can land outside `bounds`, in
+    /// logical pixels — its shadow, and then whatever its transform can do to
+    /// the box that shadow surrounds.
+    ///
+    /// The largest it can reach *from what is declared* — the value, the state
+    /// layers, and whatever an animation is holding as this is asked. A
+    /// `timeline` is not bounded here: its keyframes are the animation's, not a
+    /// declaration, so the answer for one is the frame it is on rather than the
+    /// whole play. That is sound because a playing animation queues a Paint job
+    /// per changed frame and this is recomputed from it, which
+    /// `a_declared_transform_change_invalidates_the_reach_without_a_layout`
+    /// holds in place; it is not a bound taken once and trusted.
+    ///
+    /// For everything that *is* declared it is the largest, not the one
+    /// showing, for the reason [`Self::max_elevation`] gives: a transform animates paint-only, so a
+    /// hover that lifts a card never re-runs this layout. A reach sized to the
+    /// resting value would leave the lifted card outside the rect its parent
+    /// culls against, and it would vanish for exactly as long as it was moved.
+    ///
+    /// A bound rather than a value, so the error is one-sided. Everything
+    /// downstream grows a laid-out rect by this and asks whether the result is
+    /// visible; a child's drawn rect is inside its grown rect by construction,
+    /// so a child on screen is never culled. Sometimes one is painted that has
+    /// not moved into view yet.
+    ///
+    /// The two outsets compose rather than alternate: a shadow is drawn in the
+    /// container's own space and then carried by the transform, so an elevated
+    /// card that lifts reaches further than either alone. Taking the transform
+    /// over the shadow-inflated box is also what makes `scale` scale the
+    /// shadow.
+    ///
+    /// Every read here is `_untracked`, and it has to be. Layout runs a child
+    /// inside its *parent's* scope, so a tracked read registers against
+    /// whichever ancestor is innermost and reflows that one — which is why
+    /// `a_transform_does_not_reflow_the_parent_either` asks the parent rather
+    /// than the container that declared the transform, and why being outside a
+    /// scope of one's own is not enough. `snapshot_zone` is not enough either:
+    /// it silences the non-reactive-read diagnostic and leaves the read
+    /// tracked.
+    ///
+    /// What keeps the value current is not a subscription but the schedule:
+    /// `Container::refresh_paint_bounds` runs from the Paint job that the
+    /// declaring write already queues, in the pass before this frame paints.
+    /// Blink resolves its transforms in the same gap, for the same reason.
+    pub(super) fn max_transform_reach(&self, bounds: Rect, shadow_extent: f32) -> f32 {
+        let moves = self.moving_components();
+        if !moves.any() {
+            return shadow_extent;
+        }
+
+        // The box the transform actually carries: the container plus the
+        // shadow already standing outside it. Measured back against `bounds`,
+        // because that is what every consumer grows by the answer — an outset
+        // taken against `painted` would report the excursion beyond the shadow
+        // and lose its width.
+        let painted = bounds.outset(shadow_extent);
+        let pivot = self.pivot_signal().get_or_untracked(Pivot::CENTER);
+        let anims = self.anims.as_ref();
+
+        let base_translate = self.translate_signal().get_or_untracked(Translate::NONE);
+        let base_rotate = self.rotate_signal().get_or_untracked(0.0);
+        let base_scale = self.scale_signal().get_or_untracked(Scale::NONE);
+        let base = Transform::compose(base_translate, base_rotate, base_scale);
+        let mut reach = outset_of(base, painted, bounds, pivot);
+
+        // A rotation's outset is not monotone in its angle: a box turned 0 or
+        // 180 degrees sits back where it started and somewhere between stands
+        // furthest outside. Endpoints bound a shadow, which grows with
+        // elevation; they bound nothing here. So a container that can rotate at
+        // all is given the worst angle outright.
+        //
+        // Turning about a pivot keeps every point at its own distance from it,
+        // so the whole swept shape fits the circle of radius `far` about the
+        // pivot — which bounds every angle, and every pivot, without caring
+        // which. A corner pivot sweeps a much larger circle than a centre one,
+        // and half the diagonal only ever describes the centre.
+        if moves.rotate {
+            // About `bounds`, which is where `outset_of` and `flatten` resolve
+            // it. Resolving against the shadow-inflated box instead puts the
+            // centre of the swept circle somewhere the content never turns
+            // about, and the bound comes out looser than the widest angle.
+            let (px, py) = pivot.resolve(bounds);
+            let far = [
+                (painted.x, painted.y),
+                (painted.x + painted.width, painted.y),
+                (painted.x, painted.y + painted.height),
+                (painted.x + painted.width, painted.y + painted.height),
+            ]
+            .into_iter()
+            .fold(0.0f32, |most, (x, y)| most.max((x - px).hypot(y - py)));
+            let swept = Rect::new(px - far, py - far, far * 2.0, far * 2.0);
+            reach = reach.max(swept.outset_beyond(bounds));
+        }
+
+        // Each layer is a transform this container can be in, whether or not it
+        // is in it now. Resolving only the active one would make a hover re-run
+        // layout, which is the whole thing this avoids.
+        if let Some(ref ix) = self.interaction {
+            for (_, state) in ix.states.iter() {
+                if state.translate.is_none() && state.rotate.is_none() && state.scale.is_none() {
+                    continue;
+                }
+                let candidate = Transform::compose(
+                    state
+                        .translate
+                        .map_or(base_translate, |s| s.get_untracked()),
+                    state.rotate.map_or(base_rotate, |s| s.get_untracked()),
+                    state.scale.map_or(base_scale, |s| s.get_untracked()),
+                );
+                reach = reach.max(outset_of(candidate, painted, bounds, pivot));
+            }
+        }
+
+        // A spring passes its target before it settles, so the declared reach
+        // is inflated by the overshoot still to come — the same allowance
+        // `max_elevation` makes — and the value in flight, which is already
+        // past whatever overshoot it had, is folded in flat.
+        if let Some(anims) = anims {
+            let overshoot = [
+                anims.translate.as_ref().map(|a| a.peak_overshoot()),
+                anims.rotate.as_ref().map(|a| a.peak_overshoot()),
+                anims.scale.as_ref().map(|a| a.peak_overshoot()),
+            ]
+            .into_iter()
+            .flatten()
+            .fold(0.0f32, f32::max);
+            reach *= 1.0 + overshoot;
+
+            let flying = Transform::compose(
+                anims
+                    .translate
+                    .as_ref()
+                    .map_or(base_translate, |a| *a.current()),
+                anims.rotate.as_ref().map_or(base_rotate, |a| *a.current()),
+                anims.scale.as_ref().map_or(base_scale, |a| *a.current()),
+            );
+            reach = reach.max(outset_of(flying, painted, bounds, pivot));
+        }
+
+        reach
+    }
+
     pub(super) fn effective_elevation_target(&self, id: WidgetId) -> f32 {
         let base = self.elevation.get_or(0.0);
         self.resolve_state_value(id, base, |state| state.elevation.map(|s| s.get()))
@@ -248,20 +417,11 @@ impl Container {
         // Computed once and shared with the early-out below, so the two cannot
         // disagree: a component wired into the gates and forgotten in the
         // early-out would return IDENTITY and silently stop transforming.
-        let from_state = self
-            .interaction
-            .as_ref()
-            .map(|ix| ix.declares_transform)
-            .unwrap_or_default();
-        let has_translate = from_state.translate
-            || self.translate_signal().is_some()
-            || anims.is_some_and(|a| a.translate.is_some());
-        let has_rotate = from_state.rotate
-            || self.rotate_signal().is_some()
-            || anims.is_some_and(|a| a.rotate.is_some());
-        let has_scale = from_state.scale
-            || self.scale_signal().is_some()
-            || anims.is_some_and(|a| a.scale.is_some());
+        let Moves {
+            translate: has_translate,
+            rotate: has_rotate,
+            scale: has_scale,
+        } = self.moving_components();
 
         // A plain layout box is none of the three, and most containers are one.
         if !(has_translate || has_rotate || has_scale) {
@@ -464,7 +624,7 @@ const ELEVATION_STEPS: [(f32, f32, f32); 6] = [
 /// A level that is not a number is no shadow. `.elevation(f32::NAN)` is
 /// writable, and NaN fails every comparison on the way in, so it reached the
 /// interpolating branch and came back out as a NaN extent — into
-/// `set_paint_overflow`, where it disables every `min` and `max` downstream
+/// `set_own_paint_reach`, where it disables every `min` and `max` downstream
 /// without anything failing. The same guard `SpringConfig::peak_overshoot` has,
 /// for the same reason: a number that sizes a rect has to be one.
 pub(super) fn elevation_to_shadow(level: f32) -> Shadow {
@@ -493,6 +653,30 @@ pub(super) fn elevation_to_shadow(level: f32) -> Shadow {
         0.0,
         Color::rgba(0.0, 0.0, 0.0, alpha),
     )
+}
+
+/// How far `painted`, once `transform` has carried it, stands outside `bounds`.
+///
+/// Two rects because they are two questions: `painted` is everything the widget
+/// draws, `bounds` is the box a parent knows it by, and the answer has to be in
+/// terms of the second — every consumer grows a laid-out rect by it. With no
+/// transform at all the answer is the difference between them, which is the
+/// shadow, so the shadow needs no separate accounting.
+///
+/// One number for four sides, because everything reading it grows a rect
+/// equally in every direction: a scalar cannot say a card lifts upward only,
+/// and a reach that is too generous costs paint while one that is too tight
+/// loses a widget.
+fn outset_of(transform: Transform, painted: Rect, bounds: Rect, pivot: Pivot) -> f32 {
+    let moved = if transform.is_identity() {
+        painted
+    } else {
+        // About `bounds`, which is what `flatten` resolves the pivot against
+        // when it draws. Resolving against the shadow-inflated box instead
+        // would put a corner pivot in a different place here than on screen.
+        transform.about(pivot, bounds).map_rect(painted)
+    };
+    moved.outset_beyond(bounds)
 }
 
 #[cfg(test)]
@@ -563,7 +747,7 @@ mod elevation_tests {
 
     /// A level that is not a number is no shadow either. NaN fails every
     /// comparison on the way in, so it used to reach the interpolating branch and
-    /// come back out as a NaN extent — into `set_paint_overflow`, where it
+    /// come back out as a NaN extent — into `set_own_paint_reach`, where it
     /// disables every `min` and `max` downstream without anything failing.
     #[test]
     fn a_level_that_is_not_a_number_is_no_shadow() {
@@ -578,5 +762,266 @@ mod elevation_tests {
         let s = elevation_to_shadow(0.0);
         assert_eq!(s.color, Color::TRANSPARENT);
         assert_eq!(s.blur, 0.0);
+    }
+}
+
+/// `outset_of` is the arithmetic every cull and every damage rect is grown by,
+/// and it had no test until a review worked an example by hand and found it ten
+/// pixels short.
+#[cfg(test)]
+mod reach_tests {
+    use super::*;
+    use crate::animation::{Animate, SpringConfig, Transition};
+
+    /// Turning about a corner carries the far corner around a circle of the
+    /// whole diagonal, so the box sweeps well past what a centre rotation
+    /// reaches. A bound written for the centre reports 20.7 here, and the
+    /// answer is 70.7.
+    #[test]
+    fn a_rotation_about_a_corner_sweeps_further_than_one_about_the_centre() {
+        let mut worst: f32 = 0.0;
+        for degrees in 0..360 {
+            let spin = Transform::compose(Translate::NONE, degrees as f32, Scale::NONE);
+            worst = worst.max(outset_of(spin, BOX, BOX, Pivot::TOP_LEFT));
+        }
+        // What a bound written for the centre would have said.
+        let centre_shaped = (100.0f32.hypot(100.0) - 100.0) / 2.0;
+        assert!(
+            worst > centre_shaped,
+            "a corner rotation reaches {worst}; a centre-shaped bound says \
+             {centre_shaped} and would cull a widget that is on screen"
+        );
+
+        // What the code says: every point stays its own distance from the
+        // pivot, so the swept shape fits the circle of the furthest corner.
+        let swept = 100.0f32.hypot(100.0);
+        assert!(
+            swept >= worst,
+            "the swept-circle bound {swept} does not cover the worst angle {worst}"
+        );
+    }
+
+    const BOX: Rect = Rect {
+        x: 0.0,
+        y: 0.0,
+        width: 100.0,
+        height: 100.0,
+    };
+
+    /// With nothing moving, what a widget paints outside its box is its shadow.
+    #[test]
+    fn an_untransformed_box_reaches_exactly_its_shadow() {
+        let painted = BOX.outset(10.0);
+        assert_eq!(
+            outset_of(Transform::IDENTITY, painted, BOX, Pivot::CENTER),
+            10.0
+        );
+    }
+
+    /// The shadow and the transform compose. This is the case the review
+    /// found: measured against the shadow-inflated box the answer came out 50,
+    /// and the shadow really reaches 60.
+    #[test]
+    fn a_shadow_carried_by_a_translate_reaches_past_both() {
+        let painted = BOX.outset(10.0);
+        let lift = Transform::compose(Translate::new(0.0, -50.0), 0.0, Scale::NONE);
+        assert_eq!(outset_of(lift, painted, BOX, Pivot::CENTER), 60.0);
+    }
+
+    /// And a consumer growing the box by the answer contains what is drawn,
+    /// which is the whole promise: a widget on screen is never culled.
+    #[test]
+    fn the_grown_box_contains_what_is_drawn() {
+        let painted = BOX.outset(10.0);
+        let lift = Transform::compose(Translate::new(0.0, -50.0), 0.0, Scale::NONE);
+        let reach = outset_of(lift, painted, BOX, Pivot::CENTER);
+
+        let drawn = lift.about(Pivot::CENTER, painted).map_rect(painted);
+        let grown = BOX.outset(reach);
+        assert!(
+            grown.x <= drawn.x
+                && grown.y <= drawn.y
+                && grown.x + grown.width >= drawn.x + drawn.width
+                && grown.y + grown.height >= drawn.y + drawn.height,
+            "grown {grown:?} does not contain drawn {drawn:?}"
+        );
+    }
+
+    /// A scale carries the shadow with it rather than leaving it behind.
+    #[test]
+    fn a_scale_scales_the_shadow_it_surrounds() {
+        let painted = BOX.outset(10.0);
+        let grow = Transform::compose(Translate::NONE, 0.0, Scale::uniform(2.0));
+        // The 120-wide painted box doubles about the centre it shares with
+        // bounds, reaching 120 either side of it; 70 of that stands outside the
+        // 100-wide bounds. A shadow that did not scale would reach 60.
+        assert_eq!(outset_of(grow, painted, BOX, Pivot::CENTER), 70.0);
+    }
+
+    /// The rotation bound, asked of the container rather than of the
+    /// arithmetic under it.
+    ///
+    /// `max_transform_reach` has its own branch for rotation — the swept circle
+    /// about the pivot — and the tests below reach `outset_of` directly, so
+    /// that branch was watched by nothing. It has to cover the worst angle for
+    /// the pivot it is given, and a corner pivot sweeps far wider than a centre
+    /// one.
+    #[test]
+    fn the_rotation_bound_covers_every_angle_for_the_pivot_it_is_given() {
+        // BOTTOM_RIGHT included deliberately: it is the pivot whose swept
+        // circle reaches furthest past the *far* edges rather than the near
+        // ones, so it is the only one where the circle's width and height are
+        // load-bearing rather than masked by its origin.
+        for pivot in [
+            Pivot::CENTER,
+            Pivot::TOP_LEFT,
+            Pivot::TOP,
+            Pivot::BOTTOM_RIGHT,
+        ] {
+            let turning = container()
+                .width(100.0)
+                .height(100.0)
+                .rotate(0.0)
+                .pivot(pivot);
+            // With a shadow, so the box the rotation carries does not start at
+            // the origin. At the origin `x` is zero and half the arithmetic
+            // that reads it is indistinguishable from arithmetic that does not.
+            let shadow = 6.0;
+            let painted = BOX.outset(shadow);
+            let bound = turning.max_transform_reach(BOX, shadow);
+
+            let worst = (0..360)
+                .map(|deg| {
+                    let spin = Transform::compose(Translate::NONE, deg as f32, Scale::NONE);
+                    outset_of(spin, painted, BOX, pivot)
+                })
+                .fold(0.0f32, f32::max);
+
+            assert!(
+                bound >= worst - 0.01,
+                "{pivot:?}: the bound is {bound} and the widest angle reaches \
+                 {worst}, so a container mid-rotation would be culled"
+            );
+            // And tight. A bound that is merely large is satisfied by any
+            // arithmetic that errs upward, which leaves the whole computation
+            // unwatched — and every pixel of slack is painted and damaged.
+            assert!(
+                bound <= worst + 0.01,
+                "{pivot:?}: the bound is {bound} where the widest angle reaches \
+                 only {worst}, so every rotation pays for reach it cannot use"
+            );
+        }
+    }
+
+    /// And it is a bound, not a shrug: a box that cannot rotate is not given
+    /// the reach of one that can.
+    #[test]
+    fn a_box_that_cannot_rotate_is_not_given_a_rotation_s_reach() {
+        let still = container().width(100.0).height(100.0);
+        assert_eq!(still.max_transform_reach(BOX, 0.0), 0.0);
+        assert_eq!(still.max_transform_reach(BOX, 6.0), 6.0, "only its shadow");
+    }
+
+    /// A spring passes its target before it settles, and the reach has to
+    /// cover where it goes, not where it is going.
+    ///
+    /// This is the one part of the bound that is not about geometry: a
+    /// `SNAPPY` translate to -100 reaches past -100 on the way, and a reach of
+    /// exactly 100 culls the widget at the top of its bounce.
+    #[test]
+    fn a_spring_is_given_room_for_the_overshoot_it_has_not_taken_yet() {
+        let sprung = container().width(100.0).height(100.0).translate(
+            Translate::new(0.0, -100.0).transition(Transition::spring(SpringConfig::BOUNCY)),
+        );
+
+        let reach = sprung.max_transform_reach(BOX, 0.0);
+        assert!(
+            reach > 100.0,
+            "a spring to -100 was given a reach of {reach}, so it is culled at \
+             the far end of its own overshoot"
+        );
+
+        let eased = container()
+            .width(100.0)
+            .height(100.0)
+            .translate(Translate::new(0.0, -100.0).transition(200.0));
+        assert_eq!(
+            eased.max_transform_reach(BOX, 0.0),
+            100.0,
+            "an eased translate overshoots nothing and should pay for nothing"
+        );
+    }
+
+    /// A state layer that moves only one component is still a transform this
+    /// container can be in.
+    ///
+    /// The loop skips a layer declaring none of the three, and the skip has to
+    /// mean *none* — a layer that scales but does not translate still carries
+    /// the container somewhere its resting declaration does not, and treating
+    /// "not all three" as "none" reports a reach it does not have.
+    #[test]
+    fn a_state_layer_moving_one_component_still_counts() {
+        let scaled = container()
+            .width(100.0)
+            .height(100.0)
+            .when_pressed(|s| s.scale(Scale::uniform(2.0)));
+        assert_eq!(
+            scaled.max_transform_reach(BOX, 0.0),
+            50.0,
+            "a layer that doubles this box on press was not counted, so it is \
+             culled at its resting size while it is pressed"
+        );
+
+        // Each of the three on its own, because the skip is a conjunction and a
+        // layer declaring only the first of them is where a loosened one shows.
+        let lifted = container()
+            .width(100.0)
+            .height(100.0)
+            .when_hovered(|s| s.translate(Translate::new(0.0, -25.0)));
+        assert_eq!(
+            lifted.max_transform_reach(BOX, 0.0),
+            25.0,
+            "a layer that lifts this box on hover was not counted"
+        );
+
+        let turned = container()
+            .width(100.0)
+            .height(100.0)
+            .when_hovered(|s| s.rotate(45.0));
+        assert!(
+            turned.max_transform_reach(BOX, 0.0) > 0.0,
+            "a layer that turns this box on hover was not counted"
+        );
+    }
+
+    /// The angle that puts a square furthest outside its box is 45 degrees,
+    /// where neither endpoint of a 0-to-90 rotation is. Nothing may report a
+    /// reach smaller than this while a rotation is declared.
+    ///
+    /// About the centre. A corner pivot sweeps a far bigger circle, which is
+    /// why the bound is taken from the distance to the furthest corner rather
+    /// than from half the diagonal — see the neighbour below.
+    #[test]
+    fn a_square_reaches_furthest_halfway_through_its_rotation() {
+        let at = |deg: f32| {
+            outset_of(
+                Transform::compose(Translate::NONE, deg, Scale::NONE),
+                BOX,
+                BOX,
+                Pivot::CENTER,
+            )
+        };
+        assert_eq!(at(0.0), 0.0);
+        assert!(
+            at(90.0) < 0.01,
+            "a square turned 90 degrees is back in its box"
+        );
+
+        let corner = (100.0f32.hypot(100.0) - 100.0) / 2.0;
+        assert!(
+            (at(45.0) - corner).abs() < 0.01,
+            "at 45 degrees a square stands {corner} outside its box, got {}",
+            at(45.0)
+        );
     }
 }

--- a/src/widgets/paint_children.rs
+++ b/src/widgets/paint_children.rs
@@ -52,6 +52,11 @@ pub(crate) struct ChildPaintOptions {
     /// whole, however small the cull rect: a binary search over a slice that
     /// is not partitioned answers about whichever child it probed.
     pub children_sorted_along: Option<Axis>,
+    /// The furthest any of these children paints outside its own bounds — a
+    /// shadow's reach, or the distance its own transform can move it. Both
+    /// narrowings grow by this, so a child that draws somewhere other than
+    /// where it was laid out is still reached.
+    pub children_reach: f32,
 }
 
 impl Default for ChildPaintOptions {
@@ -61,6 +66,7 @@ impl Default for ChildPaintOptions {
             cull_rect: None,
             cache_requires_full_visibility: false,
             children_sorted_along: None,
+            children_reach: 0.0,
         }
     }
 }
@@ -101,7 +107,10 @@ fn visible_window<'a>(
         return children;
     };
 
+    // Grown by the widest reach among the children, because the bounds being
+    // searched are where they were laid out and not where they draw.
     let (near, far) = cull.span(axis);
+    let (near, far) = (near - opts.children_reach, far + opts.children_reach);
     let span = |cid: WidgetId| tree.get_bounds(cid).map(|b| b.span(axis));
     let first = children.partition_point(|&cid| span(cid).is_some_and(|(_, f)| f <= near));
     // From `first`, so `last` cannot come out below it however degenerate the
@@ -109,10 +118,11 @@ fn visible_window<'a>(
     let last =
         first + children[first..].partition_point(|&cid| span(cid).is_some_and(|(n, _)| n < far));
 
-    // One either side, because these are laid-out bounds and a child draws
-    // where its own transform puts it. One child of slack is a margin, not a
-    // bound: a translate larger than a child clips against the rect anyway,
-    // which is its own defect and older than this window.
+    // One either side, for the boundary rather than for transforms: the
+    // predicates compare edges with `<=` and `<`, so a child whose edge lands
+    // exactly on the rect can fall either way under float rounding. What a
+    // child's own transform does to where it draws is `children_reach` above,
+    // measured rather than guessed at one child's width.
     let window = &children[first.saturating_sub(1)..(last + 1).min(children.len())];
     crate::render_stats::record_paint_window(children.len() as u64, window.len() as u64);
     if window.len() < children.len() {
@@ -138,12 +148,15 @@ pub(crate) fn paint_children(
         let (child_x, child_y) = (child_bounds.x, child_bounds.y);
         let child_position = Transform::translate(child_x - offset_x, child_y - offset_y);
 
-        // Cull clean children that fall outside the visible rect
+        // Cull clean children that fall outside the visible rect. By the rect
+        // the child can paint into rather than the one it was laid out in: a
+        // shadow falls outside the box that cast it, and a transform moves the
+        // box. Its own reach is what the two have in common.
         if let Some(ref cull) = opts.cull_rect
             && !tree.needs_paint(child_id)
         {
-            let child_rect = Rect::new(child_x, child_y, child_bounds.width, child_bounds.height);
-            if !cull.intersects(&child_rect) {
+            let drawn = child_bounds.outset(tree.paint_overflow(child_id));
+            if !cull.intersects(&drawn) {
                 crate::render_stats::record_paint_child_culled();
                 ctx.mark_partial();
                 continue;

--- a/src/widgets/state_layer.rs
+++ b/src/widgets/state_layer.rs
@@ -138,6 +138,12 @@ pub(crate) struct Moves {
 }
 
 impl Moves {
+    /// Whether anything moves at all — the early-out a plain layout box takes,
+    /// and most containers are one.
+    pub(crate) fn any(&self) -> bool {
+        self.translate || self.rotate || self.scale
+    }
+
     pub(crate) fn merge(&mut self, other: Moves) {
         self.translate |= other.translate;
         self.rotate |= other.rotate;

--- a/src/widgets/text.rs
+++ b/src/widgets/text.rs
@@ -228,7 +228,7 @@ impl Widget for Text {
         // Refresh cached values from content and declared style.
         // This reads signals and registers layout dependencies.
         let overflow = self.refresh(tree, id);
-        tree.set_paint_overflow(id, overflow);
+        tree.set_own_paint_reach(id, overflow);
 
         // Determine the effective max_width for measurement
         // If nowrap is true, don't pass max_width so text won't wrap

--- a/src/widgets/text_input.rs
+++ b/src/widgets/text_input.rs
@@ -1106,7 +1106,7 @@ impl Widget for TextInput {
         // Refresh cached values from reactive properties
         // This reads signals and registers layout dependencies
         let overflow = self.refresh(tree, id);
-        tree.set_paint_overflow(id, overflow);
+        tree.set_own_paint_reach(id, overflow);
 
         // Update measurement cache (has internal dirty check)
         self.update_measurements();

--- a/src/widgets/widget.rs
+++ b/src/widgets/widget.rs
@@ -256,6 +256,26 @@ impl Rect {
     pub fn outset(&self, amount: f32) -> Self {
         self.inset(-amount)
     }
+
+    /// How far this rect stands outside `inner`, on its widest side. Zero when
+    /// it does not.
+    ///
+    /// One question about two rects, asked in three places — how far a shadow
+    /// and a transform carry a widget's painting past its own box, how far a
+    /// child's painting carries past its parent's, and how far a damage rect
+    /// has to grow to cover either. Two copies of it would be two copies of
+    /// which rect is the outer one.
+    pub fn outset_beyond(&self, inner: Rect) -> f32 {
+        [
+            inner.x - self.x,
+            inner.y - self.y,
+            (self.x + self.width) - (inner.x + inner.width),
+            (self.y + self.height) - (inner.y + inner.height),
+        ]
+        .into_iter()
+        .fold(0.0f32, f32::max)
+    }
+
     pub fn intersects(&self, other: &Rect) -> bool {
         self.x < other.x + other.width
             && self.x + self.width > other.x
@@ -775,6 +795,35 @@ pub trait Widget {
         false
     }
 
+    /// Publish how far this widget's paint will land outside its own bounds,
+    /// before anything decides whether to paint it.
+    ///
+    /// Called when a Paint job is processed, which is the frame's one chance to
+    /// ask: a parent narrows its children to the visible rect at the top of its
+    /// own paint, so by the time a child paints, the decision about it has been
+    /// taken. A transform is the reason this exists — where a widget draws is
+    /// not where it was laid out, and a parent culling by laid-out bounds drops
+    /// a widget that has moved into view.
+    ///
+    /// Layout is the wrong place to answer it. A transform is a paint property
+    /// and changing one must not reflow anything, so the answer is refreshed
+    /// here, on the same signal write that schedules the repaint, in the pass
+    /// that runs before paint. Blink resolves its transforms in a PrePaint walk
+    /// between layout and paint for the same reason.
+    ///
+    /// Report it with [`Tree::set_own_paint_reach`]. The default reports
+    /// nothing, which is right for a widget that draws inside its own box.
+    ///
+    /// Which pass to publish from follows what the reach depends on. A reach
+    /// that moves with a layout-tracked signal cannot change without a layout,
+    /// so `Text` and `TextInput` publish their stroke and shadow reach from
+    /// `layout` and never implement this. A reach that moves with a paint-only
+    /// one — a transform — has no layout to publish from, and this is where it
+    /// goes. One channel, two schedules.
+    fn refresh_paint_bounds(&self, tree: &mut Tree, id: WidgetId) {
+        let _ = (tree, id);
+    }
+
     fn layout_hints(&self) -> LayoutHints {
         LayoutHints::default()
     }
@@ -810,6 +859,40 @@ pub trait Widget {
         Self: Sized + 'static,
     {
         Box::new(self)
+    }
+}
+
+#[cfg(test)]
+mod rect_tests {
+    use super::*;
+
+    /// `outset_beyond` is what every cull test and every damage rect is built
+    /// on, and it was only ever reached through something else.
+    #[test]
+    fn a_rect_reports_how_far_it_stands_outside_another() {
+        let inner = Rect::new(0.0, 0.0, 100.0, 100.0);
+
+        assert_eq!(inner.outset_beyond(inner), 0.0, "itself");
+        assert_eq!(
+            inner.inset(10.0).outset_beyond(inner),
+            0.0,
+            "wholly inside stands outside by nothing"
+        );
+
+        // Each side on its own, so a sign or a term swapped in one of the four
+        // cannot hide behind the others.
+        assert_eq!(inner.offset(-30.0, 0.0).outset_beyond(inner), 30.0, "left");
+        assert_eq!(inner.offset(0.0, -30.0).outset_beyond(inner), 30.0, "top");
+        assert_eq!(inner.offset(30.0, 0.0).outset_beyond(inner), 30.0, "right");
+        assert_eq!(inner.offset(0.0, 30.0).outset_beyond(inner), 30.0, "bottom");
+
+        // The widest side wins, and it is not the sum of them.
+        assert_eq!(inner.outset(7.0).outset_beyond(inner), 7.0, "all four");
+        assert_eq!(
+            Rect::new(-5.0, -40.0, 110.0, 180.0).outset_beyond(inner),
+            40.0,
+            "the widest, not the first"
+        );
     }
 }
 

--- a/src/widgets/widget.rs
+++ b/src/widgets/widget.rs
@@ -248,6 +248,14 @@ impl Rect {
         }
     }
 
+    /// Grow this rect by `amount` on every side.
+    ///
+    /// What "how far past its bounds does this widget paint" turns into when
+    /// something has to test against it: a shadow's falloff, or the distance a
+    /// transform can carry the box.
+    pub fn outset(&self, amount: f32) -> Self {
+        self.inset(-amount)
+    }
     pub fn intersects(&self, other: &Rect) -> bool {
         self.x < other.x + other.width
             && self.x + self.width > other.x

--- a/tests/cull_follows_the_transform.rs
+++ b/tests/cull_follows_the_transform.rs
@@ -1,0 +1,285 @@
+//! Where a widget draws, not where it was laid out.
+//!
+//! A cull rect is handed to a child translated by the child's laid-out origin.
+//! A child's own `translate`, `rotate` or `scale` is applied later, inside its
+//! own `paint`, so the rect describes where the child *would* have drawn. Both
+//! things that narrow children to that rect — the binary-search window and the
+//! per-child cull beside it — then answer about the wrong rows.
+
+mod common;
+
+use common::Harness;
+use guido::prelude::*;
+use guido::renderer::RenderNode;
+
+const ROW_WIDTH: f32 = 120.0;
+const ROW_HEIGHT: f32 = 24.0;
+const PITCH: f32 = 32.0;
+const VIEWPORT: f32 = 200.0;
+/// Enough to carry a whole column clear of the viewport it sits in.
+const LIFT: f32 = 300.0;
+/// Enough to carry row fifteen from below the fold into the middle of it.
+const ROW_LIFT: f32 = 400.0;
+/// The odd one out, told from its twenty neighbours by width — a row clamps a
+/// taller child to its own height, so a distinguishing *height* would not
+/// survive layout and would match nothing at all.
+const MARKED_WIDTH: f32 = 60.0;
+
+/// Where each leaf of a given width ended up, in the root's coordinates.
+///
+/// By position rather than by count, because a count cannot tell a window that
+/// narrowed to the right number of the wrong rows from one that narrowed to the
+/// right rows. Leaves only, because a column takes its width from the rows
+/// inside it and would otherwise be counted as one of them.
+fn tops_of_width(node: &RenderNode, width: f32, offset: f32, out: &mut Vec<f32>) {
+    let here = offset + node.local_transform.ty();
+    if node.children.is_empty() && (node.bounds.width - width).abs() < 0.01 {
+        out.push(here);
+    }
+    for child in &node.children {
+        tops_of_width(child, width, here, out);
+    }
+}
+
+fn tops(view: impl Widget + 'static, width: f32) -> Vec<f32> {
+    let mut harness = Harness::laid_out(view, 400.0, VIEWPORT);
+    let mut out = Vec::new();
+    tops_of_width(&harness.paint(), width, 0.0, &mut out);
+    out.sort_by(f32::total_cmp);
+    out
+}
+
+fn rows(n: usize) -> Vec<guido::widgets::Container> {
+    (0..n)
+        .map(|_| {
+            container()
+                .width(ROW_WIDTH)
+                .height(ROW_HEIGHT)
+                .background(Color::BLUE)
+        })
+        .collect()
+}
+
+fn scroller(children: Vec<guido::widgets::Container>) -> guido::widgets::Container {
+    container()
+        .width(200.0)
+        .height(VIEWPORT)
+        .scrollable(ScrollAxis::Vertical)
+        .layout(Flex::column().spacing(PITCH - ROW_HEIGHT))
+        .children(children)
+}
+
+/// The rows a lifted column shows are the rows the lift brings into view.
+#[test]
+fn a_translated_column_paints_the_rows_the_translate_brings_into_view() {
+    let lifted = tops(
+        container()
+            .width(200.0)
+            .height(VIEWPORT)
+            .scrollable(ScrollAxis::Vertical)
+            .child(
+                container()
+                    .layout(Flex::column().spacing(PITCH - ROW_HEIGHT))
+                    .translate(Translate::new(0.0, -LIFT))
+                    .children(rows(20)),
+            ),
+        ROW_WIDTH,
+    );
+
+    assert!(!lifted.is_empty(), "a lifted column painted nothing at all");
+    let stray: Vec<_> = lifted
+        .iter()
+        .copied()
+        .filter(|top| *top + ROW_HEIGHT < -PITCH || *top > VIEWPORT + PITCH)
+        .collect();
+    assert!(
+        stray.is_empty(),
+        "rows were painted well outside the viewport, so the rect that chose \
+         them did not follow the translate: tops {lifted:?}, strays {stray:?}"
+    );
+}
+
+/// And the untransformed case still narrows, so the fix cannot be to widen the
+/// rect until nothing is ever culled.
+#[test]
+fn an_untranslated_column_still_narrows_to_its_viewport() {
+    let plain = tops(
+        container()
+            .width(200.0)
+            .height(VIEWPORT)
+            .scrollable(ScrollAxis::Vertical)
+            .child(
+                container()
+                    .layout(Flex::column().spacing(PITCH - ROW_HEIGHT))
+                    .children(rows(20)),
+            ),
+        ROW_WIDTH,
+    );
+
+    assert!(
+        plain.len() < 20,
+        "the plain column stopped being narrowed: {} of 20 rows painted",
+        plain.len()
+    );
+}
+
+/// A row that its own transform brings into view is painted, on the first frame
+/// and on the frames after it.
+///
+/// Both frames, because the two mechanisms take turns: on a first paint every
+/// child is dirty, so the per-child cull drops nothing and only the window can
+/// lose the row; from the second frame the row is clean and the cull can.
+#[test]
+fn a_row_its_own_transform_lifts_into_view_survives_both_frames() {
+    let mut rows = rows(20);
+    rows[15] = container()
+        .width(MARKED_WIDTH)
+        .height(ROW_HEIGHT)
+        .background(Color::rgb(1.0, 0.0, 0.0))
+        .translate(Translate::new(0.0, -ROW_LIFT));
+
+    let mut harness = Harness::laid_out(scroller(rows), 400.0, VIEWPORT);
+    let mut root = RenderNode::new(harness.root.as_u64());
+
+    for frame in 1..=2 {
+        root.clear();
+        root.bounds = guido::widgets::Rect::new(0.0, 0.0, 400.0, VIEWPORT);
+        let (tree, id) = (&mut harness.tree, harness.root);
+        tree.with_widget_mut(id, |w, id, t| {
+            let mut ctx = guido::renderer::PaintContext::new(&mut root);
+            w.paint(t, id, &mut ctx);
+        });
+
+        let mut found = Vec::new();
+        tops_of_width(&root, MARKED_WIDTH, 0.0, &mut found);
+        assert_eq!(
+            found.len(),
+            1,
+            "frame {frame}: the lifted row was dropped by the rect that chose \
+             what to paint, though its own transform puts it in the viewport"
+        );
+        let expected = 15.0 * PITCH - ROW_LIFT;
+        assert!(
+            (found[0] - expected).abs() < 0.01,
+            "frame {frame}: the lifted row was painted at {} rather than {expected}",
+            found[0]
+        );
+
+        for child in &root.children {
+            guido::cache_paint_results(&mut harness.tree, child);
+        }
+        harness.tree.clear_needs_paint(harness.root);
+    }
+}
+
+/// A row that is not itself transformed, but holds something that is.
+///
+/// The reach has to gather upward. A parent narrows its children by their own
+/// bounds grown by their own reach, so a row reporting nothing is culled where
+/// it was laid out — and the box inside it that a transform brought on screen
+/// goes with it. Flutter and Blink both union descendant paint bounds up the
+/// tree for this reason.
+#[test]
+fn a_row_whose_child_is_lifted_into_view_is_kept() {
+    let mut rows = rows(20);
+    rows[15] = container().width(ROW_WIDTH).height(ROW_HEIGHT).child(
+        container()
+            .width(MARKED_WIDTH)
+            .height(ROW_HEIGHT)
+            .background(Color::rgb(1.0, 0.0, 0.0))
+            .translate(Translate::new(0.0, -ROW_LIFT)),
+    );
+
+    let lifted = tops(scroller(rows), MARKED_WIDTH);
+
+    assert_eq!(
+        lifted.len(),
+        1,
+        "the row was culled at its laid-out bounds, taking with it the box its \
+         own child's transform had brought into the viewport"
+    );
+}
+
+/// A subtree scaled to nothing is culled entirely, not painted entirely.
+///
+/// `scale(0.0)` has no inverse, so there is no rect describing where its
+/// content went. The answer is the empty rect — none of it is visible — and not
+/// "no rect", which means nothing is narrowed at all. Collapsing by scale is
+/// how a menu closes here, and the difference is every row of it painted on
+/// every frame that dirties it.
+#[test]
+fn a_subtree_scaled_to_nothing_paints_nothing() {
+    let painted = tops(
+        container()
+            .width(200.0)
+            .height(VIEWPORT)
+            .scrollable(ScrollAxis::Vertical)
+            .child(
+                container()
+                    .layout(Flex::column().spacing(PITCH - ROW_HEIGHT))
+                    .scale(Scale::uniform(0.0))
+                    .children(rows(20)),
+            ),
+        ROW_WIDTH,
+    );
+
+    // One, not none: the window keeps a child either side of what it found, for
+    // the boundary rounding that has nothing to do with transforms. All twenty
+    // is what it paints when the rect is dropped rather than emptied, which is
+    // what the subtree gets if a non-invertible transform means "no rect".
+    assert!(
+        painted.len() <= 1,
+        "a collapsed subtree painted {} rows nobody can see",
+        painted.len()
+    );
+}
+
+/// The window widens on the *near* side too, not only the far one.
+///
+/// A row whose bounds sit before the visible span can still reach into it — a
+/// shadow hangs below the box that cast it. The search grows its span by the
+/// widest reach among the children at both ends, and only the far end is
+/// obvious: everything below the fold is a far-end case. This is the other one.
+///
+/// The reach here is an elevation rather than a transform, which is the point:
+/// what the window widens by is how far a child paints outside itself, whatever
+/// put it there.
+#[test]
+fn the_window_widens_on_the_near_side_as_well() {
+    let mut rows: Vec<_> = (0..20)
+        .map(|_| {
+            container()
+                .width(ROW_WIDTH)
+                .height(ROW_HEIGHT)
+                .background(Color::BLUE)
+        })
+        .collect();
+    // Row seven ends at y=248, just above the 300..500 the lift brings into
+    // view, and its shadow hangs 100px below that — into the middle of it.
+    rows[7] = container()
+        .width(MARKED_WIDTH)
+        .height(ROW_HEIGHT)
+        .background(Color::rgb(1.0, 0.0, 0.0))
+        .elevation(24.0);
+
+    let lifted = tops(
+        container()
+            .width(200.0)
+            .height(VIEWPORT)
+            .scrollable(ScrollAxis::Vertical)
+            .child(
+                container()
+                    .layout(Flex::column().spacing(PITCH - ROW_HEIGHT))
+                    .translate(Translate::new(0.0, -LIFT))
+                    .children(rows),
+            ),
+        MARKED_WIDTH,
+    );
+
+    assert_eq!(
+        lifted.len(),
+        1,
+        "a row whose shadow reaches down into the viewport was cut by the near \
+         edge of the search, which was not widened by what its children reach"
+    );
+}

--- a/tests/snapshots/scrolling.snap
+++ b/tests/snapshots/scrolling.snap
@@ -16,6 +16,8 @@ node 0,0 648x216
         draw rect 0,0 120x24 fill=#404059ff radius=4/4/4/4
       node 0,0 120x24 at 8,206
         draw rect 0,0 120x24 fill=#404059ff radius=4/4/4/4
+      node 0,0 120x24 at 8,239
+        draw rect 0,0 120x24 fill=#404059ff radius=4/4/4/4
     node 0,0 6x196 at 192,2
       draw rect 0,0 6x196 fill=#ffffff0d radius=100/100/100/100
     node 0,0 6x60.49 at 192,2


### PR DESCRIPTION
## What changed

Two things narrow a container's children to a cull rect — the binary-search
window and the per-child cull beside it — and both asked about **laid-out**
bounds. A child's own `translate`, `rotate` or `scale` is applied inside its own
`paint`, after the parent has already decided, so a subtree lifted 300px was
still chosen by where it would have been. A scroller over a lifted column
painted eight rows and every one of them sat above the viewport.

Now the rect follows the transform as it descends, and a widget says how far its
paint can land outside its box so whoever is about to narrow it knows to keep
it. **A transform is still paint work**: nothing about this reflows anything.

Closes #316.

## What proves it

`tests/cull_follows_the_transform.rs` — five scenarios, all red before:

- a lifted column paints the rows the lift brings into view, not the rows that
  would have been there
- an *un*lifted column still narrows, so the fix cannot be "widen until nothing
  is culled"
- a row its own transform lifts into view survives **both** frames — the window
  and the per-child cull take turns, and only the second frame reaches the cull
- a row whose **child** is lifted is kept: the reach gathers upward, or the row
  is culled at its laid-out bounds and the visible box goes with it
- a subtree scaled to nothing paints nothing: `scale(0.0)` has no inverse, and
  the answer is the empty rect rather than *no* rect. **20 rows** are painted
  without that, measured.

`mod reach_tests` in `src/widgets/container/style.rs` pins the arithmetic, which
a review found ten pixels short by working an example by hand: the shadow and
the transform compose rather than alternate, and a rotation's outset is not
monotone in its angle, so it gets the worst angle outright — bounded by the
circle its furthest corner sweeps about the pivot, which a centre-shaped bound
under-reports by 50px for a corner pivot.

In `src/widgets/container/characterization.rs`, the invalidation contract:

| test | mechanism | with it removed |
| --- | --- | --- |
| `a_transform_invalidates_paint_only` | translate/rotate/scale queue `[Paint]`, not `[Layout]` | — |
| `a_transform_does_not_reflow_the_parent_either` | the reads are untracked | `got [Layout]` |
| `a_declared_transform_change_invalidates_the_reach_without_a_layout` | the `refresh_paint_bounds` hook | `left: 0.0, right: 30.0` |
| `a_reach_that_grows_under_a_relayout_boundary_still_reaches_the_parent` | `gather_reach_upward` | `left: 0.0, right: 70.0` |
| `a_reach_that_shrinks_lets_the_parent_narrow_again` | the shrink path re-measures | `left: 70.0, right: 0.0` |

Those right-hand numbers are runs, not claims: each mechanism was deleted in
turn and the test watched to fail. An earlier revision of this branch cited two
of these tests in its commit message when they had been destroyed by a stray
`git checkout` — the review caught it by mutation, which is why they are
tabulated here with what actually happens.

`tests/snapshots/scrolling.snap` gains one row, re-blessed with the maintainer's
authorisation — hence `golden-update`. Its rows carry a one-pixel translate
each, so the widest reach is 19px, the window widens by 19px on a 33px pitch,
and one more row falls inside. **One row rather than the thirteen** an
all-or-nothing answer costs — which is what an earlier attempt did, and why the
reach is a magnitude rather than a boolean.

No golden moved, and none should: no golden scenario holds a scroller.

## Prior art

The mechanism was agreed with the maintainer before it was written, after
reading up how others cull a transformed child.

- **Blink** runs a [PrePaint tree walk](https://chromium.googlesource.com/chromium/src/+/HEAD/third_party/blink/renderer/core/paint/README.md)
  between layout and paint that builds the transform property trees and computes
  cull rects, driven by `NeedsPaintPropertyUpdate` — *paint*-level dirty bits,
  never layout ones. It culls against the **visual rect**, "the bounding box of
  all pixels that will be painted", not the layout box.
- **Flutter** gives every `RenderObject` an
  [`applyPaintTransform`](https://api.flutter.dev/flutter/rendering/RenderObject/applyPaintTransform.html)
  and a [`paintsChild`](https://api.flutter.dev/flutter/rendering/RenderObject/paintsChild.html),
  so a parent can ask a child where it will paint *before* painting it. Both
  Flutter and Blink union descendant paint bounds up the tree, which is what
  `gather_reach_upward` does.
- **Qt** indexes `QGraphicsScene` on `boundingRect` and culls against it, with
  the item's transform already applied.
- **GTK4** puts the transform in the render node tree, so a `GskTransformNode`'s
  bounds are its child's run through `gsk_transform_transform_bounds`.

The common answer: **cull against geometry that already accounts for the node's
own transform, computed in a pass after layout and before paint, invalidated by
paint-level dirty bits.** Guido already had that pass — `process_jobs` — so this
adds `Widget::refresh_paint_bounds` (defaulted, so no existing implementor
breaks) and calls it from the Paint loop. Layout publishes the value too,
because the reach depends on bounds and only layout knows those, but nothing
subscribes it.

Rejected on the way, recorded so the ground is not covered twice: a structural
"does this child declare a transform" flag, which cost a 20-row list its entire
window for a decorative 1px translate; and reading the reach under
`JobType::Layout`, which made a transform a layout property — the one thing it
must not be.

## What the review found

Three passes. The first two returned **three blocking findings each round**, all
acted on; the third returned **one**, also acted on. The one that mattered most:
`snapshot_zone` does *not* suspend tracking — it silences the non-reactive-read
diagnostic and leaves the read registered — so an earlier revision claimed
transforms were paint-only while they were reflowing the *parent*. The test that
was supposed to prove it could not, because its container was the root, where
there is no enclosing scope to catch the read.

Findings answered rather than fixed:

- **The reach is one scalar for four sides**, so a widget that moves down widens
  the search and the damage rect in every direction. Deliberate; a directional
  reach would change `Tree::set_paint_overflow`'s signature and wants its own
  change.
- **`children_reach` is a shared max across siblings**, so one row lifted 400px
  widens the search for the whole list. Correct, and it costs virtualization in
  that case. The per-child cull already uses each child's own reach; only the
  binary search needs a single number, because a per-child reach makes its
  predicate non-monotone and there is nothing left to bisect.
- **A `.timeline(..)` is not bounded** by `max_transform_reach` — its keyframes
  are the animation's, not a declaration. Safe because a playing animation
  queues a Paint job per changed frame and the reach is recomputed from it; the
  doc says that now instead of claiming a bound it does not have.

## What was checked by hand

Nothing. Every claim above is a test in this branch, and the mechanisms are
watched by deleting them and running the suite. The full harness, `cargo clippy
--all-targets --all-features -- -D warnings`, `cargo test --test golden_images`
on lavapipe with `GUIDO_GPU_REQUIRED=1`, `documentation_references` and `mdbook
test` are all green.

## Left undone

- **#318** — damage covers where a transform went, never where it came back
  from. Measured: moving a child +100 damages `-90,-90 250x250`; moving it back
  damages `10,10 50x50` and the vacated pixels are never named. `main` gets
  *both* directions wrong, so this branch fixes half of it. The general form is
  wider than transforms — nothing damages what a widget vacates when any
  paint-only property shrinks its reach.
- **#319** — a widget culled before it ever painted holds no paint subscription,
  so a transform that would bring it back on screen notifies nobody. Pre-existing
  and unchanged here; what this branch adds is that a widget which *has* painted
  now refreshes correctly, which is what makes the exception worth naming.
