### PR TITLE
A derived closure runs where it was written, not where it happened to be read

### DIFF
--- a/book/src/advanced/context.md
+++ b/book/src/advanced/context.md
@@ -41,9 +41,12 @@ root, not from the surface it belongs to — so a popup reads what the
 application declared and not what the surface that opened it did, and two
 surfaces are siblings that cannot see each other's declarations.
 
-A widget factory is an ordinary function call, not a scope. A `provide_context`
-written inside one declares its value for whatever scope called it — the whole
-surface — and not for the subtree the factory is building.
+A plain widget factory is an ordinary function call, not a scope: a
+`provide_context` written inside one declares its value for whatever scope
+called it — the whole surface — and not for the subtree the factory is
+building. A closure guido *invokes* is a scope, and that is the difference: the
+factory you hand to `.child(…)` for dynamic children is called by the library,
+which opens a scope around it, so a declaration made there belongs to that row.
 
 ## Where a Read Resolves
 
@@ -51,17 +54,20 @@ In the body of the factory that builds the widgets. That is where the scope the
 value was declared for is the one that is current, so it is where guido knows
 who is asking.
 
-An event handler, a property closure and a spawned task open no scope of their
-own, so a read inside one resolves against whatever is current. For a handler
-that is the root — `App::run` enters the root scope before your setup closure
-and never leaves it — so the application's declarations are readable from one
-and a surface's are not. For a property closure it depends on when the closure
-is read: laying out a dynamic list re-enters that row's scope and painting does
-not, so one read can resolve against two different scopes on two phases of a
-frame.
+A **property closure** resolves where it was written, whenever it is read. The
+closure you hand a builder becomes a derived signal, and the scope that was
+current when the builder ran travels with it — so a property declared in a row
+of a dynamic list reads that row's declarations on every phase of every frame,
+and not the row's while laying out and the application's while painting.
 
-Read the value once in the factory body and capture it, and the question does
-not arise:
+An **event handler** and a **spawned task** open no scope and carry none, so a
+read inside one resolves against whatever is current, which in a running
+application is the root: `App::run` enters the root scope before your setup
+closure and never leaves it. The application's declarations are readable from a
+handler; a surface's are not.
+
+Reading the value once in the factory body and capturing it works everywhere,
+and is still the clearest thing to write:
 
 ```rust
 # extern crate guido;
@@ -73,7 +79,7 @@ fn themed_box() -> Container {
     let theme = expect_context::<RwSignal<Theme>>();   // here: a scope is current
 
     container()
-        .background(move || theme.get().bg_color)      // not here: the handle is captured
+        .background(move || theme.get().bg_color)      // or here: the closure keeps this scope
         .child(text(move || theme.get().title.clone()))
 }
 # }

--- a/src/reactive/context.rs
+++ b/src/reactive/context.rs
@@ -15,17 +15,19 @@
 //! the value was declared for is the scope that is current, so it is where the
 //! library knows who is asking.
 //!
-//! An event handler, a property closure and a spawned task open no scope of
-//! their own, so a read inside one resolves against whatever is current. For a
-//! handler that is the root — `App::run` enters the root scope before the setup
-//! closure and never leaves it — so the application's declarations are readable
-//! from one and a surface's are not. For a property closure it depends on when
-//! the closure is read: laying out a dynamic list re-enters that row's scope,
-//! painting does not, so the same read can resolve against two different scopes
-//! on two phases of one frame.
+//! A **property closure** resolves where it was written, whenever it is read. A
+//! closure handed to a builder becomes a derived signal, and the scope that was
+//! current when the builder ran travels with it — so a property declared in a
+//! row of a dynamic list reads that row's declarations on every phase of every
+//! frame, rather than the row's during layout and the application's during
+//! paint (#335).
 //!
-//! Read the value once in the factory body and capture the handle into the
-//! closure, and none of that arises:
+//! An **event handler** and a **spawned task** open no scope and carry none, so
+//! a read inside one resolves against whatever is current, which in a running
+//! application is the root: `App::run` enters the root scope before the setup
+//! closure and never leaves it. The application's declarations are readable
+//! from a handler; a surface's are not. Read the value in the factory body and
+//! capture the handle, and the question does not arise:
 //!
 //! ```
 //! # use guido::prelude::*;
@@ -36,7 +38,7 @@
 //! # provide_signal_context(Theme::default());
 //! fn themed_box() -> Container {
 //!     let theme = expect_context::<RwSignal<Theme>>();   // here: a scope is current
-//!     container().background(move || theme.get().bg)     // not here: the handle is captured
+//!     container().background(move || theme.get().bg)     // or here: the closure keeps this scope
 //! }
 //! # themed_box();
 //! # });
@@ -80,6 +82,10 @@ use super::signal::{RwSignal, create_signal};
 /// If no scope is current at all, or if this scope already declares the type —
 /// two of a type is what shadowing is for, and shadowing needs two scopes.
 ///
+/// A property closure is not a place to declare from, though it is a scope: it
+/// runs once per read, so the second read declares a type its own scope already
+/// has, and that is the panic you get.
+///
 /// # Example
 ///
 /// ```
@@ -112,8 +118,8 @@ pub fn provide_context<T: 'static>(value: T) {
         declared.is_some(),
         "`{}` was declared where no scope is current.\n\
          A value belongs to a scope — the application's setup, a surface, a \
-         popup, a dynamic list — and an event handler, a property closure or a \
-         spawned task is none of them. Declare it where the tree is built.",
+         popup, a dynamic list — and an event handler or a spawned task is \
+         neither. Declare it where the tree is built.",
         type_name::<T>()
     );
 }
@@ -168,9 +174,9 @@ pub fn expect_context<T: Clone + 'static>() -> T {
     use_context::<T>().unwrap_or_else(|| {
         panic!(
             "No value of type `{}` is declared in this scope or any above it.\n\
-             Either nothing declared it, or the read happened outside the scope \
-             it was declared for — an event handler, a property closure and a \
-             spawned task read against the root. Read it in the factory body and \
+             Either nothing declared it, or the read happened somewhere that \
+             carries no scope of its own — an event handler or a spawned task, \
+             which read against the root. Read it in the factory body and \
              capture the value into the closure.",
             type_name::<T>()
         )
@@ -359,6 +365,25 @@ mod tests {
             use_context::<RwSignal<i32>>().is_none(),
             "the handle went with the scope rather than outliving it"
         );
+    }
+
+    /// A property closure is a scope — the one it was written in, entered on
+    /// every read (#335) — so declaring from inside one declares into that
+    /// scope once per read, and the second read is a duplicate.
+    ///
+    /// Not a rule anybody would want, but the truthful consequence of the one
+    /// above it, and worth pinning: the message a caller meets depends on it.
+    #[test]
+    #[should_panic(expected = "already declared in this scope")]
+    fn declaring_from_a_property_closure_declares_once_per_read() {
+        create_root_owner();
+        let property = crate::reactive::create_derived(|| {
+            provide_context(1u32);
+            0u32
+        });
+
+        property.get();
+        property.get();
     }
 
     /// A declaration needs somewhere to live. With no scope current — an event

--- a/src/reactive/mod.rs
+++ b/src/reactive/mod.rs
@@ -126,3 +126,115 @@ mod tests {
         );
     }
 }
+
+#[cfg(test)]
+mod bench {
+    use std::time::{Duration, Instant};
+
+    use super::*;
+
+    /// A frame of a list, which is where the per-read number lands: three
+    /// hundred rows of four reactive properties each, laid out and painted the
+    /// way `render_surface` does, with a signal moved between frames so the
+    /// work is real rather than cached.
+    ///
+    /// `cargo test --release --lib bench:: -- --ignored --nocapture`
+    #[test]
+    #[ignore]
+    fn a_frame_of_three_hundred_rows() {
+        use crate::layout::Constraints;
+        use crate::renderer::{PaintContext, RenderNode};
+        use crate::tree::Tree;
+        use crate::widgets::widget::Color;
+        use crate::widgets::{Widget, container};
+
+        owner::create_root_owner();
+        let width = create_signal(40.0f32);
+
+        let rows: Vec<_> = (0..300)
+            .map(|row| {
+                container()
+                    .width(move || width.get() + row as f32 % 3.0)
+                    .height(move || 12.0 + row as f32 % 2.0)
+                    .background(move || Color::rgb(0.1 + width.get() / 400.0, 0.2, 0.3))
+                    .padding(move || width.get() / 20.0)
+            })
+            .collect();
+
+        let mut tree = Tree::new();
+        let root = tree.register(Box::new(container().children(rows)) as Box<dyn Widget>);
+        tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
+
+        let frames = 200u32;
+        let best = (0..5)
+            .map(|_| {
+                let started = Instant::now();
+                for frame in 0..frames {
+                    width.set(40.0 + (frame % 7) as f32);
+                    tree.with_widget_mut(root, |w, id, t| {
+                        w.layout(t, id, Constraints::new(0.0, 0.0, 400.0, 4000.0));
+                    });
+                    let mut node = RenderNode::new(root.as_u64());
+                    tree.with_widget_mut(root, |w, id, t| {
+                        let mut ctx = PaintContext::new(&mut node);
+                        w.paint(t, id, &mut ctx);
+                    });
+                    std::hint::black_box(&node);
+                }
+                started.elapsed() / frames
+            })
+            .min()
+            .expect("five rounds");
+
+        println!("a frame of 300 rows: {best:?}");
+    }
+
+    /// Not a test: the number for #335, which is what a derived read costs
+    /// now that it enters the scope it was written in.
+    /// `cargo test --release --lib bench:: -- --ignored --nocapture`
+    ///
+    /// Best of five in one process: the machine is noisy enough that two
+    /// separate runs say nothing about each other.
+    #[test]
+    #[ignore]
+    fn a_derived_read() {
+        owner::create_root_owner();
+        let source = create_signal(1u32);
+        let derived = create_derived(move || source.get() + 1);
+
+        let rounds = 1_000_000u32;
+        let best = |derived: Signal<u32>| -> Duration {
+            (0..5)
+                .map(|_| {
+                    let started = Instant::now();
+                    for _ in 0..rounds {
+                        std::hint::black_box(derived.get());
+                    }
+                    started.elapsed()
+                })
+                .min()
+                .expect("five rounds")
+        };
+
+        // Warm everything: the closure, the subscription bookkeeping, the caches.
+        for _ in 0..100_000 {
+            std::hint::black_box(derived.get());
+        }
+
+        // Read from the scope the closure was written in — every read during
+        // layout, where `OwnedWidget::layout` has already entered the row's
+        // scope — and then from another scope, which is every read during
+        // paint, where nothing has.
+        let from_its_own_scope = best(derived);
+        let (from_elsewhere, elsewhere) = owner::with_owner(|| best(derived));
+        owner::dispose_owner_now(elsewhere);
+
+        // Reported as the whole loop as well as the quotient: the per-read
+        // figure is a whole number of nanoseconds against an effect of one or
+        // two, so on its own it can only bound the cost.
+        println!(
+            "{rounds} derived reads: {from_its_own_scope:?} from their own \
+             scope, {from_elsewhere:?} from another"
+        );
+    }
+}

--- a/src/reactive/owner.rs
+++ b/src/reactive/owner.rs
@@ -37,6 +37,7 @@
 use std::any::{Any, TypeId};
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
+use std::num::NonZeroU32;
 use std::rc::Rc;
 
 use super::invalidation::clear_signal_subscribers;
@@ -51,10 +52,14 @@ type Declarations = Vec<(TypeId, Rc<dyn Any>)>;
 /// Generational: the arena recycles slot indices and bumps the generation on
 /// every reuse, so a stale `OwnerId` held after disposal can never dispose or
 /// mutate an unrelated owner that later occupied the same slot.
+///
+/// The generation counts from one so that zero is free to be the niche: an
+/// `Option<OwnerId>` is eight bytes rather than twelve, which is what
+/// `Owner::parent` and every derived closure's captured scope are made of.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub struct OwnerId {
     index: u32,
-    generation: u32,
+    generation: NonZeroU32,
 }
 
 /// An owner that manages the lifecycle of reactive primitives.
@@ -97,7 +102,7 @@ impl Owner {
 /// indices can be distinguished from their previous occupants.
 struct OwnerSlot {
     owner: Option<Owner>,
-    generation: u32,
+    generation: NonZeroU32,
 }
 
 /// Arena-based storage for owners with slot recycling.
@@ -123,7 +128,9 @@ impl OwnerArena {
         let owner = Owner::new(parent);
         if let Some(index) = self.free_indices.pop() {
             let slot = &mut self.slots[index as usize];
-            slot.generation = slot.generation.wrapping_add(1);
+            // Wrapping, and skipping zero on the way round: zero is what makes
+            // `Option<OwnerId>` eight bytes.
+            slot.generation = slot.generation.checked_add(1).unwrap_or(NonZeroU32::MIN);
             slot.owner = Some(owner);
             OwnerId {
                 index,
@@ -133,11 +140,11 @@ impl OwnerArena {
             let index = self.slots.len() as u32;
             self.slots.push(OwnerSlot {
                 owner: Some(owner),
-                generation: 0,
+                generation: NonZeroU32::MIN,
             });
             OwnerId {
                 index,
-                generation: 0,
+                generation: NonZeroU32::MIN,
             }
         }
     }
@@ -172,7 +179,10 @@ impl OwnerArena {
 }
 
 thread_local! {
-    static CURRENT_OWNER: RefCell<Option<OwnerId>> = const { RefCell::new(None) };
+    /// A `Cell` rather than a `RefCell`: an `OwnerId` is `Copy`, nothing ever
+    /// holds a borrow of this across a call, and every derived read swaps it —
+    /// so the borrow flag was bookkeeping on the hottest path in the library.
+    static CURRENT_OWNER: Cell<Option<OwnerId>> = const { Cell::new(None) };
     static OWNERS: RefCell<OwnerArena> = RefCell::new(OwnerArena::new());
     /// Remembered so [`with_root_owner`] can reach it from any depth.
     static ROOT_OWNER: Cell<Option<OwnerId>> = const { Cell::new(None) };
@@ -185,7 +195,7 @@ thread_local! {
 /// disposed, all signals, effects, and cleanup callbacks cascade.
 pub(crate) fn create_root_owner() -> OwnerId {
     let id = OWNERS.with(|owners| owners.borrow_mut().allocate(None));
-    CURRENT_OWNER.with(|current| *current.borrow_mut() = Some(id));
+    CURRENT_OWNER.with(|current| current.set(Some(id)));
     ROOT_OWNER.with(|root| root.set(Some(id)));
     id
 }
@@ -195,7 +205,7 @@ pub(crate) fn create_root_owner() -> OwnerId {
 /// Called during `App::drop()` after `dispose_owner()` has cleaned up the
 /// reactive graph. This wipes the arena so the next `App` run starts fresh.
 pub(crate) fn reset_owners() {
-    CURRENT_OWNER.with(|c| *c.borrow_mut() = None);
+    CURRENT_OWNER.with(|c| c.set(None));
     ROOT_OWNER.with(|root| root.set(None));
     OWNERS.with(|o| *o.borrow_mut() = OwnerArena::new());
     // With them, anything queued against them. Owner ids restart from zero
@@ -229,8 +239,8 @@ pub(crate) fn with_root_owner<T>(f: impl FnOnce() -> T) -> T {
 /// Run `f` with `owner_id` as the current owner, whatever it was before.
 ///
 /// The one place `CURRENT_OWNER` is swapped: [`with_owner`] allocates a scope
-/// and hands it here, [`with_root_owner`] names the root, and a widget names its
-/// own. Restoring on unwind is why they all go through it — a leaked scope
+/// and hands it here, [`with_root_owner`] names the root, and a widget names
+/// its own. Restoring on unwind is why they all go through it — a leaked scope
 /// silently re-parents every reactive resource created afterwards, and the copy
 /// that forgot the guard is the one that would have done it.
 ///
@@ -240,9 +250,7 @@ pub(crate) fn with_root_owner<T>(f: impl FnOnce() -> T) -> T {
 pub(crate) fn under_owner<T>(owner_id: OwnerId, f: impl FnOnce() -> T) -> T {
     let previous = CURRENT_OWNER.with(|current| current.replace(Some(owner_id)));
     let _guard = crate::reactive::guard::defer(move || {
-        CURRENT_OWNER.with(|current| {
-            *current.borrow_mut() = previous;
-        });
+        CURRENT_OWNER.with(|current| current.set(previous));
     });
     f()
 }
@@ -262,7 +270,7 @@ pub(crate) fn under_owner<T>(owner_id: OwnerId, f: impl FnOnce() -> T) -> T {
 /// Use `on_cleanup` for registering cleanup callbacks in user code.
 pub fn with_owner<T>(f: impl FnOnce() -> T) -> (T, OwnerId) {
     // Allocate new owner and register as child of current owner (if any)
-    let parent_id = CURRENT_OWNER.with(|current| *current.borrow());
+    let parent_id = CURRENT_OWNER.with(Cell::get);
     let owner_id = OWNERS.with(|owners| {
         let mut owners = owners.borrow_mut();
         let id = owners.allocate(parent_id);
@@ -330,7 +338,7 @@ pub(crate) fn nearest_declaration(type_id: TypeId) -> Option<Rc<dyn Any>> {
 ///
 /// Returns `None` if not currently inside an owner scope.
 pub fn current_owner() -> Option<OwnerId> {
-    CURRENT_OWNER.with(|current| *current.borrow())
+    CURRENT_OWNER.with(Cell::get)
 }
 
 /// Dispose an owner and all its resources.
@@ -871,6 +879,16 @@ mod tests {
         // Both should be disposed
         assert!(!effect_has_owner(inner_effect));
         assert!(!effect_has_owner(outer_effect));
+    }
+
+    /// The niche is the whole point of the `NonZeroU32`. `Option<OwnerId>` is
+    /// what `Owner::parent` and every derived closure's captured scope are made
+    /// of; twelve bytes there was four spent on a tag the generation can carry
+    /// itself, on a structure allocated per surface, per popup and per row.
+    #[test]
+    fn an_optional_owner_id_costs_no_more_than_an_owner_id() {
+        assert_eq!(size_of::<OwnerId>(), 8);
+        assert_eq!(size_of::<Option<OwnerId>>(), size_of::<OwnerId>());
     }
 
     #[test]

--- a/src/reactive/owner.rs
+++ b/src/reactive/owner.rs
@@ -239,8 +239,9 @@ pub(crate) fn with_root_owner<T>(f: impl FnOnce() -> T) -> T {
 /// Run `f` with `owner_id` as the current owner, whatever it was before.
 ///
 /// The one place `CURRENT_OWNER` is swapped: [`with_owner`] allocates a scope
-/// and hands it here, [`with_root_owner`] names the root, and a widget names
-/// its own. Restoring on unwind is why they all go through it — a leaked scope
+/// and hands it here, [`with_root_owner`] names the root, a widget names its
+/// own, and [`under_scope`] names the one a derived closure was written in —
+/// which is the frequent one, once per read of a reactive property. Restoring on unwind is why they all go through it — a leaked scope
 /// silently re-parents every reactive resource created afterwards, and the copy
 /// that forgot the guard is the one that would have done it.
 ///
@@ -253,6 +254,27 @@ pub(crate) fn under_owner<T>(owner_id: OwnerId, f: impl FnOnce() -> T) -> T {
         CURRENT_OWNER.with(|current| current.set(previous));
     });
     f()
+}
+
+/// Run `f` under `scope`, where there is one and it is not already current.
+///
+/// Two things are nothing to do, and both are common: a closure written outside
+/// any scope has none to enter, and entering the scope that is already current
+/// changes nothing — which is every read during layout, since
+/// `OwnedWidget::layout` has entered the row's scope before any of its
+/// properties are read.
+///
+/// The second is worth its branch and then some. Without it a frame of three
+/// hundred rows measured 77.5µs against 56.5µs with it — the swap is cheap and
+/// a frame does it thousands of times. It is also invisible to every test,
+/// because entering the scope you are already in is a no-op by definition: the
+/// mutation job reports the guard as unkilled and always will, and the
+/// benchmark in `reactive::bench` is what holds it instead.
+pub(crate) fn under_scope<T>(scope: Option<OwnerId>, f: impl FnOnce() -> T) -> T {
+    match scope {
+        Some(scope) if current_owner() != Some(scope) => under_owner(scope, f),
+        _ => f(),
+    }
 }
 
 /// Execute a closure within a new owner scope.

--- a/src/reactive/storage.rs
+++ b/src/reactive/storage.rs
@@ -21,6 +21,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
 
+use super::owner::{OwnerId, current_owner, under_scope};
 use super::runtime::SignalId;
 
 type SignalValue = Rc<dyn Any>;
@@ -166,12 +167,30 @@ pub fn allocate_signal_slot() -> SignalId {
     alloc_slot(Rc::new(()))
 }
 
+/// A derived signal's closure, and the scope it was written in.
+///
+/// The scope travels with the closure because the two are separated in time: a
+/// property is declared once, in a widget factory, and its body runs on every
+/// read from whatever phase reads it. Resolving a context against *that* would
+/// answer the row's declaration when layout asked and nothing when paint did
+/// (#335), so the closure carries where it was written and is run there.
+///
+/// The scope is held inside the `Rc`'s allocation rather than beside it in the
+/// map: the entry stays one 16-byte handle, and the eight bytes go where an
+/// allocation already was.
+struct Derived<T> {
+    scope: Option<OwnerId>,
+    call: Box<dyn Fn() -> T>,
+}
+
 /// Store a derived closure for the given signal ID.
 pub fn store_derived_closure<T: Clone + 'static>(id: SignalId, closure: impl Fn() -> T + 'static) {
+    let derived = Derived {
+        scope: current_owner(),
+        call: Box::new(closure),
+    };
     STORAGE.with(|storage| {
-        let mut storage = storage.borrow_mut();
-        let boxed: Box<dyn Fn() -> T> = Box::new(closure);
-        storage.derived.insert(id, Rc::new(boxed));
+        storage.borrow_mut().derived.insert(id, Rc::new(derived));
     });
 }
 
@@ -187,14 +206,14 @@ pub fn try_call_derived<T: Clone + 'static>(id: SignalId) -> Option<T> {
 
     // Phase 2: storage borrow released — call the closure
     closure_rc.map(|rc| {
-        let closure = rc.downcast_ref::<Box<dyn Fn() -> T>>().unwrap_or_else(|| {
+        let derived = rc.downcast_ref::<Derived<T>>().unwrap_or_else(|| {
             panic!(
                 "Derived signal {} type mismatch: closure return type does not match {}",
                 id,
                 std::any::type_name::<T>()
             )
         });
-        closure()
+        under_scope(derived.scope, || (derived.call)())
     })
 }
 
@@ -415,5 +434,40 @@ mod dispose_write_tests {
         dispose_owner_now(owner);
         sig.set(2); // must not panic
         sig.update(|v| *v += 1); // must not panic
+    }
+}
+
+#[cfg(test)]
+mod derived_scope_tests {
+    use super::live_signal_count;
+    use crate::reactive::owner::{dispose_owner_now, with_owner};
+    use crate::reactive::{create_derived, create_signal};
+
+    /// The other half of #335's rule: a derived closure's body runs under the
+    /// scope the closure was written in, so what the body *makes* is filed
+    /// there too — not under whoever happened to read it.
+    ///
+    /// Read from outside that scope, and with the reads' signals filed under
+    /// nothing, they would outlive the closure that made them for the life of
+    /// the application. Disposing the scope has to take them.
+    #[test]
+    fn what_a_derived_body_makes_belongs_to_the_scope_the_closure_was_written_in() {
+        let baseline = live_signal_count();
+
+        let (derived, scope) = with_owner(|| create_derived(|| create_signal(7u32).get()));
+        assert_eq!(derived.get(), 7);
+        assert_eq!(derived.get(), 7);
+        assert!(
+            live_signal_count() > baseline,
+            "the reads made signals, which is what this is about"
+        );
+
+        dispose_owner_now(scope);
+
+        assert_eq!(
+            live_signal_count(),
+            baseline,
+            "everything the closure made went with the scope it was written in"
+        );
     }
 }

--- a/tests/context_in_a_property_closure.rs
+++ b/tests/context_in_a_property_closure.rs
@@ -1,0 +1,127 @@
+//! One read, two answers — #335.
+//!
+//! A property closure becomes a derived signal when the builder runs and its
+//! body runs later, when something reads it. What scope is current then is not
+//! the same on both phases of a frame: laying out a dynamic list re-enters that
+//! row's scope (`OwnedWidget::layout`), painting does not. So two properties
+//! written side by side, reading the same context, could disagree — the row's
+//! value in layout, nothing in paint.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use guido::prelude::*;
+
+mod common;
+use common::Harness;
+
+/// What a property closure saw, in the order the frame asked.
+type Seen = Rc<RefCell<Vec<(&'static str, Option<u32>)>>>;
+
+/// A row in a dynamic list — the library opens a scope for the factory, so the
+/// declaration belongs to the row rather than to the surface around it.
+///
+/// Two properties on one container, reading the same declaration: `width` is
+/// read when the tree is laid out, `background` when it is painted.
+fn a_row_declaring_its_own_value(seen: Seen) -> Container {
+    let for_layout = Rc::clone(&seen);
+    let for_paint = seen;
+
+    container().width(fill()).height(fill()).child(move || {
+        // The factory runs once per build of the row, so its captures are
+        // cloned rather than moved out.
+        let for_layout = Rc::clone(&for_layout);
+        let for_paint = Rc::clone(&for_paint);
+        provide_context(42u32);
+
+        container()
+            .width(move || {
+                for_layout
+                    .borrow_mut()
+                    .push(("layout", use_context::<u32>()));
+                80.0
+            })
+            .height(20.0)
+            .background(move || {
+                for_paint.borrow_mut().push(("paint", use_context::<u32>()));
+                Color::rgb(0.5, 0.5, 0.5)
+            })
+    })
+}
+
+#[test]
+fn a_property_closure_reads_the_same_scope_on_both_phases_of_a_frame() {
+    let seen: Seen = Rc::default();
+    let mut surface = Harness::new(a_row_declaring_its_own_value(Rc::clone(&seen)));
+
+    surface.lay_out(200.0, 100.0);
+    surface.paint();
+
+    let seen = seen.borrow();
+    let in_layout: Vec<Option<u32>> = seen
+        .iter()
+        .filter(|(phase, _)| *phase == "layout")
+        .map(|(_, value)| *value)
+        .collect();
+    let in_paint: Vec<Option<u32>> = seen
+        .iter()
+        .filter(|(phase, _)| *phase == "paint")
+        .map(|(_, value)| *value)
+        .collect();
+
+    assert!(
+        !in_layout.is_empty() && !in_paint.is_empty(),
+        "both phases have to have read something for this to say anything: \
+         layout {in_layout:?}, paint {in_paint:?}"
+    );
+    assert_eq!(
+        in_layout[0], in_paint[0],
+        "one read, two answers: the row's declaration is visible to a property \
+         closure evaluated during layout and not to one evaluated during paint"
+    );
+    assert_eq!(
+        in_layout[0],
+        Some(42),
+        "and the answer is the scope the closure was written in"
+    );
+}
+
+/// The other half of the same rule: a closure written where nothing declared
+/// the type reads nothing, on either phase, rather than picking up whatever the
+/// scope it happens to be evaluated under has.
+#[test]
+fn a_property_closure_outside_the_declaration_reads_nothing_on_either_phase() {
+    let seen: Seen = Rc::default();
+    let for_layout = Rc::clone(&seen);
+    let for_paint = Rc::clone(&seen);
+
+    let mut surface = Harness::new(
+        container()
+            .width(move || {
+                for_layout
+                    .borrow_mut()
+                    .push(("layout", use_context::<u32>()));
+                80.0
+            })
+            .height(20.0)
+            .background(move || {
+                for_paint.borrow_mut().push(("paint", use_context::<u32>()));
+                Color::rgb(0.5, 0.5, 0.5)
+            })
+            .child(|| {
+                provide_context(42u32);
+                container().width(10.0).height(10.0)
+            }),
+    );
+
+    surface.lay_out(200.0, 100.0);
+    surface.paint();
+
+    for (phase, value) in seen.borrow().iter() {
+        assert_eq!(
+            *value, None,
+            "a declaration inside the row is not above the closure that reads \
+             here, on either phase — {phase} saw {value:?}"
+        );
+    }
+}


### PR DESCRIPTION
## What changed

A derived signal's closure now carries the scope it was created in and is run
there. A property closure is written once, in a widget factory, and its body
runs on every read — so what scope was current then decided what a context read
inside it saw, and that was not the same on both phases of a frame: laying out
a dynamic list re-enters that row's scope, painting does not. Two properties
written side by side, reading the same declaration, disagreed. Now they cannot:
the closure resolves where it was written, whenever it is read. Closes #335.

It fixes the same asymmetry in the other direction too. What a derived body
*creates* is filed where the closure was written rather than under whoever read
it — during a paint that meant under nothing at all, which is a signal that is
never freed.

Two supporting changes make carrying a scope cheap, in their own commit:
`CURRENT_OWNER` becomes a `Cell` (it holds a `Copy` id and nothing borrows it
across a call), and `OwnerId`'s generation counts from one so zero is free to be
the niche — `Option<OwnerId>` is eight bytes rather than twelve, which takes
`Owner` back to the 112 bytes it was before #336 put the context store on it.

## What proves it

- `tests/context_in_a_property_closure.rs` — a row of a dynamic list declaring
  its own value, read by two properties on one container: one read during
  layout, one during paint, asserted equal. Fails on `main` with
  `left: Some(42), right: None`.
- `src/reactive/storage.rs::derived_scope_tests` — what a derived body creates
  belongs to the scope the closure was written in. Fails on `main` with two
  orphaned signals.
- `src/reactive/context.rs::declaring_from_a_property_closure_declares_once_per_read`
  — the consequence a caller can hit: a property closure *is* a scope now, so
  declaring from inside one declares into it once per read and the second read
  is a duplicate. New behaviour, pinned rather than discovered.
- `src/reactive/owner.rs::an_optional_owner_id_costs_no_more_than_an_owner_id`
  — the niche, which is the whole point of the `NonZeroU32`.
- The second test in the new file passes on `main`: it guards the mechanism
  rather than proving it.

Full suite, clippy `-D warnings`, `cargo doc` denied, `mdbook test` and
`mdbook build`, goldens 10/10 on lavapipe. Nothing in the renderer moved and no
golden or snapshot is touched.

**Measurements**, on this machine, each pair run back to back against the same
tree without the change. Both instruments are `#[ignore]`d benches in
`src/reactive/mod.rs`, run with `cargo test --release --lib bench:: --
--ignored --nocapture`; CI runs neither.

| | before | after |
| --- | --- | --- |
| 1,000,000 derived reads | 21.2-22.4 ms | 21.3-21.5 ms |
| a frame: 300 rows × 4 reactive properties, laid out and painted | 56.4 µs | 56.3 µs |

Per read the difference is inside the instrument's noise; per frame there is
none. **That is not free by nature — it is one branch.** `under_scope` declines
to enter a scope that is already current, which is every read during layout,
since `OwnedWidget::layout` has entered the row's scope before any of its
properties are read. Removing that branch and measuring again gives **77.5 µs a
frame**, a third again, reproducible across three runs each way.

**On the red mutation check:** the survivor is that branch — replacing
`current_owner() != Some(scope)` with `true`. It is unkillable by construction:
entering the scope you are already in is a no-op, so no observable behaviour
separates the mutant from the original, and only a benchmark can tell them
apart. I tried the alternative first — deleting the branch, which kills the
mutant — and the frame measurement above is why it is back. The job reports
rather than blocks, per AGENTS.md; this is the case it was describing.

## What the review found

**Zero blocking findings.** Three worth answering, all three acted on:

1. `expect_context`'s panic still prescribed the workaround for the defect this
   PR removes, and `provide_context`'s named a property closure as somewhere
   without a scope — the copy a user meets at the moment of failure. Both
   rewritten, and the behaviour that replaces the second one is now a test.
2. The issue asked for two numbers and the branch had one. The frame benchmark
   is the second, and it is in the table above.
3. The chapter read as two rules — "a widget factory is not a scope" beside a
   new paragraph that depends on a dynamic child's factory being one. The
   difference is drawn now: a plain call is not a scope, a closure guido invokes
   is.

Its notes, acted on: the benchmark reports the whole loop as well as the
quotient, since the per-read figure is a whole number of nanoseconds against an
effect of one; `under_owner`'s doc names its fourth and now most frequent
caller; and the book sample's `// not here` annotation, which said the opposite
of what is true now.

It verified the lifetime consequence rather than taking it on trust: it
enumerated every `create_signal`/`create_memo`/`create_effect` site in `src/`
and none is inside a derived body, and it confirmed the captured `OwnerId` can
never come to name a different owner, because the closure and its scope are
registered together and the arena is generational.

## What was checked by hand

Nothing — no compositor, no surface, no pixels. The two benchmarks were run by
hand, and their numbers are above.

## Left undone

- **#337** — an effect's re-run, and therefore a memo's recomputation, still
  does not re-enter the scope it was written in: `run_effect_by_id` swaps
  nothing, so the first computation reads the row and every one after it reads
  the root. #335's comment claimed this mechanism covers reads outside the tree
  walk; it covers them only where the read goes through a derived signal, and
  the rest needs an argument about ownership that #335 did not need to have.
- The `book/src/advanced/context.md` sentence about a plain factory not being a
  scope was already there and already imprecise; it is corrected here rather
  than left, because the paragraph this PR adds sits directly beneath it.

https://claude.ai/code/session_01Q5KL58bdTdT533XJa1ZdDn

