### PR TITLE
A widget's reactive work belongs to the widget, not to the surface it is on

### DIFF
--- a/docs/REACTIVE.md
+++ b/docs/REACTIVE.md
@@ -598,6 +598,21 @@ fn create_child(id: u64) -> impl Widget {
 container().children(keyed(move || items.get(), |id| *id, create_child))
 ```
 
+**The scope is not only the builder closure.** A widget goes on creating
+reactive resources after its factory has returned — `register_children` folds a
+subtree's `enabled` into one signal, and `layout` builds a scroller's track and
+handle, each with a signal per declared property. `OwnedWidget` re-enters its
+own scope for both, so those die with the row exactly as the signal in the
+example above does. Before that they were filed under the surface and outlived the widget by
+the whole life of the application: a churning list leaked one signal per row for
+`enabled`, and ten for a row that scrolled.
+
+What that scope does **not** cover is `event` or `reconcile_children`. Those
+run a closure you wrote — a handler, an `items_fn` — and a signal made there may
+be handed to something that outlives the row on purpose. Disposing it with the
+row would turn every later read into a panic, so it is left alone, and there is
+a test that says so rather than a comment promising it.
+
 ### Disposing Owner Scopes: `dispose_owner`
 
 `guido::reactive::dispose_owner(id)` disposes an owner created with

--- a/src/reactive/mod.rs
+++ b/src/reactive/mod.rs
@@ -49,7 +49,7 @@ pub use memo::{Memo, create_memo};
 // with_owner and OwnerId are internal and automatically used by the
 // dynamic children system; the public dispose_owner is deferred (safe to
 // call from anywhere), the synchronous engine stays crate-internal.
-pub(crate) use owner::{OwnerId, create_root_owner, dispose_owner_now, with_owner};
+pub(crate) use owner::{OwnerId, create_root_owner, dispose_owner_now, under_owner, with_owner};
 pub use owner::{dispose_owner, on_cleanup};
 pub use trigger::{Trigger, create_trigger};
 

--- a/src/reactive/owner.rs
+++ b/src/reactive/owner.rs
@@ -195,13 +195,31 @@ pub(crate) fn reset_owners() {
 /// With no `App` — unit tests — there is no root, and the current scope is used
 /// as before.
 pub(crate) fn with_root_owner<T>(f: impl FnOnce() -> T) -> T {
-    let Some(root) = ROOT_OWNER.with(|root| root.get()) else {
-        return f();
-    };
-    let previous = CURRENT_OWNER.with(|current| current.replace(Some(root)));
-    let value = f();
-    CURRENT_OWNER.with(|current| current.replace(previous));
-    value
+    match ROOT_OWNER.with(|root| root.get()) {
+        Some(root) => under_owner(root, f),
+        None => f(),
+    }
+}
+
+/// Run `f` with `owner_id` as the current owner, whatever it was before.
+///
+/// The one place `CURRENT_OWNER` is swapped: [`with_owner`] allocates a scope
+/// and hands it here, [`with_root_owner`] names the root, and a widget names its
+/// own. Restoring on unwind is why they all go through it — a leaked scope
+/// silently re-parents every reactive resource created afterwards, and the copy
+/// that forgot the guard is the one that would have done it.
+///
+/// It does not *make* a scope. [`with_owner`] is the one that does, and picking
+/// the wrong one compiles: this one files resources under an owner somebody else
+/// disposes, that one under a fresh scope nothing does.
+pub(crate) fn under_owner<T>(owner_id: OwnerId, f: impl FnOnce() -> T) -> T {
+    let previous = CURRENT_OWNER.with(|current| current.replace(Some(owner_id)));
+    let _guard = crate::reactive::guard::defer(move || {
+        CURRENT_OWNER.with(|current| {
+            *current.borrow_mut() = previous;
+        });
+    });
+    f()
 }
 
 /// Execute a closure within a new owner scope.
@@ -234,26 +252,7 @@ pub fn with_owner<T>(f: impl FnOnce() -> T) -> (T, OwnerId) {
         id
     });
 
-    // Set as current owner
-    let prev_owner = CURRENT_OWNER.with(|current| {
-        let prev = *current.borrow();
-        *current.borrow_mut() = Some(owner_id);
-        prev
-    });
-
-    // Restore on unwind too: a leaked owner scope would silently re-parent
-    // every reactive resource created afterwards.
-    let guard = crate::reactive::guard::defer(move || {
-        CURRENT_OWNER.with(|current| {
-            *current.borrow_mut() = prev_owner;
-        });
-    });
-
-    // Execute the closure
-    let result = f();
-    drop(guard);
-
-    (result, owner_id)
+    (under_owner(owner_id, f), owner_id)
 }
 
 /// Get the current owner ID, if any.
@@ -452,6 +451,50 @@ pub(crate) fn flush_pending_disposals() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The guard is the whole of `under_owner`, and until this test the suite
+    /// said nothing about it: the restore could be moved out of `defer` and
+    /// onto the line after `f()` with every test still green.
+    ///
+    /// It matters because the corruption is silent and permanent. The one
+    /// caller of `with_root_owner` (`global.rs`) runs application code inside
+    /// it; if that panics and the owner is not put back, `CURRENT_OWNER` stays
+    /// pinned at the root, and every `with_owner` after it captures root as its
+    /// `previous` and restores *that*. Nothing ever notices.
+    ///
+    /// Both spellings are checked, because they are one function now.
+    #[test]
+    fn an_unwinding_closure_puts_the_previous_owner_back() {
+        let hushed = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+
+        let outer = create_root_owner();
+        assert_eq!(current_owner(), Some(outer));
+
+        let panicked = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            with_owner(|| panic!("a builder that gave up"));
+        }));
+        assert!(panicked.is_err());
+        assert_eq!(
+            current_owner(),
+            Some(outer),
+            "a new scope that unwound left itself current"
+        );
+
+        let panicked = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            with_root_owner(|| panic!("a global initialiser that gave up"))
+        }));
+        assert!(panicked.is_err());
+        assert_eq!(
+            current_owner(),
+            Some(outer),
+            "the root stayed current after an unwind, and would have swallowed \
+             every scope opened afterwards"
+        );
+
+        std::panic::set_hook(hushed);
+        reset_owners();
+    }
 
     #[test]
     fn test_with_owner_basic() {

--- a/src/widgets/children.rs
+++ b/src/widgets/children.rs
@@ -3,7 +3,7 @@ use std::rc::Rc;
 
 use crate::jobs::{JobRequest, request_job};
 use crate::layout::{Constraints, Size};
-use crate::reactive::{OwnerId, dispose_owner_now};
+use crate::reactive::{OwnerId, dispose_owner_now, under_owner};
 use crate::renderer::PaintContext;
 use crate::tree::{Tree, WidgetId};
 
@@ -441,7 +441,7 @@ enum OwnerHandle {
     Exclusive(OwnerId),
     /// The owner scope is shared by several widgets (one closure run built
     /// them all); it is disposed when the last of them drops.
-    Shared { _guard: SharedOwner },
+    Shared(SharedOwner),
 }
 
 /// Reference-counted owner scope: disposes the owner when the last clone
@@ -449,7 +449,7 @@ enum OwnerHandle {
 /// row inside one scope.
 #[derive(Clone)]
 pub struct SharedOwner {
-    _guard: Rc<OwnerGuard>,
+    guard: Rc<OwnerGuard>,
 }
 
 struct OwnerGuard(OwnerId);
@@ -463,7 +463,7 @@ impl Drop for OwnerGuard {
 impl SharedOwner {
     pub fn new(owner_id: OwnerId) -> Self {
         Self {
-            _guard: Rc::new(OwnerGuard(owner_id)),
+            guard: Rc::new(OwnerGuard(owner_id)),
         }
     }
 }
@@ -481,7 +481,18 @@ impl OwnedWidget {
     pub fn new_shared(inner: Box<dyn Widget>, shared: SharedOwner) -> Self {
         Self {
             inner,
-            owner: OwnerHandle::Shared { _guard: shared },
+            owner: OwnerHandle::Shared(shared),
+        }
+    }
+}
+
+impl OwnerHandle {
+    /// The scope this widget's reactive resources belong to, however it holds
+    /// it — one widget to a scope, or one scope shared by a closure's whole run.
+    fn id(&self) -> OwnerId {
+        match self {
+            OwnerHandle::Exclusive(id) => *id,
+            OwnerHandle::Shared(shared) => shared.guard.0,
         }
     }
 }
@@ -504,12 +515,41 @@ impl Widget for OwnedWidget {
         self.inner.reconcile_children(tree, id)
     }
 
+    /// Registration is reactive work, so it happens under this widget's own
+    /// scope rather than under whatever scope the frame is in.
+    ///
+    /// This and [`layout`](Self::layout) are the two that re-enter it, and the
+    /// line is drawn there because they are the two the frame runs as
+    /// *machinery*: nothing a caller wrote decides what they build.
+    ///
+    /// `event` and `reconcile_children` run a caller's own closure — a handler,
+    /// an `items_fn` — and a signal made there may be handed somewhere that
+    /// outlives the row on purpose. Disposing it would turn a later read into a
+    /// panic, so those two are left alone, and a test says so rather than a
+    /// comment promising it. That nothing in the library allocates there either
+    /// is true today and is the weaker half of the reason: it would stop being
+    /// true without anything failing, which is why it is not the argument.
+    ///
+    /// The factory ran inside `with_owner`; this runs afterwards, and anything
+    /// it creates — `Container::fold_enabled`'s derived — would otherwise be
+    /// filed under the surface and outlive the widget by the whole life of the
+    /// application.
+    ///
+    /// Descendants come along: a plain `Container` inside this one is
+    /// registered from within this call, so it is inside the scope too.
     fn register_children(&mut self, tree: &mut Tree, id: WidgetId) {
-        self.inner.register_children(tree, id)
+        under_owner(self.owner.id(), || self.inner.register_children(tree, id))
     }
 
+    /// Laying out builds things too, so it is inside the scope for the same
+    /// reason registration is.
+    ///
+    /// A scroller assembles its scrollbar's track and handle the first time it
+    /// lays out — two containers, and every declared property on them is a
+    /// signal. That is ten per row against `fold_enabled`'s one, and it needs
+    /// nothing of the caller but `.scroll(..)`.
     fn layout(&mut self, tree: &mut Tree, id: WidgetId, constraints: Constraints) -> Size {
-        self.inner.layout(tree, id, constraints)
+        under_owner(self.owner.id(), || self.inner.layout(tree, id, constraints))
     }
 
     fn paint(&self, tree: &Tree, id: WidgetId, ctx: &mut PaintContext) {
@@ -518,5 +558,279 @@ impl Widget for OwnedWidget {
 
     fn event(&mut self, tree: &mut Tree, id: WidgetId, event: &Event) -> EventResponse {
         self.inner.event(tree, id, event)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::RefCell;
+
+    use super::*;
+    use crate::jobs::pump_and_layout;
+    use crate::reactive::storage::live_signal_count;
+    use crate::reactive::{RwSignal, create_signal};
+    use crate::widgets::{AnyWidget, Scroll, container, keyed};
+
+    /// A registered root, and the two phases that make a keyed list actually
+    /// replace its rows: the queued jobs, then a layout.
+    ///
+    /// Without the jobs the reconciler never runs — the widget ids come back
+    /// identical and a leak test reads a meaningless zero. The generation
+    /// counter moving on the reused ids is what says a round happened.
+    struct Rows {
+        tree: Tree,
+        root: WidgetId,
+    }
+
+    impl Rows {
+        fn new(widget: impl Widget + 'static) -> Self {
+            let mut tree = Tree::new();
+            let root = tree.register(Box::new(widget));
+            tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
+            // The first frame builds the rows. Without it the baseline below
+            // is taken before any exist, and every round after it looks like
+            // growth.
+            let mut rows = Self { tree, root };
+            rows.frame();
+            rows
+        }
+
+        /// A press and release at a point, in the surface's coordinates.
+        fn click(&mut self, x: f32, y: f32) {
+            let root = self.root;
+            crate::reactive::diagnostics::snapshot_zone(|| {
+                for event in [
+                    Event::mouse_down(x, y, crate::widgets::widget::MouseButton::Left),
+                    Event::mouse_up(x, y, crate::widgets::widget::MouseButton::Left),
+                ] {
+                    self.tree
+                        .with_widget_mut(root, |w, id, t| w.event(t, id, &event));
+                }
+            });
+        }
+
+        fn frame(&mut self) {
+            pump_and_layout(
+                &mut self.tree,
+                self.root,
+                Constraints::new(0.0, 0.0, 200.0, 200.0),
+            );
+        }
+    }
+
+    /// Replace every key, so each round builds a full set of rows and discards
+    /// the set before it. The assertion is here so that every caller has it.
+    fn churn(rows: &mut Rows, keys: RwSignal<Vec<u32>>, round: u32) {
+        let before = rows.tree.get_children(rows.root).to_vec();
+        keys.set((0..ROWS).map(|i| round * 100 + i).collect());
+        rows.frame();
+        assert_ne!(
+            before,
+            rows.tree.get_children(rows.root).to_vec(),
+            "round {round} replaced no rows, so nothing after it measures anything"
+        );
+    }
+
+    /// How wide `churn` makes a list, whatever it started at.
+    const ROWS: u32 = 4;
+
+    /// A row's reactive resources die with the row — including the ones built
+    /// while it was being *registered*, not only the ones its factory built.
+    ///
+    /// `Container::fold_enabled` is the only thing in the widget layer that
+    /// creates a signal during `register_children`, and it does so exactly when
+    /// a row declares `enabled` inside a control that declares it too. Until
+    /// this was fixed the derived it built was filed under the *surface*, and a
+    /// list that churned leaked one signal per row for the surface's lifetime —
+    /// measured at +41 over forty rows built and discarded.
+    ///
+    /// The baseline is taken after a round rather than before, because the
+    /// dynamic-children machinery allocates one signal on its first reconcile
+    /// and never again: counting from zero would fold that one-off into the
+    /// number and make the test assert a constant instead of a slope.
+    #[test]
+    fn a_signal_built_while_a_row_registers_dies_with_the_row() {
+        let keys = create_signal(vec![0u32, 1, 2, 3]);
+        let outer = create_signal(true);
+        let mut rows = Rows::new(
+            container()
+                .width(200.0)
+                .height(200.0)
+                .enabled(outer)
+                .children(keyed(
+                    move || keys.get(),
+                    |k| *k,
+                    move |_| {
+                        let own = create_signal(true);
+                        container().width(50.0).height(10.0).enabled(own).into_any()
+                    },
+                )),
+        );
+
+        churn(&mut rows, keys, 1);
+        let settled = live_signal_count();
+
+        for round in 2..=10u32 {
+            churn(&mut rows, keys, round);
+        }
+
+        assert_eq!(
+            live_signal_count(),
+            settled,
+            "thirty-six rows built and discarded left signals behind"
+        );
+    }
+
+    /// `event` is outside the scope on purpose, and this is what says so.
+    ///
+    /// A handler runs at a caller's intent, not as machinery, and an
+    /// application may create a signal there and hand it somewhere that
+    /// outlives the row — a selection the list reports upwards, say. Wrapping
+    /// `event` would dispose it and turn every later read into a panic. So the
+    /// exclusion is a promise to the caller, and a promise nothing tested is
+    /// one the next person to widen this would break without hearing anything.
+    #[test]
+    fn a_signal_a_handler_creates_outlives_the_row_that_created_it() {
+        let keys = create_signal(vec![0u32, 1, 2, 3]);
+        let escaped: Rc<RefCell<Option<RwSignal<u32>>>> = Rc::new(RefCell::new(None));
+        let sink = escaped.clone();
+        let mut rows = Rows::new(container().width(200.0).height(200.0).children(keyed(
+            move || keys.get(),
+            |k| *k,
+            move |k| {
+                let sink = sink.clone();
+                container()
+                    .width(50.0)
+                    .height(10.0)
+                    .on_click(move || *sink.borrow_mut() = Some(create_signal(k)))
+                    .into_any()
+            },
+        )));
+
+        // Click the first row, so its handler builds a signal and hands it out.
+        rows.click(0.0, 0.0);
+        let handed_out = escaped.borrow().expect("the handler ran");
+        assert_eq!(handed_out.get_untracked(), 0);
+
+        // Now churn that row away entirely.
+        for round in 1..=3u32 {
+            churn(&mut rows, keys, round);
+        }
+
+        assert_eq!(
+            handed_out.get_untracked(),
+            0,
+            "the row's disposal took a signal its handler had given away"
+        );
+    }
+
+    /// The control, and it is what makes the test above mean anything: a row
+    /// that declares nothing for `fold_enabled` to fold allocates no signal at
+    /// registration, so it churned cleanly even before the fix. If this ever
+    /// fails, the one above is measuring the machinery rather than the defect.
+    #[test]
+    fn a_row_that_builds_nothing_at_registration_was_never_the_problem() {
+        let keys = create_signal(vec![0u32, 1, 2, 3]);
+        let mut rows = Rows::new(container().width(200.0).height(200.0).children(keyed(
+            move || keys.get(),
+            |k| *k,
+            move |_| -> AnyWidget { container().width(50.0).height(10.0).into_any() },
+        )));
+
+        churn(&mut rows, keys, 1);
+        let settled = live_signal_count();
+        for round in 2..=10u32 {
+            churn(&mut rows, keys, round);
+        }
+        assert_eq!(live_signal_count(), settled);
+    }
+
+    /// The scope a row re-enters is its own, so a list *inside* a row is inside
+    /// it too — and the rows that list builds get their owners parented there
+    /// rather than at the surface.
+    ///
+    /// Three levels of `enabled` nested in each other, which is three derived
+    /// signals per leaf and the shape that leaked hardest: +108 over nine
+    /// rounds before the fix, against +36 for the flat list above.
+    #[test]
+    fn a_list_inside_a_row_is_inside_the_row_s_scope() {
+        let outer_keys = create_signal(vec![0u32, 1, 2, 3]);
+        let enabled = create_signal(true);
+        let mut rows = Rows::new(
+            container()
+                .width(200.0)
+                .height(200.0)
+                .enabled(enabled)
+                .children(keyed(
+                    move || outer_keys.get(),
+                    |k| *k,
+                    move |k| {
+                        let inner_keys = create_signal(vec![k * 10, k * 10 + 1]);
+                        let own = create_signal(true);
+                        container()
+                            .width(100.0)
+                            .height(50.0)
+                            .enabled(own)
+                            .children(keyed(
+                                move || inner_keys.get(),
+                                |x| *x,
+                                move |_| {
+                                    let deep = create_signal(true);
+                                    container().width(10.0).height(5.0).enabled(deep).into_any()
+                                },
+                            ))
+                            .into_any()
+                    },
+                )),
+        );
+        churn(&mut rows, outer_keys, 1);
+        let settled = live_signal_count();
+        for round in 2..=10u32 {
+            churn(&mut rows, outer_keys, round);
+        }
+        assert_eq!(
+            live_signal_count(),
+            settled,
+            "a nested list left its rows' signals behind"
+        );
+    }
+
+    /// A row that scrolls builds its scrollbar during *layout*, not during
+    /// registration — and every declared property on the track and the handle
+    /// is a signal.
+    ///
+    /// This is the same defect an octave lower: ten signals per row against
+    /// `fold_enabled`'s one, measured at +360 over thirty-six rows, and it asks
+    /// nothing of the caller but `.scroll(..)`. A fix that covered only
+    /// registration would have left it exactly as it was.
+    #[test]
+    fn a_scrollbar_built_while_a_row_lays_out_dies_with_the_row() {
+        let keys = create_signal(vec![0u32, 1, 2, 3]);
+        let mut rows = Rows::new(container().width(200.0).height(200.0).children(keyed(
+            move || keys.get(),
+            |k| *k,
+            move |_| {
+                container()
+                    .width(50.0)
+                    .height(20.0)
+                    .scroll(Scroll::vertical())
+                    .children(
+                        (0..8)
+                            .map(|_| container().width(50.0).height(20.0).into_any())
+                            .collect::<Vec<_>>(),
+                    )
+                    .into_any()
+            },
+        )));
+        churn(&mut rows, keys, 1);
+        let settled = live_signal_count();
+        for round in 2..=10u32 {
+            churn(&mut rows, keys, round);
+        }
+        assert_eq!(
+            live_signal_count(),
+            settled,
+            "a scroller left its scrollbar's signals behind"
+        );
     }
 }

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -1144,12 +1144,12 @@ impl Container {
     /// which is nearly all of them, and nesting is the only case that allocates
     /// at all — one declaration inside another's reach.
     ///
-    /// That one signal belongs to the surface rather than to this widget:
-    /// `register_signal` files under `current_owner`, and registration does not
-    /// run inside the owner a dynamic row was built in. So a keyed list whose
-    /// rows declare `enabled` beneath a control that also does leaks a slot per
-    /// row created, for the surface's lifetime. Closing it means running
-    /// registration under the widget's own owner, which is #330.
+    /// That one signal belongs to this widget, and dies with it:
+    /// `OwnedWidget` re-enters its own scope for `register_children`, so a
+    /// keyed list whose rows declare `enabled` beneath a control that also does
+    /// no longer leaves a slot per row behind. It did until #330 — the leak was
+    /// found here, because this was the only thing in the widget layer creating
+    /// a signal during registration.
     fn fold_enabled(&mut self, tree: &Tree, id: WidgetId) {
         let Some(ix) = self.interaction.as_deref_mut() else {
             return;


### PR DESCRIPTION
## What changed

A widget's reactive resources now belong to the widget, not to the surface it
happens to be on.

`with_owner` wraps the *factory*, so everything a row's builder creates dies with
the row. What runs afterwards did not: `register_children` and `layout` are
called by the frame, and `register_signal` files under whatever scope the frame
is in. A signal built there outlived the widget that caused it by the whole life
of the application. `OwnedWidget` now re-enters its own scope for both.

**The scope grew past what #330 asked for, deliberately.** The issue names
registration, where `Container::fold_enabled` folds a subtree's `enabled` into
one derived signal — one slot per row. Looking for siblings turned up a second,
larger one on the `layout` path: a scroller assembles its scrollbar's track and
handle the first time it lays out, and every declared property on those two
containers is a signal. That is **ten slots per row**, and it asks nothing of the
caller but `.scroll(..)`. Measured over thirty-six rows built and discarded:

| shape | leaked |
| --- | --- |
| rows declaring `enabled` under a control that also does | +36 |
| the same, nested one list deeper | +108 |
| rows that `.scroll(..)` | **+360** |
| rows declaring neither (the control) | 0 |

Same defect, same site, same one-line fix, and each half carries its own failing
test — so it belongs under this pull request's title rather than in a follow-up.

**Where the line is drawn, and why.** `register_children` and `layout` re-enter
the scope because they are what the frame runs as *machinery* — nothing a caller
wrote decides what they build. `event` and `reconcile_children` run a closure the
caller wrote, and a signal made there may be handed somewhere that outlives the
row on purpose; disposing it would turn a later read into a panic. That is a
promise to the caller, so it has a test rather than a comment.

Commit 1 is a refactor the fix needed: `with_owner`, `with_root_owner` and the
new `under_owner` were three implementations of one mechanism, and they had
drifted — `with_root_owner` restored the current owner *after* `f()` rather than
through a `defer` guard, so an unwinding closure left it pinned. Its only caller
runs application code. That is now one function, and the guard has a test.

Closes #330.

## What proves it

Five tests in a new `mod tests` in `src/widgets/children.rs`, plus one in
`src/reactive/owner.rs`. Reverting the two `under_owner` calls:

- `a_signal_built_while_a_row_registers_dies_with_the_row` — 71 vs 35
- `a_list_inside_a_row_is_inside_the_row_s_scope` — 203 vs 95
- `a_scrollbar_built_while_a_row_lays_out_dies_with_the_row` — 553 vs 193

Each half is independently needed: with only `register_children` wrapped the
scrollbar test still fails, and with only `layout` wrapped the other two do.

`a_row_that_builds_nothing_at_registration_was_never_the_problem` is the control
— green before and after — and it is what says the numbers above are the defect
rather than the machinery.

`a_signal_a_handler_creates_outlives_the_row_that_created_it` pins the *exclusion*:
wrapping `event` makes it fail with the disposed-signal panic its doc predicts.

`an_unwinding_closure_puts_the_previous_owner_back` holds commit 1's claim.
Moving the restore out of `defer` kills it; before it existed, that mutation
passed the whole suite.

Two things the tests had to get right, both learned the hard way and written
down where they are: the baseline is taken after the first churn round, because
the dynamic-children machinery allocates one signal on its first reconcile and
never again — counting from zero folds that one-off in and asserts a constant
instead of a slope. And `churn` asserts the rows were actually replaced, because
without the job pump the reconciler never runs, the widget ids come back
identical and the test reads a meaningless zero. My first attempt at measuring
this did exactly that and reported no leak.

No golden or snapshot moved, and none should have: nothing in the renderer,
geometry or `src/platform/` changed.

## What the review found

The `reviewer` subagent ran once, over the commits, before this existed.

**One blocking finding, fixed:** commit 1's subject is a claim about unwind
safety, and nothing watched it — the reviewer deleted the `defer` guard and all
674 lib tests passed. `an_unwinding_closure_puts_the_previous_owner_back` now
covers both spellings, and I confirmed it dies under that same mutation.

Both "worth answering" findings acted on. The doc comment on `fold_enabled` that
described the leak as live and named #330 as open is now true instead — it is the
line this change falsified, so it is this change's. And commit 1 no longer
carries the `pub(crate) use` for a symbol whose only user arrives in commit 2:
each of the three commits is now clippy-clean standing alone, which I checked by
walking them.

Its fourth finding is why the `event`/`reconcile_children` argument reads as it
does. It pointed out that "nothing in the library allocates there" is the weaker
half of the reason and expires silently, and that `reconcile_children` had been
excluded with no argument at all. Both are now stated the other way round: the
reason is that those phases run the caller's own closure, and the fact about
today's library is named as the weaker half rather than the case.

Its notes — a duplicated doc block on `churn`, a false comment on `ROWS`, a
stray blank line — are fixed. `/simplify` ran before any of it, and is where the
consolidation in commit 1, the reuse of `jobs::pump_and_layout` and the
`_guard` rename came from.

## What was checked by hand

Nothing on a compositor, and nothing needed one: the change is above the
platform layer and every claim in it is a number a test reads back. The
measurements in the table were taken by running the tests against a reverted
fix, not estimated.

## Left undone

**Nothing that earns an issue.** The `event` and `reconcile_children` exclusion
is a decision rather than a residue, and it is now pinned by a test; if it should
be revisited it is a change to what a caller is allowed to do, which is the
maintainer's to open rather than mine to leave lying about.

`paint` and `advance_animations` are outside the scope too and are not
tested either way. Nothing in the library allocates there, I could not construct
a leak, and inventing a test for a thing I could not make fail would be the kind
of issue AGENTS.md says not to write.

https://claude.ai/code/session_016cdRGJettCQPPACDkS1CtM
