### PR TITLE
A value nothing can compute is read as if it had not been declared

### DIFF
--- a/src/animation/animatable.rs
+++ b/src/animation/animatable.rs
@@ -54,7 +54,7 @@ pub trait Animatable: Copy + PartialEq + Send + Sync + 'static {
 
     /// The value as the vector of numbers the animation interpolates.
     ///
-    /// Only `carry_velocity` reads this, and only as a direction: a spring's
+    /// `carry_velocity` and the finiteness check read this, and only as a direction: a spring's
     /// momentum is a vector in this space, and what a new segment inherits is
     /// the part of it pointing along itself. The channels may be in different
     /// units — `Corners` carries four radii in pixels beside a unitless

--- a/src/finite.rs
+++ b/src/finite.rs
@@ -128,6 +128,9 @@ impl AllFinite for crate::pivot::Pivot {
             V::Percent(p) | V::Px(p) => p.is_finite(),
             _ => true,
         };
+        // Both arms, and both are watched: the enumeration test puts the bad
+        // number in the horizontal anchor and the hit-testing one puts it in
+        // the vertical, so neither can be deleted unnoticed.
         horizontal && vertical
     }
 }

--- a/src/finite.rs
+++ b/src/finite.rs
@@ -1,0 +1,133 @@
+//! Whether a declared value is a number arithmetic can carry on with.
+//!
+//! A property is a closure the application wrote, and a division by a measured
+//! zero is all it takes to produce a NaN. Once one is in it stays: `lerp` from
+//! a NaN start is NaN at every `t`, so a later and perfectly finite target
+//! animates from nothing to nothing for the life of the process — and
+//! `animate_to`'s `new_target == self.target` early-out never fires, because
+//! NaN is equal to nothing including itself, so the surface asks for another
+//! frame at the compositor's rate for ever.
+//!
+//! The answer is CSS's: a value that is not a number is coerced *where it is
+//! resolved*, once, so no consumer downstream ever has to know it happened. The
+//! alternative — a guard at each consumer — is what was tried before, and each
+//! guard changed what the next one saw.
+//!
+//! This lives apart from [`Animatable`](crate::animation::Animatable) on
+//! purpose. "Can this be interpolated" and "is this a number" are different
+//! questions, and hanging the second on the first put the door out of reach of
+//! every declared value that is not animatable — a [`Length`], a [`Pivot`], a
+//! gradient — which is most of the ways a bad number gets in.
+//!
+//! [`Length`]: crate::layout::Length
+//! [`Pivot`]: crate::pivot::Pivot
+
+use crate::reactive::Signal;
+
+/// A value that can say whether every number inside it is finite.
+///
+/// Implemented for every type a property can be declared with. The name is
+/// `all_finite` rather than `is_finite` because `f32` already has an inherent
+/// method by that name: a trait method taking `&self` matches a `&f32` receiver
+/// *exactly* while the inherent one needs a deref, so `c.is_finite()` inside a
+/// blanket body resolves to the trait and calls itself until the stack ends.
+pub(crate) trait AllFinite {
+    /// Whether this value is one arithmetic can carry on with.
+    fn all_finite(&self) -> bool;
+}
+
+impl AllFinite for f32 {
+    fn all_finite(&self) -> bool {
+        f32::is_finite(*self)
+    }
+}
+
+/// Reading a declared property, with a value nothing can compute treated as no
+/// declaration at all.
+pub(crate) trait FiniteOr<T> {
+    /// The value, or `default` where it is not finite.
+    ///
+    /// `property` is only for the diagnostic, and is the name a caller would
+    /// recognise — the setter they wrote, not the accessor that resolves it.
+    fn get_finite_or(&self, default: T, id: crate::tree::WidgetId, property: &'static str) -> T;
+
+    /// The same, for the paths that read a snapshot rather than subscribing —
+    /// the reach calculation, which runs beside a paint that is reading the
+    /// same signal and has already reported it.
+    fn get_finite_or_untracked(&self, default: T) -> T;
+}
+
+impl<T: AllFinite + Clone + 'static> FiniteOr<T> for Option<Signal<T>> {
+    fn get_finite_or(&self, default: T, id: crate::tree::WidgetId, property: &'static str) -> T {
+        let value = crate::reactive::OptionSignalExt::get_or(self, default.clone());
+        if value.all_finite() {
+            value
+        } else {
+            crate::reactive::diagnostics::non_finite_value(id, property);
+            default
+        }
+    }
+
+    fn get_finite_or_untracked(&self, default: T) -> T {
+        let value = crate::reactive::OptionSignalExt::get_or_untracked(self, default.clone());
+        if value.all_finite() { value } else { default }
+    }
+}
+
+/// Every type a `Container` property is declared with, answered from the
+/// numbers it is made of.
+///
+/// The animatable ones already have to say which numbers those are in order to
+/// be interpolated at all, so they answer from
+/// [`channels`](crate::animation::Animatable::channels) and cannot go stale
+/// when a field is added — the last attempt at this wrote the check out per
+/// type, covered three of seven, and nobody noticed the other four.
+macro_rules! finite_by_channels {
+    ($($t:ty),* $(,)?) => {
+        $(impl AllFinite for $t {
+            fn all_finite(&self) -> bool {
+                crate::animation::Animatable::channels(self)
+                    .iter()
+                    .copied()
+                    .all(f32::is_finite)
+            }
+        })*
+    };
+}
+
+finite_by_channels!(
+    crate::widgets::Color,
+    crate::renderer::Shadow,
+    crate::widgets::Padding,
+    crate::widgets::Corners,
+    crate::transform::Translate,
+    crate::transform::Scale,
+);
+
+impl AllFinite for crate::layout::Length {
+    /// Four optional numbers and a flag. An absent one cannot be bad, and
+    /// `fill` is not a number at all.
+    fn all_finite(&self) -> bool {
+        [self.min, self.max, self.exact, self.fraction]
+            .into_iter()
+            .flatten()
+            .all(f32::is_finite)
+    }
+}
+
+impl AllFinite for crate::pivot::Pivot {
+    /// An anchor is only a number when it is a `Percent` or a `Px`; the named
+    /// ones are constants and cannot be anything else.
+    fn all_finite(&self) -> bool {
+        use crate::pivot::{HorizontalAnchor as H, VerticalAnchor as V};
+        let horizontal = match self.horizontal {
+            H::Percent(p) | H::Px(p) => p.is_finite(),
+            _ => true,
+        };
+        let vertical = match self.vertical {
+            V::Percent(p) | V::Px(p) => p.is_finite(),
+            _ => true,
+        };
+        horizontal && vertical
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod backdrop;
 mod blur;
 pub mod compositor;
 mod deferred;
+pub(crate) mod finite;
 pub mod image_metadata;
 mod ingress;
 mod jobs;

--- a/src/reactive/diagnostics.rs
+++ b/src/reactive/diagnostics.rs
@@ -57,6 +57,24 @@ pub(crate) fn check_reactive_scope() {
     imp::check();
 }
 
+/// Report that a declared value was not a number arithmetic can carry on with,
+/// and was read as if it had not been declared.
+///
+/// Once per call site — which names the property, because each is resolved by
+/// its own accessor — rather than once per process, so a rotation and a
+/// background that both go bad both say so. A property that silently stops
+/// following its signal is the hardest failure in this library to find by
+/// looking, and it is silent by construction: the picture is *correct*, it is
+/// just not the picture the signal asked for.
+///
+/// Debug builds only, which is where Flutter puts the same assertion.
+pub(crate) fn non_finite_value(id: crate::tree::WidgetId, property: &'static str) {
+    #[cfg(debug_assertions)]
+    imp::non_finite(id, property);
+    #[cfg(not(debug_assertions))]
+    let _ = (id, property);
+}
+
 #[cfg(debug_assertions)]
 mod imp {
     use std::cell::{Cell, RefCell};
@@ -118,8 +136,33 @@ mod imp {
         }
     }
 
+    thread_local! {
+        /// Its own set, so this warning's rate limit is not spent by the one
+        /// above it — the last attempt at this shared one process-wide limit
+        /// with every other caller and went quiet for the wrong reasons.
+        ///
+        /// Keyed on the widget and the property rather than the call site,
+        /// which is what makes the message's own words true: it names a widget,
+        /// so a second widget with the same bad property has to be able to say
+        /// so too.
+        static NON_FINITE: RefCell<FxHashSet<(crate::tree::WidgetId, &'static str)>> =
+            RefCell::new(FxHashSet::default());
+    }
+
+    pub(super) fn non_finite(id: crate::tree::WidgetId, property: &'static str) {
+        if !NON_FINITE.with(|r| r.borrow_mut().insert((id, property))) {
+            return;
+        }
+        report(format!(
+            "widget {id:?}: `{property}` resolved to a value that is not a \
+             finite number, so it was read as if it had not been declared. A \
+             division by a measured zero is the usual cause. (debug builds only)"
+        ));
+    }
+
     /// Forget every reported call site (used by `reset_reactive`).
     pub(crate) fn reset() {
+        NON_FINITE.with(|r| r.borrow_mut().clear());
         REPORTED.with(|r| r.borrow_mut().clear());
         DEPTH.with(|d| d.set(0));
         REPORTS.with(|c| c.set(0));

--- a/src/reactive/diagnostics.rs
+++ b/src/reactive/diagnostics.rs
@@ -91,9 +91,7 @@ mod imp {
             return;
         }
 
-        REPORTS.with(|c| c.set(c.get() + 1));
-
-        let message = format!(
+        report(format!(
             "{}:{}:{}: signal read with no reactive scope — this value is a \
              snapshot and will not update. Pass a closure instead (e.g. \
              `move || …` rather than the value it computes), or use \
@@ -102,11 +100,17 @@ mod imp {
             loc.file(),
             loc.line(),
             loc.column(),
-        );
-        // The audience for this warning is whoever just wrote their first
-        // guido app, who quite likely has no logger installed yet — with the
-        // log crate uninitialised `max_level` is Off and a `warn!` would go
-        // nowhere, so say it on stderr instead.
+        ));
+    }
+
+    /// Say it once, wherever it can be heard.
+    ///
+    /// The audience for these is whoever just wrote their first guido app, who
+    /// quite likely has no logger installed yet — with the log crate
+    /// uninitialised `max_level` is Off and a `warn!` would go nowhere, so say
+    /// it on stderr instead. Shared, so a second diagnostic cannot forget it.
+    fn report(message: String) {
+        REPORTS.with(|c| c.set(c.get() + 1));
         if log::max_level() == log::LevelFilter::Off {
             eprintln!("guido: {message}");
         } else {

--- a/src/widgets/container/anim_bridge.rs
+++ b/src/widgets/container/anim_bridge.rs
@@ -144,7 +144,7 @@ impl Container {
             with_signal_tracking(id, JobType::Animation, || {
                 // Read for the subscription even where the value is unused.
                 if pd_init {
-                    let _ = self.padding.get_or(Padding::default());
+                    let _ = self.effective_padding_target(id);
                 }
                 if bw_init {
                     let _ = self.effective_border_width_target(id);
@@ -199,7 +199,7 @@ impl Container {
             if let Some(a) = &anims.padding {
                 drift |= moved(
                     a.is_initial(),
-                    *a.target() == self.padding.get_or(Padding::default()),
+                    *a.target() == self.effective_padding_target(id),
                 );
                 drift |= a.wants_play();
             }

--- a/src/widgets/container/box_model.rs
+++ b/src/widgets/container/box_model.rs
@@ -27,6 +27,7 @@
 //! [`resolve_size`]: Container::resolve_size
 
 use super::*;
+use crate::finite::FiniteOr;
 use crate::layout::Axis;
 
 /// The container's own size declarations, resolved for one layout pass.
@@ -91,9 +92,9 @@ impl Container {
         let (padding, mut width, mut height, overflow) =
             with_signal_tracking(id, JobType::Layout, || {
                 (
-                    self.animated_padding(),
-                    self.width.as_ref().map(|w| w.get()).unwrap_or_default(),
-                    self.height.as_ref().map(|h| h.get()).unwrap_or_default(),
+                    self.animated_padding(id),
+                    self.width.get_finite_or(Length::default(), id, "width"),
+                    self.height.get_finite_or(Length::default(), id, "height"),
                     self.overflow.get_or(Overflow::Visible),
                 )
             });

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -4423,6 +4423,9 @@ fn a_property_follows_its_signal_again_once_the_signal_recovers() {
 /// Hit testing is where it lands: `untransform_point` composes the transform
 /// about the pivot, and a NaN origin makes every `contains` answer no, so a
 /// container stops taking the clicks that are plainly inside it.
+///
+/// The bad number is the *vertical* anchor here and the horizontal one in the
+/// enumeration above, so neither arm of the answer can be deleted unnoticed.
 #[test]
 fn a_pivot_that_is_not_a_number_does_not_swallow_a_click() {
     let clicks = std::rc::Rc::new(std::cell::Cell::new(0));
@@ -4430,7 +4433,7 @@ fn a_pivot_that_is_not_a_number_does_not_swallow_a_click() {
     let mut h = H::new(
         box_of(50.0, 50.0)
             .rotate(45.0)
-            .pivot(move || Pivot::percent(f32::NAN, 50.0))
+            .pivot(move || Pivot::percent(50.0, f32::NAN))
             .on_click(move || counter.set(counter.get() + 1)),
     );
     h.fit(200.0, 200.0);
@@ -4497,7 +4500,10 @@ fn every_declared_property_is_resolved_to_a_finite_value() {
             .rotate(nan)
             .scale(nan)
             .translate((nan, nan))
-            .pivot(Pivot::percent(nan, nan))
+            // Horizontal only: with both anchors bad, either arm of the
+            // answer still detects it and neither can be deleted noticeably.
+            // The hit-testing test takes the vertical for the same reason.
+            .pivot(Pivot::percent(nan, 50.0))
             .background(Color::rgba(nan, 0.0, 0.0, 1.0))
             .shadow(Shadow::new((nan, nan), nan, nan, Color::BLACK))
     };

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -4303,3 +4303,277 @@ fn a_disabled_scroller_does_not_scroll() {
         "the same scroller, enabled, takes the wheel"
     );
 }
+
+// ---------------------------------------------------------------------------
+// A signal that stops being a number
+// ---------------------------------------------------------------------------
+
+/// The one that costs a battery. `animate_to`'s early-out is
+/// `new_target == self.target`, and NaN is equal to nothing including itself,
+/// so every pass reads a new target, begins a segment and asks for another
+/// Animation job. The surface never goes idle again.
+#[test]
+fn a_value_that_is_not_a_number_lets_the_surface_go_idle() {
+    let angle = create_signal(0.0f32);
+    let mut h = H::new(box_of(50.0, 50.0).rotate(angle.transition(200.0)));
+    h.fit(200.0, 200.0);
+    h.paint();
+
+    angle.set(f32::NAN);
+    let t0 = std::time::Instant::now();
+    // Well past any transition this could have started.
+    for step in 0..6 {
+        frame_at(
+            &mut h,
+            t0 + std::time::Duration::from_millis(step * 200),
+            200.0,
+            200.0,
+        );
+    }
+
+    assert!(
+        !pump(&mut h),
+        "the surface is still animating towards a value that will never arrive"
+    );
+}
+
+/// What a coerced value leaves behind: the property reads as if it had not
+/// been declared, which for every transform component is identity.
+///
+/// Not NaN, and not "somewhere" — a defined value, which is the whole of the
+/// CSS rule this follows: a bad number is replaced once, where it is resolved,
+/// so nothing downstream ever has to know it happened.
+#[test]
+fn a_value_that_is_not_a_number_reads_as_if_it_were_not_declared() {
+    let angle = create_signal(45.0f32);
+    let mut h = H::new(box_of(50.0, 50.0).rotate(angle));
+    h.fit(200.0, 200.0);
+    assert!(
+        !h.paint().local_transform.is_identity(),
+        "the control turns before the bad number arrives"
+    );
+
+    angle.set(f32::NAN);
+    assert!(
+        h.paint().local_transform.is_identity(),
+        "a rotation nobody can compute is a rotation nobody asked for"
+    );
+}
+
+/// Worse than wrong for one frame: NaN is stored as the segment's start, and
+/// `lerp(NaN, target, t)` is NaN at every `t`, so a later and perfectly finite
+/// target animates from NaN to NaN for the life of the process.
+///
+/// Coercing where the value is resolved is what stops that reaching the
+/// animation at all. Asserted against a control that was never given a bad
+/// number, so the claim is "these two agree" rather than a restatement of which
+/// way round the matrix stores a sine.
+#[test]
+fn a_property_follows_its_signal_again_once_the_signal_recovers() {
+    let poisoned = create_signal(0.0f32);
+    let clean = create_signal(0.0f32);
+    let mut h = H::new(
+        container()
+            .layout(Flex::row())
+            .child(box_of(50.0, 50.0).rotate(poisoned.transition(200.0)))
+            .child(box_of(50.0, 50.0).rotate(clean.transition(200.0))),
+    );
+    h.fit(400.0, 200.0);
+    h.paint();
+
+    let t0 = std::time::Instant::now();
+    poisoned.set(f32::NAN);
+    // Two frames, so a bad number would be not merely the target but through
+    // `lerp` into `current` — which `begin_segment` then keeps as the start of
+    // every segment after it.
+    frame_at(&mut h, t0, 400.0, 200.0);
+    frame_at(
+        &mut h,
+        t0 + std::time::Duration::from_millis(50),
+        400.0,
+        200.0,
+    );
+
+    // Both are now asked for the same quarter turn, and given the same time.
+    poisoned.set(90.0);
+    clean.set(90.0);
+    for step in 1..=4 {
+        frame_at(
+            &mut h,
+            t0 + std::time::Duration::from_millis(step * 100),
+            400.0,
+            200.0,
+        );
+    }
+
+    // The rotation only: the two sit at different x in the row, and where a box
+    // was laid out is not what this is about.
+    let painted = h.paint();
+    let turn = |t: Transform| [t.a(), t.b(), t.c(), t.d()];
+    assert_eq!(
+        turn(painted.children[0].local_transform),
+        turn(painted.children[1].local_transform),
+        "a property given one bad number never followed its signal again"
+    );
+}
+
+/// `Pivot` is the fourth transform component, and it does not go through a
+/// state layer — so the door the other three pass is not on its way.
+///
+/// Hit testing is where it lands: `untransform_point` composes the transform
+/// about the pivot, and a NaN origin makes every `contains` answer no, so a
+/// container stops taking the clicks that are plainly inside it.
+#[test]
+fn a_pivot_that_is_not_a_number_does_not_swallow_a_click() {
+    let clicks = std::rc::Rc::new(std::cell::Cell::new(0));
+    let counter = clicks.clone();
+    let mut h = H::new(
+        box_of(50.0, 50.0)
+            .rotate(45.0)
+            .pivot(move || Pivot::percent(f32::NAN, 50.0))
+            .on_click(move || counter.set(counter.get() + 1)),
+    );
+    h.fit(200.0, 200.0);
+
+    for event in click_at(25.0, 25.0) {
+        h.send(event);
+    }
+    assert_eq!(
+        clicks.get(),
+        1,
+        "a pivot nobody can compute stopped the container being clicked"
+    );
+}
+
+/// The third of the three things the fix owes: it says so, and says so once.
+///
+/// A property that quietly stops following its signal is the hardest failure in
+/// this library to find by looking — the picture is *correct*, it is just not
+/// the one that was asked for — so the silence is the defect, not a detail of
+/// it. Once per property rather than once per frame, because paint reads this
+/// again every time it runs.
+#[cfg(debug_assertions)]
+#[test]
+fn a_value_that_is_not_a_number_is_reported_once() {
+    use crate::reactive::diagnostics::report_count;
+
+    let angle = create_signal(f32::NAN);
+    let mut h = H::new(box_of(50.0, 50.0).rotate(angle));
+    h.fit(200.0, 200.0);
+
+    let before = report_count();
+    for _ in 0..5 {
+        h.paint();
+    }
+    let reports = report_count() - before;
+    assert_eq!(reports, 1, "five paints, and it should have said so once");
+}
+
+/// Every declared property goes through the door, not the six somebody
+/// remembered.
+///
+/// The design rests on one claim — that a bad number is coerced *where it is
+/// resolved*, so no consumer downstream has to know — and a door with holes in
+/// it is not that claim, it is six special cases. The first draft of this fix
+/// converted six accessors and left `shadow`, `padding`, `width`, `height` and
+/// the three untracked transform reads behind.
+///
+/// So this asks each resolver directly rather than looking for a symptom
+/// further down. A symptom test passes for the wrong reason all the time —
+/// the first version of this one did, because a NaN width is clamped into a
+/// finite size by the layout below it, and a NaN shadow never reaches a drawn
+/// rect. What the door promises is about the value it hands out, so that is
+/// what is asserted.
+#[test]
+fn every_declared_property_is_resolved_to_a_finite_value() {
+    let nan = f32::NAN;
+    let declared = || {
+        box_of(50.0, 50.0)
+            .width(nan)
+            .height(nan)
+            .padding(nan)
+            .corners(nan)
+            .border(nan, Color::rgba(nan, 0.0, 0.0, 1.0))
+            .rotate(nan)
+            .scale(nan)
+            .translate((nan, nan))
+            .pivot(Pivot::percent(nan, nan))
+            .background(Color::rgba(nan, 0.0, 0.0, 1.0))
+            .shadow(Shadow::new((nan, nan), nan, nan, Color::BLACK))
+    };
+
+    // One copy in a tree, so the accessors have a laid-out widget to answer
+    // for, and one in hand to ask — they take the id rather than reading it
+    // off themselves, and nothing here declares a state layer.
+    let mut h = H::new(declared());
+    h.fit(200.0, 200.0);
+    let id = h.root;
+    let c = declared();
+
+    let finite = |name: &str, channels: Vec<f32>| {
+        assert!(
+            channels.iter().all(|c| c.is_finite()),
+            "{name} resolved to a value that is not finite: {channels:?}"
+        );
+    };
+
+    {
+        finite(
+            "background",
+            c.effective_background_target(id).channels().to_vec(),
+        );
+        finite(
+            "border_color",
+            c.effective_border_color_target(id).channels().to_vec(),
+        );
+        finite("border_width", vec![c.effective_border_width_target(id)]);
+        finite(
+            "corners",
+            c.effective_corners_target(id).channels().to_vec(),
+        );
+        finite("shadow", c.effective_shadow_target(id).channels().to_vec());
+        finite(
+            "padding",
+            c.effective_padding_target(id).channels().to_vec(),
+        );
+        finite(
+            "translate",
+            c.effective_translate_target(id).channels().to_vec(),
+        );
+        finite("rotate", vec![c.effective_rotate_target(id)]);
+        finite("scale", c.effective_scale_target(id).channels().to_vec());
+        let pivot = c.resolved_pivot(id);
+        let (px, py) = pivot.resolve(Rect::new(0.0, 0.0, 50.0, 50.0));
+        finite("pivot", vec![px, py]);
+        let lengths = c.read_box_lengths(id, Constraints::new(0.0, 0.0, 200.0, 200.0));
+        finite("padding (laid out)", lengths.padding.channels().to_vec());
+        let numbers = |l: crate::layout::Length| {
+            [l.min, l.max, l.exact, l.fraction]
+                .into_iter()
+                .flatten()
+                .collect::<Vec<f32>>()
+        };
+        finite("width", numbers(lengths.width));
+        finite("height", numbers(lengths.height));
+        // Shadow has two resolvers, and the first draft of this fix converted
+        // one: with the extent left raw, a container with a bad shadow and a
+        // transform reported a damage rect that did not cover where it drew.
+        finite("shadow extent", vec![c.max_shadow_extent(id)]);
+    }
+
+    // And a state layer's override is passed over the same way, so the base
+    // shows through rather than the layer's bad number replacing it.
+    let hovered = container()
+        .width(50.0)
+        .height(50.0)
+        .background(Color::RED)
+        .when_hovered(|s| s.background(Color::rgba(nan, 0.0, 0.0, 1.0)));
+    let mut h = H::new(hovered);
+    h.fit(200.0, 200.0);
+    set_hover(&mut h, true);
+    assert_eq!(
+        rects(&h.paint()).first().map(|(_, c)| *c),
+        Some(Color::RED),
+        "a hover layer nobody can compute replaced the background anyway"
+    );
+}

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -1261,7 +1261,7 @@ impl Widget for Container {
                 scale_target,
             ) = crate::reactive::diagnostics::snapshot_zone(|| {
                 (
-                    self.padding.get_or(Padding::default()),
+                    self.effective_padding_target(id),
                     self.effective_border_width_target(id),
                     self.effective_background_target(id),
                     self.effective_corners_target(id),
@@ -1572,7 +1572,7 @@ impl Widget for Container {
         // Kept as well as published, because paint clamps to it: the shadow that
         // is drawn and the rect that is repainted have to be one number, not two
         // computations of it made a frame apart.
-        let reach = with_signal_tracking(id, JobType::Layout, || self.max_shadow_extent());
+        let reach = with_signal_tracking(id, JobType::Layout, || self.max_shadow_extent(id));
         self.shadow_reach.set(reach);
         // The shadow's reach is layout's to publish — it follows the shadow,
         // which layout already tracks. What a transform adds is not: a
@@ -1626,7 +1626,7 @@ impl Widget for Container {
             bounds: tree.get_bounds(id).unwrap_or_default(),
             corners: self.animated_corners(id),
             transform: self.animated_transform(id),
-            pivot: self.pivot_signal().get_or(Pivot::CENTER),
+            pivot: self.resolved_pivot(id),
         };
 
         // Undo our own transform before hit testing against the laid-out
@@ -1723,7 +1723,7 @@ impl Widget for Container {
                 self.animated_corners(id),
                 self.animated_shadow(id),
                 self.animated_transform(id),
-                self.pivot_signal().get_or(Pivot::CENTER),
+                self.resolved_pivot(id),
                 self.animated_border_width(id),
                 self.animated_border_color(id),
                 self.gradient.as_ref().and_then(|g| g.get()),

--- a/src/widgets/container/style.rs
+++ b/src/widgets/container/style.rs
@@ -19,6 +19,7 @@
 //! a size or in a colour.
 
 use super::*;
+use crate::finite::{AllFinite, FiniteOr};
 
 impl Container {
     // -----------------------------------------------------------------------
@@ -27,7 +28,7 @@ impl Container {
 
     /// Apply the active state layer's override to `base`, if it declares one.
     /// Priority is pressed > focused > hovered.
-    fn resolve_state_value<T: Clone>(
+    fn resolve_state_value<T: AllFinite + Clone>(
         &self,
         id: WidgetId,
         base: T,
@@ -53,7 +54,11 @@ impl Container {
         // so `when_hovered(|s| s.lighter(0.1))` still lightens under a pressed
         // layer that only scales.
         for (when, state) in ix.states.iter().rev() {
-            let Some(value) = extractor(state) else {
+            // A layer whose value is not finite is passed over exactly as one
+            // that says nothing about this property is — the base it falls
+            // through to was resolved the same way, so what comes out of here
+            // is finite whatever the application computed.
+            let Some(value) = extractor(state).filter(|v| v.all_finite()) else {
                 continue;
             };
             if control.is_active(when) {
@@ -66,7 +71,9 @@ impl Container {
     /// The background a state layer resolves to: its own colour if it declares
     /// one, its own alpha if it declares one, otherwise the base.
     pub(super) fn effective_background_target(&self, id: WidgetId) -> Color {
-        let base = self.background.get_or(Color::TRANSPARENT);
+        let base = self
+            .background
+            .get_finite_or(Color::TRANSPARENT, id, "background");
         self.resolve_state_value(id, base, |state| {
             let bg_color = state
                 .background
@@ -89,32 +96,38 @@ impl Container {
     }
 
     pub(super) fn effective_border_width_target(&self, id: WidgetId) -> f32 {
-        let base = self.border_width.get_or(0.0);
+        let base = self.border_width.get_finite_or(0.0, id, "border_width");
         self.resolve_state_value(id, base, |state| state.border.map(|b| b.width.get()))
     }
 
     pub(super) fn effective_border_color_target(&self, id: WidgetId) -> Color {
-        let base = self.border_color.get_or(Color::TRANSPARENT);
+        let base = self
+            .border_color
+            .get_finite_or(Color::TRANSPARENT, id, "border_color");
         self.resolve_state_value(id, base, |state| state.border.map(|b| b.color.get()))
     }
 
     pub(super) fn effective_corners_target(&self, id: WidgetId) -> crate::widgets::Corners {
-        let base = self.corners.get_or(crate::widgets::Corners::SQUARE);
+        let base = self
+            .corners
+            .get_finite_or(crate::widgets::Corners::SQUARE, id, "corners");
         self.resolve_state_value(id, base, |state| state.corners.map(|s| s.get()))
     }
 
     pub(super) fn effective_translate_target(&self, id: WidgetId) -> Translate {
-        let base = self.translate_signal().get_or(Translate::NONE);
+        let base = self
+            .translate_signal()
+            .get_finite_or(Translate::NONE, id, "translate");
         self.resolve_state_value(id, base, |state| state.translate.map(|s| s.get()))
     }
 
     pub(super) fn effective_rotate_target(&self, id: WidgetId) -> f32 {
-        let base = self.rotate_signal().get_or(0.0);
+        let base = self.rotate_signal().get_finite_or(0.0, id, "rotate");
         self.resolve_state_value(id, base, |state| state.rotate.map(|s| s.get()))
     }
 
     pub(super) fn effective_scale_target(&self, id: WidgetId) -> Scale {
-        let base = self.scale_signal().get_or(Scale::NONE);
+        let base = self.scale_signal().get_finite_or(Scale::NONE, id, "scale");
         self.resolve_state_value(id, base, |state| state.scale.map(|s| s.get()))
     }
 
@@ -143,14 +156,16 @@ impl Container {
     /// `.shadow(none).when_hovered(|s| s.shadow(lifted))` — both constants — is
     /// laid out once; `when_hovered(|s| s.shadow(lift))` with `lift` a signal
     /// re-lays out the container when it moves.
-    pub(super) fn max_shadow_extent(&self) -> f32 {
-        let base = self.shadow.get_or(Shadow::none());
+    pub(super) fn max_shadow_extent(&self, id: WidgetId) -> f32 {
+        let base = self.shadow.get_finite_or(Shadow::none(), id, "shadow");
         let anim = self.anims.as_ref().and_then(|a| a.shadow.as_ref());
         let declared = self
             .interaction
             .iter()
             .flat_map(|ix| ix.states.iter())
-            .filter_map(|(_, state)| state.shadow.map(|s| s.get().extent()))
+            .filter_map(|(_, state)| state.shadow.map(|s| s.get()))
+            .filter(AllFinite::all_finite)
+            .map(|shadow| shadow.extent())
             .fold(base.extent(), f32::max);
 
         match anim {
@@ -254,12 +269,14 @@ impl Container {
         // taken against `painted` would report the excursion beyond the shadow
         // and lose its width.
         let painted = bounds.outset(shadow_extent);
-        let pivot = self.pivot_signal().get_or_untracked(Pivot::CENTER);
+        let pivot = self.resolved_pivot_untracked();
         let anims = self.anims.as_ref();
 
-        let base_translate = self.translate_signal().get_or_untracked(Translate::NONE);
-        let base_rotate = self.rotate_signal().get_or_untracked(0.0);
-        let base_scale = self.scale_signal().get_or_untracked(Scale::NONE);
+        let base_translate = self
+            .translate_signal()
+            .get_finite_or_untracked(Translate::NONE);
+        let base_rotate = self.rotate_signal().get_finite_or_untracked(0.0);
+        let base_scale = self.scale_signal().get_finite_or_untracked(Scale::NONE);
         let base = Transform::compose(base_translate, base_rotate, base_scale);
         let mut reach = outset_of(base, painted, bounds, pivot);
 
@@ -341,7 +358,7 @@ impl Container {
     }
 
     pub(super) fn effective_shadow_target(&self, id: WidgetId) -> Shadow {
-        let base = self.shadow.get_or(Shadow::none());
+        let base = self.shadow.get_finite_or(Shadow::none(), id, "shadow");
         self.resolve_state_value(id, base, |state| state.shadow.map(|s| s.get()))
     }
 
@@ -349,9 +366,34 @@ impl Container {
     // Animation: the in-flight value when one is running
     // -----------------------------------------------------------------------
 
-    pub(super) fn animated_padding(&self) -> Padding {
+    /// The declared pivot, with one nobody can compute reading as undeclared —
+    /// the same rule every other property is resolved by, spelled here because
+    /// a pivot has no state layer to be resolved through.
+    pub(super) fn resolved_pivot(&self, id: WidgetId) -> Pivot {
+        self.pivot_signal()
+            .get_finite_or(Pivot::CENTER, id, "pivot")
+    }
+
+    /// The same, for the reach calculation, which reads a snapshot rather than
+    /// subscribing — and says nothing, because the paint that reports it is
+    /// reading the same signal in the same frame and one warning is the point.
+    pub(super) fn resolved_pivot_untracked(&self) -> Pivot {
+        self.pivot_signal().get_finite_or_untracked(Pivot::CENTER)
+    }
+
+    /// The declared padding, coerced like every other property.
+    ///
+    /// Its own accessor because four places read it — the seeding pass, the
+    /// drift check, layout and the animated reader — and a property resolved
+    /// four ways is a property three of them will eventually resolve wrongly.
+    pub(super) fn effective_padding_target(&self, id: WidgetId) -> Padding {
+        self.padding
+            .get_finite_or(Padding::default(), id, "padding")
+    }
+
+    pub(super) fn animated_padding(&self, id: WidgetId) -> Padding {
         get_animated_value(self.anims.as_ref().and_then(|a| a.padding.as_ref()), || {
-            self.padding.get_or(Padding::default())
+            self.effective_padding_target(id)
         })
     }
 


### PR DESCRIPTION
## What changed

A declared value that is not a number arithmetic can carry on with is now
coerced **where it is resolved**, once, and reads as if it had not been
declared. Nothing downstream — the matrix, the animation, hit testing, the
damage rect — needs a guard, because none of them can be handed one any more.

That placement is the whole design, and it was chosen after prior art rather
than by preference. CSS coerces a NaN escaping a `calc()` at computed-value
time so no property ever sees one; Web Animations falls back to the identity
easing; Flutter asserts in debug; Qt warns. Nobody lets it reach the matrix
silently, and the *one that fixes all three symptoms at once* is CSS's, because
downstream never sees a bad number to be poisoned by.

The three symptoms #228 names, and why one door closes all of them:

- **The matrix.** `sin_cos(NaN)` makes the whole affine NaN, `is_identity`
  compares equal to nothing so it is applied, and `inverse`'s
  `det.abs() < 1e-10` is false for NaN so hit testing returns NaN coordinates.
- **The animation, permanently.** `lerp` from a NaN start is NaN at every `t`,
  so a later and perfectly finite target animates from nothing to nothing for
  the life of the process. Confirmed against `AnimationState` directly; the
  widget-level path masks it, which is why the recovery test here guards
  recovery rather than proving the poisoning.
- **The frame loop.** `animate_to`'s early-out is `new_target == self.target`,
  and NaN is equal to nothing including itself — so every pass began a segment
  and asked for another Animation job, at the compositor's rate, for ever.

`AllFinite` deliberately does **not** hang off `Animatable`: "can this be
interpolated" and "is this a number" are different questions, and the first
draft that conflated them could not spell the door for `Length` or `Pivot` —
which is most of the ways a bad number gets in. The animatable types answer
from `channels()`, which they already provide, so the check cannot go stale
when a field is added.

Closes #228.

## What proves it

Six tests in `src/widgets/container/characterization.rs`, each failing without
the change:

- `..._reads_as_if_it_were_not_declared` — the coerced value is the property's
  own default, not NaN and not "somewhere".
- `..._lets_the_surface_go_idle` — the battery symptom.
- `a_property_follows_its_signal_again_once_the_signal_recovers` — against a
  control that was never given a bad number, so the assertion is "these two
  agree" rather than a restatement of which way round the matrix stores a sine.
- `a_pivot_that_is_not_a_number_does_not_swallow_a_click` — the pivot reaches
  `center_at` with no state layer on its way, and what a bad one costs is not a
  wrong picture but a **dead widget**: every hit test answers no and the
  container silently stops taking clicks plainly inside it.
- `..._is_reported_once` — five paints, one message.
- `every_declared_property_is_resolved_to_a_finite_value` — the door itself.

That last one is the load-bearing test and it took three attempts to write
honestly. It asks each resolver for the value it hands out, because the two
versions before it asserted on painted output and **passed with the doors
removed** — a NaN width is clamped into a finite size by the layout beneath it,
and a NaN shadow never reaches a drawn rect. I verified the current one fails
when each of `shadow`, `shadow extent`, `width` and the state-layer filter is
taken away.

No golden or snapshot moved, and none should: the change alters behaviour only
when a declared value is non-finite, which no existing scenario declares.

## What the review found

`/simplify` ran first, four readings. Its altitude pass found the blocking
problem of this change: **the door had seven holes.** `shadow` and `padding`
caused exactly the never-settles bug the issue is named after; `max_transform_reach`
fed `Transform::compose` three raw values; `width`/`height` could not use the
door at all. All closed, and the predicate moved off `Animatable` so
non-animatable types can reach it. Its efficiency pass measured the guard as
**free in release** — the `SmallVec` disappears and the check auto-vectorizes;
hand-writing per type is 52 instructions against 47 and no SIMD. In debug it is
~10× a hand-written check, with no fix available (no inliner at `-O0`); worth
knowing before anyone profiles a debug build, not worth a change.

The `reviewer` subagent then ran over the commits. **One blocking finding, fixed:**
`shadow` has a *second* resolver, `max_shadow_extent`, still reading raw — so a
container with a bad shadow and a transform published a damage rect that did not
cover where it drew. Closed, and the enumeration test now asks it.

Its three "worth answering" findings are all acted on: the test now asserts
`width`, `height`, the shadow extent and a state-layer override; the commits
were re-split so each compiles under `-D warnings` alone (the first version had
commit 1 calling a symbol introduced in commit 2, which I confirmed by checking
it out); and the `Text`/`TextInput` residue is filed as #333 rather than left in
this body. Its notes are done too — `finite` is `pub(crate)` rather than public
API nobody can use, and two `track_caller` attributes that read no location are
gone.

## What was checked by hand

Nothing on a compositor, and none needed: every claim here is a number a test
reads back. Two things were measured rather than reasoned about — the animation
poisoning, probed directly against `AnimationState` because the widget path
masks it, and each door removal, to confirm the enumeration test actually fails.

## Left undone

**#333 — `Text` and `TextInput` resolve their font size with a plain read**, so
a non-finite one still reaches `animate_to` and poisons that animation for good.
It is the one residue that meets the bar: reachable with
`text("x").font_size((move || w.get() / n.get()).transition(200.0))`, a caller is
worse off today, and its acceptance criterion is one this change's tests cannot
state — `TextStyle` has no state-layer resolution, so there is no
`resolve_state_value` to hang a door on and the widgets need one built.

Three more unguarded reads were checked and **do not** earn an issue, which is
the point of checking: gradients and ripple colour are paint-only and reach the
shader rather than the matrix, layout, hit testing or the damage rect;
`Scroll`'s metrics are unguarded but `(max_width - gutter).max(0.0)` turns the
NaN into a zero before it reaches geometry. Nobody is worse off today in a way I
can name.

The substitute is the property's **own default** — identity for every transform
component — rather than the last finite value it held. That is CSS's semantics
and needs no per-property storage; holding the last value would mean a `Cell`
per property and was the alternative I would otherwise have recommended. It
means a widget rotated 45° snaps upright rather than freezing at 45°, which is
visible, defined, and cannot be mistaken for still following.

https://claude.ai/code/session_016cdRGJettCQPPACDkS1CtM
