### PR TITLE
A reach that shrinks names the ring it is giving up

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -570,6 +570,13 @@ The paint system tracks which widgets need repainting:
   per-surface `DamageRegion` (None/Partial/Full), keyed by the surface's root widget so
   multi-surface apps can't consume each other's damage. Damage is set as pending state
   BEFORE presenting, so it rides the commit that `present()` performs internally.
+- **Vacated rects**: that rect always describes the widget as it is *now*, so anything
+  that makes a widget cover *less* has to name what it is leaving before it changes —
+  `set_origin` and `cache_layout` damage the old rect and then the new one, and
+  `set_own_paint_reach` damages the ring a shrinking reach gives up (a transform coming
+  back to rest, an elevation falling to zero). Without it the buffer is redrawn correctly
+  and the compositor is never told to re-composite the pixels the widget has left, so the
+  old position survives on screen as a fringe.
 - **Incremental flatten**: `RenderNode` caches its flattened commands. Clean subtrees
   (with `repainted == false`) reuse cached commands with a translation offset, skipping
   the full recursive flatten.

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1455,6 +1455,15 @@ mod tests {
         );
     }
 
+    /// The damage rect a surface root is holding, which every question about
+    /// damage below is asked of.
+    fn partial_damage(tree: &mut Tree, root: WidgetId) -> Rect {
+        match tree.take_damage(root) {
+            DamageRegion::Partial(rect) => rect,
+            other => panic!("expected partial damage, got {other:?}"),
+        }
+    }
+
     /// Build `root -> [a, b]`, both laid out and clean.
     fn two_children_tree() -> (Tree, WidgetId, WidgetId, WidgetId) {
         let mut tree = Tree::new();
@@ -1528,15 +1537,11 @@ mod tests {
             Size::new(10.0, 20.0),
         );
 
-        match tree.take_damage(root) {
-            DamageRegion::Partial(rect) => {
-                assert!(
-                    rect.width >= 40.0,
-                    "damage must cover the old 40px-wide box, got {rect:?}"
-                );
-            }
-            other => panic!("expected partial damage, got {other:?}"),
-        }
+        let rect = partial_damage(&mut tree, root);
+        assert!(
+            rect.width >= 40.0,
+            "damage must cover the old 40px-wide box, got {rect:?}"
+        );
     }
 
     /// Moving a widget damages both where it was and where it lands. Its own
@@ -1547,19 +1552,15 @@ mod tests {
 
         tree.set_origin(a, 0.0, 60.0);
 
-        match tree.take_damage(root) {
-            DamageRegion::Partial(rect) => {
-                assert!(
-                    rect.y <= 0.0,
-                    "damage must reach the old position, got {rect:?}"
-                );
-                assert!(
-                    rect.y + rect.height >= 80.0,
-                    "damage must reach the new position, got {rect:?}"
-                );
-            }
-            other => panic!("expected partial damage, got {other:?}"),
-        }
+        let rect = partial_damage(&mut tree, root);
+        assert!(
+            rect.y <= 0.0,
+            "damage must reach the old position, got {rect:?}"
+        );
+        assert!(
+            rect.y + rect.height >= 80.0,
+            "damage must reach the new position, got {rect:?}"
+        );
         assert!(
             !tree.needs_paint(a),
             "a widget that only moved keeps its cached paint"
@@ -1577,19 +1578,15 @@ mod tests {
 
         tree.mark_needs_paint(a);
 
-        match tree.take_damage(root) {
-            DamageRegion::Partial(rect) => {
-                assert!(
-                    rect.x <= -8.0 && rect.y <= -8.0,
-                    "damage must reach above and left of the widget, got {rect:?}"
-                );
-                assert!(
-                    rect.width >= 40.0 + 16.0 && rect.height >= 20.0 + 16.0,
-                    "and past its far edges, got {rect:?}"
-                );
-            }
-            other => panic!("expected partial damage, got {other:?}"),
-        }
+        let rect = partial_damage(&mut tree, root);
+        assert!(
+            rect.x <= -8.0 && rect.y <= -8.0,
+            "damage must reach above and left of the widget, got {rect:?}"
+        );
+        assert!(
+            rect.width >= 40.0 + 16.0 && rect.height >= 20.0 + 16.0,
+            "and past its far edges, got {rect:?}"
+        );
     }
 
     /// The widest child shrinking is the case the prune must not skip.
@@ -1827,14 +1824,12 @@ mod tests {
         );
 
         tree.mark_needs_paint(card);
-        match tree.take_damage(root) {
-            DamageRegion::Partial(rect) => assert!(
-                rect.x <= 60.0 && rect.y <= 60.0 && rect.width >= 80.0 && rect.height >= 60.0,
-                "the card's shadow is outside the damage rect, so it is left on \
-                 screen as a fringe: got {rect:?}"
-            ),
-            other => panic!("expected partial damage, got {other:?}"),
-        }
+        let rect = partial_damage(&mut tree, root);
+        assert!(
+            rect.x <= 60.0 && rect.y <= 60.0 && rect.width >= 80.0 && rect.height >= 60.0,
+            "the card's shadow is outside the damage rect, so it is left on \
+             screen as a fringe: got {rect:?}"
+        );
     }
 
     #[test]
@@ -1843,12 +1838,8 @@ mod tests {
 
         tree.mark_needs_paint(a);
 
-        match tree.take_damage(root) {
-            DamageRegion::Partial(rect) => {
-                assert_eq!((rect.x, rect.y), (0.0, 0.0));
-                assert_eq!((rect.width, rect.height), (40.0, 20.0));
-            }
-            other => panic!("expected partial damage, got {other:?}"),
-        }
+        let rect = partial_damage(&mut tree, root);
+        assert_eq!((rect.x, rect.y), (0.0, 0.0));
+        assert_eq!((rect.width, rect.height), (40.0, 20.0));
     }
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -503,6 +503,11 @@ impl Tree {
     /// carried outside it reports nothing, an ancestor narrowing by laid-out
     /// bounds drops the row, and the visible box goes with it. Flutter and
     /// Blink union descendant paint bounds up the tree for the same reason.
+    ///
+    /// A reach that shrinks damages the ring it is vacating before it goes, on
+    /// the same contract as `set_origin`: the rect a repaint reports is built
+    /// from the reach the widget has *now*, so nothing else would ever name
+    /// the pixels it painted a frame ago.
     pub fn set_own_paint_reach(&mut self, id: WidgetId, reach: f32) {
         let Some(idx) = self.get_dense_index(id) else {
             return;
@@ -515,9 +520,20 @@ impl Tree {
         // reads `paint_overflow`, so a widget whose children already reach
         // further has moved nothing anyone can see, and the walk above it —
         // whose shrink path re-measures siblings — is pure cost.
-        let before = self.paint_overflow(id);
+        let before = self.paint_overflow_from(self.dense[idx].own_paint_reach, idx);
+        let after = self.paint_overflow_from(reach, idx);
+        // A reach that shrinks vacates the ring between the two, and the rect
+        // built from the new one stops short of it. Damaged before the write,
+        // while the old reach is still what this widget answers — the same
+        // shape `set_origin` uses for the geometry it owns, and for the same
+        // reason. A reach that *grows* needs none of it: the mark that follows
+        // builds a rect from the wider value, and it contains the narrower one.
+        if after < before
+            && let Some((root, vacated)) = self.surface_relative_bounds_and_root(id)
+        {
+            self.expand_damage_rect(root, vacated);
+        }
         self.dense[idx].own_paint_reach = reach;
-        let after = self.paint_overflow(id);
         if before == after {
             return;
         }
@@ -712,10 +728,14 @@ impl Tree {
     /// somewhere other than where it was laid out.
     pub(crate) fn paint_overflow(&self, id: WidgetId) -> f32 {
         self.get_dense_index(id).map_or(0.0, |idx| {
-            self.dense[idx]
-                .own_paint_reach
-                .max(self.dense[idx].children_outset)
+            self.paint_overflow_from(self.dense[idx].own_paint_reach, idx)
         })
+    }
+
+    /// The same, for a reach the caller names — which is how a write asks what
+    /// its own answer is about to become while the old one is still standing.
+    fn paint_overflow_from(&self, reach: f32, idx: usize) -> f32 {
+        reach.max(self.dense[idx].children_outset)
     }
 
     /// Get the children of a widget (returns a slice to avoid heap allocation).
@@ -1841,5 +1861,88 @@ mod tests {
         let rect = partial_damage(&mut tree, root);
         assert_eq!((rect.x, rect.y), (0.0, 0.0));
         assert_eq!((rect.width, rect.height), (40.0, 20.0));
+    }
+
+    /// A 50x50 child inset in a 200x200 root, with its damage taken and its
+    /// paint flags cleared — the shape both questions below are asked of.
+    fn inset_child() -> (Tree, WidgetId, WidgetId) {
+        let mut tree = Tree::new();
+        let root = tree.register(Box::new(MockWidget::new()));
+        let child = tree.register(Box::new(MockWidget::new()));
+        tree.set_parent(child, root);
+
+        let c = Constraints::new(0.0, 0.0, 200.0, 200.0);
+        tree.cache_layout(root, c, Size::new(200.0, 200.0));
+        tree.cache_layout(child, c, Size::new(50.0, 50.0));
+        tree.set_origin(child, 10.0, 10.0);
+        for id in [root, child] {
+            tree.clear_needs_paint(id);
+        }
+        let _ = tree.take_damage(root);
+        (tree, root, child)
+    }
+
+    /// A transform carries a widget away from its box and then back, and the
+    /// frame it comes back on has to name the pixels it is leaving.
+    ///
+    /// The outbound frame damages where the widget went, because the reach is
+    /// refreshed before the rect is built and the rect is built from the reach.
+    /// The return frame is refreshed the same way and reports the widget's own
+    /// 50x50 box — so the pixels at its old position are never handed to
+    /// `wl_surface.damage_buffer` and the compositor leaves the widget there.
+    #[test]
+    fn damage_covers_where_a_transform_came_back_from() {
+        let (mut tree, root, child) = inset_child();
+
+        // Out: a translate of 100 reaches 100 past every edge.
+        tree.set_own_paint_reach(child, 100.0);
+        tree.mark_needs_paint(child);
+        let went = partial_damage(&mut tree, root);
+        assert_eq!(
+            Rect::new(10.0, 110.0, 50.0, 50.0).outset_beyond(went),
+            0.0,
+            "the outbound frame does not even cover where it went: {went:?}"
+        );
+
+        tree.clear_needs_paint(child);
+        tree.clear_needs_paint(root);
+
+        // Back to rest, on the frame after.
+        tree.set_own_paint_reach(child, 0.0);
+        tree.mark_needs_paint(child);
+        let came_back = partial_damage(&mut tree, root);
+        assert_eq!(
+            went.outset_beyond(came_back),
+            0.0,
+            "the return frame damages {came_back:?}, which leaves the pixels \
+             the widget occupied at {went:?} on screen as a fringe"
+        );
+    }
+
+    /// The same defect without a transform anywhere near it.
+    ///
+    /// An elevation falling to nothing shrinks the same reach by the same
+    /// route, and predates transforms contributing to it at all. Here so the
+    /// fix is not made transform-shaped when the defect is not.
+    #[test]
+    fn damage_covers_the_shadow_an_elevation_drop_leaves_behind() {
+        let (mut tree, root, child) = inset_child();
+
+        tree.set_own_paint_reach(child, 8.0);
+        tree.mark_needs_paint(child);
+        let with_shadow = partial_damage(&mut tree, root);
+
+        tree.clear_needs_paint(child);
+        tree.clear_needs_paint(root);
+
+        tree.set_own_paint_reach(child, 0.0);
+        tree.mark_needs_paint(child);
+        let without = partial_damage(&mut tree, root);
+        assert_eq!(
+            with_shadow.outset_beyond(without),
+            0.0,
+            "the frame that drops the shadow damages {without:?}, so the ring \
+             it cast at {with_shadow:?} stays on screen"
+        );
     }
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1882,6 +1882,44 @@ mod tests {
         (tree, root, child)
     }
 
+    /// A reach that shrinks without moving the union vacates nothing, and so
+    /// damages nothing.
+    ///
+    /// The guard is `after < before`, and equality is the boundary it turns on.
+    /// A widget whose children already reach further than it does can drop its
+    /// own reach to nothing without a pixel changing hands — `paint_overflow`
+    /// answers the children's number before and after — so a rect damaged here
+    /// would be a rect re-composited for no reason, on every frame of the
+    /// return leg of every spring under a wider sibling.
+    ///
+    /// Reading `<=` instead is what this refuses. Nothing else does: the two
+    /// spellings agree everywhere except exactly here.
+    #[test]
+    fn a_reach_that_shrinks_under_its_children_damages_nothing() {
+        let (mut tree, root, child) = inset_child();
+
+        // The child reaches 90 past the root's own box, so the root's union is
+        // the child's from here on.
+        tree.set_own_paint_reach(child, 100.0);
+        assert_eq!(tree.children_outset(root), 90.0, "the setup, not the claim");
+        tree.set_own_paint_reach(root, 30.0);
+        let _ = tree.take_damage(root);
+
+        let held = tree.paint_overflow(root);
+        tree.set_own_paint_reach(root, 10.0);
+        assert_eq!(
+            tree.paint_overflow(root),
+            held,
+            "the union has to be the children's on both sides, or this asks \
+             nothing"
+        );
+
+        assert!(
+            matches!(tree.take_damage(root), DamageRegion::None),
+            "nothing was vacated, so nothing should have been damaged"
+        );
+    }
+
     /// A transform carries a widget away from its box and then back, and the
     /// frame it comes back on has to name the pixels it is leaving.
     ///

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -2697,6 +2697,62 @@ fn a_falling_elevation_animates_down_instead_of_snapping() {
     assert_eq!(shadow_count(&h.paint()), 0, "and settles flat");
 }
 
+/// An elevation that goes flat damages the ring the shadow gave up, whichever
+/// line gets there first.
+///
+/// A shrinking reach vacates a ring that a rect built from the *new* reach
+/// stops short of. Two separate things cover it here, and the point of this
+/// test is that it does not care which:
+///
+/// - `Container::layout` calls `cache_layout` before `publish_paint_reach`, so
+///   the mark happens while the old reach is still standing.
+/// - `Tree::set_own_paint_reach` damages the ring itself when the reach shrinks.
+///
+/// So this is not what proves that fix — an elevation never takes the path the
+/// fix was written for, which is the Paint job (`refresh_paint_bounds` shrinks
+/// the reach, `mark_needs_paint` follows), and that is watched at the `Tree`
+/// level. What this says is that the *outcome* holds for a real elevation on a
+/// real container, and keeps holding if either of the two ever goes away: swap
+/// the two lines in `layout` and the setter still covers it, take the setter's
+/// damage out and the order still does.
+#[test]
+fn an_elevation_going_flat_damages_the_ring_the_shadow_gave_up() {
+    let level = create_signal(8.0f32);
+    let mut h = H::new(
+        container()
+            .width(40.0)
+            .height(40.0)
+            .background(Color::RED)
+            .elevation(move || level.get()),
+    );
+    h.fit(100.0, 100.0);
+    h.paint();
+
+    let lifted = h.tree.paint_overflow(h.root);
+    assert!(lifted > 0.0, "a lifted card has to reach past its box");
+    let ring = h.tree.get_bounds(h.root).expect("laid out").outset(lifted);
+    let _ = h.tree.take_damage(h.root);
+
+    level.set(0.0);
+    pump(&mut h);
+    h.fit(100.0, 100.0);
+    assert_eq!(
+        h.tree.paint_overflow(h.root),
+        0.0,
+        "the shadow is what this frame gives up"
+    );
+
+    match h.tree.take_damage(h.root) {
+        crate::tree::DamageRegion::Partial(rect) => assert_eq!(
+            ring.outset_beyond(rect),
+            0.0,
+            "the frame that flattens the shadow damages {rect:?}, so the ring \
+             it cast at {ring:?} is left on screen"
+        ),
+        other => panic!("expected partial damage, got {other:?}"),
+    }
+}
+
 /// The clamp the descent above must not trip is still doing its job.
 ///
 /// A spring keeps its momentum across a retarget, so hover flicker pumps it:


### PR DESCRIPTION
## What changed

A widget's damage rect is its bounds grown by `paint_overflow`, and that value is
refreshed before the rect is built — so the rect always described the widget as
it is *now*, and the pixels it covered a moment ago were never named. A 50x50
child that translates 100 down damaged `-90,-90 250x250` going out and
`10,10 50x50` coming back, leaving the widget's old position on screen as a
fringe for whatever the compositor did not re-composite. `Tree::set_own_paint_reach`
now damages the ring a shrinking reach gives up, before the write, the same way
`set_origin` and `cache_layout` already damage the geometry they vacate. Closes #318.

## What proves it

- `tree::tests::damage_covers_where_a_transform_came_back_from` — the issue's
  scenario and its numbers. Fails without the fix with exactly the reported
  `10,10 50x50` against `-90,-90 250x250`.
- `tree::tests::damage_covers_the_shadow_an_elevation_drop_leaves_behind` — the
  same through a reach that is a shadow rather than a transform. Fails without
  the fix with `10,10 50x50` against `2,2 66x66`.
- `container::characterization::an_elevation_going_flat_damages_the_ring_the_shadow_gave_up`
  — a real container and a real elevation, added after review. It does **not**
  fail without the fix, and says so in its own comment: see the review section.

- `tree::tests::a_reach_that_shrinks_under_its_children_damages_nothing` — added
  after CI. The mutation job found `<` and `<=` indistinguishable in the new
  guard; they differ only where a widget's children already reach further than
  it does, which is where `<=` would re-composite a rect for nothing on every
  frame of a spring's return leg. Confirmed by applying the mutant and watching
  it fail.

No golden or snapshot moved, and none should. Damage is what the compositor is
told to re-composite; a golden renders one frame into a texture and never
consults the damage region, so no pixel test can see this either way.

Harness: `cargo fmt --check`, `clippy --all-targets --all-features -D warnings`,
`cargo test --all-features`, the 9 goldens on lavapipe, the whole suite again
with the lavapipe ICD and `GUIDO_GPU_REQUIRED=1` so nothing skipped,
`RUSTDOCFLAGS="-D warnings" cargo doc`, and `documentation_references`.

## What the review found

**Zero blocking.** Two findings worth answering, both acted on.

1. *The commit body's justification was wrong at one call site.* It claimed an
   unconditional `mark_needs_paint` would be a no-op at all of them; in
   `Container::layout`, `cache_layout` (line 1396) runs before
   `publish_paint_reach` (line 1437), so the mark carries the *old* reach and
   the claim is false. Verified and the commit message rewritten to say what is
   actually true: the fix closes the Paint-job path, and the other writers were
   already covered by call order.

2. *The elevation twin went through the same one-scalar setter as the transform
   one, so it could not distinguish what the issue asked it to.* Correct. I tried
   to make it real at the `Container` level and found something better than a
   test: **an elevation never takes the broken path at all.** Its reach shrinks
   during layout, where `cache_layout` has already marked with the old reach — I
   confirmed this by probing, the reach stays at 25.6 across six job pumps and
   only drops on the next `fit`. So the elevation case was never a live instance
   of this bug; it was covered by the order of two lines, and nothing said so.
   The new container-level test pins the outcome rather than the mechanism: it
   fails only if *both* the ordering and the setter's damage go away. Its doc
   comment states plainly that it is not what proves the fix.

Notes taken and not acted on: `measure_children` still spells the
`own_paint_reach.max(children_outset)` union inline, so "one home for the
formula" holds for the two sides of the new comparison but not tree-wide;
`book/src/architecture/rendering.md` describes damage in the terms the docs
paragraph was extended past, which leaves it incomplete rather than untrue.

## What was checked by hand

Nothing on a compositor. This change is about what goes out on
`wl_surface.damage_buffer`, which is the harness table's one uncovered row — and
the recorder cannot see it either, as noted under Left undone. What I did check by hand
is the ordering claim above, by reading the two call sites and by probing when
the reach actually drops; and I verified the container-level test's failure modes
by swapping the two lines in `Container::layout` in both directions and running it.

## Left undone

- **Damage stops at `Tree` because nothing above it can see damage.** The
  `Headless` recorder takes the `Platform` trait's no-op `damage`
  (`src/lib.rs:840-842`) and discards what the loop tells it, so no test in
  `tests/` can assert what a frame actually reported through `iterate`. That is
  why the proof here asserts `Tree::take_damage` rather than the rect the
  compositor would be handed. Worth closing if anyone extends the recorder;
  recorded here rather than as an issue.
- The issue's own non-goals stand: the one-scalar symmetric reach, and damage
  for a subtree under a moved widget (`surface_relative_bounds_and_root` sums
  ancestor origins and ignores ancestor transforms).
- The review noted `remeasure_children` can also shrink `paint_overflow` without
  damaging a vacated rect. I did not file it: the altitude reading found it is
  covered by construction, since the shrink there is always caused by a child
  that damaged its own vacated rect first, and an ancestor's ring is a uniform
  outset of its own box. Recording the reasoning here rather than an issue,
  since the conclusion is "nothing to do" rather than "later".

https://claude.ai/code/session_01VApCRoAUGzxx4cZEHohTsj

