### PR TITLE
A subtree can be told not to take input, and a field can be told not to take edits

### DIFF
--- a/.claude/skills/widgets/SKILL.md
+++ b/.claude/skills/widgets/SKILL.md
@@ -12,8 +12,8 @@ declarations do not.**
 
 Reactive: `background`, `gradient`, `backdrop_blur`, `overflow`, `corners`,
 `border`, `translate`, `rotate`, `scale`, `pivot`, `width`, `height`,
-`padding`, `visible`, `shadow` — and beyond `Container`, `Text`'s `wrap`,
-`Image`'s `content_fit`, `TextInput`'s `password`, `mask_char` and `caret`,
+`padding`, `visible`, `enabled`, `shadow` — and beyond `Container`, `Text`'s `wrap`,
+`Image`'s `content_fit`, `TextInput`'s `password`, `mask_char`, `caret` and `readonly`,
 `RippleConfig`'s colour, and the direction a `Flex` is built with.
 
 Structural: `layout`, `child`, `children`, `control`, the axis a `Scroll` is

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -33,6 +33,7 @@
 - [Interactivity](interactivity/README.md)
     - [State Layer API](interactivity/state-layer.md)
     - [Hover & Pressed States](interactivity/states.md)
+    - [Disabling a Subtree](interactivity/disabled.md)
     - [Ripple Effects](interactivity/ripples.md)
     - [Event Handling](interactivity/events.md)
 

--- a/book/src/interactivity/README.md
+++ b/book/src/interactivity/README.md
@@ -30,6 +30,7 @@ The framework handles:
 
 - [State Layer API](state-layer.md) - Overview of the state layer system
 - [Hover & Pressed States](states.md) - Define visual overrides per state
+- [Disabling a Subtree](disabled.md) - Stop a whole subtree taking input, and style it
 - [Ripple Effects](ripples.md) - Material Design-style touch feedback
 - [Event Handling](events.md) - Click, hover, and scroll events
 

--- a/book/src/interactivity/disabled.md
+++ b/book/src/interactivity/disabled.md
@@ -1,0 +1,102 @@
+# Disabling a Subtree
+
+A form that stops responding while a request is in flight is one declaration,
+not a check inside every handler:
+
+```rust
+# extern crate guido;
+# use guido::prelude::*;
+# fn main() {
+# let busy = create_signal(false);
+# let submit = || {};
+container()
+    .enabled(move || !busy.get())
+    .child(container().on_click(submit).child(text("Send")))
+# ;
+# }
+```
+
+`enabled(false)` stops every event at that container. Nothing below it — a
+click, a key, a scroll, a nested button's handler — is reached, and nothing
+below it has to know why.
+
+## It propagates, and cannot be undone from below
+
+A container declaring `enabled(true)` inside one declaring `enabled(false)` is
+**disabled**. There is no way for a descendant to re-enable itself, which is
+what lets a whole form be switched off in one place and is the rule Qt, GTK and
+SwiftUI all settled on.
+
+## The look is declared beside the behaviour
+
+A disabled subtree is painted exactly as declared — guido does not pick a grey
+for you. `when_disabled` is how you pick one, and it reads the same declaration
+that stopped the events, so the two cannot come apart:
+
+```rust
+# extern crate guido;
+# use guido::prelude::*;
+# fn main() {
+# let busy = create_signal(false);
+container()
+    .enabled(move || !busy.get())
+    .child(
+        text("Send")
+            .color(Color::WHITE)
+            .when_disabled(|s| s.color(Color::rgb(0.5, 0.5, 0.5))),
+    )
+# ;
+# }
+```
+
+The text asks its **control** — the nearest enclosing interaction unit, which
+declaring `enabled` makes the container into. That is why the label greys with
+the form around it without being handed the signal itself.
+
+A condition you already hold reads the same at one call site:
+`state(busy, |s| s.darker(0.2))`. What it cannot do is promise that two widgets
+in two files mean the same thing by it. `Disabled` is the control's answer, with
+its ancestors folded in, so it means one thing everywhere.
+
+## What a disabled subtree gives up, and what it keeps
+
+**It gives up the pointer and the keyboard.** A disabled control is neither
+hovered nor pressed nor focused, so `when_hovered`, `when_pressed` and
+`when_focused` all switch off with it — no stale highlight, and no focus ring on
+something that is not taking keys. Qt, GTK, SwiftUI and `<fieldset disabled>`
+all behave this way.
+
+**It is still laid out and still painted.** Disabling changes what an event
+does, not where anything sits — so it costs no layout pass.
+
+## Not the same as read-only
+
+There is a second thing you may want, and it is not this one: a field that stops
+accepting *edits* but goes on saying the keyboard is aimed at it. A lock screen
+that has sent the password to PAM wants exactly that — the typed characters must
+go nowhere, but on a multi-monitor setup the `when_focused` ring is the only
+thing saying which screen you are typing at, and disabling would take it away.
+
+That is `readonly`, and it is a different setter for a different job:
+
+```rust
+# extern crate guido;
+# use guido::prelude::*;
+# fn main() {
+# let value = create_signal(String::new());
+# let busy = create_signal(false);
+text_input(value).readonly(busy).caret(move || !busy.get())
+# ;
+# }
+```
+
+It refuses every edit — typing, backspace, delete, paste, cut, undo — and
+nothing else. The caret still moves, a selection can still be made and copied,
+`Enter` still reaches `on_submit`, and the focus stays put. The caret is not
+part of it: a field that should stop blinking says so with `caret`, driven by
+the same signal, as above.
+
+Every toolkit keeps these two apart, and for this reason: `readonly` beside
+`disabled` on the web, `setReadOnly` beside `setEnabled` in Qt, `readOnly`
+beside `enabled` in Flutter. Reach for `enabled` when the thing is not
+available, and for `readonly` when it is yours but frozen.

--- a/book/src/interactivity/state-layer.md
+++ b/book/src/interactivity/state-layer.md
@@ -7,6 +7,8 @@ The state layer system provides declarative style overrides based on widget inte
 State layers let containers define how they should look when:
 - **Hovered** - Mouse cursor is over the widget
 - **Pressed** - Mouse button is held down on the widget
+- **Focused** - The keyboard focus is inside the widget
+- **Disabled** - The widget, or something above it, was declared `enabled(false)` — see [Disabling a Subtree](disabled.md)
 
 Changes are defined declaratively, and the framework handles state transitions, animations, and rendering.
 

--- a/docs/STATE_LAYER.md
+++ b/docs/STATE_LAYER.md
@@ -8,6 +8,7 @@ State layers allow containers to define how they should look when:
 - **Hovered**: Mouse cursor is over the widget
 - **Pressed**: Mouse button is held down on the widget
 - **Focused**: Any child widget has keyboard focus (e.g., text input)
+- **Disabled**: the control, or something above it, was declared `enabled(false)`
 - **A condition the app owns**: `state(condition, |s| ...)` — the last submit failed, this row is selected
 
 Style changes are defined declaratively using builder methods, and the framework handles all state transitions, animations, and rendering automatically.
@@ -66,6 +67,51 @@ container()
 
 The same signal can be read anywhere else that needs it, independently. That is why there is one generic `state` rather than a named method per case.
 
+### Disabled
+
+`when_disabled` is the one state that is *declared* rather than noticed:
+`Container::enabled` stops every event at that container, and the layer reads
+the same declaration, so the look and the behaviour cannot come apart. The rule
+is that disabling propagates down and a descendant cannot undo it. What that
+means for a caller is in
+[the book](../book/src/interactivity/disabled.md); what it costs is here.
+
+The question has to be answerable **with no tree in hand** — a container
+resolves the text colour it publishes below it from inside a `create_derived`
+closure — so ancestry cannot be walked where the question is asked. It is walked
+once instead, at `register_children`, and left behind as a signal on the
+`Control`:
+
+- `InteractionState::declared_enabled` is what this container said. It gates
+  events, and only it: dispatch is one recursive walk, so a container returning
+  before it asks its children *is* the propagation, and folding there would ask
+  the same ancestors twice.
+- `InteractionState::enabled` is that folded with the enclosing control's, which
+  is what a style resolves against. `Container::fold_enabled` builds it, and
+  because registration is top-down the parent's fold has already happened — so
+  one `&&` per nested declaration is the whole chain.
+
+Declaring `enabled` therefore makes a container an interaction unit, because a
+unit is what a descendant asks. A container that declares nothing keeps `None`
+and allocates no signal, and `OptionSignalExt::get_or` on a `None` reads
+nothing, so every container that does not use this pays two branches.
+
+Context is not an alternative: `reactive::context` is app-global with one value
+per type, so it cannot carry a value scoped to a subtree.
+
+`Control::is_hovered`, `is_pressed` and `has_focus` are all gated on the answer:
+a disabled unit is under no pointer and is not where the keyboard is aimed, so
+its `when_focused` ring goes with the rest of it. Keeping the ring while
+refusing the keys is a *different* concept and has its own setter —
+`TextInput::readonly` — which is why this one does not have to compromise. Every
+toolkit keeps the two apart for that reason: `readonly` beside `disabled` on the
+web, `setReadOnly` beside `setEnabled` in Qt, `readOnly` beside `enabled` in
+Flutter.
+
+One asymmetry worth not rediscovering: `InteractionState::is_hovered` is the
+*raw* flag, untracked and ungated, unlike the `Control` method of the same name.
+Event handling may use it because it never reaches a disabled container.
+
 ## Interaction Units
 
 When a text declares a hover style, hover *of what*? Not its own glyphs — a
@@ -88,13 +134,13 @@ inside its subtree. Which is what makes the case above work at all — the focus
 is in a *sibling*, and both belong to the same unit.
 
 `control()` is rarely written by hand. Anything the pointer can act on is a
-unit by necessity, so `on_click`, `on_hover`, `on_scroll`, `scroll` and a
-declared state layer all imply it. Write it where the boundary is real but
+unit by necessity, so `on_click`, `on_hover`, `on_scroll`, `scroll`,
+`enabled` and a declared state layer all imply it. Write it where the boundary is real but
 nothing else announces it — a field's label and input, a row whose highlight
 belongs to the row.
 
-Leaves declare states with `when_hovered`, `when_pressed`, `when_focused` and
-`state`, from the `Stateful` trait. The closure receives the same partial style
+Leaves declare states with `when_hovered`, `when_pressed`, `when_focused`,
+`when_disabled` and `state`, from the `Stateful` trait. The closure receives the same partial style
 the widget itself is built with, because an override *is* another partial
 style:
 

--- a/examples/disabled_form.rs
+++ b/examples/disabled_form.rs
@@ -1,0 +1,112 @@
+//! A panel that can be switched off, and what that does to everything in it.
+//!
+//! **Busy** is outside the panel and always works. Turn it on and the panel
+//! goes dead from one declaration: the button stops responding, the field stops
+//! taking keys, and both grey themselves out from the same signal that stopped
+//! the events — that is what `when_disabled` is for.
+//!
+//! Two things to look for while it is off. The button does not light up under
+//! the pointer, and the field's focus ring goes out: a disabled subtree is
+//! neither under the pointer nor where the keyboard is aimed.
+//!
+//! The **Frozen** field below is the other half, and the contrast is the point.
+//! It is `readonly`, not disabled: it refuses every edit and keeps its ring, so
+//! it goes on saying the keyboard is aimed at it. That is what a lock screen
+//! wants while PAM answers.
+//!
+//! The nested `enabled(true)` on the button is deliberate: it re-enables
+//! nothing. Disabling propagates down and a descendant cannot undo it.
+
+use guido::prelude::*;
+
+fn main() {
+    App::new().run(|app| {
+        app.add_surface(
+            SurfaceConfig::new()
+                .width(420)
+                .height(250)
+                .anchor(Anchor::TOP)
+                .background_color(Color::rgb(0.1, 0.1, 0.15)),
+            || {
+                let busy = create_signal(false);
+                let value = create_signal(String::new());
+                let frozen = create_signal("you cannot change this".to_owned());
+                let sent = create_signal(0);
+
+                container()
+                    .padding(16.0)
+                    .layout(Flex::column().spacing(12.0))
+                    .child(
+                        container()
+                            .padding(8.0)
+                            .corners(6.0)
+                            .background(Color::rgb(0.25, 0.25, 0.3))
+                            .when_hovered(|s| s.lighter(0.1))
+                            .on_click(move || busy.update(|b| *b = !*b))
+                            .child(
+                                text(move || {
+                                    if busy.get() {
+                                        "Busy — click to let the form work".to_owned()
+                                    } else {
+                                        "Idle — click to switch the form off".to_owned()
+                                    }
+                                })
+                                .color(Color::WHITE),
+                            ),
+                    )
+                    .child(
+                        container()
+                            .padding(12.0)
+                            .corners(8.0)
+                            .background(Color::rgb(0.16, 0.16, 0.22))
+                            .layout(Flex::column().spacing(10.0))
+                            // The one declaration the whole panel hangs from.
+                            .enabled(move || !busy.get())
+                            .child(
+                                container()
+                                    .padding(8.0)
+                                    .corners(6.0)
+                                    .border(1.0, Color::rgb(0.3, 0.3, 0.4))
+                                    .when_focused(|s| s.border(1.0, Color::rgb(0.4, 0.8, 1.0)))
+                                    .child(
+                                        text_input(value)
+                                            .placeholder("Say something")
+                                            .when_disabled(|s| {
+                                                s.color(Color::rgb(0.45, 0.45, 0.5))
+                                            }),
+                                    ),
+                            )
+                            .child(
+                                container()
+                                    .padding(10.0)
+                                    .corners(6.0)
+                                    .background(Color::rgb(0.2, 0.4, 0.7))
+                                    // Says nothing: the panel above already said no.
+                                    .enabled(true)
+                                    .when_hovered(|s| s.lighter(0.15))
+                                    .when_disabled(|s| s.darker(0.4))
+                                    .on_click(move || sent.update(|n| *n += 1))
+                                    .child(
+                                        text("Send").color(Color::WHITE).when_disabled(|s| {
+                                            s.color(Color::rgb(0.55, 0.55, 0.6))
+                                        }),
+                                    ),
+                            ),
+                    )
+                    .child(
+                        container()
+                            .padding(8.0)
+                            .corners(6.0)
+                            .border(1.0, Color::rgb(0.3, 0.3, 0.4))
+                            .when_focused(|s| s.border(1.0, Color::rgb(0.4, 0.8, 1.0)))
+                            .child(
+                                text_input(frozen)
+                                    .placeholder("Frozen — click in, then type")
+                                    .readonly(true),
+                            ),
+                    )
+                    .child(text(move || format!("sent {} times", sent.get())))
+            },
+        );
+    });
+}

--- a/src/reactive/mod.rs
+++ b/src/reactive/mod.rs
@@ -30,9 +30,7 @@ pub use context::{
 pub(crate) use cursor::take_cursor_change;
 pub use cursor::{CursorIcon, set_cursor};
 pub use effect::create_effect;
-pub(crate) use focus::{
-    focus_path, has_focus, release_focus, release_focus_if_within, request_focus,
-};
+pub(crate) use focus::{has_focus, release_focus, release_focus_if_within, request_focus};
 pub(crate) use into_signal::converting_signals;
 #[doc(hidden)]
 pub use into_signal::{

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -2515,7 +2515,8 @@ fn a_translate_sequence_and_a_scale_sequence_move_the_transform() {
 /// a widget that no longer exists.
 #[test]
 fn unregistering_a_focused_widget_releases_the_focus() {
-    use crate::reactive::{focus_path, request_focus};
+    use crate::reactive::focus::focus_path;
+    use crate::reactive::request_focus;
 
     let mut h = H::new(
         container()

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -4110,3 +4110,196 @@ fn a_fully_transparent_gradient_draws_nothing() {
         Some(Color::GRAY)
     );
 }
+
+// ---------------------------------------------------------------------------
+// Enabled
+// ---------------------------------------------------------------------------
+
+/// The subtree gate, at its plainest: the handler is on the child, the
+/// declaration on the parent, and the click reaches neither.
+///
+/// `Ignored` rather than a merely silent handler, because a click a disabled
+/// form swallows must not be swallowed at all — the container behind it is
+/// entitled to it.
+#[test]
+fn a_click_does_not_reach_a_handler_below_a_disabled_container() {
+    let clicks = std::rc::Rc::new(std::cell::Cell::new(0));
+    let counter = clicks.clone();
+    let mut h = H::new(
+        container()
+            .width(100.0)
+            .height(100.0)
+            .enabled(false)
+            .child(box_of(50.0, 20.0).on_click(move || counter.set(counter.get() + 1))),
+    );
+    h.fit(500.0, 500.0);
+
+    for event in click_at(5.0, 5.0) {
+        assert_eq!(h.send(event), EventResponse::Ignored);
+    }
+    assert_eq!(clicks.get(), 0, "the handler is below a disabled container");
+}
+
+/// Disabling propagates down and a descendant cannot undo it — the rule Qt,
+/// GTK and SwiftUI all settled on, asserted here so it is not re-litigated one
+/// widget at a time.
+///
+/// Both halves, because they are two mechanisms: the click is stopped by the
+/// early-out in `event`, and the inner control's *answer* is a signal folded
+/// at registration. A change that kept one and lost the other would leave a
+/// subtree that refuses input while styling itself as if it took it.
+#[test]
+fn a_descendant_declaring_itself_enabled_stays_disabled() {
+    let clicks = std::rc::Rc::new(std::cell::Cell::new(0));
+    let counter = clicks.clone();
+    let mut h = H::new(
+        container().width(100.0).height(100.0).enabled(false).child(
+            container()
+                .width(80.0)
+                .height(80.0)
+                .enabled(true)
+                .child(box_of(50.0, 20.0).on_click(move || counter.set(counter.get() + 1))),
+        ),
+    );
+    h.fit(500.0, 500.0);
+
+    for event in click_at(5.0, 5.0) {
+        h.send(event);
+    }
+    assert_eq!(clicks.get(), 0, "an ancestor said no");
+
+    let inner = h.children()[0];
+    assert!(
+        h.tree
+            .nearest_control(inner)
+            .expect("declaring `enabled` makes a container an interaction unit")
+            .is_disabled(),
+        "the inner unit answers for its ancestors as well as itself"
+    );
+}
+
+/// The gate is a signal like every other declared property: flipping it back
+/// lets the next click through, and the write moves nothing, so it costs no
+/// layout.
+#[test]
+fn re_enabling_lets_the_next_click_through_and_costs_no_layout() {
+    let enabled = create_signal(false);
+    let clicks = std::rc::Rc::new(std::cell::Cell::new(0));
+    let counter = clicks.clone();
+    let mut h = H::new(
+        container()
+            .width(100.0)
+            .height(100.0)
+            .enabled(enabled)
+            .child(box_of(50.0, 20.0).on_click(move || counter.set(counter.get() + 1))),
+    );
+    h.fit(500.0, 500.0);
+
+    for event in click_at(5.0, 5.0) {
+        h.send(event);
+    }
+    assert_eq!(clicks.get(), 0);
+
+    let jobs = h.jobs_from(|| enabled.set(true));
+    assert!(
+        !jobs.contains(&JobType::Layout),
+        "enabling changes what an event does, not where anything sits: {jobs:?}"
+    );
+
+    for event in click_at(5.0, 5.0) {
+        h.send(event);
+    }
+    assert_eq!(clicks.get(), 1, "the gate is open again");
+}
+
+/// The trap in copying the `visible` early-out: it returns before
+/// `track_pointer`, so a container disabled under the pointer would keep
+/// `HOVERED` set for ever and `when_hovered` would stick.
+#[test]
+fn a_container_disabled_while_hovered_is_no_longer_hovered() {
+    let enabled = create_signal(true);
+    let mut h = H::new(
+        container()
+            .width(100.0)
+            .height(100.0)
+            .control()
+            .enabled(enabled)
+            .when_hovered(|s| s.background(Color::BLUE)),
+    );
+    h.fit(500.0, 500.0);
+    let control = h.tree.nearest_control(h.root).expect("a control");
+
+    set_hover(&mut h, true);
+    assert!(control.is_hovered());
+
+    enabled.set(false);
+    assert!(
+        !control.is_hovered(),
+        "a unit that refuses the pointer is not under it"
+    );
+
+    // And the flag itself is given up, not merely masked: the pointer leaves
+    // while the container is disabled, and re-enabling must not light it again.
+    set_hover(&mut h, false);
+    enabled.set(true);
+    assert!(
+        !control.is_hovered(),
+        "the pointer is somewhere else entirely"
+    );
+}
+
+/// The reason the answer is a signal on the control rather than a walk of the
+/// tree: a descendant resolves its own colour from inside a tracking scope
+/// that has no tree in hand.
+#[test]
+fn a_text_below_a_disabled_container_styles_itself_from_it() {
+    let enabled = create_signal(true);
+    let mut h = H::new(
+        container()
+            .width(100.0)
+            .height(40.0)
+            .enabled(enabled)
+            .child(
+                crate::widgets::text("Label")
+                    .color(Color::WHITE)
+                    .when_disabled(|s| s.color(Color::GRAY)),
+            ),
+    );
+
+    assert_eq!(painted_text_color(&mut h), Color::WHITE);
+    enabled.set(false);
+    assert_eq!(painted_text_color(&mut h), Color::GRAY);
+    enabled.set(true);
+    assert_eq!(painted_text_color(&mut h), Color::WHITE);
+}
+
+/// The question the issue left to the implementation: a disabled subtree does
+/// not scroll either.
+///
+/// Scrolling is something a subtree does in answer to an event, and the gate
+/// is on the event — so this follows from where the gate sits rather than from
+/// a decision taken about scrolling separately.
+#[test]
+fn a_disabled_scroller_does_not_scroll() {
+    let enabled = create_signal(false);
+    let rows: Vec<crate::widgets::AnyWidget> =
+        (0..10).map(|_| box_of(40.0, 20.0).into_any()).collect();
+    let mut h = H::new(
+        container()
+            .width(40.0)
+            .height(30.0)
+            .enabled(enabled)
+            .scroll(Scroll::vertical())
+            .children(rows),
+    );
+    h.fit(40.0, 30.0);
+
+    let wheel = || Event::scroll(20.0, 15.0, 0.0, 60.0, ScrollSource::Wheel);
+    assert_eq!(h.send(wheel()), EventResponse::Ignored);
+    enabled.set(true);
+    assert_eq!(
+        h.send(wheel()),
+        EventResponse::Handled,
+        "the same scroller, enabled, takes the wheel"
+    );
+}

--- a/src/widgets/container/interaction.rs
+++ b/src/widgets/container/interaction.rs
@@ -101,6 +101,57 @@ impl Container {
         }
     }
 
+    /// Give up the pointer: the hover, the press, and a ripple that will now
+    /// never be completed.
+    ///
+    /// Two events lead here and they mean the same thing. A `MouseLeave` says
+    /// the pointer went somewhere else; the gate at the top of
+    /// [`event`](Widget::event) says this container stopped accepting it. In
+    /// both cases nothing was activated, so the ripple is cancelled rather than
+    /// completed, and `on_hover(false)` is owed to whoever asked to be told.
+    ///
+    /// The gate needs this because it returns before
+    /// [`track_pointer`](Self::track_pointer): nothing else would ever take
+    /// `HOVERED` off a container the pointer left while it was switched off,
+    /// and it would light up again the moment it was switched back on with the
+    /// pointer somewhere else entirely. (The *reads* are gated too — see
+    /// [`Control::is_hovered`] — which is what makes the flip itself immediate;
+    /// this is what keeps it true afterwards.)
+    ///
+    /// Every write here is change-guarded, so the events that keep arriving
+    /// over a disabled subtree cost one comparison each and wake nobody.
+    ///
+    /// [`Control::is_hovered`]: crate::widgets::Control::is_hovered
+    pub(super) fn pointer_left(&mut self, id: WidgetId, now: Instant) {
+        let Some(ref mut ix) = self.interaction else {
+            return;
+        };
+        let was_hovered = ix.is_hovered();
+        let was_pressed = ix.is_pressed();
+        if was_hovered {
+            ix.set_flag(InteractionFlags::HOVERED, false);
+            if let Some(ref callback) = ix.on_hover {
+                callback(false);
+            }
+        }
+        ix.set_flag(InteractionFlags::PRESSED, false);
+
+        // The pointer left without releasing, so nothing was activated and
+        // there is nothing to complete: the ripple just goes.
+        if ix.ripple.is_active()
+            && let Some(config) = ix.ripple_config()
+        {
+            ix.ripple.cancel(&config, now);
+            request_job(id, JobRequest::Animation(RequiredJob::Paint));
+        }
+
+        if (was_hovered && ix.declares(|w| matches!(w, StateWhen::Hovered)))
+            || (was_pressed && ix.declares(|w| matches!(w, StateWhen::Pressed)))
+        {
+            self.request_state_change_repaint(id);
+        }
+    }
+
     /// Update hover state and fire the pointer-move callback, before children
     /// get the event: a child that handles a `MouseMove` must not stop its
     /// ancestors from tracking their own hover.
@@ -334,35 +385,7 @@ impl Container {
                 }
             }
 
-            Event::MouseLeave => {
-                if let Some(ref mut ix) = self.interaction {
-                    let was_hovered = ix.is_hovered();
-                    let was_pressed = ix.is_pressed();
-                    if ix.is_hovered() {
-                        ix.set_flag(InteractionFlags::HOVERED, false);
-                        if let Some(ref callback) = ix.on_hover {
-                            callback(false);
-                        }
-                    }
-                    ix.set_flag(InteractionFlags::PRESSED, false);
-
-                    // The pointer left without releasing, so nothing was
-                    // activated and there is nothing to complete: the ripple
-                    // just goes.
-                    if ix.ripple.is_active()
-                        && let Some(config) = ix.ripple_config()
-                    {
-                        ix.ripple.cancel(&config, now);
-                        request_job(id, JobRequest::Animation(RequiredJob::Paint));
-                    }
-
-                    if (was_hovered && ix.declares(|w| matches!(w, StateWhen::Hovered)))
-                        || (was_pressed && ix.declares(|w| matches!(w, StateWhen::Pressed)))
-                    {
-                        self.request_state_change_repaint(id);
-                    }
-                }
-            }
+            Event::MouseLeave => self.pointer_left(id, now),
 
             Event::Scroll {
                 at,

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -29,7 +29,8 @@ use crate::jobs::{JobRequest, JobType, RequiredJob, request_job};
 use crate::layout::{Axis, Constraints, Flex, Layout, Length, Size};
 use crate::pivot::Pivot;
 use crate::reactive::{
-    IntoSignal, OptionSignalExt, RwSignal, Signal, create_signal, with_signal_tracking,
+    IntoSignal, OptionSignalExt, RwSignal, Signal, create_derived, create_signal,
+    with_signal_tracking,
 };
 use crate::renderer::{GradientDir, PaintContext, Shadow};
 use crate::transform::{Scale, Transform, Translate};
@@ -274,6 +275,18 @@ pub(super) struct InteractionState {
     /// and a single bit would have made it pay for a translate and a rotate
     /// nothing declares.
     pub(super) declares_transform: Moves,
+    /// What this container was declared with, and — once the tree has been in
+    /// hand — what that means with the enclosing control's answer folded in.
+    ///
+    /// Two fields because they answer two questions. `declared_enabled` is
+    /// what gates events: dispatch is one recursive walk, so a container that
+    /// returns before asking its children *is* the propagation, and reading
+    /// the folded answer there would be asking the same ancestors twice.
+    /// `enabled` is what a style resolves against, and that question has to be
+    /// answerable with no tree — from inside a `create_derived` closure — so
+    /// the ancestry is folded once, at registration, into a signal.
+    pub(super) declared_enabled: Option<Signal<bool>>,
+    pub(super) enabled: Option<Signal<bool>>,
     pub(super) ripple: RippleState,
 }
 
@@ -292,12 +305,18 @@ impl Default for InteractionState {
             flags: create_signal(InteractionFlags::empty()),
             states: Vec::new(),
             declares_transform: Moves::default(),
+            declared_enabled: None,
+            enabled: None,
             ripple: RippleState::new(),
         }
     }
 }
 
 impl InteractionState {
+    /// The raw flag, untracked and **ungated by `enabled`** — unlike
+    /// [`Control::is_hovered`], which is what a style asks. Event handling can
+    /// use it because it never reaches a disabled container: the gate at the
+    /// top of `Container::event` returned long before.
     pub(super) fn is_hovered(&self) -> bool {
         self.flags
             .get_untracked()
@@ -354,7 +373,7 @@ impl InteractionState {
     /// A container asks [`Control::is_active`] exactly as a `Text` below it
     /// does, so the two cannot come to disagree about the unit they share.
     pub(super) fn as_control(&self, id: WidgetId) -> Control {
-        Control::new(id, self.flags)
+        Control::new(id, self.flags, self.enabled)
     }
 }
 
@@ -824,6 +843,54 @@ impl Container {
         self
     }
 
+    /// Whether this container and everything below it accepts input.
+    ///
+    /// A disabled subtree takes no clicks, no keys and no scrolls: the event
+    /// stops here, so nothing below it has to know why. It is still laid out
+    /// and still painted exactly as declared — greying it out is
+    /// [`when_disabled`](crate::widgets::Stateful::when_disabled), which reads
+    /// the same declaration, so the look and the behaviour cannot come apart:
+    ///
+    /// ```
+    /// use guido::prelude::*;
+    ///
+    /// let busy = create_signal(false);
+    /// let _ = container()
+    ///     .enabled(move || !busy.get())
+    ///     .child(container().on_click(|| println!("send")))
+    ///     .child(text("Send").when_disabled(|s| s.color(Color::GRAY)));
+    /// ```
+    ///
+    /// **Disabling propagates and a descendant cannot undo it.** A container
+    /// declaring `enabled(true)` inside one declaring `enabled(false)` is
+    /// disabled — the rule Qt, GTK and SwiftUI all settled on, and the only one
+    /// under which a form can be switched off in a single place.
+    ///
+    /// A disabled subtree is not where the keyboard is aimed: it resolves no
+    /// `when_focused` layer, so the ring goes with the rest of it. That is what
+    /// Qt, GTK, SwiftUI and a `<fieldset disabled>` all do. A field that must go
+    /// on saying the keys are *its* while refusing them is not disabled — it is
+    /// [read-only](crate::widgets::TextInput::readonly), which is the other
+    /// half of this and keeps its focus.
+    ///
+    /// Declaring it makes the container an interaction unit, as every other
+    /// behaviour does, because that is what a descendant asks.
+    ///
+    /// Enabling is a *declaration*, not a state override: there is no way to
+    /// say a container is enabled only while hovered, the same way there is no
+    /// way to declare a timing on an override.
+    ///
+    /// ```compile_fail
+    /// use guido::prelude::*;
+    ///
+    /// let _ = container().when_hovered(|s| s.enabled(false));
+    /// ```
+    pub fn enabled<M>(mut self, enabled: impl IntoSignal<bool, M>) -> Self {
+        let signal = enabled.into_signal();
+        self.interact_mut().declared_enabled = Some(signal);
+        self
+    }
+
     /// Scroll this container, and say what its scrollbar looks like.
     ///
     /// One value rather than three setters. `scrollbar_visibility` and
@@ -1062,6 +1129,41 @@ impl Container {
         self
     }
 
+    /// Fold the enclosing unit's answer into this one's, once, where the tree
+    /// is in hand.
+    ///
+    /// This is the whole mechanism the propagation rests on. Ancestry cannot be
+    /// walked from where the question is asked — a descendant resolves its
+    /// colour inside a `create_derived` closure, which has no tree — so the walk
+    /// happens here, at registration, and leaves behind a signal. The parent's
+    /// own fold has already happened, because registration is top-down and
+    /// `set_control` runs before the children are registered, so one `&&` per
+    /// nested declaration is the whole chain.
+    ///
+    /// A container that declares nothing keeps `None` and allocates no signal,
+    /// which is nearly all of them, and nesting is the only case that allocates
+    /// at all — one declaration inside another's reach.
+    ///
+    /// That one signal belongs to the surface rather than to this widget:
+    /// `register_signal` files under `current_owner`, and registration does not
+    /// run inside the owner a dynamic row was built in. So a keyed list whose
+    /// rows declare `enabled` beneath a control that also does leaks a slot per
+    /// row created, for the surface's lifetime. Closing it means running
+    /// registration under the widget's own owner, which is #330.
+    fn fold_enabled(&mut self, tree: &Tree, id: WidgetId) {
+        let Some(ix) = self.interaction.as_deref_mut() else {
+            return;
+        };
+        let inherited = tree
+            .get_parent(id)
+            .and_then(|parent| tree.nearest_control(parent))
+            .and_then(|control| control.enabled_signal());
+        ix.enabled = match (ix.declared_enabled, inherited) {
+            (Some(own), Some(above)) => Some(create_derived(move || above.get() && own.get())),
+            (own, above) => own.or(above),
+        };
+    }
+
     /// Whether this container is an interaction unit.
     ///
     /// A pointer target *is* one — it has to know whether it is being pointed
@@ -1073,7 +1175,8 @@ impl Container {
             return true;
         }
         self.interaction.as_ref().is_some_and(|ix| {
-            ix.has_any_state()
+            ix.declared_enabled.is_some()
+                || ix.has_any_state()
                 || ix.on_click.is_some()
                 || ix.on_right_click.is_some()
                 || ix.on_middle_click.is_some()
@@ -1325,13 +1428,14 @@ impl Widget for Container {
         // Set container_id for children source
         self.children_source.set_container_id(id);
 
+        self.fold_enabled(tree, id);
         tree.set_control(
             id,
             self.is_control()
                 .then(|| {
                     self.interaction
                         .as_ref()
-                        .map(|ix| Control::new(id, ix.flags))
+                        .map(|ix| Control::new(id, ix.flags, ix.enabled))
                 })
                 .flatten(),
         );
@@ -1506,6 +1610,15 @@ impl Widget for Container {
 
     fn event(&mut self, tree: &mut Tree, id: WidgetId, event: &Event) -> EventResponse {
         if !self.visible.get_or(true) {
+            return EventResponse::Ignored;
+        }
+        // The subtree gate. Only this container's own declaration, because
+        // returning before the children are asked *is* the propagation: an
+        // ancestor that is disabled has already stopped the event above us.
+        if let Some(ref ix) = self.interaction
+            && !ix.declared_enabled.get_or(true)
+        {
+            self.pointer_left(id, tree.event_instant());
             return EventResponse::Ignored;
         }
 

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -29,7 +29,7 @@ use crate::jobs::{JobRequest, JobType, RequiredJob, request_job};
 use crate::layout::{Axis, Constraints, Flex, Layout, Length, Size};
 use crate::pivot::Pivot;
 use crate::reactive::{
-    IntoSignal, OptionSignalExt, RwSignal, Signal, create_signal, focus_path, with_signal_tracking,
+    IntoSignal, OptionSignalExt, RwSignal, Signal, create_signal, with_signal_tracking,
 };
 use crate::renderer::{GradientDir, PaintContext, Shadow};
 use crate::transform::{Scale, Transform, Translate};
@@ -348,20 +348,13 @@ impl InteractionState {
             .and_then(|(_, s)| s.ripple)
     }
 
-    /// Whether the layer is active right now. Reading this is what subscribes
-    /// the caller to the state, which is why it is not asked for layers that
-    /// declare nothing about the property being resolved.
-    pub(super) fn is_active(&self, id: WidgetId, when: &StateWhen) -> bool {
-        match when {
-            StateWhen::Hovered => self.flags.get().contains(InteractionFlags::HOVERED),
-            StateWhen::Pressed => self.flags.get().contains(InteractionFlags::PRESSED),
-            // The path, rather than a walk of this container's descendants:
-            // the same question has to be answerable from a `create_derived`
-            // closure, which has no tree, and that is where a container
-            // resolves the text colour it publishes below it.
-            StateWhen::Focused => focus_path().contains(id),
-            StateWhen::When(condition) => condition.get(),
-        }
+    /// This container as the interaction unit it is, which is what resolves its
+    /// own state layers.
+    ///
+    /// A container asks [`Control::is_active`] exactly as a `Text` below it
+    /// does, so the two cannot come to disagree about the unit they share.
+    pub(super) fn as_control(&self, id: WidgetId) -> Control {
+        Control::new(id, self.flags)
     }
 }
 

--- a/src/widgets/container/style.rs
+++ b/src/widgets/container/style.rs
@@ -44,6 +44,10 @@ impl Container {
             return base;
         }
 
+        // Built once for the whole walk rather than per layer: eight properties
+        // resolve per paint, each walking these same layers.
+        let control = ix.as_control(id);
+
         // Backwards: the last layer declared wins. A layer that says nothing
         // about *this* property is passed over rather than ending the search,
         // so `when_hovered(|s| s.lighter(0.1))` still lightens under a pressed
@@ -52,7 +56,7 @@ impl Container {
             let Some(value) = extractor(state) else {
                 continue;
             };
-            if ix.is_active(id, when) {
+            if control.is_active(when) {
                 return value;
             }
         }

--- a/src/widgets/control.rs
+++ b/src/widgets/control.rs
@@ -37,6 +37,7 @@ use crate::reactive::signal::RwSignal;
 use crate::tree::WidgetId;
 
 use super::container::InteractionFlags;
+use super::state_layer::StateWhen;
 
 /// A handle on the interaction unit a widget belongs to.
 ///
@@ -69,7 +70,31 @@ impl Control {
     }
 
     /// Whether the keyboard focus is inside the control's subtree.
+    ///
+    /// The path, rather than a walk of the unit's descendants: the same
+    /// question has to be answerable from a `create_derived` closure, which has
+    /// no tree, and that is where a container resolves the text colour it
+    /// publishes below it.
     pub fn has_focus(&self) -> bool {
         focus_path().contains(self.id)
+    }
+
+    /// Whether a state layer with this trigger applies right now.
+    ///
+    /// The single statement of what each [`StateWhen`] means. Everything that
+    /// resolves a state layer against a unit goes through here — the container
+    /// its own layers, a `Text` or a `TextInput` the layers it declares — so no
+    /// two of them can come to disagree about the unit they share.
+    ///
+    /// Reading the answer is what subscribes the caller, which is why it is
+    /// asked only for a layer that declares something about the property being
+    /// resolved.
+    pub(crate) fn is_active(&self, when: &StateWhen) -> bool {
+        match when {
+            StateWhen::Hovered => self.is_hovered(),
+            StateWhen::Pressed => self.is_pressed(),
+            StateWhen::Focused => self.has_focus(),
+            StateWhen::When(condition) => condition.get(),
+        }
     }
 }

--- a/src/widgets/control.rs
+++ b/src/widgets/control.rs
@@ -33,7 +33,7 @@
 //! switch the row's highlight off while the pointer is plainly still on it.
 
 use crate::reactive::focus::focus_path;
-use crate::reactive::signal::RwSignal;
+use crate::reactive::signal::{OptionSignalExt, RwSignal, Signal};
 use crate::tree::WidgetId;
 
 use super::container::InteractionFlags;
@@ -47,11 +47,21 @@ use super::state_layer::StateWhen;
 pub struct Control {
     id: WidgetId,
     flags: RwSignal<InteractionFlags>,
+    /// Whether this unit takes input, with its ancestors already folded in —
+    /// see [`Container::enabled`](crate::widgets::Container::enabled).
+    ///
+    /// `None` where nothing at or above this unit was declared with one, which
+    /// is nearly every control there is and costs no signal at all.
+    enabled: Option<Signal<bool>>,
 }
 
 impl Control {
-    pub(crate) fn new(id: WidgetId, flags: RwSignal<InteractionFlags>) -> Self {
-        Self { id, flags }
+    pub(crate) fn new(
+        id: WidgetId,
+        flags: RwSignal<InteractionFlags>,
+        enabled: Option<Signal<bool>>,
+    ) -> Self {
+        Self { id, flags, enabled }
     }
 
     /// The container that declared the boundary.
@@ -60,13 +70,17 @@ impl Control {
     }
 
     /// Whether the pointer is inside the control.
+    ///
+    /// A disabled unit is never hovered and never pressed: it refuses the
+    /// pointer, so it is not under one. The declaration is read first, so a
+    /// control that is off does not subscribe to flags it would ignore.
     pub fn is_hovered(&self) -> bool {
-        self.flags.get().contains(InteractionFlags::HOVERED)
+        self.is_enabled() && self.flags.get().contains(InteractionFlags::HOVERED)
     }
 
     /// Whether the pointer is down on the control.
     pub fn is_pressed(&self) -> bool {
-        self.flags.get().contains(InteractionFlags::PRESSED)
+        self.is_enabled() && self.flags.get().contains(InteractionFlags::PRESSED)
     }
 
     /// Whether the keyboard focus is inside the control's subtree.
@@ -75,16 +89,38 @@ impl Control {
     /// question has to be answerable from a `create_derived` closure, which has
     /// no tree, and that is where a container resolves the text colour it
     /// publishes below it.
+    ///
+    /// Gated on the declaration, like hover and press: a disabled unit shows no
+    /// focus ring, which is what Qt, GTK and a `<fieldset disabled>` all show.
+    /// A field that must go on saying the keyboard is *its* is not disabled —
+    /// it is [read-only](crate::widgets::TextInput::readonly), which is a
+    /// different thing and keeps everything here.
     pub fn has_focus(&self) -> bool {
-        focus_path().contains(self.id)
+        self.is_enabled() && focus_path().contains(self.id)
+    }
+
+    /// Whether this unit, and every unit above it, takes input.
+    pub fn is_enabled(&self) -> bool {
+        self.enabled.get_or(true)
+    }
+
+    /// The complement, which is how a state layer reads it.
+    pub fn is_disabled(&self) -> bool {
+        !self.is_enabled()
+    }
+
+    /// The folded answer itself, so a nested unit can fold its own into it.
+    pub(crate) fn enabled_signal(&self) -> Option<Signal<bool>> {
+        self.enabled
     }
 
     /// Whether a state layer with this trigger applies right now.
     ///
     /// The single statement of what each [`StateWhen`] means. Everything that
     /// resolves a state layer against a unit goes through here — the container
-    /// its own layers, a `Text` or a `TextInput` the layers it declares — so no
-    /// two of them can come to disagree about the unit they share.
+    /// its own layers, a `Text` or a `TextInput` the layers it declares — so
+    /// "a disabled unit is never hovered" is written once rather than once per
+    /// widget that could disagree about it.
     ///
     /// Reading the answer is what subscribes the caller, which is why it is
     /// asked only for a layer that declares something about the property being
@@ -94,6 +130,7 @@ impl Control {
             StateWhen::Hovered => self.is_hovered(),
             StateWhen::Pressed => self.is_pressed(),
             StateWhen::Focused => self.has_focus(),
+            StateWhen::Disabled => self.is_disabled(),
             StateWhen::When(condition) => condition.get(),
         }
     }

--- a/src/widgets/state_layer.rs
+++ b/src/widgets/state_layer.rs
@@ -67,10 +67,15 @@ impl RippleConfig {
 /// When a state layer applies.
 ///
 /// The first three are noticed by the container itself — the pointer is inside
-/// it, the pointer is down on it, the focus is somewhere below it. The fourth
+/// it, the pointer is down on it, the focus is somewhere below it. The fifth
 /// is a condition the app already holds: "the last submit failed", "this row
 /// is selected". Nothing has to propagate for that one, so it needs no
 /// mechanism beyond reading the signal where the style is resolved.
+///
+/// [`Disabled`](Self::Disabled) is the one that propagates: it is declared
+/// with [`enabled`](crate::widgets::Container::enabled) on a container and
+/// answered by every widget below it, which is what a bare `When(busy)` cannot
+/// promise across two widgets in two files.
 #[derive(Clone, Copy)]
 pub enum StateWhen {
     /// The pointer is inside the container's shape.
@@ -79,6 +84,8 @@ pub enum StateWhen {
     Pressed,
     /// The container, or anything below it, holds the keyboard focus.
     Focused,
+    /// The control, or something above it, was declared not enabled.
+    Disabled,
     /// A condition the app owns.
     When(Signal<bool>),
 }
@@ -433,6 +440,20 @@ pub trait Stateful: Sized {
     /// the focus is in a *sibling*, and both belong to the same control.
     fn when_focused(mut self, f: impl FnOnce(Self::Style) -> Self::Style) -> Self {
         self.push_state_style(StateWhen::Focused, f(Self::Style::default()));
+        self
+    }
+
+    /// While the control refuses input.
+    ///
+    /// The look declared beside the behaviour:
+    /// [`enabled`](crate::widgets::Container::enabled) is what stops the
+    /// events, and this is what says so — so a greyed field and a dead one
+    /// cannot come apart, and `Disabled` means the same thing in every file.
+    ///
+    /// It reads the *effective* answer, ancestors folded in, so a label inside
+    /// a disabled form greys with the form without being told twice.
+    fn when_disabled(mut self, f: impl FnOnce(Self::Style) -> Self::Style) -> Self {
+        self.push_state_style(StateWhen::Disabled, f(Self::Style::default()));
         self
     }
 

--- a/src/widgets/text.rs
+++ b/src/widgets/text.rs
@@ -180,10 +180,11 @@ impl Text {
             // No control above: this text is its own unit. It can notice the
             // pointer over its own bounds, and it can hold the focus if
             // something gave it — but it cannot be pressed, because being
-            // pressed means being activated and it has nothing to activate.
+            // pressed means being activated and it has nothing to activate,
+            // and it cannot be disabled, because it takes no input to refuse.
             (StateWhen::Hovered, None) => self.own_hover.is_some_and(|h| h.get()),
             (StateWhen::Focused, None) => crate::reactive::focus::focus_path().contains(id),
-            (StateWhen::Pressed, None) => false,
+            (StateWhen::Pressed | StateWhen::Disabled, None) => false,
         }
     }
 

--- a/src/widgets/text.rs
+++ b/src/widgets/text.rs
@@ -174,9 +174,9 @@ impl Text {
     fn is_state_active(&self, id: WidgetId, control: Option<&Control>, when: &StateWhen) -> bool {
         match (when, control) {
             (StateWhen::When(condition), _) => condition.get(),
-            (StateWhen::Hovered, Some(control)) => control.is_hovered(),
-            (StateWhen::Pressed, Some(control)) => control.is_pressed(),
-            (StateWhen::Focused, Some(control)) => control.has_focus(),
+            // Inside a unit, every state is that unit's answer, whatever the
+            // state is — the whole point of `Control`.
+            (_, Some(control)) => control.is_active(when),
             // No control above: this text is its own unit. It can notice the
             // pointer over its own bounds, and it can hold the focus if
             // something gave it — but it cannot be pressed, because being

--- a/src/widgets/text_input.rs
+++ b/src/widgets/text_input.rs
@@ -364,9 +364,7 @@ impl TextInput {
     fn is_state_active(&self, id: WidgetId, control: Option<&Control>, when: &StateWhen) -> bool {
         match (when, control) {
             (StateWhen::When(condition), _) => condition.get(),
-            (StateWhen::Hovered, Some(control)) => control.is_hovered(),
-            (StateWhen::Pressed, Some(control)) => control.is_pressed(),
-            (StateWhen::Focused, Some(control)) => control.has_focus(),
+            (_, Some(control)) => control.is_active(when),
             // No control above: the field is its own unit. It already tracks
             // the pointer for its cursor, and it is the thing that holds the
             // focus, so both answers are its own.

--- a/src/widgets/text_input.rs
+++ b/src/widgets/text_input.rs
@@ -370,7 +370,8 @@ impl TextInput {
             // focus, so both answers are its own.
             (StateWhen::Hovered, None) => self.hover.get(),
             (StateWhen::Focused, None) => crate::reactive::focus::focus_path().contains(id),
-            (StateWhen::Pressed, None) => false,
+            // Nothing above it declared `enabled`, so nothing switched it off.
+            (StateWhen::Pressed | StateWhen::Disabled, None) => false,
         }
     }
 

--- a/src/widgets/text_input.rs
+++ b/src/widgets/text_input.rs
@@ -237,6 +237,11 @@ pub struct TextInput {
     mask_char: Option<Signal<char>>,
     cached_mask_char: char,
 
+    /// Whether the text refuses to change. Not the same as disabled: a
+    /// read-only field still takes the focus, still says so, and still lets a
+    /// selection be made and copied — it only refuses the edit.
+    readonly: Option<Signal<bool>>,
+
     /// Whether a caret is drawn at all. Off costs nothing: no caret, no blink,
     /// nothing to wake the loop for.
     caret: Option<Signal<bool>>,
@@ -316,6 +321,7 @@ impl TextInput {
             cached_password: false,
             mask_char: None,
             cached_mask_char: '•',
+            readonly: None,
             caret: None,
             cached_caret: true,
             widget_ref: None,
@@ -359,6 +365,20 @@ impl TextInput {
         style
     }
 
+    /// Give up the hover, and the cursor icon that goes with it.
+    ///
+    /// Two events mean the same thing — the pointer moved out of the bounds, or
+    /// it left the surface — and both used to spell the three lines out. The
+    /// guard lives here rather than at the call sites so that neither can
+    /// forget it: an unchanged pointer move must not cost a signal write.
+    fn release_pointer(&mut self) {
+        if self.is_hovered {
+            self.is_hovered = false;
+            self.hover.set(false);
+            set_cursor(CursorIcon::Default);
+        }
+    }
+
     /// Whether an override applies. Reading the answer subscribes the field to
     /// its control, so it is asked only for a state it declares.
     fn is_state_active(&self, id: WidgetId, control: Option<&Control>, when: &StateWhen) -> bool {
@@ -370,7 +390,8 @@ impl TextInput {
             // focus, so both answers are its own.
             (StateWhen::Hovered, None) => self.hover.get(),
             (StateWhen::Focused, None) => crate::reactive::focus::focus_path().contains(id),
-            // Nothing above it declared `enabled`, so nothing switched it off.
+            // Nothing above it declared `enabled`, so nothing switched it off —
+            // and being read-only is not being disabled.
             (StateWhen::Pressed | StateWhen::Disabled, None) => false,
         }
     }
@@ -388,6 +409,45 @@ impl TextInput {
     /// Set custom mask character for password mode (default: '•')
     pub fn mask_char<M>(mut self, c: impl IntoSignal<char, M>) -> Self {
         self.mask_char = Some(c.into_signal());
+        self
+    }
+
+    /// Refuse edits, and nothing else.
+    ///
+    /// For the field whose answer is already in flight: a lock screen that has
+    /// sent the password to PAM must stop taking the characters typed while it
+    /// waits, because they can never be sent and are thrown away when the
+    /// answer arrives.
+    ///
+    /// **It keeps the focus, and the ring that says so.** That is the whole
+    /// reason this is not
+    /// [`Container::enabled`](crate::widgets::Container::enabled): a disabled
+    /// thing is not available and gives the keyboard up, while a read-only one
+    /// is still where your typing is aimed — on a multi-monitor lock screen the
+    /// `when_focused` ring is the only thing naming the screen. Every toolkit
+    /// keeps these two apart for exactly this reason: `readonly` beside
+    /// `disabled` on the web, `setReadOnly` beside `setEnabled` in Qt,
+    /// `readOnly` beside `enabled` in Flutter.
+    ///
+    /// The caret is not part of it. A field that should stop blinking while it
+    /// waits says so with the property that owns that —
+    /// [`caret`](Self::caret) — driven by the same signal.
+    ///
+    /// ```
+    /// use guido::prelude::*;
+    ///
+    /// let value = create_signal(String::new());
+    /// let busy = create_signal(false);
+    /// let _ = text_input(value).readonly(busy).caret(move || !busy.get());
+    /// ```
+    ///
+    /// What it refuses is every *edit*: typing, backspace, delete, paste, cut
+    /// and undo. What it keeps is everything that only reads — the caret moves,
+    /// a selection can be made and copied, and `Enter` still reaches
+    /// [`on_submit`](Self::on_submit), which is Qt's line and the one a caller
+    /// can put its own guard behind.
+    pub fn readonly<M>(mut self, readonly: impl IntoSignal<bool, M>) -> Self {
+        self.readonly = Some(readonly.into_signal());
         self
     }
 
@@ -752,7 +812,23 @@ impl TextInput {
     }
 
     /// Insert text at cursor, replacing any selection
+    /// Whether the field is refusing edits right now.
+    ///
+    /// Asked by each of the four functions that write the text, rather than at
+    /// the entrance: a keystroke is not the only way in — a middle click pastes
+    /// the primary selection straight into `insert_text` — and a guard at one
+    /// entrance is a guard the next one does not have. Untracked for the same
+    /// reason the clipboard guards are: an event does not wait for a layout, so
+    /// a field told to freeze must be frozen for the very next key rather than
+    /// for the frame after the next pass.
+    fn refuses_edits(&self) -> bool {
+        self.readonly.as_ref().is_some_and(|r| r.get_untracked())
+    }
+
     fn insert_text(&mut self, text: &str, edit: Edit) {
+        if self.refuses_edits() {
+            return;
+        }
         // Save state before modification
         self.save_to_history(EditType::Insert, edit.at);
 
@@ -780,6 +856,9 @@ impl TextInput {
 
     /// Delete selected text or character before/after cursor
     fn delete(&mut self, forward: bool, edit: Edit) {
+        if self.refuses_edits() {
+            return;
+        }
         // Check if there's anything to delete
         let has_content_to_delete = if self.selection.has_selection() {
             true
@@ -999,6 +1078,9 @@ impl TextInput {
 
     /// Undo the last change
     fn undo(&mut self, edit: Edit) {
+        if self.refuses_edits() {
+            return;
+        }
         let current = self.current_history_entry();
         if let Some(previous) = self.history.undo(current) {
             self.cached_value = previous.text;
@@ -1016,6 +1098,9 @@ impl TextInput {
 
     /// Redo the last undone change
     fn redo(&mut self, edit: Edit) {
+        if self.refuses_edits() {
+            return;
+        }
         let current = self.current_history_entry();
         if let Some(next) = self.history.redo(current) {
             self.cached_value = next.text;
@@ -1043,6 +1128,14 @@ impl TextInput {
 
     /// Handle key down event
     fn handle_key(&mut self, key: &Key, ctrl: bool, shift: bool, edit: Edit) -> EventResponse {
+        // What the *answer* is for a key a read-only field will not use — the
+        // refusal itself is at the four writers, which is what makes it hold
+        // for the middle-click paste as well. `Ignored` rather than `Handled`,
+        // because a keystroke this field will not use is a keystroke somebody
+        // else may: Qt's read-only line edit ignores them for the same reason.
+        if mutates(key, ctrl) && self.refuses_edits() {
+            return EventResponse::Ignored;
+        }
         match key {
             Key::Backspace => {
                 self.delete(false, edit);
@@ -1132,6 +1225,20 @@ impl TextInput {
             }
             _ => EventResponse::Ignored,
         }
+    }
+}
+
+/// Whether this keystroke would change the text.
+///
+/// Only decides what a read-only field *answers* — the edit is already refused
+/// at the writers — so a key missing from this list is a key answered
+/// `Handled` that changes nothing, rather than a hole.
+fn mutates(key: &Key, ctrl: bool) -> bool {
+    match key {
+        Key::Backspace | Key::Delete => true,
+        Key::Char(c) if ctrl => matches!(c.to_ascii_lowercase(), 'x' | 'v' | 'z' | 'y'),
+        Key::Char(c) => !c.is_control(),
+        _ => false,
     }
 }
 
@@ -1382,10 +1489,8 @@ impl Widget for TextInput {
                     self.is_hovered = true;
                     self.hover.set(true);
                     set_cursor(CursorIcon::Text);
-                } else if !in_bounds && self.is_hovered {
-                    self.is_hovered = false;
-                    self.hover.set(false);
-                    set_cursor(CursorIcon::Default);
+                } else if !in_bounds {
+                    self.release_pointer();
                 }
 
                 if let Some(at) = at
@@ -1446,11 +1551,7 @@ impl Widget for TextInput {
                 self.is_dragging = false;
                 request_job(id, JobRequest::Paint);
             }
-            Event::MouseLeave if self.is_hovered => {
-                self.is_hovered = false;
-                self.hover.set(false);
-                set_cursor(CursorIcon::Default);
-            }
+            Event::MouseLeave => self.release_pointer(),
             _ => {}
         }
 

--- a/tests/signal_conversions.rs
+++ b/tests/signal_conversions.rs
@@ -120,6 +120,15 @@ fn the_values_that_became_signals_take_all_three_forms() {
         .mask_char(mask)
         .caret(wraps);
 
+    let live = create_signal(true);
+    let _ = container().enabled(false);
+    let _ = container().enabled(move || live.get());
+    let _ = container().enabled(live);
+
+    let _ = text_input(create_signal(String::new())).readonly(true);
+    let _ = text_input(create_signal(String::new())).readonly(move || !live.get());
+    let _ = text_input(create_signal(String::new())).readonly(live);
+
     let _ = container().layout(Flex::new(Axis::Horizontal));
     let _ = container().layout(Flex::new(move || axis.get()));
     let _ = container().layout(Flex::new(axis));

--- a/tests/text_input_editing.rs
+++ b/tests/text_input_editing.rs
@@ -26,6 +26,7 @@ use guido::reactive::clipboard::{
     clear_system_clipboard, clipboard_paste, primary_copy, take_clipboard_change,
 };
 use guido::reactive::focus::{clear_focus, focus_path, request_focus};
+use guido::renderer::{DrawCommand, RenderNode};
 use guido::tree::WidgetId;
 
 /// Narrow enough that a sentence does not fit, which is what the scrolling
@@ -188,6 +189,20 @@ impl Field {
     /// Where the caret is drawn, if it is showing.
     fn caret_x(&mut self) -> Option<f32> {
         self.caret().map(|c| c.x)
+    }
+
+    /// The colour the field's own glyphs were drawn in.
+    fn text_colour(&mut self) -> Option<Color> {
+        fn find(node: &RenderNode) -> Option<Color> {
+            for cmd in &node.commands {
+                if let DrawCommand::Text { color, .. } = &**cmd {
+                    return Some(*color);
+                }
+            }
+            node.children.iter().find_map(|child| find(child))
+        }
+        self.harness.lay_out(WIDTH, HEIGHT);
+        find(&self.harness.paint())
     }
 
     /// The caret's rectangle, if it is showing.
@@ -716,14 +731,41 @@ fn a_read_only_field_refuses_every_edit() {
             .child(text_input(value).readonly(readonly)),
     );
 
-    field.key(Key::Char('x'));
-    field.key(Key::Backspace);
-    field.key(Key::Delete);
-    field.ctrl('a');
-    field.ctrl('x');
-    field.ctrl('v');
-    field.ctrl('z');
-    field.ctrl('y');
+    // The response as well as the text. The refusal itself is at the writers,
+    // so the text would be right even if the keyboard gate were gone entirely —
+    // what says the gate is still there is the field declining the key, which
+    // is what lets somebody else have it.
+    for key in [Key::Char('x'), Key::Backspace, Key::Delete] {
+        assert_eq!(
+            field.key(key),
+            EventResponse::Ignored,
+            "a key it will not use is a key somebody else may"
+        );
+    }
+    for c in ['x', 'v', 'z', 'y'] {
+        assert_eq!(
+            field.press(
+                Key::Char(c),
+                Modifiers {
+                    ctrl: true,
+                    ..Default::default()
+                }
+            ),
+            EventResponse::Ignored,
+            "ctrl+{c} edits, so it is refused too"
+        );
+    }
+    // Ctrl+A only selects, so it is not refused.
+    assert_eq!(
+        field.press(
+            Key::Char('a'),
+            Modifiers {
+                ctrl: true,
+                ..Default::default()
+            }
+        ),
+        EventResponse::Handled
+    );
     assert_eq!(field.text(), "hi", "not one of those may change the text");
 
     readonly.set(false);
@@ -758,6 +800,39 @@ fn a_read_only_field_refuses_a_middle_click_paste() {
         field.text().contains("pasted"),
         "and the same click works when the field is not read-only: {}",
         field.text()
+    );
+}
+
+/// A field resolves its own state layers through its control, exactly as a
+/// `Text` beside it does — nothing declared one on a `TextInput` before, so the
+/// whole of `is_state_active` could be replaced by a constant unnoticed.
+#[test]
+fn a_field_styles_itself_from_its_control() {
+    const CALM: Color = Color::rgb(0.5, 0.5, 0.5);
+    const LIT: Color = Color::rgb(1.0, 1.0, 1.0);
+
+    let value = create_signal("hi".to_owned());
+    let enabled = create_signal(true);
+    let mut field = Field::wrapped(
+        value,
+        container()
+            .width(WIDTH)
+            .height(HEIGHT)
+            .enabled(enabled)
+            .child(text_input(value).color(CALM).when_focused(|s| s.color(LIT))),
+    );
+
+    assert_eq!(
+        field.text_colour(),
+        Some(LIT),
+        "the field holds the focus, so its focused layer applies"
+    );
+
+    enabled.set(false);
+    assert_eq!(
+        field.text_colour(),
+        Some(CALM),
+        "a disabled unit is not where the keyboard is aimed, so the layer lifts"
     );
 }
 

--- a/tests/text_input_editing.rs
+++ b/tests/text_input_editing.rs
@@ -22,8 +22,11 @@ use std::time::{Duration, Instant};
 
 use common::Harness;
 use guido::prelude::*;
-use guido::reactive::clipboard::{clear_system_clipboard, clipboard_paste, take_clipboard_change};
-use guido::reactive::focus::{clear_focus, request_focus};
+use guido::reactive::clipboard::{
+    clear_system_clipboard, clipboard_paste, primary_copy, take_clipboard_change,
+};
+use guido::reactive::focus::{clear_focus, focus_path, request_focus};
+use guido::tree::WidgetId;
 
 /// Narrow enough that a sentence does not fit, which is what the scrolling
 /// tests below need and what the rest are indifferent to.
@@ -76,7 +79,27 @@ impl Field {
         Self::around(value, text_input(value))
     }
 
-    fn around(value: RwSignal<String>, input: TextInput) -> Self {
+    /// A focused field wrapped in whatever the test wants to say about it — a
+    /// container declaring the whole subtree disabled, mostly. The *field*
+    /// holds the focus, not the wrapper, which is what the tests below turn on.
+    fn wrapped(value: RwSignal<String>, root: impl Widget + 'static) -> Self {
+        let field = Self::around(value, root);
+        request_focus(&field.harness.tree, field.input());
+        field
+    }
+
+    /// The field itself: the last child of the wrapper, or the root when
+    /// nothing wraps it.
+    fn input(&self) -> WidgetId {
+        self.harness
+            .tree
+            .get_children(self.harness.root)
+            .last()
+            .copied()
+            .unwrap_or(self.harness.root)
+    }
+
+    fn around(value: RwSignal<String>, input: impl Widget + 'static) -> Self {
         // The focus and the selection a previous field in this thread published
         // would otherwise answer for this one.
         clear_focus();
@@ -132,6 +155,13 @@ impl Field {
         );
     }
 
+    /// A middle press at a point, which is the primary-selection paste.
+    fn middle_click(&mut self, x: f32, y: f32) {
+        self.now += Duration::from_millis(1);
+        self.harness
+            .send_at(Event::mouse_down(x, y, MouseButton::Middle), self.now);
+    }
+
     fn type_text(&mut self, text: &str) {
         for c in text.chars() {
             self.key(Key::Char(c));
@@ -155,6 +185,12 @@ impl Field {
     }
 
     /// Where the caret is drawn, if it is showing.
+    /// Where the caret is drawn, if it is showing.
+    fn caret_x(&mut self) -> Option<f32> {
+        self.caret().map(|c| c.x)
+    }
+
+    /// The caret's rectangle, if it is showing.
     fn caret(&mut self) -> Option<Rect> {
         let painted = self.harness.painted_rects();
         assert!(
@@ -601,4 +637,198 @@ fn the_view_comes_back_to_the_start_when_the_cursor_does() {
         0.0,
         "a cursor at the start of the text belongs at the start of the field",
     );
+}
+
+// ---------------------------------------------------------------------------
+// A field that has been told to stop
+// ---------------------------------------------------------------------------
+
+/// The other half of the subtree gate: keys take the same dispatch path as the
+/// pointer, so a container that refuses one refuses the other.
+#[test]
+fn a_field_below_a_disabled_container_does_not_hear_the_keyboard() {
+    let value = create_signal("hi".to_owned());
+    let mut field = Field::wrapped(
+        value,
+        container()
+            .width(WIDTH)
+            .height(HEIGHT)
+            .enabled(false)
+            .child(text_input(value)),
+    );
+
+    let response = field.key(Key::Char('x'));
+
+    assert_eq!(response, EventResponse::Ignored);
+    assert_eq!(
+        field.text(),
+        "hi",
+        "a field under a disabled container took a keystroke"
+    );
+}
+
+/// A disabled subtree shows no focus ring — the same answer Qt, GTK and a
+/// `<fieldset disabled>` give, and the reason `readonly` exists beside it.
+///
+/// The focus itself is not asserted here: what a caller can see is what its
+/// control answers, and a disabled unit answers no.
+#[test]
+fn a_disabled_container_stops_claiming_the_focus_below_it() {
+    let value = create_signal(String::new());
+    let enabled = create_signal(true);
+    let field = Field::wrapped(
+        value,
+        container()
+            .width(WIDTH)
+            .height(HEIGHT)
+            .enabled(enabled)
+            .child(text_input(value)),
+    );
+    let control = field
+        .harness
+        .tree
+        .nearest_control(field.input())
+        .expect("declaring `enabled` makes a container an interaction unit");
+
+    assert!(control.has_focus(), "the field below it holds the keyboard");
+    enabled.set(false);
+    assert!(
+        !control.has_focus(),
+        "a disabled unit is not where the keyboard is aimed"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Read-only: refusing the edit, and nothing else
+// ---------------------------------------------------------------------------
+
+/// #211: a lock screen that has sent the password to PAM must stop taking the
+/// characters typed while it waits, because they can never be sent.
+#[test]
+fn a_read_only_field_refuses_every_edit() {
+    let value = create_signal("hi".to_owned());
+    let readonly = create_signal(true);
+    let mut field = Field::wrapped(
+        value,
+        container()
+            .width(WIDTH)
+            .height(HEIGHT)
+            .child(text_input(value).readonly(readonly)),
+    );
+
+    field.key(Key::Char('x'));
+    field.key(Key::Backspace);
+    field.key(Key::Delete);
+    field.ctrl('a');
+    field.ctrl('x');
+    field.ctrl('v');
+    field.ctrl('z');
+    field.ctrl('y');
+    assert_eq!(field.text(), "hi", "not one of those may change the text");
+
+    readonly.set(false);
+    field.key(Key::End);
+    field.key(Key::Char('x'));
+    assert_eq!(field.text(), "hix", "and it takes them again when it may");
+}
+
+/// A keystroke is not the only way into the text. A middle click pastes the
+/// primary selection straight into `insert_text`, so a guard that sat at
+/// `handle_key` would have let it through — on a lock screen, into the password
+/// PAM is already answering.
+#[test]
+fn a_read_only_field_refuses_a_middle_click_paste() {
+    let value = create_signal("hi".to_owned());
+    let readonly = create_signal(true);
+    let mut field = Field::wrapped(
+        value,
+        container()
+            .width(WIDTH)
+            .height(HEIGHT)
+            .child(text_input(value).readonly(readonly)),
+    );
+    primary_copy("pasted");
+
+    field.middle_click(4.0, 5.0);
+    assert_eq!(field.text(), "hi", "the primary selection got in");
+
+    readonly.set(false);
+    field.middle_click(4.0, 5.0);
+    assert!(
+        field.text().contains("pasted"),
+        "and the same click works when the field is not read-only: {}",
+        field.text()
+    );
+}
+
+/// `Enter` is deliberately not an edit, and this is the half that carries
+/// allock: `readonly` is set from inside the submit path, so a field that
+/// swallowed its own `Enter` would go permanently unsubmittable.
+#[test]
+fn a_read_only_field_still_submits() {
+    let value = create_signal("hi".to_owned());
+    let submits = Rc::new(RefCell::new(Vec::new()));
+    let sink = submits.clone();
+    let mut field = Field::wrapped(
+        value,
+        container().width(WIDTH).height(HEIGHT).child(
+            text_input(value)
+                .readonly(true)
+                .on_submit(move |text| sink.borrow_mut().push(text.to_owned())),
+        ),
+    );
+
+    assert_eq!(field.key(Key::Enter), EventResponse::Handled);
+    assert_eq!(submits.borrow().as_slice(), ["hi"]);
+}
+
+/// The whole reason this is not `enabled`. A field that has stopped taking
+/// edits is still the one the keyboard is aimed at, and on a multi-monitor
+/// lock screen the `when_focused` ring is the only thing naming the screen.
+#[test]
+fn a_read_only_field_keeps_the_focus_and_the_ring() {
+    let value = create_signal("hi".to_owned());
+    let readonly = create_signal(false);
+    let field = Field::wrapped(
+        value,
+        container()
+            .width(WIDTH)
+            .height(HEIGHT)
+            .control()
+            .child(text_input(value).readonly(readonly)),
+    );
+    let control = field.harness.tree.nearest_control(field.input()).unwrap();
+    let before = focus_path();
+    assert!(before.contains(field.input()));
+    assert!(control.has_focus());
+
+    readonly.set(true);
+
+    assert_eq!(before, focus_path(), "the focus path is untouched");
+    assert!(
+        control.has_focus(),
+        "read-only is not disabled: the ring stays"
+    );
+}
+
+/// It refuses the edit and nothing else, which is Qt's line: the caret still
+/// moves, so a caller can still see and copy what is there.
+#[test]
+fn a_read_only_field_still_moves_its_caret() {
+    let value = create_signal(SENTENCE.to_owned());
+    let mut field = Field::wrapped(
+        value,
+        container()
+            .width(WIDTH)
+            .height(HEIGHT)
+            .child(text_input(value).readonly(true)),
+    );
+
+    assert_eq!(field.key(Key::End), EventResponse::Handled);
+    assert_ne!(
+        field.caret_x(),
+        Some(0.0),
+        "End moved the caret off the start"
+    );
+    assert_eq!(field.key(Key::Home), EventResponse::Handled);
 }


### PR DESCRIPTION
## What changed

A subtree can be declared not to take input — `Container::enabled(signal)` — and
it propagates: a descendant declaring `enabled(true)` inside one declaring
`enabled(false)` is disabled. `StateWhen::Disabled` and `Stateful::when_disabled`
style it, so the look is declared beside the behaviour rather than threaded into
every handler by hand. Separately, `TextInput::readonly(signal)` refuses every
edit while keeping the focus.

**This deviates from the shape #242 agreed, deliberately.** #242 specified one
hybrid concept: `enabled` refuses input but *keeps* the keyboard focus, and
`TextInput::enabled` as the same setter with a smaller scope. The first review
found that promise was already false — `dispatch_events` (`src/lib.rs:643`)
releases the focus on any `MouseDown` the root does not return `Handled` for, so
a press on a disabled panel dropped the very ring the feature existed to keep. I
reproduced it through `Headless`: enabled, a press on a focus box's padding keeps
the focus; disabled, the same press drops it.

Researching that turned up the real problem, which #242's prior art had missed by
looking at the wrong axis. It weighed `disabled` against `inert` — one control
versus a subtree — and never against `readonly`, which is where the focus
question actually lives. Every toolkit splits these two, and splits them
*because* of the focus difference: `readonly`/`disabled` on the web,
`setReadOnly`/`setEnabled` in Qt, `readOnly`/`enabled` in Flutter,
`editable`/`sensitive` in GTK. Guido's hybrid would have been the only one of its
kind, and the requirement that produced it — allock's field must stop taking keys
while keeping the ring that names the monitor — is a description of `readonly`,
not of `disabled`.

So the shape agreed in this session, and what is here:

- `Container::enabled` is the propagating disable, and gives up the keyboard as
  well as the pointer: a disabled unit resolves no `when_hovered`, no
  `when_pressed` and no `when_focused`. That is Qt, GTK, SwiftUI and
  `<fieldset disabled>`, and it makes the press question moot — there is no ring
  left to protect.
- `TextInput::enabled` became `TextInput::readonly`, which is what closes #211.

`#242` still describes the old shape; it is superseded by this, not contradicted.

**Scroll**, which #242 left to the implementation: a disabled subtree does not
scroll. It follows from where the gate sits rather than from a separate decision,
and `a_disabled_scroller_does_not_scroll` says so.

Closes #242. Closes #211.

## What proves it

Every acceptance bullet in #242 has a test that fails without the change.

In `src/widgets/container/characterization.rs`:
`a_click_does_not_reach_a_handler_below_a_disabled_container`,
`a_descendant_declaring_itself_enabled_stays_disabled`,
`re_enabling_lets_the_next_click_through_and_costs_no_layout`,
`a_container_disabled_while_hovered_is_no_longer_hovered`,
`a_text_below_a_disabled_container_styles_itself_from_it`,
`a_disabled_scroller_does_not_scroll`.

In `tests/text_input_editing.rs`:
`a_field_below_a_disabled_container_does_not_hear_the_keyboard`,
`a_disabled_container_stops_claiming_the_focus_below_it`,
`a_read_only_field_refuses_every_edit`,
`a_read_only_field_refuses_a_middle_click_paste`,
`a_read_only_field_keeps_the_focus_and_the_ring`,
`a_read_only_field_still_moves_its_caret`,
`a_read_only_field_still_submits`.

Plus the `compile_fail` doctest that `when_hovered(|s| s.enabled(false))` does
not compile, the three spellings in `tests/signal_conversions.rs`, and
`mdbook test` over the new chapter.

No golden or snapshot moved, and none should have: nothing in the renderer,
geometry or `src/platform/` changed. The style resolution is watched at the
render-tree level by `a_text_below_a_disabled_container_styles_itself_from_it`,
which reads a painted colour.

## What the review found

The `reviewer` subagent ran twice, because the design changed between them.

**First pass: one blocking finding** — the focus promise above. It is what sent
this back to the maintainer and produced the readonly split. Also raised, and
acted on: `TextInput`'s own state arm had no test (it no longer exists — the arm
collapsed into the generic one when `enabled` left the widget).

**Second pass, over the reworked change: one blocking finding.** A middle click
pastes the primary selection straight into `insert_text`, bypassing the guard
that sat at `handle_key` — on a lock screen, into the password PAM is answering.
Fixed by moving the refusal to the four functions that write the text, so a
future fifth entrance is covered by construction;
`a_read_only_field_refuses_a_middle_click_paste` fails without it. Its two
"worth answering" findings are both acted on: `Enter`, `Ctrl+X` and `Ctrl+Y` are
now exercised (`a_read_only_field_still_submits` and the extended refusal test).

Its remaining notes: `tests/signal_conversions.rs` carries the spellings for both
setters in commit 4 rather than in the commits that introduced them, so neither
of those two is revertible entirely on its own. The spellings are present and
pass, which is what that rule is for.

Before either review, `/simplify` applied four passes. The one that mattered
structurally: `Control::is_active` is now the single statement of what each
`StateWhen` means, where the container, `Text` and `TextInput` each spelled it
out separately before — that is commit 1, and it stands on its own.

## What was checked by hand

Nothing on a compositor. `examples/disabled_form.rs` exists and builds — it puts
a disabled panel and a read-only field side by side, which is the only way the
difference is obvious — but I did not run it, so the claims in its header are
asserted by the tests above rather than by my having looked at a surface. Worth a
minute on niri before merge.

One thing was checked below the harness rather than by eye: the focus behaviour
that sent this back was reproduced through `guido::testing::Headless`, driving
the real loop and `dispatch_events`, because `Harness::send` calls
`widget.event` directly and cannot see the dispatcher's rule. That probe was
thrown away once the design changed and the behaviour it measured no longer
exists.

## Left undone

**A descendant of a newly-disabled subtree is never told the pointer left.**
`pointer_left` runs on the gating container only, and the gate returns before the
children are asked — so a `TextInput` that was hovered keeps its I-beam over a
field that takes nothing. `visible(false)` strands identically today, which is
why this is not filed against this branch: it belongs to the shared early-out,
and a fix there wants an acceptance criterion covering both. Named here so the
next reader of that gate does not re-find it.

**#330** — a signal created during `register_children` is filed under the surface
rather than the widget, so a keyed list whose rows declare `enabled` beneath a
control that also does leaks one slot per row. Found at the definition,
documented there, and filed rather than left in this body. Closing it means
running registration under the widget's own owner, which is a cross-cutting
change and the maintainer's call.

**A disabled field keeps blinking its caret**, since it keeps the focus it holds
in guido's internal sense even though no ring resolves. `.caret(move || !busy.get())`
expresses it, which is why the caret was deliberately left out of `readonly`
rather than bundled into it. No issue: nobody is worse off who cannot say so in
one setter.

https://claude.ai/code/session_016cdRGJettCQPPACDkS1CtM
