### PR TITLE
Keeping the focus and consuming the press are two different sentences

### DIFF
--- a/book/src/building-ui/text-input.md
+++ b/book/src/building-ui/text-input.md
@@ -195,7 +195,8 @@ a container with only an `on_click` does not claim a right press, and a right
 press it did not claim is a press on nothing like any other.
 
 A press inside the focused field is always the field's, whichever button it
-was.
+was — and it keeps the keyboard without consuming the press, so a row wrapping
+the field still gets its own click or context menu.
 
 The box drawn around a field is the third case, and it is the one worth knowing:
 a container that declares `when_focused` and currently holds that focus keeps

--- a/book/src/building-ui/text-input.md
+++ b/book/src/building-ui/text-input.md
@@ -199,8 +199,11 @@ was.
 
 The box drawn around a field is the third case, and it is the one worth knowing:
 a container that declares `when_focused` and currently holds that focus keeps
-presses inside itself. Clicking its padding, its border, the space beside the
-caret, is clicking the field it draws.
+that focus against a press inside itself. Clicking its padding, its border, the
+space beside the caret, is clicking the field it draws.
+
+The press still travels. The box keeps the keyboard and consumes nothing, so a
+clickable ancestor wrapping the field is clicked as it would be anywhere else.
 
 ```rust
 # extern crate guido;

--- a/book/src/interactivity/states.md
+++ b/book/src/interactivity/states.md
@@ -320,10 +320,15 @@ pointer over its own bounds. It is never pressed: being pressed means being
 activated, and it has nothing to activate.
 
 **`when_focused` also keeps the focus.** A press that no widget claimed takes
-the keyboard off whatever held it, and a container declaring `when_focused`
-while that focus is inside it claims presses on itself. A box that says it
-lights up for a field has said the box is part of the field, so clicking its
-padding does not blur what it draws. See
+the keyboard off whatever held it, and a press inside a container declaring
+`when_focused` while that focus is inside it is not one of those. A box that
+says it lights up for a field has said the box is part of the field, so
+clicking its padding does not blur what it draws.
+
+It keeps the focus without consuming the press. A clickable row wrapping a
+decorated field still sees the click, still lights its pressed layer and still
+fires its `on_click` — keeping the keyboard and swallowing the event are two
+different things. See
 [Losing Focus](../building-ui/text-input.md#losing-focus).
 
 ## Which Layer Wins

--- a/docs/STATE_LAYER.md
+++ b/docs/STATE_LAYER.md
@@ -44,9 +44,14 @@ The declaration carries a second meaning, and it is load-bearing rather than
 decorative. `dispatch_events` takes the focus off a `MouseDown` that came back
 `Ignored` from the root the focus path ends at — a press nobody claimed is a
 press on nothing. A container declaring `when_focused` while that focus is
-inside it therefore claims presses on itself (`handle_own_event`), so the
-padding and the border of the box above belong to the field it draws rather than
-blurring it.
+inside it therefore keeps the focus against a press inside itself
+(`handle_own_event`), so the padding and the border of the box above belong to
+the field it draws rather than blurring it.
+
+It keeps the focus without consuming the press: the box says so on the tree's
+per-event channel rather than by returning `Handled`, so an outer clickable row
+still receives the press and fires. The two used to share `Handled`, which made
+the row work or not depending on where the keyboard was (#308).
 
 The coupling is deliberate and is the whole of the mechanism: there is no
 separate `.keeps_focus()`, and the box that lights up for a focus is the box

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3153,6 +3153,43 @@ mod a_press_nothing_claimed_takes_the_focus_with_it {
         );
     }
 
+    /// The field itself keeps the focus on a press it does not otherwise claim,
+    /// and that must not silence an ancestor either.
+    ///
+    /// A right press inside a focused field falls past every arm that grants
+    /// focus, so the field has to say the press is its own. Saying it with
+    /// `Handled` meant a row wrapping the field never got its context menu —
+    /// and got one when the field was not focused. The same conflation as the
+    /// box, one widget over.
+    #[test]
+    fn a_field_keeping_its_own_focus_does_not_swallow_the_press() {
+        let field = a_field();
+        let menus = std::rc::Rc::new(std::cell::Cell::new(0u32));
+        let counted = std::rc::Rc::clone(&menus);
+        let mut screen = Screen::new(
+            container()
+                .width(200.0)
+                .height(100.0)
+                .on_right_click(move || counted.set(counted.get() + 1))
+                .child(text_input(create_signal(String::new())).widget_ref(field)),
+        );
+
+        screen.press(100.0, 8.0);
+        assert!(field.is_focused(), "the press reached the field");
+
+        let root = screen.root;
+        screen.press_button(root, 100.0, 8.0, MouseButton::Right);
+        assert!(
+            field.is_focused(),
+            "a press inside the field is the field's, whatever the button"
+        );
+        assert_eq!(
+            menus.get(),
+            1,
+            "and the row around it still opens its context menu"
+        );
+    }
+
     /// A toolbar button acting on the field, spelled the way every button is
     /// spelled: it has an `on_click`, so it claims the press, so the press is
     /// not a press on nothing.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -643,8 +643,15 @@ fn dispatch_events(
             // goes with it. This is the only place that can tell: a widget is
             // handed the presses that miss it, but never learns whether one of
             // them turned out to be somebody else's.
+            //
+            // Two ways to be somebody's. A widget consumed it, which is what
+            // `Handled` says. Or the focus itself claims it — the box drawn
+            // around a focused field is that field to the eye — which is a
+            // different sentence and arrives on its own channel, because
+            // saying it with `Handled` also silenced every ancestor (#308).
             if matches!(event, widgets::Event::MouseDown { .. })
                 && response != Some(widgets::EventResponse::Handled)
+                && !tree.focus_claimed_the_press()
             {
                 reactive::focus::release_focus_under(root);
             }
@@ -2845,6 +2852,18 @@ mod a_press_nothing_claimed_takes_the_focus_with_it {
             self.press_button(root, x, y, MouseButton::Left);
         }
 
+        /// A press and its release, which is the gesture a click is made of:
+        /// `on_click` fires on the release and only if the press was seen.
+        fn click(&mut self, x: f32, y: f32) {
+            self.press(x, y);
+            let root = self.root;
+            let events = [(
+                std::time::Instant::now(),
+                Event::mouse_up(x, y, MouseButton::Left),
+            )];
+            dispatch_events(&events, root, &mut self.tree, &Default::default());
+        }
+
         fn press_button(&mut self, root: WidgetId, x: f32, y: f32, button: MouseButton) {
             let events = [(std::time::Instant::now(), Event::mouse_down(x, y, button))];
             dispatch_events(&events, root, &mut self.tree, &Default::default());
@@ -3008,6 +3027,129 @@ mod a_press_nothing_claimed_takes_the_focus_with_it {
         assert!(
             field.is_focused(),
             "the padding of the box that lights up for this focus belongs to it"
+        );
+    }
+
+    /// Keeping the keyboard and consuming the press are two different
+    /// sentences, and the box that keeps the focus says only the first.
+    ///
+    /// A clickable row wrapping a decorated field: pressing the box's padding
+    /// is pressing the field as far as the focus goes, and pressing the row as
+    /// far as the row goes. Answering with `Handled` said both at once, so the
+    /// row never saw the press and its `on_click` never fired — and which of
+    /// the two happened depended on where the keyboard was.
+    #[test]
+    fn a_box_that_keeps_the_focus_does_not_swallow_the_press() {
+        let field = a_field();
+        let clicks = std::rc::Rc::new(std::cell::Cell::new(0u32));
+        let counted = std::rc::Rc::clone(&clicks);
+        let mut screen = Screen::new(
+            container()
+                .width(200.0)
+                .height(100.0)
+                .on_click(move || counted.set(counted.get() + 1))
+                .child(
+                    container()
+                        .padding(8.0)
+                        .when_focused(|s| s.border(2.0, crate::widgets::Color::WHITE))
+                        .child(text_input(create_signal(String::new())).widget_ref(field)),
+                ),
+        );
+
+        // Released, because a press left down leaves the field dragging a
+        // selection and the next release is the field's by right.
+        screen.click(100.0, 12.0);
+        assert!(field.is_focused(), "the press reached the field");
+        assert_eq!(
+            clicks.get(),
+            0,
+            "which the field claimed, so the row did not"
+        );
+
+        screen.click(4.0, 4.0);
+        assert!(
+            field.is_focused(),
+            "the padding of the box that lights up for this focus belongs to it"
+        );
+        assert_eq!(
+            clicks.get(),
+            1,
+            "and the row around it is still a row that can be clicked"
+        );
+    }
+
+    /// The claim belongs to the press that earned it and to no other.
+    ///
+    /// It is one field on the tree, and what makes it mean "this press" rather
+    /// than "some press once" is that `dispatch_events` clears it going into
+    /// every event. Without that line the first press on a focused box latches
+    /// it, and nothing blurs a field again for the life of the process — the
+    /// whole of #206 undone, silently, by a flag nobody reset.
+    #[test]
+    fn a_claim_does_not_outlive_the_press_that_made_it() {
+        let field = a_field();
+        let mut screen = Screen::new(
+            container().width(200.0).height(100.0).child(
+                container()
+                    .padding(8.0)
+                    .when_focused(|s| s.border(2.0, crate::widgets::Color::WHITE))
+                    .child(text_input(create_signal(String::new())).widget_ref(field)),
+            ),
+        );
+
+        screen.press(100.0, 12.0);
+        assert!(field.is_focused(), "the press reached the field");
+
+        screen.press(4.0, 4.0);
+        assert!(field.is_focused(), "the box's padding claims this one");
+
+        screen.press(100.0, 80.0);
+        assert!(
+            !field.is_focused(),
+            "the claim belonged to the press before it, not to this one"
+        );
+    }
+
+    /// The box is asked where the press landed, and it is asked in its own
+    /// coordinates.
+    ///
+    /// The box sits 50 down the surface and at zero inside its own parent, so
+    /// the two answers cannot be confused for one another: its surface rows are
+    /// 50 to 90, its parent-relative rows are 0 to 40, and the press below is
+    /// in the first and not the second. Only the walk knows the difference —
+    /// by the time the event reaches the box the point has been rebased through
+    /// every ancestor. Resolving this from outside, against the bounds the tree
+    /// stores, tests the press against a rectangle somewhere else entirely.
+    #[test]
+    fn a_box_offset_from_the_surface_is_asked_in_its_own_coordinates() {
+        let field = a_field();
+        let mut screen = Screen::new(
+            container()
+                .width(200.0)
+                .height(100.0)
+                .layout(Flex::column())
+                .child(container().width(200.0).height(50.0))
+                .child(
+                    container().layout(Flex::column()).child(
+                        container()
+                            .width(200.0)
+                            .height(40.0)
+                            .padding(8.0)
+                            .when_focused(|s| s.border(2.0, crate::widgets::Color::WHITE))
+                            .child(text_input(create_signal(String::new())).widget_ref(field)),
+                    ),
+                ),
+        );
+
+        screen.press(100.0, 65.0);
+        assert!(field.is_focused(), "the press reached the field");
+
+        // The bottom padding of the box: inside it on the surface, outside the
+        // rectangle the tree stores for it.
+        screen.press(100.0, 85.0);
+        assert!(
+            field.is_focused(),
+            "the padding of the box belongs to it wherever the box happens to be"
         );
     }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -206,6 +206,29 @@ pub struct Tree {
     /// `dispatch_events` writes it, once per event, because it delivers them one
     /// at a time. `None` outside a dispatch, where nobody should be reading it.
     event_instant: Option<std::time::Instant>,
+
+    /// Whether the press being dispatched was claimed by the focus it landed
+    /// on, and so must not release it.
+    ///
+    /// A container that draws the focus it holds *is* the focused field to the
+    /// person looking at it — its padding, its border, the gap beside the caret
+    /// — so a press there is not a press on nothing. Only the widget can say
+    /// so: by the time an event reaches it the point has been rebased through
+    /// every ancestor, the scroll offset applied and the transform undone, and
+    /// none of that can be redone from outside without walking the tree again.
+    ///
+    /// It used to say it by returning `EventResponse::Handled`, which also
+    /// means "consumed" — so an outer clickable row never saw the press, and
+    /// whether it worked depended on where the keyboard was (#308). The two are
+    /// different sentences, and this is the channel for the one `Handled` was
+    /// never meant to carry. The web splits them the same way: `preventDefault`
+    /// cancels what the event would otherwise cause, `stopPropagation` stops it
+    /// travelling, and a mousedown's default action is the focus change.
+    ///
+    /// `dispatch_events` clears it before each event and reads it after.
+    /// Cleared going in rather than coming out, so nothing that returns early
+    /// can leave it set for the next press.
+    focus_claimed_the_press: bool,
 }
 
 impl Tree {
@@ -218,6 +241,7 @@ impl Tree {
             damage: std::collections::HashMap::new(),
             frame_instant: None,
             event_instant: None,
+            focus_claimed_the_press: false,
         }
     }
 
@@ -274,13 +298,38 @@ impl Tree {
         }
     }
 
+    /// Say that the press being dispatched landed on the focus, and so must not
+    /// take it away.
+    ///
+    /// Called by a widget that draws the focus it is holding, from its own
+    /// event handling, where the point is already in its coordinates. Reset for
+    /// every event by `dispatch_events`.
+    pub fn keep_the_focus_this_press_landed_on(&mut self) {
+        self.focus_claimed_the_press = true;
+    }
+
+    /// Whether anything claimed the focus during the event just dispatched.
+    ///
+    /// `dispatch_events` is the only caller there should ever be: it is the one
+    /// place that knows a press went unclaimed, which is the only question this
+    /// answers. The setter beside it is public because a widget written outside
+    /// this crate has to be able to say it; this one has no such caller.
+    pub(crate) fn focus_claimed_the_press(&self) -> bool {
+        self.focus_claimed_the_press
+    }
+
     /// Declare when the event about to be dispatched happened, or `None` when
     /// the dispatch is over.
     ///
     /// `dispatch_events` is the caller in the loop; a test that wants to place
     /// an event in time is the other one.
+    ///
+    /// It also forgets any focus claim made for the previous event, which is
+    /// what makes that claim mean *this* press — see
+    /// [`keep_the_focus_this_press_landed_on`](Self::keep_the_focus_this_press_landed_on).
     pub fn set_event_instant(&mut self, at: Option<std::time::Instant>) {
         self.event_instant = at;
+        self.focus_claimed_the_press = false;
     }
 
     /// Declare the instant of the frame about to run, or `None` when it is

--- a/src/widgets/container/interaction.rs
+++ b/src/widgets/container/interaction.rs
@@ -16,9 +16,9 @@
 //! [`handle_own_event`]: Container::handle_own_event
 
 use crate::clock::EventInstant;
+use crate::reactive::focus::focus_within;
 
 use super::*;
-use crate::reactive::focus::focus_within;
 
 /// The geometry an event is resolved against: where the container ended up,
 /// what shape it is, and the transform standing between the two.
@@ -255,16 +255,16 @@ impl Container {
     /// against.
     pub(super) fn handle_own_event(
         &mut self,
+        tree: &mut Tree,
         id: WidgetId,
         hit: &HitContext,
         event: &Event,
         local: &Event,
         now: EventInstant,
     ) -> EventResponse {
-        // One question for a press, asked once and answered up to twice: by the
-        // arm that handles it, and by the focus claim at the end of the
-        // function. `contains` runs the corner SDF, and a press inside the
-        // shape is exactly the case that would run it twice.
+        // Asked once and read by whichever arm handles the press: `contains`
+        // runs the corner SDF, and a press inside the shape is exactly the
+        // case that would otherwise run it more than once.
         let pressed_inside =
             matches!(local, Event::MouseDown { .. }) && hit.contains(local.coords());
 
@@ -274,8 +274,6 @@ impl Container {
             // containers from tracking their own.
             Event::MouseEnter { .. } | Event::MouseMove { .. } => {}
 
-            // Claiming a press here is not only about the callback: the focus
-            // claim at the end of the function reads the same `pressed_inside`.
             Event::MouseDown { button, .. } if *button != MouseButton::Left => {
                 if pressed_inside && let Some(ref ix) = self.interaction {
                     let callback = match button {
@@ -444,12 +442,19 @@ impl Container {
         }
 
         // A press inside the box that lights up for this focus is a press on
-        // the field the box draws — its padding, its border, the gap beside
-        // the caret. The dispatcher takes the focus off a press nobody
-        // claimed, so claiming it here is how the box says the keyboard is
-        // still its own.
+        // the field the box draws — its padding, its border, the gap beside the
+        // caret. The dispatcher takes the focus off a press nobody claimed, so
+        // this is how the box says the keyboard is still its own.
+        //
+        // Said here and not there because `hit` is this container's: the point
+        // arrived rebased through every ancestor, with the scroll offset added
+        // and the transform undone. Nothing outside the walk has that point
+        // without redoing the walk. Said on the tree and not by returning
+        // `Handled` because that also means consumed, which silenced an outer
+        // clickable row and made it work or not depending on where the keyboard
+        // was (#308).
         if pressed_inside && self.holds_the_focus_it_draws(id) {
-            return EventResponse::Handled;
+            tree.keep_the_focus_this_press_landed_on();
         }
 
         EventResponse::Ignored

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -1690,7 +1690,7 @@ impl Widget for Container {
             }
         }
 
-        self.handle_own_event(id, &hit, event, &local_event, at)
+        self.handle_own_event(tree, id, &hit, event, &local_event, at)
     }
 
     fn refresh_paint_bounds(&self, tree: &mut Tree, id: WidgetId) {

--- a/src/widgets/text_input.rs
+++ b/src/widgets/text_input.rs
@@ -1545,10 +1545,15 @@ impl Widget for TextInput {
             // press nobody claimed, and the arms above claim only left and
             // middle — so a right press on the caret used to blur the very
             // field it landed on.
+            //
+            // Said on the tree rather than by returning `Handled`, which also
+            // means consumed: a row wrapping the field declaring `on_right_click`
+            // never saw the press, and whether it fired depended on where the
+            // keyboard was. The same conflation as #308, one widget over.
             Event::MouseDown { at: Some(at), .. }
                 if has_focus(id) && bounds.contains(at.x, at.y) =>
             {
-                return EventResponse::Handled;
+                tree.keep_the_focus_this_press_landed_on();
             }
             Event::KeyDown { key, modifiers } if has_focus(id) => {
                 let response = self.handle_key(key, modifiers.ctrl, modifiers.shift, edit);


### PR DESCRIPTION
## What changed

A container that draws the focus it holds used to stop a press from blurring its field by returning `EventResponse::Handled` — a value that already means "consumed". So a clickable row wrapping a decorated field never saw the press, and whether the row worked at all depended on where the keyboard happened to be. The two sentences now travel separately: `Tree` carries "the focus claims this press" for the duration of the event being dispatched, beside `event_instant`, and `Handled` means only "consumed" again. Closes #308.

## What proves it

Two tests that fail on `origin/main` for the stated reason, one per commit: `a_box_that_keeps_the_focus_does_not_swallow_the_press` (the ancestor's `on_click` never fires) and `a_field_keeping_its_own_focus_does_not_swallow_the_press` (its `on_right_click` never fires). The review confirmed both independently by applying only the test hunks onto main.

Two more that guard the design rather than the defect, and I say so because neither fails on main:

- `a_box_offset_from_the_surface_is_asked_in_its_own_coordinates` pins the coordinate space. I verified it distinguishes the two designs by simulating the abandoned one: it fails, while the pre-existing padding test still passes.
- `a_claim_does_not_outlive_the_press_that_made_it` pins the one line that makes the fact per-event. Verified by deleting that line: it fails and nothing else does.

No golden and no snapshot moved, correctly — nothing in the paint path changed.

## What the review found

**One blocking finding, fixed.** The clearing line had no test: deleting it left all 730 tests green while latching the flag forever, so the first press on a focused box would mean no press ever blurs a field again. That is the total silent failure of the design and it is now `a_claim_does_not_outlive_the_press_that_made_it`.

Worth answering, all acted on: `docs/STATE_LAYER.md` still said the box "claims presses on itself", the exact wording this change disproves and the file an agent reads before touching state layers; the design recorded on #308 was no longer the design that shipped, now corrected in a comment there; and the second site in `TextInput` needed naming as deliberate rather than growth.

Notes acted on: the book sentence about the field was in the commit before its fix, so reverting the second commit alone would have left the book lying — moved; `set_event_instant`'s doc now says it also forgets the claim; `Tree::focus_claimed_the_press` is `pub(crate)` since only the dispatcher should ask, while the setter stays public for out-of-crate widgets; and the inlined condition is a named predicate again.

**The agreed design was abandoned mid-implementation, with your agreement.** It resolved the rule in `dispatch_events` against `tree.get_bounds`, which is parent-relative while the dispatcher's point is surface-space. For the test layout the tree stores rows 0 to 40 for a box that actually occupies rows 50 to 90, so a press at y=85 is real padding 45px below the stored rectangle. Scroll offset and container transforms are applied during the walk and are in no stored bounds either. The full reasoning and the measurement are on #308.

## What was checked by hand

Nothing. The dispatcher, the container and the field are all reachable from the unit tests, and `dispatch_events` is the same function the loop drives.

## Left undone

Nothing that earns an issue. #206's larger question stands untouched and out of scope: guido releases focus on an unclaimed press, where Qt, GTK and AppKit instead let each widget declare whether it takes focus on click and never release it. That is the rule itself rather than the channel it speaks on, and #206 decided it deliberately.

https://claude.ai/code/session_01Xb5BYhQqkrE8ngiyKE6FRX