### PR TITLE
Scrolling is one value, and its scrollbar is the two containers it always was

### DIFF
--- a/.claude/skills/widgets/SKILL.md
+++ b/.claude/skills/widgets/SKILL.md
@@ -16,9 +16,20 @@ Reactive: `background`, `gradient`, `backdrop_blur`, `overflow`, `corners`,
 `Image`'s `content_fit`, `TextInput`'s `password`, `mask_char` and `caret`,
 `RippleConfig`'s colour, and the direction a `Flex` is built with.
 
-Structural: `layout`, `child`, `children`, `scrollable`, `scrollbar`,
-`scrollbar_visibility`, `control`, the event handlers — and the *motion* a
-value is declared with, which is the next section.
+Structural: `layout`, `child`, `children`, `control`, the axis a `Scroll` is
+built with, the event handlers — and the *motion* a value is declared with,
+which is the next section.
+
+`Scroll` is what a family of setters looks like once it is one value.
+`scrollable`, `scrollbar_visibility` and `scrollbar` were three, and the last
+two were silent no-ops on a container that never became scrollable. Now
+`container().scroll(Scroll::vertical())`, and the parts cannot be spelled apart
+from the thing they configure. Its measurements — `width`, `hover_width`,
+`margin`, `min_handle_size`, `reserve_gutter`, `visibility` — are reactive; its
+appearance is `Container`'s own vocabulary, reached through `.track(|t| ..)`
+and `.handle(|h| ..)`, because the scrollbar *is* two containers. Styling a
+part means styling a container, so nothing has to be mirrored into a second
+vocabulary as `Container` grows.
 
 `autofocus` is the one that looks structural and is neither: it is a one-shot
 consumed at the first layout, so "take focus when this appears" is an event,

--- a/book/src/building-ui/styling.md
+++ b/book/src/building-ui/styling.md
@@ -218,8 +218,8 @@ A blur radius of `0.0` is "no blur", on a container and on a text alike, which
 is what lets one signal switch the effect on and off rather than forcing the
 caller to rebuild the widget in a Rust branch.
 
-**What is not reactive** is structural: `.layout(..)`, `.scrollable(..)`,
-`.scrollbar(..)`, `.scrollbar_visibility(..)`, `.control()`, and the motion a
+**What is not reactive** is structural: `.layout(..)`, the axis a `.scroll(..)`
+is built with, `.control()`, and the motion a
 value is declared with — `.transition(..)` and `.timeline(..)`. These say what
 kind of thing the container *is*; change one and you are describing a different
 widget, so declare it in the closure that builds the widget instead. The

--- a/book/src/concepts/container.md
+++ b/book/src/concepts/container.md
@@ -240,7 +240,7 @@ Make containers scrollable when content overflows:
 container()
     .width(200.0)
     .height(200.0)
-    .scrollable(ScrollAxis::Vertical)
+    .scroll(Scroll::vertical())
     .child(large_content())
 # ;
 # }
@@ -248,12 +248,18 @@ container()
 
 ### Scroll Axes
 
-| Axis | Description |
+The axis is chosen by constructor, and it is the one part of a `Scroll` that
+takes no signal — it decides what kind of widget this is, as `layout` and
+`control` do.
+
+| Constructor | Description |
 |------|-------------|
-| `ScrollAxis::None` | No scrolling (default) |
-| `ScrollAxis::Vertical` | Vertical scrolling only |
-| `ScrollAxis::Horizontal` | Horizontal scrolling only |
-| `ScrollAxis::Both` | Both directions |
+| `Scroll::vertical()` | Vertical scrolling only |
+| `Scroll::horizontal()` | Horizontal scrolling only |
+| `Scroll::both()` | Both directions |
+
+A container with no `.scroll(..)` does not scroll, which is what the old
+`ScrollAxis::None` said.
 
 ### Custom Scrollbars
 
@@ -262,13 +268,14 @@ container()
 # use guido::prelude::*;
 # fn main() {
 container()
-    .scrollable(ScrollAxis::Vertical)
-    .scrollbar(|sb| {
-        sb.width(6.0)
-          .handle_color(Color::rgb(0.4, 0.6, 0.9))
-          .handle_hover_color(Color::rgb(0.5, 0.7, 1.0))
-          .handle_corner_radius(3.0)
-    })
+    .scroll(
+        Scroll::vertical()
+            .width(6.0)
+            .handle(|h| h
+                .background(Color::rgb(0.4, 0.6, 0.9))
+                .corners(3.0)
+                .when_hovered(|s| s.background(Color::rgb(0.5, 0.7, 1.0)))),
+    )
 # ;
 # }
 ```
@@ -280,8 +287,7 @@ container()
 # use guido::prelude::*;
 # fn main() {
 container()
-    .scrollable(ScrollAxis::Vertical)
-    .scrollbar_visibility(ScrollbarVisibility::Hidden)
+    .scroll(Scroll::vertical().visibility(ScrollbarVisibility::Hidden))
 # ;
 # }
 ```
@@ -370,6 +376,11 @@ Declared on the value, not beside it:
 - `.visible(condition)` - Show or hide the container (accepts static, signal, or closure)
 
 ### Scrolling
-- `.scrollable(axis)` - Enable scrolling (None, Vertical, Horizontal, Both)
-- `.scrollbar(|sb| ...)` - Customize scrollbar appearance
-- `.scrollbar_visibility(visibility)` - Show or hide scrollbar
+- `.scroll(Scroll::vertical() | Scroll::horizontal() | Scroll::both())` - Scroll,
+  and say what the scrollbar looks like. One value: the parts cannot be declared
+  apart from the thing they configure
+- `Scroll::width`, `hover_width`, `margin`, `min_handle_size`, `reserve_gutter` /
+  `overlay()`, `visibility(..)` - the measurements the container's layout needs,
+  each taking a static value, a signal or a closure
+- `Scroll::track(|t| ..)` and `Scroll::handle(|h| ..)` - the scrollbar is two
+  containers, so these take everything a container takes

--- a/book/src/interactivity/states.md
+++ b/book/src/interactivity/states.md
@@ -279,7 +279,7 @@ container()
 ```
 
 `on_click` makes that container a control, because anything the pointer can act
-on is a unit by necessity. So do `on_hover`, `on_scroll`, `scrollable` and any
+on is a unit by necessity. So do `on_hover`, `on_scroll`, `scroll` and any
 declared state layer. Write `control()` yourself where the boundary is real but
 nothing else announces it:
 

--- a/docs/STATE_LAYER.md
+++ b/docs/STATE_LAYER.md
@@ -88,7 +88,7 @@ inside its subtree. Which is what makes the case above work at all — the focus
 is in a *sibling*, and both belong to the same unit.
 
 `control()` is rarely written by hand. Anything the pointer can act on is a
-unit by necessity, so `on_click`, `on_hover`, `on_scroll`, `scrollable` and a
+unit by necessity, so `on_click`, `on_hover`, `on_scroll`, `scroll` and a
 declared state layer all imply it. Write it where the boundary is real but
 nothing else announces it — a field's label and input, a row whose highlight
 belongs to the row.

--- a/docs/STYLING.md
+++ b/docs/STYLING.md
@@ -217,9 +217,9 @@ A blur radius of `0.0` is "no blur", on a container and on a text alike, which
 is what lets one signal switch the effect on and off rather than forcing the
 caller to rebuild the widget in a Rust branch.
 
-**What is not reactive** is structural: `.layout(..)`, `.scrollable(..)`,
-`.scrollbar(..)`, `.scrollbar_visibility(..)`, `.control()`, and the motion a
-value is declared with — `.transition(..)` and `.timeline(..)`. These say what
+**What is not reactive** is structural: `.layout(..)`, the axis a `.scroll(..)`
+is built with, `.control()`, and the motion a value is declared with —
+`.transition(..)` and `.timeline(..)`. These say what
 kind of thing the container *is*; change one and you are describing a different
 widget, so declare it in the closure that builds the widget instead. The
 *value* a motion decorates is as reactive as any other.

--- a/examples/bench_list.rs
+++ b/examples/bench_list.rs
@@ -32,7 +32,7 @@ fn main() {
             move || {
                 container()
                     .background(Color::rgb(0.10, 0.10, 0.14))
-                    .scrollable(ScrollAxis::Vertical)
+                    .scroll(Scroll::vertical())
                     .child(
                         container()
                             .layout(Flex::column().spacing(4.0))

--- a/examples/perf_stress_test.rs
+++ b/examples/perf_stress_test.rs
@@ -73,7 +73,7 @@ fn main() {
             .child(
                 container()
                     .height(300.0)
-                    .scrollable(ScrollAxis::Vertical)
+                    .scroll(Scroll::vertical())
                     .child(dyn_container_view),
             );
 

--- a/examples/scroll_example.rs
+++ b/examples/scroll_example.rs
@@ -24,7 +24,7 @@ fn main() {
                         .height(200.0)
                         .background(Color::rgb(0.15, 0.15, 0.2))
                         .corners(8.0)
-                        .scrollable(ScrollAxis::Vertical)
+                        .scroll(Scroll::vertical())
                         .child(
                             container()
                                 .layout(Flex::column().spacing(8.0))
@@ -58,7 +58,7 @@ fn main() {
                         .height(80.0)
                         .background(Color::rgb(0.15, 0.15, 0.2))
                         .corners(8.0)
-                        .scrollable(ScrollAxis::Horizontal)
+                        .scroll(Scroll::horizontal())
                         .child(
                             container()
                                 .layout(Flex::row().spacing(8.0))
@@ -101,15 +101,19 @@ fn main() {
                         .height(200.0)
                         .background(Color::rgb(0.15, 0.15, 0.2))
                         .corners(8.0)
-                        .scrollable(ScrollAxis::Vertical)
-                        .scrollbar(|sb| {
-                            sb.width(6.0)
-                                .handle_color(Color::rgb(0.4, 0.6, 0.9))
-                                .handle_hover_color(Color::rgb(0.5, 0.7, 1.0))
-                                .handle_pressed_color(Color::rgb(0.6, 0.8, 1.0))
-                                .handle_corner_radius(3.0)
-                                .track_color(Color::rgba(0.4, 0.6, 0.9, 0.1))
-                        })
+                        .scroll(
+                            Scroll::vertical()
+                                .width(6.0)
+                                .track(|t| t.background(Color::rgba(0.4, 0.6, 0.9, 0.1)))
+                                .handle(|h| {
+                                    h.background(Color::rgb(0.4, 0.6, 0.9))
+                                        .corners(3.0)
+                                        .when_hovered(|s| s.background(Color::rgb(0.5, 0.7, 1.0)))
+                                        .when_pressed(|s| {
+                                            s.background(Color::rgb(0.6, 0.8, 1.0)).ripple()
+                                        })
+                                }),
+                        )
                         .child(
                             container()
                                 .layout(Flex::column().spacing(8.0))
@@ -143,8 +147,7 @@ fn main() {
                         .height(200.0)
                         .background(Color::rgb(0.15, 0.15, 0.2))
                         .corners(8.0)
-                        .scrollable(ScrollAxis::Vertical)
-                        .scrollbar_visibility(ScrollbarVisibility::Hidden)
+                        .scroll(Scroll::vertical().visibility(ScrollbarVisibility::Hidden))
                         .child(
                             container()
                                 .layout(Flex::column().spacing(8.0))

--- a/examples/scroll_mixed_content.rs
+++ b/examples/scroll_mixed_content.rs
@@ -79,13 +79,16 @@ fn main() {
                             .height(400.0)
                             .background(Color::rgb(0.12, 0.12, 0.18))
                             .corners(12.0)
-                            .scrollable(ScrollAxis::Vertical)
-                            .scrollbar(|sb| {
-                                sb.width(6.0)
-                                    .handle_color(Color::rgb(0.4, 0.5, 0.6))
-                                    .handle_hover_color(Color::rgb(0.5, 0.6, 0.7))
-                                    .track_color(Color::rgba(0.3, 0.3, 0.4, 0.3))
-                            })
+                            .scroll(
+                                Scroll::vertical()
+                                    .width(6.0)
+                                    .track(|t| t.background(Color::rgba(0.3, 0.3, 0.4, 0.3)))
+                                    .handle(|h| {
+                                        h.background(Color::rgb(0.4, 0.5, 0.6)).when_hovered(|s| {
+                                            s.background(Color::rgb(0.5, 0.6, 0.7))
+                                        })
+                                    }),
+                            )
                             .child(
                                 container()
                                     .layout(Flex::column().spacing(16.0))
@@ -252,13 +255,16 @@ fn main() {
                             .height(160.0)
                             .background(Color::rgb(0.12, 0.12, 0.18))
                             .corners(12.0)
-                            .scrollable(ScrollAxis::Horizontal)
-                            .scrollbar(|sb| {
-                                sb.width(6.0)
-                                    .handle_color(Color::rgb(0.5, 0.6, 0.4))
-                                    .handle_hover_color(Color::rgb(0.6, 0.7, 0.5))
-                                    .track_color(Color::rgba(0.3, 0.4, 0.3, 0.3))
-                            })
+                            .scroll(
+                                Scroll::horizontal()
+                                    .width(6.0)
+                                    .track(|t| t.background(Color::rgba(0.3, 0.4, 0.3, 0.3)))
+                                    .handle(|h| {
+                                        h.background(Color::rgb(0.5, 0.6, 0.4)).when_hovered(|s| {
+                                            s.background(Color::rgb(0.6, 0.7, 0.5))
+                                        })
+                                    }),
+                            )
                             .child(
                                 container()
                                     .layout(Flex::row().spacing(12.0))
@@ -286,12 +292,10 @@ fn main() {
                             .height(100.0)
                             .background(Color::rgb(0.12, 0.12, 0.18))
                             .corners(12.0)
-                            .scrollable(ScrollAxis::Horizontal)
-                            .scrollbar(|sb| {
-                                sb.width(4.0)
-                                    .handle_color(Color::rgb(0.6, 0.5, 0.7))
-                                    .handle_hover_color(Color::rgb(0.7, 0.6, 0.8))
-                            })
+                            .scroll(Scroll::horizontal().width(4.0).handle(|h| {
+                                h.background(Color::rgb(0.6, 0.5, 0.7))
+                                    .when_hovered(|s| s.background(Color::rgb(0.7, 0.6, 0.8)))
+                            }))
                             .child(
                                 container()
                                     .layout(Flex::row().spacing(16.0))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,9 +191,9 @@ pub mod prelude {
         AnyWidget, Border, Color, Container, ContentFit, Control, CornerRadii, Corners, Event,
         EventResponse, FontFamily, FontWeight, GradientDirection, Image, ImageSource, InputStyle,
         InputStyled, IntoChildren, IntoClickHandler, Key, LinearGradient, Modifiers, MouseButton,
-        Overflow, Padding, Point, Rect, ScrollAxis, ScrollSource, ScrollbarBuilder,
-        ScrollbarVisibility, Selection, StateStyle, Stateful, Text, TextInput, TextShadow,
-        TextStroke, TextStyle, TextStyled, Widget, container, image, keyed, text, text_input,
+        Overflow, Padding, Point, Rect, Scroll, ScrollSource, ScrollbarVisibility, Selection,
+        StateStyle, Stateful, Text, TextInput, TextShadow, TextStroke, TextStyle, TextStyled,
+        Widget, container, image, keyed, text, text_input,
     };
     pub use crate::{
         App, ExitReason, SignalFields, component, default_font_family, load_font, quit_app,

--- a/src/widgets/container/box_model.rs
+++ b/src/widgets/container/box_model.rs
@@ -178,10 +178,10 @@ impl Container {
         // A reserved gutter is space the content never gets, scrollbar shown
         // or not — that is the point of reserving it.
         if let Some(ref sd) = self.scroll_data
-            && sd.scrollbar_config.reserve_gutter
+            && sd.metrics.reserve_gutter
             && sd.scrollbar_visibility != ScrollbarVisibility::Hidden
         {
-            let gutter = sd.scrollbar_config.width + sd.scrollbar_config.margin * 2.0;
+            let gutter = sd.metrics.width + sd.metrics.margin * 2.0;
             if self.scroll_axis.allows_vertical() {
                 max_width = (max_width - gutter).max(0.0);
             }

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -20,6 +20,7 @@ use crate::jobs::{self, JobType};
 use crate::layout::{Constraints, Flex, at_least, at_most, fill, fraction};
 use crate::reactive::create_signal;
 use crate::renderer::{DrawCommand, PaintContext, RenderNode};
+use crate::widgets::CornerRadii;
 use crate::widgets::TextStyled;
 use crate::widgets::widget::{Event, EventResponse, MouseButton};
 
@@ -482,6 +483,107 @@ fn fixed_size_makes_a_relayout_boundary() {
 // Scroll
 // ---------------------------------------------------------------------------
 
+/// The colour and corner radii of every rounded rect a paint produced.
+fn painted_rects_with_style(node: &RenderNode) -> Vec<(Color, CornerRadii)> {
+    fn walk(node: &RenderNode, out: &mut Vec<(Color, CornerRadii)>) {
+        for cmd in &node.commands {
+            if let DrawCommand::RoundedRect { color, radius, .. } = &**cmd {
+                out.push((*color, *radius));
+            }
+        }
+        for child in &node.children {
+            walk(child, out);
+        }
+    }
+    let mut out = Vec::new();
+    walk(node, &mut out);
+    out
+}
+
+/// A scroller with a handle the test can find by its colour.
+fn scroller(scroll: Scroll) -> H {
+    H::new(
+        container()
+            .height(100.0)
+            .scroll(scroll)
+            .child(box_of(40.0, 900.0)),
+    )
+}
+
+/// The scrollbar is styled as what it is — two containers — so a signal reaches
+/// it like it reaches anything else.
+///
+/// This is the whole point of the change. `ScrollbarConfig` held plain colours
+/// captured at build time, so a theme switch restyled every surface except its
+/// scrollbars.
+#[test]
+fn a_handle_colour_declared_with_a_signal_follows_it() {
+    let hot = create_signal(Color::rgb(1.0, 0.0, 0.0));
+    let mut h = scroller(Scroll::vertical().handle(move |c: Container| c.background(hot)));
+    h.fit(500.0, 500.0);
+
+    let before = painted_rects_with_style(&h.paint());
+    assert!(
+        before.iter().any(|(c, _)| c.r > 0.9 && c.g < 0.1),
+        "the declared handle colour has to reach the paint: {before:?}"
+    );
+
+    hot.set(Color::rgb(0.0, 0.0, 1.0));
+    pump(&mut h);
+    h.fit(500.0, 500.0);
+
+    let after = painted_rects_with_style(&h.paint());
+    assert!(
+        after.iter().any(|(c, _)| c.b > 0.9 && c.r < 0.1),
+        "the handle kept the colour it was built with: {after:?}"
+    );
+}
+
+/// And it takes corners the old pair could not spell.
+///
+/// `ScrollbarConfig` carried a radius and a K-value, which reaches
+/// `Corners::superellipse` and nothing else. A bevel, a scoop or a per-corner
+/// radius were all expressible downstream and unreachable from the API.
+#[test]
+fn a_handle_takes_corners_the_old_pair_could_not_spell() {
+    let mut h = scroller(Scroll::vertical().handle(|c: Container| {
+        c.background(Color::rgb(1.0, 0.0, 0.0))
+            .corners([8.0, 0.0, 8.0, 0.0])
+    }));
+    h.fit(500.0, 500.0);
+
+    let (_, radii) = painted_rects_with_style(&h.paint())
+        .into_iter()
+        .find(|(c, _)| c.r > 0.9 && c.g < 0.1)
+        .expect("the handle, found by its declared colour");
+
+    assert!(
+        radii.top_left > 7.9 && radii.top_right < 0.1,
+        "a per-corner radius has to survive to paint, got {radii:?}"
+    );
+}
+
+/// A scrollbar that comes and goes on a signal, with the content scrollable
+/// either way.
+#[test]
+fn visibility_answers_to_a_signal() {
+    let shown = create_signal(ScrollbarVisibility::Always);
+    let mut h = scroller(Scroll::vertical().visibility(shown));
+    h.fit(500.0, 500.0);
+    let with_bar = h.paint().children.len();
+
+    shown.set(ScrollbarVisibility::Hidden);
+    pump(&mut h);
+    h.fit(500.0, 500.0);
+    let without = h.paint().children.len();
+
+    assert!(
+        without < with_bar,
+        "the scrollbar stayed on screen after the signal hid it: {with_bar} \
+         then {without}"
+    );
+}
+
 /// Whether a scrollbar exists at all comes down to one comparison — content
 /// against viewport — so the viewport a scroller records has to be its
 /// *visible* extent, never the unbounded constraint the scrolled axis is laid
@@ -490,12 +592,7 @@ fn fixed_size_makes_a_relayout_boundary() {
 /// is exactly what "the scrollbars stopped appearing" means.
 #[test]
 fn an_overflowing_scroller_paints_its_scrollbar() {
-    let mut h = H::new(
-        container()
-            .height(100.0)
-            .scrollable(ScrollAxis::Vertical)
-            .child(box_of(40.0, 900.0)),
-    );
+    let mut h = scroller(Scroll::vertical());
     h.fit(500.0, 500.0);
 
     let node = h.paint();
@@ -511,7 +608,7 @@ fn an_overflowing_horizontal_scroller_paints_its_scrollbar() {
     let mut h = H::new(
         container()
             .width(100.0)
-            .scrollable(ScrollAxis::Horizontal)
+            .scroll(Scroll::horizontal())
             .child(box_of(900.0, 40.0)),
     );
     h.fit(500.0, 500.0);
@@ -524,7 +621,7 @@ fn a_scroller_whose_content_fits_paints_no_scrollbar() {
     let mut h = H::new(
         container()
             .height(100.0)
-            .scrollable(ScrollAxis::Vertical)
+            .scroll(Scroll::vertical())
             .child(box_of(40.0, 20.0)),
     );
     h.fit(500.0, 500.0);
@@ -540,7 +637,7 @@ fn a_vertical_scroller_offers_children_unbounded_height() {
     let mut h = H::new(
         container()
             .height(100.0)
-            .scrollable(ScrollAxis::Vertical)
+            .scroll(Scroll::vertical())
             .child(box_of(40.0, 900.0)),
     );
     assert_eq!(
@@ -3024,7 +3121,7 @@ fn a_clipping_container_does_not_carry_its_content_s_overhang() {
         container()
             .width(100.0)
             .height(100.0)
-            .scrollable(ScrollAxis::Vertical)
+            .scroll(Scroll::vertical())
             .layout(Flex::column())
             .children(rows),
     );
@@ -3064,7 +3161,7 @@ fn a_clipping_container_keeps_not_carrying_it_when_a_child_moves() {
         container()
             .width(100.0)
             .height(100.0)
-            .scrollable(ScrollAxis::Vertical)
+            .scroll(Scroll::vertical())
             .layout(Flex::column())
             .children(rows),
     );
@@ -3329,7 +3426,7 @@ fn scrolling_a_frosted_card_away_withdraws_its_blur() {
         container()
             .width(40.0)
             .height(30.0)
-            .scrollable(ScrollAxis::Vertical)
+            .scroll(Scroll::vertical())
             .children(rows),
     );
     assert!(

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -563,24 +563,46 @@ fn a_handle_takes_corners_the_old_pair_could_not_spell() {
     );
 }
 
-/// A scrollbar that comes and goes on a signal, with the content scrollable
-/// either way.
+/// A scrollbar that comes back after being hidden.
+///
+/// Starting Hidden is the half worth testing, and the half the agreed design
+/// chose a property over a `.hidden()` flag for — "a flag can only be set, and
+/// this has to be able to come back". A container laid out Hidden returns from
+/// `ensure_scrollbar_containers` before registering the track and the handle,
+/// so the flip back has to create them *and* lay them out in one pass; and it
+/// only gets that pass because `resolve_scroll` reads the visibility under
+/// layout tracking, which is what marks the container and keeps it off the
+/// unchanged-constraints fast path.
+///
+/// That the content still scrolls while the bar is hidden is not re-asserted
+/// here — `Hidden` gates only the drawing, and the scroll tests in
+/// `tests/scroll_momentum.rs` and `tests/scrollbar_handle_tracking.rs` own that
+/// question.
 #[test]
 fn visibility_answers_to_a_signal() {
-    let shown = create_signal(ScrollbarVisibility::Always);
+    let shown = create_signal(ScrollbarVisibility::Hidden);
     let mut h = scroller(Scroll::vertical().visibility(shown));
     h.fit(500.0, 500.0);
-    let with_bar = h.paint().children.len();
+    let hidden_children = h.paint().children.len();
+
+    shown.set(ScrollbarVisibility::Always);
+    pump(&mut h);
+    h.fit(500.0, 500.0);
+    let shown_children = h.paint().children.len();
+
+    assert!(
+        shown_children > hidden_children,
+        "the scrollbar never came back: {hidden_children} children hidden, \
+         {shown_children} shown"
+    );
 
     shown.set(ScrollbarVisibility::Hidden);
     pump(&mut h);
     h.fit(500.0, 500.0);
-    let without = h.paint().children.len();
-
-    assert!(
-        without < with_bar,
-        "the scrollbar stayed on screen after the signal hid it: {with_bar} \
-         then {without}"
+    assert_eq!(
+        h.paint().children.len(),
+        hidden_children,
+        "and it goes away again"
     );
 }
 

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -606,6 +606,70 @@ fn visibility_answers_to_a_signal() {
     );
 }
 
+/// The gutter a reserved scrollbar takes out of the content is the bar plus a
+/// margin on each side.
+///
+/// `reserve_gutter` is the point of the setting — space the content never gets,
+/// scrollbar drawn or not — so the arithmetic that decides how much is worth
+/// pinning: `width + margin * 2`, not `width + margin + 2`, and not the margin
+/// counted once.
+#[test]
+fn a_reserved_gutter_is_the_bar_and_a_margin_on_each_side() {
+    fn content_width(width: f32, margin: f32) -> f32 {
+        let mut h = H::new(
+            container()
+                .width(200.0)
+                .height(100.0)
+                .scroll(Scroll::vertical().width(width).margin(margin))
+                .child(container().width(fill()).height(900.0)),
+        );
+        h.fit(500.0, 500.0);
+        // The content is the first child; a fill-width box reports what it was
+        // offered, which is the container minus the gutter.
+        h.paint().children[0].bounds.width
+    }
+
+    let wide_margin = content_width(6.0, 2.0);
+    let no_margin = content_width(6.0, 0.0);
+    assert_eq!(
+        no_margin - wide_margin,
+        4.0,
+        "two margins of 2 is 4px of content, so the margin is counted on both \
+         sides: {no_margin} against {wide_margin}"
+    );
+}
+
+/// A vertical scroller builds the parts for one axis, not for both.
+///
+/// The two branches that create them are guarded on the axis *and* on not
+/// having built them already. Loosen either to an `or` and a vertical scroller
+/// registers a horizontal track and handle as well — which nothing lays out and
+/// nothing paints, so the count has to be read off the tree rather than off the
+/// paint, or the waste is invisible.
+#[test]
+fn a_one_axis_scroller_builds_one_axis_worth_of_parts() {
+    let mut vertical = scroller(Scroll::vertical());
+    vertical.fit(500.0, 500.0);
+    let one_axis = vertical.tree.get_children(vertical.root).len();
+
+    let mut both = H::new(
+        container()
+            .width(100.0)
+            .height(100.0)
+            .scroll(Scroll::both())
+            .child(box_of(900.0, 900.0)),
+    );
+    both.fit(500.0, 500.0);
+    let two_axes = both.tree.get_children(both.root).len();
+
+    assert_eq!(
+        two_axes - one_axis,
+        2,
+        "one axis is a track and a handle, so two axes is exactly two more: \
+         {one_axis} against {two_axes}"
+    );
+}
+
 /// Whether a scrollbar exists at all comes down to one comparison — content
 /// against viewport — so the viewport a scroller records has to be its
 /// *visible* extent, never the unbounded constraint the scrolled axis is laid

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -40,9 +40,7 @@ use super::children::ChildrenSource;
 use super::control::Control;
 use super::into_child::{IntoChild, IntoChildren};
 use super::paint_children::{ChildPaintOptions, paint_children};
-use super::scroll::{
-    ScrollAxis, ScrollState, ScrollbarBuilder, ScrollbarConfig, ScrollbarVisibility,
-};
+use super::scroll::{Scroll, ScrollAxis, ScrollState, ScrollbarMetrics, ScrollbarVisibility};
 use super::state_layer::{
     Moves, RippleConfig, StateStyle, StateWhen, Stateful, resolve_background,
 };
@@ -365,10 +363,16 @@ impl InteractionState {
 }
 
 /// Scroll state and configuration, boxed to avoid bloating Container.
-/// Only allocated when `.scrollable()` is called.
+/// Only allocated when `.scroll()` is called.
 pub(super) struct ScrollData {
+    /// What the application declared. Holds the signals and the two styling
+    /// closures; nothing reads it per frame except to resolve the metrics.
+    pub(super) scroll: Scroll,
+    /// The declared measurements, resolved under this pass's layout tracking.
+    /// The track and handle rects are arithmetic and read this, not signals.
+    pub(super) metrics: ScrollbarMetrics,
+    /// What `visibility` said when layout last read it.
     pub(super) scrollbar_visibility: ScrollbarVisibility,
-    pub(super) scrollbar_config: ScrollbarConfig,
     pub(super) scroll_state: ScrollState,
     pub(super) v_scrollbar_track_id: Option<WidgetId>,
     pub(super) v_scrollbar_handle_id: Option<WidgetId>,
@@ -378,11 +382,18 @@ pub(super) struct ScrollData {
     pub(super) h_scrollbar_scale_anim: Option<AnimationState<f32>>,
 }
 
-impl Default for ScrollData {
-    fn default() -> Self {
+impl ScrollData {
+    /// Built from the declaration and nothing else — there is no default axis
+    /// to invent, because a `Scroll` always names one.
+    ///
+    /// The resolved fields start at their own defaults and are overwritten by
+    /// `resolve_scroll` at the top of the first layout, before anything reads
+    /// them.
+    fn new(scroll: Scroll) -> Self {
         Self {
+            scroll,
+            metrics: ScrollbarMetrics::default(),
             scrollbar_visibility: ScrollbarVisibility::Always,
-            scrollbar_config: ScrollbarConfig::default(),
             scroll_state: ScrollState::default(),
             v_scrollbar_track_id: None,
             v_scrollbar_handle_id: None,
@@ -521,8 +532,38 @@ impl Container {
         tree.set_own_paint_reach(id, self.max_transform_reach(bounds, shadow));
     }
 
+    /// Resolve the declared scroll measurements for this pass.
+    ///
+    /// Under layout tracking, and at the top of `layout`, because the gutter
+    /// these describe comes out of the content box before anything is measured
+    /// — so a width written to a signal has to re-run this container's layout,
+    /// not merely repaint it. The geometry below reads the resolved numbers:
+    /// a track rect is arithmetic, and arithmetic should not be reading signals
+    /// halfway through.
+    fn resolve_scroll(&mut self, id: WidgetId) {
+        let Some(data) = self.scroll_data.as_mut() else {
+            return;
+        };
+        let scroll = &data.scroll;
+        let defaults = ScrollbarMetrics::default();
+        let (metrics, visibility) = with_signal_tracking(id, JobType::Layout, || {
+            (
+                ScrollbarMetrics {
+                    width: scroll.width.get_or(defaults.width),
+                    hover_width: scroll.hover_width.get_or(defaults.hover_width),
+                    margin: scroll.margin.get_or(defaults.margin),
+                    min_handle_size: scroll.min_handle_size.get_or(defaults.min_handle_size),
+                    reserve_gutter: scroll.reserve_gutter.get_or(defaults.reserve_gutter),
+                },
+                scroll.visibility.get_or(ScrollbarVisibility::Always),
+            )
+        });
+        data.metrics = metrics;
+        data.scrollbar_visibility = visibility;
+    }
+
     /// Get scroll data (panics if not scrollable — only call when scroll_axis != None)
-    fn scroll(&self) -> &ScrollData {
+    fn scroll_data(&self) -> &ScrollData {
         self.scroll_data.as_deref().expect("scroll_data not set")
     }
 
@@ -534,10 +575,6 @@ impl Container {
     }
 
     /// Get or create scroll data
-    fn scroll_or_init(&mut self) -> &mut ScrollData {
-        self.scroll_data.get_or_insert_with(Box::default)
-    }
-
     /// Get or create the transform components.
     fn transform_mut(&mut self) -> &mut TransformProps {
         self.transform.get_or_insert_with(Box::default)
@@ -789,28 +826,29 @@ impl Container {
         self
     }
 
-    /// Enable scrolling on this container.
-    pub fn scrollable(mut self, axis: ScrollAxis) -> Self {
-        self.scroll_axis = axis;
-        if axis != ScrollAxis::None {
-            self.scroll_data = Some(Box::default());
-        }
-        self
-    }
-
-    /// Configure scrollbar visibility.
-    pub fn scrollbar_visibility(mut self, visibility: ScrollbarVisibility) -> Self {
-        self.scroll_or_init().scrollbar_visibility = visibility;
-        self
-    }
-
-    /// Customize scrollbar appearance.
-    pub fn scrollbar<F>(mut self, f: F) -> Self
-    where
-        F: FnOnce(ScrollbarBuilder) -> ScrollbarBuilder,
-    {
-        let builder = f(ScrollbarBuilder::default());
-        self.scroll_or_init().scrollbar_config = builder.build();
+    /// Scroll this container, and say what its scrollbar looks like.
+    ///
+    /// One value rather than three setters. `scrollbar_visibility` and
+    /// `scrollbar` used to be separate and were silent no-ops on a container
+    /// that never became scrollable — half a configuration that compiled and
+    /// did nothing. There is no way to write that now:
+    ///
+    /// ```compile_fail,E0599
+    /// # use guido::prelude::*;
+    /// // The parts cannot be declared apart from the thing they configure.
+    /// // E0599 pinned on purpose: a bare `compile_fail` passes on any error at
+    /// // all, including a typo in the test itself, so it would go on passing
+    /// // long after it stopped meaning anything.
+    /// container().scrollbar_visibility(ScrollbarVisibility::Hidden);
+    /// ```
+    ///
+    /// ```ignore
+    /// container().scroll(Scroll::vertical())
+    /// container().scroll(Scroll::both().overlay().handle(|h| h.background(RED)))
+    /// ```
+    pub fn scroll(mut self, scroll: Scroll) -> Self {
+        self.scroll_axis = scroll.axis;
+        self.scroll_data = Some(Box::new(ScrollData::new(scroll)));
         self
     }
 
@@ -1317,6 +1355,12 @@ impl Widget for Container {
             return size;
         }
 
+        // Before `ensure_scrollbar_containers`, which reads the resolved
+        // visibility to decide whether to build the parts at all — and before
+        // the gutter `child_layout` takes out of the content box, which is
+        // measured from the resolved width and margin.
+        self.resolve_scroll(id);
+
         tree.set_relayout_boundary(id, self.is_relayout_boundary_for(constraints));
         self.ensure_scrollbar_containers(tree, id);
 
@@ -1481,7 +1525,7 @@ impl Widget for Container {
             Some(at) => {
                 let mut child_at = hit.rebase(at);
                 if self.scroll_axis != ScrollAxis::None {
-                    let sd = self.scroll();
+                    let sd = self.scroll_data();
                     child_at = child_at.offset(sd.scroll_state.offset_x, sd.scroll_state.offset_y);
                 }
                 Cow::Owned(local_event.with_coords(Some(child_at)))
@@ -1623,7 +1667,7 @@ impl Widget for Container {
         // For scrollable containers: viewport mapped to layout space (before scroll transform).
         // For non-scrollable containers: inherited from parent via PaintContext.
         let effective_cull_rect = if is_scrollable {
-            let sd = self.scroll();
+            let sd = self.scroll_data();
             Some(Rect::new(
                 sd.scroll_state.offset_x,
                 sd.scroll_state.offset_y,
@@ -1644,7 +1688,7 @@ impl Widget for Container {
         let all_children = self.children_source.get();
 
         let scroll_offset = if is_scrollable {
-            let sd = self.scroll();
+            let sd = self.scroll_data();
             (sd.scroll_state.offset_x, sd.scroll_state.offset_y)
         } else {
             (0.0, 0.0)

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -574,7 +574,6 @@ impl Container {
             .expect("scroll_data not set")
     }
 
-    /// Get or create scroll data
     /// Get or create the transform components.
     fn transform_mut(&mut self) -> &mut TransformProps {
         self.transform.get_or_insert_with(Box::default)
@@ -842,9 +841,20 @@ impl Container {
     /// container().scrollbar_visibility(ScrollbarVisibility::Hidden);
     /// ```
     ///
-    /// ```ignore
-    /// container().scroll(Scroll::vertical())
-    /// container().scroll(Scroll::both().overlay().handle(|h| h.background(RED)))
+    /// ```compile_fail,E0599
+    /// # use guido::prelude::*;
+    /// // ... and neither can the styling.
+    /// container().scrollbar(|sb| sb.width(6.0));
+    /// ```
+    ///
+    /// ```
+    /// # use guido::prelude::*;
+    /// container().scroll(Scroll::vertical());
+    /// container().scroll(
+    ///     Scroll::both()
+    ///         .overlay()
+    ///         .handle(|h| h.background(Color::RED)),
+    /// );
     /// ```
     pub fn scroll(mut self, scroll: Scroll) -> Self {
         self.scroll_axis = scroll.axis;

--- a/src/widgets/container/scrollable.rs
+++ b/src/widgets/container/scrollable.rs
@@ -7,6 +7,7 @@ use crate::jobs::{JobRequest, RequiredJob, request_job};
 use crate::layout::Constraints;
 use crate::renderer::PaintContext;
 use crate::tree::{Tree, WidgetId};
+use crate::widgets::Scroll;
 use crate::widgets::scroll::{ScrollAxis, ScrollbarAxis, ScrollbarVisibility};
 use crate::widgets::widget::{Event, EventResponse, MouseButton, Point, Rect, ScrollSource};
 
@@ -15,22 +16,21 @@ use super::animations::AnimationState;
 use super::interaction::{HitContext, untransform_point};
 use crate::pivot::Pivot;
 use crate::transform::Transform;
-use crate::widgets::state_layer::Stateful;
 
 impl Container {
     /// Initialize scrollbar containers if scrolling is enabled and they don't exist yet.
     /// Scrollbar containers are registered in Tree as real widgets.
     pub(super) fn ensure_scrollbar_containers(&mut self, tree: &mut Tree, id: WidgetId) {
         if self.scroll_axis == ScrollAxis::None
-            || self.scroll().scrollbar_visibility == ScrollbarVisibility::Hidden
+            || self.scroll_data().scrollbar_visibility == ScrollbarVisibility::Hidden
         {
             return;
         }
 
         // Create vertical scrollbar containers if needed
-        if self.scroll_axis.allows_vertical() && self.scroll().v_scrollbar_track_id.is_none() {
+        if self.scroll_axis.allows_vertical() && self.scroll_data().v_scrollbar_track_id.is_none() {
             let (track, handle, scale_anim) =
-                Self::create_scrollbar_components(&self.scroll().scrollbar_config);
+                Self::create_scrollbar_components(&self.scroll_data().scroll);
 
             // Register track in Tree
             let track_id = tree.register(Box::new(track));
@@ -46,9 +46,10 @@ impl Container {
         }
 
         // Create horizontal scrollbar containers if needed
-        if self.scroll_axis.allows_horizontal() && self.scroll().h_scrollbar_track_id.is_none() {
+        if self.scroll_axis.allows_horizontal() && self.scroll_data().h_scrollbar_track_id.is_none()
+        {
             let (track, handle, scale_anim) =
-                Self::create_scrollbar_components(&self.scroll().scrollbar_config);
+                Self::create_scrollbar_components(&self.scroll_data().scroll);
 
             // Register track in Tree
             let track_id = tree.register(Box::new(track));
@@ -64,34 +65,25 @@ impl Container {
         }
     }
 
-    fn create_scrollbar_components(
-        config: &crate::widgets::scroll::ScrollbarConfig,
-    ) -> (Container, Container, AnimationState<f32>) {
-        use crate::widgets::state_layer::StateStyle;
+    /// The track and the handle, as the two containers they are.
+    ///
+    /// The defaults are what a scrollbar looks like with nothing declared; the
+    /// closures on [`Scroll`] are applied over them, so an application that
+    /// sets a colour keeps the corners and vice versa. Everything a container
+    /// can be told is available here, and reactive, because these *are*
+    /// containers — which is the whole reason the flat config is gone.
+    fn create_scrollbar_components(scroll: &Scroll) -> (Container, Container, AnimationState<f32>) {
+        let track = Scroll::default_track();
+        let track = match &scroll.track {
+            Some(f) => f(track),
+            None => track,
+        };
 
-        let track_color = config.track_color;
-        let track_corner_radius = config.track_corner_radius;
-        let track_corner_curvature = config.track_corner_curvature;
-        let handle_color = config.handle_color;
-        let handle_corner_radius = config.handle_corner_radius;
-        let handle_corner_curvature = config.handle_corner_curvature;
-        let handle_hover_color = config.handle_hover_color;
-        let handle_pressed_color = config.handle_pressed_color;
-
-        // Track container
-        let track = Container::new().background(track_color).corners(
-            crate::widgets::Corners::superellipse(track_corner_radius, track_corner_curvature),
-        );
-
-        // Handle container with hover state for color change and ripple on press
-        let handle = Container::new()
-            .background(handle_color)
-            .corners(crate::widgets::Corners::superellipse(
-                handle_corner_radius,
-                handle_corner_curvature,
-            ))
-            .when_hovered(move |s: StateStyle| s.background(handle_hover_color))
-            .when_pressed(move |s: StateStyle| s.background(handle_pressed_color).ripple());
+        let handle = Scroll::default_handle();
+        let handle = match &scroll.handle {
+            Some(f) => f(handle),
+            None => handle,
+        };
 
         // Scale animation for hover expansion (starts at 1.0 = normal size)
         // Custom spring: high stiffness (fast) + low damping (bouncy)
@@ -113,13 +105,13 @@ impl Container {
         size: crate::layout::Size,
     ) {
         if self.scroll_axis == ScrollAxis::None
-            || self.scroll().scrollbar_visibility == ScrollbarVisibility::Hidden
+            || self.scroll_data().scrollbar_visibility == ScrollbarVisibility::Hidden
         {
             return;
         }
 
-        let sd = self.scroll();
-        let scale_factor = sd.scrollbar_config.hover_width / sd.scrollbar_config.width;
+        let sd = self.scroll_data();
+        let scale_factor = sd.metrics.hover_width / sd.metrics.width;
         let needs_vertical = sd.scroll_state.needs_vertical_scrollbar();
         let needs_horizontal = sd.scroll_state.needs_horizontal_scrollbar();
 
@@ -162,17 +154,17 @@ impl Container {
         needs_other_scrollbar: bool,
         local_bounds: Rect,
     ) {
-        let sd = self.scroll();
+        let sd = self.scroll_data();
         let track_rect = sd.scroll_state.scrollbar_track_rect(
             axis,
             local_bounds,
-            &sd.scrollbar_config,
+            &sd.metrics,
             needs_other_scrollbar,
         );
         let handle_rect = sd.scroll_state.scrollbar_handle_rect(
             axis,
             local_bounds,
-            &sd.scrollbar_config,
+            &sd.metrics,
             needs_other_scrollbar,
         );
 
@@ -244,13 +236,13 @@ impl Container {
         now: std::time::Instant,
     ) -> bool {
         if self.scroll_axis == ScrollAxis::None
-            || self.scroll().scrollbar_visibility == ScrollbarVisibility::Hidden
+            || self.scroll_data().scrollbar_visibility == ScrollbarVisibility::Hidden
         {
             return false;
         }
 
-        let sd = self.scroll();
-        let scale_factor = sd.scrollbar_config.hover_width / sd.scrollbar_config.width;
+        let sd = self.scroll_data();
+        let scale_factor = sd.metrics.hover_width / sd.metrics.width;
         let needs_vertical = sd.scroll_state.needs_vertical_scrollbar();
         let needs_horizontal = sd.scroll_state.needs_horizontal_scrollbar();
         let mut any_animating = false;
@@ -278,7 +270,7 @@ impl Container {
         now: std::time::Instant,
     ) -> bool {
         // Determine target scale based on hover state
-        let sd = self.scroll();
+        let sd = self.scroll_data();
         let is_hovered = sd.scroll_state.is_track_hovered(axis)
             || sd.scroll_state.is_handle_hovered(axis)
             || sd.scroll_state.is_dragging(axis);
@@ -331,17 +323,14 @@ impl Container {
         // transform carries the container's own position.
         let local_bounds = Rect::new(0.0, 0.0, bounds.width, bounds.height);
 
-        let sd = self.scroll();
+        let sd = self.scroll_data();
         let needs_other = match axis {
             ScrollbarAxis::Vertical => sd.scroll_state.needs_horizontal_scrollbar(),
             ScrollbarAxis::Horizontal => sd.scroll_state.needs_vertical_scrollbar(),
         };
-        let rect = sd.scroll_state.scrollbar_handle_rect(
-            axis,
-            local_bounds,
-            &sd.scrollbar_config,
-            needs_other,
-        );
+        let rect =
+            sd.scroll_state
+                .scrollbar_handle_rect(axis, local_bounds, &sd.metrics, needs_other);
         (rect.x, rect.y)
     }
 
@@ -355,7 +344,7 @@ impl Container {
         id: WidgetId,
         ctx: &mut PaintContext,
     ) {
-        let sd = self.scroll();
+        let sd = self.scroll_data();
 
         if sd.scrollbar_visibility == ScrollbarVisibility::Hidden {
             return;
@@ -473,7 +462,7 @@ impl Container {
     /// missing — the pressed colour and the ripple, on a handle sitting visibly
     /// under the pointer.
     fn forward_to_handle(&self, tree: &mut Tree, id: WidgetId, axis: ScrollbarAxis, event: &Event) {
-        let sd = self.scroll();
+        let sd = self.scroll_data();
         let handle_id = match axis {
             ScrollbarAxis::Vertical => sd.v_scrollbar_handle_id,
             ScrollbarAxis::Horizontal => sd.h_scrollbar_handle_id,
@@ -526,7 +515,7 @@ impl Container {
         event: &Event,
     ) -> Option<EventResponse> {
         if self.scroll_axis == ScrollAxis::None
-            || self.scroll().scrollbar_visibility == ScrollbarVisibility::Hidden
+            || self.scroll_data().scrollbar_visibility == ScrollbarVisibility::Hidden
         {
             return None;
         }
@@ -545,7 +534,7 @@ impl Container {
             } if *button == MouseButton::Left => {
                 // Check vertical scrollbar
                 if self.scroll_axis.allows_vertical()
-                    && self.scroll().scroll_state.needs_vertical_scrollbar()
+                    && self.scroll_data().scroll_state.needs_vertical_scrollbar()
                     && let Some(response) = self.handle_scrollbar_click(
                         tree,
                         id,
@@ -561,7 +550,7 @@ impl Container {
 
                 // Check horizontal scrollbar
                 if self.scroll_axis.allows_horizontal()
-                    && self.scroll().scroll_state.needs_horizontal_scrollbar()
+                    && self.scroll_data().scroll_state.needs_horizontal_scrollbar()
                     && let Some(response) = self.handle_scrollbar_click(
                         tree,
                         id,
@@ -585,7 +574,7 @@ impl Container {
             Event::MouseMove { at } => {
                 // Handle dragging
                 if let Some(at) = at {
-                    if self.scroll().scroll_state.scrollbar_dragging {
+                    if self.scroll_data().scroll_state.scrollbar_dragging {
                         return Some(self.handle_scrollbar_drag(
                             id,
                             bounds,
@@ -593,7 +582,7 @@ impl Container {
                             at.y,
                         ));
                     }
-                    if self.scroll().scroll_state.h_scrollbar_dragging {
+                    if self.scroll_data().scroll_state.h_scrollbar_dragging {
                         return Some(self.handle_scrollbar_drag(
                             id,
                             bounds,
@@ -607,7 +596,7 @@ impl Container {
                 let mut needs_repaint = false;
 
                 if self.scroll_axis.allows_vertical()
-                    && self.scroll().scroll_state.needs_vertical_scrollbar()
+                    && self.scroll_data().scroll_state.needs_vertical_scrollbar()
                 {
                     needs_repaint |= self.update_scrollbar_hover(
                         tree,
@@ -620,7 +609,7 @@ impl Container {
                 }
 
                 if self.scroll_axis.allows_horizontal()
-                    && self.scroll().scroll_state.needs_horizontal_scrollbar()
+                    && self.scroll_data().scroll_state.needs_horizontal_scrollbar()
                 {
                     needs_repaint |= self.update_scrollbar_hover(
                         tree,
@@ -638,13 +627,13 @@ impl Container {
             }
 
             Event::MouseUp { button, .. } if *button == MouseButton::Left => {
-                if self.scroll().scroll_state.scrollbar_dragging {
+                if self.scroll_data().scroll_state.scrollbar_dragging {
                     self.scroll_mut().scroll_state.scrollbar_dragging = false;
                     self.forward_to_handle(tree, id, ScrollbarAxis::Vertical, event);
                     request_job(id, JobRequest::Paint);
                     return Some(EventResponse::Handled);
                 }
-                if self.scroll().scroll_state.h_scrollbar_dragging {
+                if self.scroll_data().scroll_state.h_scrollbar_dragging {
                     self.scroll_mut().scroll_state.h_scrollbar_dragging = false;
                     self.forward_to_handle(tree, id, ScrollbarAxis::Horizontal, event);
                     request_job(id, JobRequest::Paint);
@@ -690,17 +679,17 @@ impl Container {
         y: f32,
         event: &Event,
     ) -> Option<EventResponse> {
-        let sd = self.scroll();
+        let sd = self.scroll_data();
         let needs_other = match axis {
             ScrollbarAxis::Vertical => sd.scroll_state.needs_horizontal_scrollbar(),
             ScrollbarAxis::Horizontal => sd.scroll_state.needs_vertical_scrollbar(),
         };
         let handle_rect =
             sd.scroll_state
-                .scrollbar_handle_rect(axis, bounds, &sd.scrollbar_config, needs_other);
-        let hit_area =
-            sd.scroll_state
-                .scrollbar_hit_area(axis, bounds, &sd.scrollbar_config, needs_other);
+                .scrollbar_handle_rect(axis, bounds, &sd.metrics, needs_other);
+        let hit_area = sd
+            .scroll_state
+            .scrollbar_hit_area(axis, bounds, &sd.metrics, needs_other);
         // The handle paints wider on hover (hover_width); accept drags across
         // that full width, not just the resting-width strip
         let handle_hit = widen_across_axis(axis, handle_rect, hit_area);
@@ -722,20 +711,15 @@ impl Container {
             return Some(EventResponse::Handled);
         } else if hit_area.contains(x, y) {
             // Click on track - jump to position
-            let sd = self.scroll();
-            let track_rect = sd.scroll_state.scrollbar_track_rect(
-                axis,
-                bounds,
-                &sd.scrollbar_config,
-                needs_other,
-            );
+            let sd = self.scroll_data();
+            let track_rect =
+                sd.scroll_state
+                    .scrollbar_track_rect(axis, bounds, &sd.metrics, needs_other);
             let (track_size, handle_size, click_pos) = match axis {
                 ScrollbarAxis::Vertical => {
-                    let handle_size = sd.scroll_state.scrollbar_handle_size(
-                        axis,
-                        track_rect.height,
-                        &sd.scrollbar_config,
-                    );
+                    let handle_size =
+                        sd.scroll_state
+                            .scrollbar_handle_size(axis, track_rect.height, &sd.metrics);
                     (
                         track_rect.height,
                         handle_size,
@@ -743,11 +727,9 @@ impl Container {
                     )
                 }
                 ScrollbarAxis::Horizontal => {
-                    let handle_size = sd.scroll_state.scrollbar_handle_size(
-                        axis,
-                        track_rect.width,
-                        &sd.scrollbar_config,
-                    );
+                    let handle_size =
+                        sd.scroll_state
+                            .scrollbar_handle_size(axis, track_rect.width, &sd.metrics);
                     (
                         track_rect.width,
                         handle_size,
@@ -776,21 +758,21 @@ impl Container {
         axis: ScrollbarAxis,
         pos: f32,
     ) -> EventResponse {
-        let sd = self.scroll();
+        let sd = self.scroll_data();
         let needs_other = match axis {
             ScrollbarAxis::Vertical => sd.scroll_state.needs_horizontal_scrollbar(),
             ScrollbarAxis::Horizontal => sd.scroll_state.needs_vertical_scrollbar(),
         };
-        let track =
-            sd.scroll_state
-                .scrollbar_track_rect(axis, bounds, &sd.scrollbar_config, needs_other);
+        let track = sd
+            .scroll_state
+            .scrollbar_track_rect(axis, bounds, &sd.metrics, needs_other);
         let track_size = match axis {
             ScrollbarAxis::Vertical => track.height,
             ScrollbarAxis::Horizontal => track.width,
         };
-        let handle_size =
-            sd.scroll_state
-                .scrollbar_handle_size(axis, track_size, &sd.scrollbar_config);
+        let handle_size = sd
+            .scroll_state
+            .scrollbar_handle_size(axis, track_size, &sd.metrics);
         let available = track_size - handle_size;
 
         if available > 0.0 {
@@ -817,17 +799,17 @@ impl Container {
         at: Option<Point>,
         _event: &Event,
     ) -> bool {
-        let sd = self.scroll();
+        let sd = self.scroll_data();
         let needs_other = match axis {
             ScrollbarAxis::Vertical => sd.scroll_state.needs_horizontal_scrollbar(),
             ScrollbarAxis::Horizontal => sd.scroll_state.needs_vertical_scrollbar(),
         };
-        let hit_area =
-            sd.scroll_state
-                .scrollbar_hit_area(axis, bounds, &sd.scrollbar_config, needs_other);
+        let hit_area = sd
+            .scroll_state
+            .scrollbar_hit_area(axis, bounds, &sd.metrics, needs_other);
         let handle_rect =
             sd.scroll_state
-                .scrollbar_handle_rect(axis, bounds, &sd.scrollbar_config, needs_other);
+                .scrollbar_handle_rect(axis, bounds, &sd.metrics, needs_other);
         // Hover follows the same widened area the drag hit-test uses
         let handle_hit = widen_across_axis(axis, handle_rect, hit_area);
 

--- a/src/widgets/diagnostic_audit.rs
+++ b/src/widgets/diagnostic_audit.rs
@@ -26,7 +26,7 @@ use crate::reactive::diagnostics::report_count;
 use crate::renderer::{PaintContext, RenderNode};
 use crate::tree::Tree;
 use crate::widgets::widget::{Event, Key, Modifiers, MouseButton, ScrollSource};
-use crate::widgets::{Color, ImageSource, LinearGradient, Overflow, ScrollAxis};
+use crate::widgets::{Color, ImageSource, LinearGradient, Overflow, Scroll};
 use crate::widgets::{
     InputStyled, Stateful, TextStyled, Widget, container, image, text, text_input,
 };
@@ -165,7 +165,7 @@ fn a_scrollable_container_is_quiet() {
     let widget = container()
         .width(100.0)
         .height(100.0)
-        .scrollable(ScrollAxis::Both)
+        .scroll(Scroll::both())
         .padding(move || n.get())
         .child(container().width(500.0).height(500.0));
 

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -30,7 +30,7 @@ pub use input_style::{InputStyle, InputStyled};
 pub use into_child::{
     DynamicChildren, IntoChild, IntoChildren, IntoDynChild, KeyedChildren, StaticChildren, keyed,
 };
-pub use scroll::{ScrollAxis, ScrollbarBuilder, ScrollbarConfig, ScrollbarVisibility};
+pub use scroll::{Scroll, ScrollbarVisibility};
 pub use state_layer::{
     BackgroundOverride, BorderOverride, RippleConfig, StateStyle, StateWhen, Stateful,
 };

--- a/src/widgets/scroll.rs
+++ b/src/widgets/scroll.rs
@@ -1,6 +1,8 @@
 //! Scroll configuration types for scrollable containers.
 
-use super::widget::{Color, Rect};
+use super::widget::Rect;
+use crate::reactive::{IntoSignal, Signal};
+use crate::widgets::{Color, Container};
 
 /// Axis for scrollbar calculations (vertical or horizontal)
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -45,183 +47,201 @@ pub enum ScrollbarVisibility {
     Hidden,
 }
 
-/// Configuration for scrollbar appearance
-#[derive(Debug, Clone)]
-pub struct ScrollbarConfig {
+/// The measurements the container's own layout needs before anything paints.
+///
+/// Resolved once per layout pass from the signals on [`Scroll`], and handed to
+/// the geometry below as plain numbers — the track and handle rects are
+/// arithmetic, and arithmetic should not be reading signals halfway through.
+///
+/// What is *not* here is appearance. Colour, corners, borders and the hover and
+/// pressed states are `Container`'s vocabulary, reached through
+/// [`Scroll::track`] and [`Scroll::handle`], because the scrollbar is two
+/// containers and always was.
+#[derive(Debug, Clone, Copy)]
+pub struct ScrollbarMetrics {
     /// Width of the scrollbar track and handle (normal state)
     pub width: f32,
     /// Width of the scrollbar when hovered (expanded state)
     pub hover_width: f32,
     /// Margin from the edge of the container
     pub margin: f32,
-    /// Color of the scrollbar track
-    pub track_color: Color,
-    /// Corner radius of the track
-    pub track_corner_radius: f32,
-    /// Corner curvature of the track (K-value: 0=bevel, 1=circular, 2=squircle)
-    pub track_corner_curvature: f32,
-    /// Color of the scrollbar handle
-    pub handle_color: Color,
-    /// Corner radius of the handle
-    pub handle_corner_radius: f32,
-    /// Corner curvature of the handle (K-value: 0=bevel, 1=circular, 2=squircle)
-    pub handle_corner_curvature: f32,
-    /// Color of the handle when hovered
-    pub handle_hover_color: Color,
-    /// Color of the handle when pressed/dragged
-    pub handle_pressed_color: Color,
     /// Minimum size of the handle (to ensure it's always grabbable)
     pub min_handle_size: f32,
-    /// Whether scrollbar reserves gutter space in layout
+    /// Whether the scrollbar reserves gutter space in layout
     pub reserve_gutter: bool,
 }
 
-impl Default for ScrollbarConfig {
+impl Default for ScrollbarMetrics {
     fn default() -> Self {
         Self {
             width: 6.0,
             hover_width: 10.0,
             margin: 2.0,
-            track_color: Color::rgba(1.0, 1.0, 1.0, 0.05),
-            track_corner_radius: 100.0, // Large value to ensure pill shape (clamped to half width)
-            track_corner_curvature: 1.0, // Circular corners (standard)
-            handle_color: Color::rgba(1.0, 1.0, 1.0, 0.3),
-            handle_corner_radius: 100.0, // Large value to ensure pill shape (clamped to half width)
-            handle_corner_curvature: 1.0, // Circular corners (standard)
-            handle_hover_color: Color::rgba(1.0, 1.0, 1.0, 0.5),
-            handle_pressed_color: Color::rgba(1.0, 1.0, 1.0, 0.6),
             min_handle_size: 20.0,
             reserve_gutter: true,
         }
     }
 }
 
-/// Builder for customizing scrollbar appearance
-#[derive(Default)]
-pub struct ScrollbarBuilder {
-    config: ScrollbarConfig,
+/// A radius far past half the width, which the shader clamps — so a scrollbar
+/// stays a pill at whatever width is declared.
+fn pill() -> crate::widgets::Corners {
+    crate::widgets::Corners::rounded(100.0)
 }
 
-impl ScrollbarBuilder {
-    /// Create a new scrollbar builder with default settings
-    pub fn new() -> Self {
-        Self::default()
+/// How a container scrolls, and what its scrollbar looks like.
+///
+/// One value rather than three setters. `scrollable`, `scrollbar_visibility`
+/// and `scrollbar` were separate, and the last two were silent no-ops on a
+/// container that never became scrollable — half a scroll configuration that
+/// compiled and did nothing. Reached through [`Container::scroll`], there is no
+/// way to spell the parts apart from the thing they configure.
+///
+/// ```ignore
+/// container().scroll(Scroll::vertical())
+///
+/// container().scroll(
+///     Scroll::vertical()
+///         .width(6.0)
+///         .handle(|h| h.background(theme.handle)
+///             .when_hovered(|s| s.background(theme.hot))),
+/// )
+/// ```
+///
+/// The axis is structural — it decides what kind of widget this is — so it is
+/// chosen by constructor and takes no signal, as `layout` and `control` do not.
+/// Everything else here is declared and therefore reactive.
+pub struct Scroll {
+    pub(crate) axis: ScrollAxis,
+    pub(crate) visibility: Option<Signal<ScrollbarVisibility>>,
+    pub(crate) width: Option<Signal<f32>>,
+    pub(crate) hover_width: Option<Signal<f32>>,
+    pub(crate) margin: Option<Signal<f32>>,
+    pub(crate) min_handle_size: Option<Signal<f32>>,
+    pub(crate) reserve_gutter: Option<Signal<bool>>,
+    pub(crate) track: Option<Box<dyn Fn(Container) -> Container>>,
+    pub(crate) handle: Option<Box<dyn Fn(Container) -> Container>>,
+}
+
+impl Scroll {
+    fn new(axis: ScrollAxis) -> Self {
+        Self {
+            axis,
+            visibility: None,
+            width: None,
+            hover_width: None,
+            margin: None,
+            min_handle_size: None,
+            reserve_gutter: None,
+            track: None,
+            handle: None,
+        }
     }
 
-    /// Set the width of the scrollbar (normal state)
-    pub fn width(mut self, width: f32) -> Self {
-        self.config.width = width;
+    /// Scroll vertically.
+    pub fn vertical() -> Self {
+        Self::new(ScrollAxis::Vertical)
+    }
+
+    /// Scroll horizontally.
+    pub fn horizontal() -> Self {
+        Self::new(ScrollAxis::Horizontal)
+    }
+
+    /// Scroll on both axes.
+    pub fn both() -> Self {
+        Self::new(ScrollAxis::Both)
+    }
+
+    /// Whether the scrollbar is drawn. Hidden still scrolls.
+    pub fn visibility<M>(mut self, visibility: impl IntoSignal<ScrollbarVisibility, M>) -> Self {
+        self.visibility = Some(visibility.into_signal());
         self
     }
 
-    /// Set the width of the scrollbar when hovered (expanded state)
-    pub fn hover_width(mut self, width: f32) -> Self {
-        self.config.hover_width = width;
+    /// The width of the track and handle at rest.
+    pub fn width<M>(mut self, width: impl IntoSignal<f32, M>) -> Self {
+        self.width = Some(width.into_signal());
         self
     }
 
-    /// Set the margin from the container edge
-    pub fn margin(mut self, margin: f32) -> Self {
-        self.config.margin = margin;
+    /// The width the handle grows to under the pointer.
+    ///
+    /// Not a `when_hovered(|s| s.width(..))`: the growth is a scale animation on
+    /// the handle, so it belongs to the geometry rather than to the styling.
+    pub fn hover_width<M>(mut self, width: impl IntoSignal<f32, M>) -> Self {
+        self.hover_width = Some(width.into_signal());
         self
     }
 
-    /// Set the track color
-    pub fn track_color(mut self, color: Color) -> Self {
-        self.config.track_color = color;
+    /// The gap between the scrollbar and the container's edges.
+    pub fn margin<M>(mut self, margin: impl IntoSignal<f32, M>) -> Self {
+        self.margin = Some(margin.into_signal());
         self
     }
 
-    /// Set the track corner radius
-    pub fn track_corner_radius(mut self, radius: f32) -> Self {
-        self.config.track_corner_radius = radius;
+    /// How short the handle is allowed to get, so it stays grabbable.
+    pub fn min_handle_size<M>(mut self, size: impl IntoSignal<f32, M>) -> Self {
+        self.min_handle_size = Some(size.into_signal());
         self
     }
 
-    /// Set the track corner curvature (K-value)
-    /// - 0.0 = bevel (diagonal cut)
-    /// - 1.0 = circular (standard, default)
-    /// - 2.0 = squircle (iOS-style smooth)
-    pub fn track_corner_curvature(mut self, curvature: f32) -> Self {
-        self.config.track_corner_curvature = curvature;
+    /// Whether the scrollbar takes space from the content or floats over it.
+    pub fn reserve_gutter<M>(mut self, reserve: impl IntoSignal<bool, M>) -> Self {
+        self.reserve_gutter = Some(reserve.into_signal());
         self
     }
 
-    /// Set the track to use squircle corners (K=2, iOS-style)
-    pub fn track_squircle(mut self) -> Self {
-        self.config.track_corner_curvature = 2.0;
+    /// Float the scrollbar over the content. Shorthand for
+    /// `reserve_gutter(false)`.
+    pub fn overlay(self) -> Self {
+        self.reserve_gutter(false)
+    }
+
+    /// The track as it looks with nothing declared.
+    ///
+    /// Named rather than buried in the scroll code so an application can read
+    /// the values it is overriding, and so [`track`](Self::track) has something
+    /// to say when it says the closure composes over a default.
+    pub fn default_track() -> Container {
+        Container::new()
+            .background(Color::rgba(1.0, 1.0, 1.0, 0.05))
+            .corners(pill())
+    }
+
+    /// The handle as it looks with nothing declared, hover and press included.
+    pub fn default_handle() -> Container {
+        use crate::widgets::state_layer::{StateStyle, Stateful};
+        Container::new()
+            .background(Color::rgba(1.0, 1.0, 1.0, 0.3))
+            .corners(pill())
+            .when_hovered(|s: StateStyle| s.background(Color::rgba(1.0, 1.0, 1.0, 0.5)))
+            .when_pressed(|s: StateStyle| s.background(Color::rgba(1.0, 1.0, 1.0, 0.6)).ripple())
+    }
+
+    /// Style the track — the groove the handle runs in.
+    ///
+    /// The closure receives the `Container` the track is, so everything a
+    /// container declares is available and reactive by construction. It
+    /// receives [`default_track`](Self::default_track), so what it does not set
+    /// it keeps — and ignoring the argument (`|_| container()`) is how you get
+    /// a track with no default styling at all.
+    ///
+    /// Its geometry is not yours to set: the scroll code lays both parts out
+    /// from the measurements above under tight constraints, so `width`,
+    /// `height` and any position set here are overwritten.
+    pub fn track(mut self, f: impl Fn(Container) -> Container + 'static) -> Self {
+        self.track = Some(Box::new(f));
         self
     }
 
-    /// Set the handle color
-    pub fn handle_color(mut self, color: Color) -> Self {
-        self.config.handle_color = color;
+    /// Style the handle — the part that moves and answers a drag.
+    ///
+    /// The same contract as [`track`](Self::track), over
+    /// [`default_handle`](Self::default_handle), and the same geometry caveat.
+    pub fn handle(mut self, f: impl Fn(Container) -> Container + 'static) -> Self {
+        self.handle = Some(Box::new(f));
         self
-    }
-
-    /// Set the handle corner radius
-    pub fn handle_corner_radius(mut self, radius: f32) -> Self {
-        self.config.handle_corner_radius = radius;
-        self
-    }
-
-    /// Set the handle corner curvature (K-value)
-    /// - 0.0 = bevel (diagonal cut)
-    /// - 1.0 = circular (standard, default)
-    /// - 2.0 = squircle (iOS-style smooth)
-    pub fn handle_corner_curvature(mut self, curvature: f32) -> Self {
-        self.config.handle_corner_curvature = curvature;
-        self
-    }
-
-    /// Set the handle to use squircle corners (K=2, iOS-style)
-    pub fn handle_squircle(mut self) -> Self {
-        self.config.handle_corner_curvature = 2.0;
-        self
-    }
-
-    /// Set both track and handle to use squircle corners (K=2, iOS-style)
-    pub fn squircle(mut self) -> Self {
-        self.config.track_corner_curvature = 2.0;
-        self.config.handle_corner_curvature = 2.0;
-        self
-    }
-
-    /// Set the handle hover color
-    pub fn handle_hover_color(mut self, color: Color) -> Self {
-        self.config.handle_hover_color = color;
-        self
-    }
-
-    /// Set the handle pressed/dragged color
-    pub fn handle_pressed_color(mut self, color: Color) -> Self {
-        self.config.handle_pressed_color = color;
-        self
-    }
-
-    /// Set the minimum handle size
-    pub fn min_handle_size(mut self, size: f32) -> Self {
-        self.config.min_handle_size = size;
-        self
-    }
-
-    /// Set whether scrollbar reserves gutter space in layout
-    /// When true (default), content area is reduced to make room for scrollbar
-    /// When false, scrollbar overlays the content
-    pub fn reserve_gutter(mut self, reserve: bool) -> Self {
-        self.config.reserve_gutter = reserve;
-        self
-    }
-
-    /// Make the scrollbar overlay content (no gutter space reserved)
-    pub fn overlay(mut self) -> Self {
-        self.config.reserve_gutter = false;
-        self
-    }
-
-    /// Build the scrollbar configuration
-    pub fn build(self) -> ScrollbarConfig {
-        self.config
     }
 }
 
@@ -484,7 +504,7 @@ impl ScrollState {
         &self,
         axis: ScrollbarAxis,
         bounds: Rect,
-        config: &ScrollbarConfig,
+        config: &ScrollbarMetrics,
         needs_other_scrollbar: bool,
     ) -> Rect {
         let margin = config.margin;
@@ -518,7 +538,7 @@ impl ScrollState {
         &self,
         axis: ScrollbarAxis,
         bounds: Rect,
-        config: &ScrollbarConfig,
+        config: &ScrollbarMetrics,
         needs_other_scrollbar: bool,
     ) -> Rect {
         let margin = config.margin;
@@ -551,7 +571,7 @@ impl ScrollState {
         &self,
         axis: ScrollbarAxis,
         track_size: f32,
-        config: &ScrollbarConfig,
+        config: &ScrollbarMetrics,
     ) -> f32 {
         let (viewport, content) = match axis {
             ScrollbarAxis::Vertical => (self.viewport_height, self.content_height),
@@ -591,7 +611,7 @@ impl ScrollState {
         &self,
         axis: ScrollbarAxis,
         bounds: Rect,
-        config: &ScrollbarConfig,
+        config: &ScrollbarMetrics,
         needs_other_scrollbar: bool,
     ) -> Rect {
         let track = self.scrollbar_track_rect(axis, bounds, config, needs_other_scrollbar);
@@ -1023,7 +1043,7 @@ mod tests {
             ..Default::default()
         };
 
-        let config = ScrollbarConfig::default();
+        let config = ScrollbarMetrics::default();
 
         // Vertical: viewport/content = 0.5, so handle should be 50% of track
         let v_handle = state.scrollbar_handle_size(ScrollbarAxis::Vertical, 400.0, &config);
@@ -1042,7 +1062,7 @@ mod tests {
             ..Default::default()
         };
 
-        let config = ScrollbarConfig::default();
+        let config = ScrollbarMetrics::default();
 
         // Handle should be at least min_handle_size
         let handle = state.scrollbar_handle_size(ScrollbarAxis::Vertical, 400.0, &config);

--- a/tests/cull_follows_the_transform.rs
+++ b/tests/cull_follows_the_transform.rs
@@ -64,7 +64,7 @@ fn scroller(children: Vec<guido::widgets::Container>) -> guido::widgets::Contain
     container()
         .width(200.0)
         .height(VIEWPORT)
-        .scrollable(ScrollAxis::Vertical)
+        .scroll(Scroll::vertical())
         .layout(Flex::column().spacing(PITCH - ROW_HEIGHT))
         .children(children)
 }
@@ -76,7 +76,7 @@ fn a_translated_column_paints_the_rows_the_translate_brings_into_view() {
         container()
             .width(200.0)
             .height(VIEWPORT)
-            .scrollable(ScrollAxis::Vertical)
+            .scroll(Scroll::vertical())
             .child(
                 container()
                     .layout(Flex::column().spacing(PITCH - ROW_HEIGHT))
@@ -107,7 +107,7 @@ fn an_untranslated_column_still_narrows_to_its_viewport() {
         container()
             .width(200.0)
             .height(VIEWPORT)
-            .scrollable(ScrollAxis::Vertical)
+            .scroll(Scroll::vertical())
             .child(
                 container()
                     .layout(Flex::column().spacing(PITCH - ROW_HEIGHT))
@@ -213,7 +213,7 @@ fn a_subtree_scaled_to_nothing_paints_nothing() {
         container()
             .width(200.0)
             .height(VIEWPORT)
-            .scrollable(ScrollAxis::Vertical)
+            .scroll(Scroll::vertical())
             .child(
                 container()
                     .layout(Flex::column().spacing(PITCH - ROW_HEIGHT))
@@ -266,7 +266,7 @@ fn the_window_widens_on_the_near_side_as_well() {
         container()
             .width(200.0)
             .height(VIEWPORT)
-            .scrollable(ScrollAxis::Vertical)
+            .scroll(Scroll::vertical())
             .child(
                 container()
                     .layout(Flex::column().spacing(PITCH - ROW_HEIGHT))

--- a/tests/paint_cache_across_frames.rs
+++ b/tests/paint_cache_across_frames.rs
@@ -84,7 +84,7 @@ fn column() -> Container {
                 .width(VIEWPORT)
                 .height(VIEWPORT)
                 .background(Color::rgb(0.15, 0.15, 0.2))
-                .scrollable(ScrollAxis::Vertical)
+                .scroll(Scroll::vertical())
                 .child(
                     // The list itself is drawn, not just its rows: it spans
                     // the whole content, so it is never culled and never

--- a/tests/render_snapshots.rs
+++ b/tests/render_snapshots.rs
@@ -307,19 +307,19 @@ fn scrolling() {
             box_of(200.0, 200.0)
                 .background(Color::rgb(0.15, 0.15, 0.2))
                 .corners(8.0)
-                .scrollable(ScrollAxis::Vertical)
+                .scroll(Scroll::vertical())
                 .child(column(20)),
         )
         .child(
             box_of(200.0, 200.0)
                 .background(Color::rgb(0.15, 0.15, 0.2))
-                .scrollable(ScrollAxis::Vertical)
+                .scroll(Scroll::vertical())
                 .child(column(2)),
         )
         .child(
             box_of(200.0, 80.0)
                 .background(Color::rgb(0.15, 0.15, 0.2))
-                .scrollable(ScrollAxis::Horizontal)
+                .scroll(Scroll::horizontal())
                 .child(
                     container()
                         .layout(Flex::row().spacing(8.0))
@@ -573,7 +573,7 @@ fn bar_like_composition() {
         .child(container().width(fill()).height(1.0))
         .child(
             box_of(90.0, 24.0)
-                .scrollable(ScrollAxis::Horizontal)
+                .scroll(Scroll::horizontal())
                 .background(Color::rgb(0.15, 0.15, 0.2))
                 .corners(6.0)
                 .child(

--- a/tests/scroll_momentum.rs
+++ b/tests/scroll_momentum.rs
@@ -22,7 +22,7 @@ impl H {
         let view = container()
             .width(200.0)
             .height(200.0)
-            .scrollable(ScrollAxis::Vertical)
+            .scroll(Scroll::vertical())
             .child(
                 container()
                     .layout(Flex::column().spacing(8.0))

--- a/tests/scroll_virtualization.rs
+++ b/tests/scroll_virtualization.rs
@@ -77,7 +77,7 @@ fn a_wrapped_list_paints_the_rows_an_unwrapped_one_paints() {
         container()
             .width(200.0)
             .height(VIEWPORT)
-            .scrollable(ScrollAxis::Vertical)
+            .scroll(Scroll::vertical())
             .layout(Flex::column().spacing(SPACING))
             .children(rows(ROWS)),
         VIEWPORT,
@@ -87,7 +87,7 @@ fn a_wrapped_list_paints_the_rows_an_unwrapped_one_paints() {
         container()
             .width(200.0)
             .height(VIEWPORT)
-            .scrollable(ScrollAxis::Vertical)
+            .scroll(Scroll::vertical())
             .child(
                 container()
                     .layout(Flex::column().spacing(SPACING))
@@ -135,7 +135,7 @@ fn a_scroller_whose_children_are_ordered_along_neither_axis_paints_all_of_them()
         container()
             .width(200.0)
             .height(100.0)
-            .scrollable(ScrollAxis::Vertical)
+            .scroll(Scroll::vertical())
             .layout(Scatter(SCATTERED.to_vec()))
             .children(rows(SCATTERED.len())),
         100.0,
@@ -195,7 +195,7 @@ fn the_counter_separates_a_narrowed_window_from_one_that_could_not_narrow() {
         container()
             .width(200.0)
             .height(VIEWPORT)
-            .scrollable(ScrollAxis::Vertical)
+            .scroll(Scroll::vertical())
             .layout(Flex::column().spacing(SPACING))
             .children(rows(ROWS)),
         VIEWPORT,
@@ -220,7 +220,7 @@ fn the_counter_separates_a_narrowed_window_from_one_that_could_not_narrow() {
         container()
             .width(200.0)
             .height(100.0)
-            .scrollable(ScrollAxis::Vertical)
+            .scroll(Scroll::vertical())
             .layout(Scatter(SCATTERED.to_vec()))
             .children(rows(8)),
         100.0,

--- a/tests/scrollbar_handle_tracking.rs
+++ b/tests/scrollbar_handle_tracking.rs
@@ -835,3 +835,34 @@ fn a_drag_that_loses_its_position_does_not_snap_the_offset() {
          {after}, was at {dragged_to}"
     );
 }
+
+/// A drag ends on the button that began it, and not on any other.
+///
+/// The `MouseUp` arm is guarded on `MouseButton::Left`, and a drag can only
+/// *start* on Left — so the guard looks like it cannot matter, and `cargo
+/// mutants` replacing it with `true` went unnoticed. It matters while a drag is
+/// live: a right-click released over a scroller mid-drag would drop the drag,
+/// and the handle would stop following a pointer whose button is still down.
+#[test]
+fn a_right_release_does_not_end_a_left_drag() {
+    let mut h = H::vertical();
+    let (x, y) = (
+        VIEWPORT - BAR_WIDTH / 2.0 - TRACK_START,
+        TRACK_START + V_HANDLE / 2.0,
+    );
+
+    h.dispatch(Event::mouse_move(x, y));
+    h.dispatch(Event::mouse_down(x, y, MouseButton::Left));
+
+    // The other button goes up while the drag is still held.
+    h.dispatch(Event::mouse_up(x, y, MouseButton::Right));
+
+    h.dispatch(Event::mouse_move(x, y + 40.0));
+    let dragged = h.handle_pos();
+    assert!(
+        dragged > TRACK_START + 1.0,
+        "the handle sat at {dragged} after the pointer moved 40px with the \
+         button still down: a release of a button that never started this drag \
+         ended it"
+    );
+}

--- a/tests/scrollbar_handle_tracking.rs
+++ b/tests/scrollbar_handle_tracking.rs
@@ -32,6 +32,9 @@ const VIEWPORT: f32 = 200.0;
 const TRACK_START: f32 = 2.0;
 const TRACK_LENGTH: f32 = 196.0;
 const BAR_WIDTH: f32 = 6.0;
+/// What the bar widens to under the pointer — `Scroll`'s own default, and the
+/// numerator of the scale the widening is made of.
+const HOVER_WIDTH: f32 = 10.0;
 
 /// A vertical scroller: 200x200 over 648px of content — 20 rows of 24, spaced
 /// 8, padded 8. The handle is `viewport / content * track` long.
@@ -467,10 +470,19 @@ fn the_width_a_hover_adds_to_the_handle_answers_a_press_too() {
     let painted = h.handle_node().local_transform;
     let (left, _) = painted.transform_point(0.0, V_HANDLE / 2.0);
     let (right, _) = painted.transform_point(BAR_WIDTH, V_HANDLE / 2.0);
+    let widened = right - left;
     assert!(
-        right - left > BAR_WIDTH + 0.5,
-        "the hover widened the handle to {} from {BAR_WIDTH}: nothing was added to press on",
-        right - left
+        widened > BAR_WIDTH + 0.5,
+        "the hover widened the handle to {widened} from {BAR_WIDTH}: nothing was added to press on"
+    );
+    // And widened *by the ratio the two widths make*, not by some other
+    // arithmetic on them. A lower bound alone is satisfied by any scale at all,
+    // including the ~60x that multiplying the widths together would give; the
+    // spring is bouncy, so the ceiling allows an overshoot and no more.
+    assert!(
+        widened < HOVER_WIDTH * 1.5,
+        "the handle grew to {widened}, which is not the {HOVER_WIDTH} the hover \
+         width asks for"
     );
 
     let pressed = hovered + Duration::from_millis(200);

--- a/tests/scrollbar_handle_tracking.rs
+++ b/tests/scrollbar_handle_tracking.rs
@@ -74,7 +74,7 @@ impl H {
             container()
                 .width(VIEWPORT)
                 .height(VIEWPORT)
-                .scrollable(ScrollAxis::Vertical)
+                .scroll(Scroll::vertical())
                 .child(
                     container()
                         .layout(Flex::column().spacing(8.0))
@@ -113,7 +113,7 @@ impl H {
             container()
                 .width(VIEWPORT)
                 .height(H_VIEWPORT)
-                .scrollable(ScrollAxis::Horizontal)
+                .scroll(Scroll::horizontal())
                 .child(
                     container()
                         .layout(Flex::row().spacing(8.0))


### PR DESCRIPTION
## What changed

`Container::scrollable(axis)`, `scrollbar_visibility(v)` and `scrollbar(|sb| ..)`
become one `Container::scroll(Scroll)`. `ScrollbarConfig` and its 17-setter
builder are deleted. Closes #216.

The finding that decided the shape: **the scrollbar was already two
`Container`s**, and the flat config was a lossy funnel into an API that was
already reactive and already complete — `Corners::superellipse` from a radius
and a K-value, `when_hovered`/`when_pressed` from three named colour fields,
`background(Color)` where a signal would have been taken without complaint. So
the frozen-ness lived entirely in the struct, and making its seventeen setters
reactive would have kept a second styling vocabulary to extend by hand every
time `Container` gained a property.

The split is a rule rather than a judgement call: what the container's own
layout must know before anything paints stays on `Scroll` as signals —
`width`, `hover_width`, `margin`, `min_handle_size`, `reserve_gutter`,
`visibility` — and everything else is `Container`'s vocabulary, through
`track(|t| ..)` and `handle(|h| ..)`. Colour, corners, borders, gradients,
elevation and the state layers come free and stay in step for nothing.

## What proves it

All six acceptance criteria, five of them by something that runs:

- `a_handle_colour_declared_with_a_signal_follows_it` — a signal restyles the
  handle after the first frame. The point of the change.
- `a_handle_takes_corners_the_old_pair_could_not_spell` — a per-corner radius,
  asserted on the painted command. The old radius+K pair could not say it.
- `visibility_answers_to_a_signal` — starts **Hidden**, flips back, flips away.
  Starting hidden is the half that matters: `ensure_scrollbar_containers`
  returns before registering the parts, so the flip has to create *and* lay them
  out in one pass. Verified by making the visibility read untracked and watching
  it fail.
- Two `compile_fail,E0599` doctests — the inert setters are gone. `E0599` pinned
  on purpose: a bare `compile_fail` passes on any error at all, including a typo
  in the test, so it would go on passing long after it stopped meaning anything.
- Hover growth unchanged: `tests/scrollbar_handle_tracking.rs` passes with only
  its two `.scrollable(..)` lines renamed.

**No snapshot and no golden moved**, which is the sixth criterion and is
provable rather than lucky: `Corners::rounded(r)` *is* `superellipse(r, 1.0)`,
so the defaults are numerically what the old radius-and-K pair produced. The API
under the pixels was replaced wholesale and the pixels did not notice.

Full harness green including `mdbook test` and `cargo doc -D warnings`.

**CI's mutation job found seven survivors and three are now watched** — all
three about what this change made declarable. `hover_width / width` read the
same as `*`, because the existing hover test had a lower bound only and a scale
of sixty clears it as happily as one of 1.67; the gutter's `margin * 2` read the
same as `+ 2`, with nothing asking how much space `reserve_gutter` reserves; and
the axis guard's `&&` read the same as `||`, which registers a horizontal track
and handle on a vertical scroller that nothing lays out or paints — invisible
from the render tree, so that count comes off the widget tree. Each verified by
applying the mutant and watching the new assertion fail.

## What the review found

**Zero blocking.** Two worth answering, both acted on.

1. *The visibility criterion was half proved, and the untested half was the one
   the design was chosen for.* Correct — the test only went Always → Hidden. It
   now starts Hidden and comes back. I did try to assert scrollability in both
   states as the reviewer suggested and could not read the content offset out of
   the render tree cheaply; `Hidden` gates only the drawing, and the scroll tests
   own that question, so the test says so instead of pretending.
2. *An orphaned doc comment* — `scroll_or_init` was deleted and its `///` line
   came to rest above `transform_mut`'s own. Fixed, along with two notes: the
   `compile_fail` pinned only one of the two named setters, and the `ignore`d
   usage sample was pseudo-code sitting unchecked in the public docs when both
   its lines compile as a real doctest.

One correction to my own framing: I had told the reviewer that `ScrollAxis` and
`ScrollbarMetrics` name no public signature any more. Not true —
`guido::widgets::scroll` is a `pub mod`, so they stay reachable and
`ScrollState`'s public geometry methods take `&ScrollbarMetrics`. Only the
prelude re-export moved. The condition is pre-existing, `ScrollbarConfig` was
exposed the same way, and the code is right; the sentence was wrong.

## What was checked by hand

The commit split. The API change is **one commit** because the old setters and
the new one cannot coexist without keeping dead API alive for a commit, so the
type, the wiring and all 52 call sites move together; the prose is separate.
Both were checked to build alone with `cargo check --all-features --all-targets`
— though commit 1 alone still has the book teaching `.scrollable(..)`, so it is
green under `cargo check` and not under `mdbook test`. That is what the second
commit is for.

## Left undone

- **No golden covers a scrollbar at all**, so "no golden moved" carries no
  information here — the pixel claim rests on `scrolling.snap` plus the
  definitional identity above, which is exact. A scrollbar golden is what would
  notice if anyone later changed the default shape. Pre-existing gap, not one
  this change created, and nobody is worse off today.
- **A default state layer cannot be cancelled.** `.handle(|h| h)` keeps the
  default's ripple, because `StateStyle` has no way for a later layer to clear
  an earlier one's property. `|_| container()` is the escape and the doc says
  so. The general gap is a state-layer question affecting every widget, not a
  scroll one.
- **Four mutants are left alive, and two of them are equivalent.**
  `hover_width / width` at the layout site (`scrollable.rs:114`) feeds a scale
  target that `advance_scrollbar_scale_axis` recomputes and overwrites a moment
  later, so nothing can tell `/` from `%` or `*` there — that block is a
  duplicate of the advance path, which is worth knowing and is pre-existing
  rather than this change's to remove. The other two guard hover updates for an
  axis that has no scrollbar, where both spellings do nothing. The fifth had a
  caller who would notice and is now tested: a right-click released mid-drag
  used to drop a left-button drag.
- Re-expressing hover growth as an animated width stays a non-goal, as #216 says.

https://claude.ai/code/session_01VApCRoAUGzxx4cZEHohTsj

