### PR TITLE
A conversion is declared once, and every form comes from that declaration

### DIFF
--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: reviewer
-description: Reviews a change against Guido's own rules — harness coverage, the reactivity rule, the three spellings, atomic commits, documentation. Use before opening a pull request, or on an existing PR diff. Reports findings; does not fix them.
+description: Reviews a change against Guido's own rules — harness coverage, the reactivity rule, the five spellings, atomic commits, documentation. Use before opening a pull request, or on an existing PR diff. Reports findings; does not fix them.
 tools: Read, Grep, Glob, Bash
 ---
 
@@ -42,9 +42,14 @@ them.
 
 - **The reactivity rule**: anything that survives to paint takes
   `impl IntoSignal<T, M>`; structural declarations do not.
-- **The three spellings**: a new conversion needs `From`, `IntoVal` *and*
-  `converting_signals!`, plus a line in `tests/signal_conversions.rs`. A missing
-  signal form compiles fine and refuses at a call site months later.
+- **The five spellings**: a new conversion is one `converts!` entry, which
+  emits the closure and signal forms together, plus a line in
+  `tests/signal_conversions.rs`. An `S => T` entry needs the `From` beside the
+  type, and will not compile without it; an `S as T` entry is a widening std
+  has no `From` for, where the macro emits the value form too and a `From`
+  would make the marker ambiguous. An `IntoVal` impl written by hand
+  is the drift #226 closed: it gives the closure form and not the signal one,
+  which compiles fine and refuses at a call site months later.
 - Position and bounds live in the `Tree`, never on the widget.
 - Performance claims come with a measurement, before and after.
 - Commits are atomic and their subjects are sentences saying what is now true.

--- a/.claude/skills/widgets/SKILL.md
+++ b/.claude/skills/widgets/SKILL.md
@@ -57,36 +57,50 @@ than a value quietly ignored.
 A new property lands on one side of that line. If it changes what a pixel looks
 like, it is reactive.
 
-## A reactive property has three spellings, and they must agree
+## A reactive property has five spellings, and they must agree
 
-`IntoSignal` accepts a value, a closure, or a signal. A property is only
-properly reactive when the *same expression* compiles in all three positions:
+`IntoSignal` accepts a value, a closure, a signal, a writable signal or a memo.
+A property is only properly reactive when the *same expression* compiles in
+every position:
 
 ```rust
 container().width(100.0)             // value
 container().width(move || w.get())   // closure
-container().width(w)                 // signal
+container().width(w)                 // signal, writable signal or memo
 ```
 
-Three different sets of impls serve them, and they drift apart silently —
-nothing fails to build when one is missing; a call site refuses months later.
+**A conversion is declared once, and `converts!` emits every form:**
 
-**Adding a conversion to a property type means adding all three:**
+```rust
+crate::reactive::converts!(
+    f32 => Length,
+    f64 => Length,
+);
+```
 
-| spelling | impl | where |
-| --- | --- | --- |
-| value | `From<S> for T` | beside `T` |
-| closure | `IntoVal<T> for S` | beside `T` |
-| signal | `converting_signals!(S => T)` | beside `T` |
+That writes `IntoVal<Length> for f32` — the closure form — and the
+`Signal<f32>`, `RwSignal<f32>` and `Memo<f32>` impls into `Length`. The value
+form is the `From<f32> for Length` beside the type, which the `=>` arm calls,
+so a pair that compiles through `converts!` has all five by construction.
 
-They cannot be collapsed into one blanket impl: `IntoVal` is reflexive, so a
-blanket `S: IntoVal<T>` also covers `Signal<T> -> T`, collides with the
-passthrough impl, and leaves the marker generic undecidable. Excluding the
-reflexive case needs negative bounds or specialisation, neither stable.
+A widening std has no `From` for is spelled `f64 as f32`, and there the value
+form is the macro's too. A pair that *has* a `From` must not use `as`: both
+value impls would then apply and the marker generic would be undecidable.
 
-So the lists are hand-kept, and `tests/signal_conversions.rs` is the only thing
-standing between them and drift: **add a spelling there in the same change.**
-Tracked in #226.
+It was two lists that mirrored each other by hand, and they drifted: nothing
+failed to build when one was missing, and a call site refused months later.
+That is what #225 fixed by hand and #226 closed at the definition.
+
+The signal impls still name their source type rather than being one blanket
+impl: `IntoVal` is reflexive, so a blanket `S: IntoVal<T>` also covers
+`Signal<T> -> T`, collides with the passthrough impl, and leaves the marker
+generic undecidable. Excluding the reflexive case needs negative bounds or
+specialisation, neither stable. So the pairs are a list — but one list, and the
+macro is the only way to write an entry in it.
+
+`tests/signal_conversions.rs` is the list of spellings a caller can reach, and
+`one_declaration_covers_every_form` in `reactive::into_signal` is what says the
+macro still emits all five. **Add a spelling to the first in the same change.**
 
 ## The Widget trait
 
@@ -167,8 +181,8 @@ container().corners(Corners::superellipse(12.0, 1.5))
 ## Adding a widget property, end to end
 
 1. Decide reactive or structural (the rule above).
-2. Add the setter; if it takes a new conversion, add all three spellings and a
-   line in `tests/signal_conversions.rs`.
+2. Add the setter; if it takes a new conversion, add one `converts!` entry and
+   a line in `tests/signal_conversions.rs`.
 3. Make it reach paint, and add a scenario to `tests/golden_images.rs` if it
    changes pixels — see the `visual-verification` skill.
 4. Update `docs/` where the pattern is described, and the book chapter that

--- a/src/backdrop.rs
+++ b/src/backdrop.rs
@@ -95,29 +95,10 @@ impl From<f64> for BackdropBlur {
     }
 }
 
-// A closure may return a bare radius where a blur is expected, so the same
-// conversions have to exist for `IntoVal` — that is what makes
-// `.backdrop_blur(move || if glass { 16.0 } else { 0.0 })` compile.
-impl crate::reactive::IntoVal<BackdropBlur> for f32 {
-    fn into_val(self) -> BackdropBlur {
-        BackdropBlur::new(self)
-    }
-}
-
-impl crate::reactive::IntoVal<BackdropBlur> for f64 {
-    fn into_val(self) -> BackdropBlur {
-        BackdropBlur::new(self as f32)
-    }
-}
-
-impl crate::reactive::IntoVal<BackdropBlur> for i32 {
-    fn into_val(self) -> BackdropBlur {
-        BackdropBlur::new(self as f32)
-    }
-}
-
-// A signal accepts what a closure returning the same type accepts.
-crate::reactive::converting_signals!(
+// Every conversion a blur accepts, declared once — which is what makes
+// `.backdrop_blur(move || if glass { 16.0 } else { 0.0 })` compile, and
+// `.backdrop_blur(radius)` on a signal beside it.
+crate::reactive::converts!(
     f32 => BackdropBlur,
     f64 => BackdropBlur,
     i32 => BackdropBlur,

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -239,39 +239,6 @@ impl From<u32> for Length {
     }
 }
 
-// IntoVal<Length> impls for closures returning numeric types
-use crate::reactive::IntoVal;
-
-impl IntoVal<Length> for i32 {
-    fn into_val(self) -> Length {
-        Length::from(self)
-    }
-}
-
-impl IntoVal<Length> for u32 {
-    fn into_val(self) -> Length {
-        Length::from(self)
-    }
-}
-
-impl IntoVal<Length> for u16 {
-    fn into_val(self) -> Length {
-        Length::from(self)
-    }
-}
-
-impl IntoVal<Length> for f32 {
-    fn into_val(self) -> Length {
-        Length::from(self)
-    }
-}
-
-impl IntoVal<Length> for f64 {
-    fn into_val(self) -> Length {
-        Length::from(self as f32)
-    }
-}
-
 /// Trait for layout strategies that position multiple children
 pub trait Layout {
     /// Perform layout on children and return the total size.
@@ -321,11 +288,11 @@ pub enum CrossAlignment {
     Baseline,
 }
 
-// A signal accepts what a closure returning the same type accepts; the list
-// mirrors the `IntoVal<Length>` impls above one for one. See
-// `reactive::into_signal` for why it cannot be one blanket impl, and the
-// `widgets` skill for the rule that keeps the two lists together.
-crate::reactive::converting_signals!(
+// Every conversion a length accepts, declared once: the closure form and the
+// three signal forms. The value form is the `From` above. See
+// `reactive::into_signal` for why the signal forms name their source type, and
+// the `widgets` skill for the rule that a property takes all five.
+crate::reactive::converts!(
     f32 => Length,
     f64 => Length,
     i32 => Length,

--- a/src/reactive/into_signal.rs
+++ b/src/reactive/into_signal.rs
@@ -59,34 +59,6 @@ impl<T> IntoVal<Option<T>> for T {
     }
 }
 
-// Lossy f64 → f32: bare float literals in closures default to f64, and
-// accepting them avoids the deprecated f32 inference fallback
-// (rust-lang/rust#154024)
-impl IntoVal<f32> for f64 {
-    fn into_val(self) -> f32 {
-        self as f32
-    }
-}
-
-// Lossy integer → f32 conversions (no std From impl)
-impl IntoVal<f32> for i32 {
-    fn into_val(self) -> f32 {
-        self as f32
-    }
-}
-
-impl IntoVal<f32> for u32 {
-    fn into_val(self) -> f32 {
-        self as f32
-    }
-}
-
-impl IntoVal<f32> for u16 {
-    fn into_val(self) -> f32 {
-        self as f32
-    }
-}
-
 // ============================================================================
 // Blanket IntoSignal impls with distinct markers
 // ============================================================================
@@ -98,28 +70,7 @@ impl<T: Clone + 'static, I: Into<T>> IntoSignal<T, ValueMarker> for I {
     }
 }
 
-// 2. Lossy f64/i32/u32 → f32 static conversions (no std From, can't use the
-// Into blanket). f64 matters most: bare float literals default to f64, so
-// accepting them avoids the deprecated f32 inference fallback.
-impl IntoSignal<f32, LossyMarker> for f64 {
-    fn into_signal(self) -> Signal<f32> {
-        create_stored(self as f32)
-    }
-}
-
-impl IntoSignal<f32, LossyMarker> for i32 {
-    fn into_signal(self) -> Signal<f32> {
-        create_stored(self as f32)
-    }
-}
-
-impl IntoSignal<f32, LossyMarker> for u32 {
-    fn into_signal(self) -> Signal<f32> {
-        create_stored(self as f32)
-    }
-}
-
-// 3. Closures: Fn() -> R where R: IntoVal<T>
+// 2. Closures: Fn() -> R where R: IntoVal<T>
 impl<T, R, F> IntoSignal<T, ClosureMarker> for F
 where
     T: Clone + 'static,
@@ -131,27 +82,43 @@ where
     }
 }
 
-// 3b. A signal whose value converts to the property's type.
+// 3. A conversion, in every form a property accepts.
 //
-// Without these a signal is the one form of `IntoSignal` that does not take
-// what the others take: `width(100.0)` and `width(move || w.get())` both
-// compile, and `width(w)` on a `Signal<f32>` did not, because `Length` is a
-// different type and so a different key. The rule these restore is that **a
-// signal accepts what a closure returning the same type accepts** — which is
-// exactly the `IntoVal` relation, so that is what they are written over.
+// A property takes a value, a closure, a signal, a writable signal or a memo,
+// and the same expression has to compile in all five or the property is only
+// reactive by accident. This macro is where a pair is declared, once, and it
+// emits every form the pair does not already have — so a pair cannot exist in
+// one and not the others. It was two lists mirrored by hand, and they drifted.
 //
-// Written out per source type rather than as a blanket `S: IntoVal<T>`, which
-// cannot work: `IntoVal` is reflexive, so a blanket impl also covers
-// `Signal<Length> -> Length`, collides with the passthrough below, and leaves
-// the marker undecidable. Naming the source excludes the reflexive case by
-// construction, so a signal already holding the property's own type still
-// arrives by identity rather than through a derived signal.
+// The `=>` shape is a pair std can convert: the body is `<To>::from`, which
+// will not compile unless the `From` beside the type exists, so the value form
+// is proved rather than mirrored. The `as` shape is a widening std has no
+// `From` for, and there the value form is ours to emit too. A pair that has a
+// `From` must not use `as`: both value impls would apply and the marker would
+// be undecidable.
 //
-// The cost of that is a list: a new conversion gets the value and closure
-// forms from one `IntoVal` impl and the signal form only if someone adds it
-// here too. See #226.
-macro_rules! converting_signals {
-    ($($from:ty => $to:ty),* $(,)?) => {$(
+// The two shapes cannot be mixed in one invocation — a list is all `=>` or all
+// `as` — and `@pair` is the internal rule they share, not a way in: it takes
+// the conversion body directly, which is exactly the proof the `=>` arm buys.
+//
+// The signal impls name their source type rather than being one blanket
+// `S: IntoVal<T>`. `IntoVal` is reflexive, so a blanket also covers
+// `Signal<Length> -> Length` and collides with the passthrough impl, leaving
+// the marker undecidable. Dropping the passthrough would make the blanket
+// compile — the collision is not a language limit — but then every
+// `.width(sig)` already holding the property's type would build a derived node
+// to hand itself through, and that is the commonest call in the library. So
+// the pairs stay a list, and this is the only way to write an entry in it.
+macro_rules! converts {
+    // One pair, in every reactive form. Both shapes below arrive here.
+    (@pair $from:ty, $to:ty, |$value:ident| $conversion:expr) => {
+        impl $crate::reactive::IntoVal<$to> for $from {
+            fn into_val(self) -> $to {
+                let $value = self;
+                $conversion
+            }
+        }
+
         impl $crate::reactive::IntoSignal<$to, $crate::reactive::ConvertedSignalMarker>
             for $crate::reactive::Signal<$from>
         {
@@ -161,6 +128,7 @@ macro_rules! converting_signals {
                 })
             }
         }
+
         impl $crate::reactive::IntoSignal<$to, $crate::reactive::ConvertedSignalMarker>
             for $crate::reactive::RwSignal<$from>
         {
@@ -171,6 +139,7 @@ macro_rules! converting_signals {
                 })
             }
         }
+
         impl $crate::reactive::IntoSignal<$to, $crate::reactive::ConvertedSignalMarker>
             for $crate::reactive::Memo<$from>
         {
@@ -180,17 +149,35 @@ macro_rules! converting_signals {
                 })
             }
         }
+    };
+
+    // A pair std converts, which is every pair but three.
+    ($($from:ty => $to:ty),* $(,)?) => {$(
+        $crate::reactive::converts!(@pair $from, $to, |value| <$to>::from(value));
+    )*};
+
+    // A widening std has no `From` for, so the value form is emitted here.
+    ($($from:ty as $to:ty),* $(,)?) => {$(
+        $crate::reactive::converts!(@pair $from, $to, |value| value as $to);
+
+        impl $crate::reactive::IntoSignal<$to, $crate::reactive::LossyMarker> for $from {
+            fn into_signal(self) -> $crate::reactive::Signal<$to> {
+                $crate::reactive::create_stored(self as $to)
+            }
+        }
     )*};
 }
-pub(crate) use converting_signals;
+pub(crate) use converts;
 
-// The numeric widenings, beside the `IntoVal<f32>` impls they mirror.
-converting_signals!(
-    f64 => f32,
-    i32 => f32,
-    u32 => f32,
-    u16 => f32,
-);
+// The numeric widenings. `f64` matters most: a bare float literal defaults to
+// it, so accepting it avoids the deprecated f32 inference fallback
+// (rust-lang/rust#154024).
+converts!(f64 as f32, i32 as f32, u32 as f32);
+
+// `u16` widens without loss, so std has the `From` and the value form arrives
+// through the `Into` blanket above. Declaring it with `as` would emit a second
+// value impl and make `4u16` ambiguous between the two markers.
+converts!(u16 => f32);
 
 // The optional case generalises where the others cannot. `IntoVal<Option<T>>
 // for T` already lets a closure return a bare value where an optional one is
@@ -338,5 +325,73 @@ mod tests {
 
         count.set(10);
         assert_eq!(derived.get(), 20);
+    }
+}
+
+#[cfg(test)]
+mod one_declaration_covers_every_form {
+    use super::*;
+    use crate::reactive::{create_memo, create_signal};
+
+    /// A type with no conversions of its own beyond the `From` every value
+    /// needs, so the only thing that can carry it into a property is the
+    /// declaration below.
+    #[derive(Clone, Copy, PartialEq, Debug)]
+    struct Millimetres(f32);
+
+    impl From<f32> for Millimetres {
+        fn from(size: f32) -> Self {
+            Self(size)
+        }
+    }
+
+    converts!(f32 => Millimetres);
+
+    /// What a property setter does with what it is given.
+    fn resolve<M>(source: impl IntoSignal<Millimetres, M>) -> Millimetres {
+        source.into_signal().get()
+    }
+
+    /// One declaration, and the pair arrives in all five spellings a property
+    /// accepts. Drop any impl the macro emits and this stops compiling — which
+    /// is the whole point of the pair being declared once.
+    #[test]
+    fn a_pair_declared_once_arrives_in_every_form() {
+        let count = create_signal(4.0f32);
+        let read = count.read_only();
+        let doubled = create_memo(move || count.get() * 2.0);
+
+        assert_eq!(resolve(4.0f32), Millimetres(4.0), "a value");
+        assert_eq!(resolve(move || 4.0f32), Millimetres(4.0), "a closure");
+        assert_eq!(resolve(read), Millimetres(4.0), "a signal");
+        assert_eq!(resolve(count), Millimetres(4.0), "a writable signal");
+        assert_eq!(resolve(doubled), Millimetres(8.0), "a memo");
+    }
+
+    /// The other shape, where std has no `From` and so the value form is the
+    /// macro's to emit as well. `i64` is a source nothing else in the library
+    /// converts from, so these five impls are the declaration below and
+    /// nothing else.
+    mod a_widening_std_cannot_do {
+        use super::*;
+
+        converts!(i64 as f32);
+
+        fn resolve<M>(source: impl IntoSignal<f32, M>) -> f32 {
+            source.into_signal().get()
+        }
+
+        #[test]
+        fn arrives_in_every_form_too() {
+            let count = create_signal(4i64);
+            let read = count.read_only();
+            let doubled = create_memo(move || count.get() * 2);
+
+            assert_eq!(resolve(4i64), 4.0, "a value");
+            assert_eq!(resolve(move || 4i64), 4.0, "a closure");
+            assert_eq!(resolve(read), 4.0, "a signal");
+            assert_eq!(resolve(count), 4.0, "a writable signal");
+            assert_eq!(resolve(doubled), 8.0, "a memo");
+        }
     }
 }

--- a/src/reactive/mod.rs
+++ b/src/reactive/mod.rs
@@ -31,7 +31,7 @@ pub(crate) use cursor::take_cursor_change;
 pub use cursor::{CursorIcon, set_cursor};
 pub use effect::create_effect;
 pub(crate) use focus::{has_focus, release_focus, release_focus_if_within, request_focus};
-pub(crate) use into_signal::converting_signals;
+pub(crate) use into_signal::converts;
 #[doc(hidden)]
 pub use into_signal::{
     ClosureMarker, ConvertedSignalMarker, LossyMarker, MemoMarker, RwSignalMarker, SignalMarker,

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -97,39 +97,10 @@ macro_rules! scale_from_scalar {
 }
 scale_from_scalar!(f32, f64, i32, u32);
 
-// A closure has to accept whatever the constant form accepts, or the same
-// expression compiles in one position and not the other — the asymmetry
-// `IntoSignal` exists to remove. `From` covers the constants; these cover the
-// closures.
-macro_rules! into_val_pairs {
-    ($t:ty $(, $n:ty)*) => {$(
-        impl crate::reactive::IntoVal<$t> for ($n, $n) {
-            fn into_val(self) -> $t {
-                self.into()
-            }
-        }
-        impl crate::reactive::IntoVal<$t> for [$n; 2] {
-            fn into_val(self) -> $t {
-                self.into()
-            }
-        }
-    )*};
-}
-into_val_pairs!(Translate, f32, f64, i32, u32);
-into_val_pairs!(Scale, f32, f64, i32, u32);
-
-macro_rules! into_val_scalar {
-    ($($n:ty),*) => {$(
-        impl crate::reactive::IntoVal<Scale> for $n {
-            fn into_val(self) -> Scale {
-                Scale::uniform(self as f32)
-            }
-        }
-    )*};
-}
-into_val_scalar!(f32, f64, i32, u32);
-
-crate::reactive::converting_signals!(
+// Every conversion a scale or a translation accepts, declared once. `From`
+// covers the constants, above; this covers the closure and the three signal
+// forms, so the same expression compiles in every position.
+crate::reactive::converts!(
     f32 => Scale,
     f64 => Scale,
     i32 => Scale,

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -42,143 +42,19 @@ pub use widget::{
     Point, Rect, ScrollSource, Widget,
 };
 
-// IntoVal<Padding> impls for closures returning numeric types
-use crate::reactive::IntoVal;
-
-// And for a closure that returns a bare size where a corner shape is wanted.
-impl IntoVal<Corners> for f32 {
-    fn into_val(self) -> Corners {
-        Corners::from(self)
-    }
-}
-
-impl IntoVal<Corners> for f64 {
-    fn into_val(self) -> Corners {
-        Corners::from(self as f32)
-    }
-}
-
-impl IntoVal<Corners> for i32 {
-    fn into_val(self) -> Corners {
-        Corners::from(self)
-    }
-}
-
-impl IntoVal<Corners> for crate::renderer::CornerRadii {
-    fn into_val(self) -> Corners {
-        self.into()
-    }
-}
-
-impl IntoVal<Corners> for u16 {
-    fn into_val(self) -> Corners {
-        self.into()
-    }
-}
-
-impl IntoVal<Corners> for (f32, f32, f32, f32) {
-    fn into_val(self) -> Corners {
-        self.into()
-    }
-}
-
-impl IntoVal<Corners> for u32 {
-    fn into_val(self) -> Corners {
-        Corners::from(self)
-    }
-}
-
-impl IntoVal<Corners> for [i32; 2] {
-    fn into_val(self) -> Corners {
-        Corners::from(self)
-    }
-}
-
-impl IntoVal<Corners> for [i32; 4] {
-    fn into_val(self) -> Corners {
-        Corners::from(self)
-    }
-}
-
-impl IntoVal<Corners> for [f32; 2] {
-    fn into_val(self) -> Corners {
-        Corners::from(self)
-    }
-}
-
-impl IntoVal<Corners> for [f32; 4] {
-    fn into_val(self) -> Corners {
-        Corners::from(self)
-    }
-}
-
-impl IntoVal<Padding> for i32 {
-    fn into_val(self) -> Padding {
-        Padding::from(self)
-    }
-}
-
-impl IntoVal<Padding> for u32 {
-    fn into_val(self) -> Padding {
-        Padding::from(self)
-    }
-}
-
-impl IntoVal<Padding> for u16 {
-    fn into_val(self) -> Padding {
-        Padding::from(self)
-    }
-}
-
-impl IntoVal<Padding> for f32 {
-    fn into_val(self) -> Padding {
-        Padding::from(self)
-    }
-}
-
-impl IntoVal<Padding> for [f32; 2] {
-    fn into_val(self) -> Padding {
-        self.into()
-    }
-}
-
-impl IntoVal<Padding> for [f32; 4] {
-    fn into_val(self) -> Padding {
-        self.into()
-    }
-}
-
-impl IntoVal<Padding> for [i32; 2] {
-    fn into_val(self) -> Padding {
-        self.into()
-    }
-}
-
-impl IntoVal<Padding> for [i32; 4] {
-    fn into_val(self) -> Padding {
-        self.into()
-    }
-}
-
-impl IntoVal<Padding> for f64 {
-    fn into_val(self) -> Padding {
-        Padding::from(self as f32)
-    }
-}
-
-// A signal accepts what a closure returning the same type accepts. The lists
-// mirror the `IntoVal` impls above one for one; see `reactive::into_signal`
-// for why they cannot be one blanket impl.
-crate::reactive::converting_signals!(
+// Every conversion a corner shape or a padding accepts, declared once. The
+// value form is the `From` beside each type; these are the other four. See
+// `reactive::into_signal` for why the signal forms name their source type.
+crate::reactive::converts!(
     f32 => Corners,
     f64 => Corners,
     i32 => Corners,
     u32 => Corners,
+    u16 => Corners,
     [f32; 2] => Corners,
     [f32; 4] => Corners,
     [i32; 2] => Corners,
     [i32; 4] => Corners,
-    u16 => Corners,
     (f32, f32, f32, f32) => Corners,
     crate::renderer::CornerRadii => Corners,
 

--- a/tests/signal_conversions.rs
+++ b/tests/signal_conversions.rs
@@ -1,16 +1,19 @@
 //! A signal accepts what a closure returning the same type accepts.
 //!
-//! `IntoSignal` has three forms — a value, a closure, a signal — and the
-//! conversions have to line up across all three or the same expression compiles
-//! in one position and not another. The value and closure forms share the
-//! `From`/`IntoVal` impls beside each type; the signal form needs its own, and
-//! for a long time did not have them, so `width(100.0)` and
-//! `width(move || w.get())` compiled while `width(w)` on a `Signal<f32>` did
-//! not.
+//! `IntoSignal` has five forms — a value, a closure, a signal, a writable
+//! signal and a memo — and the conversions have to line up across all of them
+//! or the same expression compiles in one position and not another. The value
+//! form is the `From` beside each type and the rest come from one `converts!`
+//! entry; before that entry existed they were separate lists, so
+//! `width(100.0)` and `width(move || w.get())` compiled while `width(w)` on a
+//! `Signal<f32>` did not.
 //!
-//! A test that only has to build. It is a list rather than a rule because the
-//! impls are a list — see `reactive::into_signal` for why they cannot be one
-//! blanket impl, and #226 for the drift that leaves.
+//! A test that only has to build. It is a list because the pairs are a list —
+//! see `reactive::into_signal` for why they cannot be one blanket impl — but
+//! one list now: `converts!` emits the closure form and the three signal forms
+//! from a single declaration, so a pair can no longer be in one and not the
+//! other. What that macro still emits is checked beside it, in
+//! `one_declaration_covers_every_form`; what a caller can reach is here.
 
 use guido::prelude::*;
 
@@ -50,9 +53,9 @@ fn a_memo_reaches_a_property_it_can_convert_into() {
 }
 
 /// The pair and array forms, in every numeric type the value form takes. These
-/// are the ones the first list of `converting_signals!` left out — the drift
-/// the rule in `.claude/skills/widgets` exists to stop, committed in the same
-/// change that wrote the rule.
+/// are the ones the first signal list left out — the drift the rule in
+/// `.claude/skills/widgets` exists to stop, committed in the same change that
+/// wrote the rule, and closed at the definition by #226.
 #[test]
 fn the_pair_and_array_forms_convert_in_every_numeric_type() {
     let ints = create_signal((10i32, 20i32));
@@ -81,17 +84,17 @@ fn a_signal_of_the_property_type_is_unaffected() {
     let _ = container().corners(c).scale(s).padding(p);
 }
 
-/// The properties that stopped being read once, in all three spellings.
+/// The properties that stopped being read once, in every spelling.
 ///
 /// The point of the change was that these take a signal at all; the point of
 /// this test is that they still take the other two. A setter widened to
 /// `impl IntoSignal<T, M>` accepts the value form through the blanket `Into`
 /// impl and the closure form through `IntoVal`'s reflexive one, so nothing has
-/// to be added to `converting_signals!` for a property whose declared type is
+/// to be declared with `converts!` for a property whose declared type is
 /// the type it is given — but nothing checks that until somebody writes it
 /// down, which is what this is.
 #[test]
-fn the_values_that_became_signals_take_all_three_forms() {
+fn the_values_that_became_signals_take_every_form() {
     let masked = create_signal(true);
     let mask = create_signal('*');
     let fit = create_signal(ContentFit::Cover);
@@ -137,11 +140,11 @@ fn the_values_that_became_signals_take_all_three_forms() {
     let _ = container().when_pressed(move |s| s.ripple_with_color(move || hot.get()));
     let _ = container().when_pressed(move |s| s.ripple_with_color(hot));
 
-    // `shadow` takes a `Shadow` and nothing convertible into one, so there is no
-    // entry in `converting_signals!` for it — which is exactly the case this
-    // test exists to cover: the three forms have to arrive through the blanket
-    // impls, and nothing checks that they do until it is written down. On the
-    // state layer too, where the override is a value and never a motion.
+    // `shadow` takes a `Shadow` and nothing convertible into one, so there is
+    // no `converts!` entry for it — which is exactly the case this test exists
+    // to cover: the forms have to arrive through the blanket impls, and nothing
+    // checks that they do until it is written down. On the state layer too,
+    // where the override is a value and never a motion.
     let lift = create_signal(Shadow::new((0.0, 6.0), 10.0, 0.0, Color::BLACK));
     let _ = container().shadow(Shadow::none());
     let _ = container().shadow(move || lift.get());


### PR DESCRIPTION
## What changed

A property's conversions were two lists kept in step by hand — an `IntoVal<To> for From` beside each type, and a `converting_signals!(From => To)` invocation repeating the same pairs — and nothing enforced the mirror, so a pair added to one and not the other compiled as a closure and refused as a signal at somebody else's call site months later. There is now one `converts!` macro and it emits every form from a single declaration. The `=>` shape calls `<To>::from`, which will not compile unless the `From` beside the type exists, so the value form is proved rather than mirrored; the `as` shape is a widening std has no `From` for, and there the macro emits the value form too. The same 52 pairs convert as before. Closes #226.

## What proves it

`one_declaration_covers_every_form` in `src/reactive/into_signal.rs`, two tests over two throwaway pairs — `f32 => Millimetres` for the `=>` shape and `i64 as f32` for the `as` shape — each exercising all five spellings a property accepts. Both fail to compile before the macro exists, for the stated reason: the value form arrives through `From` and the other four do not exist.

The review deleted each of the five emitted impls in turn and confirmed every deletion breaks the build with these tests among the failing sites, the `Memo` and `Signal` cases failing **only** there. I ran the same experiment on the `LossyMarker` impl the `as` arm now emits, and the failure names `i64`.

`tests/signal_conversions.rs` is the caller-facing list and does not shrink. Full suite 980 passing, clippy clean, goldens 10 passing on lavapipe, `cargo doc`, `mdbook build` and `mdbook test` clean. No golden moved and none should: this touches no renderer code.

## What the review found

Zero blocking. Three worth answering, all acted on:

- A commit message called the `u16` case drift. It is the opposite — std has `From<u16> for f32`, so a second value impl would make `4u16` ambiguous between the two markers, and `u16` belongs in the `=>` shape for that reason. The message now says so, since a wrong sentence there outlives the change.
- The same message claimed a byte-level size win with no reproducible method. Removed rather than dressed up.
- The reviewer's own rule described only the `=>` shape, so a reviewer applying it would ask an author for a `From` that an `as` entry must not have. Both shapes are spelled out now.

Its notes are also applied: the macro's comment says the two shapes cannot be mixed in one invocation and that `@pair` is internal, and the stale "three forms" wording in `tests/signal_conversions.rs` is now five.

Before that, four cleanup readings found the macro was a token-muncher where all ten other macros in the crate are flat repetitions, and that the three `LossyMarker` impls were themselves a hand-kept mirror of the `as` list — the very defect this closes, sitting twenty lines above the macro, and already out of step with it. Both are fixed in the commits rather than on top of them.

## What was checked by hand

Nothing. The harness covers all of it. Sixty examples exercise the value form with bare literals and compile as part of clippy's `--all-targets`.

## Left undone

The pairs #226 lists as uncovered stay uncovered, deliberately: `ImageSource` from a `String` or a `&str`, and `Color` into optional properties beyond the gradient. `ImageSource` is worse than the issue says — it has three `From` impls and no `IntoVal` at all, so its *closure* form is missing too, not only its signal form. That is a missing pair rather than a missing mechanism, it is separately provable now that one declaration exists, and it stays on #226's successor rather than being smuggled in here.

`converts!` is `pub(crate)`, so a widget crate outside guido still cannot declare a conversion pair, even though `IntoVal` is public and in the prelude for exactly that audience. Unchanged by this diff and out of scope for #226 — exporting a macro is a public API decision. No issue opened: I cannot name somebody worse off today rather than somebody who might be.

https://claude.ai/code/session_01Q5KL58bdTdT533XJa1ZdDn