### PR TITLE
An issue is what clears a bar, not whatever is left over

### DIFF
--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -63,8 +63,12 @@ learns to skim, and then the one finding that mattered is skimmed with it.
 - **Worth answering.** Real, and the author may act on it or say in the pull
   request why they did not. Silence is what is not allowed, not disagreement.
 - **Note.** A nit, a wording, a thing to consider if somebody touches this
-  again. It goes in the pull request or an issue. It never stops anything, and a
-  reader who ignores every note has lost nothing.
+  again. It goes in the pull request, and by default that is where it stays: a
+  note becomes an issue only when somebody is worse off today and the fix needs
+  an acceptance criterion this change's test cannot state, which is the bar
+  AGENTS.md step 7 sets. Offering both homes with no way to choose is how a
+  review that found nothing wrong still files three issues. It never stops
+  anything, and a reader who ignores every note has lost nothing.
 
 For each finding: what is wrong, where — file and line — and what would have to
 be true instead. Distinguish what you verified by reading or running it from

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -120,7 +120,11 @@ Push the branch, `gh pr create`, fill in the template. Link the issue with
 `Closes #$ARGUMENTS`.
 
 Whatever goes under **Left undone** that has to outlive this change gets an
-issue in the same act, and the template gets its number. `AGENTS.md` says why.
+issue in the same act, and the template gets its number. `AGENTS.md` says why —
+and sets the bar for which of them earns one, which is that somebody is worse
+off today and the fix needs an acceptance criterion this change's test cannot
+state. Everything else is a sentence in the body. Do not open an issue for
+something you could have fixed under this pull request's own title.
 
 Then report back, in five lines: what changed, what proves it, what the review
 found, what you looked at by hand, and anything you left undone, why, and

--- a/.claude/skills/renderer/SKILL.md
+++ b/.claude/skills/renderer/SKILL.md
@@ -73,10 +73,28 @@ never allocate it.
 
 ## Rendering somewhere other than a screen
 
-`Renderer::render_to_view(view, width, height, commands, layers, clear)` draws a
-frame into any texture. `render()` is that, plus acquiring a swapchain texture
-and presenting. This is what the golden image tests use, and it means anything
-in this pipeline can be tested without a compositor.
+`Renderer::render(target, commands, layers, clear)` takes a `RenderTarget`, and
+a frame lands in one of two places. `RenderTarget::Swapchain` is the
+compositor's: acquired per frame, presented after, and able to fail — `render`
+returns `false` for a lost or outdated swapchain, which is common right after a
+resize. `RenderTarget::Offscreen` is an `OffscreenTarget`, a texture the caller
+owns and nobody shows; it cannot fail that way because it is already there.
+Everything upstream draws the same commands either way.
+
+The offscreen half is behind `#[cfg(any(test, feature = "testing"))]`, so a test
+outside the crate turns on the `testing` feature to reach it. Read a frame back
+with `OffscreenTarget::read_pixel(x, y)`, which owns the row padding wgpu
+requires and the map-then-poll order — written correctly once here rather than
+copied wrongly per caller.
+
+`Renderer::render_to_view(view, width, height, commands, layers, clear)` is the
+layer under both: it draws into a texture view and knows nothing about where the
+view came from. `tests/golden_images.rs` still calls it and builds its own
+target. Everything since goes through `RenderTarget::offscreen(&gpu, width,
+height)` instead — `Headless` in `src/testing.rs` builds one per surface, which
+is what `tests/headless_app.rs` drives without naming it. That is the path to
+follow: it is the same `render` the compositor branch runs, and a third way to
+build a target is how the two drift.
 
 ## Performance
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -49,5 +49,10 @@ time. Which example, which compositor, what you saw. Screenshots welcome.
 Anything deliberately out of scope, and why. "Nothing" is a fine answer.
 
 Whatever has to outlive this change gets an issue in the same act; put its
-number here.
+number here. What earns one is a bar, not whatever is left over: ask who is
+worse off today and what they would see. Nobody worse off is a sentence here
+and no issue. Worse off, and it fits under this pull request's title, is
+something you should have done rather than listed. Worse off, and it needs an
+acceptance criterion this change's test cannot state, is the issue. AGENTS.md
+step 7 has the three in full.
 -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,6 +229,28 @@ themselves when the task touches them; you do not need to read them up front.
    issue in the same act — nobody opens a merged pull request's body again, and
    a follow-up recorded only there is written down and lost in one motion.
 
+   **What earns one is a bar, not whatever is left over.** The rule above with
+   no threshold is a machine for making issues: fifteen of thirty-six open ones
+   were raised by our own reviews of our own pull requests, and one of those was
+   about the rule that raises them. Ask **who is worse off today, and what would
+   they see** — a caller, a frame, an agent misled by a document — and the
+   answer picks one of three:
+
+   - **Nobody is.** A nit, a tidier spelling, something that would matter only
+     if somebody wrote a test nobody has asked for. It is a sentence in the pull
+     request body, or it is nothing. It is never an issue. If the issue you
+     would write has to say *there is no failing test to write today*, it is
+     this one.
+   - **Somebody is, and the fix belongs under this pull request's own title.**
+     Do it here, however many lines it takes. Size is not the question and never
+     was — a defect at a definition you are already editing is this one.
+   - **Somebody is, and it needs an acceptance criterion this change's test
+     cannot state.** That is the issue: not "too big", which nobody measures,
+     but separately provable.
+
+   You have to be able to name who. "Somebody might one day want to" is the
+   first case.
+
 `/implement <issue>` does all seven.
 
 ## Commits and pull requests

--- a/tests/agent_workflow.rs
+++ b/tests/agent_workflow.rs
@@ -547,3 +547,60 @@ fn what_is_left_undone_is_given_a_home_outside_the_pull_request() {
          question whose answer points past this change"
     );
 }
+
+/// And the rule that says *which* of them earns one.
+///
+/// "Whatever has to outlive this change gets an issue" has no threshold, so
+/// every observation clears it. Measured on 2026-09-02: fifteen of the
+/// thirty-six open issues were raised by our own reviews of our own pull
+/// requests, one of them about the rule that raises them. A workflow whose
+/// output is its own input does not converge.
+///
+/// The reason for the rule is unchanged — a follow-up written only in a merged
+/// body is written down and lost in one motion. What it needed was a bar, and
+/// the bar is a question with three answers rather than a size, because size is
+/// what everybody argues about and nobody measures.
+///
+/// Pinned in the two places an agent reads while deciding: the contract, and
+/// the reviewer's own description of what a note is for. The reviewer is the
+/// one that leaked — it said a note goes in the pull request *or* an issue and
+/// gave no way to choose, which for anything trying to be thorough reads as
+/// "an issue".
+#[test]
+fn an_issue_is_what_clears_a_bar_rather_than_whatever_is_left_over() {
+    const TRIAGE: &str = "worse off";
+
+    let agents = read("AGENTS.md");
+    let reviewer = read(".claude/agents/reviewer.md");
+    let template = read(".github/pull_request_template.md");
+
+    for (name, section) in [
+        (
+            "AGENTS.md's step 7",
+            section_from(&agents, "**Open the pull request**", "\n\n## "),
+        ),
+        (
+            "the template's `Left undone`",
+            section_from(&template, "## Left undone", "\n## "),
+        ),
+        (
+            "the reviewer's `Note` level",
+            section_from(&reviewer, "- **Note.**", "\n\n"),
+        ),
+    ] {
+        assert!(
+            unwrapped(section).contains(TRIAGE),
+            "{name} does not ask who is `{TRIAGE}` today, so nothing separates \
+             the follow-up that earns an issue from the one that is a nit"
+        );
+    }
+
+    // The reviewer used to offer the two homes and no way to pick between
+    // them. That exact phrasing is what the bar replaces, so it must not come
+    // back — a reworded rule elsewhere is survivable, this sentence is not.
+    assert!(
+        !unwrapped(&reviewer).contains("the pull request or an issue"),
+        "the reviewer offers a note both homes and no criterion, which is the \
+         sentence the bar exists to replace"
+    );
+}


### PR DESCRIPTION
## What changed

`Left undone` had a rule with no threshold — *whatever has to outlive this change
gets an issue* — so every observation cleared it. It now has a bar: **who is worse
off today, and what would they see.** Nobody worse off is a sentence in the pull
request body and never an issue; worse off but inside this pull request's own
title should have been done rather than listed; worse off and needing an
acceptance criterion this change's test cannot state is the issue.

Size is deliberately not the question. "Too big for this PR" is what everybody
argues about and nobody measures; *separately provable* is checkable.

## What proves it

`tests/agent_workflow.rs::an_issue_is_what_clears_a_bar_rather_than_whatever_is_left_over`
— fails without the change. It pins the triage in the three documents an agent
reads while deciding (the contract, the template, the reviewer's `Note` level),
and pins the reviewer's old "goes in the pull request or an issue" as a sentence
that must not come back. That sentence is where this leaked: two homes and no
criterion reads as "an issue" to anything trying to be thorough.

The existing `what_is_left_undone_is_given_a_home_outside_the_pull_request` still
passes — the reason for the rule is untouched, only the threshold is new.

Full harness green: fmt, clippy `-D warnings`, `cargo test --all-features`.

## What the review found

Not run. This is a change to the process documents and their test, with no
library code in it; the `reviewer` subagent's criteria are about commits, diffs
and harness coverage of behaviour. Saying so rather than reporting a review that
did not happen.

## What was checked by hand

Applied the bar to the fifteen self-generated issues to see whether it decides
rather than restates. It does: #309, #286, #284 and #266 fall in the first case
by their own wording — #286 says it "works and is the reason this is a tidiness
issue rather than a defect", #284 says "the point is not the 48ms", #309 says
"there is no failing test to write today". #273 is a stale paragraph in a skill, which the bar
says to *do* rather than track — an agent misled by a document is somebody
worse off, and the fix is a paragraph. It is the second commit here. The rest name somebody worse off
and need their own criterion, and stay. #309, #286, #284 and #266 are closed, each with the case of the bar
it falls under and its own wording quoted back.

## Left undone

Two judgment calls left open rather than decided quietly, both about harness
gaps, which is the shape closest to the line:

- **#276** (headless cannot stamp an input event with a named instant) stays
  open, where #321 — the recorder discarding damage, raised while writing #322 —
  was closed. The distinction is who asked: #276 is a capability #264'''s own
  **Expected** specified and did not deliver, so somebody asked for that test.
  #321 was invented by an agent to satisfy the rule this pull request fixes.
- **#221** (the  draft) is untouched. It is a record of a design
  decision with an unmerged branch behind it, not work waiting to be done, so
  the bar has nothing to say about it — that one is yours.

Nothing else. Tested against its own bar: the sweep is part of this act, not a
follow-up to it.

https://claude.ai/code/session_01VApCRoAUGzxx4cZEHohTsj
