### PR TITLE
An Option is a child, so child is the only way to say one

### DIFF
--- a/.claude/skills/widgets/SKILL.md
+++ b/.claude/skills/widgets/SKILL.md
@@ -117,7 +117,8 @@ prelude — see `tests/external_widget.rs`.
 `Flex::column()`, `ZStack`. The `Layout` trait is public, so an application can
 write its own.
 
-Children: `.child()` and `.maybe_child()` for static ones. `.children()` takes
+Children: `.child()` for a static one — a widget, or an `Option` of one that
+is simply absent when `None`. `.children()` takes
 whatever `IntoChildren` fits — an iterator of widgets is static, a closure is
 dynamic and re-runs when what it read changes, and `keyed(data, key, build)`
 reconciles by key so widget state survives a reorder:

--- a/book/src/concepts/container.md
+++ b/book/src/concepts/container.md
@@ -44,16 +44,31 @@ container().children([
 
 ### Conditional Children
 
-```rust,ignore
+An `Option` is a child, so `child` takes one — absent when `None`:
+
+```rust
 # extern crate guido;
 # use guido::prelude::*;
 # fn main() {
 let show_extra = create_signal(false);
 
-container().children([
-    text("Always shown"),
-    container().maybe_child(show_extra, || text("Sometimes shown")),
-])
+container()
+    .child(text("Always shown"))
+    .child(show_extra.get().then(|| text("Sometimes shown")))
+# ;
+# }
+```
+
+That reads the signal once, when the tree is built, so it never changes again.
+For a child that comes and goes, pass a closure — it re-runs when a signal it
+read changes:
+
+```rust
+# extern crate guido;
+# use guido::prelude::*;
+# fn main() {
+# let show_extra = create_signal(false);
+container().child(move || show_extra.get().then(|| text("Sometimes shown")))
 # ;
 # }
 ```
@@ -226,7 +241,7 @@ container().visible(move || tab.get() == "settings")
 # }
 ```
 
-Unlike `.maybe_child()` which adds or removes a child from the tree, `.visible()` keeps the widget in the tree but hides it completely. This is useful when you want to toggle visibility without recreating the widget and its state.
+Unlike `.child(Option)`, which adds or removes a child from the tree, `.visible()` keeps the widget in the tree but hides it completely. This is useful when you want to toggle visibility without recreating the widget and its state.
 
 ## Scrolling
 
@@ -324,7 +339,7 @@ fn create_button(label: &str, on_click: impl Fn() + 'static) -> Container {
 ### Children
 - `.child(widget)` - Add single child
 - `.children([...])` - Add multiple children
-- `.maybe_child(Option<widget>)` - Conditional child
+- `.child(Option<widget>)` - Conditional child, absent when `None`
 - `.child(move || ..)` - Reactive child, rebuilt when a signal it read changes
 - `.children(keyed(items, key_fn, view_fn))` - Keyed reactive list
 

--- a/book/src/getting-started/examples.md
+++ b/book/src/getting-started/examples.md
@@ -194,7 +194,7 @@ cargo run --example children_example
 **Features demonstrated:**
 - `.child()` for single children
 - `.children([...])` for multiple children
-- `.maybe_child()` for conditional rendering
+- `.child(Option)` for conditional rendering
 - `.children(keyed(..))` for reactive lists
 
 ---

--- a/examples/children_example.rs
+++ b/examples/children_example.rs
@@ -2,7 +2,7 @@
 //!
 //! This example shows:
 //! 1. Static children with .child() - Fixed at creation
-//! 2. Conditional static with .maybe_child() - NOT reactive (evaluated once)
+//! 2. Conditional static with .child(Option) - NOT reactive (evaluated once)
 //! 3. Dynamic list with .children() - Fully reactive with keyed reconciliation
 //! 4. NEW: Mixing static and dynamic children - Now works in any order!
 //! 5. Unified .child() and .children() APIs - Accept both static and dynamic
@@ -97,13 +97,13 @@ fn main() {
                     container()
                         .layout(Flex::column().spacing(8.0))
                         .child(
-                            container().child(text("2. .maybe_child() - NOT REACTIVE!").color(Color::rgb(1.0, 0.9, 0.9)))
+                            container().child(text("2. .child(Option) - NOT REACTIVE!").color(Color::rgb(1.0, 0.9, 0.9)))
                         )
                         .child(
                             container().child(text("LIMITATION: Evaluated ONCE at creation").color(Color::rgb(1.0, 0.7, 0.7)))
                         )
                         .child(
-                            container().child(text(move || format!("Signal: {} (but .maybe_child won't react!)", show_optional.get())).color(Color::WHITE))
+                            container().child(text(move || format!("Signal: {} (but .child(Option) won't react!)", show_optional.get())).color(Color::WHITE))
                         )
                         .child(
                             container()
@@ -112,7 +112,7 @@ fn main() {
                                 // Evaluated ONCE at creation — it will never
                                 // update. Debug builds warn about exactly this
                                 // read; the closure below is the fix.
-                                .maybe_child(
+                                .child(
                                     if show_optional.get() {
                                         Some(
                                             container()

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -606,18 +606,16 @@ impl Container {
         self
     }
 
-    /// Add a single child: a widget value, or a closure returning one for
-    /// reactive content.
+    /// Add a single child: a widget value, an `Option` of one, or a closure
+    /// returning either for reactive content.
+    ///
+    /// ```ignore
+    /// container().child(text("always"))
+    /// container().child(admin.then(|| text("sometimes")))   // absent when None
+    /// container().child(move || count.get().is_positive().then(|| badge()))
+    /// ```
     pub fn child<M>(mut self, child: impl IntoChild<M>) -> Self {
         child.add_to_container(&mut self.children_source);
-        self
-    }
-
-    /// Add a child if Some (static mode)
-    pub fn maybe_child(mut self, widget: Option<impl Widget + 'static>) -> Self {
-        if let Some(w) = widget {
-            self = self.child(w);
-        }
         self
     }
 

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -609,10 +609,13 @@ impl Container {
     /// Add a single child: a widget value, an `Option` of one, or a closure
     /// returning either for reactive content.
     ///
-    /// ```ignore
-    /// container().child(text("always"))
-    /// container().child(admin.then(|| text("sometimes")))   // absent when None
-    /// container().child(move || count.get().is_positive().then(|| badge()))
+    /// ```
+    /// # use guido::prelude::*;
+    /// # let admin = true;
+    /// # let count = create_signal(0i32);
+    /// container().child(text("always"));
+    /// container().child(admin.then(|| text("sometimes")));  // absent when None
+    /// container().child(move || (count.get() > 0).then(|| text("badge")));
     /// ```
     pub fn child<M>(mut self, child: impl IntoChild<M>) -> Self {
         child.add_to_container(&mut self.children_source);

--- a/src/widgets/into_child.rs
+++ b/src/widgets/into_child.rs
@@ -45,11 +45,12 @@ pub struct DynamicChild;
 ///
 /// Accepted forms:
 /// - a widget value — static, evaluated once
+/// - `Option<widget>` — static, and absent when `None`
 /// - `move || widget` / `move || Option<widget>` — reactive: the closure
 ///   re-runs when a signal it reads changes, and its result replaces the
 ///   previous child (`None` removes it)
 #[diagnostic::on_unimplemented(
-    message = "`.child()` takes a widget or a reactive closure, and `{Self}` is neither",
+    message = "`.child()` takes a widget, an `Option` of one, or a reactive closure, and `{Self}` is none of them",
     note = "reactive forms: `.child(move || widget)` or `.child(move || Option<widget>)` — the closure re-runs and replaces the child when a signal it reads changes",
     note = "for reactive lists use `.children(...)` with a closure or `keyed(data, key, build)`"
 )]
@@ -61,6 +62,22 @@ pub trait IntoChild<Marker = StaticChild> {
 impl<W: Widget + 'static> IntoChild<StaticChild> for W {
     fn add_to_container(self, children_source: &mut ChildrenSource) {
         children_source.add_static(Box::new(self));
+    }
+}
+
+/// A child that may not be there — static, like the widget it wraps. `None` is
+/// a child that was never added rather than one that can come back; the
+/// reactive form of the same question is `move || Option<widget>`.
+///
+/// It shares `StaticChild` with the blanket above and does not overlap it:
+/// `Option` is not `#[fundamental]`, so no downstream crate can write
+/// `impl Widget for Option<_>`, and coherence knows `Option<W>: Widget` never
+/// holds.
+impl<W: Widget + 'static> IntoChild<StaticChild> for Option<W> {
+    fn add_to_container(self, children_source: &mut ChildrenSource) {
+        if let Some(widget) = self {
+            widget.add_to_container(children_source);
+        }
     }
 }
 
@@ -451,6 +468,7 @@ mod tests {
     use crate::layout::{Constraints, Size};
     use crate::reactive::{create_signal, on_cleanup};
     use crate::tree::{Tree, WidgetId};
+    use crate::widgets::{Container, container};
 
     struct TestWidget;
     impl Widget for TestWidget {
@@ -467,6 +485,32 @@ mod tests {
         let mut source = ChildrenSource::default();
         source.set_container_id(parent);
         (tree, source)
+    }
+
+    /// An `Option` is a child, so `child` is the only way in.
+    ///
+    /// Counted off the tree rather than off the `ChildrenSource`, because a
+    /// static child is registered when the container registers its children
+    /// and not before — the source holds it pending until then.
+    #[test]
+    fn an_optional_child_is_a_child() {
+        fn registered(container: Container) -> usize {
+            let mut tree = Tree::new();
+            let id = tree.register(Box::new(container));
+            tree.with_widget_mut(id, |w, id, t| w.register_children(t, id));
+            tree.get_children(id).len()
+        }
+
+        assert_eq!(
+            registered(container().child(Some(TestWidget))),
+            1,
+            "`Some(w)` is the widget"
+        );
+        assert_eq!(
+            registered(container().child(None::<TestWidget>)),
+            0,
+            "`None` is no child at all"
+        );
     }
 
     /// Two keys that a 64-bit hash cannot tell apart must still be two rows.


### PR DESCRIPTION
## What changed

`Container::maybe_child(Option<W>)` is gone. `impl IntoChild for Option<W>` puts
the `None` case where the other forms of a child live, so
`child(cond.then(|| w))` means what `maybe_child(cond.then(|| w))` meant, and
`Container` has one fewer thing to choose between. No call site changed except
dropping the prefix. Closes #217.

It shares the existing `StaticChild` marker rather than inventing a third — an
optional child *is* static, and the impls do not overlap because `Option` is not
`#[fundamental]`, so no downstream crate can write `impl Widget for Option<_>`
and coherence knows `Option<W>: Widget` never holds.

## What proves it

`into_child::tests::an_optional_child_is_a_child`. Without the impl it does not
compile, and it is tight both ways: `Some` asserts one registered child, `None`
asserts zero, so an impl that dropped the widget and one that added an empty
child both fail. It counts off the `Tree` after `register_children` rather than
off the `ChildrenSource`, because a static child is pending until the container
registers it.

No golden or snapshot moved and none should: the impl delegates to the same
`add_static` the old method reached through `child`, so the tree it builds is
identical. Harness green including `mdbook test` against a freshly built lib.

**The book was already wrong here.** `book/src/concepts/container.md` called
`maybe_child` with *two* arguments against a one-argument method. It sat in a
`rust,ignore` fence, so nothing ever compiled it. It is now a compiled sample,
and gained the sentence it was missing: reading a signal in that position
evaluates once, and a child that comes and goes is a closure.

## What the review found

**Zero blocking.** One note acted on: the doc block I added to `child` called a
`badge()` that exists nowhere, inside an `ignore` fence — the same condition my
own commit body cites as how the book sample rotted. It is a compiled doctest
now, in its own commit.

The other note is a naming point for this body, and it is right: a bare
`child(None)` cannot infer its widget type, so the criterion above is stated as
`child(cond.then(|| w))`. Not a regression — `maybe_child(None)` had the same
cliff — and no doc claims otherwise.

## What was checked by hand

The issue's open sub-question: *does `children_source` need to be public, or is
the component macro its only caller?* **It stays public.** It is not
macro-internal — `examples/component_example.rs:34` and
`book/src/advanced/components.md:229,350` call it directly, which is how a
`#[component]` forwards a children prop into the container it builds. No code
changed; recorded so the question is not asked a third time.

Also by hand: the `/simplify` pass found my first version's `OptionalChild`
marker unnecessary *and* its explanatory comment wrong — it claimed `Option<W>`
would overlap the blanket impl. I verified the correction by compiling without
the marker rather than taking it on trust. The commit body records that the
first version taught a false rule, because that is worth having in the history.

## Left undone

Nothing that clears the bar. One thing considered and rejected as an issue:
`Container::children_source` is documented as "useful for components" while
being the forwarding mechanism two documented call sites depend on, so its
contract is thinner than its importance. Nobody is worse off today — the two
callers work and are themselves documented — so it is this sentence rather than
a tracker entry.

https://claude.ai/code/session_016cdRGJettCQPPACDkS1CtM