### PR TITLE
A value is read from the scope that declared it, and not from a bag the whole process shares

### DIFF
--- a/book/src/advanced/context.md
+++ b/book/src/advanced/context.md
@@ -1,6 +1,8 @@
 # Context
 
-Context provides a way to share app-wide state (config, theme, services) across widgets without passing values through every level of the widget tree.
+Context shares state across widgets without passing it through every level of
+the tree: a value is declared for a **scope**, and every widget built below that
+scope can read it back by type.
 
 ## When to Use Context
 
@@ -11,22 +13,77 @@ Use context for **cross-cutting concerns** that many widgets need:
 - Service handles (loggers, API clients)
 - User preferences
 
-For state that only a few nearby widgets share, passing signals directly is simpler and preferred.
+For state that only a few nearby widgets share, passing signals directly is
+simpler and preferred.
+
+## Scopes
+
+A scope is a lifetime, and guido opens one wherever it invokes a closure of
+yours: the `App::run` setup, each surface, each popup, and each dynamic children
+factory. A value declared with `provide_context` belongs to the scope that is
+current when the call runs, and a read walks from the reader's scope upward and
+takes the nearest declaration.
+
+Three things follow, and they are the whole model:
+
+- **An inner declaration shadows an outer one** for its own scope only. A popup
+  that declares its own `RwSignal<Theme>` does not disturb the bar it opened
+  from.
+- **A declaration dies with its scope.** When the popup closes, what it declared
+  goes with it; nothing is left behind for a later read to find.
+- **Declaring the same type twice in one scope panics.** Two of a type is what
+  shadowing is for, and shadowing needs two scopes — a second declaration in one
+  scope would replace the first with nothing to say it had.
+
+A widget factory is an ordinary function call, not a scope. A `provide_context`
+written inside one declares its value for whatever scope called it — the whole
+surface — and not for the subtree the factory is building.
+
+## Where a Read Resolves
+
+In the body of the factory that builds the widgets. That is where the scope the
+value was declared for is the one that is current, so it is where guido knows
+who is asking.
+
+An event handler, a property closure and a spawned task open no scope of their
+own, so a read inside one resolves against whatever is current, and in a running
+application that is the root — `App::run` enters the root scope before your
+setup closure and never leaves it. What the application declared is therefore
+readable from a handler; what a surface or a popup declared is not.
+
+Read the value once in the factory body and capture it, and the question does
+not arise:
+
+```rust
+# extern crate guido;
+# use guido::prelude::*;
+# #[derive(Clone, PartialEq, Default)]
+# struct Theme { bg_color: Color, title: String }
+# fn main() {
+fn themed_box() -> Container {
+    let theme = expect_context::<RwSignal<Theme>>();   // here: a scope is current
+
+    container()
+        .background(move || theme.get().bg_color)      // not here: the handle is captured
+        .child(text(move || theme.get().title.clone()))
+}
+# }
+```
 
 ## Providing Context
 
-Call `provide_context` in your `App::run()` setup to make a value available everywhere:
+Call `provide_context` in your `App::run()` setup to make a value available to
+every surface:
 
-```rust,ignore
+```rust,no_run
 # extern crate guido;
+# use guido::prelude::*;
 # fn build_ui() -> Container { container() }
 # #[derive(Clone, Default)]
-# struct Config;
-# impl Config { fn load() -> Self { Self } }
+# struct Config { warn_threshold: f64 }
+# impl Config { fn load() -> Self { Self::default() } }
 # fn main() {
 # let config = SurfaceConfig::new();
-use guido::prelude::*;
-
 App::new().run(|app| {
     provide_context(Config::load());
 
@@ -40,14 +97,13 @@ App::new().run(|app| {
 
 ### use_context (fallible)
 
-Returns `Option<T>` — useful when the context is optional:
+Returns `Option<T>` — `None` when no scope at or above this one declared it:
 
-```rust,ignore
+```rust
 # extern crate guido;
 # use guido::prelude::*;
 # #[derive(Clone, Default)]
-# struct Config;
-# impl Config { fn load() -> Self { Self } }
+# struct Config { warn_threshold: f64 }
 # fn main() {
 if let Some(cfg) = use_context::<Config>() {
     println!("threshold: {}", cfg.warn_threshold);
@@ -58,14 +114,14 @@ if let Some(cfg) = use_context::<Config>() {
 
 ### expect_context (infallible)
 
-Panics with a helpful message if the context was not provided:
+Panics if nothing declared it, naming the type and both of the reasons it can be
+missing:
 
 ```rust,no_run
 # extern crate guido;
 # use guido::prelude::*;
 # #[derive(Clone, Default)]
-# struct Config;
-# impl Config { fn load() -> Self { Self } }
+# struct Config { warn_threshold: f64 }
 # fn main() {
 let cfg = expect_context::<Config>();
 # ;
@@ -74,29 +130,30 @@ let cfg = expect_context::<Config>();
 
 ### with_context (zero-clone)
 
-Borrows the value without cloning — ideal for large structs when you only need one field:
+Borrows the value without cloning — ideal for large structs when you only need
+one field:
 
-```rust,ignore
+```rust
 # extern crate guido;
 # use guido::prelude::*;
 # #[derive(Clone, Default)]
-# struct Config;
-# impl Config { fn load() -> Self { Self } }
+# struct Config { warn_threshold: f64 }
 # fn main() {
-let threshold = with_context::<Config, _>(|cfg| cfg.cpu.warn_threshold);
+let threshold = with_context::<Config, _>(|cfg| cfg.warn_threshold);
 # ;
 # }
 ```
 
 ### has_context (existence check)
 
-Check if a context has been provided without retrieving it:
+Check whether a type is declared without retrieving it:
 
-```rust,ignore
+```rust
 # extern crate guido;
 # use guido::prelude::*;
 # #[derive(Clone, Default)]
 # struct Logger;
+# impl Logger { fn info(&self, _: &str) {} }
 # fn main() {
 if has_context::<Logger>() {
     expect_context::<Logger>().info("ready");
@@ -107,20 +164,24 @@ if has_context::<Logger>() {
 
 ## Reactive Context
 
-For mutable shared state, store a `Signal<T>` as context. This is the most powerful pattern — any widget reading the signal during paint/layout auto-tracks it for reactive updates.
+For mutable shared state, declare an `RwSignal<T>`. Any widget reading the
+signal during paint or layout tracks it, so a write anywhere repaints everything
+that reads it.
 
 ### provide_signal_context
 
-Creates an `RwSignal` and provides it as context in one step:
+Creates an `RwSignal` and declares it in one step:
 
-```rust,ignore
+```rust,no_run
 # extern crate guido;
 # use guido::prelude::*;
 # fn build_ui() -> Container { container() }
+# #[derive(Clone, PartialEq, Default)]
+# struct Theme { bg_color: Color, title: String }
 # fn main() {
 # let config = SurfaceConfig::new();
 App::new().run(|app| {
-    // Creates RwSignal<Theme> and stores it as context
+    // Creates RwSignal<Theme> and declares it for the root scope
     let theme = provide_signal_context(Theme::default());
 
     app.add_surface(config, || build_ui());
@@ -129,23 +190,13 @@ App::new().run(|app| {
 # }
 ```
 
-### Reading a signal context
-
-```rust,ignore
-fn themed_box() -> Container {
-    let theme = expect_context::<RwSignal<Theme>>();
-
-    container()
-        .background(move || theme.get().bg_color)
-        .child(text(move || theme.get().title.clone()))
-}
-```
-
-When the signal is updated anywhere, all widgets reading it automatically repaint.
+What it declares is an `RwSignal<T>`, and that is the type to ask for. Asking
+for a `Signal<T>` finds nothing: a different type is a different key.
 
 ## Combining with SignalFields
 
-For config structs with many fields, use `#[derive(SignalFields)]` with context so each widget only repaints when the specific field it reads changes:
+For config structs with many fields, use `#[derive(SignalFields)]` with context
+so each widget only repaints when the specific field it reads changes:
 
 ```rust,ignore
 #[derive(Clone, PartialEq, SignalFields)]
@@ -189,12 +240,14 @@ fn cpu_indicator() -> Container {
 | **Pass signals directly** | Parent-child, 1-2 levels deep, few consumers |
 | **Context** | App-wide state, many consumers across modules |
 
-Since `Signal<T>` is `Copy`, passing them directly is zero-cost. Context adds a Vec scan + downcast, which is negligible but unnecessary when only a few widgets need the value.
+Since `Signal<T>` is `Copy`, passing them directly is zero-cost. A context read
+scans the declarations of the current scope and then of each scope above it,
+which is negligible but unnecessary when only a few widgets need the value.
 
 ## API Reference
 
-```rust,ignore
-// Store a value (one per type, replaces if exists)
+```text
+// Declare a value for the current scope
 pub fn provide_context<T: 'static>(value: T);
 
 // Retrieve (clones)
@@ -207,7 +260,7 @@ pub fn with_context<T: 'static, R>(f: impl FnOnce(&T) -> R) -> Option<R>;
 // Existence check
 pub fn has_context<T: 'static>() -> bool;
 
-// Create signal + provide as context
+// Create signal + declare it
 pub fn provide_signal_context<T: Clone + PartialEq + Send + 'static>(
     value: T
 ) -> RwSignal<T>;

--- a/book/src/advanced/context.md
+++ b/book/src/advanced/context.md
@@ -27,13 +27,19 @@ takes the nearest declaration.
 Three things follow, and they are the whole model:
 
 - **An inner declaration shadows an outer one** for its own scope only. A popup
-  that declares its own `RwSignal<Theme>` does not disturb the bar it opened
-  from.
+  that declares its own `RwSignal<Theme>` reads that one rather than the
+  application's, and leaves the application's alone for everything else.
 - **A declaration dies with its scope.** When the popup closes, what it declared
   goes with it; nothing is left behind for a later read to find.
 - **Declaring the same type twice in one scope panics.** Two of a type is what
   shadowing is for, and shadowing needs two scopes — a second declaration in one
   scope would replace the first with nothing to say it had.
+
+The scopes are one level deep. A surface, a popup and a surface spawned at
+runtime are all children of the root — the loop opens each one's scope from the
+root, not from the surface it belongs to — so a popup reads what the
+application declared and not what the surface that opened it did, and two
+surfaces are siblings that cannot see each other's declarations.
 
 A widget factory is an ordinary function call, not a scope. A `provide_context`
 written inside one declares its value for whatever scope called it — the whole
@@ -46,10 +52,13 @@ value was declared for is the one that is current, so it is where guido knows
 who is asking.
 
 An event handler, a property closure and a spawned task open no scope of their
-own, so a read inside one resolves against whatever is current, and in a running
-application that is the root — `App::run` enters the root scope before your
-setup closure and never leaves it. What the application declared is therefore
-readable from a handler; what a surface or a popup declared is not.
+own, so a read inside one resolves against whatever is current. For a handler
+that is the root — `App::run` enters the root scope before your setup closure
+and never leaves it — so the application's declarations are readable from one
+and a surface's are not. For a property closure it depends on when the closure
+is read: laying out a dynamic list re-enters that row's scope and painting does
+not, so one read can resolve against two different scopes on two phases of a
+frame.
 
 Read the value once in the factory body and capture it, and the question does
 not arise:

--- a/book/src/concepts/reactive-model.md
+++ b/book/src/concepts/reactive-model.md
@@ -360,23 +360,23 @@ text(format!("Count: {}", value))  // Won't update!
 
 For values that many widgets across different modules need (config, theme, services), use the [Context API](../advanced/context.md) instead of passing signals through every function:
 
-```rust
+```rust,no_run
 # extern crate guido;
 # use guido::prelude::*;
 # #[derive(Clone, Default)]
 # struct Config;
 # impl Config { fn load() -> Self { Self } }
 # fn main() {
-// Setup
+// In the App::run setup, which is the root scope
 provide_context(Config::load());
 
-// Any widget, any module
+// In any widget factory below it, in any module
 let cfg = expect_context::<Config>();
 # ;
 # }
 ```
 
-For mutable shared state, use `provide_signal_context` to combine context with reactivity.
+A value is declared for the scope that is current — the setup, a surface, a popup, a dynamic list — and read by the scopes below it. For mutable shared state, use `provide_signal_context` to combine context with reactivity.
 
 ### Use Memo for Derived State
 

--- a/docs/STATE_LAYER.md
+++ b/docs/STATE_LAYER.md
@@ -96,8 +96,9 @@ unit is what a descendant asks. A container that declares nothing keeps `None`
 and allocates no signal, and `OptionSignalExt::get_or` on a `None` reads
 nothing, so every container that does not use this pays two branches.
 
-Context is not an alternative: `reactive::context` is app-global with one value
-per type, so it cannot carry a value scoped to a subtree.
+Context is not an alternative: `reactive::context` is scoped to the reactive
+owner — the application, a surface, a popup, a row of a dynamic list — and a
+container is none of those, so it cannot carry a value scoped to a subtree.
 
 `Control::is_hovered`, `is_pressed` and `has_focus` are all gated on the answer:
 a disabled unit is under no pointer and is not where the keyboard is aimed, so

--- a/src/reactive/context.rs
+++ b/src/reactive/context.rs
@@ -1,183 +1,253 @@
-//! App-global context system for sharing state across widgets.
+//! Values declared for a scope, read by the scopes below it.
 //!
-//! Context provides a way to store and retrieve app-wide values (config, theme,
-//! services) without passing them through every level of the widget tree. Values
-//! are keyed by their concrete type — one value per type.
+//! A value is keyed by its type and lives on the reactive scope that declared
+//! it — the application's setup, a surface, a popup, a dynamic list. A read
+//! walks from the current scope upward and takes the nearest declaration, so an
+//! inner one shadows an outer one for its own subtree and leaves the rest of the
+//! tree alone. Leptos, SolidJS, Floem and Dioxus all resolve context this way,
+//! and #220 is why we do now: in one process-wide bag, two declarations of a
+//! type overwrote each other silently, and a value declared inside a popup went
+//! on being found after the popup was gone.
+//!
+//! ## Where a read resolves
+//!
+//! In the body of the factory that builds the widgets — that is where the scope
+//! the value was declared for is the scope that is current, so it is where the
+//! library knows who is asking.
+//!
+//! An event handler, a property closure and a spawned task open no scope of
+//! their own, so a read inside one resolves against whatever is current. For a
+//! handler that is the root — `App::run` enters the root scope before the setup
+//! closure and never leaves it — so the application's declarations are readable
+//! from one and a surface's are not. For a property closure it depends on when
+//! the closure is read: laying out a dynamic list re-enters that row's scope,
+//! painting does not, so the same read can resolve against two different scopes
+//! on two phases of one frame.
+//!
+//! Read the value once in the factory body and capture the handle into the
+//! closure, and none of that arises:
+//!
+//! ```
+//! # use guido::prelude::*;
+//! # use guido::reactive::__internal::with_owner;
+//! # #[derive(Clone, Copy, PartialEq, Default)]
+//! # struct Theme { bg: Color }
+//! # let (_, _scope) = with_owner(|| {
+//! # provide_signal_context(Theme::default());
+//! fn themed_box() -> Container {
+//!     let theme = expect_context::<RwSignal<Theme>>();   // here: a scope is current
+//!     container().background(move || theme.get().bg)     // not here: the handle is captured
+//! }
+//! # themed_box();
+//! # });
+//! ```
+//!
+//! ## The scopes are one level deep
+//!
+//! A surface, a popup and a surface spawned at runtime are all children of the
+//! root: the loop opens each one's scope from the root rather than from the
+//! surface it belongs to. So a popup does not read what the surface that opened
+//! it declared — only what the application did — and two surfaces are siblings
+//! that cannot see each other's declarations.
+//!
+//! ## A declaration belongs to a scope, not to a widget
+//!
+//! Scopes branch where guido invokes a closure: a surface, a popup, a dynamic
+//! list. A widget factory is an ordinary function call the caller makes, so a
+//! [`provide_context`] written inside one declares its value for the
+//! *surrounding* scope — the whole surface, not the subtree being built. Per
+//! container declarations are not part of this.
 //!
 //! ## Storage
 //!
-//! Uses `Vec<(TypeId, Box<dyn Any>)>` with linear scan. Context stores ~3-8
-//! values in practice (config, theme, services), so this fits in 1-2 cache
-//! lines and avoids HashMap overhead. `TypeId` comparison is a single `u64` eq.
-//!
-//! ## Reactive Context
-//!
-//! Storing `Signal<T>` as context is the recommended pattern for mutable state.
-//! Any widget reading the signal during paint/layout auto-tracks it:
-//!
-//! ```ignore
-//! // In App::run() setup:
-//! let theme = provide_signal_context(MyTheme::default());
-//!
-//! // In any widget:
-//! let theme = expect_context::<Signal<MyTheme>>();
-//! container().background(move || theme.get().bg_color)
-//! ```
+//! A `Vec<(TypeId, Rc<dyn Any>)>` per scope, scanned linearly: a scope declares
+//! a handful at most, a `TypeId` comparison is two words, and a miss walks the
+//! two or three parents between a widget and the root.
 
-use std::any::{Any, TypeId};
-use std::cell::RefCell;
+use std::any::{TypeId, type_name};
+use std::rc::Rc;
 
+use super::owner::{nearest_declaration, with_scope_declarations};
 use super::signal::{RwSignal, create_signal};
 
-thread_local! {
-    static CONTEXTS: RefCell<Vec<(TypeId, Box<dyn Any>)>> = const { RefCell::new(Vec::new()) };
-}
-
-/// Store a value in the global context, keyed by its type.
+/// Declare a value for the current scope, keyed by its type.
 ///
-/// If a value of the same type already exists, it is replaced.
-///
-/// # Example
-///
-/// ```ignore
-/// App::new().run(|app| {
-///     provide_context(MyConfig::load());
-///     provide_context(create_signal(Theme::default())); // Signal as context
-///     // ...
-/// });
-/// ```
-pub fn provide_context<T: 'static>(value: T) {
-    let type_id = TypeId::of::<T>();
-    CONTEXTS.with(|ctx| {
-        let mut ctx = ctx.borrow_mut();
-        // Replace if exists
-        for entry in ctx.iter_mut() {
-            if entry.0 == type_id {
-                entry.1 = Box::new(value);
-                return;
-            }
-        }
-        ctx.push((type_id, Box::new(value)));
-    });
-}
-
-/// Retrieve a context value by type, returning `None` if not provided.
-///
-/// Clones the value — for large structs, use [`with_context`] to borrow
-/// or store a `Signal<T>` instead.
-///
-/// # Example
-///
-/// ```ignore
-/// if let Some(cfg) = use_context::<MyConfig>() {
-///     println!("threshold: {}", cfg.warn_threshold);
-/// }
-/// ```
-pub fn use_context<T: Clone + 'static>() -> Option<T> {
-    let type_id = TypeId::of::<T>();
-    CONTEXTS.with(|ctx| {
-        let ctx = ctx.borrow();
-        for entry in ctx.iter() {
-            if entry.0 == type_id {
-                return Some(
-                    entry
-                        .1
-                        .downcast_ref::<T>()
-                        .expect("context type mismatch (should be impossible)")
-                        .clone(),
-                );
-            }
-        }
-        None
-    })
-}
-
-/// Retrieve a context value by type, panicking if not provided.
-///
-/// Use this when the context is required and its absence is a programming error.
+/// Every scope below this one reads it, until one of them declares the same
+/// type and shadows it.
 ///
 /// # Panics
 ///
-/// Panics with a helpful message including the type name if the context
-/// was not provided.
+/// If no scope is current at all, or if this scope already declares the type —
+/// two of a type is what shadowing is for, and shadowing needs two scopes.
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```
+/// # use guido::prelude::*;
+/// # use guido::reactive::__internal::with_owner;
+/// # #[derive(Clone, PartialEq)]
+/// # struct MyConfig { warn_threshold: u32 }
+/// # let (_, _scope) = with_owner(|| {
+/// // In `App::run`'s setup, or in a surface's factory:
+/// provide_context(MyConfig { warn_threshold: 80 });
+/// assert_eq!(expect_context::<MyConfig>().warn_threshold, 80);
+/// # });
+/// ```
+pub fn provide_context<T: 'static>(value: T) {
+    let type_id = TypeId::of::<T>();
+    let declared = with_scope_declarations(move |declarations| {
+        assert!(
+            !declarations
+                .iter()
+                .any(|(declared, _)| *declared == type_id),
+            "`{}` is already declared in this scope.\n\
+             A scope below this one shadows it, which is how two of a type \
+             coexist; a second declaration here would replace the first with \
+             nothing to say it had.",
+            type_name::<T>()
+        );
+        declarations.push((type_id, Rc::new(value)));
+    });
+    assert!(
+        declared.is_some(),
+        "`{}` was declared where no scope is current.\n\
+         A value belongs to a scope — the application's setup, a surface, a \
+         popup, a dynamic list — and an event handler, a property closure or a \
+         spawned task is none of them. Declare it where the tree is built.",
+        type_name::<T>()
+    );
+}
+
+/// Read the nearest declaration of `T`, or `None` if there is none.
+///
+/// Clones the value — for a large struct use [`with_context`] to borrow it, or
+/// declare a signal and clone the handle instead.
+///
+/// # Example
+///
+/// ```
+/// # use guido::prelude::*;
+/// # use guido::reactive::__internal::with_owner;
+/// # #[derive(Clone, PartialEq)]
+/// # struct MyConfig { warn_threshold: u32 }
+/// # let (_, _scope) = with_owner(|| {
+/// provide_context(MyConfig { warn_threshold: 80 });
+/// if let Some(cfg) = use_context::<MyConfig>() {
+///     assert_eq!(cfg.warn_threshold, 80);
+/// }
+/// assert!(use_context::<u32>().is_none());
+/// # });
+/// ```
+pub fn use_context<T: Clone + 'static>() -> Option<T> {
+    with_context::<T, T>(Clone::clone)
+}
+
+/// Read the nearest declaration of `T`, panicking if there is none.
+///
+/// Use it where the value is required and its absence is a programming error.
+///
+/// # Panics
+///
+/// Naming the type, and both of the reasons it can be missing: nothing declared
+/// it, or the read happened where no scope is current.
+///
+/// # Example
+///
+/// ```
+/// # use guido::prelude::*;
+/// # use guido::reactive::__internal::with_owner;
+/// # #[derive(Clone, PartialEq, Debug)]
+/// # struct MyConfig { warn_threshold: u32 }
+/// # let (_, _scope) = with_owner(|| {
+/// provide_context(MyConfig { warn_threshold: 80 });
 /// let cfg = expect_context::<MyConfig>();
+/// assert_eq!(cfg.warn_threshold, 80);
+/// # });
 /// ```
 pub fn expect_context<T: Clone + 'static>() -> T {
     use_context::<T>().unwrap_or_else(|| {
         panic!(
-            "Context not found for type `{}`.\n\
-             Did you forget to call provide_context() in your App::run() setup?",
-            std::any::type_name::<T>()
+            "No value of type `{}` is declared in this scope or any above it.\n\
+             Either nothing declared it, or the read happened outside the scope \
+             it was declared for — an event handler, a property closure and a \
+             spawned task read against the root. Read it in the factory body and \
+             capture the value into the closure.",
+            type_name::<T>()
         )
     })
 }
 
-/// Borrow a context value without cloning.
+/// Borrow the nearest declaration of `T` without cloning it.
 ///
-/// Returns `None` if the context was not provided. Use this for large structs
-/// where you only need to read a single field.
+/// `None` if there is none. Use it for a large struct when one field is all the
+/// reader needs.
 ///
 /// # Example
 ///
-/// ```ignore
-/// let threshold = with_context::<Config, _>(|cfg| cfg.cpu.warn_threshold);
+/// ```
+/// # use guido::prelude::*;
+/// # use guido::reactive::__internal::with_owner;
+/// # struct Config { warn_threshold: u32 }
+/// # let (_, _scope) = with_owner(|| {
+/// provide_context(Config { warn_threshold: 80 });
+/// let threshold = with_context::<Config, _>(|cfg| cfg.warn_threshold);
+/// assert_eq!(threshold, Some(80));
+/// # });
 /// ```
 pub fn with_context<T: 'static, R>(f: impl FnOnce(&T) -> R) -> Option<R> {
-    let type_id = TypeId::of::<T>();
-    CONTEXTS.with(|ctx| {
-        let ctx = ctx.borrow();
-        for entry in ctx.iter() {
-            if entry.0 == type_id {
-                let value = entry
-                    .1
-                    .downcast_ref::<T>()
-                    .expect("context type mismatch (should be impossible)");
-                return Some(f(value));
-            }
-        }
-        None
-    })
+    let value = nearest_declaration(TypeId::of::<T>())?;
+    let value = value
+        .downcast_ref::<T>()
+        .expect("a declaration is keyed by the type it holds");
+    Some(f(value))
 }
 
-/// Check if a context value of type `T` has been provided.
+/// Whether any scope at or above this one declares `T`.
 ///
-/// Useful for optional features: "if a logger context exists, use it."
+/// For an optional feature: "if a logger was declared, log through it".
 ///
 /// # Example
 ///
-/// ```ignore
-/// if has_context::<Logger>() {
-///     let logger = expect_context::<Logger>();
-///     logger.info("widget created");
-/// }
+/// ```
+/// # use guido::prelude::*;
+/// # use guido::reactive::__internal::with_owner;
+/// # #[derive(Clone, PartialEq)]
+/// # struct Logger;
+/// # let (_, _scope) = with_owner(|| {
+/// assert!(!has_context::<Logger>());
+/// provide_context(Logger);
+/// assert!(has_context::<Logger>());
+/// # });
 /// ```
 pub fn has_context<T: 'static>() -> bool {
-    let type_id = TypeId::of::<T>();
-    CONTEXTS.with(|ctx| {
-        let ctx = ctx.borrow();
-        ctx.iter().any(|entry| entry.0 == type_id)
-    })
+    nearest_declaration(TypeId::of::<T>()).is_some()
 }
 
-/// Provide a `Signal<T>` context wrapping the given value.
+/// Declare an `RwSignal<T>` holding `value`, and hand it back.
 ///
-/// This is the recommended pattern for mutable shared state. Creates a signal,
-/// stores it as context, and returns it. Any widget reading the signal during
-/// paint/layout auto-tracks it for reactive updates.
+/// The pattern for mutable shared state: the signal is declared for the scope,
+/// and a widget that reads it during paint or layout tracks it, so a write
+/// anywhere repaints everything that reads it.
+///
+/// What is declared is an `RwSignal<T>` — that is the type to ask for, and
+/// asking for a `Signal<T>` finds nothing, because a different type is a
+/// different key.
 ///
 /// # Example
 ///
-/// ```ignore
-/// // In setup:
+/// ```
+/// # use guido::prelude::*;
+/// # use guido::reactive::__internal::with_owner;
+/// # #[derive(Clone, Copy, PartialEq, Debug, Default)]
+/// # struct Theme { bg: f32 }
+/// # let (_, _scope) = with_owner(|| {
 /// let theme = provide_signal_context(Theme::default());
 ///
-/// // In any widget:
-/// let theme = expect_context::<Signal<Theme>>();
-/// container().background(move || theme.get().bg_color)
+/// // In any factory below it:
+/// let read_back = expect_context::<RwSignal<Theme>>();
+/// theme.set(Theme { bg: 1.0 });
+/// assert_eq!(read_back.get().bg, 1.0);
+/// # });
 /// ```
 pub fn provide_signal_context<T: Clone + PartialEq + Send + 'static>(value: T) -> RwSignal<T> {
     let signal = create_signal(value);
@@ -185,85 +255,229 @@ pub fn provide_signal_context<T: Clone + PartialEq + Send + 'static>(value: T) -
     signal
 }
 
-/// Reset all context state.
-///
-/// Called during `App::drop()` to wipe thread-local context storage,
-/// enabling clean restart of the application.
-pub(crate) fn reset_contexts() {
-    CONTEXTS.with(|ctx| ctx.borrow_mut().clear());
-}
-
 #[cfg(test)]
 mod tests {
+    use std::cell::Cell;
+    use std::rc::Rc;
+
     use super::*;
+    use crate::layout::Constraints;
+    use crate::reactive::owner::{create_root_owner, dispose_owner_now, under_owner, with_owner};
+    use crate::reactive::signal::create_signal;
+    use crate::tree::Tree;
+    use crate::widgets::container;
+    use crate::widgets::widget::{Event, MouseButton};
 
-    // Reset contexts before each test to avoid cross-test contamination.
-    // Tests in Rust run in the same thread sequentially per file.
-    fn setup() {
-        reset_contexts();
+    /// Run `f` in a scope below the current one, and take the scope away
+    /// again — what a surface, a popup or a row of a list is, for a test.
+    fn in_a_child_scope<T>(f: impl FnOnce() -> T) -> T {
+        let (value, scope) = with_owner(f);
+        dispose_owner_now(scope);
+        value
     }
 
+    /// The half that already worked: a scope reads what a scope above it
+    /// declared, and the value it gets back is the one that was put there.
     #[test]
-    fn test_provide_and_use_context() {
-        setup();
+    fn a_scope_reads_what_an_ancestor_declared() {
+        create_root_owner();
+        provide_context(7u32);
+
+        assert_eq!(in_a_child_scope(use_context::<u32>), Some(7));
+    }
+
+    /// A declaration belongs to the scope that made it. A sibling is not below
+    /// it, so a sibling cannot see it — which is the whole difference between a
+    /// scoped store and a bag keyed by type.
+    #[test]
+    fn a_sibling_scope_does_not_see_the_declaration() {
+        create_root_owner();
+
+        let ((), declaring) = with_owner(|| provide_context(42u32));
+        let (seen, reading) = with_owner(use_context::<u32>);
+
+        assert_eq!(
+            seen, None,
+            "a value declared beside this scope is not above it"
+        );
+        dispose_owner_now(declaring);
+        dispose_owner_now(reading);
+    }
+
+    /// Shadowing, which is what makes two providers of one type safe: the inner
+    /// declaration wins below itself and leaves everything else alone.
+    #[test]
+    fn an_inner_declaration_shadows_an_outer_one_for_its_own_scope() {
+        create_root_owner();
+        provide_context(1u32);
+
+        let inner = in_a_child_scope(|| {
+            provide_context(2u32);
+            use_context::<u32>()
+        });
+
+        assert_eq!(inner, Some(2), "the nearest declaration wins");
+        assert_eq!(
+            use_context::<u32>(),
+            Some(1),
+            "and the outer scope is untouched by it"
+        );
+    }
+
+    /// Defect 2 of #220: two scopes each declaring their own `RwSignal` used to
+    /// overwrite one another in a process-wide bag, last writer winning. Both
+    /// declarations happen before either read, which is what the old store
+    /// could not survive.
+    #[test]
+    fn two_scopes_declaring_one_type_each_read_their_own() {
+        create_root_owner();
+
+        let ((), first) = with_owner(|| provide_context(create_signal(1i32)));
+        let ((), second) = with_owner(|| provide_context(create_signal(2i32)));
+
+        let from_first = under_owner(first, || expect_context::<RwSignal<i32>>().get());
+        let from_second = under_owner(second, || expect_context::<RwSignal<i32>>().get());
+
+        assert_eq!((from_first, from_second), (1, 2));
+        dispose_owner_now(first);
+        dispose_owner_now(second);
+    }
+
+    /// Defect 3 of #220: a signal declared in a scope that dies used to leave a
+    /// live-looking handle in the bag — `use_context` answered `Some`, and the
+    /// `.get()` after it panicked with "signal was disposed". The declaration
+    /// now dies with the scope, so the answer is `None` and there is nothing to
+    /// call `.get()` on.
+    #[test]
+    fn a_declaration_dies_with_the_scope_that_made_it() {
+        create_root_owner();
+
+        let ((), popup) = with_owner(|| provide_context(create_signal(1i32)));
+        dispose_owner_now(popup);
+
+        assert!(
+            use_context::<RwSignal<i32>>().is_none(),
+            "the handle went with the scope rather than outliving it"
+        );
+    }
+
+    /// A declaration needs somewhere to live. With no scope current — an event
+    /// handler, a property closure, a spawned task — there is none, and the
+    /// value would go nowhere rather than everywhere.
+    #[test]
+    #[should_panic(expected = "no scope is current")]
+    fn declaring_with_no_scope_current_panics() {
+        provide_context(1u32);
+    }
+
+    /// Two declarations of one type in one scope is the overwrite that defect 2
+    /// was about, minus the distance that made it invisible. Shadowing needs two
+    /// scopes; this is one, so it is a mistake and says so.
+    #[test]
+    #[should_panic(expected = "already declared in this scope")]
+    fn declaring_one_type_twice_in_a_scope_panics() {
+        create_root_owner();
+        provide_context(1u32);
+        provide_context(2u32);
+    }
+
+    /// Where a read resolves, stated as a test rather than as a promise in the
+    /// docs.
+    ///
+    /// An event handler runs with no scope of its own — `OwnedWidget::event`
+    /// declines to re-enter one, deliberately — so it reads against whatever is
+    /// current, and in a running application that is the root: `App::run`
+    /// creates the root scope before the setup closure and never leaves it. So
+    /// the application's own declarations are readable from a handler, and a
+    /// surface's are not. The rule for a caller is the same either way: read it
+    /// in the factory body and capture the value.
+    ///
+    /// It builds a tree because that is the only way to make the claim about
+    /// handlers rather than about closures in general, and it lives here
+    /// because the rule is this module's and only a test inside the crate can
+    /// open a scope.
+    #[test]
+    fn an_event_handler_reads_against_the_root_and_not_against_the_surface() {
+        create_root_owner();
         provide_context(42u32);
-        assert_eq!(use_context::<u32>(), Some(42));
+
+        let seen = Rc::new(Cell::new(None));
+        let from_root = Rc::clone(&seen);
+        let from_surface = Rc::clone(&seen);
+
+        // The surface's scope, declaring something of its own.
+        let (widget, surface) = with_owner(move || {
+            provide_context("the surface's".to_string());
+            assert_eq!(
+                use_context::<String>().as_deref(),
+                Some("the surface's"),
+                "the factory body is where a read resolves"
+            );
+            container().width(80.0).height(20.0).on_click(move || {
+                from_root.set(Some((use_context::<u32>(), use_context::<String>())));
+            })
+        });
+
+        let mut tree = Tree::new();
+        let root = tree.register(Box::new(widget));
+        tree.with_widget_mut(root, |w, id, tree| w.register_children(tree, id));
+        tree.with_widget_mut(root, |w, id, tree| {
+            w.layout(tree, id, Constraints::new(0.0, 0.0, 200.0, 100.0));
+        });
+        for event in [
+            Event::mouse_down(10.0, 10.0, MouseButton::Left),
+            Event::mouse_up(10.0, 10.0, MouseButton::Left),
+        ] {
+            tree.with_widget_mut(root, |w, id, tree| w.event(tree, id, &event));
+        }
+
+        assert_eq!(
+            seen.take(),
+            Some((Some(42), None)),
+            "the handler read against the root: the application's value is \
+             there, the surface's is not"
+        );
+        drop(from_surface);
+        dispose_owner_now(surface);
     }
 
+    /// Borrowing rather than cloning, over the scope chain like every other
+    /// read.
     #[test]
-    fn test_use_context_returns_none_when_missing() {
-        setup();
-        assert_eq!(use_context::<String>(), None);
-    }
-
-    #[test]
-    fn test_expect_context_returns_value() {
-        setup();
-        provide_context("hello".to_string());
-        assert_eq!(expect_context::<String>(), "hello");
-    }
-
-    #[test]
-    #[should_panic(expected = "Context not found for type")]
-    fn test_expect_context_panics_when_missing() {
-        setup();
-        expect_context::<f64>();
-    }
-
-    #[test]
-    fn test_with_context_borrows_without_clone() {
-        setup();
+    fn a_borrowed_read_walks_the_same_chain() {
+        create_root_owner();
         provide_context(vec![1, 2, 3]);
-        let sum = with_context::<Vec<i32>, _>(|v| v.iter().sum::<i32>());
+
+        let sum = in_a_child_scope(|| with_context::<Vec<i32>, _>(|v| v.iter().sum::<i32>()));
         assert_eq!(sum, Some(6));
     }
 
     #[test]
-    fn test_with_context_returns_none_when_missing() {
-        setup();
-        let result = with_context::<Vec<i32>, _>(|v| v.len());
-        assert_eq!(result, None);
-    }
-
-    #[test]
-    fn test_has_context() {
-        setup();
+    fn asking_whether_a_type_is_declared_walks_it_too() {
+        create_root_owner();
         assert!(!has_context::<u64>());
         provide_context(99u64);
-        assert!(has_context::<u64>());
+
+        assert!(in_a_child_scope(has_context::<u64>));
     }
 
     #[test]
-    fn test_provide_replaces_existing() {
-        setup();
-        provide_context(10u32);
-        provide_context(20u32);
-        assert_eq!(use_context::<u32>(), Some(20));
+    fn a_type_nothing_declared_is_not_found() {
+        create_root_owner();
+        assert_eq!(use_context::<String>(), None);
+        assert_eq!(with_context::<Vec<i32>, _>(|v| v.len()), None);
     }
 
     #[test]
-    fn test_multiple_types() {
-        setup();
+    #[should_panic(expected = "No value of type")]
+    fn expecting_a_type_nothing_declared_panics() {
+        create_root_owner();
+        expect_context::<f64>();
+    }
+
+    #[test]
+    fn types_do_not_collide() {
+        create_root_owner();
         provide_context(42u32);
         provide_context("hello".to_string());
         provide_context(2.72f64);
@@ -273,27 +487,17 @@ mod tests {
         assert_eq!(use_context::<f64>(), Some(2.72));
     }
 
+    /// `provide_signal_context` deposits an `RwSignal<T>`, which is what the
+    /// docs have to say it deposits: the example that asked for a `Signal<T>`
+    /// was five months wrong because nothing ran it.
     #[test]
-    fn test_reset_clears_all() {
-        setup();
-        provide_context(42u32);
-        provide_context("hello".to_string());
-        reset_contexts();
-        assert_eq!(use_context::<u32>(), None);
-        assert_eq!(use_context::<String>(), None);
-    }
-
-    #[test]
-    fn test_provide_signal_context() {
-        setup();
+    fn a_provided_signal_is_read_back_as_the_read_write_handle() {
+        create_root_owner();
         let signal = provide_signal_context(100i32);
-        assert_eq!(signal.get(), 100);
 
-        // Retrieve via use_context (stored as RwSignal)
-        let retrieved = use_context::<RwSignal<i32>>().unwrap();
+        let retrieved = expect_context::<RwSignal<i32>>();
         assert_eq!(retrieved.get(), 100);
 
-        // Signal set propagates
         signal.set(200);
         assert_eq!(retrieved.get(), 200);
     }

--- a/src/reactive/mod.rs
+++ b/src/reactive/mod.rs
@@ -85,3 +85,44 @@ pub(crate) fn reset_reactive() {
     cursor::reset_cursor();
     diagnostics::reset();
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `App::drop` is the only caller, and until now nothing said what it is
+    /// for: the next `App` on this thread starts on the arena the last one
+    /// left, and an id kept across that names a signal somebody else now owns.
+    ///
+    /// Named by the mutation job on #220's diff — deleting the body of
+    /// `reset_reactive` changed nothing any test could see.
+    #[test]
+    fn resetting_leaves_nothing_for_the_next_app_to_inherit() {
+        owner::create_root_owner();
+        let _signal = create_signal(1u32);
+        provide_context(7u32);
+        assert!(
+            storage::live_signal_count() > 0,
+            "the App under test has state to wipe"
+        );
+
+        reset_reactive();
+
+        assert_eq!(
+            storage::live_signal_count(),
+            0,
+            "a signal from the last App is still in the arena the next one allocates from"
+        );
+        assert!(
+            owner::current_owner().is_none(),
+            "the next App would file its setup under a scope that no longer exists"
+        );
+
+        owner::create_root_owner();
+        assert_eq!(
+            use_context::<u32>(),
+            None,
+            "the next App would read the last one's declarations"
+        );
+    }
+}

--- a/src/reactive/mod.rs
+++ b/src/reactive/mod.rs
@@ -54,7 +54,9 @@ pub use owner::{dispose_owner, on_cleanup};
 pub use trigger::{Trigger, create_trigger};
 
 /// Internal module for macro support. NOT PART OF PUBLIC API.
-/// Do not use directly - these are re-exported for proc macros only.
+/// Do not use directly - these are re-exported for the proc macros, and for the
+/// doc tests of `context`, which need a scope to declare a value in and have no
+/// public way to open one.
 #[doc(hidden)]
 pub mod __internal {
     pub use super::owner::{OwnerId, dispose_owner_now as dispose_owner, with_owner};
@@ -81,6 +83,5 @@ pub(crate) fn reset_reactive() {
     invalidation::reset_invalidation();
     clipboard::reset_clipboard();
     cursor::reset_cursor();
-    context::reset_contexts();
     diagnostics::reset();
 }

--- a/src/reactive/owner.rs
+++ b/src/reactive/owner.rs
@@ -34,12 +34,17 @@
 //! // All signals, effects, and cleanup callbacks are now disposed
 //! ```
 
+use std::any::{Any, TypeId};
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
+use std::rc::Rc;
 
 use super::invalidation::clear_signal_subscribers;
 use super::runtime::{EffectId, SignalId, with_runtime};
 use super::storage::dispose_signal;
+
+/// The values one scope declares, in declaration order.
+type Declarations = Vec<(TypeId, Rc<dyn Any>)>;
 
 /// Unique identifier for an owner in the owner arena.
 ///
@@ -61,6 +66,18 @@ struct Owner {
     effects: Vec<EffectId>,
     cleanups: Vec<Box<dyn FnOnce()>>,
     children: Vec<OwnerId>,
+    /// Values declared for this scope and everything below it, keyed by type.
+    ///
+    /// Behind an `Option<Box<..>>` because declaring anything is the exception:
+    /// a scope is allocated per surface, per popup and per row of a dynamic
+    /// list, and almost none of them declare. Eight bytes rather than
+    /// twenty-four keeps the arena — walked on every signal and effect
+    /// registration — the size it was.
+    ///
+    /// `Rc` rather than `Box` on the value so a lookup can clone the handle and
+    /// drop the arena borrow before the value reaches a caller's closure: that
+    /// closure reads signals, and a signal read borrows the arena again.
+    contexts: Option<Box<Declarations>>,
 }
 
 impl Owner {
@@ -71,6 +88,7 @@ impl Owner {
             effects: Vec::new(),
             cleanups: Vec::new(),
             children: Vec::new(),
+            contexts: None,
         }
     }
 }
@@ -122,6 +140,13 @@ impl OwnerArena {
                 generation: 0,
             }
         }
+    }
+
+    fn get(&self, id: OwnerId) -> Option<&Owner> {
+        self.slots
+            .get(id.index as usize)
+            .filter(|slot| slot.generation == id.generation)
+            .and_then(|slot| slot.owner.as_ref())
     }
 
     fn get_mut(&mut self, id: OwnerId) -> Option<&mut Owner> {
@@ -253,6 +278,52 @@ pub fn with_owner<T>(f: impl FnOnce() -> T) -> (T, OwnerId) {
     });
 
     (under_owner(owner_id, f), owner_id)
+}
+
+/// Hand the current scope's declarations to `f`, or `None` if no scope is
+/// current.
+///
+/// What may be declared, and what a second declaration of a type means, is the
+/// caller's to decide — see `context`. This is the storage and nothing else.
+pub(crate) fn with_scope_declarations<R>(f: impl FnOnce(&mut Declarations) -> R) -> Option<R> {
+    let id = current_owner()?;
+    OWNERS.with(|owners| {
+        let mut owners = owners.borrow_mut();
+        // A current scope that is no longer in the arena is a scope that is
+        // gone, which is the same answer as none at all — and the caller has a
+        // better sentence for it than an `expect` here would.
+        let owner = owners.get_mut(id)?;
+        Some(f(owner.contexts.get_or_insert_default()))
+    })
+}
+
+/// The nearest declaration of `type_id` at or above the current scope.
+///
+/// `None` where nothing declared it and where no scope is current at all — a
+/// handler, a paint closure — which are the same answer on purpose: both mean
+/// *there is nothing here to read*.
+///
+/// The handle is cloned and the arena borrow released before it goes back to
+/// the caller, which is what lets a borrowed read hand the value to a closure
+/// that reads a signal — the shape `try_call_derived` uses, for the same
+/// reason.
+pub(crate) fn nearest_declaration(type_id: TypeId) -> Option<Rc<dyn Any>> {
+    let mut scope = current_owner();
+    OWNERS.with(|owners| {
+        let owners = owners.borrow();
+        while let Some(id) = scope {
+            let owner = owners.get(id)?;
+            let declared = owner
+                .contexts
+                .as_deref()
+                .and_then(|declarations| declarations.iter().find(|(d, _)| *d == type_id));
+            if let Some((_, value)) = declared {
+                return Some(Rc::clone(value));
+            }
+            scope = owner.parent;
+        }
+        None
+    })
 }
 
 /// Get the current owner ID, if any.


### PR DESCRIPTION
## What changed

The context store moves off a process-wide `Vec<(TypeId, Box<dyn Any>)>` and
onto the reactive scope: a value declared with `provide_context` belongs to the
owner that is current, and a read walks from the reader's scope up through its
parents to the nearest declaration — which is what Leptos, SolidJS, Floem and
Dioxus all do. An inner declaration shadows an outer one for its own subtree, a
declaration dies with its scope, a second declaration of a type in one scope is
a panic rather than a silent overwrite, and a declaration with no scope current
has nowhere to go and says so. The module's recommended example — which asked
for a `Signal<T>` where `provide_signal_context` deposits an `RwSignal<T>`, and
had panicked since #105 — is fixed and now executes. Closes #220.

The direction, the prior art behind it and the trade-offs are in #220's
comments; #221 (`.provide()` on a container) was closed as part of the same
decision, so per-container scoping is not here.

## What proves it

`src/reactive/context.rs`'s tests, fourteen of them, all new, each asserting
something the old store could not do:

- `a_sibling_scope_does_not_see_the_declaration`, `a_declaration_dies_with_the_scope_that_made_it` — the popup's dead handle, gone
- `two_scopes_declaring_one_type_each_read_their_own`, `an_inner_declaration_shadows_an_outer_one_for_its_own_scope` — the silent overwrite, gone
- `declaring_with_no_scope_current_panics`, `declaring_one_type_twice_in_a_scope_panics`
- `an_event_handler_reads_against_the_root_and_not_against_the_surface` — a tree, a real click, and the rule about where a read resolves
- seven doc tests that **execute**: the whole of defect 1 was that nothing ran them, so `ignore` was the defect and not the symptom

Full suite, clippy `-D warnings`, `cargo doc` with warnings denied, `mdbook
test` and `mdbook build`, and `cargo test --test golden_images` on lavapipe
(10 passed — nothing in the renderer moved, and no golden or snapshot is
touched).

## What the review found

**Zero blocking findings.** Four worth answering, all four fixed here:

1. A popup's scope hangs off the root, not off the surface that opened it —
   the loop opens every surface and popup scope from the root. The book's
   wording invited the opposite inference. Both the chapter and the module docs
   now say the scopes are one level deep.
2. The property-closure half was documented too generally: `OwnedWidget::layout`
   *does* re-enter its row's scope, so a read there resolves against the row
   while the same read during paint does not. Documented precisely, and filed
   as #335.
3. `docs/STATE_LAYER.md` gave "context is app-global with one value per type"
   as the reason a state layer cannot use it — the conclusion holds, the reason
   was repealed by this change. Rewritten.
4. The storage commit did not build on its own (four `dead_code` errors until
   the caller arrived). Squashed into the commit that uses it; both commits now
   pass clippy standalone, checked in a scratch worktree.

Its notes: it weighed `guido::reactive::__internal::with_owner` in the doc
tests' hidden lines and came down in favour — `no_run` would not have caught
the five-month-stale example, a public `scope(…)` is per-container scoping
which #221 closed, and the diff adds no public surface. It asked for the
`__internal` comment to stop saying "proc macros only" and for the visible
example to say where a declaration belongs; both done.

The `/simplify` pass before it applied seven changes, inside these commits:
the declaration policy moved out of `owner.rs` into `context.rs` (the arena
stores, the caller decides), the store went behind an `Option<Box<..>>`, the
test harness struct became inline steps, a shared `in_a_child_scope` fixture
replaced six copies of the same setup, and the book's signal-context sample now
compiles. It also proposed skipping the `Rc` clone in `has_context` and
`use_context`: not taken, two non-atomic refcount ops at build time cost less
than the code that would remove them.

The mutation job over this diff named one survivor — deleting the body of
`reset_reactive` changed nothing any test could see — and the third commit
closes it: an App's worth of state, a reset, and what the next App on the
thread must not find. Verified by stubbing the body out and watching the test
go red.

## What was checked by hand

Nothing — no compositor, no surface, no pixels. This is the reactive store and
its documentation; the harness sees all of it.

## Left undone

- **#335** — a context read inside a property closure resolves against the
  phase that runs it: the row's scope during layout, the root during paint. It
  is documented rather than mechanised, which #220 decided deliberately; the
  two mechanisms that would fix it, and their measured costs, are in the issue.
- Nothing pins the *shape* of the scope tree — that a popup is a child of the
  root and not of its surface is now written in the book and in the module
  docs, and no test would notice if the loop's parenting changed. It cannot be
  written from `tests/` today: `Headless` does not hold a root scope, so a test
  there cannot reproduce "the root stays current" that `App::run` establishes.
  Nobody is worse off today — the documentation is true — so this is a sentence
  rather than an issue, and the first change to that parenting is where it
  becomes one.

https://claude.ai/code/session_01Q5KL58bdTdT533XJa1ZdDn

