### PR TITLE
Text style declares how it moves, and both widgets move the same way

### DIFF
--- a/book/src/animations/properties.md
+++ b/book/src/animations/properties.md
@@ -174,6 +174,36 @@ Both are correct, and the second is the one to reach for when the depth is
 driven by something other than pointer state. Prefer the state layer when it can
 say the same thing.
 
+## Text Colour and Size
+
+Declared on the widget that draws the glyphs — a `text` or a `text_input` —
+because that is where text style is declared at all:
+
+```rust
+# extern crate guido;
+# use guido::prelude::*;
+# fn main() {
+# let busy = create_signal(false);
+text("saving…").color(
+    (move || if busy.get() { Color::rgb(0.9, 0.6, 0.2) } else { Color::WHITE })
+        .transition(200.0),
+)
+# ;
+# }
+```
+
+`color` and `font_size` are the two that move. A family and a weight snap to an
+installed face, and a stroke and a shadow are records with nothing to
+interpolate, so those four take values only.
+
+An easing `font_size` re-measures the text on every frame it moves, which
+reflows whatever contains it — worth a shorter duration than a colour, and worth
+avoiding in a long list.
+
+A state override supplies a value and never a timing, here as everywhere:
+`when_hovered(|s| s.color(..))` takes a colour, and a transition on it is a
+compile error rather than something quietly ignored.
+
 ## Multiple Animations
 
 Each property carries its own, where it is declared:
@@ -215,6 +245,8 @@ container()
 | Scale | `scale(..)` | Spring or Duration |
 | Width, height | `width(..)`, `height(..)` | Spring |
 | Elevation | `elevation(..)` | Duration, EaseOut |
+| Text colour | `color(..)` on a `text` or `text_input` | Duration, EaseOut |
+| Font size | `font_size(..)` on a `text` or `text_input` | Duration |
 
 ## Best Practices
 

--- a/book/src/building-ui/text.md
+++ b/book/src/building-ui/text.md
@@ -30,9 +30,28 @@ text("Hello").font_size(24.0).color(theme.text)
 # }
 ```
 
-The methods come from the `TextStyled` trait — `color`, `font_size`,
-`font_family`, `font_weight`, `bold`, `mono`, `text_stroke`, `text_shadow` —
-implemented by the two widgets that draw glyphs, `Text` and `TextInput`.
+The methods — `color`, `font_size`, `font_family`, `font_weight`, `bold`,
+`mono`, `text_stroke`, `text_shadow` — belong to the two widgets that draw
+glyphs, `Text` and `TextInput`, and are written from one list so the two always
+offer the same thing.
+
+`color` and `font_size` are *declarations*, so they say how they move as well as
+what they are:
+
+```rust
+# extern crate guido;
+# use guido::prelude::*;
+# fn main() {
+# let busy = create_signal(false);
+text("saving…").color((move || if busy.get() { Color::RED } else { Color::WHITE })
+    .transition(200.0))
+# ;
+# }
+```
+
+A state override supplies a value and never a timing — `when_hovered(|s|
+s.color(..))` takes a colour alone, and a transition there is a compile error
+rather than something quietly ignored.
 
 ### Repeating a style
 

--- a/docs/STATE_LAYER.md
+++ b/docs/STATE_LAYER.md
@@ -232,7 +232,8 @@ quietly ignored, because [`Animated`] is deliberately not an [`IntoSignal`]:
 
 Every animatable property takes a motion the same way — `background`, `border`
 (each half separately), `corners`, `padding`, `elevation`, `width`, `height`,
-`translate`, `rotate` and `scale`.
+`translate`, `rotate` and `scale` on a container, and `color` and `font_size` on
+a `text` or a `text_input`.
 
 [`Animated`]: ../src/animation/animated.rs
 [`IntoSignal`]: ../src/reactive/into_signal.rs

--- a/docs/STYLING.md
+++ b/docs/STYLING.md
@@ -233,8 +233,12 @@ text("Hello").font_size(16.0).color(Color::WHITE)
 ```
 
 `color`, `font_size`, `font_family`, `font_weight`, `bold`, `mono`,
-`text_stroke` and `text_shadow` come from the `TextStyled` trait, implemented
-by `Text` and `TextInput` — the two widgets that draw glyphs. A `TextInput`
+`text_stroke` and `text_shadow` are declared on `Text` and `TextInput` — the two
+widgets that draw glyphs — from one list, so the two cannot drift apart.
+`color` and `font_size` are declarations, so they carry how they move as well
+as what they are: `color(theme.warn.transition(200.0))`. The rest take values,
+because a family and a weight snap to an installed face and a stroke and a
+shadow have nothing to interpolate. A `TextInput`
 also implements `InputStyled` for `cursor_color`, `selection_color` and
 `placeholder_color`, which only it can draw.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,8 +192,8 @@ pub mod prelude {
         EventResponse, FontFamily, FontWeight, GradientDirection, Image, ImageSource, InputStyle,
         InputStyled, IntoChildren, IntoClickHandler, Key, LinearGradient, Modifiers, MouseButton,
         Overflow, Padding, Point, Rect, Scroll, ScrollSource, ScrollbarVisibility, Selection,
-        StateStyle, Stateful, Text, TextInput, TextShadow, TextStroke, TextStyle, TextStyled,
-        Widget, container, image, keyed, text, text_input,
+        StateStyle, Stateful, Text, TextInput, TextShadow, TextStroke, TextStyle, Widget,
+        container, image, keyed, text, text_input,
     };
     pub use crate::{
         App, ExitReason, SignalFields, component, default_font_family, load_font, quit_app,

--- a/src/widgets/container/animations.rs
+++ b/src/widgets/container/animations.rs
@@ -28,7 +28,7 @@ struct Timeline<T> {
 /// A transition of no duration: a timeline speaks for its property while it
 /// plays, and outside it the declared value applies at once, exactly as it
 /// would with no animation at all.
-pub(super) fn instant_transition() -> Transition {
+pub(crate) fn instant_transition() -> Transition {
     Transition::new(0.0, crate::animation::TimingFunction::Linear)
 }
 

--- a/src/widgets/container/animations.rs
+++ b/src/widgets/container/animations.rs
@@ -28,7 +28,7 @@ struct Timeline<T> {
 /// A transition of no duration: a timeline speaks for its property while it
 /// plays, and outside it the declared value applies at once, exactly as it
 /// would with no animation at all.
-pub(crate) fn instant_transition() -> Transition {
+pub(super) fn instant_transition() -> Transition {
     Transition::new(0.0, crate::animation::TimingFunction::Linear)
 }
 

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -21,7 +21,6 @@ use crate::layout::{Constraints, Flex, at_least, at_most, fill, fraction};
 use crate::reactive::create_signal;
 use crate::renderer::{DrawCommand, PaintContext, RenderNode};
 use crate::widgets::CornerRadii;
-use crate::widgets::TextStyled;
 use crate::widgets::widget::{Event, EventResponse, MouseButton};
 
 // ---------------------------------------------------------------------------

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -11,7 +11,7 @@ mod style;
 #[cfg(test)]
 mod characterization;
 
-use animations::instant_transition;
+pub(crate) use animations::instant_transition;
 pub(crate) use animations::with_measure_final;
 pub use animations::{AdvanceResult, AnimationState, get_animated_value};
 use interaction::{HitContext, untransform_point};
@@ -1819,10 +1819,10 @@ fn sorted_axis(tree: &Tree, children: &[WidgetId]) -> Option<Axis> {
 /// layout by `seed_animations`, which reads the signal rather than this
 /// snapshot; those two are read there only for their subscription, so their
 /// seed survives into the first advance.
-fn declare<T: Animatable, M>(
-    anims: &mut Option<Box<ContainerAnims>>,
+pub(crate) fn declare<A: Default, T: Animatable, M>(
+    anims: &mut Option<Box<A>>,
     value: impl IntoAnimated<T, M>,
-    slot: impl FnOnce(&mut ContainerAnims) -> &mut Option<AnimationState<T>>,
+    slot: impl FnOnce(&mut A) -> &mut Option<AnimationState<T>>,
 ) -> Signal<T> {
     let (signal, motion) = value.into_animated().into_parts();
     let installed = motion.map(|motion| {
@@ -1843,9 +1843,9 @@ fn declare<T: Animatable, M>(
 /// Nothing into a container that has no animation box is the overwhelmingly
 /// common case — every plain `background(RED)` — so it must not be the thing
 /// that allocates one.
-fn write_slot<T: Animatable>(
-    anims: &mut Option<Box<ContainerAnims>>,
-    slot: impl FnOnce(&mut ContainerAnims) -> &mut Option<AnimationState<T>>,
+fn write_slot<A: Default, T: Animatable>(
+    anims: &mut Option<Box<A>>,
+    slot: impl FnOnce(&mut A) -> &mut Option<AnimationState<T>>,
     installed: Option<AnimationState<T>>,
 ) {
     match anims.as_deref_mut() {

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -11,7 +11,7 @@ mod style;
 #[cfg(test)]
 mod characterization;
 
-pub(crate) use animations::instant_transition;
+use animations::instant_transition;
 pub(crate) use animations::with_measure_final;
 pub use animations::{AdvanceResult, AnimationState, get_animated_value};
 use interaction::{HitContext, untransform_point};

--- a/src/widgets/diagnostic_audit.rs
+++ b/src/widgets/diagnostic_audit.rs
@@ -27,9 +27,7 @@ use crate::renderer::{PaintContext, RenderNode};
 use crate::tree::Tree;
 use crate::widgets::widget::{Event, Key, Modifiers, MouseButton, ScrollSource};
 use crate::widgets::{Color, ImageSource, LinearGradient, Overflow, Scroll};
-use crate::widgets::{
-    InputStyled, Stateful, TextStyled, Widget, container, image, text, text_input,
-};
+use crate::widgets::{InputStyled, Stateful, Widget, container, image, text, text_input};
 
 /// Put a widget through the whole `Widget` trait and return how many reads the
 /// library performed with no reactive scope.

--- a/src/widgets/input_style.rs
+++ b/src/widgets/input_style.rs
@@ -43,7 +43,7 @@ impl InputStyle {}
 /// Implemented by [`TextInput`](crate::widgets::TextInput) alone, because it
 /// is the only widget that draws any of it. That is the whole point of the
 /// trait existing separately from
-/// [`TextStyled`](crate::widgets::TextStyled): a placeholder colour has
+/// the text style on [`TextInput`](crate::widgets::TextInput): a placeholder colour has
 /// nowhere to land except on the widget that draws the placeholder.
 pub trait InputStyled: Sized {
     #[doc(hidden)]

--- a/src/widgets/input_style.rs
+++ b/src/widgets/input_style.rs
@@ -43,7 +43,7 @@ impl InputStyle {}
 /// Implemented by [`TextInput`](crate::widgets::TextInput) alone, because it
 /// is the only widget that draws any of it. That is the whole point of the
 /// trait existing separately from
-/// the text style on [`TextInput`](crate::widgets::TextInput): a placeholder colour has
+/// the text style beside it: a placeholder colour has
 /// nowhere to land except on the widget that draws the placeholder.
 pub trait InputStyled: Sized {
     #[doc(hidden)]

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -36,7 +36,7 @@ pub use state_layer::{
 };
 pub use text::{Text, text};
 pub use text_input::{Selection, TextInput, text_input};
-pub use text_style::{TextShadow, TextStroke, TextStyle, TextStyled};
+pub use text_style::{TextShadow, TextStroke, TextStyle};
 pub use widget::{
     AnyWidget, Color, Event, EventResponse, Key, LayoutHints, Modifiers, MouseButton, Padding,
     Point, Rect, ScrollSource, Widget,

--- a/src/widgets/text.rs
+++ b/src/widgets/text.rs
@@ -231,13 +231,11 @@ impl Stateful for Text {
 crate::widgets::text_style::declares_text_style!(Text, style, anims);
 
 impl Widget for Text {
-    /// Move the declared motions on, and ask for another frame while either is
-    /// still running.
+    /// Move the declared motions on, and ask for the frame that carries them
+    /// further.
     ///
-    /// The targets come from `declared_*`, snapshotted by the last `refresh`,
-    /// because this runs outside a tracking scope: reading a signal here would
-    /// subscribe the widget to it from the animation pass, which is the
-    /// non-reactive-read the diagnostic exists to catch.
+    /// Where they are pointed is decided in `retarget_text_anims`, during
+    /// layout, so there is no target to resolve here — only time to pass.
     fn advance_animations(&mut self, tree: &mut Tree, id: WidgetId) -> bool {
         self.advance_text_anims(tree, id)
     }
@@ -562,33 +560,118 @@ mod tests {
     }
 
     /// The same for a size, which moves layout rather than paint — so the claim
-    /// is about what was measured, not about what was drawn.
+    /// is what the *container* measured, not what the text drew.
+    ///
+    /// Inside a container on purpose. A size that eases has to reflow whatever
+    /// encloses it, and `Text` is not a relayout boundary, so the wake walks up
+    /// to the nearest one; asserting on a bare root text would prove the value
+    /// moved and say nothing about the subtree that has to follow it.
     #[test]
     fn a_declared_transition_eases_the_font_size() {
         let size = create_signal(10.0f32);
         let mut tree = Tree::new();
         let root = tree.register(Box::new(
-            Text::new("x").font_size((move || size.get()).transition(400.0)),
+            container().child(Text::new("x").font_size((move || size.get()).transition(400.0))),
         ));
         tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
 
         let t0 = std::time::Instant::now();
-        let (_, from) = frame_at(&mut tree, root, t0);
-        assert!((from - 10.0).abs() < 0.01, "starts where it was declared");
+        tree.set_frame_instant(Some(t0));
+        let from = measured(&mut tree, root, 800.0).height;
+        tree.set_frame_instant(None);
 
         size.set(30.0);
-        // As above: the write's own frame starts the ease, the next one shows it.
-        frame_at(&mut tree, root, t0 + std::time::Duration::from_millis(1));
-        let (_, midway) = frame_at(&mut tree, root, t0 + std::time::Duration::from_millis(100));
+        // The write's own frame is where the ease begins; the next shows it.
+        tree.set_frame_instant(Some(t0 + std::time::Duration::from_millis(1)));
+        measured(&mut tree, root, 800.0);
+        tree.set_frame_instant(None);
+
+        tree.set_frame_instant(Some(t0 + std::time::Duration::from_millis(100)));
+        let midway = measured(&mut tree, root, 800.0).height;
+        tree.set_frame_instant(None);
+
+        tree.set_frame_instant(Some(t0 + std::time::Duration::from_millis(600)));
+        let arrived = measured(&mut tree, root, 800.0).height;
+        tree.set_frame_instant(None);
+
         assert!(
-            midway > 10.01 && midway < 29.99,
-            "the size has to be on its way rather than arrived, got {midway}"
+            midway > from + 0.5 && midway < arrived - 0.5,
+            "the container has to be re-measured while the size eases: {from} \
+             then {midway} then {arrived}"
+        );
+        assert!(
+            arrived > from + 1.0,
+            "and it arrives larger: {from} then {arrived}"
+        );
+    }
+
+    /// A text that only *paints* a colour signal does not subscribe its layout
+    /// to it.
+    ///
+    /// Retargeting a motion needs the resolved colour during layout, so the
+    /// read has to happen in that scope — but only where there is a motion to
+    /// retarget. Read unconditionally, every label in a surface re-measures
+    /// when a theme colour changes, and `Text` is not a relayout boundary, so
+    /// that walk reaches the enclosing subtree.
+    #[test]
+    fn a_colour_without_a_motion_wakes_no_layout() {
+        let hue = create_signal(Color::rgb(0.0, 0.0, 0.0));
+        let mut tree = Tree::new();
+        let root = tree.register(Box::new(Text::new("x").color(hue)));
+        tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
+        frame(&mut tree, root);
+        jobs::clear_pending_jobs();
+
+        hue.set(Color::rgb(1.0, 1.0, 1.0));
+        let woken = jobs::queued_job_types(root);
+        assert!(
+            !woken.contains(&JobType::Layout),
+            "a painted colour must not re-measure the text: {woken:?}"
         );
 
-        let (_, arrived) = frame_at(&mut tree, root, t0 + std::time::Duration::from_millis(600));
+        // And the text that *does* declare a motion is the one that pays for it.
+        let moved = create_signal(Color::rgb(0.0, 0.0, 0.0));
+        let mut tree = Tree::new();
+        let root = tree.register(Box::new(
+            Text::new("x").color((move || moved.get()).transition(400.0)),
+        ));
+        tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
+        frame(&mut tree, root);
+        jobs::clear_pending_jobs();
+
+        moved.set(Color::rgb(1.0, 1.0, 1.0));
+        let woken = jobs::queued_job_types(root);
         assert!(
-            (arrived - 30.0).abs() < 0.01,
-            "and it arrives, got {arrived}"
+            woken.contains(&JobType::Layout),
+            "a declared motion has to be retargeted, which is a layout read: \
+             {woken:?}"
+        );
+    }
+
+    /// A motion that has never run starts where the signal is now, not where it
+    /// was when the builder ran.
+    ///
+    /// The seed is taken with `get_untracked` at declaration time, so a write
+    /// landing between construction and the first layout would otherwise make
+    /// the first frame ease up from a stale value instead of simply being there.
+    #[test]
+    fn a_motion_seeds_rather_than_eases_on_its_first_frame() {
+        let hue = create_signal(Color::rgb(0.0, 0.0, 0.0));
+        let text = Text::new("x").color((move || hue.get()).transition(400.0));
+
+        // Between the builder and the first layout, as a popup's content is
+        // built one frame and laid out the next.
+        hue.set(Color::rgb(1.0, 1.0, 1.0));
+
+        let mut tree = Tree::new();
+        let root = tree.register(Box::new(text));
+        tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
+
+        let (first, _) = frame_at(&mut tree, root, std::time::Instant::now());
+        assert!(
+            first.r > 0.99,
+            "the first frame has to be where the signal is, not eased up from \
+             what the builder saw: got {first:?}"
         );
     }
 

--- a/src/widgets/text.rs
+++ b/src/widgets/text.rs
@@ -675,6 +675,132 @@ mod tests {
         );
     }
 
+    /// A transition inside its delay keeps asking to be woken, and stops asking
+    /// once it has arrived.
+    ///
+    /// The delay is the window where a motion is running and has produced no
+    /// new value. Asking for a paint there wakes the loop every frame for a
+    /// picture that has not changed; asking for *nothing at all* strands the
+    /// ease, because the frame that would carry it never comes. So it asks to
+    /// be woken without asking for a picture.
+    ///
+    /// Note what this test must not do: clear the pending jobs mid-flight. The
+    /// queued Animation job *is* the chain — `Text` takes an
+    /// unchanged-constraints early-out, so a cleared queue means no layout, no
+    /// retarget and no advance, and the ease stops for good. The first draft of
+    /// this test did exactly that and read the result as a defect.
+    #[test]
+    fn a_delayed_transition_asks_to_be_woken_without_asking_for_a_picture() {
+        use crate::animation::{TimingFunction, Transition};
+
+        let hue = create_signal(Color::rgb(0.0, 0.0, 0.0));
+        let mut tree = Tree::new();
+        let root = tree.register(Box::new(
+            Text::new("x").color(
+                (move || hue.get())
+                    .transition(Transition::new(100.0, TimingFunction::Linear).delay(200.0)),
+            ),
+        ));
+        tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
+
+        let t0 = std::time::Instant::now();
+        frame_at(&mut tree, root, t0);
+        hue.set(Color::rgb(1.0, 1.0, 1.0));
+        frame_at(&mut tree, root, t0 + std::time::Duration::from_millis(1));
+
+        // Inside the delay: nothing drawn has changed, and it still has to come
+        // back for the frames that will carry it.
+        let inside = frame_at(&mut tree, root, t0 + std::time::Duration::from_millis(50)).0;
+        assert!(
+            inside.r < 0.01,
+            "the delay has not elapsed, so the colour must not have moved: {inside:?}"
+        );
+        assert!(
+            jobs::queued_job_types(root).contains(&JobType::Animation),
+            "a motion inside its delay has to ask to be woken: {:?}",
+            jobs::queued_job_types(root)
+        );
+
+        // Past the delay and the duration, it has arrived.
+        let arrived = frame_at(&mut tree, root, t0 + std::time::Duration::from_millis(400)).0;
+        assert!(
+            arrived.r > 0.99,
+            "a delayed ease still has to run once the delay is up: {arrived:?}"
+        );
+
+        // And then it stops asking, or a still surface never idles.
+        frame_at(&mut tree, root, t0 + std::time::Duration::from_millis(500));
+        jobs::clear_pending_jobs();
+        frame_at(&mut tree, root, t0 + std::time::Duration::from_millis(600));
+        assert!(
+            !jobs::queued_job_types(root).contains(&JobType::Animation),
+            "a settled motion has to stop asking for frames: {:?}",
+            jobs::queued_job_types(root)
+        );
+    }
+
+    /// A font-size motion does not drag the colour into the layout scope with
+    /// it.
+    ///
+    /// The guard is per property: a text that eases its size still paints its
+    /// colour, so a colour write must not re-measure it. Read off the jobs,
+    /// because the widget has an animation box either way — which is the case
+    /// the `is_some_and` on the box cannot distinguish on its own.
+    #[test]
+    fn easing_a_size_does_not_make_the_colour_a_layout_read() {
+        let hue = create_signal(Color::rgb(0.0, 0.0, 0.0));
+        let size = create_signal(10.0f32);
+        let mut tree = Tree::new();
+        let root = tree.register(Box::new(
+            Text::new("x")
+                .font_size((move || size.get()).transition(400.0))
+                .color(hue),
+        ));
+        tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
+        frame(&mut tree, root);
+        jobs::clear_pending_jobs();
+
+        hue.set(Color::rgb(1.0, 1.0, 1.0));
+        let woken = jobs::queued_job_types(root);
+        assert!(
+            !woken.contains(&JobType::Layout),
+            "only the size was declared with a motion, so the colour is still a \
+             paint read: {woken:?}"
+        );
+    }
+
+    /// A state override reaches every text property, not only the colour.
+    ///
+    /// `TextStyle`'s setters are the override half of the vocabulary, and each
+    /// one is a separate two-line body — `cargo mutants` emptied five of the
+    /// six and nothing objected, because the only override anyone had tested
+    /// was a colour. Asserted on the size, which is the one an override can
+    /// move that shows up in what was measured.
+    #[test]
+    fn a_state_override_reaches_more_than_the_colour() {
+        let hot = create_signal(true);
+        let mut tree = Tree::new();
+        let root = tree.register(Box::new(
+            Text::new("x")
+                .font_size(10.0)
+                .state(hot, |s: TextStyle| s.font_size(30.0)),
+        ));
+        tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
+
+        let (_, overridden) = frame(&mut tree, root);
+        assert!(
+            (overridden - 30.0).abs() < 0.01,
+            "the override supplies the size while it is active, got {overridden}"
+        );
+
+        hot.set(false);
+        let (_, declared) = frame(&mut tree, root);
+        assert!(
+            (declared - 10.0).abs() < 0.01,
+            "and the declaration comes back when it is not, got {declared}"
+        );
+    }
+
     /// Lay out and paint, returning the first text command's colour and size.
     ///
     /// The queued jobs are processed first, which is what turns a signal write

--- a/src/widgets/text.rs
+++ b/src/widgets/text.rs
@@ -820,6 +820,7 @@ mod tests {
             s.font_family(FontFamily::Monospace)
                 .font_weight(FontWeight::BOLD)
                 .text_stroke(TextStroke::new(3.0, Color::WHITE))
+                .text_shadow(TextShadow::new(0.0, 0.0, 9.0, Color::WHITE))
         })));
         tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
 
@@ -830,13 +831,28 @@ mod tests {
             "the family override applies"
         );
         assert_eq!(styled.1, FontWeight::BOLD, "and the weight");
-        let with_stroke = measured(&mut tree, root, 800.0);
+        // A stroke and a shadow reach paint as the slop the text publishes,
+        // never as a field of the command, so that is where they are asked
+        // about.
+        let decorated = tree.paint_overflow(root);
+        assert!(
+            decorated >= 3.0,
+            "the stroke and shadow overrides have to reach the published reach, \
+             got {decorated}"
+        );
 
         hot.set(false);
         let plain = painted_style(&mut tree, root);
-        assert_ne!(plain.0, FontFamily::Monospace, "and both come back off");
+        assert_ne!(
+            plain.0,
+            FontFamily::Monospace,
+            "and all of them come back off"
+        );
         assert_ne!(plain.1, FontWeight::BOLD);
-        let _ = with_stroke;
+        assert!(
+            tree.paint_overflow(root) < decorated,
+            "including the two only the reach can see"
+        );
     }
 
     /// The family and weight of the first painted text command.

--- a/src/widgets/text.rs
+++ b/src/widgets/text.rs
@@ -728,9 +728,11 @@ mod tests {
             "a delayed ease still has to run once the delay is up: {arrived:?}"
         );
 
-        // And then it stops asking, or a still surface never idles.
+        // And then it stops asking, or a still surface never idles. No clearing
+        // here: an empty queue would mean no job to process, so nothing would
+        // ask for another frame either way and the assertion would hold however
+        // the code behaved.
         frame_at(&mut tree, root, t0 + std::time::Duration::from_millis(500));
-        jobs::clear_pending_jobs();
         frame_at(&mut tree, root, t0 + std::time::Duration::from_millis(600));
         assert!(
             !jobs::queued_job_types(root).contains(&JobType::Animation),
@@ -799,6 +801,66 @@ mod tests {
             (declared - 10.0).abs() < 0.01,
             "and the declaration comes back when it is not, got {declared}"
         );
+    }
+
+    /// Every override setter, not just the one an earlier test happened to
+    /// reach.
+    ///
+    /// `TextStyle`'s setters are six separate two-line bodies, and each can be
+    /// emptied on its own — `cargo mutants` did exactly that to four of them
+    /// after a first pass covered only the size. The family and the weight are
+    /// read off the painted command; the stroke and the shadow off the reach
+    /// they publish, which is the only place a decoration shows up in something
+    /// a test can name.
+    #[test]
+    fn every_override_setter_supplies_its_property() {
+        let hot = create_signal(true);
+        let mut tree = Tree::new();
+        let root = tree.register(Box::new(Text::new("x").state(hot, |s: TextStyle| {
+            s.font_family(FontFamily::Monospace)
+                .font_weight(FontWeight::BOLD)
+                .text_stroke(TextStroke::new(3.0, Color::WHITE))
+        })));
+        tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
+
+        let styled = painted_style(&mut tree, root);
+        assert_eq!(
+            styled.0,
+            FontFamily::Monospace,
+            "the family override applies"
+        );
+        assert_eq!(styled.1, FontWeight::BOLD, "and the weight");
+        let with_stroke = measured(&mut tree, root, 800.0);
+
+        hot.set(false);
+        let plain = painted_style(&mut tree, root);
+        assert_ne!(plain.0, FontFamily::Monospace, "and both come back off");
+        assert_ne!(plain.1, FontWeight::BOLD);
+        let _ = with_stroke;
+    }
+
+    /// The family and weight of the first painted text command.
+    fn painted_style(tree: &mut Tree, root: WidgetId) -> (FontFamily, FontWeight) {
+        measured(tree, root, 800.0);
+        let mut node = RenderNode::new(root.as_u64());
+        tree.with_widget_mut(root, |w, id, t| {
+            let mut ctx = PaintContext::new(&mut node);
+            w.paint(t, id, &mut ctx);
+        });
+        fn find(node: &RenderNode) -> Option<(FontFamily, FontWeight)> {
+            for cmd in &node.commands {
+                if let DrawCommand::Text {
+                    font_family,
+                    font_weight,
+                    ..
+                } = &**cmd
+                {
+                    return Some((font_family.clone(), *font_weight));
+                }
+            }
+            node.children.iter().find_map(|c| find(c))
+        }
+        find(&node).expect("a text command")
     }
 
     /// Lay out and paint, returning the first text command's colour and size.

--- a/src/widgets/text.rs
+++ b/src/widgets/text.rs
@@ -6,10 +6,11 @@ use crate::reactive::{IntoSignal, OptionSignalExt, Signal, with_signal_tracking}
 use crate::renderer::{PaintContext, measure_text_full};
 use crate::tree::{Tree, WidgetId};
 
+use super::container::get_animated_value;
 use super::control::Control;
 use super::font::{FontFamily, FontWeight};
 use super::state_layer::{StateWhen, Stateful};
-use super::text_style::{TextShadow, TextStroke, TextStyle, TextStyled};
+use super::text_style::{TextAnims, TextShadow, TextStroke, TextStyle};
 use super::widget::{Color, Event, EventResponse, Rect, Widget};
 
 /// How far a stroke and a shadow reach past the glyphs they decorate.
@@ -26,8 +27,9 @@ pub(crate) fn decoration_overflow(stroke: Option<TextStroke>, shadow: Option<Tex
 
 /// A run of text.
 ///
-/// Style is declared here — [`TextStyled`] — because this is the widget that
-/// draws the glyphs. Whatever it does not declare falls back to the defaults:
+/// Style is declared here — see `declares_text_style` — because this is the
+/// widget that draws the glyphs. Whatever it does not declare falls back to
+/// the defaults:
 /// white, 14 logical pixels, the registered family, normal weight.
 ///
 /// ```ignore
@@ -52,6 +54,9 @@ pub struct Text {
     /// Blur radius for the backdrop the glyphs cut out of what is behind them.
     /// `None` for every text that is not made of glass.
     backdrop_blur: Option<Signal<f32>>,
+    /// How the declared colour and size move, when they were declared with a
+    /// motion. Absent for every text that only says what it is.
+    anims: Option<Box<TextAnims>>,
     /// Cached values for painting (avoid re-reading signals)
     cached_text: String,
     cached_font_size: f32,
@@ -74,6 +79,7 @@ impl Text {
             own_hover: None,
             wrap: None,
             backdrop_blur: None,
+            anims: None,
             cached_text: String::new(), // Will be set during first layout
             cached_font_size: 14.0,
             cached_font_family: default_family,
@@ -128,10 +134,10 @@ impl Text {
     /// Legibility is not what it buys on its own, and of the two decorations
     /// that give it, one composes and one does not.
     ///
-    /// A [`text_stroke`](super::TextStyled::text_stroke) does: over frost it is
+    /// A [`text_stroke`](Self::text_stroke) does: over frost it is
     /// drawn as a true contour — dilated from the same coverage mask, laid
     /// outside the letter — rather than as copies of the glyphs under the fill.
-    /// A [`text_shadow`](super::TextStyled::text_shadow) does not: it is still
+    /// A [`text_shadow`](Self::text_shadow) does not: it is still
     /// copies, so it covers the letter's own area as well as its edge, which is
     /// invisible under an opaque fill and an opaque letter over glass.
     pub fn backdrop_blur<M>(mut self, radius: impl IntoSignal<f32, M>) -> Self {
@@ -189,16 +195,25 @@ impl Text {
     ///
     /// Returns how far the decoration reaches past the glyphs, which the
     /// caller records as damage slop.
-    fn refresh(&mut self, tree: &Tree, id: WidgetId) -> f32 {
-        with_signal_tracking(id, JobType::Layout, || {
+    fn refresh(&mut self, tree: &Tree, id: WidgetId) -> (f32, Option<Color>) {
+        let mut declared_color = None;
+        let overflow = with_signal_tracking(id, JobType::Layout, || {
             let style = self.resolved_style(tree, id);
             self.cached_text = self.content.get();
             self.cached_font_size = style.font_size.get_or(14.0);
+            // Only where a colour motion was declared. Reading it here
+            // subscribes this text's *layout* to the colour, and a text that
+            // merely paints one has no reason to re-measure when it changes —
+            // paint reads it under its own scope, as it always did.
+            declared_color = self
+                .animates_text_color()
+                .then(|| style.color.get_or(Color::WHITE));
             self.cached_font_family = style.font_family.get_or_else(default_font_family);
             self.cached_font_weight = style.font_weight.get_or(FontWeight::NORMAL);
             self.cached_wrap = self.wrap.get_or(true);
             decoration_overflow(style.stroke.map(|s| s.get()), style.shadow.map(|s| s.get()))
-        })
+        });
+        (overflow, declared_color)
     }
 }
 
@@ -213,13 +228,20 @@ impl Stateful for Text {
     }
 }
 
-impl TextStyled for Text {
-    fn text_style_mut(&mut self) -> &mut TextStyle {
-        self.style.get_or_insert_with(Box::default)
-    }
-}
+crate::widgets::text_style::declares_text_style!(Text, style, anims);
 
 impl Widget for Text {
+    /// Move the declared motions on, and ask for another frame while either is
+    /// still running.
+    ///
+    /// The targets come from `declared_*`, snapshotted by the last `refresh`,
+    /// because this runs outside a tracking scope: reading a signal here would
+    /// subscribe the widget to it from the animation pass, which is the
+    /// non-reactive-read the diagnostic exists to catch.
+    fn advance_animations(&mut self, tree: &mut Tree, id: WidgetId) -> bool {
+        self.advance_text_anims(tree, id)
+    }
+
     fn layout(&mut self, tree: &mut Tree, id: WidgetId, constraints: Constraints) -> Size {
         // Text widgets are never relayout boundaries
         tree.set_relayout_boundary(id, false);
@@ -243,7 +265,15 @@ impl Widget for Text {
 
         // Refresh cached values from content and declared style.
         // This reads signals and registers layout dependencies.
-        let overflow = self.refresh(tree, id);
+        let (overflow, declared_color) = self.refresh(tree, id);
+        // Pointed at the freshly resolved target here, where both it and the
+        // frame's instant are in hand.
+        self.cached_font_size = self.retarget_text_anims(
+            tree,
+            id,
+            declared_color.unwrap_or(Color::WHITE),
+            self.cached_font_size,
+        );
         tree.set_own_paint_reach(id, overflow);
 
         // Determine the effective max_width for measurement
@@ -332,7 +362,9 @@ impl Widget for Text {
         let (color, stroke, shadow, blur) = with_signal_tracking(id, JobType::Paint, || {
             let style = self.resolved_style(tree, id);
             (
-                style.color.get_or(Color::WHITE),
+                get_animated_value(self.anims.as_ref().and_then(|a| a.color.as_ref()), || {
+                    style.color.get_or(Color::WHITE)
+                }),
                 style.stroke.map(|s| s.get()),
                 style.shadow.map(|s| s.get()),
                 self.backdrop_blur.map(|radius| radius.get()),
@@ -386,12 +418,12 @@ pub fn text<M>(content: impl IntoSignal<String, M>) -> Text {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::animation::Animate;
     use crate::jobs;
     use crate::layout::Constraints;
     use crate::reactive::create_signal;
     use crate::renderer::{DrawCommand, RenderNode};
     use crate::widgets::container;
-    use crate::widgets::text_style::TextStyled;
 
     /// Lay out after draining queued jobs, and hand back the measured size.
     fn measured(tree: &mut Tree, root: WidgetId, width: f32) -> crate::layout::Size {
@@ -430,6 +462,133 @@ mod tests {
             unwrapped.width > wrapped.width,
             "an unwrapped line has to run past the width a wrapped one fits in: \
              {wrapped:?} then {unwrapped:?}"
+        );
+    }
+
+    /// Every text command a frame drew, in paint order.
+    fn all_text(tree: &mut Tree, root: WidgetId, at: std::time::Instant) -> Vec<(Color, f32)> {
+        tree.set_frame_instant(Some(at));
+        measured(tree, root, 800.0);
+        let mut node = RenderNode::new(root.as_u64());
+        tree.with_widget_mut(root, |w, id, t| {
+            let mut ctx = PaintContext::new(&mut node);
+            w.paint(t, id, &mut ctx);
+        });
+        tree.set_frame_instant(None);
+
+        fn walk(node: &RenderNode, out: &mut Vec<(Color, f32)>) {
+            for cmd in &node.commands {
+                if let DrawCommand::Text {
+                    color, font_size, ..
+                } = &**cmd
+                {
+                    out.push((*color, *font_size));
+                }
+            }
+            for c in &node.children {
+                walk(c, out);
+            }
+        }
+        let mut out = Vec::new();
+        walk(&node, &mut out);
+        out
+    }
+
+    /// A frame at a named instant: jobs, layout, animations, paint.
+    ///
+    /// The instant is named because an eased colour is a function of how long
+    /// it has been running, and a test that let the clock decide would assert
+    /// on whatever the machine managed between two calls.
+    fn frame_at(tree: &mut Tree, root: WidgetId, at: std::time::Instant) -> (Color, f32) {
+        tree.set_frame_instant(Some(at));
+        let out = frame(tree, root);
+        tree.set_frame_instant(None);
+        out
+    }
+
+    /// A declared colour carries how it moves, so it eases where a bare one
+    /// snaps.
+    ///
+    /// The pair differs in nothing but the transition, and both are written the
+    /// same signal — so the eased one being *between* the two colours a frame
+    /// later is the whole claim, and the plain one being already arrived is
+    /// what says the test is not merely watching a slow machine.
+    #[test]
+    fn a_declared_transition_eases_the_colour() {
+        const FROM: Color = Color::rgb(0.0, 0.0, 0.0);
+        const TO: Color = Color::rgb(1.0, 1.0, 1.0);
+
+        let sig = create_signal(FROM);
+
+        // Both texts in one tree: two `Tree`s number their widgets from zero,
+        // so the pair would share ids and the job queue — which is keyed by id
+        // — would hand one widget's animation frame to the other.
+        let mut tree = Tree::new();
+        let root = tree.register(Box::new(
+            container()
+                .child(Text::new("eased").color((move || sig.get()).transition(400.0)))
+                .child(Text::new("plain").color(sig)),
+        ));
+        tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
+
+        let t0 = std::time::Instant::now();
+        all_text(&mut tree, root, t0);
+
+        sig.set(TO);
+
+        // The frame the write lands on is where the ease *begins*, so it is
+        // still at the old colour there. The one after it is where the claim is.
+        all_text(&mut tree, root, t0 + std::time::Duration::from_millis(1));
+        let drawn = all_text(&mut tree, root, t0 + std::time::Duration::from_millis(100));
+
+        let (eased, plain) = (drawn[0].0, drawn[1].0);
+        assert!(
+            plain.r > 0.99,
+            "a colour declared without a transition arrives on the next paint, \
+             got {plain:?}"
+        );
+        assert!(
+            eased.r > 0.01 && eased.r < 0.99,
+            "a quarter of the way through a 400ms ease the colour has to be \
+             between the two, got {eased:?}"
+        );
+
+        let settled = all_text(&mut tree, root, t0 + std::time::Duration::from_millis(600));
+        assert!(
+            settled[0].0.r > 0.99,
+            "the ease never finished, got {:?}",
+            settled[0].0
+        );
+    }
+
+    /// The same for a size, which moves layout rather than paint — so the claim
+    /// is about what was measured, not about what was drawn.
+    #[test]
+    fn a_declared_transition_eases_the_font_size() {
+        let size = create_signal(10.0f32);
+        let mut tree = Tree::new();
+        let root = tree.register(Box::new(
+            Text::new("x").font_size((move || size.get()).transition(400.0)),
+        ));
+        tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
+
+        let t0 = std::time::Instant::now();
+        let (_, from) = frame_at(&mut tree, root, t0);
+        assert!((from - 10.0).abs() < 0.01, "starts where it was declared");
+
+        size.set(30.0);
+        // As above: the write's own frame starts the ease, the next one shows it.
+        frame_at(&mut tree, root, t0 + std::time::Duration::from_millis(1));
+        let (_, midway) = frame_at(&mut tree, root, t0 + std::time::Duration::from_millis(100));
+        assert!(
+            midway > 10.01 && midway < 29.99,
+            "the size has to be on its way rather than arrived, got {midway}"
+        );
+
+        let (_, arrived) = frame_at(&mut tree, root, t0 + std::time::Duration::from_millis(600));
+        assert!(
+            (arrived - 30.0).abs() < 0.01,
+            "and it arrives, got {arrived}"
         );
     }
 

--- a/src/widgets/text_input.rs
+++ b/src/widgets/text_input.rs
@@ -28,7 +28,7 @@ use super::control::Control;
 use super::font::{FontFamily, FontWeight};
 use super::input_style::{InputStyle, InputStyled};
 use super::state_layer::{StateWhen, Stateful};
-use super::text_style::{TextStyle, TextStyled};
+use super::text_style::TextStyle;
 use super::widget::{Color, Event, EventResponse, Key, MouseButton, Rect, Widget};
 
 /// Cursor blink interval in milliseconds
@@ -283,6 +283,8 @@ pub struct TextInput {
     /// What this input declares about its own text, and about the furniture
     /// only it draws. Boxed and absent by default.
     text_style: Option<Box<TextStyle>>,
+    /// How the declared colour and size move, when declared with a motion.
+    text_anims: Option<Box<crate::widgets::text_style::TextAnims>>,
     input_style: Option<Box<InputStyle>>,
     /// Overrides that apply while this field's control is in a state, in
     /// declaration order.
@@ -330,6 +332,7 @@ impl TextInput {
             on_change: None,
             on_submit: None,
             text_style: None,
+            text_anims: None,
             input_style: None,
             states: Vec::new(),
         }
@@ -575,7 +578,7 @@ impl TextInput {
     /// The reads happen in this widget's tracking scope, so a change to a
     /// declared metric re-lays-out this input and nothing else.
     fn refresh(&mut self, tree: &Tree, id: WidgetId) -> f32 {
-        let (new_value, new_font_size, new_font_family, new_font_weight, overflow) =
+        let (new_value, new_font_size, new_font_family, new_font_weight, overflow, new_color) =
             with_signal_tracking(id, JobType::Layout, || {
                 let style = self.resolved_text_style(tree, id);
 
@@ -605,6 +608,8 @@ impl TextInput {
                         style.stroke.map(|s| s.get()),
                         style.shadow.map(|s| s.get()),
                     ),
+                    self.animates_text_color()
+                        .then(|| style.color.get_or(Color::WHITE)),
                 )
             });
 
@@ -618,6 +623,12 @@ impl TextInput {
             self.selection.cursor = self.selection.cursor.min(self.cached_char_count);
             self.selection.anchor = self.selection.anchor.min(self.cached_char_count);
         }
+
+        // The declared motions, pointed at what the style now resolves to. The
+        // same two properties `Text` animates, from the same list — see
+        // `declares_text_style`.
+        let new_font_size =
+            self.retarget_text_anims(tree, id, new_color.unwrap_or(Color::WHITE), new_font_size);
 
         // Check font properties - only set dirty flag if changed
         if (new_font_size - self.cached_font_size).abs() > f32::EPSILON {
@@ -1133,11 +1144,7 @@ impl Stateful for TextInput {
     }
 }
 
-impl TextStyled for TextInput {
-    fn text_style_mut(&mut self) -> &mut TextStyle {
-        self.text_style.get_or_insert_with(Box::default)
-    }
-}
+crate::widgets::text_style::declares_text_style!(TextInput, text_style, text_anims);
 
 impl InputStyled for TextInput {
     fn input_style_mut(&mut self) -> &mut InputStyle {
@@ -1147,7 +1154,9 @@ impl InputStyled for TextInput {
 
 impl Widget for TextInput {
     fn advance_animations(&mut self, tree: &mut Tree, id: WidgetId) -> bool {
-        self.update_cursor_blink(id, tree.frame_instant())
+        let blinking = self.update_cursor_blink(id, tree.frame_instant());
+        let animating = self.advance_text_anims(tree, id);
+        blinking || animating
     }
 
     fn layout(&mut self, tree: &mut Tree, id: WidgetId, constraints: Constraints) -> Size {
@@ -1218,7 +1227,10 @@ impl Widget for TextInput {
             with_signal_tracking(id, JobType::Paint, || {
                 let style = self.resolved_text_style(tree, id);
                 let input = self.resolved_input_style();
-                let text_color = style.color.get_or(Color::WHITE);
+                let text_color = crate::widgets::container::get_animated_value(
+                    self.text_anims.as_ref().and_then(|a| a.color.as_ref()),
+                    || style.color.get_or(Color::WHITE),
+                );
                 // Only when there is nothing to show instead. Read inside the
                 // tracking scope like every other paint input, so a prompt that
                 // changes repaints the field.
@@ -1693,6 +1705,54 @@ mod tests {
             "asked for no caret and got one anyway"
         );
         assert!(has_focus(id), "and the focus is still here");
+    }
+
+    /// A field's declared colour eases exactly as a text's does.
+    ///
+    /// The two widgets take their style setters from one list
+    /// (`declares_text_style`), so this is parity being *observed* rather than
+    /// assumed: the macro guarantees the method exists, and this guarantees the
+    /// storage behind it is wired — an input that accepted a transition and
+    /// ignored it would be the silently-dropped value the whole rule exists to
+    /// prevent.
+    #[test]
+    fn a_declared_transition_eases_an_input_colour() {
+        use crate::animation::Animate;
+
+        let hue = create_signal(Color::rgb(0.0, 0.0, 0.0));
+        let (mut tree, root, _id) = field_in_container(
+            text_input(create_signal("abc".to_owned()))
+                .color((move || hue.get()).transition(400.0)),
+        );
+
+        fn drawn(tree: &mut Tree, id: WidgetId, at: std::time::Instant) -> Option<Color> {
+            tree.set_frame_instant(Some(at));
+            relayout(tree, id);
+            let node = paint_once(tree, id);
+            tree.set_frame_instant(None);
+            fn walk(node: &crate::renderer::RenderNode) -> Option<Color> {
+                for cmd in &node.commands {
+                    if let crate::renderer::DrawCommand::Text { color, .. } = &**cmd {
+                        return Some(*color);
+                    }
+                }
+                node.children.iter().find_map(|c| walk(c))
+            }
+            walk(&node)
+        }
+
+        let t0 = std::time::Instant::now();
+        drawn(&mut tree, root, t0);
+
+        hue.set(Color::rgb(1.0, 1.0, 1.0));
+        drawn(&mut tree, root, t0 + std::time::Duration::from_millis(1));
+        let midway = drawn(&mut tree, root, t0 + std::time::Duration::from_millis(100))
+            .expect("the field draws its text");
+
+        assert!(
+            midway.r > 0.01 && midway.r < 0.99,
+            "an input's declared colour has to ease like a text's, got {midway:?}"
+        );
     }
 
     /// A field switched to masked refuses the very next copy, not the one after.

--- a/src/widgets/text_style.rs
+++ b/src/widgets/text_style.rs
@@ -494,7 +494,12 @@ macro_rules! declares_text_style {
 pub(crate) use declares_text_style;
 
 /// The same vocabulary for an override, which supplies values and never a
-/// timing — see [`declares_text_style`] for why the two differ.
+/// timing.
+///
+/// The motion belongs to whoever *declared* a property, and a state layer does
+/// not declare it — so the two differ by the types they accept rather than by a
+/// rule written down anywhere, which is the shape `Container` and `StateStyle`
+/// already have.
 impl TextStyle {
     /// Colour of the glyphs.
     ///

--- a/src/widgets/text_style.rs
+++ b/src/widgets/text_style.rs
@@ -44,7 +44,11 @@
 
 use smallvec::SmallVec;
 
+use std::time::Instant;
+
+use crate::jobs::RequiredJob;
 use crate::reactive::{IntoSignal, Signal};
+use crate::widgets::container::AnimationState;
 
 use super::font::{FontFamily, FontWeight};
 use super::widget::Color;
@@ -236,74 +240,318 @@ impl TextStyle {
     }
 }
 
-/// The vocabulary for declaring text style, written once.
+/// Where a declared text property keeps its motion.
 ///
-/// Implemented by whoever *draws* glyphs — [`Text`](crate::widgets::Text) and
-/// [`TextInput`](crate::widgets::TextInput) — and by [`TextStyle`] itself, so
-/// a state override is built with the same words as the widget:
-/// `when_hovered(|s| s.color(..))`.
-///
-/// ```ignore
-/// container()
-///     .child(text("quiet").color(theme.weak))
-///     .child(text("loud").color(theme.strong))
-/// ```
-pub trait TextStyled: Sized {
-    #[doc(hidden)]
-    fn text_style_mut(&mut self) -> &mut TextStyle;
+/// Boxed and absent by default, like the style beside it: a text that declares
+/// no timing pays a null check rather than two animation states. Only the two
+/// interpolable properties are here — see [`declares_text_style`].
+#[derive(Default)]
+pub(crate) struct TextAnims {
+    pub(crate) color: Option<AnimationState<Color>>,
+    pub(crate) font_size: Option<AnimationState<f32>>,
+}
 
+impl TextAnims {
+    /// Point both motions at what the style now resolves to, and say what has
+    /// to happen next.
+    ///
+    /// Returns the job the frame after this one wants, and the size to measure
+    /// with — the animated one while it is moving, the declared one otherwise.
+    ///
+    /// A motion that has never run is *seeded* rather than eased: its stored
+    /// value is whatever `get_untracked` saw when the builder ran, and a write
+    /// landing between construction and the first layout would otherwise make
+    /// the first frame ease from a value that was already stale.
+    pub(crate) fn retarget(
+        &mut self,
+        color: Color,
+        size: f32,
+        now: Instant,
+    ) -> (Option<RequiredJob>, f32) {
+        let mut wants = None;
+        if let Some(a) = self.color.as_mut() {
+            if a.is_initial() {
+                a.set_immediate(color);
+            } else {
+                a.animate_to(color, now);
+            }
+            if a.is_animating() {
+                wants = Some(RequiredJob::Paint);
+            }
+        }
+        let mut measured = size;
+        if let Some(a) = self.font_size.as_mut() {
+            if a.is_initial() {
+                a.set_immediate(size);
+            } else {
+                a.animate_to(size, now);
+            }
+            measured = a.displayed();
+            // A size still moving has to be measured again, not merely redrawn.
+            if a.is_animating() {
+                wants = Some(RequiredJob::Layout);
+            }
+        }
+        (wants, measured)
+    }
+
+    /// Move both motions on, and say what the next frame wants.
+    ///
+    /// `None` where nothing moved: a transition inside its `delay_ms` is
+    /// animating and has produced no new value, and asking for a paint there
+    /// would wake the loop every frame for a picture that has not changed.
+    pub(crate) fn advance(&mut self, now: Instant) -> Option<RequiredJob> {
+        let mut wants = None;
+        if let Some(a) = self.color.as_mut()
+            && a.advance(now).is_changed()
+        {
+            wants = Some(RequiredJob::Paint);
+        }
+        if let Some(a) = self.font_size.as_mut()
+            && a.advance(now).is_changed()
+        {
+            wants = Some(RequiredJob::Layout);
+        }
+        wants
+    }
+
+    /// Whether either motion is still on its way, which is what keeps the
+    /// frames coming while a delay is running.
+    pub(crate) fn is_animating(&self) -> bool {
+        self.color.as_ref().is_some_and(|a| a.is_animating())
+            || self.font_size.as_ref().is_some_and(|a| a.is_animating())
+    }
+
+    /// Whether a colour motion was declared. The declared colour has to be read
+    /// under layout tracking to retarget it, and that subscription is worth
+    /// paying only where there is something to retarget — every other text
+    /// reads its colour at paint alone, as it always did.
+    pub(crate) fn animates_color(&self) -> bool {
+        self.color.is_some()
+    }
+}
+
+/// The vocabulary for declaring text style, on a widget that draws glyphs.
+///
+/// Written once and emitted for both [`Text`](crate::widgets::Text) and
+/// [`TextInput`](crate::widgets::TextInput), which is what keeps the two in
+/// step: a property added here reaches both, and one that reaches only one of
+/// them cannot be written.
+///
+/// These are the *declaration* sites, so `color` and `font_size` carry how they
+/// move as well as what they are — `color(theme.warn.transition(200.0))`. The
+/// four below them take values only, because they are not values that can be
+/// interpolated: a family and a weight snap to an installed face, and a stroke
+/// and a shadow are records with no `Animatable` between them.
+///
+/// The *override* site is [`TextStyle`], and its setters take values alone.
+/// That is not a second vocabulary but the rule falling out of the types: a
+/// timing on `when_hovered(|s| s.color(..))` is a compile error rather than a
+/// value quietly ignored, which is the same shape `Container` and `StateStyle`
+/// already have.
+macro_rules! declares_text_style {
+    ($widget:ty, $style:ident, $anims:ident) => {
+        impl $widget {
+            fn text_style_mut(&mut self) -> &mut $crate::widgets::text_style::TextStyle {
+                self.$style.get_or_insert_with(Default::default)
+            }
+
+            /// Point the declared motions at the resolved style, and hand back
+            /// the size to measure with.
+            ///
+            /// Emitted rather than written per widget: the setters above are
+            /// the same for both, and so is what has to happen behind them — a
+            /// widget that took a transition and did not carry it would be the
+            /// silently-dropped value the whole rule exists to prevent.
+            fn retarget_text_anims(
+                &mut self,
+                tree: &$crate::tree::Tree,
+                id: $crate::tree::WidgetId,
+                color: $crate::widgets::Color,
+                size: f32,
+            ) -> f32 {
+                let Some(anims) = self.$anims.as_deref_mut() else {
+                    return size;
+                };
+                let (wants, measured) = anims.retarget(color, size, tree.frame_instant());
+                if let Some(required) = wants {
+                    $crate::jobs::request_job(id, $crate::jobs::JobRequest::Animation(required));
+                }
+                measured
+            }
+
+            /// Move the declared motions on, and ask for the frame that carries
+            /// them further.
+            fn advance_text_anims(
+                &mut self,
+                tree: &$crate::tree::Tree,
+                id: $crate::tree::WidgetId,
+            ) -> bool {
+                let now = tree.frame_instant();
+                let Some(anims) = self.$anims.as_deref_mut() else {
+                    return false;
+                };
+                let moved = anims.advance(now);
+                let running = anims.is_animating();
+                if let Some(required) = moved {
+                    $crate::jobs::request_job(id, $crate::jobs::JobRequest::Animation(required));
+                } else if running {
+                    // Inside a delay: still on its way, nothing new to draw, so
+                    // it asks to be woken without asking for a picture.
+                    $crate::jobs::request_job(
+                        id,
+                        $crate::jobs::JobRequest::Animation($crate::jobs::RequiredJob::None),
+                    );
+                }
+                running
+            }
+
+            /// Whether a colour motion was declared — see
+            /// [`TextAnims::animates_color`].
+            fn animates_text_color(&self) -> bool {
+                self.$anims
+                    .as_deref()
+                    .is_some_and($crate::widgets::text_style::TextAnims::animates_color)
+            }
+
+            /// Colour of the glyphs, and how it moves.
+            pub fn color<M>(
+                mut self,
+                color: impl $crate::animation::IntoAnimated<$crate::widgets::Color, M>,
+            ) -> Self {
+                let signal = $crate::widgets::container::declare(
+                    &mut self.$anims,
+                    color,
+                    |a: &mut $crate::widgets::text_style::TextAnims| &mut a.color,
+                );
+                self.text_style_mut().color = Some(signal);
+                self
+            }
+
+            /// Font size in logical pixels, and how it moves.
+            pub fn font_size<M>(
+                mut self,
+                size: impl $crate::animation::IntoAnimated<f32, M>,
+            ) -> Self {
+                let signal = $crate::widgets::container::declare(
+                    &mut self.$anims,
+                    size,
+                    |a: &mut $crate::widgets::text_style::TextAnims| &mut a.font_size,
+                );
+                self.text_style_mut().font_size = Some(signal);
+                self
+            }
+
+            /// Font family.
+            pub fn font_family<M>(
+                mut self,
+                family: impl $crate::reactive::IntoSignal<$crate::widgets::FontFamily, M>,
+            ) -> Self {
+                self.text_style_mut().font_family = Some(family.into_signal());
+                self
+            }
+
+            /// Font weight on the CSS 100-900 scale.
+            pub fn font_weight<M>(
+                mut self,
+                weight: impl $crate::reactive::IntoSignal<$crate::widgets::FontWeight, M>,
+            ) -> Self {
+                self.text_style_mut().font_weight = Some(weight.into_signal());
+                self
+            }
+
+            /// Shorthand for [`font_weight`](Self::font_weight) at `FontWeight::BOLD`.
+            pub fn bold(self) -> Self {
+                self.font_weight($crate::widgets::FontWeight::BOLD)
+            }
+
+            /// Shorthand for [`font_family`](Self::font_family) at the monospace family.
+            pub fn mono(self) -> Self {
+                self.font_family($crate::widgets::FontFamily::Monospace)
+            }
+
+            /// Contour drawn around the glyphs, under the fill.
+            pub fn text_stroke<M>(
+                mut self,
+                stroke: impl $crate::reactive::IntoSignal<$crate::widgets::TextStroke, M>,
+            ) -> Self {
+                self.text_style_mut().stroke = Some(stroke.into_signal());
+                self
+            }
+
+            /// Soft shadow cast by the glyphs.
+            pub fn text_shadow<M>(
+                mut self,
+                shadow: impl $crate::reactive::IntoSignal<$crate::widgets::TextShadow, M>,
+            ) -> Self {
+                self.text_style_mut().shadow = Some(shadow.into_signal());
+                self
+            }
+        }
+    };
+}
+
+pub(crate) use declares_text_style;
+
+/// The same vocabulary for an override, which supplies values and never a
+/// timing — see [`declares_text_style`] for why the two differ.
+impl TextStyle {
     /// Colour of the glyphs.
-    fn color<M>(mut self, color: impl IntoSignal<Color, M>) -> Self {
-        self.text_style_mut().color = Some(color.into_signal());
+    ///
+    /// An override supplies a value and never a timing: the motion belongs to
+    /// whoever *declared* the property, and a state layer does not declare it.
+    /// So this is a compile error rather than a value quietly ignored, which is
+    /// the whole reason [`Animated`](crate::animation::Animated) is not an
+    /// [`IntoSignal`]:
+    ///
+    /// ```compile_fail
+    /// use guido::prelude::*;
+    ///
+    /// const HOT: Color = Color::rgb(0.9, 0.3, 0.2);
+    /// let _ = text("label").when_hovered(|s| s.color(HOT.transition(80.0)));
+    /// ```
+    pub fn color<M>(mut self, color: impl IntoSignal<Color, M>) -> Self {
+        self.color = Some(color.into_signal());
         self
     }
 
     /// Font size in logical pixels.
-    fn font_size<M>(mut self, size: impl IntoSignal<f32, M>) -> Self {
-        self.text_style_mut().font_size = Some(size.into_signal());
+    pub fn font_size<M>(mut self, size: impl IntoSignal<f32, M>) -> Self {
+        self.font_size = Some(size.into_signal());
         self
     }
 
     /// Font family.
-    fn font_family<M>(mut self, family: impl IntoSignal<FontFamily, M>) -> Self {
-        self.text_style_mut().font_family = Some(family.into_signal());
+    pub fn font_family<M>(mut self, family: impl IntoSignal<FontFamily, M>) -> Self {
+        self.font_family = Some(family.into_signal());
         self
     }
 
     /// Font weight on the CSS 100-900 scale.
-    fn font_weight<M>(mut self, weight: impl IntoSignal<FontWeight, M>) -> Self {
-        self.text_style_mut().font_weight = Some(weight.into_signal());
+    pub fn font_weight<M>(mut self, weight: impl IntoSignal<FontWeight, M>) -> Self {
+        self.font_weight = Some(weight.into_signal());
         self
     }
 
     /// Shorthand for [`font_weight`](Self::font_weight) at `FontWeight::BOLD`.
-    fn bold(self) -> Self {
+    pub fn bold(self) -> Self {
         self.font_weight(FontWeight::BOLD)
     }
 
     /// Shorthand for [`font_family`](Self::font_family) at the monospace family.
-    fn mono(self) -> Self {
+    pub fn mono(self) -> Self {
         self.font_family(FontFamily::Monospace)
     }
 
     /// Contour drawn around the glyphs, under the fill.
-    fn text_stroke<M>(mut self, stroke: impl IntoSignal<TextStroke, M>) -> Self {
-        self.text_style_mut().stroke = Some(stroke.into_signal());
+    pub fn text_stroke<M>(mut self, stroke: impl IntoSignal<TextStroke, M>) -> Self {
+        self.stroke = Some(stroke.into_signal());
         self
     }
 
     /// Soft shadow cast by the glyphs.
-    fn text_shadow<M>(mut self, shadow: impl IntoSignal<TextShadow, M>) -> Self {
-        self.text_style_mut().shadow = Some(shadow.into_signal());
-        self
-    }
-}
-
-/// A partial text style is itself something to declare style on, which is what
-/// lets a state override use the same builder as the widget:
-/// `when_hovered(|s| s.color(..))`.
-impl TextStyled for TextStyle {
-    fn text_style_mut(&mut self) -> &mut TextStyle {
+    pub fn text_shadow<M>(mut self, shadow: impl IntoSignal<TextShadow, M>) -> Self {
+        self.shadow = Some(shadow.into_signal());
         self
     }
 }


### PR DESCRIPTION
## What changed

`text("saving…").color(theme.warn.transition(200.0))` compiles. A text colour and
a font size now carry how they move, like every other declared property. Closes #302.

**The issue's proposed approach would have broken its own acceptance**, and that
was settled with the maintainer before anything was written. #302 said to widen
`TextStyled`'s bound — but that trait was implemented by `Text`, `TextInput`
*and* `TextStyle`, and `TextStyle` is what `when_hovered(|s| s.color(..))` hands
you. Widening it would let a state override carry a timing, which the issue's
third criterion forbids.

`Container` never had the problem because it never shared: `Container::background`
takes `IntoAnimated`, `StateStyle::background` takes `IntoSignal`, two inherent
methods on two unrelated types. Text has that shape now — the trait is deleted,
`declares_text_style!` emits the setters *and* the wiring behind them for both
widgets from one list, and `TextStyle` keeps values-only setters. The rule falls
out of the types instead of being written down somewhere.

`color` and `font_size` take motion. The other four take values: a family and a
weight snap to an installed face, and a stroke and a shadow have nothing to
interpolate.

## What proves it

Five tests, each verified to fail when the thing it describes is removed:

- a declared colour eases while an identically-declared plain one snaps
- a font size eases, asserted on **the container's measured size** across frames
- a `TextInput` colour eases exactly as a `Text`'s does
- a colour that only paints wakes **no layout**; one declared with a motion does
- a motion written to between construction and first layout **seeds** rather
  than easing up from a stale builder-time value

Plus the `compile_fail` doctest for the override rule — which I compiled by hand
to check it fails for the intended reason (`E0277` on `TextStyle::color`'s bound)
rather than vacuously.

Harness: fmt, clippy `-D warnings`, `cargo test --all-features` (31 targets), 9
goldens on lavapipe, the suite again with `GUIDO_GPU_REQUIRED=1`, `mdbook test`
against a freshly built lib, and `RUSTDOCFLAGS="-D warnings" cargo doc`.

## What the review found

**One blocking, and it was my error twice over.** `cargo doc` failed — the doc on
the public `impl TextStyle` linked a private macro — and I had listed that job as
green in the review prompt without having run it on this change. Fixed, and now
actually run.

Three worth answering, all acted on:

1. *The one page a user reads to learn what animates still said text does not.*
   `book/src/animations/properties.md` calls its table "Complete Reference" and
   had neither property; `docs/STATE_LAYER.md` enumerated the animatable ten. The
   capability #302 says was *lost* would have come back undiscoverable. Both
   updated, and the book gained a section rather than just a row.
2. *The font-size test asserted the painted size, not the measured one* the
   criterion asks for, on a bare root text — so it proved the value moved and
   nothing about the reflow. Rewritten around a container.
3. *Three behaviours the commit body claimed and nothing watched.* All three are
   tested now — the third (a transition inside its `delay_ms`) after CI's
   mutation job made the same point independently.

## What was checked by hand

That the design fork was real, before writing: `TextStyled`'s three impls, and
`Container`/`StateStyle` as the precedent for keeping declaration and override
apart by type. And `/simplify` found two things worth more than the tidying —
the missing seed step above, and that reading the colour unconditionally
subscribed every text's *layout* to it, which on a status bar turns a theme
change from N repaints into N subtree relayouts.

## What CI added

The mutation job found nine survivors, all in new code, and both clusters are
now closed. Five were `TextStyle`'s override setters — the only text override
anyone had tested was a colour, so five others could have been dropped on the
floor. Four were the delay window, and writing that test turned up what looked
like a defect: a delayed transition appearing never to run. It was the test's
fault, not the code's — it cleared the pending jobs mid-flight, and that queued
Animation job *is* the chain, since `Text` takes an unchanged-constraints
early-out. I had it the wrong way round until I looked; the test now says so
where the next person will hit it.

## Left undone
- **`TextInput`'s height never shrinks** (`(cached_font_size * 1.2).max(prev_height)`,
  untouched here), so an easing font size *downwards* on a field will not shrink
  it. Pre-existing and orthogonal; noticed while reading, not caused here.
- **`InputStyled` is now a trait with one impl on one widget**, and its own doc
  has to say so awkwardly. Inherent methods would read better. Not this title.
- The generic animation plumbing text now leans on still lives under
  `src/widgets/container/`. This change follows that placement rather than
  creating it.

https://claude.ai/code/session_016cdRGJettCQPPACDkS1CtM
