### PR TITLE
An effect body runs in the scope the effect was created in, on every run and not just the first

### DIFF
--- a/book/src/advanced/context.md
+++ b/book/src/advanced/context.md
@@ -60,11 +60,18 @@ current when the builder ran travels with it — so a property declared in a row
 of a dynamic list reads that row's declarations on every phase of every frame,
 and not the row's while laying out and the application's while painting.
 
-An **event handler** and a **spawned task** open no scope and carry none, so a
-read inside one resolves against whatever is current, which in a running
-application is the root: `App::run` enters the root scope before your setup
-closure and never leaves it. The application's declarations are readable from a
-handler; a surface's are not.
+An **effect** and a **memo** are the same story on a different clock. Their
+bodies run once where they were created and again whenever a dependency
+changes — and that second run happens at a flush, which belongs to the
+application rather than to whatever declared the value. They carry their scope
+too, so a memo of a row's declaration is that row's on its first computation and
+on every one after it.
+
+An **event handler** and a **spawned task** are what is left: they open no
+scope and carry none, so a read inside one resolves against whatever is
+current, which in a running application is the root — `App::run` enters the
+root scope before your setup closure and never leaves it. The application's
+declarations are readable from a handler; a surface's are not.
 
 Reading the value once in the factory body and capturing it works everywhere,
 and is still the clearest thing to write:

--- a/docs/REACTIVE.md
+++ b/docs/REACTIVE.md
@@ -187,7 +187,8 @@ name.set("Guido".to_string()); // Effect re-runs, prints: Hello, Guido!
 
 A signal belongs to the scope that was current when it was created, and that
 scope is ambient: inside a widget factory it is that surface's, inside a click
-handler the root, on an effect's first run whoever created the effect. For the
+handler the root, inside an effect or a property closure the scope that effect
+or closure was written in — on every run of it, not only the first. For the
 handful of things with one instance per process — what the compositor reports,
 where the keyboard focus is — the owner is none of those. It is the
 application.

--- a/src/reactive/context.rs
+++ b/src/reactive/context.rs
@@ -22,12 +22,20 @@
 //! frame, rather than the row's during layout and the application's during
 //! paint (#335).
 //!
-//! An **event handler** and a **spawned task** open no scope and carry none, so
-//! a read inside one resolves against whatever is current, which in a running
-//! application is the root: `App::run` enters the root scope before the setup
-//! closure and never leaves it. The application's declarations are readable
-//! from a handler; a surface's are not. Read the value in the factory body and
-//! capture the handle, and the question does not arise:
+//! An **effect** and a **memo** are the same story on a different clock. Their
+//! bodies run once where they were created and again whenever a dependency
+//! changes — and that second run happens at a flush, which belongs to the
+//! application rather than to whatever declared the value. They carry their
+//! scope too, so a memo of a row's declaration is that row's
+//! on its first computation and on every one after it (#337).
+//!
+//! An **event handler** and a **spawned task** are what is left: they open no
+//! scope and carry none, so a read inside one resolves against whatever is
+//! current, which in a running application is the root — `App::run` enters the
+//! root scope before the setup closure and never leaves it. The application's
+//! declarations are readable from a handler; a surface's are not. Read the
+//! value in the factory body and capture the handle, and the question does not
+//! arise:
 //!
 //! ```
 //! # use guido::prelude::*;
@@ -365,6 +373,120 @@ mod tests {
             use_context::<RwSignal<i32>>().is_none(),
             "the handle went with the scope rather than outliving it"
         );
+    }
+
+    /// A memo's body is an effect body, and it runs twice: once where it was
+    /// created, and again whenever a dependency changes — which happens at the
+    /// flush, with the root current. So the row's declaration answered the
+    /// first computation and the application's answered every one after it
+    /// (#337).
+    #[test]
+    fn a_memo_reads_its_own_scope_on_every_recomputation() {
+        create_root_owner();
+        provide_context("the application's".to_string());
+        let trigger = create_signal(0u32);
+
+        let (memo, row) = with_owner(|| {
+            provide_context("the row's".to_string());
+            crate::reactive::create_memo(move || {
+                trigger.get();
+                use_context::<String>()
+            })
+        });
+
+        assert_eq!(
+            memo.get().as_deref(),
+            Some("the row's"),
+            "the first computation runs where the memo was created"
+        );
+
+        trigger.set(1);
+
+        assert_eq!(
+            memo.get().as_deref(),
+            Some("the row's"),
+            "and so does every one after it"
+        );
+        dispose_owner_now(row);
+    }
+
+    /// The same for a bare effect, which is what a memo is made of: its re-run
+    /// is scheduled, and what scope the schedule happens to be flushed under is
+    /// not the effect's business.
+    #[test]
+    fn an_effect_reads_its_own_scope_on_every_run() {
+        create_root_owner();
+        provide_context("the application's".to_string());
+        let trigger = create_signal(0u32);
+
+        let seen = Rc::new(Cell::new(None));
+        let recorder = Rc::clone(&seen);
+        let ((), row) = with_owner(move || {
+            provide_context("the row's".to_string());
+            crate::reactive::create_effect(move || {
+                trigger.get();
+                recorder.set(use_context::<String>());
+            });
+        });
+
+        assert_eq!(seen.take().as_deref(), Some("the row's"), "the first run");
+
+        trigger.set(1);
+
+        assert_eq!(
+            seen.take().as_deref(),
+            Some("the row's"),
+            "and the run the change scheduled"
+        );
+        dispose_owner_now(row);
+    }
+
+    /// An effect's slot is recycled when the effect is disposed, and the next
+    /// effect gets it — a row of a list going away hands its memo's slot to the
+    /// row that replaces it. The scope in that slot has to be replaced with the
+    /// new effect's, and nothing else says so: the two tests above run in a
+    /// process where nothing has been freed yet, so they only ever see a fresh
+    /// slot.
+    ///
+    /// With the slot's scope left as it was, this reads a scope that has been
+    /// disposed — `None`, and a signal made there would register nowhere.
+    #[test]
+    fn an_effect_in_a_recycled_slot_reads_its_own_scope_and_not_the_dead_one() {
+        create_root_owner();
+        let trigger = create_signal(0u32);
+
+        let ((), dead_row) = with_owner(|| {
+            provide_context("the dead row's".to_string());
+            crate::reactive::create_effect(move || {
+                trigger.get();
+            });
+        });
+        dispose_owner_now(dead_row);
+
+        let seen = Rc::new(Cell::new(None));
+        let recorder = Rc::clone(&seen);
+        let ((), live_row) = with_owner(move || {
+            provide_context("the live row's".to_string());
+            crate::reactive::create_effect(move || {
+                trigger.get();
+                recorder.set(use_context::<String>());
+            });
+        });
+
+        assert_eq!(
+            seen.take().as_deref(),
+            Some("the live row's"),
+            "its first run"
+        );
+
+        trigger.set(1);
+
+        assert_eq!(
+            seen.take().as_deref(),
+            Some("the live row's"),
+            "and the scheduled one, from a slot the disposed effect used to hold"
+        );
+        dispose_owner_now(live_row);
     }
 
     /// A property closure is a scope — the one it was written in, entered on

--- a/src/reactive/mod.rs
+++ b/src/reactive/mod.rs
@@ -133,6 +133,61 @@ mod bench {
 
     use super::*;
 
+    /// Best of five: the machine is noisy enough that a single round says
+    /// nothing about the one before it.
+    fn best_of_five(mut round: impl FnMut() -> Duration) -> Duration {
+        (0..5).map(|_| round()).min().expect("five rounds")
+    }
+
+    /// What an effect's re-run costs now that it enters the scope it was
+    /// created in: a signal written a million times, with one effect reading
+    /// it, which is a million scheduled re-runs.
+    ///
+    /// Twice, because `under_scope` declines to enter a scope already current:
+    /// an effect created where the flush runs pays a compare, and one created
+    /// in a scope of its own — a row of a list, which is the case this exists
+    /// for — pays the swap.
+    ///
+    /// `cargo test --release --lib bench:: -- --ignored --nocapture`
+    #[test]
+    #[ignore]
+    fn an_effect_rerun() {
+        let rounds = 1_000_000u32;
+        let time_a_million_reruns = |in_a_scope_of_its_own: bool| -> Duration {
+            owner::create_root_owner();
+            let source = create_signal(0u32);
+            let seen = std::rc::Rc::new(std::cell::Cell::new(0u32));
+            let recorder = std::rc::Rc::clone(&seen);
+
+            let effect = move || {
+                let recorder = std::rc::Rc::clone(&recorder);
+                create_effect(move || recorder.set(source.get()));
+            };
+            if in_a_scope_of_its_own {
+                owner::with_owner(effect);
+            } else {
+                effect();
+            }
+
+            let best = best_of_five(|| {
+                let started = Instant::now();
+                for round in 0..rounds {
+                    source.set(round);
+                }
+                started.elapsed()
+            });
+            assert_eq!(seen.get(), rounds - 1, "the effect ran");
+            best
+        };
+
+        let where_the_flush_is = time_a_million_reruns(false);
+        let in_a_scope_of_its_own = time_a_million_reruns(true);
+        println!(
+            "{rounds} effect re-runs: {where_the_flush_is:?} for an effect of the \
+             flush's own scope, {in_a_scope_of_its_own:?} for one in a scope below it"
+        );
+    }
+
     /// A frame of a list, which is where the per-read number lands: three
     /// hundred rows of four reactive properties each, laid out and painted the
     /// way `render_surface` does, with a signal moved between frames so the
@@ -166,25 +221,22 @@ mod bench {
         tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
 
         let frames = 200u32;
-        let best = (0..5)
-            .map(|_| {
-                let started = Instant::now();
-                for frame in 0..frames {
-                    width.set(40.0 + (frame % 7) as f32);
-                    tree.with_widget_mut(root, |w, id, t| {
-                        w.layout(t, id, Constraints::new(0.0, 0.0, 400.0, 4000.0));
-                    });
-                    let mut node = RenderNode::new(root.as_u64());
-                    tree.with_widget_mut(root, |w, id, t| {
-                        let mut ctx = PaintContext::new(&mut node);
-                        w.paint(t, id, &mut ctx);
-                    });
-                    std::hint::black_box(&node);
-                }
-                started.elapsed() / frames
-            })
-            .min()
-            .expect("five rounds");
+        let best = best_of_five(|| {
+            let started = Instant::now();
+            for frame in 0..frames {
+                width.set(40.0 + (frame % 7) as f32);
+                tree.with_widget_mut(root, |w, id, t| {
+                    w.layout(t, id, Constraints::new(0.0, 0.0, 400.0, 4000.0));
+                });
+                let mut node = RenderNode::new(root.as_u64());
+                tree.with_widget_mut(root, |w, id, t| {
+                    let mut ctx = PaintContext::new(&mut node);
+                    w.paint(t, id, &mut ctx);
+                });
+                std::hint::black_box(&node);
+            }
+            started.elapsed() / frames
+        });
 
         println!("a frame of 300 rows: {best:?}");
     }
@@ -204,16 +256,13 @@ mod bench {
 
         let rounds = 1_000_000u32;
         let best = |derived: Signal<u32>| -> Duration {
-            (0..5)
-                .map(|_| {
-                    let started = Instant::now();
-                    for _ in 0..rounds {
-                        std::hint::black_box(derived.get());
-                    }
-                    started.elapsed()
-                })
-                .min()
-                .expect("five rounds")
+            best_of_five(|| {
+                let started = Instant::now();
+                for _ in 0..rounds {
+                    std::hint::black_box(derived.get());
+                }
+                started.elapsed()
+            })
         };
 
         // Warm everything: the closure, the subscription bookkeeping, the caches.

--- a/src/reactive/owner.rs
+++ b/src/reactive/owner.rs
@@ -36,7 +36,6 @@
 
 use std::any::{Any, TypeId};
 use std::cell::{Cell, RefCell};
-use std::collections::HashMap;
 use std::num::NonZeroU32;
 use std::rc::Rc;
 
@@ -110,9 +109,6 @@ struct OwnerArena {
     slots: Vec<OwnerSlot>,
     /// Vacant slot indices available for reuse.
     free_indices: Vec<u32>,
-    /// Reverse mapping from effect ID to owner ID for O(1) lookup.
-    /// This avoids linear search through all owners when checking if an effect is owned.
-    effect_owners: HashMap<EffectId, OwnerId>,
 }
 
 impl OwnerArena {
@@ -120,7 +116,6 @@ impl OwnerArena {
         Self {
             slots: Vec::new(),
             free_indices: Vec::new(),
-            effect_owners: HashMap::new(),
         }
     }
 
@@ -416,12 +411,6 @@ pub fn dispose_owner_now(id: OwnerId) {
         crate::reactive::diagnostics::snapshot_zone(cleanup);
     }
 
-    // Dispose effects and remove from reverse mapping
-    for effect_id in &owner.effects {
-        OWNERS.with(|owners| {
-            owners.borrow_mut().effect_owners.remove(effect_id);
-        });
-    }
     for effect_id in owner.effects {
         with_runtime(|rt| rt.dispose_effect(effect_id));
     }
@@ -494,19 +483,20 @@ pub(crate) fn register_effect(id: EffectId) {
             let mut owners = owners.borrow_mut();
             if let Some(owner) = owners.get_mut(owner_id) {
                 owner.effects.push(id);
-                owners.effect_owners.insert(id, owner_id);
             }
         });
     }
 }
 
-/// Check if an effect is owned by any owner, in O(1) via the reverse mapping.
+/// Check if an effect is owned by any owner.
 ///
-/// Only the ownership tests below ask this: nothing in the running library
-/// needs to, since an effect's lifetime is entirely its scope's.
+/// The effect's slot in the runtime is where the answer lives, since #337 put
+/// the scope there so a re-run could be given it without a lookup. A map here
+/// beside it would be a second copy of one fact, maintained on the creation and
+/// disposal paths to answer a question only these tests ask.
 #[cfg(test)]
 pub(crate) fn effect_has_owner(id: EffectId) -> bool {
-    OWNERS.with(|owners| owners.borrow().effect_owners.contains_key(&id))
+    crate::reactive::runtime::with_runtime(|rt| rt.effect_scope(id)).is_some()
 }
 
 // Owners scheduled for deferred disposal (see `dispose_owner`).

--- a/src/reactive/runtime.rs
+++ b/src/reactive/runtime.rs
@@ -28,6 +28,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use smallvec::SmallVec;
 
 use super::invalidation::suspend_widget_tracking;
+use super::owner::{OwnerId, current_owner, under_scope};
 
 /// Buffered signal reads for an effect. Most effects read 1–4 signals,
 /// so SmallVec avoids heap allocation in the common case.
@@ -248,11 +249,21 @@ enum EffectState {
     DisposedWhileRunning,
 }
 
+/// An effect's callback, taken out of its slot to be run, and the scope to run
+/// it in.
+type EffectRun = (Box<dyn FnMut()>, Option<OwnerId>);
+
 /// Storage slot for one effect. The generation survives disposal so recycled
 /// indices can be told apart from their previous occupants.
 #[derive(Default)]
 struct EffectSlot {
     callback: Option<Box<dyn FnMut()>>,
+    /// The scope the effect was created in, which is where its body runs —
+    /// every run, not just the first (#337).
+    ///
+    /// Held here rather than looked up in the owner arena's `effect_owners`
+    /// map: a re-run would pay a hash for it, and the slot is already in hand.
+    scope: Option<OwnerId>,
     /// Signals this effect reads. Vec with dedup — most effects depend on
     /// 1–3 signals, making linear scan faster than HashSet.
     dependencies: Vec<SignalId>,
@@ -314,12 +325,16 @@ impl Runtime {
     }
 
     pub fn allocate_effect(&mut self, callback: Box<dyn FnMut()>) -> EffectId {
+        // Reading the current scope borrows nothing this call holds: it is a
+        // `Cell` beside the arena, not the arena.
+        let scope = current_owner();
         // Reuse a freed slot if available, bumping its generation so stale
         // ids for the previous occupant can never act on this effect
         if let Some(index) = self.free_effect_indices.pop() {
             let slot = &mut self.effects[index as usize];
             slot.generation = slot.generation.wrapping_add(1);
             slot.callback = Some(callback);
+            slot.scope = scope;
             slot.dependencies.clear();
             slot.state = EffectState::Idle;
             return EffectId {
@@ -331,6 +346,7 @@ impl Runtime {
         let index = self.effects.len() as u32;
         self.effects.push(EffectSlot {
             callback: Some(callback),
+            scope,
             dependencies: Vec::new(),
             generation: 0,
             state: EffectState::Idle,
@@ -364,12 +380,13 @@ impl Runtime {
     /// id, clear old dependencies, and hand the callback out so it can run
     /// WITHOUT the runtime borrowed. Returns `None` for stale/disposed ids
     /// or if the effect is already running (re-entrant trigger).
-    fn begin_effect(&mut self, effect_id: EffectId) -> Option<Box<dyn FnMut()>> {
+    fn begin_effect(&mut self, effect_id: EffectId) -> Option<EffectRun> {
         let slot = self.effect_slot_mut(effect_id)?;
         if slot.state != EffectState::Idle {
             return None;
         }
         let callback = slot.callback.take()?;
+        let scope = slot.scope;
         slot.state = EffectState::Running;
 
         // Clear old dependencies; they are re-established from this run's reads
@@ -379,7 +396,7 @@ impl Runtime {
                 vec_remove(subs, &effect_id);
             }
         }
-        Some(callback)
+        Some((callback, scope))
     }
 
     /// Phase 3 of effect execution (under the runtime borrow): restore the
@@ -420,6 +437,21 @@ impl Runtime {
                 drop(callback);
             }
         }
+    }
+
+    /// The scope an effect belongs to, or `None` for a stale id or a slot that
+    /// has been disposed.
+    ///
+    /// Only the ownership tests ask in this form: the running library gets the
+    /// scope from [`begin_effect`](Self::begin_effect), which hands it out with
+    /// the callback it is about to run.
+    #[cfg(test)]
+    pub(crate) fn effect_scope(&self, effect_id: EffectId) -> Option<OwnerId> {
+        let slot = self.effects.get(effect_id.index as usize)?;
+        if slot.generation != effect_id.generation || slot.state == EffectState::Vacant {
+            return None;
+        }
+        slot.scope
     }
 
     pub fn dispose_effect(&mut self, effect_id: EffectId) {
@@ -477,7 +509,7 @@ thread_local! {
 /// work), then restore it and register the tracked reads.
 pub(crate) fn run_effect_by_id(effect_id: EffectId) {
     // Phase 1 (borrow): take the callback out
-    let Some(mut callback) = with_runtime(|rt| rt.begin_effect(effect_id)) else {
+    let Some((mut callback, scope)) = with_runtime(|rt| rt.begin_effect(effect_id)) else {
         return;
     };
 
@@ -488,8 +520,12 @@ pub(crate) fn run_effect_by_id(effect_id: EffectId) {
     EFFECT_TRACKING.with(|stack| {
         stack.borrow_mut().push((effect_id, EffectReads::new()));
     });
+    // Under the scope the effect was created in, not the one the flush happens
+    // to be under: a context read in the body answers the same on the first run
+    // and on every one a dependency schedules (#337), and a signal the body
+    // makes belongs where the effect does rather than outliving it.
     let panic_payload = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        suspend_widget_tracking(&mut *callback);
+        under_scope(scope, || suspend_widget_tracking(&mut *callback));
     }))
     .err();
     let reads = EFFECT_TRACKING

--- a/src/reactive/storage.rs
+++ b/src/reactive/storage.rs
@@ -471,3 +471,40 @@ mod derived_scope_tests {
         );
     }
 }
+
+#[cfg(test)]
+mod effect_scope_tests {
+    use super::live_signal_count;
+    use crate::reactive::owner::{dispose_owner_now, with_owner};
+    use crate::reactive::{create_effect, create_signal};
+
+    /// The half of #337 that is about lifetimes rather than lookup: an effect
+    /// body runs under the scope the effect was created in, so what the body
+    /// makes belongs there too.
+    ///
+    /// The first run always did — it happens inside the scope. The run a
+    /// dependency schedules did not: it happens at the flush, under whatever is
+    /// current there, and what it made outlived the effect that made it.
+    #[test]
+    fn what_an_effect_body_makes_belongs_to_the_scope_the_effect_was_created_in() {
+        let baseline = live_signal_count();
+        let trigger = create_signal(0u32);
+
+        let ((), scope) = with_owner(|| {
+            create_effect(move || {
+                trigger.get();
+                create_signal(1u32);
+            });
+        });
+        trigger.set(1);
+
+        dispose_owner_now(scope);
+
+        assert_eq!(
+            live_signal_count(),
+            baseline + 1,
+            "everything the body made went with the scope, and only the trigger \
+             — made outside it — is left"
+        );
+    }
+}


### PR DESCRIPTION
## What changed

An effect's body runs under the scope the effect was created in, on every run
rather than only the first. Its first run always did, because that is where the
call is; every run after it happened at a flush, under whatever scope the flush
was reached from — the root, in an application. So a context read inside an
effect answered its own scope once and the application's from then on, and a
memo, being an effect that sets a signal, carried that into every
recomputation: a memo of a row's declaration was the row's value until the
first dependency changed and the application's forever after. Closes #337.

The scope lives in the effect's slot beside its callback, and `begin_effect`
hands the two out together, so a re-run enters it without asking anybody. That
is the shape #335 gave a derived closure, at the other end of the same
asymmetry — and it carries the ownership half too: a signal the body makes on a
scheduled run belongs to the effect's scope rather than to whatever the flush
was under, which for a row that has since gone means freed rather than kept for
the life of the application.

`OwnerArena::effect_owners` goes with it: a `HashMap` maintained on the creation
and disposal paths to answer which scope an effect belongs to, which the slot
now answers, and which had no reader left but a test.

## What proves it

In `src/reactive/context.rs`, all three failing on `main` with
`Some("the application's")` where the row's value belongs:

- `a_memo_reads_its_own_scope_on_every_recomputation`
- `an_effect_reads_its_own_scope_on_every_run`
- `an_effect_in_a_recycled_slot_reads_its_own_scope_and_not_the_dead_one` —
  a disposed effect's slot goes to the next effect, which is what happens when
  a row of a list is replaced. Fails with `None` if the slot's scope is not
  replaced along with its callback.

And in `src/reactive/storage.rs`,
`what_an_effect_body_makes_belongs_to_the_scope_the_effect_was_created_in` —
the lifetime half; fails on `main` with the signal from the scheduled run still
live after its scope is disposed.

Full suite, clippy `-D warnings`, `cargo doc` denied, `mdbook test` and
`mdbook build`, goldens 10/10 on lavapipe. Nothing here reaches the renderer and
no golden or snapshot is touched.

**Measured**, back to back against the same tree without the change, for an
effect in a scope of its own — the case that pays the swap:

| | before | after |
| --- | --- | --- |
| 1,000,000 effect re-runs | 59.5-62.2 ms | 58.9-59.7 ms |

No regression, and the swap is under the instrument's noise. The first draft
looked the scope up in `effect_owners` instead of carrying it in the slot and
cost **+12 ns a run** — the hash was the whole of it, which is why the map is
gone rather than merely unused. `cargo test --release --lib bench:: -- --ignored
--nocapture` runs the instruments; CI does not.

## What the review found

**One blocking finding, fixed.** The recycled-slot branch — `slot.scope = scope`
in `allocate_effect`'s reuse arm — was unwatched: deleting that line left the
whole suite green, and it is the branch a running application takes every time a
row of a dynamic list is replaced. `an_effect_in_a_recycled_slot_...` is the
test that was missing; with the line deleted it fails with `None`, which is a
memo reading a scope that has been disposed.

Three worth answering, all acted on:

1. The new benchmark did not take the branch it was added to measure — the
   effect was created under the root, so `under_scope`'s guard skipped the swap
   it exists to time. It now measures both positions, and the table above is
   from the one that swaps.
2. `docs/REACTIVE.md` still said a signal made in an effect belongs to its
   creator "on an effect's first run" — the qualifier this change removes, in
   the developer reference for ownership, which `tests/documentation_references.rs`
   cannot see because it checks names rather than claims.
3. The `best_of_five` extraction left a vestigial block in the frame benchmark,
   and the book said a flush "belongs to nobody" when in an application it
   belongs to the root — which is what made the old behaviour wrong rather than
   empty.

It verified the ownership consequence rather than taking it on trust: nothing in
the library creates a signal inside an effect body, the process-wide signals are
anchored by `with_root_owner` rather than by whatever is current, and a
scheduled effect whose owner was disposed before the flush never reaches
`under_scope` because `begin_effect` refuses a vacant slot. It also checked that
removing `effect_owners` left the ownership tests meaning what they meant.

## What was checked by hand

Nothing — no compositor, no surface, no pixels. The benchmarks were run by hand
and their numbers are above.

## Left undone

Nothing this change leaves behind. The three places a context read can happen —
a property closure, an effect or memo, a handler or task — now each have a
stated rule, a test, and the same answer in the module docs, the book and
`docs/REACTIVE.md`.

https://claude.ai/code/session_01Q5KL58bdTdT533XJa1ZdDn
