### PR TITLE
A blur is asked for by what it says, not by a radius the other half never reads

### DIFF
--- a/book/src/advanced/wayland.md
+++ b/book/src/advanced/wayland.md
@@ -664,6 +664,26 @@ small rectangles because `wl_region` has no notion of curves, and the
 protocol carries no radius — the compositor picks its own, so `radius`
 does not apply there. Check availability with `compositor_effects()`.
 
+Which is why a blur restricted to the compositor asks for its region on
+its sources alone, and a radius of zero there is a request rather than a
+refusal:
+
+```rust
+# extern crate guido;
+# use guido::prelude::*;
+# fn main() {
+// Blur nothing of our own; let the compositor blur the desktop behind us.
+container().backdrop_blur(
+    BackdropBlur::new(0.0).sources(BackdropSources::COMPOSITOR),
+)
+# ;
+# }
+```
+
+Everywhere the surface is a source, a radius of zero still means no blur
+— that is how a blur is switched off by the same signal that switches it
+on. To switch off a compositor-only one, empty its sources instead.
+
 The **surface** side is guido's own: the frame is drawn into an
 offscreen target, each region is downsampled, blurred with a separable
 gaussian and composited back masked to the container's rounded shape.

--- a/book/src/building-ui/styling.md
+++ b/book/src/building-ui/styling.md
@@ -220,7 +220,10 @@ container()
 
 A blur radius of `0.0` is "no blur", on a container and on a text alike, which
 is what lets one signal switch the effect on and off rather than forcing the
-caller to rebuild the widget in a Rust branch.
+caller to rebuild the widget in a Rust branch. That holds wherever the surface
+is one of the sources, which is everything by default. A container that
+restricts itself to the compositor has no radius of its own — the protocol
+carries none — so it asks on its sources alone, and empties them to switch off.
 
 **What is not reactive** is structural: `.layout(..)`, the axis a `.scroll(..)`
 is built with, `.control()`, and the motion a

--- a/docs/STYLING.md
+++ b/docs/STYLING.md
@@ -239,7 +239,10 @@ container()
 
 A blur radius of `0.0` is "no blur", on a container and on a text alike, which
 is what lets one signal switch the effect on and off rather than forcing the
-caller to rebuild the widget in a Rust branch.
+caller to rebuild the widget in a Rust branch. That holds wherever the surface
+is one of the sources, which is everything by default. A container that
+restricts itself to the compositor has no radius of its own — the protocol
+carries none — so it asks on its sources alone, and empties them to switch off.
 
 **What is not reactive** is structural: `.layout(..)`, the axis a `.scroll(..)`
 is built with, `.control()`, and the motion a value is declared with —

--- a/src/backdrop.rs
+++ b/src/backdrop.rs
@@ -74,6 +74,19 @@ impl BackdropBlur {
         self.sources = sources;
         self
     }
+
+    /// Whether this request asks for anything at all.
+    ///
+    /// Where the surface is a source the radius decides, and zero means off.
+    /// Otherwise the sources decide alone, for the reason
+    /// [`BackdropSources::COMPOSITOR`] gives: that half carries no radius.
+    pub(crate) fn asks_for_anything(&self) -> bool {
+        if self.sources.contains(BackdropSources::SURFACE) {
+            self.radius > 0.0
+        } else {
+            !self.sources.is_empty()
+        }
+    }
 }
 
 impl From<f32> for BackdropBlur {

--- a/src/blur.rs
+++ b/src/blur.rs
@@ -218,6 +218,37 @@ mod tests {
         EllipticalRadii::circular(CornerRadii::uniform(radius))
     }
 
+    /// The radius belongs to the blur guido runs in its own shader. The
+    /// compositor picks its own, so a region is published for a compositor
+    /// source whatever the radius says — including zero, which is the spelling
+    /// for "blur nothing yourself, let the compositor blur what is behind me".
+    #[test]
+    fn a_compositor_region_does_not_need_a_radius() {
+        let command = FlattenedCommand {
+            command: std::rc::Rc::new(DrawCommand::BackdropBlur {
+                rect: Rect::new(0.0, 0.0, 100.0, 50.0),
+                sources: BackdropSources::COMPOSITOR,
+                radius: 0.0,
+                corner_radii: CornerRadii::uniform(0.0),
+                curvature: Default::default(),
+            }),
+            world_transform: Default::default(),
+            world_transform_origin: None,
+            layer: Default::default(),
+            clip: None,
+            clip_is_local: false,
+        };
+        assert_eq!(
+            regions_from_commands(&[command]),
+            vec![BlurRect {
+                x: 0,
+                y: 0,
+                width: 100,
+                height: 50
+            }]
+        );
+    }
+
     #[test]
     fn zero_radius_is_bounding_box() {
         let rects = rounded_rect_to_blur_rects(Rect::new(10.0, 20.0, 100.0, 50.0), round(0.0));

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -3839,6 +3839,54 @@ fn a_surface_only_blur_publishes_no_compositor_region() {
     assert_eq!(blur_radii(&frame.node), vec![24.0], "but it draws one");
 }
 
+/// A compositor-only blur has no radius of its own — `ext-background-effect-v1`
+/// carries none, the compositor picks it — so a zero radius is not "no blur"
+/// there, and the region has to be published anyway. It was the switch that
+/// decided whether the command existed at all, so the one spelling the
+/// documentation describes emitted nothing and the compositor blurred the whole
+/// surface, or nothing, but never the container's shape.
+#[test]
+fn a_compositor_only_blur_is_published_without_a_radius() {
+    let mut h = H::new(
+        container()
+            .width(40.0)
+            .height(20.0)
+            .backdrop_blur(BackdropBlur::new(0.0).sources(BackdropSources::COMPOSITOR)),
+    );
+    let frame = h.frame(100.0, 100.0);
+    assert!(
+        !frame.blur.is_empty(),
+        "the compositor's half does not read the radius"
+    );
+    assert_eq!(
+        blur_radii(&frame.node),
+        vec![0.0],
+        "and the command carries the zero, so the surface half draws nothing"
+    );
+}
+
+/// And emptying the sources is the off switch for a blur that has no radius to
+/// switch off — which is what the documentation on `backdrop_blur` tells a
+/// caller to reach for, so it has to be true at any radius.
+#[test]
+fn an_emptied_source_set_asks_for_nothing_at_any_radius() {
+    for radius in [0.0, 24.0] {
+        let mut h = H::new(
+            container()
+                .width(40.0)
+                .height(20.0)
+                .backdrop_blur(BackdropBlur::new(radius).sources(BackdropSources::empty())),
+        );
+        let frame = h.frame(100.0, 100.0);
+        assert_eq!(frame.blur, Vec::new(), "radius {radius} publishes nothing");
+        assert_eq!(
+            blur_radii(&frame.node),
+            Vec::<f32>::new(),
+            "radius {radius} draws nothing"
+        );
+    }
+}
+
 /// A hidden panel blurs nothing, and neither does anything inside it. The
 /// parent's paint returns at the visibility gate before its children are
 /// painted, so a blurred *descendant* never gets to withdraw its own region —

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -740,6 +740,10 @@ impl Container {
     /// A radius of `0.0` is "no blur", so a blur can be switched off by the
     /// same signal that switches it on — the shape
     /// [`Text::backdrop_blur`](crate::widgets::Text::backdrop_blur) already has.
+    /// That is the radius saying so, so it holds wherever the surface is a
+    /// source. A blur restricted to the compositor has no radius of its own to
+    /// say it with, and asks for its region on its sources alone; switch that
+    /// one off with [`BackdropSources::empty`](crate::backdrop::BackdropSources::empty).
     pub fn backdrop_blur<M>(mut self, blur: impl IntoSignal<BackdropBlur, M>) -> Self {
         self.backdrop_blur = Some(blur.into_signal());
         self
@@ -1758,7 +1762,7 @@ impl Widget for Container {
         // dropped by the render tree itself rather than by a registry that has
         // to be told.
         if let Some(blur) = backdrop_blur
-            && blur.radius > 0.0
+            && blur.asks_for_anything()
         {
             ctx.draw_backdrop_blur(
                 local_bounds,

--- a/tests/render_snapshots.rs
+++ b/tests/render_snapshots.rs
@@ -280,6 +280,13 @@ fn swatch(w: f32, h: f32, c: Color) -> Container {
     box_of(w, h).background(c)
 }
 
+/// A translucent card, the shape both backdrop-blur scenarios blur behind.
+fn panel() -> Container {
+    box_of(80.0, 60.0)
+        .background(Color::rgba(1.0, 1.0, 1.0, 0.15))
+        .corners(16.0)
+}
+
 // ---------------------------------------------------------------------------
 // Scenarios
 // ---------------------------------------------------------------------------
@@ -461,12 +468,7 @@ fn corners_borders_and_shadows() {
 /// `a_transformed_blur_publishes_the_shape_it_is_drawn_as`.
 #[test]
 fn backdrop_blur_sources_and_geometry() {
-    let frosted = |radius: f32| {
-        box_of(80.0, 60.0)
-            .background(Color::rgba(1.0, 1.0, 1.0, 0.15))
-            .corners(16.0)
-            .backdrop_blur(radius)
-    };
+    let frosted = |radius: f32| panel().backdrop_blur(radius);
 
     let view = container()
         .layout(Flex::row().spacing(20.0))
@@ -485,6 +487,30 @@ fn backdrop_blur_sources_and_geometry() {
         .child(frosted(24.0).scale(2.0));
 
     assert_snapshot("backdrop_blur", render(view, 700.0, 200.0));
+}
+
+/// After `examples/blur_example.rs`, which asks the compositor to blur the
+/// desktop behind a translucent panel and nothing of its own.
+///
+/// The radius is the radius of the blur guido runs in its own shader.
+/// `ext-background-effect-v1` carries none, so a compositor source is asked for
+/// by its sources alone — and a zero radius there is a request, not a refusal.
+/// Where the surface is a source the radius is the only thing that could say
+/// "off", so zero still means off.
+#[test]
+fn a_compositor_blur_needs_no_radius_of_its_own() {
+    let view = container()
+        .layout(Flex::row().spacing(20.0))
+        .padding(20.0)
+        // Asks for a region and draws nothing itself.
+        .child(panel().backdrop_blur(BackdropBlur::new(0.0).sources(BackdropSources::COMPOSITOR)))
+        // Both sources, and a radius of zero: still off, and no command at all.
+        .child(panel().backdrop_blur(BackdropBlur::new(0.0)));
+
+    assert_snapshot(
+        "compositor_blur_without_a_radius",
+        render(view, 300.0, 120.0),
+    );
 }
 
 /// After `examples/clip_test.rs`: hidden overflow clips its children, and a

--- a/tests/snapshots/compositor_blur_without_a_radius.snap
+++ b/tests/snapshots/compositor_blur_without_a_radius.snap
@@ -1,0 +1,6 @@
+node 0,0 220x100
+  node 0,0 80x60 at 20,20
+    draw backdrop-blur 0,0 80x60 sources=BackdropSources(COMPOSITOR) radius=0 corners=16/16/16/16 k=1
+    draw rect 0,0 80x60 fill=#ffffff26 radius=16/16/16/16
+  node 0,0 80x60 at 120,20
+    draw rect 0,0 80x60 fill=#ffffff26 radius=16/16/16/16


### PR DESCRIPTION
## What changed

A container that asked only the compositor to blur its backdrop emitted no draw command, so nothing downstream could recover: no command meant no `compositor_blur` after flattening, so `sync_blur_region` was never called, so the region pass that correctly tessellates the rounded shape was never reached. The guard was `blur.radius > 0.0`, and that radius belongs to the blur guido runs in its own shader — the documentation beside `BackdropSources::COMPOSITOR` says in as many words that it does not apply there, because the protocol carries no radius. The rule now lives beside that documentation: where the surface is a source the radius decides and zero means off, otherwise the sources decide alone. Closes #268.

## What proves it

`a_compositor_blur_needs_no_radius_of_its_own` in `tests/render_snapshots.rs`, which is the acceptance criterion verbatim — two containers, a `BackdropBlur` command for the compositor-only one and none for the both-sources one. It is a new scenario with a new reference, so no existing snapshot was rewritten and no `golden-update` label is needed.

Beside it, `a_compositor_only_blur_is_published_without_a_radius` and `an_emptied_source_set_asks_for_nothing_at_any_radius` in the container characterization, which drive a real frame. All three fail with the guard reverted; the review confirmed that independently by reverting it.

`a_compositor_region_does_not_need_a_radius` in `src/blur.rs` is the unit test the issue asked for, and it passes with or without the fix — `regions_from_commands` was always correct, and this is the first test it has ever had. It is regression coverage for the chain, not proof of the change, and should not be counted as such.

No golden moved, which is the right outcome rather than a missing scenario: a compositor-only command is routed to the Shapes layer, produces no instance, and `command_to_backdrop_region` returns `None` without `SURFACE`, so it draws no pixels guido controls.

## What the review found

Zero blocking. Both findings worth answering are acted on:

- The divergence between the issue's **Expected** and **Acceptance** sections was recorded only in this change, not where somebody would look for it. It is now a comment on #268 saying which reading was implemented and why the other would have broken two existing tests.
- `docs/STYLING.md` and the styling chapter taught the zero rule unqualified, and that is where a reader learns it. Both now name the exception.

Before that, four cleanup readings found the predicate I first wrote was an instance of the rule rather than the rule: `BackdropSources::empty()` at a non-zero radius returned true from a method called `asks_for_anything`, which contradicted the off switch the same change was documenting. Fixed in the commit, and `an_emptied_source_set_asks_for_nothing_at_any_radius` is what holds it — it fails against the first spelling.

Two notes not acted on. The efficiency reading found the new command adds one rect to the Shapes layer bounds and makes frames run the region scan that previously skipped it; both are what a compositor blur at radius 16 already paid, so neither is new machinery. And `draw_text_backdrop_blur` keeps its equivalent guard inside the paint context while `draw_backdrop_blur` leans on its single caller — two altitudes for one kind of decision, with nobody worse off while the container is the only caller.

## What was checked by hand

**Nothing, and this is the one claim that is unproven at the layer the bug was seen.** #268 opened with a `WAYLAND_DEBUG=1` table from niri 26.04 showing zero `get_background_effect` requests at radius `0.0`. The matching after-row has not been run, because doing so opens a surface on the maintainer's screen. Everything up to and including the region contents is covered automatically; the last hop, the flag reaching `sync_blur_region`, is watched by nothing — which is #344.

I can run `WAYLAND_DEBUG=1 cargo run --example blur_example` to a log file on request and report the row.

## Left undone

`BackdropBlur::new(24.0).sources(BackdropSources::empty())` used to emit an inert command that neither consumer read, and now emits nothing. No pixels and no region either way, it has its own test, and it is what makes the documented off switch true — named here so it is not discovered later as an unexplained change.

**#344** — nothing tests whether a blur region ever reaches the platform, only what it would contain. The container harness discards `flatten_root_into`'s `compositor_blur` return and calls the region pass unconditionally, so forcing that flag to `false` would leave the entire blur suite green. That needs `tests/headless_app.rs` and the real loop, which is an acceptance criterion this change's tests cannot state by construction.

https://claude.ai/code/session_01Q5KL58bdTdT533XJa1ZdDn