### PR TITLE
Seven declared values are read once and never again

### DIFF
--- a/.claude/skills/widgets/SKILL.md
+++ b/.claude/skills/widgets/SKILL.md
@@ -12,11 +12,28 @@ declarations do not.**
 
 Reactive: `background`, `gradient`, `backdrop_blur`, `overflow`, `corners`,
 `border`, `translate`, `rotate`, `scale`, `pivot`, `width`, `height`,
-`padding`, `visible`, `elevation`.
+`padding`, `visible`, `elevation` — and beyond `Container`, `Text`'s `wrap`,
+`Image`'s `content_fit`, `TextInput`'s `password`, `mask_char` and `caret`,
+`RippleConfig`'s colour, and the direction a `Flex` is built with.
 
 Structural: `layout`, `child`, `children`, `scrollable`, `scrollbar`,
 `scrollbar_visibility`, `control`, the event handlers — and the *motion* a
 value is declared with, which is the next section.
+
+`autofocus` is the one that looks structural and is neither: it is a one-shot
+consumed at the first layout, so "take focus when this appears" is an event,
+and a signal form would mean something else.
+
+A zero-argument setter naming the off case — `nowrap()`, `no_caret()` — is a
+shorthand for the property beside it (`wrap(false)`, `caret(false)`), not a
+second way to say it. The property is what takes the signal.
+
+**A value read from an event handler is the exception, and it is a real one.**
+`TextInput`'s two clipboard guards ask whether the field masks *now*, untracked,
+rather than reading the copy layout took: an event does not wait for a layout
+pass, so the cached answer would export a secret for the frame after the field
+was told to hide it. Reading a declared value outside layout or paint means
+asking why the cache is not good enough, and saying so where it is read.
 
 An animatable property takes `impl IntoAnimated<T, M>` instead, which is
 everything `IntoSignal` accepts plus a value carrying its own motion:

--- a/book/src/building-ui/images.md
+++ b/book/src/building-ui/images.md
@@ -97,6 +97,25 @@ the pixels land. `Contain` takes only the largest rect of the image's own
 aspect ratio that fits, so the empty strip is left to the parent's alignment
 rather than painted.
 
+Like every declared value, it takes a signal as readily as a value, so an image
+can change how it fills its box without being rebuilt:
+
+```rust
+# extern crate guido;
+# use guido::prelude::*;
+# fn main() {
+# let cropped = create_signal(true);
+image("./photo.jpg").content_fit(move || {
+    if cropped.get() {
+        ContentFit::Cover
+    } else {
+        ContentFit::Contain
+    }
+})
+# ;
+# }
+```
+
 ```rust,ignore
 # extern crate guido;
 # use guido::prelude::*;

--- a/book/src/building-ui/text-input.md
+++ b/book/src/building-ui/text-input.md
@@ -483,10 +483,11 @@ fn login_form() -> Container {
 text_input(signal: Signal<String>) -> TextInput
 
 impl TextInput {
-    pub fn password(self, enabled: bool) -> Self;
-    pub fn mask_char(self, c: char) -> Self;
+    pub fn password<M>(self, enabled: impl IntoSignal<bool, M>) -> Self;
+    pub fn mask_char<M>(self, c: impl IntoSignal<char, M>) -> Self;
     pub fn autofocus(self) -> Self;
-    pub fn no_caret(self) -> Self;
+    pub fn caret<M>(self, caret: impl IntoSignal<bool, M>) -> Self;
+    pub fn no_caret(self) -> Self;  // Shorthand for caret(false)
     pub fn placeholder<M>(self, text: impl IntoSignal<String, M>) -> Self;
     pub fn on_change<F: Fn(&str) + 'static>(self, callback: F) -> Self;
     pub fn on_submit<F: Fn(&str) + 'static>(self, callback: F) -> Self;

--- a/book/src/building-ui/text-input.md
+++ b/book/src/building-ui/text-input.md
@@ -123,6 +123,21 @@ text_input(password)
 # }
 ```
 
+Masking is a declared value, so it takes a signal — which is what an eye icon
+beside the field needs. Declaring it rather than rebuilding the input is what
+keeps the caret, the selection and the focus where they were:
+
+```rust
+# extern crate guido;
+# use guido::prelude::*;
+# fn main() {
+# let password = create_signal(String::new());
+# let hidden = create_signal(true);
+text_input(password).password(hidden)
+# ;
+# }
+```
+
 By default, characters are masked with `•`. Customize the mask character:
 
 ```rust

--- a/book/src/building-ui/text.md
+++ b/book/src/building-ui/text.md
@@ -477,6 +477,7 @@ impl Text {
     pub fn font_weight<M>(self, weight: impl IntoSignal<FontWeight, M>) -> Self;
     pub fn bold(self) -> Self;      // Shorthand for FontWeight::BOLD
     pub fn mono(self) -> Self;      // Shorthand for FontFamily::Monospace
-    pub fn nowrap(self) -> Self;
+    pub fn wrap<M>(self, wrap: impl IntoSignal<bool, M>) -> Self;
+    pub fn nowrap(self) -> Self;    // Shorthand for wrap(false)
 }
 ```

--- a/book/src/interactivity/ripples.md
+++ b/book/src/interactivity/ripples.md
@@ -136,7 +136,12 @@ the two speeds can put the disc back where it started, half-grown and already
 invisible.
 
 Both speeds are clamped to a sane range, so a zero or a negative one degrades
-instead of stalling the frame loop:
+instead of stalling the frame loop.
+
+The colour is a `Signal<Color>`, as every other declared value is, so it is
+built through `RippleConfig::with_color` — which takes a value, a closure or a
+signal — rather than assigned as a bare `Color`. The two speeds stay plain
+numbers:
 
 ```rust,ignore
 # extern crate guido;
@@ -144,9 +149,9 @@ instead of stalling the frame loop:
 # fn main() {
 # container()
 .when_pressed(|s| s.ripple_config(RippleConfig {
-    color: Color::rgba(1.0, 1.0, 1.0, 0.3),
     expand_speed: 1.5,   // faster growth
     fade_speed: 1.0,
+    ..RippleConfig::with_color(Color::rgba(1.0, 1.0, 1.0, 0.3))
 }))
 # ;
 # }

--- a/book/src/interactivity/states.md
+++ b/book/src/interactivity/states.md
@@ -491,6 +491,6 @@ impl StateStyleBuilder {
 
     // Ripple
     pub fn ripple(self) -> Self;
-    pub fn ripple_with_color(self, color: Color) -> Self;
+    pub fn ripple_with_color<M>(self, color: impl IntoSignal<Color, M>) -> Self;
 }
 ```

--- a/src/jobs.rs
+++ b/src/jobs.rs
@@ -545,6 +545,35 @@ pub(crate) fn queued_job_types(widget_id: WidgetId) -> Vec<JobType> {
     })
 }
 
+/// Run everything a signal write queued for `root`'s surface, then lay it out.
+///
+/// The drain is what turns a write into `needs_layout` on the widget that read
+/// the signal — and, because `mark_needs_layout` walks to the relayout
+/// boundary, on the ancestors that have to descend to reach it. Skip it and
+/// every container takes its unchanged-constraints early-out, so nothing below
+/// is asked to lay out again and the test measures the cache instead of the
+/// resolution.
+///
+/// Here rather than in each `mod tests` that wants it: five of them had written
+/// this out, and one said so in its own comment, which is a duplicate
+/// cross-referencing a duplicate.
+#[cfg(test)]
+pub(crate) fn pump_and_layout(
+    tree: &mut Tree,
+    root: WidgetId,
+    constraints: crate::layout::Constraints,
+) -> Option<crate::layout::Size> {
+    let roots: rustc_hash::FxHashSet<WidgetId> = [root].into_iter().collect();
+    distribute_jobs(tree, &roots);
+    let drained = drain_surface_jobs(root);
+    let mut layout_roots = Vec::new();
+    process_jobs(&drained, tree, &mut layout_roots);
+    recycle_job_buffer(drained);
+    recycle_job_buffer(drain_orphan_jobs());
+
+    tree.with_widget_mut(root, |w, id, t| w.layout(t, id, constraints))
+}
+
 /// Forget every scheduled job (for testing).
 #[cfg(test)]
 pub(crate) fn clear_scheduled_jobs() {

--- a/src/layout/flex_layout.rs
+++ b/src/layout/flex_layout.rs
@@ -30,7 +30,7 @@
 
 use super::{Axis, Constraints, CrossAlignment, Layout, MainAlignment, Size};
 use crate::{
-    reactive::{IntoSignal, OptionSignalExt, Signal, create_stored},
+    reactive::{IntoSignal, OptionSignalExt, Signal},
     tree::{Tree, WidgetId},
 };
 
@@ -55,9 +55,9 @@ impl Flex {
     /// Default alignments match CSS Flexbox:
     /// - `main_alignment`: `Start` (CSS `justify-content: flex-start`)
     /// - `cross_alignment`: `Stretch` (CSS `align-items: stretch`)
-    pub fn new(direction: Axis) -> Self {
+    pub fn new<M>(direction: impl IntoSignal<Axis, M>) -> Self {
         Self {
-            direction: create_stored(direction),
+            direction: direction.into_signal(),
             spacing: None,
             main_alignment: None,
             cross_alignment: None,
@@ -425,4 +425,65 @@ impl Layout for Flex {
 /// aligns a baseline-less box among text.
 fn baseline_of(tree: &Tree, id: WidgetId, cross_size: f32) -> f32 {
     tree.baseline(id).unwrap_or(cross_size)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::jobs;
+    use crate::reactive::create_signal;
+    use crate::widgets::container;
+
+    fn frame(tree: &mut Tree, root: WidgetId) {
+        jobs::pump_and_layout(tree, root, Constraints::new(0.0, 0.0, 400.0, 400.0));
+    }
+
+    /// A row becomes a column on a write, with the same widgets in the tree.
+    ///
+    /// The direction has always been held as `Signal<Axis>` and read through it
+    /// on every pass — only `Flex::new`'s signature stood between here and a
+    /// layout that answers to one. Asserted on the children's origins rather
+    /// than on the container's size, because two boxes of the same size in a
+    /// square make the row and the column the same size and only the placement
+    /// tells them apart.
+    #[test]
+    fn a_row_becomes_a_column_when_its_direction_says_so() {
+        let horizontal = create_signal(true);
+        let axis = move || {
+            if horizontal.get() {
+                Axis::Horizontal
+            } else {
+                Axis::Vertical
+            }
+        };
+
+        let mut tree = Tree::new();
+        let root = tree.register(Box::new(container().layout(Flex::new(axis)).children(
+            vec![
+                container().width(20.0).height(20.0),
+                container().width(20.0).height(20.0),
+            ],
+        )));
+        tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
+
+        frame(&mut tree, root);
+        let kids = tree.get_children(root).to_vec();
+        assert_eq!(kids.len(), 2, "two children, laid out");
+        let second = tree.get_origin(kids[1]).expect("laid out");
+        assert!(
+            second.0 > 0.0 && second.1 == 0.0,
+            "a row puts the second child to the right, got {second:?}"
+        );
+
+        horizontal.set(false);
+        frame(&mut tree, root);
+
+        let same_kids = tree.get_children(root).to_vec();
+        assert_eq!(same_kids, kids, "the children were rebuilt, not relaid out");
+        let second = tree.get_origin(kids[1]).expect("laid out");
+        assert!(
+            second.1 > 0.0 && second.0 == 0.0,
+            "a column puts the second child below, got {second:?}"
+        );
+    }
 }

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -1379,6 +1379,76 @@ fn a_press_held_for_a_named_time_has_grown_by_a_named_amount() {
     );
 }
 
+/// The colour of the first overlay disc, which is the ripple.
+fn painted_ripple_color(h: &mut H) -> Option<Color> {
+    h.paint()
+        .overlay_commands
+        .iter()
+        .find_map(|cmd| match &**cmd {
+            DrawCommand::Circle { color, .. } => Some(*color),
+            _ => None,
+        })
+}
+
+/// A ripple's colour is declared, so a theme switch reaches it.
+///
+/// The one colour that animates under a finger was the one frozen at build
+/// time: `RippleConfig::color` was a `Color` where every other `StateStyle`
+/// setter took a signal. Now it is a `Signal<Color>`, as `BorderOverride`'s
+/// halves are, and the two speeds beside it stay plain.
+///
+/// Asserted on the drawn disc, and on its hue rather than its alpha, because
+/// the alpha is multiplied by the ripple's own opacity and falls as the disc
+/// fades — the hue is what the declaration decides.
+///
+/// What this cannot tell apart, and no test can: whether the read subscribes.
+/// A ripple only has a colour worth changing while it is running, and a running
+/// ripple repaints on every frame anyway — so the disc would follow the signal
+/// even if paint read it untracked. What is pinned here is the half that was
+/// actually broken: the colour is read per frame rather than captured when the
+/// state layer was declared.
+#[test]
+fn a_ripple_takes_the_colour_it_is_given_now() {
+    let hot = create_signal(Color::rgba(1.0, 0.0, 0.0, 0.4));
+    let mut h = H::new(
+        container()
+            .width(100.0)
+            .height(100.0)
+            .when_pressed(move |s: StateStyle| s.ripple_with_color(hot))
+            .on_click(|| {}),
+    );
+    h.fit(400.0, 400.0);
+
+    let t0 = std::time::Instant::now() - std::time::Duration::from_secs(60);
+    send_at(&mut h, t0, Event::mouse_down(50.0, 50.0, MouseButton::Left));
+    frame_at(
+        &mut h,
+        t0 + std::time::Duration::from_millis(8),
+        400.0,
+        400.0,
+    );
+
+    let red = painted_ripple_color(&mut h).expect("the press starts a ripple");
+    assert!(
+        red.r > 0.9 && red.g < 0.1,
+        "the declared colour is what the disc is drawn with, got {red:?}"
+    );
+
+    hot.set(Color::rgba(0.0, 0.0, 1.0, 0.4));
+    frame_at(
+        &mut h,
+        t0 + std::time::Duration::from_millis(16),
+        400.0,
+        400.0,
+    );
+
+    let blue = painted_ripple_color(&mut h).expect("the ripple is still running");
+    assert!(
+        blue.b > 0.9 && blue.r < 0.1,
+        "the ripple kept the colour it was built with, got {blue:?}"
+    );
+}
+
 /// Lay out, run the queued jobs, paint, and report the first text colour.
 fn painted_text_color(h: &mut H) -> Color {
     pump(h);

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -1379,6 +1379,32 @@ fn a_press_held_for_a_named_time_has_grown_by_a_named_amount() {
     );
 }
 
+/// One frame at a named instant, through the skip-frame gate.
+///
+/// `frame_at` pumps and lays out but leaves painting to the caller, so a test
+/// that then calls `h.paint()` repaints unconditionally and cannot see a frame
+/// the loop would have skipped. This one goes through `H::frame`, which serves
+/// the retained node when nothing needs paint — which is the whole difference
+/// between a value the loop noticed and one it did not.
+fn gated_frame_at(h: &mut H, now: std::time::Instant, width: f32, height: f32) -> Frame {
+    h.tree.set_frame_instant(Some(now));
+    let frame = h.frame(width, height);
+    h.tree.set_frame_instant(None);
+    frame
+}
+
+/// The colour of the first overlay disc in a frame the loop actually produced.
+fn ripple_color_of(frame: &Frame) -> Option<Color> {
+    frame
+        .node
+        .overlay_commands
+        .iter()
+        .find_map(|cmd| match &**cmd {
+            DrawCommand::Circle { color, .. } => Some(*color),
+            _ => None,
+        })
+}
+
 /// The colour of the first overlay disc, which is the ripple.
 fn painted_ripple_color(h: &mut H) -> Option<Color> {
     h.paint()
@@ -1401,12 +1427,18 @@ fn painted_ripple_color(h: &mut H) -> Option<Color> {
 /// the alpha is multiplied by the ripple's own opacity and falls as the disc
 /// fades — the hue is what the declaration decides.
 ///
-/// What this cannot tell apart, and no test can: whether the read subscribes.
-/// A ripple only has a colour worth changing while it is running, and a running
-/// ripple repaints on every frame anyway — so the disc would follow the signal
-/// even if paint read it untracked. What is pinned here is the half that was
-/// actually broken: the colour is read per frame rather than captured when the
-/// state layer was declared.
+/// The second half holds the press past its growth, which is the state the
+/// declaration has to survive: a ripple that has finished growing stops asking
+/// for frames so the loop can go quiet — see `Ripple::advance` — so the disc
+/// under a still finger is not being repainted by an animation, and a colour
+/// written then reaches the screen only because paint subscribed to it.
+///
+/// What this still does not pin is the subscription itself. Reading the colour
+/// untracked passes here too, because `Tree::cache_layout` marks the widget for
+/// paint on every layout pass — running layout *is* the invalidation signal —
+/// so the skip-frame gate never comes up after a `fit` and each frame repaints
+/// whatever the last write left. The read is tracked because the held case is
+/// real, not because anything in `src/` would object if it stopped being.
 #[test]
 fn a_ripple_takes_the_colour_it_is_given_now() {
     let hot = create_signal(Color::rgba(1.0, 0.0, 0.0, 0.4));
@@ -1446,6 +1478,32 @@ fn a_ripple_takes_the_colour_it_is_given_now() {
     assert!(
         blue.b > 0.9 && blue.r < 0.1,
         "the ripple kept the colour it was built with, got {blue:?}"
+    );
+
+    // Now hold it past its growth, which is where the loop is allowed to go
+    // quiet and where an unsubscribed read would strand the colour.
+    let settled = t0 + std::time::Duration::from_secs(2);
+    gated_frame_at(&mut h, settled, 400.0, 400.0);
+    assert!(
+        !pump(&mut h),
+        "a ripple held past its growth has to stop asking for frames, or the \
+         case this is about does not arise"
+    );
+
+    hot.set(Color::rgba(0.0, 1.0, 0.0, 0.4));
+    eprintln!("needs_paint after write = {}", h.tree.needs_paint(h.root));
+    let frame = gated_frame_at(
+        &mut h,
+        settled + std::time::Duration::from_millis(8),
+        400.0,
+        400.0,
+    );
+
+    eprintln!("frame colour = {:?}", ripple_color_of(&frame));
+    let green = ripple_color_of(&frame).expect("the finger is still down");
+    assert!(
+        green.g > 0.9 && green.b < 0.1,
+        "the disc under a still finger never saw the write, got {green:?}"
     );
 }
 

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -1505,6 +1505,49 @@ fn a_ripple_takes_the_colour_it_is_given_now() {
         green.g > 0.9 && green.b < 0.1,
         "the disc under a still finger never saw the write, got {green:?}"
     );
+    // The alpha is the declared one scaled by the disc's own opacity, which is
+    // 1.0 for a ripple held at full growth — so here the two coincide and the
+    // scaling is visible as itself rather than as some other arithmetic.
+    assert!(
+        (green.a - 0.4).abs() < 0.01,
+        "the declared alpha is scaled by the disc's opacity, not combined with \
+         it some other way: got {green:?}"
+    );
+}
+
+/// The pressed layer's ripple is the one that paints, even when another layer
+/// declares one too.
+///
+/// `ripple_config` asks for a layer that is *both* `Pressed` and has a ripple.
+/// Loosen that to either and the search — which runs in reverse declaration
+/// order — answers with whichever was declared last, so a hover ripple
+/// declared after a pressed one would take over the press.
+#[test]
+fn a_hover_ripple_does_not_stand_in_for_the_pressed_one() {
+    let mut h = H::new(
+        container()
+            .width(100.0)
+            .height(100.0)
+            .when_pressed(|s: StateStyle| s.ripple_with_color(Color::rgba(1.0, 0.0, 0.0, 0.4)))
+            .when_hovered(|s: StateStyle| s.ripple_with_color(Color::rgba(0.0, 0.0, 1.0, 0.4)))
+            .on_click(|| {}),
+    );
+    h.fit(400.0, 400.0);
+
+    let t0 = std::time::Instant::now() - std::time::Duration::from_secs(60);
+    send_at(&mut h, t0, Event::mouse_down(50.0, 50.0, MouseButton::Left));
+    frame_at(
+        &mut h,
+        t0 + std::time::Duration::from_millis(8),
+        400.0,
+        400.0,
+    );
+
+    let drawn = painted_ripple_color(&mut h).expect("the press starts a ripple");
+    assert!(
+        drawn.r > 0.9 && drawn.b < 0.1,
+        "the hover layer's colour reached a press it does not describe: {drawn:?}"
+    );
 }
 
 /// Lay out, run the queued jobs, paint, and report the first text colour.

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -1679,13 +1679,14 @@ impl Widget for Container {
             // Clips the ripples without affecting children.
             ctx.set_overlay_clip(local_bounds, corner_radii, corner_curvature);
 
-            // Once for the frame rather than once per disc, and untracked: the
-            // discs are what carry the colour, so a container with none has
-            // nothing to subscribe for — and a ripple that is running repaints
-            // every frame anyway, which is what keeps the colour current
-            // without a subscription. This sits outside the tracked block above
-            // because that block runs whether or not a ripple exists.
-            let declared = ripple_config.color.get_untracked();
+            // Once for the frame rather than once per disc, and tracked: a
+            // ripple held past its growth stops animating on purpose so the
+            // loop can go quiet — see `Ripple::advance` — so a colour written
+            // while the finger is still down would reach nothing at all
+            // without the subscription. Its own scope rather than the block
+            // above, because that block runs whether or not a disc exists and
+            // this read is already inside the guard that says one does.
+            let declared = with_signal_tracking(id, JobType::Paint, || ripple_config.color.get());
 
             for ripple in ix.ripple.iter() {
                 let opacity = ripple.opacity();

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -344,7 +344,7 @@ impl InteractionState {
             .iter()
             .rev()
             .find(|(when, s)| matches!(when, StateWhen::Pressed) && s.ripple.is_some())
-            .and_then(|(_, s)| s.ripple.clone())
+            .and_then(|(_, s)| s.ripple)
     }
 
     /// Whether the layer is active right now. Reading this is what subscribes
@@ -1679,6 +1679,14 @@ impl Widget for Container {
             // Clips the ripples without affecting children.
             ctx.set_overlay_clip(local_bounds, corner_radii, corner_curvature);
 
+            // Once for the frame rather than once per disc, and untracked: the
+            // discs are what carry the colour, so a container with none has
+            // nothing to subscribe for — and a ripple that is running repaints
+            // every frame anyway, which is what keeps the colour current
+            // without a subscription. This sits outside the tracked block above
+            // because that block runs whether or not a ripple exists.
+            let declared = ripple_config.color.get_untracked();
+
             for ripple in ix.ripple.iter() {
                 let opacity = ripple.opacity();
                 if opacity <= 0.0 {
@@ -1687,12 +1695,8 @@ impl Widget for Container {
                 let (center_x, center_y) = ripple.center(bounds.width, bounds.height);
                 let radius = ripple.radius(bounds.width, bounds.height);
 
-                let ripple_color = Color::rgba(
-                    ripple_config.color.r,
-                    ripple_config.color.g,
-                    ripple_config.color.b,
-                    ripple_config.color.a * opacity,
-                );
+                let ripple_color =
+                    Color::rgba(declared.r, declared.g, declared.b, declared.a * opacity);
 
                 ctx.draw_overlay_circle(center_x, center_y, radius, ripple_color);
             }

--- a/src/widgets/container/ripple.rs
+++ b/src/widgets/container/ripple.rs
@@ -339,7 +339,6 @@ mod tests {
     use std::time::Duration;
 
     use super::*;
-    use crate::widgets::Color;
 
     fn cfg() -> RippleConfig {
         RippleConfig::default()
@@ -498,9 +497,9 @@ mod tests {
     fn an_impossible_speed_does_not_stall_or_invert_the_effect() {
         for (expand, fade) in [(0.0, 0.0), (-2.0, -2.0), (f32::NAN, f32::INFINITY)] {
             let config = RippleConfig {
-                color: Color::WHITE,
                 expand_speed: expand,
                 fade_speed: fade,
+                ..Default::default()
             };
             let t0 = Instant::now();
             let mut state = RippleState::new();

--- a/src/widgets/image.rs
+++ b/src/widgets/image.rs
@@ -289,6 +289,52 @@ mod tests {
         jobs::pump_and_layout(tree, root, c).expect("the root is registered")
     }
 
+    /// A square SVG, inline, so the test needs no asset on disk and no decoder.
+    fn svg(side: u32) -> ImageSource {
+        let src = format!(
+            r#"<svg xmlns="http://www.w3.org/2000/svg" width="{side}" height="{side}"><rect width="{side}" height="{side}" fill="red"/></svg>"#
+        );
+        ImageSource::SvgBytes(src.into_bytes().into())
+    }
+
+    /// An image draws itself, at the box it was given and the fit it declares.
+    ///
+    /// `paint` had nothing watching it at all: emptying the whole method was
+    /// invisible to every test, because the one that asks about `content_fit`
+    /// asks the *measured size* and never looks at what was drawn.
+    #[test]
+    fn an_image_draws_its_source_into_its_own_box() {
+        let mut tree = Tree::new();
+        let root = tree.register(Box::new(Image::new(svg(20)).content_fit(ContentFit::Fill)));
+        tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
+        measured(&mut tree, root, Constraints::new(0.0, 0.0, 40.0, 40.0));
+
+        let mut node = crate::renderer::RenderNode::new(root.as_u64());
+        tree.with_widget_mut(root, |w, id, t| {
+            let mut ctx = crate::renderer::PaintContext::new(&mut node);
+            w.paint(t, id, &mut ctx);
+        });
+
+        let drawn = node
+            .commands
+            .iter()
+            .find_map(|cmd| match &**cmd {
+                crate::renderer::DrawCommand::Image {
+                    rect, content_fit, ..
+                } => Some((*rect, *content_fit)),
+                _ => None,
+            })
+            .expect("an image command");
+
+        assert_eq!(
+            (drawn.0.width, drawn.0.height),
+            (40.0, 40.0),
+            "the image is drawn into the box layout gave it, got {:?}",
+            drawn.0
+        );
+        assert_eq!(drawn.1, ContentFit::Fill, "and with the fit it declares");
+    }
+
     /// How an image fills its box is a value it can be told.
     ///
     /// Read under the same tracking as the source, because the fit decides the

--- a/src/widgets/image.rs
+++ b/src/widgets/image.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use crate::jobs::JobType;
 use crate::layout::{Constraints, Size};
-use crate::reactive::{IntoSignal, Signal, with_signal_tracking};
+use crate::reactive::{IntoSignal, OptionSignalExt, Signal, with_signal_tracking};
 use crate::renderer::PaintContext;
 use crate::tree::{Tree, WidgetId};
 
@@ -106,7 +106,9 @@ pub enum ContentFit {
 /// ```
 pub struct Image {
     source: Signal<ImageSource>,
-    content_fit: ContentFit,
+    content_fit: Option<Signal<ContentFit>>,
+    /// Read under layout tracking, and used again by paint on the same frame.
+    cached_content_fit: ContentFit,
     /// Cached intrinsic size from the image source
     intrinsic_size: Option<(u32, u32)>,
     /// Cached source for change detection
@@ -118,15 +120,16 @@ impl Image {
     pub fn new<M>(source: impl IntoSignal<ImageSource, M>) -> Self {
         Self {
             source: source.into_signal(),
-            content_fit: ContentFit::default(),
+            content_fit: None,
+            cached_content_fit: ContentFit::default(),
             intrinsic_size: None,
             cached_source: None,
         }
     }
 
     /// Set the content fit mode.
-    pub fn content_fit(mut self, fit: ContentFit) -> Self {
-        self.content_fit = fit;
+    pub fn content_fit<M>(mut self, fit: impl IntoSignal<ContentFit, M>) -> Self {
+        self.content_fit = Some(fit.into_signal());
         self
     }
 
@@ -169,7 +172,7 @@ impl Image {
             intrinsic_h
         };
 
-        let size = match self.content_fit {
+        let size = match self.cached_content_fit {
             ContentFit::None => Size::new(intrinsic_w, intrinsic_h),
             ContentFit::Fill | ContentFit::Cover => Size::new(offered_w, offered_h),
             ContentFit::Contain => {
@@ -203,7 +206,15 @@ impl Widget for Image {
         tree.set_relayout_boundary(id, false);
 
         // Read the source with signal tracking so a change triggers re-layout
-        let current_source = with_signal_tracking(id, JobType::Layout, || self.source.get());
+        // Both under the same tracking: the fit decides the measured size, so a
+        // write to it has to re-run layout exactly as a new source does.
+        let (current_source, fit) = with_signal_tracking(id, JobType::Layout, || {
+            (
+                self.source.get(),
+                self.content_fit.get_or(ContentFit::default()),
+            )
+        });
+        self.cached_content_fit = fit;
 
         // Load intrinsic size if not cached or source changed
         let source_changed = self
@@ -236,7 +247,7 @@ impl Widget for Image {
         if let Some(ref source) = self.cached_source {
             let size = tree.cached_size(id).unwrap_or_default();
             let local_bounds = Rect::new(0.0, 0.0, size.width, size.height);
-            ctx.draw_image(source.clone(), local_bounds, self.content_fit);
+            ctx.draw_image(source.clone(), local_bounds, self.cached_content_fit);
         }
     }
 }
@@ -266,4 +277,63 @@ impl Widget for Image {
 /// ```
 pub fn image<M>(source: impl IntoSignal<ImageSource, M>) -> Image {
     Image::new(source)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::jobs;
+    use crate::reactive::create_signal;
+
+    fn measured(tree: &mut Tree, root: WidgetId, c: Constraints) -> Size {
+        jobs::pump_and_layout(tree, root, c).expect("the root is registered")
+    }
+
+    /// How an image fills its box is a value it can be told.
+    ///
+    /// Read under the same tracking as the source, because the fit decides the
+    /// measured size — `ContentFit::None` reports the intrinsic size whatever
+    /// is on offer, `Fill` reports what is offered — so a write has to re-run
+    /// layout rather than only repaint. Those two are the pair asserted here:
+    /// they disagree by construction whenever the offer is not the intrinsic
+    /// size, which needs no image file to be true.
+    #[test]
+    fn content_fit_answers_to_a_signal() {
+        let fills = create_signal(true);
+        let fit = move || {
+            if fills.get() {
+                ContentFit::Fill
+            } else {
+                ContentFit::None
+            }
+        };
+
+        // Under a container, and measured from the container, because that is
+        // what makes this a test of *reactivity* rather than of plumbing: a
+        // container takes an unchanged-constraints early-out and never asks its
+        // children again, so the second pass only reaches the image if the
+        // write marked it. An image laid out directly re-measures on every call
+        // and would pass with the fit read untracked.
+        let mut tree = Tree::new();
+        let root = tree.register(Box::new(crate::widgets::container().child(
+            Image::new(ImageSource::Path("does-not-exist.png".into())).content_fit(fit),
+        )));
+        tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
+
+        let offered = Constraints::new(0.0, 0.0, 200.0, 120.0);
+        let filled = measured(&mut tree, root, offered);
+
+        fills.set(false);
+        let intrinsic = measured(&mut tree, root, offered);
+
+        assert_ne!(
+            filled, intrinsic,
+            "the fit was read once: both passes measured {filled:?}"
+        );
+        assert_eq!(
+            filled,
+            Size::new(200.0, 120.0),
+            "Fill takes what is offered"
+        );
+    }
 }

--- a/src/widgets/state_layer.rs
+++ b/src/widgets/state_layer.rs
@@ -14,15 +14,20 @@
 //!     .child(text("Interactive button"))
 //! ```
 
-use crate::reactive::{IntoSignal, Signal};
+use crate::reactive::{IntoSignal, Signal, create_stored};
 use crate::transform::{Scale, Translate};
 use crate::widgets::Color;
 
 /// Configuration for ripple effect animation.
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy)]
 pub struct RippleConfig {
-    /// Color of the ripple (usually semi-transparent white)
-    pub color: Color,
+    /// Color of the ripple (usually semi-transparent white).
+    ///
+    /// A signal, as `BorderOverride`'s halves are, so a theme switch reaches the
+    /// one colour that animates under a finger. The two speeds beside it stay
+    /// plain: nobody themes how fast a ripple expands, and a signal there would
+    /// be a guess at a caller that does not exist.
+    pub color: Signal<Color>,
     /// Speed multiplier for ripple expansion (higher = faster)
     pub expand_speed: f32,
     /// Speed multiplier for ripple fade out (higher = faster)
@@ -32,7 +37,7 @@ pub struct RippleConfig {
 impl Default for RippleConfig {
     fn default() -> Self {
         Self {
-            color: Color::rgba(1.0, 1.0, 1.0, 0.3),
+            color: create_stored(Color::rgba(1.0, 1.0, 1.0, 0.3)),
             expand_speed: 1.0,
             fade_speed: 1.0,
         }
@@ -46,10 +51,14 @@ impl RippleConfig {
     }
 
     /// Create a ripple config with a custom color.
-    pub fn with_color(color: Color) -> Self {
+    pub fn with_color<M>(color: impl IntoSignal<Color, M>) -> Self {
+        // The speeds spelled out rather than `..Default::default()`, which now
+        // builds a stored signal for the colour and drops it — and a dropped
+        // `Signal` frees nothing, since the slot lives as long as its owner.
         Self {
-            color,
-            ..Default::default()
+            color: color.into_signal(),
+            expand_speed: 1.0,
+            fade_speed: 1.0,
         }
     }
 }
@@ -330,7 +339,7 @@ impl StateStyle {
     ///     .when_pressed(|s| s.ripple_with_color(Color::rgba(1.0, 0.5, 0.0, 0.3)))
     ///     .child(text("Orange ripple"))
     /// ```
-    pub fn ripple_with_color(mut self, color: Color) -> Self {
+    pub fn ripple_with_color<M>(mut self, color: impl IntoSignal<Color, M>) -> Self {
         self.ripple = Some(RippleConfig::with_color(color));
         self
     }

--- a/src/widgets/text.rs
+++ b/src/widgets/text.rs
@@ -46,8 +46,9 @@ pub struct Text {
     /// control encloses this text — the case where it is its own unit and has
     /// to notice the pointer itself.
     own_hover: Option<RwSignal<bool>>,
-    /// If true, text won't wrap and will be clipped by parent container
-    nowrap: bool,
+    /// Whether the text wraps at the width it is given. `None` is the default,
+    /// which wraps — an absent signal costs a null check rather than a read.
+    wrap: Option<Signal<bool>>,
     /// Blur radius for the backdrop the glyphs cut out of what is behind them.
     /// `None` for every text that is not made of glass.
     backdrop_blur: Option<Signal<f32>>,
@@ -56,6 +57,7 @@ pub struct Text {
     cached_font_size: f32,
     cached_font_family: FontFamily,
     cached_font_weight: FontWeight,
+    cached_wrap: bool,
 }
 
 impl Text {
@@ -70,19 +72,32 @@ impl Text {
             style: None,
             states: Vec::new(),
             own_hover: None,
-            nowrap: false,
+            wrap: None,
             backdrop_blur: None,
             cached_text: String::new(), // Will be set during first layout
             cached_font_size: 14.0,
             cached_font_family: default_family,
             cached_font_weight: FontWeight::NORMAL,
+            cached_wrap: true,
         }
     }
 
     /// Prevent text from wrapping. Text will be clipped by parent container.
     /// Use this for text inside animated containers to prevent re-wrapping during animation.
-    pub fn nowrap(mut self) -> Self {
-        self.nowrap = true;
+    ///
+    /// The shorthand for [`wrap(false)`](Self::wrap), which is the common case
+    /// and the one worth a name of its own.
+    pub fn nowrap(self) -> Self {
+        self.wrap(false)
+    }
+
+    /// Whether the text wraps at the width it is given.
+    ///
+    /// Wrapping is a layout decision — an unwrapped text is measured with no
+    /// maximum width and clipped by whatever contains it — so a write here
+    /// re-measures rather than merely repainting.
+    pub fn wrap<M>(mut self, wrap: impl IntoSignal<bool, M>) -> Self {
+        self.wrap = Some(wrap.into_signal());
         self
     }
 
@@ -181,6 +196,7 @@ impl Text {
             self.cached_font_size = style.font_size.get_or(14.0);
             self.cached_font_family = style.font_family.get_or_else(default_font_family);
             self.cached_font_weight = style.font_weight.get_or(FontWeight::NORMAL);
+            self.cached_wrap = self.wrap.get_or(true);
             decoration_overflow(style.stroke.map(|s| s.get()), style.shadow.map(|s| s.get()))
         })
     }
@@ -231,8 +247,9 @@ impl Widget for Text {
         tree.set_own_paint_reach(id, overflow);
 
         // Determine the effective max_width for measurement
-        // If nowrap is true, don't pass max_width so text won't wrap
-        let max_width = if self.nowrap {
+        // An unwrapped text is measured with no maximum, so it runs on one line
+        // and whatever contains it does the clipping.
+        let max_width = if !self.cached_wrap {
             None
         } else if constraints.max_width.is_finite() {
             Some(constraints.max_width)
@@ -368,8 +385,6 @@ pub fn text<M>(content: impl IntoSignal<String, M>) -> Text {
 
 #[cfg(test)]
 mod tests {
-    use rustc_hash::FxHashSet;
-
     use super::*;
     use crate::jobs;
     use crate::layout::Constraints;
@@ -377,6 +392,46 @@ mod tests {
     use crate::renderer::{DrawCommand, RenderNode};
     use crate::widgets::container;
     use crate::widgets::text_style::TextStyled;
+
+    /// Lay out after draining queued jobs, and hand back the measured size.
+    fn measured(tree: &mut Tree, root: WidgetId, width: f32) -> crate::layout::Size {
+        jobs::pump_and_layout(tree, root, Constraints::new(0.0, 0.0, width, 600.0))
+            .expect("the root is registered")
+    }
+
+    /// Wrapping is a declared value, so it answers to a write.
+    ///
+    /// `nowrap()` is the shorthand and stays; `wrap(signal)` is the property.
+    /// Asserted on the measured height rather than on anything drawn, because
+    /// wrapping is a layout decision — `max_width` is withheld from the
+    /// measurer — and the height is what a second line adds. The text is long
+    /// enough that no installed font can fit it on one line at this width,
+    /// which is what keeps the assertion off the font metrics.
+    #[test]
+    fn wrapping_answers_to_a_signal() {
+        let wrap = create_signal(true);
+        let mut tree = Tree::new();
+        let root = tree.register(Box::new(
+            Text::new("a considerable quantity of words, far more than fit").wrap(wrap),
+        ));
+        tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
+
+        let wrapped = measured(&mut tree, root, 80.0);
+
+        wrap.set(false);
+        let unwrapped = measured(&mut tree, root, 80.0);
+
+        assert!(
+            unwrapped.height < wrapped.height,
+            "the text kept wrapping after the signal said not to: {wrapped:?} \
+             then {unwrapped:?}"
+        );
+        assert!(
+            unwrapped.width > wrapped.width,
+            "an unwrapped line has to run past the width a wrapped one fits in: \
+             {wrapped:?} then {unwrapped:?}"
+        );
+    }
 
     /// Lay out and paint, returning the first text command's colour and size.
     ///
@@ -387,17 +442,7 @@ mod tests {
     /// its unchanged-constraints early-out, so the text is never asked to lay
     /// out again and the test measures the cache instead of the resolution.
     fn frame(tree: &mut Tree, root: WidgetId) -> (Color, f32) {
-        let roots: FxHashSet<WidgetId> = [root].into_iter().collect();
-        jobs::distribute_jobs(tree, &roots);
-        let drained = jobs::drain_surface_jobs(root);
-        let mut layout_roots = Vec::new();
-        jobs::process_jobs(&drained, tree, &mut layout_roots);
-        jobs::recycle_job_buffer(drained);
-        jobs::recycle_job_buffer(jobs::drain_orphan_jobs());
-
-        tree.with_widget_mut(root, |w, id, t| {
-            w.layout(t, id, Constraints::new(0.0, 0.0, 800.0, 600.0))
-        });
+        measured(tree, root, 800.0);
         let mut node = RenderNode::new(root.as_u64());
         tree.with_widget_mut(root, |w, id, t| {
             let mut ctx = PaintContext::new(&mut node);

--- a/src/widgets/text_input.rs
+++ b/src/widgets/text_input.rs
@@ -230,12 +230,17 @@ pub struct TextInput {
     cached_font_weight: FontWeight,
 
     // Password mode
-    is_password: bool,
-    mask_char: char,
+    password: Option<Signal<bool>>,
+    /// What `password` said when layout last read it, which is what the masked
+    /// display and its measurements were built from.
+    cached_password: bool,
+    mask_char: Option<Signal<char>>,
+    cached_mask_char: char,
 
     /// Whether a caret is drawn at all. Off costs nothing: no caret, no blink,
     /// nothing to wake the loop for.
-    caret: bool,
+    caret: Option<Signal<bool>>,
+    cached_caret: bool,
 
     /// Handle for application code to reach this input — to focus it, mostly.
     widget_ref: Option<WidgetRef>,
@@ -305,9 +310,12 @@ impl TextInput {
             cached_font_size: 14.0,
             cached_font_family: default_family,
             cached_font_weight: FontWeight::NORMAL,
-            is_password: false,
-            mask_char: '•',
-            caret: true,
+            password: None,
+            cached_password: false,
+            mask_char: None,
+            cached_mask_char: '•',
+            caret: None,
+            cached_caret: true,
             widget_ref: None,
             placeholder: None,
             autofocus_pending: false,
@@ -370,14 +378,14 @@ impl TextInput {
     }
 
     /// Enable password mode (masks text with bullet characters)
-    pub fn password(mut self, enabled: bool) -> Self {
-        self.is_password = enabled;
+    pub fn password<M>(mut self, enabled: impl IntoSignal<bool, M>) -> Self {
+        self.password = Some(enabled.into_signal());
         self
     }
 
     /// Set custom mask character for password mode (default: '•')
-    pub fn mask_char(mut self, c: char) -> Self {
-        self.mask_char = c;
+    pub fn mask_char<M>(mut self, c: impl IntoSignal<char, M>) -> Self {
+        self.mask_char = Some(c.into_signal());
         self
     }
 
@@ -420,8 +428,17 @@ impl TextInput {
     /// It is also the cheapest field there is. A blinking caret is the one thing
     /// a still screen redraws on its own, twice a second, forever; without it an
     /// idle surface wakes the loop for nothing at all.
-    pub fn no_caret(mut self) -> Self {
-        self.caret = false;
+    pub fn no_caret(self) -> Self {
+        self.caret(false)
+    }
+
+    /// Whether a caret is drawn at all.
+    ///
+    /// The property [`no_caret`](Self::no_caret) is the shorthand for. Read
+    /// where the rest of the declared values are read, so a field can be told
+    /// to stop drawing one without being rebuilt and losing its focus.
+    pub fn caret<M>(mut self, caret: impl IntoSignal<bool, M>) -> Self {
+        self.caret = Some(caret.into_signal());
         self
     }
 
@@ -461,11 +478,27 @@ impl TextInput {
         self
     }
 
+    /// Whether this field masks its contents **right now**.
+    ///
+    /// Asked by the two guards that refuse to export a secret, and they run
+    /// from event handling rather than from layout — so they read the signal
+    /// itself rather than `cached_password`, which is only as fresh as the last
+    /// pass. A field switched to masked between two frames must refuse the very
+    /// next Ctrl+C, not the one after it.
+    ///
+    /// Untracked on purpose: an event handler is not a tracking scope, and
+    /// subscribing here would tie a copy to a keystroke.
+    fn masks_now(&self) -> bool {
+        self.password.get_or_untracked(false)
+    }
+
     /// Get the display text (masked if password mode), using cache when clean
     fn display_text(&mut self) -> &str {
         if self.display_text_dirty {
-            self.cached_display_text = if self.is_password {
-                self.mask_char.to_string().repeat(self.cached_char_count)
+            self.cached_display_text = if self.cached_password {
+                self.cached_mask_char
+                    .to_string()
+                    .repeat(self.cached_char_count)
             } else {
                 self.cached_value.clone()
             };
@@ -545,6 +578,24 @@ impl TextInput {
         let (new_value, new_font_size, new_font_family, new_font_weight, overflow) =
             with_signal_tracking(id, JobType::Layout, || {
                 let style = self.resolved_text_style(tree, id);
+
+                // Assigned here rather than returned, as the font metrics are:
+                // the rule in this function is that a value comes back through
+                // the tuple only when it is compared against its cache below to
+                // raise a dirty flag. These three raise their own or none.
+                self.cached_caret = self.caret.get_or(true);
+                let password = self.password.get_or(false);
+                let mask_char = self.mask_char.get_or('•');
+                if password != self.cached_password || mask_char != self.cached_mask_char {
+                    // Both feed `display_text`, and the masked string is what
+                    // the measurements are taken from, so either changing
+                    // invalidates the same two caches a new value does.
+                    self.cached_password = password;
+                    self.cached_mask_char = mask_char;
+                    self.display_text_dirty = true;
+                    self.measurements_dirty = true;
+                }
+
                 (
                     self.value.get(),
                     style.font_size.get_or(14.0),
@@ -595,7 +646,7 @@ impl TextInput {
     /// A focused field is the normal state of a lock screen, and that ran all
     /// night.
     fn update_cursor_blink(&mut self, id: WidgetId, now: Instant) -> bool {
-        if !self.caret || !has_focus(id) {
+        if !self.cached_caret || !has_focus(id) {
             return false;
         }
         let period = Duration::from_millis(CURSOR_BLINK_MS);
@@ -880,7 +931,7 @@ impl TextInput {
     /// theatre banking sites are mocked for: it stops password managers, not
     /// attackers, and pushes people towards passwords they can type.
     fn exportable_selection(&self) -> Option<String> {
-        if self.is_password {
+        if self.masks_now() {
             return None;
         }
         self.get_selected_text()
@@ -898,7 +949,7 @@ impl TextInput {
         // A cut that cannot copy is not a cut. Refusing the gesture outright is
         // what GtkPasswordEntry does, and it keeps Ctrl+X from quietly becoming
         // a delete while the user believes the clipboard was filled.
-        if self.is_password {
+        if self.masks_now() {
             return;
         }
         if self.selection.has_selection() {
@@ -1251,7 +1302,7 @@ impl Widget for TextInput {
         // `self.caret` gates the *drawing*, not only the blink: stopping the blink
         // leaves `cursor_visible` at whatever it last was — true, from the
         // constructor — and a field asked for no caret got a permanent one.
-        if self.caret && is_focused {
+        if self.cached_caret && is_focused {
             // The toggle happens in `advance_animations`, and this is what asks
             // for the wake that runs it. It has to be here, not at the moment
             // focus arrives: focus comes from a click, from `autofocus`, or from
@@ -1506,6 +1557,178 @@ mod tests {
         );
     }
 
+    /// A field inside a container, laid out from the container, focused.
+    ///
+    /// The container is what makes these tests about *reactivity* rather than
+    /// about plumbing. A `TextInput` re-runs its own layout on every call, so a
+    /// value read without tracking still reaches a second direct `layout(..)`
+    /// and the test passes while nothing subscribes. A container takes its
+    /// unchanged-constraints early-out and never asks its children again, so
+    /// the second pass reaches the field only if the write marked it.
+    fn field_in_container(input: TextInput) -> (Tree, WidgetId, WidgetId) {
+        clear_pending_jobs();
+        clear_scheduled_jobs();
+        crate::reactive::focus::clear_focus();
+
+        let mut tree = Tree::new();
+        let root = tree.register(Box::new(crate::widgets::container().child(input)));
+        tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
+        let id = tree.get_children(root)[0];
+        relayout(&mut tree, root);
+        request_focus(&tree, id);
+        clear_pending_jobs();
+        (tree, root, id)
+    }
+
+    /// Re-lay out from `root` after draining the jobs a signal write queued.
+    ///
+    /// The drain is what turns a write into `needs_layout` on the widget that
+    /// read it; without it the second pass measures the cache.
+    fn relayout(tree: &mut Tree, root: WidgetId) {
+        crate::jobs::pump_and_layout(tree, root, Constraints::new(0.0, 0.0, 200.0, 40.0));
+    }
+
+    /// Put the caret at the end, which is where its x becomes a measurement of
+    /// the displayed text rather than a constant zero.
+    fn caret_to_end(tree: &mut Tree, id: WidgetId) {
+        tree.with_widget_mut(id, |w, wid, t| {
+            w.event(
+                t,
+                wid,
+                &Event::KeyDown {
+                    key: Key::End,
+                    modifiers: crate::widgets::widget::Modifiers::default(),
+                },
+            )
+        });
+    }
+
+    /// Every rectangle the field draws. Focused with no selection, the caret is
+    /// the only one there can be, and its x is where the displayed text ends.
+    fn drawn_rects(tree: &mut Tree, id: WidgetId) -> Vec<crate::widgets::Rect> {
+        fn collect(node: &crate::renderer::RenderNode, out: &mut Vec<crate::widgets::Rect>) {
+            for cmd in &node.commands {
+                if let crate::renderer::DrawCommand::RoundedRect { rect, .. } = &**cmd {
+                    out.push(*rect);
+                }
+            }
+            for child in &node.children {
+                collect(child, out);
+            }
+        }
+        let mut out = Vec::new();
+        collect(&paint_once(tree, id), &mut out);
+        out
+    }
+
+    /// Masking is a value the field can be told, and the eye icon beside a
+    /// password box is what needs it.
+    ///
+    /// Read off the caret's x, which sits at the end of the *displayed* text:
+    /// bullets and `iiii` are different widths in any font, so the assertion
+    /// does not depend on which one is installed — only that they differ.
+    #[test]
+    fn masking_answers_to_a_signal() {
+        let masked = create_signal(true);
+        let (mut tree, root, id) =
+            field_in_container(text_input(create_signal("iiiiiiii".to_owned())).password(masked));
+
+        caret_to_end(&mut tree, id);
+        let with_bullets = drawn_rects(&mut tree, id);
+        assert_eq!(with_bullets.len(), 1, "the caret, and nothing else");
+
+        masked.set(false);
+        relayout(&mut tree, root);
+        let with_letters = drawn_rects(&mut tree, id);
+
+        assert_ne!(
+            with_bullets[0].x, with_letters[0].x,
+            "the field kept drawing bullets after the signal said not to"
+        );
+        assert!(
+            has_focus(id),
+            "the point of declaring this rather than rebuilding the widget is \
+             that the focus survives it"
+        );
+    }
+
+    /// The same for what the mask is made of.
+    #[test]
+    fn the_mask_character_answers_to_a_signal() {
+        let mask = create_signal('.');
+        let (mut tree, root, id) = field_in_container(
+            text_input(create_signal("aaaaaaaa".to_owned()))
+                .password(true)
+                .mask_char(mask),
+        );
+
+        caret_to_end(&mut tree, id);
+        let narrow = drawn_rects(&mut tree, id);
+
+        mask.set('W');
+        relayout(&mut tree, root);
+        let wide = drawn_rects(&mut tree, id);
+
+        assert!(
+            wide[0].x > narrow[0].x,
+            "eight W's have to be wider than eight full stops: {narrow:?} then \
+             {wide:?}"
+        );
+    }
+
+    /// Whether a caret is drawn at all, likewise.
+    #[test]
+    fn the_caret_answers_to_a_signal() {
+        let show = create_signal(true);
+        let (mut tree, root, id) =
+            field_in_container(text_input(create_signal("hi".to_owned())).caret(show));
+
+        assert_eq!(drawn_rects(&mut tree, id).len(), 1, "a caret to begin with");
+
+        show.set(false);
+        relayout(&mut tree, root);
+
+        assert!(
+            drawn_rects(&mut tree, id).is_empty(),
+            "asked for no caret and got one anyway"
+        );
+        assert!(has_focus(id), "and the focus is still here");
+    }
+
+    /// A field switched to masked refuses the very next copy, not the one after.
+    ///
+    /// The two guards that refuse to export a secret run from event handling,
+    /// which is not a tracking scope and does not wait for a layout pass. So
+    /// they ask the signal rather than `cached_password`, which is only as
+    /// fresh as the last pass — reading the copy would hand out the secret for
+    /// one frame after the field was told to hide it.
+    #[test]
+    fn masking_refuses_an_export_before_the_next_layout() {
+        let masked = create_signal(false);
+        let mut input = text_input(create_signal("hunter2".to_owned())).password(masked);
+        input.cached_value = "hunter2".to_owned();
+        input.cached_char_count = 7;
+        input.selection = Selection {
+            cursor: 7,
+            anchor: 0,
+        };
+
+        assert_eq!(
+            input.exportable_selection().as_deref(),
+            Some("hunter2"),
+            "an unmasked field exports its selection"
+        );
+
+        masked.set(true);
+        // No layout in between: this is the frame the write landed in.
+
+        assert_eq!(
+            input.exportable_selection(),
+            None,
+            "the field exported a secret it had just been told to mask"
+        );
+    }
+
     /// A laid-out input, focused unless told otherwise.
     fn field(input: TextInput, focused: bool) -> (Tree, WidgetId) {
         clear_pending_jobs();
@@ -1530,12 +1753,13 @@ mod tests {
             .unwrap_or(false)
     }
 
-    fn paint_once(tree: &mut Tree, id: WidgetId) {
+    fn paint_once(tree: &mut Tree, id: WidgetId) -> crate::renderer::RenderNode {
         let mut node = crate::renderer::RenderNode::new(id.as_u64());
         tree.with_widget_mut(id, |w, id, t| {
             let mut ctx = crate::renderer::PaintContext::new(&mut node);
             w.paint(t, id, &mut ctx);
         });
+        node
     }
 
     #[test]

--- a/tests/signal_conversions.rs
+++ b/tests/signal_conversions.rs
@@ -81,3 +81,51 @@ fn a_signal_of_the_property_type_is_unaffected() {
     let p = create_signal(Padding::all(4.0));
     let _ = container().corners(c).scale(s).padding(p);
 }
+
+/// The properties that stopped being read once, in all three spellings.
+///
+/// The point of the change was that these take a signal at all; the point of
+/// this test is that they still take the other two. A setter widened to
+/// `impl IntoSignal<T, M>` accepts the value form through the blanket `Into`
+/// impl and the closure form through `IntoVal`'s reflexive one, so nothing has
+/// to be added to `converting_signals!` for a property whose declared type is
+/// the type it is given — but nothing checks that until somebody writes it
+/// down, which is what this is.
+#[test]
+fn the_values_that_became_signals_take_all_three_forms() {
+    let masked = create_signal(true);
+    let mask = create_signal('*');
+    let fit = create_signal(ContentFit::Cover);
+    let wraps = create_signal(false);
+    let axis = create_signal(Axis::Vertical);
+    let hot = create_signal(Color::RED);
+
+    let _ = text("value").wrap(false);
+    let _ = text("closure").wrap(move || wraps.get());
+    let _ = text("signal").wrap(wraps);
+
+    let _ = image("x.png").content_fit(ContentFit::Cover);
+    let _ = image("x.png").content_fit(move || fit.get());
+    let _ = image("x.png").content_fit(fit);
+
+    let _ = text_input(create_signal(String::new()))
+        .password(true)
+        .mask_char('*')
+        .caret(false);
+    let _ = text_input(create_signal(String::new()))
+        .password(move || masked.get())
+        .mask_char(move || mask.get())
+        .caret(move || wraps.get());
+    let _ = text_input(create_signal(String::new()))
+        .password(masked)
+        .mask_char(mask)
+        .caret(wraps);
+
+    let _ = container().layout(Flex::new(Axis::Horizontal));
+    let _ = container().layout(Flex::new(move || axis.get()));
+    let _ = container().layout(Flex::new(axis));
+
+    let _ = container().when_pressed(|s| s.ripple_with_color(Color::RED));
+    let _ = container().when_pressed(move |s| s.ripple_with_color(move || hot.get()));
+    let _ = container().when_pressed(move |s| s.ripple_with_color(hot));
+}


### PR DESCRIPTION
## What changed

Six declared values were plain fields set at build time, each sitting in a
struct beside a `Signal<T>` — so a text could change what it said but not
whether it wrapped, and a password box could not be given an eye icon. They now
take `impl IntoSignal<T, M>`: `Text::wrap`, `Image::content_fit`,
`TextInput::password` / `mask_char` / `caret`, `StateStyle::ripple_with_color`,
and the direction a `Flex` is built with. `nowrap()` and `no_caret()` stay as
shorthands for `wrap(false)` and `caret(false)`. Closes #324.

`Flex` cost almost nothing: it has always held `direction: Signal<Axis>` and
read it per pass, so only the constructor's parameter stood in the way.

## What proves it

One criterion, six tests, each in its widget's own module:

- `flex_layout::tests::a_row_becomes_a_column_when_its_direction_says_so`
- `text::tests::wrapping_answers_to_a_signal`
- `image::tests::content_fit_answers_to_a_signal`
- `text_input::tests::masking_answers_to_a_signal`, `the_mask_character_answers_to_a_signal`, `the_caret_answers_to_a_signal` — the last two also assert the focus survives, which is the point of declaring rather than rebuilding
- `text_input::tests::masking_refuses_an_export_before_the_next_layout`
- `container::characterization::a_ripple_takes_the_colour_it_is_given_now`

**Five of them were verified by mutation**, not by passing: making the
corresponding read `get_untracked()` makes each fail. That took a second pass —
the first versions laid the widget out directly and passed with an untracked
read, because `Text`, `Image` and `TextInput` all re-measure on every call. They
now lay out *through a container*, which takes an unchanged-constraints
early-out and only descends if the write marked the child. The comments say so.

`tests/signal_conversions.rs` pins all three spellings (value, closure, signal)
for every widened setter — no `converting_signals!` entry was needed, and that
test is what records why.

No golden moved and none should: these change widget plumbing, not shaders, and
a default-configured widget draws exactly what it drew. Harness green including
the 9 goldens on lavapipe, the full suite again with `GUIDO_GPU_REQUIRED=1` so
nothing skipped, `cargo doc -D warnings`, and `mdbook test`. Every one of the
eight commits was checked to build on its own.

## What the review found

**Two blocking, both real, both fixed.**

1. *The ripple colour was read untracked, and my justification for it was
   false.* I had written that a running ripple repaints every frame anyway. It
   does not: `Ripple::advance` returns false once a held disc reaches full
   growth, deliberately, so the loop can go quiet while the finger is still
   down. So a colour written during a held press reached nothing — exactly the
   case #324 was opened for. Now read under `JobType::Paint` tracking, with the
   held press added to the test.
2. *The book taught code that no longer compiled.* `interactivity/ripples.md`
   built a `RippleConfig` by struct literal with a bare `Color`. It is a
   `rust,ignore` fence, so `mdbook test` never compiled it and
   `documentation_references` reads only prose — nothing watched it. Rebuilt on
   `RippleConfig::with_color` and compiled by hand against this branch. Three
   API listings stating old signatures were corrected with it.

Worth answering, both acted on: `ripple_config(RippleConfig)` still takes a
value while its `color` no longer does — the book now shows the
`..RippleConfig::with_color(..)` spelling that reconciles them. And `caret` is
read under `JobType::Layout` though it affects only paint; `refresh` is the one
tracked scope the field has, and splitting it for one boolean would cost a
`Cell` to buy a layout pass on a keystroke-rare toggle. Stated here rather than
left to look accidental.

## What was checked by hand

The book sample above, compiled against this branch's `libguido.rlib`, because
no automated thing compiles a `rust,ignore` fence. All 27 existing call sites
across `examples/` still compile untouched, which is what says the widening is
backward compatible. And the claim behind blocking finding 1 was verified by
reading `Ripple::advance` and the `if ripple_animating` guard that decides
whether another frame is requested.

## Left undone

- **Nothing watches the ripple colour's subscription.** An untracked read passes
  its test, because `Tree::cache_layout` marks a widget for paint on every
  layout pass, so the characterization harness never reaches its skip-frame gate
  after a `fit`. The read is tracked because the held-press case is real, not
  because a test would object. Recorded in the test's own comment. No issue: the
  bar asks who is worse off today, and nobody is — this is a gap in what would
  catch a future regression, not a defect anyone can hit.
- **`RippleConfig` is not in the prelude**, which is why that book sample was
  `rust,ignore` and therefore uncompiled for however long it had been wrong.
  Same bar, same answer: a sentence here rather than an issue, since the sample
  is correct now and the import is one line for anyone who needs it.
- `expand_speed` and `fade_speed` stay plain values, and `autofocus` stays
  non-reactive — both decided in #324 with reasons, not left out by accident.

https://claude.ai/code/session_01VApCRoAUGzxx4cZEHohTsj