### PR TITLE
Two clocks, two types, so reaching for the wrong one stops compiling

### DIFF
--- a/book/src/architecture/events.md
+++ b/book/src/architecture/events.md
@@ -214,7 +214,11 @@ fn event(&mut self, tree: &mut Tree, id: WidgetId, event: &Event) -> EventRespon
         }
         Event::MouseDown { at: Some(at), .. } => {
             self.flags.update(|f| f.insert(InteractionFlags::PRESSED));
-            self.ripple.start(at.x, at.y, Instant::now());
+            // The event's own moment, not the wall clock: a ripple begins
+            // when the press arrived, and `event_instant` is the only thing
+            // that knows when that was. `as_frame_start` is the crossing —
+            // the ripple then grows on frames.
+            self.ripple.start(at.x, at.y, tree.event_instant().as_frame_start());
         }
         // ...
     }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -441,11 +441,21 @@ saw it happen, not when the handler ran: the two differ by however long the
 event sat in the queue, and that difference is what a velocity or a
 double-keystroke window would otherwise measure by mistake.
 
+The two answer different types — `FrameInstant` and `EventInstant`, from
+`clock` — so the difference is the compiler's business rather than a reader's
+memory. Neither carries `elapsed()`, and neither can be differenced against the
+other: a moment belongs to the sequence its pass owns, and crossing between them
+takes `EventInstant::as_frame_start`, which is named so the crossings can be
+found. What that costs when it is invisible is #265: a flick was cancelled on
+its first frame because the loop's own input latency had been differenced
+against a staleness threshold.
+
 Neither is `Instant::now()`. Reading the clock inside a widget makes one frame
 several instants, and makes the middle of an animation — or the gap between two
 keystrokes — something no test can ask about, only sleep towards.
 `set_frame_instant` and `set_event_instant` are how a test names the moment it
-is asking about.
+is asking about, and reading either clock outside the pass that sets it reports
+a diagnostic in a debug build rather than quietly handing back the wall clock.
 
 ### Widgets written outside the crate
 

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -1,0 +1,113 @@
+//! Two clocks, two types.
+//!
+//! A `Tree` answers two questions about time and they are not the same
+//! question: *when is this frame being drawn for* and *when did the event now
+//! being dispatched happen*. An event's instant is the older of the two — it
+//! was stamped when the compositor sent it and is read when the frame that
+//! carries it runs — so differencing one against the other measures the loop's
+//! input latency, which is almost never what the differencing code meant.
+//!
+//! Both were `std::time::Instant`, so a value from either fitted anywhere the
+//! other was expected and the mistake compiled. `ScrollState::momentum_since`
+//! is what that costs: written from the event clock when a finger lifts,
+//! written from the frame clock while the flick runs, and differenced against
+//! the frame clock to decide whether the motion had gone stale — so the first
+//! frame after a lift measured input latency against a 200ms threshold and
+//! could cancel a flick that had only just started (#265).
+//!
+//! Neither type carries `elapsed()`. Nor is either a wall against a determined
+//! caller — `From<Instant>` and `into_inner` are both public, because a job
+//! deadline genuinely leaves the pass's sequence. What the types buy is that
+//! crossing has to be *written*, and every crossing can be found by grepping
+//! for the two names that do it.
+//!
+//! That there is no `elapsed()` is the other half of the same rule: an instant from a pass is a moment in that pass's own
+//! sequence, and the wall clock is not in it. Ask the pass what time it is
+//! instead.
+
+use std::time::{Duration, Instant};
+
+macro_rules! pass_clock {
+    ($name:ident, $what:literal, $owner:literal) => {
+        #[doc = concat!("The moment ", $what, ".")]
+        ///
+        #[doc = concat!("Declared by ", $owner, " and read from anywhere below it. Comparable")]
+        /// and differenceable only against its own kind: the other clock
+        /// answers a different question, and arithmetic across the two is the
+        /// mistake this type exists to stop.
+        #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+        pub struct $name(Instant);
+
+        impl $name {
+            /// How much of this clock's own sequence separates two of its
+            /// moments. Panics if `earlier` is later, as `Instant` does.
+            pub fn duration_since(self, earlier: Self) -> Duration {
+                self.0.duration_since(earlier.0)
+            }
+
+            /// The same, answering zero rather than panicking when the order
+            /// is the other way round.
+            pub fn saturating_duration_since(self, earlier: Self) -> Duration {
+                self.0.saturating_duration_since(earlier.0)
+            }
+
+            /// This moment as a plain `Instant`.
+            ///
+            /// For the places that genuinely leave the pass's sequence: a job
+            /// deadline the loop will compare against the wall clock, a
+            /// duration added to reach one. Every other use is the arithmetic
+            /// the type exists to prevent, written the long way round.
+            pub fn into_inner(self) -> Instant {
+                self.0
+            }
+        }
+
+        impl std::ops::Add<Duration> for $name {
+            type Output = Self;
+
+            /// A moment later on the same clock, which is what a deadline
+            /// inside a pass's own sequence is.
+            fn add(self, later: Duration) -> Self {
+                Self(self.0 + later)
+            }
+        }
+
+        impl From<Instant> for $name {
+            fn from(at: Instant) -> Self {
+                Self(at)
+            }
+        }
+    };
+}
+
+pass_clock!(
+    FrameInstant,
+    "the frame now running is being drawn for",
+    "`render_surface`, around the three passes a frame is made of"
+);
+pass_clock!(
+    EventInstant,
+    "the event now being dispatched happened",
+    "`dispatch_events`, once per event"
+);
+
+impl EventInstant {
+    /// The same moment, read as the start of a frame timeline.
+    ///
+    /// A widget whose animation runs on frames is often *started* by an event:
+    /// a ripple by the press under it, a caret's blink by the keystroke that
+    /// moved it. The two clocks are separated by the loop's input latency, so
+    /// this shifts such a timeline's start by that much.
+    ///
+    /// Sound where the value is where a timeline *begins* — the moment
+    /// progress is measured forward from, including a phase origin like the
+    /// caret's blink. Not sound where it is a *deadline* whose crossing
+    /// cancels something, because then the latency is the thing being
+    /// measured: #265 is a flick cancelled on its first frame because a loop's
+    /// lateness was read as the motion having gone idle.
+    ///
+    /// Deliberate, greppable, and the only way across.
+    pub fn as_frame_start(self) -> FrameInstant {
+        FrameInstant(self.0)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod animation;
 pub mod backdrop;
 mod blur;
+pub mod clock;
 pub mod compositor;
 mod deferred;
 pub(crate) mod finite;
@@ -219,6 +220,7 @@ pub mod prelude {
 /// that makes a widget's signal reads *its own*, so a change to its content
 /// re-runs it rather than the nearest ancestor that happened to open a scope.
 pub mod widget_prelude {
+    pub use crate::clock::{EventInstant, FrameInstant};
     pub use crate::layout::{Constraints, IntoF32, Layout};
     pub use crate::reactive::{JobType, OptionSignalExt, with_signal_tracking};
     pub use crate::renderer::{PaintContext, RenderNode};
@@ -2719,7 +2721,7 @@ mod dispatch_declares_the_moment {
 
     /// A widget that records what time the tree said it was when it was handed
     /// an event.
-    struct Spy(std::rc::Rc<std::cell::Cell<Option<std::time::Instant>>>);
+    struct Spy(std::rc::Rc<std::cell::Cell<Option<crate::clock::EventInstant>>>);
 
     impl widgets::Widget for Spy {
         fn layout(
@@ -2758,6 +2760,7 @@ mod dispatch_declares_the_moment {
         // An hour ago: no clock this process could read would answer with it,
         // so the widget can only have got it from the event.
         let happened = std::time::Instant::now() - std::time::Duration::from_secs(3600);
+        let happened_on_the_event_clock = crate::clock::EventInstant::from(happened);
         let events = [(
             happened,
             Event::MouseMove {
@@ -2769,7 +2772,7 @@ mod dispatch_declares_the_moment {
 
         assert_eq!(
             seen.get(),
-            Some(happened),
+            Some(happened_on_the_event_clock),
             "the widget has to be told the moment the queue carried, not the \
              moment the dispatch ran"
         );
@@ -2777,7 +2780,7 @@ mod dispatch_declares_the_moment {
         // reader gets is the clock, not the last event's time.
         let after = tree.event_instant();
         assert!(
-            after > happened,
+            after > happened_on_the_event_clock,
             "the moment has to be cleared when the dispatch ends, got {after:?} \
              for an event from an hour ago"
         );

--- a/src/reactive/diagnostics.rs
+++ b/src/reactive/diagnostics.rs
@@ -75,6 +75,25 @@ pub(crate) fn non_finite_value(id: crate::tree::WidgetId, property: &'static str
     let _ = (id, property);
 }
 
+/// Report that a clock was read outside the pass that sets it, so what came
+/// back is the wall clock rather than the moment that was asked for.
+///
+/// `read` is the getter that was called and `owner` is the pass that would have
+/// set it; the message names the other clock too, because reaching for the
+/// wrong one and reaching for the right one at the wrong time look identical
+/// from the call site and the fix is different.
+///
+/// Debug builds only, and the fallback stays either way: a widget asking the
+/// time between passes gets a usable number rather than a panic on somebody's
+/// bar (#265).
+#[track_caller]
+pub(crate) fn clock_outside_its_pass(read: &'static str, owner: &'static str, other: &'static str) {
+    #[cfg(debug_assertions)]
+    imp::clock_outside_its_pass(read, owner, other);
+    #[cfg(not(debug_assertions))]
+    let _ = (read, owner, other);
+}
+
 #[cfg(debug_assertions)]
 mod imp {
     use std::cell::{Cell, RefCell};
@@ -160,8 +179,40 @@ mod imp {
         ));
     }
 
+    #[track_caller]
+    pub(super) fn clock_outside_its_pass(
+        read: &'static str,
+        owner: &'static str,
+        other: &'static str,
+    ) {
+        let loc = std::panic::Location::caller();
+        if !CLOCKS.with(|r| {
+            r.borrow_mut()
+                .insert((loc.file(), loc.line(), loc.column()))
+        }) {
+            return;
+        }
+        report(format!(
+            "{}:{}:{}: `{read}()` was read outside {owner}, so it answered \
+             with the wall clock rather than the moment asked for. Either \
+             the read belongs inside {owner}, or the question was \
+             `{other}()`. (debug builds only)",
+            loc.file(),
+            loc.line(),
+            loc.column(),
+        ));
+    }
+
+    thread_local! {
+        /// Its own set, for the reason `NON_FINITE` has its own: a rate limit
+        /// shared with another diagnostic goes quiet for the wrong reasons.
+        static CLOCKS: RefCell<FxHashSet<(&'static str, u32, u32)>> =
+            RefCell::new(FxHashSet::default());
+    }
+
     /// Forget every reported call site (used by `reset_reactive`).
     pub(crate) fn reset() {
+        CLOCKS.with(|r| r.borrow_mut().clear());
         NON_FINITE.with(|r| r.borrow_mut().clear());
         REPORTED.with(|r| r.borrow_mut().clear());
         DEPTH.with(|d| d.set(0));

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -229,7 +229,7 @@ impl Tree {
     /// rather than a panic on somebody's bar. A debug build says so first,
     /// naming the call site and the other clock.
     #[track_caller]
-    pub fn frame_instant(&self) -> std::time::Instant {
+    pub fn frame_instant(&self) -> crate::clock::FrameInstant {
         Self::in_pass(
             self.frame_instant,
             "frame_instant",
@@ -243,7 +243,7 @@ impl Tree {
     /// Falls back to the clock outside a dispatch, and says so, exactly as
     /// [`Self::frame_instant`] does.
     #[track_caller]
-    pub fn event_instant(&self) -> std::time::Instant {
+    pub fn event_instant(&self) -> crate::clock::EventInstant {
         Self::in_pass(
             self.event_instant,
             "event_instant",
@@ -2100,11 +2100,11 @@ mod clock_diagnostics {
 
         tree.set_frame_instant(Some(now));
         let before = report_count();
-        assert_eq!(tree.frame_instant(), now);
+        assert_eq!(tree.frame_instant(), now.into());
         tree.set_frame_instant(None);
 
         tree.set_event_instant(Some(now));
-        assert_eq!(tree.event_instant(), now);
+        assert_eq!(tree.event_instant(), now.into());
         tree.set_event_instant(None);
 
         assert_eq!(

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -224,17 +224,54 @@ impl Tree {
     /// What time it is for the pass now running.
     ///
     /// Falls back to the clock for a call that arrives outside a pass — the
-    /// behaviour every caller had before there was a frame instant at all.
+    /// behaviour every caller had before there was a frame instant at all,
+    /// kept so a widget asking the time between passes gets a usable number
+    /// rather than a panic on somebody's bar. A debug build says so first,
+    /// naming the call site and the other clock.
+    #[track_caller]
     pub fn frame_instant(&self) -> std::time::Instant {
-        self.frame_instant.unwrap_or_else(std::time::Instant::now)
+        Self::in_pass(
+            self.frame_instant,
+            "frame_instant",
+            "a frame",
+            "event_instant",
+        )
     }
 
     /// When the event being dispatched happened.
     ///
-    /// Falls back to the clock outside a dispatch — the behaviour every caller
-    /// had before an event carried its own time.
+    /// Falls back to the clock outside a dispatch, and says so, exactly as
+    /// [`Self::frame_instant`] does.
+    #[track_caller]
     pub fn event_instant(&self) -> std::time::Instant {
-        self.event_instant.unwrap_or_else(std::time::Instant::now)
+        Self::in_pass(
+            self.event_instant,
+            "event_instant",
+            "a dispatch",
+            "frame_instant",
+        )
+    }
+
+    /// The moment a pass declared, or the wall clock and a word about it.
+    ///
+    /// `#[track_caller]` all the way down, and no closure in between: the
+    /// message names the site that asked, and the rate limit is keyed on that
+    /// site — so a `unwrap_or_else` here would collapse every caller in the
+    /// application onto one key and silence all but the first.
+    #[track_caller]
+    fn in_pass<T: From<std::time::Instant>>(
+        declared: Option<std::time::Instant>,
+        read: &'static str,
+        owner: &'static str,
+        other: &'static str,
+    ) -> T {
+        match declared {
+            Some(at) => at.into(),
+            None => {
+                crate::reactive::diagnostics::clock_outside_its_pass(read, owner, other);
+                std::time::Instant::now().into()
+            }
+        }
     }
 
     /// Declare when the event about to be dispatched happened, or `None` when
@@ -1981,6 +2018,100 @@ mod tests {
             0.0,
             "the frame that drops the shadow damages {without:?}, so the ring \
              it cast at {with_shadow:?} stays on screen"
+        );
+    }
+}
+
+/// Reading a clock outside the pass that owns it.
+///
+/// Both getters answer with the wall clock when their pass is not running, so
+/// the reader gets a plausible number rather than an error — deliberately, and
+/// #265 is not about removing that. It is about the number being plausible in
+/// silence: an animation that read the event clock advanced by the age of the
+/// input, and a widget that read either between passes measured against
+/// whenever it happened to ask.
+#[cfg(all(test, debug_assertions))]
+mod clock_diagnostics {
+    use std::time::Instant;
+
+    use super::*;
+    use crate::reactive::diagnostics::report_count;
+
+    #[test]
+    fn reading_the_frame_clock_outside_a_frame_is_reported() {
+        let tree = Tree::new();
+
+        let before = report_count();
+        let _ = tree.frame_instant();
+
+        assert_eq!(
+            report_count(),
+            before + 1,
+            "the wall clock came back where the frame's instant was asked for, \
+             and nothing said so"
+        );
+    }
+
+    #[test]
+    fn reading_the_event_clock_outside_a_dispatch_is_reported() {
+        let tree = Tree::new();
+
+        let before = report_count();
+        let _ = tree.event_instant();
+
+        assert_eq!(
+            report_count(),
+            before + 1,
+            "the wall clock came back where the event's instant was asked for, \
+             and nothing said so"
+        );
+    }
+
+    /// The message names the call site, so each site has to be its own entry
+    /// in the rate limit: with one key for the whole getter, the first misuse
+    /// anywhere in an application silences every other one for good, and the
+    /// location it printed was the diagnostic's own.
+    #[test]
+    fn every_call_site_reports_once_and_the_next_site_still_reports() {
+        let tree = Tree::new();
+
+        let before = report_count();
+        for _ in 0..3 {
+            let _ = tree.frame_instant();
+        }
+        assert_eq!(
+            report_count(),
+            before + 1,
+            "one site, however often it is read, says it once"
+        );
+
+        let _ = tree.frame_instant();
+        assert_eq!(
+            report_count(),
+            before + 2,
+            "and the next site is a different site, not the same one again"
+        );
+    }
+
+    #[test]
+    fn each_clock_is_quiet_inside_the_pass_that_owns_it() {
+        let mut tree = Tree::new();
+        let now = Instant::now();
+
+        tree.set_frame_instant(Some(now));
+        let before = report_count();
+        assert_eq!(tree.frame_instant(), now);
+        tree.set_frame_instant(None);
+
+        tree.set_event_instant(Some(now));
+        assert_eq!(tree.event_instant(), now);
+        tree.set_event_instant(None);
+
+        assert_eq!(
+            report_count(),
+            before,
+            "a clock read inside its own pass is the ordinary case and says \
+             nothing"
         );
     }
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -2093,6 +2093,39 @@ mod clock_diagnostics {
         );
     }
 
+    /// The rate limit is per call site and lasts for the life of the process,
+    /// so the reset that wipes the reactive state between `App`s has to wipe it
+    /// too: the second application on this thread makes the same mistakes as
+    /// the first, and would be told nothing.
+    ///
+    /// Named by the mutation job — deleting the body of `diagnostics::reset`
+    /// changed nothing any test could see.
+    #[test]
+    fn a_reset_forgets_the_sites_that_have_already_reported() {
+        let tree = Tree::new();
+        // One site, read twice: a closure so both reads are the same line.
+        let read_outside_a_frame = || {
+            let _ = tree.frame_instant();
+        };
+
+        read_outside_a_frame();
+        assert_eq!(report_count(), 1, "the site said it once");
+
+        crate::reactive::reset_reactive();
+
+        assert_eq!(
+            report_count(),
+            0,
+            "the reset forgets what has been reported, counter included"
+        );
+        read_outside_a_frame();
+        assert_eq!(
+            report_count(),
+            1,
+            "and the site is free to say it to the next application"
+        );
+    }
+
     #[test]
     fn each_clock_is_quiet_inside_the_pass_that_owns_it() {
         let mut tree = Tree::new();

--- a/src/widgets/container/animations.rs
+++ b/src/widgets/container/animations.rs
@@ -1,4 +1,4 @@
-use std::time::Instant;
+use crate::clock::FrameInstant;
 
 use crate::animation::{
     Animatable, Keyframes, SpringState, Transition, TransitionConfig, carry_velocity,
@@ -13,7 +13,7 @@ use crate::reactive::Signal;
 struct Timeline<T> {
     keyframes: Keyframes<T>,
     /// When the current run started, if one is running.
-    playing: Option<Instant>,
+    playing: Option<FrameInstant>,
     /// A signal whose every change plays the sequence once, and the count last
     /// acted on.
     ///
@@ -62,7 +62,7 @@ pub struct AnimationState<T: Animatable> {
     /// When the running segment began, if one is running. `None` until the
     /// first one does: a state that has never animated has no start, and a
     /// placeholder instant would be a time nobody chose.
-    start_time: Option<Instant>,
+    start_time: Option<FrameInstant>,
     /// Forward transition (used when value increases or no reverse is set)
     transition: Transition,
     /// Optional reverse transition (used when value decreases)
@@ -118,7 +118,7 @@ impl<T: Animatable> AnimationState<T> {
     }
 
     /// Start animating to a new target value
-    pub fn animate_to(&mut self, new_target: T, now: Instant) {
+    pub fn animate_to(&mut self, new_target: T, now: FrameInstant) {
         // Don't restart if we're already animating to this target
         if new_target == self.target {
             return;
@@ -145,12 +145,12 @@ impl<T: Animatable> AnimationState<T> {
     }
 
     /// Start a fresh run toward the current target, from rest.
-    fn begin_segment_from(&mut self, from: T, now: Instant) {
+    fn begin_segment_from(&mut self, from: T, now: FrameInstant) {
         self.begin_segment(from, 0.0, now);
     }
 
     /// The bookkeeping every new segment shares.
-    fn begin_segment(&mut self, from: T, carried: f32, now: Instant) {
+    fn begin_segment(&mut self, from: T, carried: f32, now: FrameInstant) {
         let is_spring = matches!(
             self.active_transition().timing,
             crate::animation::TimingFunction::Spring(_)
@@ -197,7 +197,7 @@ impl<T: Animatable> AnimationState<T> {
     }
 
     /// Advance the animation and return whether the value changed
-    pub fn advance(&mut self, now: Instant) -> AdvanceResult<T> {
+    pub fn advance(&mut self, now: FrameInstant) -> AdvanceResult<T> {
         // A sequence speaks for the property while it runs, and nothing else
         // does — the same rule the cascade gives a CSS animation over a normal
         // declaration.
@@ -367,7 +367,7 @@ impl<T: Animatable> AnimationState<T> {
 
     /// Start the sequence, from the top. Playing it again while it runs
     /// restarts it: the second refusal is not half a shake.
-    pub(crate) fn play(&mut self, now: Instant) {
+    pub(crate) fn play(&mut self, now: FrameInstant) {
         if let Some(timeline) = &mut self.timeline
             && !timeline.keyframes.is_empty()
         {
@@ -377,7 +377,7 @@ impl<T: Animatable> AnimationState<T> {
 
     /// Advance the running timeline. `None` when there is none, or when the
     /// one that was running has just handed the property back.
-    fn advance_timeline(&mut self, now: Instant) -> Option<AdvanceResult<T>> {
+    fn advance_timeline(&mut self, now: FrameInstant) -> Option<AdvanceResult<T>> {
         // Both halves together, so a `playing` without a sequence to play
         // cannot survive the question. On its own it would keep
         // `is_animating` true for good: a surface asking for a frame every
@@ -559,6 +559,8 @@ pub fn get_animated_value<T: Animatable + Copy>(
 
 #[cfg(test)]
 mod tests {
+    use std::time::Instant;
+
     use super::*;
 
     /// on_complete fires exactly once per completed run; a retarget that
@@ -578,16 +580,16 @@ mod tests {
         );
         anim.set_immediate(0.0);
 
-        anim.animate_to(1.0, Instant::now());
+        anim.animate_to(1.0, FrameInstant::from(Instant::now()));
         std::thread::sleep(std::time::Duration::from_millis(10));
-        anim.advance(Instant::now());
+        anim.advance(FrameInstant::from(Instant::now()));
         assert_eq!(fired.get(), 1, "settle must fire the callback once");
-        anim.advance(Instant::now());
+        anim.advance(FrameInstant::from(Instant::now()));
         assert_eq!(fired.get(), 1, "no refire after completion");
 
-        anim.animate_to(2.0, Instant::now());
+        anim.animate_to(2.0, FrameInstant::from(Instant::now()));
         std::thread::sleep(std::time::Duration::from_millis(10));
-        anim.advance(Instant::now());
+        anim.advance(FrameInstant::from(Instant::now()));
         assert_eq!(fired.get(), 2, "a new completed run fires again");
     }
     use crate::animation::TimingFunction;
@@ -621,7 +623,7 @@ mod tests {
             never_played(),
         );
 
-        anim.play(Instant::now());
+        anim.play(FrameInstant::from(Instant::now()));
         assert!(anim.is_animating(), "a playing timeline is an animation");
 
         play_at(&mut anim, 30);
@@ -632,7 +634,7 @@ mod tests {
         );
 
         // The declared value moves while the sequence is running.
-        anim.animate_to(3.0, Instant::now());
+        anim.animate_to(3.0, FrameInstant::from(Instant::now()));
         play_at(&mut anim, 70);
         at(&mut anim, 10);
         assert_eq!(*anim.current(), 3.0, "over, and back to what is declared");
@@ -652,12 +654,12 @@ mod tests {
             never_played(),
         );
 
-        anim.play(Instant::now());
+        anim.play(FrameInstant::from(Instant::now()));
         play_at(&mut anim, 60);
         let far = *anim.current();
 
-        anim.play(Instant::now());
-        anim.advance(Instant::now());
+        anim.play(FrameInstant::from(Instant::now()));
+        anim.advance(FrameInstant::from(Instant::now()));
         assert!(
             *anim.current() < far,
             "back near the top of the run, got {} after {far}",
@@ -682,11 +684,11 @@ mod tests {
             never_played(),
         );
 
-        anim.play(Instant::now());
+        anim.play(FrameInstant::from(Instant::now()));
         play_at(&mut anim, 30);
 
         // Something declares a new value while the sequence is running.
-        anim.animate_to(100.0, Instant::now());
+        anim.animate_to(100.0, FrameInstant::from(Instant::now()));
 
         // The sequence runs out.
         play_at(&mut anim, 70);
@@ -722,8 +724,8 @@ mod tests {
             never_played(),
         );
 
-        anim.animate_to(1.0, Instant::now());
-        anim.play(Instant::now());
+        anim.animate_to(1.0, FrameInstant::from(Instant::now()));
+        anim.play(FrameInstant::from(Instant::now()));
         play_at(&mut anim, 30);
         assert_eq!(fired.get(), 0, "nothing has arrived yet");
 
@@ -739,8 +741,8 @@ mod tests {
     fn a_play_without_a_sequence_does_not_pin_the_frame_loop() {
         let mut anim = AnimationState::new(0.0_f32, Transition::new(10.0, TimingFunction::Linear));
         anim.set_immediate(0.0);
-        anim.play(Instant::now());
-        anim.advance(Instant::now());
+        anim.play(FrameInstant::from(Instant::now()));
+        anim.advance(FrameInstant::from(Instant::now()));
         assert!(!anim.is_animating(), "nothing to play, nothing to animate");
     }
 
@@ -812,14 +814,14 @@ mod tests {
 
         let mut anim = AnimationState::new(0.0_f32, spring(SpringConfig::BOUNCY));
         anim.set_immediate(0.0);
-        anim.animate_to(1.0, Instant::now());
+        anim.animate_to(1.0, FrameInstant::from(Instant::now()));
         run(&mut anim, 40);
         assert!(
             *anim.current() > 0.0,
             "the spring has to be moving before it can be interrupted"
         );
 
-        anim.animate_to(0.0, Instant::now());
+        anim.animate_to(0.0, FrameInstant::from(Instant::now()));
         let velocity = velocity_of(&anim);
         assert!(
             velocity < 0.0,
@@ -836,9 +838,9 @@ mod tests {
 
         let mut anim = AnimationState::new(0.0_f32, spring(SpringConfig::BOUNCY));
         anim.set_immediate(0.0);
-        anim.animate_to(1.0, Instant::now());
+        anim.animate_to(1.0, FrameInstant::from(Instant::now()));
         run(&mut anim, 40);
-        anim.animate_to(0.0, Instant::now());
+        anim.animate_to(0.0, FrameInstant::from(Instant::now()));
         let (low, _) = run(&mut anim, 400);
 
         assert!(
@@ -855,10 +857,10 @@ mod tests {
 
         let mut anim = AnimationState::new(0.0_f32, spring(SpringConfig::DEFAULT));
         anim.set_immediate(0.0);
-        anim.animate_to(1.0, Instant::now());
+        anim.animate_to(1.0, FrameInstant::from(Instant::now()));
         run(&mut anim, 40);
 
-        anim.animate_to(2.0, Instant::now());
+        anim.animate_to(2.0, FrameInstant::from(Instant::now()));
         assert!(
             velocity_of(&anim) > 0.0,
             "still heading there, got {}",
@@ -878,11 +880,11 @@ mod tests {
 
         let mut anim = AnimationState::new(0.0_f32, spring(SpringConfig::DEFAULT));
         anim.set_immediate(0.0);
-        anim.animate_to(1.0, Instant::now());
+        anim.animate_to(1.0, FrameInstant::from(Instant::now()));
         run(&mut anim, 1200);
         assert!(!anim.is_animating(), "it has to have settled first");
 
-        anim.animate_to(1.0001, Instant::now());
+        anim.animate_to(1.0001, FrameInstant::from(Instant::now()));
         assert_eq!(
             velocity_of(&anim),
             0.0,
@@ -903,7 +905,7 @@ mod tests {
 
         let mut anim = AnimationState::new(0.0_f32, spring(SpringConfig::BOUNCY));
         anim.set_immediate(0.0);
-        anim.animate_to(1.0, Instant::now());
+        anim.animate_to(1.0, FrameInstant::from(Instant::now()));
         run(&mut anim, 184);
 
         assert!(
@@ -915,7 +917,7 @@ mod tests {
         );
 
         // Falling toward 1.0 from above is falling toward 0.0 as well.
-        anim.animate_to(0.0, Instant::now());
+        anim.animate_to(0.0, FrameInstant::from(Instant::now()));
         assert!(
             velocity_of(&anim) > 0.0,
             "it was already heading that way, so the new segment closes on its \
@@ -939,14 +941,20 @@ mod tests {
 
         let mut anim = AnimationState::new(Translate::NONE, spring(SpringConfig::DEFAULT));
         anim.set_immediate(Translate::NONE);
-        anim.animate_to(Translate::new(200.0, 0.0), Instant::now());
+        anim.animate_to(
+            Translate::new(200.0, 0.0),
+            FrameInstant::from(Instant::now()),
+        );
         at(&mut anim, 40);
         assert!(velocity_of(&anim) > 0.0, "it has to be moving first");
 
         // Straight down from wherever the rightward slide got to: the y
         // channel moves, the x channel does not.
         let here = *anim.current();
-        anim.animate_to(Translate::new(here.x, here.y + 200.0), Instant::now());
+        anim.animate_to(
+            Translate::new(here.x, here.y + 200.0),
+            FrameInstant::from(Instant::now()),
+        );
 
         assert!(
             velocity_of(&anim).abs() < 0.5,
@@ -965,7 +973,7 @@ mod tests {
 
         let mut anim = AnimationState::new(0.0_f32, Transition::new(100.0, TimingFunction::Linear));
         anim.set_immediate(0.0);
-        anim.animate_to(180.0, Instant::now());
+        anim.animate_to(180.0, FrameInstant::from(Instant::now()));
 
         let mut smallest = f32::INFINITY;
         for frame in 0..=25 {
@@ -987,7 +995,7 @@ mod tests {
     fn a_full_turn_is_a_turn_and_not_a_no_op() {
         let mut anim = AnimationState::new(0.0_f32, Transition::new(100.0, TimingFunction::Linear));
         anim.set_immediate(0.0);
-        anim.animate_to(360.0, Instant::now());
+        anim.animate_to(360.0, FrameInstant::from(Instant::now()));
 
         at(&mut anim, 50);
         let halfway = *anim.current();
@@ -1011,7 +1019,7 @@ mod tests {
     fn an_angle_past_the_wrap_keeps_going_forward() {
         let mut anim = AnimationState::new(0.0_f32, Transition::new(100.0, TimingFunction::Linear));
         anim.set_immediate(350.0);
-        anim.animate_to(370.0, Instant::now());
+        anim.animate_to(370.0, FrameInstant::from(Instant::now()));
 
         at(&mut anim, 50);
         let halfway = *anim.current();
@@ -1028,7 +1036,7 @@ mod tests {
     fn the_angle_moves_at_the_rate_the_easing_asks_for() {
         let mut anim = AnimationState::new(0.0_f32, Transition::new(100.0, TimingFunction::Linear));
         anim.set_immediate(0.0);
-        anim.animate_to(90.0, Instant::now());
+        anim.animate_to(90.0, FrameInstant::from(Instant::now()));
 
         at(&mut anim, 25);
         assert!(
@@ -1049,7 +1057,7 @@ mod tests {
 
         // 40 frames of the target creeping upward, then it stops.
         for frame in 1..=40u64 {
-            anim.animate_to(frame as f32, Instant::now());
+            anim.animate_to(frame as f32, FrameInstant::from(Instant::now()));
             at(&mut anim, 8);
         }
         let (_, high) = run(&mut anim, 800);
@@ -1070,7 +1078,7 @@ mod tests {
     fn a_property_with_no_timeline_cannot_be_played() {
         let mut anim = AnimationState::new(0.0_f32, Transition::new(10.0, TimingFunction::Linear));
         anim.set_immediate(0.0);
-        anim.play(Instant::now());
+        anim.play(FrameInstant::from(Instant::now()));
         assert!(!anim.is_animating(), "nothing to play");
     }
 
@@ -1084,11 +1092,11 @@ mod tests {
         let delayed = Transition::new(0.0, TimingFunction::Spring(SpringConfig::BOUNCY)).delay(200);
         let mut anim = AnimationState::new(0.0_f32, delayed);
         anim.set_immediate(0.0);
-        anim.animate_to(1.0, Instant::now());
+        anim.animate_to(1.0, FrameInstant::from(Instant::now()));
         run(&mut anim, 400);
         assert!(*anim.current() > 0.0, "past the delay and moving");
 
-        anim.animate_to(0.0, Instant::now());
+        anim.animate_to(0.0, FrameInstant::from(Instant::now()));
         assert_eq!(velocity_of(&anim), 0.0);
     }
 
@@ -1098,9 +1106,9 @@ mod tests {
     fn a_timed_transition_has_no_spring_to_carry() {
         let mut anim = AnimationState::new(0.0_f32, Transition::new(100.0, TimingFunction::Linear));
         anim.set_immediate(0.0);
-        anim.animate_to(1.0, Instant::now());
+        anim.animate_to(1.0, FrameInstant::from(Instant::now()));
         run(&mut anim, 24);
-        anim.animate_to(0.0, Instant::now());
+        anim.animate_to(0.0, FrameInstant::from(Instant::now()));
         assert!(anim.spring_state.is_none());
     }
 
@@ -1120,7 +1128,7 @@ mod tests {
         let transition = Transition::new(300.0, TimingFunction::Linear);
         let mut state = AnimationState::new(0.0f32, transition);
 
-        state.animate_to(100.0, Instant::now());
+        state.animate_to(100.0, FrameInstant::from(Instant::now()));
 
         assert_eq!(*state.target(), 100.0);
         assert!(state.is_animating());
@@ -1131,11 +1139,11 @@ mod tests {
         let transition = Transition::new(300.0, TimingFunction::Linear);
         let mut state = AnimationState::new(0.0f32, transition);
 
-        state.animate_to(100.0, Instant::now());
+        state.animate_to(100.0, FrameInstant::from(Instant::now()));
         let first_start_time = state.start_time;
 
         // Animate to same target should not restart
-        state.animate_to(100.0, Instant::now());
+        state.animate_to(100.0, FrameInstant::from(Instant::now()));
         assert_eq!(state.start_time, first_start_time);
     }
 

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -1041,9 +1041,14 @@ fn advancing_animations_does_not_report_a_missing_scope() {
 
     let before = report_count();
     let root = h.root;
+    // Advancing animations is a frame's first pass, and it runs with the
+    // frame's instant declared — reading it without one is a different
+    // diagnostic (#265), and this test is about the reactive one.
+    h.tree.set_frame_instant(Some(std::time::Instant::now()));
     h.tree.with_widget_mut(root, |w, id, tree| {
         w.advance_animations(tree, id);
     });
+    h.tree.set_frame_instant(None);
     assert_eq!(
         report_count() - before,
         0,

--- a/src/widgets/container/interaction.rs
+++ b/src/widgets/container/interaction.rs
@@ -425,9 +425,10 @@ impl Container {
                 }
             }
 
-            // The finger lifted. Momentum starts here or not at all — and it
-            // starts now, on the event, rather than becoming due for whatever
-            // frame happens along next.
+            // The finger lifted. Whether there is a momentum at all is decided
+            // here, on the event that ended the gesture; when it starts is the
+            // first frame that carries it, because the gap between the two is
+            // the loop's latency and not the motion going stale (#265).
             Event::ScrollEnd { at } => {
                 if self.scroll_axis != ScrollAxis::None && hit.contains(*at) {
                     let sd = self.scroll_mut();

--- a/src/widgets/container/interaction.rs
+++ b/src/widgets/container/interaction.rs
@@ -15,7 +15,7 @@
 //! [`track_pointer`]: Container::track_pointer
 //! [`handle_own_event`]: Container::handle_own_event
 
-use std::time::Instant;
+use crate::clock::EventInstant;
 
 use super::*;
 use crate::reactive::focus::focus_within;
@@ -122,7 +122,7 @@ impl Container {
     /// over a disabled subtree cost one comparison each and wake nobody.
     ///
     /// [`Control::is_hovered`]: crate::widgets::Control::is_hovered
-    pub(super) fn pointer_left(&mut self, id: WidgetId, now: Instant) {
+    pub(super) fn pointer_left(&mut self, id: WidgetId, now: EventInstant) {
         let Some(ref mut ix) = self.interaction else {
             return;
         };
@@ -141,7 +141,7 @@ impl Container {
         if ix.ripple.is_active()
             && let Some(config) = ix.ripple_config()
         {
-            ix.ripple.cancel(&config, now);
+            ix.ripple.cancel(&config, now.as_frame_start());
             request_job(id, JobRequest::Animation(RequiredJob::Paint));
         }
 
@@ -160,7 +160,7 @@ impl Container {
         id: WidgetId,
         hit: &HitContext,
         event: &Event,
-        now: Instant,
+        now: EventInstant,
     ) {
         let has_animated = self.has_animated_state_properties();
         // Read before the mutable borrow: cancelling a ripple below needs it.
@@ -230,7 +230,7 @@ impl Container {
                     && ix.ripple.is_active()
                     && let Some(ref config) = ripple_config
                 {
-                    ix.ripple.cancel(config, now);
+                    ix.ripple.cancel(config, now.as_frame_start());
                     request_job(id, JobRequest::Animation(RequiredJob::Paint));
                 }
 
@@ -259,7 +259,7 @@ impl Container {
         hit: &HitContext,
         event: &Event,
         local: &Event,
-        now: Instant,
+        now: EventInstant,
     ) -> EventResponse {
         // One question for a press, asked once and answered up to twice: by the
         // arm that handles it, and by the focus claim at the end of the
@@ -309,7 +309,7 @@ impl Container {
                         // rebased for this container.
                         let on_screen = event.coords().unwrap_or(*at);
                         if let Some(local) = hit.local(on_screen) {
-                            ix.ripple.start(local.x, local.y, now);
+                            ix.ripple.start(local.x, local.y, now.as_frame_start());
                         }
                         request_job(id, JobRequest::Animation(RequiredJob::Paint));
                     }
@@ -350,9 +350,9 @@ impl Container {
                         && let Some(config) = ix.ripple_config()
                     {
                         if hit.contains(*at) {
-                            ix.ripple.release(&config, now);
+                            ix.ripple.release(&config, now.as_frame_start());
                         } else {
-                            ix.ripple.cancel(&config, now);
+                            ix.ripple.cancel(&config, now.as_frame_start());
                         }
                         request_job(id, JobRequest::Animation(RequiredJob::Paint));
                     }

--- a/src/widgets/container/ripple.rs
+++ b/src/widgets/container/ripple.rs
@@ -36,7 +36,9 @@
 //! that restarts loses the second. [`MAX_LIVE_RIPPLES`] bounds the work; past it the
 //! oldest is dropped, which is the one nearest to invisible anyway.
 
-use std::time::{Duration, Instant};
+use std::time::Duration;
+
+use crate::clock::FrameInstant;
 
 use crate::widgets::state_layer::RippleConfig;
 
@@ -89,7 +91,7 @@ fn ease_out(t: f32) -> f32 {
     1.0 - (1.0 - t).powi(3)
 }
 
-fn since(start: Instant, now: Instant) -> f32 {
+fn since(start: FrameInstant, now: FrameInstant) -> f32 {
     now.saturating_duration_since(start).as_secs_f32()
 }
 
@@ -107,7 +109,7 @@ enum ExitKind {
 #[derive(Debug, Clone, Copy)]
 struct Exit {
     kind: ExitKind,
-    at: Instant,
+    at: FrameInstant,
     /// Growth when the exit began, so the remainder can be compressed into it
     /// instead of restarting from zero.
     growth: f32,
@@ -118,7 +120,7 @@ struct Exit {
 pub struct Ripple {
     /// Where the pointer went down, in local container coordinates.
     origin: (f32, f32),
-    born: Instant,
+    born: FrameInstant,
     exit: Option<Exit>,
     /// 0 at [`START_RADIUS`], 1 fully expanded.
     growth: f32,
@@ -126,7 +128,7 @@ pub struct Ripple {
 }
 
 impl Ripple {
-    fn new(origin: (f32, f32), now: Instant) -> Self {
+    fn new(origin: (f32, f32), now: FrameInstant) -> Self {
         Self {
             origin,
             born: now,
@@ -174,7 +176,7 @@ impl Ripple {
     /// the frame's animation pass runs, so a touch tap — down and up in one
     /// batch — arrives before `advance` has ever run, and the compressed
     /// remainder has to start from the real growth rather than a stale zero.
-    fn begin_exit(&mut self, kind: ExitKind, config: &RippleConfig, now: Instant) {
+    fn begin_exit(&mut self, kind: ExitKind, config: &RippleConfig, now: FrameInstant) {
         if self.exit.is_some() {
             return;
         }
@@ -193,7 +195,7 @@ impl Ripple {
     /// was. Cutting the rise off at the release instead — the obvious reading —
     /// makes every click shorter than the rise dimmer than the one before it,
     /// and a tap that arrives in a single event batch invisible outright.
-    fn opacity_at(&self, config: &RippleConfig, now: Instant) -> f32 {
+    fn opacity_at(&self, config: &RippleConfig, now: FrameInstant) -> f32 {
         let fade_speed = sane_speed(config.fade_speed);
         let rise_over = FADE_IN / fade_speed;
         let risen = phase(since(self.born, now), rise_over);
@@ -211,7 +213,7 @@ impl Ripple {
     }
 
     /// When the disc has finished leaving, so it can be dropped.
-    fn gone(&self, config: &RippleConfig, now: Instant) -> bool {
+    fn gone(&self, config: &RippleConfig, now: FrameInstant) -> bool {
         let Some(exit) = self.exit else {
             return false;
         };
@@ -227,13 +229,13 @@ impl Ripple {
     }
 
     /// The growth a ripple nobody has released yet has reached.
-    fn held_growth(&self, config: &RippleConfig, now: Instant) -> f32 {
+    fn held_growth(&self, config: &RippleConfig, now: FrameInstant) -> f32 {
         let duration = HELD_GROWTH / sane_speed(config.expand_speed);
         ease_out(phase(since(self.born, now), duration))
     }
 
     /// Advance, and report whether this ripple is still worth drawing.
-    fn advance(&mut self, config: &RippleConfig, now: Instant) -> bool {
+    fn advance(&mut self, config: &RippleConfig, now: FrameInstant) -> bool {
         self.opacity = self.opacity_at(config, now);
 
         let Some(exit) = self.exit else {
@@ -282,7 +284,7 @@ impl RippleState {
     /// Begin a ripple at the given local coordinates.
     ///
     /// The coordinates are relative to the container's origin (0,0 = top-left).
-    pub fn start(&mut self, local_x: f32, local_y: f32, now: Instant) {
+    pub fn start(&mut self, local_x: f32, local_y: f32, now: FrameInstant) {
         // At capacity the oldest goes. It is the one furthest through its own
         // fade, so it is the least of them to lose.
         while self.live.len() >= MAX_LIVE_RIPPLES {
@@ -295,14 +297,14 @@ impl RippleState {
     ///
     /// Only the ripple still being held is confirmed. The others already have
     /// an exit of their own and keep it.
-    pub fn release(&mut self, config: &RippleConfig, now: Instant) {
+    pub fn release(&mut self, config: &RippleConfig, now: FrameInstant) {
         if let Some(held) = self.live.iter_mut().rev().find(|r| !r.is_leaving()) {
             held.begin_exit(ExitKind::Confirmed, config, now);
         }
     }
 
     /// The press was abandoned: every ripple still being held just goes.
-    pub fn cancel(&mut self, config: &RippleConfig, now: Instant) {
+    pub fn cancel(&mut self, config: &RippleConfig, now: FrameInstant) {
         for ripple in self.live.iter_mut().filter(|r| !r.is_leaving()) {
             ripple.begin_exit(ExitKind::Cancelled, config, now);
         }
@@ -323,7 +325,7 @@ impl RippleState {
     /// Returns whether any is still animating. Dropping a ripple at zero
     /// opacity needs no deferred frame: it draws nothing at that point, so
     /// there is no last frame to preserve.
-    pub fn advance(&mut self, config: &RippleConfig, now: Instant) -> bool {
+    pub fn advance(&mut self, config: &RippleConfig, now: FrameInstant) -> bool {
         let mut animating = false;
         self.live.retain_mut(|ripple| {
             let alive = ripple.advance(config, now);
@@ -336,6 +338,7 @@ impl RippleState {
 
 #[cfg(test)]
 mod tests {
+
     use std::time::Duration;
 
     use super::*;
@@ -344,7 +347,7 @@ mod tests {
         RippleConfig::default()
     }
 
-    fn at(base: Instant, ms: u64) -> Instant {
+    fn at(base: FrameInstant, ms: u64) -> FrameInstant {
         base + Duration::from_millis(ms)
     }
 
@@ -352,7 +355,7 @@ mod tests {
     /// pulls it back.
     #[test]
     fn a_click_never_moves_the_radius_backwards() {
-        let t0 = Instant::now();
+        let t0 = FrameInstant::from(std::time::Instant::now());
         let mut state = RippleState::new();
         state.start(10.0, 10.0, t0);
 
@@ -380,7 +383,7 @@ mod tests {
     /// instead of abandoning it.
     #[test]
     fn a_click_completes_the_expansion_it_started() {
-        let t0 = Instant::now();
+        let t0 = FrameInstant::from(std::time::Instant::now());
         let mut state = RippleState::new();
         state.start(10.0, 10.0, t0);
         state.advance(&cfg(), at(t0, 80));
@@ -403,7 +406,7 @@ mod tests {
     /// for its whole life — a ripple that drew nothing, for 375ms of frames.
     #[test]
     fn a_tap_released_before_its_first_frame_is_still_seen() {
-        let t0 = Instant::now();
+        let t0 = FrameInstant::from(std::time::Instant::now());
         let mut state = RippleState::new();
         state.start(10.0, 10.0, t0);
         state.release(&cfg(), t0);
@@ -426,7 +429,7 @@ mod tests {
     #[test]
     fn a_click_shorter_than_the_rise_still_reaches_full_strength() {
         for click_ms in [20, 40, 60, 74] {
-            let t0 = Instant::now();
+            let t0 = FrameInstant::from(std::time::Instant::now());
             let mut state = RippleState::new();
             state.start(10.0, 10.0, t0);
             state.advance(&cfg(), at(t0, click_ms));
@@ -448,7 +451,7 @@ mod tests {
     /// edge press cover the box long before the growth ended.
     #[test]
     fn the_size_does_not_depend_on_where_the_press_landed() {
-        let t0 = Instant::now();
+        let t0 = FrameInstant::from(std::time::Instant::now());
         let (w, h) = (200.0, 40.0);
 
         let mut corner = RippleState::new();
@@ -469,7 +472,7 @@ mod tests {
     /// inside, and it was not already inside a third of the way back.
     #[test]
     fn a_finished_ripple_covers_the_container_and_not_before() {
-        let t0 = Instant::now();
+        let t0 = FrameInstant::from(std::time::Instant::now());
         let (w, h) = (200.0, 40.0);
         let mut state = RippleState::new();
         state.start(0.0, 0.0, t0);
@@ -501,7 +504,7 @@ mod tests {
                 fade_speed: fade,
                 ..Default::default()
             };
-            let t0 = Instant::now();
+            let t0 = FrameInstant::from(std::time::Instant::now());
             let mut state = RippleState::new();
             state.start(10.0, 10.0, t0);
             state.release(&config, t0);
@@ -528,7 +531,7 @@ mod tests {
 
     #[test]
     fn a_confirmed_ripple_leaves_when_it_has_faded() {
-        let t0 = Instant::now();
+        let t0 = FrameInstant::from(std::time::Instant::now());
         let mut state = RippleState::new();
         state.start(10.0, 10.0, t0);
         state.release(&cfg(), at(t0, 80));
@@ -544,7 +547,7 @@ mod tests {
     /// exit: no completion, and a fade short enough to get out of the way.
     #[test]
     fn leaving_without_releasing_does_not_complete_the_expansion() {
-        let t0 = Instant::now();
+        let t0 = FrameInstant::from(std::time::Instant::now());
         let mut state = RippleState::new();
         state.start(10.0, 10.0, t0);
         state.advance(&cfg(), at(t0, 80));
@@ -566,7 +569,7 @@ mod tests {
     /// other.
     #[test]
     fn a_second_press_does_not_erase_the_first() {
-        let t0 = Instant::now();
+        let t0 = FrameInstant::from(std::time::Instant::now());
         let mut state = RippleState::new();
         state.start(10.0, 10.0, t0);
         state.release(&cfg(), at(t0, 80));
@@ -582,7 +585,7 @@ mod tests {
     /// A release confirms the press being held, not the ones already leaving.
     #[test]
     fn a_release_confirms_only_the_ripple_still_held() {
-        let t0 = Instant::now();
+        let t0 = FrameInstant::from(std::time::Instant::now());
         let mut state = RippleState::new();
         state.start(10.0, 10.0, t0);
         state.release(&cfg(), at(t0, 50));
@@ -599,7 +602,7 @@ mod tests {
 
     #[test]
     fn the_oldest_goes_when_the_bound_is_reached() {
-        let t0 = Instant::now();
+        let t0 = FrameInstant::from(std::time::Instant::now());
         let mut state = RippleState::new();
         for i in 0..(MAX_LIVE_RIPPLES + 2) {
             state.start(i as f32, 0.0, at(t0, i as u64 * 10));
@@ -612,7 +615,7 @@ mod tests {
 
     #[test]
     fn a_held_ripple_stops_asking_for_frames_once_it_is_fully_grown() {
-        let t0 = Instant::now();
+        let t0 = FrameInstant::from(std::time::Instant::now());
         let mut state = RippleState::new();
         state.start(10.0, 10.0, t0);
 

--- a/src/widgets/container/scrollable.rs
+++ b/src/widgets/container/scrollable.rs
@@ -233,7 +233,7 @@ impl Container {
     pub(super) fn advance_scrollbar_scale_animations_internal(
         &mut self,
         id: WidgetId,
-        now: std::time::Instant,
+        now: crate::clock::FrameInstant,
     ) -> bool {
         if self.scroll_axis == ScrollAxis::None
             || self.scroll_data().scrollbar_visibility == ScrollbarVisibility::Hidden
@@ -267,7 +267,7 @@ impl Container {
         axis: ScrollbarAxis,
         scale_factor: f32,
         id: WidgetId,
-        now: std::time::Instant,
+        now: crate::clock::FrameInstant,
     ) -> bool {
         // Determine target scale based on hover state
         let sd = self.scroll_data();
@@ -855,7 +855,7 @@ impl Container {
         delta_x: f32,
         delta_y: f32,
         source: ScrollSource,
-        at: std::time::Instant,
+        at: crate::clock::EventInstant,
     ) -> bool {
         let axis = self.scroll_axis;
         let sd = self.scroll_mut();

--- a/src/widgets/diagnostic_audit.rs
+++ b/src/widgets/diagnostic_audit.rs
@@ -38,6 +38,13 @@ fn diagnostics_from_full_lifecycle(widget: impl Widget + 'static) -> u64 {
     let root = tree.register(Box::new(widget));
     tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
 
+    // The frame's passes run with the frame's instant declared, as
+    // `render_surface` declares it: a widget that asks the time during one is
+    // asking about this frame, and answering with the wall clock instead is
+    // the thing #265's diagnostic exists to say. The audit answers "what will a
+    // user see in their console", so it has to name the moment the loop names.
+    tree.set_frame_instant(Some(std::time::Instant::now()));
+
     // layout_hints is what a parent asks before laying a child out
     tree.with_widget(root, |w| w.layout_hints());
 
@@ -58,10 +65,13 @@ fn diagnostics_from_full_lifecycle(widget: impl Widget + 'static) -> u64 {
         w.reconcile_children(t, id);
     });
 
-    // Event dispatch runs inside a snapshot zone in the real loop
-    // (`render_surface`, lib.rs), so it is wrapped here too. The audit answers
+    // Event dispatch runs outside the frame and carries its own instant, which
+    // `dispatch_events` declares per event. It also runs inside a snapshot zone
+    // in the real loop (`render_surface`, lib.rs), so it is wrapped here too. The audit answers
     // "what will a user see in their console", and that question is only
     // meaningful against the call sites the library actually uses.
+    tree.set_frame_instant(None);
+    tree.set_event_instant(Some(std::time::Instant::now()));
     crate::reactive::diagnostics::snapshot_zone(|| {
         for event in [
             Event::mouse_enter(10.0, 10.0),
@@ -79,6 +89,9 @@ fn diagnostics_from_full_lifecycle(widget: impl Widget + 'static) -> u64 {
         }
     });
 
+    tree.set_event_instant(None);
+    tree.set_frame_instant(Some(std::time::Instant::now()));
+
     // A second pass: the first one seeded caches, this one exercises the
     // steady-state paths (early-outs, paint-cache reuse, target re-sync).
     tree.with_widget_mut(root, |w, id, t| w.layout(t, id, constraints));
@@ -95,10 +108,11 @@ fn diagnostics_from_full_lifecycle(widget: impl Widget + 'static) -> u64 {
 fn assert_quiet(what: &str, count: u64) {
     assert_eq!(
         count, 0,
-        "{what} made {count} signal read(s) the diagnostic considers \
-         non-reactive. Re-run with `--nocapture` to see the file and line. \
-         Either the read needs a tracking scope, or it is a legitimate \
-         snapshot and needs to say so with `snapshot_zone`."
+        "{what} drew {count} diagnostic(s) from the library. Re-run with \
+         `--nocapture` to see which and where. A read with no reactive scope \
+         either needs a tracking scope or is a legitimate snapshot and needs \
+         to say so with `snapshot_zone`; a clock read outside its pass either \
+         belongs inside one or is asking the wrong clock."
     );
 }
 

--- a/src/widgets/scroll.rs
+++ b/src/widgets/scroll.rs
@@ -392,7 +392,14 @@ impl ScrollState {
         }
         self.gesture_ended = true;
         self.gesture_samples = 0;
-        self.momentum_since = Some(at.as_frame_start());
+        // Not stamped here. The lift is an event and the momentum runs on
+        // frames, and the difference between the two clocks is the loop's
+        // input latency — which this field is differenced against a 200ms
+        // threshold, so stamping it from the event meant a stalled loop read
+        // its own lateness as the flick having gone stale and cancelled it on
+        // the first frame (#265). Nothing has advanced this momentum yet, and
+        // `None` is what that means.
+        self.momentum_since = None;
     }
 
     /// Discard a momentum that stopped being advanced `idle_ms` ago.
@@ -758,6 +765,37 @@ mod tests {
             state.record_gesture_sample(0.0, delta, dt);
         }
         end_gesture_after(state, dt_ms);
+    }
+
+    /// The flick and the frame that carries it are on different clocks: the
+    /// lift is stamped when the compositor sent it, the frame when it began.
+    /// Between them is the loop's input latency, and `momentum_since` used to
+    /// be stamped from the lift and then differenced against the frame — so a
+    /// loop 250ms behind read its own lateness as the flick having gone stale
+    /// and cancelled it before it moved a pixel (#265).
+    #[test]
+    fn a_flick_survives_a_loop_that_was_late_delivering_the_lift() {
+        let mut state = scroller();
+        gesture(&mut state, 5, 20.0, 8.0);
+        assert!(
+            state.should_apply_momentum(),
+            "the gesture left a velocity to fling"
+        );
+
+        // The first frame to carry it starts a quarter of a second after the
+        // lift — longer than MOMENTUM_STALE_MS, which is the trap.
+        let late =
+            FrameInstant::from(std::time::Instant::now() + std::time::Duration::from_millis(250));
+
+        assert!(
+            state.advance_momentum(late),
+            "the flick has to run on the frame that finally arrived, not be \
+             expired by how long it took to arrive"
+        );
+        assert!(
+            state.offset_y != 0.0,
+            "and it has to have moved the content"
+        );
     }
 
     /// How far the momentum carries the content once the finger has lifted.

--- a/src/widgets/scroll.rs
+++ b/src/widgets/scroll.rs
@@ -1,6 +1,7 @@
 //! Scroll configuration types for scrollable containers.
 
 use super::widget::Rect;
+use crate::clock::{EventInstant, FrameInstant};
 use crate::reactive::{IntoSignal, Signal};
 use crate::widgets::{Color, Container};
 
@@ -276,14 +277,14 @@ pub(crate) struct ScrollState {
     pub velocity_y: f32,
     /// Timestamp of the last gesture sample, for the interval between samples
     /// and for how old the gesture is when it ends.
-    pub last_scroll_time: Option<std::time::Instant>,
+    pub last_scroll_time: Option<EventInstant>,
     /// The gesture that produced the velocity is over, so the momentum may run.
     /// Set by an end-of-gesture, cleared by the next sample.
     pub gesture_ended: bool,
     /// When the momentum became due, refreshed by every step it takes. A
     /// momentum that stops being advanced has been abandoned, and the field is
     /// what says how long ago that was.
-    pub momentum_since: Option<std::time::Instant>,
+    pub momentum_since: Option<FrameInstant>,
     /// Samples in the current gesture, so the first timed one seeds the
     /// estimate instead of being smoothed against a velocity from before it.
     pub gesture_samples: u32,
@@ -377,7 +378,7 @@ impl ScrollState {
     /// in. `last_scroll_time` is this state's own field, and a caller measuring
     /// it with a second clock is how the sample path and the end path came to
     /// disagree about what time it was inside one gesture.
-    pub fn end_gesture(&mut self, at: std::time::Instant) {
+    pub fn end_gesture(&mut self, at: EventInstant) {
         let since_last_sample_ms = self
             .last_scroll_time
             .map(|t| at.duration_since(t).as_secs_f32() * 1000.0);
@@ -391,7 +392,7 @@ impl ScrollState {
         }
         self.gesture_ended = true;
         self.gesture_samples = 0;
-        self.momentum_since = Some(at);
+        self.momentum_since = Some(at.as_frame_start());
     }
 
     /// Discard a momentum that stopped being advanced `idle_ms` ago.
@@ -422,7 +423,7 @@ impl ScrollState {
     }
 
     /// How long since the momentum was last advanced, if one is due.
-    pub fn momentum_idle_ms(&self, now: std::time::Instant) -> Option<f32> {
+    pub fn momentum_idle_ms(&self, now: FrameInstant) -> Option<f32> {
         self.momentum_since
             .map(|t| now.duration_since(t).as_secs_f32() * 1000.0)
     }
@@ -444,7 +445,7 @@ impl ScrollState {
     }
 
     /// Advance kinetic scrolling animation, returns true if still animating
-    pub fn advance_momentum(&mut self, now: std::time::Instant) -> bool {
+    pub fn advance_momentum(&mut self, now: FrameInstant) -> bool {
         const FRICTION: f32 = 0.92;
         const VELOCITY_THRESHOLD: f32 = 0.5;
 
@@ -736,8 +737,8 @@ mod tests {
     fn end_gesture_after(state: &mut ScrollState, gap_ms: f32) {
         let at = std::time::Instant::now();
         state.last_scroll_time =
-            Some(at - std::time::Duration::from_micros((gap_ms * 1000.0) as u64));
-        state.end_gesture(at);
+            Some((at - std::time::Duration::from_micros((gap_ms * 1000.0) as u64)).into());
+        state.end_gesture(at.into());
     }
     use super::*;
 
@@ -763,7 +764,7 @@ mod tests {
     fn coast(state: &mut ScrollState) -> f32 {
         let start = state.offset_y;
         for _ in 0..600 {
-            if !state.advance_momentum(std::time::Instant::now()) {
+            if !state.advance_momentum(std::time::Instant::now().into()) {
                 break;
             }
         }
@@ -820,7 +821,7 @@ mod tests {
         assert!(state.velocity_y.abs() > 0.5, "the gesture built a speed");
         assert!(!state.should_apply_momentum(), "but it is not due");
         assert!(
-            !state.advance_momentum(std::time::Instant::now()),
+            !state.advance_momentum(std::time::Instant::now().into()),
             "and nothing is animating, so the loop is not kept awake for it"
         );
         assert_eq!(coast(&mut state), 0.0);
@@ -835,7 +836,7 @@ mod tests {
         assert!(state.should_apply_momentum(), "the flick is due");
 
         // A few frames run, and then nothing does.
-        state.advance_momentum(std::time::Instant::now());
+        state.advance_momentum(std::time::Instant::now().into());
         assert!(state.should_apply_momentum(), "still due between frames");
 
         state.expire_stale_momentum(400.0);

--- a/src/widgets/text_input.rs
+++ b/src/widgets/text_input.rs
@@ -11,6 +11,7 @@
 use std::collections::VecDeque;
 use std::time::{Duration, Instant};
 
+use crate::clock::{EventInstant, FrameInstant};
 use crate::default_font_family;
 use crate::jobs::{JobRequest, JobType, RequiredJob, request_job, request_job_at};
 use crate::layout::{Constraints, Size};
@@ -57,7 +58,7 @@ const HISTORY_COALESCE_MS: u64 = 500;
 #[derive(Clone, Copy)]
 struct Edit {
     width: f32,
-    at: Instant,
+    at: EventInstant,
 }
 
 /// Type alias for text input callbacks
@@ -88,7 +89,7 @@ struct History {
     /// Stack of undone states for redo
     redo_stack: VecDeque<HistoryEntry>,
     /// Time of last edit (for coalescing)
-    last_edit_time: Instant,
+    last_edit_time: EventInstant,
     /// Type of last edit (for coalescing)
     last_edit_type: Option<EditType>,
 }
@@ -98,14 +99,14 @@ impl History {
         Self {
             undo_stack: VecDeque::new(),
             redo_stack: VecDeque::new(),
-            last_edit_time: Instant::now(),
+            last_edit_time: Instant::now().into(),
             last_edit_type: None,
         }
     }
 
     /// Push a new state to history (clears redo stack)
     /// Uses coalescing to merge similar edits within a time window
-    fn push(&mut self, entry: HistoryEntry, edit_type: EditType, at: Instant) {
+    fn push(&mut self, entry: HistoryEntry, edit_type: EditType, at: EventInstant) {
         let since_last = at.duration_since(self.last_edit_time);
 
         // Don't push if it's the same as the last entry
@@ -263,7 +264,7 @@ pub struct TextInput {
 
     // Cursor blinking
     cursor_visible: bool,
-    last_cursor_toggle: Instant,
+    last_cursor_toggle: FrameInstant,
 
     // Mouse drag selection
     is_dragging: bool,
@@ -329,7 +330,7 @@ impl TextInput {
             autofocus_pending: false,
             selection: Selection::new(0),
             cursor_visible: true,
-            last_cursor_toggle: Instant::now(),
+            last_cursor_toggle: Instant::now().into(),
             is_dragging: false,
             is_hovered: false,
             hover: crate::reactive::signal::create_signal(false),
@@ -715,7 +716,7 @@ impl TextInput {
     /// changes twice a second, so 113 frames out of 114 repaint the same pixels.
     /// A focused field is the normal state of a lock screen, and that ran all
     /// night.
-    fn update_cursor_blink(&mut self, id: WidgetId, now: Instant) -> bool {
+    fn update_cursor_blink(&mut self, id: WidgetId, now: FrameInstant) -> bool {
         if !self.cached_caret || !has_focus(id) {
             return false;
         }
@@ -728,7 +729,16 @@ impl TextInput {
     }
 
     /// Reset cursor to visible (called on input)
-    fn reset_cursor_blink(&mut self, at: Instant) {
+    /// Restart the caret's blink from the edit that moved it.
+    ///
+    /// The blink runs on frames and the edit happened on an event, so the
+    /// phase starts a loop's input latency earlier than the frame that will
+    /// draw it — which shifts the first blink and nothing else. That is the
+    /// crossing, made here rather than at each of the callers, which is the
+    /// only reason this takes an [`EventInstant`] and not the clock it
+    /// measures against.
+    fn reset_cursor_blink(&mut self, at: EventInstant) {
+        let at = at.as_frame_start();
         self.cursor_visible = true;
         self.last_cursor_toggle = at;
     }
@@ -1055,7 +1065,7 @@ impl TextInput {
     }
 
     /// Save current state to history (call before making changes)
-    fn save_to_history(&mut self, edit_type: EditType, at: Instant) {
+    fn save_to_history(&mut self, edit_type: EditType, at: EventInstant) {
         self.history.push(
             HistoryEntry {
                 text: self.cached_value.clone(),
@@ -1430,7 +1440,9 @@ impl Widget for TextInput {
             request_job_at(
                 id,
                 JobRequest::Animation(RequiredJob::Paint),
-                self.last_cursor_toggle + Duration::from_millis(CURSOR_BLINK_MS),
+                // A deadline the loop compares against the wall clock, so it
+                // leaves the frame's sequence here.
+                (self.last_cursor_toggle + Duration::from_millis(CURSOR_BLINK_MS)).into_inner(),
             );
 
             if self.cursor_visible {
@@ -1640,7 +1652,7 @@ mod tests {
         };
 
         let inside = {
-            let t0 = Instant::now();
+            let t0: EventInstant = Instant::now().into();
             let mut history = History::new();
             history.push(entry("a"), EditType::Insert, t0);
             history.push(
@@ -1656,7 +1668,7 @@ mod tests {
         );
 
         let outside = {
-            let t0 = Instant::now();
+            let t0: EventInstant = Instant::now().into();
             let mut history = History::new();
             history.push(entry("a"), EditType::Insert, t0);
             history.push(entry("ab"), EditType::Insert, t0 + Duration::from_secs(5));

--- a/src/widgets/text_style.rs
+++ b/src/widgets/text_style.rs
@@ -44,8 +44,7 @@
 
 use smallvec::SmallVec;
 
-use std::time::Instant;
-
+use crate::clock::FrameInstant;
 use crate::jobs::RequiredJob;
 use crate::reactive::{IntoSignal, Signal};
 use crate::widgets::container::AnimationState;
@@ -266,7 +265,7 @@ impl TextAnims {
         &mut self,
         color: Color,
         size: f32,
-        now: Instant,
+        now: FrameInstant,
     ) -> (Option<RequiredJob>, f32) {
         let mut wants = None;
         if let Some(a) = self.color.as_mut() {
@@ -300,7 +299,7 @@ impl TextAnims {
     /// `None` where nothing moved: a transition inside its `delay_ms` is
     /// animating and has produced no new value, and asking for a paint there
     /// would wake the loop every frame for a picture that has not changed.
-    pub(crate) fn advance(&mut self, now: Instant) -> Option<RequiredJob> {
+    pub(crate) fn advance(&mut self, now: FrameInstant) -> Option<RequiredJob> {
         let mut wants = None;
         if let Some(a) = self.color.as_mut()
             && a.advance(now).is_changed()

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -128,13 +128,20 @@ impl Harness {
     }
 
     /// Paint the whole tree and hand back what it drew.
+    ///
+    /// Inside a frame, because a paint is one of the three passes a frame is
+    /// made of: a widget that asks the time while drawing — a scrollbar's
+    /// hover expansion does — is asking about this frame, and the loop always
+    /// has an answer. Without one it gets the wall clock and a diagnostic.
     pub fn paint(&mut self) -> RenderNode {
         let root = self.root;
+        self.tree.set_frame_instant(Some(std::time::Instant::now()));
         let mut node = RenderNode::new(root.as_u64());
         self.tree.with_widget_mut(root, |w, id, t| {
             let mut ctx = PaintContext::new(&mut node);
             w.paint(t, id, &mut ctx);
         });
+        self.tree.set_frame_instant(None);
         node
     }
 


### PR DESCRIPTION
## What changed

`Tree`'s two clocks are two types. `frame_instant()` answers a `FrameInstant`
and `event_instant()` an `EventInstant` (`src/clock.rs`), and the widget timing
they feed takes the one it means — animations, the ripple and the caret's blink
on frames; gesture samples, the edit history and pointer timestamps on events.
Neither carries `elapsed()` and neither can be differenced against the other,
so the two ways of being wrong that #265 names are now a compile error and a
diagnostic respectively:

- **the wrong clock** stops compiling, and crossing where it is right is one
  named call, `EventInstant::as_frame_start`, which says in its own docs what
  makes a crossing sound: the value is where a timeline *begins*, not a
  deadline whose crossing cancels something;
- **the right clock outside its pass** reports in a debug build, on the
  machinery the "signal read with no reactive scope" warning already uses —
  once per call site, counted where a test reads the count, naming the other
  clock too. The fallback stays, per the issue's non-goal: a widget asking the
  time between passes still gets a usable number.

And the bug the types exposed on their first run is fixed: `momentum_since` was
stamped from the event clock at a lift and differenced against the frame clock,
so a loop's input latency was read as the flick having gone stale and could
cancel it before it moved a pixel. Closes #265.

## What proves it

- `src/tree.rs::clock_diagnostics` — both acceptance bullets (a read outside a
  frame, a read outside a dispatch), the quiet case, and one that would catch
  the caller-tracking collapse an earlier draft of mine had: two sites report
  twice, one site read three times reports once.
- **The widget-level criterion the issue asks for is met by `diagnostic_audit`**,
  which counts the same reports: adding `tree.frame_instant()` inside
  `Container::event` fails all nine of its tests. The review verified that by
  doing it.
- `src/widgets/scroll.rs::a_flick_survives_a_loop_that_was_late_delivering_the_lift`
  — 250ms between lift and first frame, which the old cross-clock stamp
  cancelled. Fails if the stamp comes back.
- The conversion itself is checked by the compiler across five files, and the
  crossings are countable: seven, all greppable.

Full suite, clippy `-D warnings`, `cargo doc` denied, `mdbook test`/`build`,
goldens 10/10 on lavapipe. Each of the first three commits builds and passes
clippy standalone.

## What the review found

**Zero blocking findings.** Five worth answering; four fixed here:

1. `as_frame_start`'s stated rule excluded the caret's blink, which crosses to
   seed a phase origin and then measures progress against it. The rule was too
   narrow, not the call site: it now separates a timeline's beginning from a
   deadline, which is the distinction that made the momentum case a bug.
2. `book/src/architecture/events.md` still showed `ripple.start(.., Instant::now())`
   inside a widget's `event` — the mistake this change exists to stop, in the
   sample a first widget gets copied from, calling a public API that no longer
   takes an `Instant`. Fixed; the block is `ignore`, so nothing in the harness
   would have caught it.
3. `assert_quiet` named one kind of diagnostic in its failure message and now
   catches two, sending the next person the wrong way.
4. A comment in `interaction.rs` that commit 3 made false.

And the correction I owed on my own commit message: the types did not *refuse*
the momentum crossing — written as `as_frame_start()` it compiles, and does at
the second commit. What they did was make somebody write the line and say which
clock the field is on. The message says that now, because it is the evidence
for the design.

## What was checked by hand

Nothing — no compositor, no surface, no pixels. The diagnostic's messages were
read on stderr (`cargo test --lib clock_diagnostics -- --nocapture`) to confirm
they name the caller's file and line rather than the library's.

## Left undone

- **#340** — the fifth review finding, and a real one. With the lift no longer
  stamping `momentum_since`, *no* elapsed time can cancel a flick before its
  first frame, where the old stamp cancelled it too eagerly. The window is
  reachable: `render_surface` dispatches events and can return at `paced_out`
  before running jobs, so an occluded surface can sit there. Bounding it needs
  a comparison between the two clocks at a threshold large enough that input
  latency cannot reach it — which is a decision about a number, and the issue
  says so rather than my picking one here.
- `src/widgets/text_input.rs` initialises `last_edit_time` and
  `last_cursor_toggle` with `Instant::now()` at construction, the placeholder
  pattern `animations.rs` explicitly rejects. Pre-existing; this change only
  respells it, and nobody is worse off today.

https://claude.ai/code/session_01Q5KL58bdTdT533XJa1ZdDn
