### PR TITLE
A value can say where it starts, not only how it moves

### DIFF
--- a/.claude/skills/widgets/SKILL.md
+++ b/.claude/skills/widgets/SKILL.md
@@ -205,6 +205,21 @@ A bare number is milliseconds, eased out — the one place the animation
 vocabulary has two defaults, because `Transition::default()` is a spring and
 has no duration for a number to attach to.
 
+`.entering_from(..)` is the third verb, and a modifier on the first rather than
+a peer: a transition says how a value moves, an enter says where it starts the
+one time the widget appears, and CSS keeps the same two apart as `transition`
+and `@starting-style`. It plays once, at the first layout, and is consumed
+there.
+
+```rust
+container().background(theme.surface.transition(200.0).entering_from(Color::TRANSPARENT))
+```
+
+The take lives on `AnimationState`, not in the initialiser that seeds most
+properties — there are four of those, and an enter asked for in one of them
+compiles on every setter and works on half. That is #303's own defect, and the
+rule is that a property is *placed* in exactly one place, whichever it is.
+
 Three rules the shape depends on, in order of how easily they are broken:
 
 - **A declaration is the whole property.** Restating one replaces the value

--- a/book/src/transforms/animated.md
+++ b/book/src/transforms/animated.md
@@ -20,6 +20,50 @@ container()
 
 When `rotation_signal` changes, the transform animates smoothly.
 
+## Appearing mid-animation
+
+`transition` says how a value moves. `entering_from` says where it starts the
+one time the widget appears — the CSS pair, where `transition` supplies the
+motion and `@starting-style` supplies the before-value.
+
+```rust
+# extern crate guido;
+# use guido::prelude::*;
+# fn main() {
+# let open = create_signal(true);
+# let collapsed = Scale::new(1.0, 0.0);
+container()
+    .scale(
+        (move || if open.get() { Scale::NONE } else { collapsed })
+            .transition(Transition::spring(SpringConfig::SNAPPY))
+            .entering_from(collapsed),
+    )
+    .pivot(Pivot::TOP)
+# ;
+# }
+```
+
+A menu that scales open on its first layout, and closes by the same transition
+running the other way.
+
+It is not transform-shaped: the verb hangs off the value, so it reaches every
+animatable property. A card can fade in.
+
+```rust
+# extern crate guido;
+# use guido::prelude::*;
+# fn main() {
+container()
+    .background(Color::rgb(0.1, 0.1, 0.15).transition(200.0).entering_from(Color::TRANSPARENT))
+# ;
+# }
+```
+
+The enter plays once, at the first layout, and is consumed there: a relayout, a
+resize or a state change is not an appearance and does not replay it. It needs a
+transition to travel with, so declaring one on a timeline is a panic rather than
+a value quietly ignored — a timeline already says where it starts.
+
 ## Duration-Based Animation
 
 Standard easing curve transitions:
@@ -199,6 +243,9 @@ impl Container {
     pub fn rotate<M>(self, degrees: impl IntoAnimated<f32, M>) -> Self;
     pub fn scale<M>(self, factor: impl IntoAnimated<Scale, M>) -> Self;
 }
+
+// Where a property starts the one time its widget appears.
+Animated::entering_from(self, from: T) -> Animated<T>
 
 // Duration-based
 Transition::new(duration_ms: f32, timing: TimingFunction) -> Transition

--- a/docs/STYLING.md
+++ b/docs/STYLING.md
@@ -246,7 +246,8 @@ carries none — so it asks on its sources alone, and empties them to switch off
 
 **What is not reactive** is structural: `.layout(..)`, the axis a `.scroll(..)`
 is built with, `.control()`, and the motion a value is declared with —
-`.transition(..)` and `.timeline(..)`. These say what
+`.transition(..)`, `.timeline(..)` and the `.entering_from(..)` that says where
+a transition begins on the frame the widget appears. These say what
 kind of thing the container *is*; change one and you are describing a different
 widget, so declare it in the closure that builds the widget instead. The
 *value* a motion decorates is as reactive as any other.

--- a/src/animation/animated.rs
+++ b/src/animation/animated.rs
@@ -24,7 +24,7 @@
 //! .when_hovered(|s| s.background(HOT.transition(900.0)))   // does not compile
 //! ```
 
-use crate::reactive::{IntoSignal, Signal};
+use crate::reactive::{IntoSignal, IntoVal, Signal};
 
 use super::{Animatable, Keyframes, TransitionConfig};
 
@@ -45,6 +45,50 @@ pub struct Animated<T> {
 }
 
 impl<T> Animated<T> {
+    /// Start somewhere else the one time this widget appears, and travel to
+    /// the declared value with the transition already named.
+    ///
+    /// `transition` says how a value moves; this says where it begins. They are
+    /// separate questions and compose on one property, which is the split CSS
+    /// makes between `transition` and `@starting-style`.
+    ///
+    /// ```ignore
+    /// // a menu that scales open on its first layout
+    /// container().transform(
+    ///     (move || if open.get() { Transform::IDENTITY } else { collapsed })
+    ///         .transition(Transition::spring(SpringConfig::SNAPPY))
+    ///         .entering_from(collapsed),
+    /// )
+    /// // and the same verb on anything else that animates
+    /// container().background(theme.surface.transition(200.0).entering_from(Color::TRANSPARENT))
+    /// ```
+    ///
+    /// Played once, at the first layout, and consumed there: a relayout, a
+    /// resize or a state change is not an appearance and does not replay it.
+    ///
+    /// Panics if a timeline was declared instead of a transition: a timeline
+    /// already says where it begins, so an enter has nothing to add and would
+    /// be dropped in silence. Caught the first time the widget is built.
+    pub fn entering_from(mut self, from: impl IntoVal<T>) -> Self {
+        match self.motion.as_deref_mut() {
+            Some(Motion::Ease { enter_from, .. }) => *enter_from = Some(from.into_val()),
+            Some(Motion::Play { .. }) => panic!(
+                "`entering_from` needs a transition to travel with, and a timeline \
+                 already says where it starts — declare the enter on a \
+                 `transition(..)` value instead"
+            ),
+            // Loud rather than silent, for the reason `into_eased` gives: an
+            // `Animated<T>` with no motion is only made inside a setter, so a
+            // caller cannot spell this — and the day one can, it has to say so
+            // rather than dropping the value.
+            None => unreachable!(
+                "an `Animated<T>` with no motion is only made by `into_animated`, \
+                 inside the setter that immediately consumes it"
+            ),
+        }
+        self
+    }
+
     /// The value and its motion, taken apart by the setter that installs them.
     pub(crate) fn into_parts(self) -> (Signal<T>, Option<Box<Motion<T>>>) {
         (self.signal, self.motion)
@@ -60,9 +104,9 @@ impl<T> Animated<T> {
     /// not exist. That bound is what makes this a narrowing rather than a
     /// value quietly dropped, and relaxing it would have to bring a spelling
     /// for a timeline on a size with it.
-    pub(crate) fn into_eased(self) -> (Signal<T>, Option<TransitionConfig>) {
+    pub(crate) fn into_eased(self) -> (Signal<T>, Option<(TransitionConfig, Option<T>)>) {
         let ease = match self.motion.map(|motion| *motion) {
-            Some(Motion::Ease(config)) => Some(config),
+            Some(Motion::Ease { config, enter_from }) => Some((config, enter_from)),
             None => None,
             // Loud rather than `None`, because the thing that makes this
             // unreachable is a bound three types away: silently dropping a
@@ -81,8 +125,14 @@ impl<T> Animated<T> {
 /// means a pointer event here and scrolling calls its own `momentum`, so a
 /// public name about easing would sit between two unrelated meanings.
 pub(crate) enum Motion<T> {
-    /// Ease to each new value instead of jumping to it.
-    Ease(TransitionConfig),
+    /// Ease to each new value instead of jumping to it, and — if an enter was
+    /// declared — begin from somewhere else on the first layout.
+    Ease {
+        config: TransitionConfig,
+        /// Where the property starts the one time the widget appears. `None`
+        /// for almost every declaration; see [`Animated::entering_from`].
+        enter_from: Option<T>,
+    },
     /// Play a sequence whenever the trigger changes, and rest on the declared
     /// value in between.
     Play {
@@ -111,7 +161,10 @@ pub trait Animate<T: Clone + 'static, M>: IntoSignal<T, M> + Sized {
     fn transition(self, transition: impl Into<TransitionConfig>) -> Animated<T> {
         Animated {
             signal: self.into_signal(),
-            motion: Some(Box::new(Motion::Ease(transition.into()))),
+            motion: Some(Box::new(Motion::Ease {
+                config: transition.into(),
+                enter_from: None,
+            })),
         }
     }
 

--- a/src/renderer/text.rs
+++ b/src/renderer/text.rs
@@ -206,10 +206,10 @@ impl TextRenderState {
             } else {
                 // Cache miss — create and shape a new buffer
                 let scaled_font_size = entry.font_size * scale_factor;
-                let mut buffer = Buffer::new(
-                    &mut self.font_system,
-                    Metrics::new(scaled_font_size, scaled_font_size * 1.2),
-                );
+                let (size, line_height) =
+                    crate::renderer::text_measurer::shapeable_metrics(scaled_font_size);
+                let mut buffer =
+                    Buffer::new(&mut self.font_system, Metrics::new(size, line_height));
                 buffer.set_size(
                     &mut self.font_system,
                     Some((entry.rect.width.max(200.0)) * scale_factor),

--- a/src/renderer/text_mask.rs
+++ b/src/renderer/text_mask.rs
@@ -199,10 +199,8 @@ impl TextMaskRenderer {
 
         // Shaped the way the on-screen text is shaped, or the hole would not be
         // the shape of the letters that land in it.
-        let mut buffer = Buffer::new(
-            &mut shaper.font_system,
-            Metrics::new(font_size, font_size * 1.2),
-        );
+        let (size, line_height) = crate::renderer::text_measurer::shapeable_metrics(font_size);
+        let mut buffer = Buffer::new(&mut shaper.font_system, Metrics::new(size, line_height));
         buffer.set_size(
             &mut shaper.font_system,
             Some(spec.logical.0.max(200.0) * spec.scale_factor),

--- a/src/renderer/text_measurer.rs
+++ b/src/renderer/text_measurer.rs
@@ -3,6 +3,39 @@ use crate::widgets::font::{FontFamily, FontWeight};
 use cosmic_text::{Attrs, Buffer, FontSystem, Metrics, Shaping};
 use rustc_hash::FxHashMap;
 use std::cell::RefCell;
+
+/// The smallest font size guido will hand to the shaper.
+///
+/// Not a taste decision: `Metrics` built from a non-positive size does not
+/// terminate inside cosmic-text, so a `font_size(-1.0)` — or any size computed
+/// from a width that went negative — hangs the process with nothing drawn and
+/// nothing said (#349). Well below a pixel, so a size that was merely very
+/// small still measures as itself.
+const SMALLEST_SHAPEABLE: f32 = 0.01;
+
+/// A size the shaper can actually work with, and the line height that goes
+/// with it.
+///
+/// One door, because there are four places that build `Metrics` from a font
+/// size — this measurer and the three draw paths — and each would otherwise
+/// have to know that a non-finite or non-positive one is the single input that
+/// does not come back. Returns the size rather than the metrics because the
+/// draw paths build theirs from glyphon's own copy of cosmic-text, which is a
+/// different type from this one.
+///
+/// A clamped size draws a glyph far too small to see, which is what a caller
+/// who asked for nothing drawable should get.
+pub(crate) fn shapeable_metrics(font_size: f32) -> (f32, f32) {
+    let size = if font_size.is_finite() && font_size >= SMALLEST_SHAPEABLE {
+        font_size
+    } else {
+        SMALLEST_SHAPEABLE
+    };
+    (size, size * LINE_HEIGHT_RATIO)
+}
+
+/// The line height guido asks for, as a multiple of the font size.
+const LINE_HEIGHT_RATIO: f32 = 1.2;
 use std::hash::{Hash, Hasher};
 
 /// Cache key for measurement results.
@@ -165,7 +198,8 @@ impl TextMeasurer {
         font_family: &FontFamily,
         font_weight: FontWeight,
     ) -> Buffer {
-        let metrics = Metrics::new(font_size, font_size * 1.2);
+        let (size, line_height) = shapeable_metrics(font_size);
+        let metrics = Metrics::new(size, line_height);
         let mut buffer = Buffer::new(&mut self.font_system, metrics);
 
         buffer.set_size(&mut self.font_system, max_width, None);
@@ -425,6 +459,43 @@ pub fn char_index_from_x_styled(
 #[cfg(test)]
 mod baseline_tests {
     use super::*;
+
+    /// A size that cannot be shaped comes back rather than spinning.
+    ///
+    /// `Metrics` built from a non-positive size does not terminate inside
+    /// cosmic-text: `text("...").font_size(-1.0)` hung the process with nothing
+    /// drawn and nothing said, and it was the mutation job that found it — the
+    /// mutant that returned `-1.0` from `TextAnims::retarget` was the one
+    /// non-caught mutant of fifty-one, and it timed out rather than surviving
+    /// (#349).
+    ///
+    /// Run on a thread with a deadline, because the failure this guards is a
+    /// hang: asserted inline, a regression would take CI down with it instead
+    /// of failing.
+    #[test]
+    fn a_size_that_cannot_be_shaped_still_answers() {
+        let (done, waiting) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            for font_size in [-1.0f32, 0.0, -0.0, f32::NAN, f32::NEG_INFINITY] {
+                let m = measure_text_full(
+                    "a line of words",
+                    font_size,
+                    Some(100.0),
+                    &FontFamily::default(),
+                    FontWeight::NORMAL,
+                );
+                assert!(
+                    m.size.width.is_finite() && m.size.height.is_finite(),
+                    "a {font_size} size measured as {:?}",
+                    m.size
+                );
+            }
+            let _ = done.send(());
+        });
+        waiting
+            .recv_timeout(std::time::Duration::from_secs(10))
+            .expect("a font size that cannot be shaped has to come back, not spin");
+    }
 
     /// A baseline sits below the ascenders and above the descenders — never
     /// at the very bottom of the line box, which is what "align by the bottom

--- a/src/renderer/text_quad.rs
+++ b/src/renderer/text_quad.rs
@@ -217,10 +217,9 @@ impl TextQuadRenderer {
         }
 
         // Cache miss: shape and rasterize
-        let mut buffer = Buffer::new(
-            &mut self.font_system,
-            Metrics::new(scaled_font_size, scaled_font_size * 1.2),
-        );
+        let (size, line_height) =
+            crate::renderer::text_measurer::shapeable_metrics(scaled_font_size);
+        let mut buffer = Buffer::new(&mut self.font_system, Metrics::new(size, line_height));
         buffer.set_size(
             &mut self.font_system,
             Some(buffer_width),

--- a/src/widgets/container/anim_bridge.rs
+++ b/src/widgets/container/anim_bridge.rs
@@ -88,8 +88,14 @@ impl Container {
 
             if anim.is_initial() {
                 // Mark initialized at the first layout whatever the value, so
-                // later changes animate instead of snapping.
-                anim.set_immediate(target);
+                // later changes animate instead of snapping — unless an enter
+                // was declared, in which case this is the appearance it was
+                // waiting for and the size animates from there.
+                if anim.begin_enter(target, || tree.frame_instant()) {
+                    retargeted = true;
+                } else {
+                    anim.set_immediate(target);
+                }
             } else if (target - *anim.target()).abs() > 0.001 {
                 anim.animate_to(target, tree.frame_instant());
                 retargeted = true;
@@ -109,7 +115,7 @@ impl Container {
     /// value its signal actually holds, not the one captured at construction.
     ///
     /// See the module docs for why this cannot wait for the first paint.
-    pub(super) fn seed_animations(&mut self, id: WidgetId) {
+    pub(super) fn seed_animations(&mut self, tree: &Tree, id: WidgetId) {
         // Written out one by one: each property animates a different type, so
         // there is no single accessor to loop over.
         let anims = self.anims.as_ref();
@@ -140,15 +146,17 @@ impl Container {
 
         // Targets are computed under `&self` first: the writes below need
         // `&mut self.anims`, and the effective_* readers need `&self`.
+        let (pd_target, bw_target) = with_signal_tracking(id, JobType::Animation, || {
+            // Read for the subscription, and kept: these two keep the
+            // seed they were built with rather than being re-seeded here,
+            // but an enter declared on them still has to begin somewhere.
+            (
+                pd_init.then(|| self.effective_padding_target(id)),
+                bw_init.then(|| self.effective_border_width_target(id)),
+            )
+        });
         let (bg_target, cr_target, sh_target, bc_target, tr_target, ro_target, sc_target) =
             with_signal_tracking(id, JobType::Animation, || {
-                // Read for the subscription even where the value is unused.
-                if pd_init {
-                    let _ = self.effective_padding_target(id);
-                }
-                if bw_init {
-                    let _ = self.effective_border_width_target(id);
-                }
                 (
                     bg_init.then(|| self.effective_background_target(id)),
                     cr_init.then(|| self.effective_corners_target(id)),
@@ -165,13 +173,23 @@ impl Container {
         };
         // One line per property rather than a loop: each animates a
         // different type, so there is nothing to iterate over.
-        seed(&mut anims.background, bg_target);
-        seed(&mut anims.corners, cr_target);
-        seed(&mut anims.shadow, sh_target);
-        seed(&mut anims.border_color, bc_target);
-        seed(&mut anims.translate, tr_target);
-        seed(&mut anims.rotate, ro_target);
-        seed(&mut anims.scale, sc_target);
+        let now = || tree.frame_instant();
+        let mut entered = false;
+        entered |= seed_or_enter(&mut anims.background, bg_target, now);
+        entered |= seed_or_enter(&mut anims.corners, cr_target, now);
+        entered |= seed_or_enter(&mut anims.shadow, sh_target, now);
+        entered |= seed_or_enter(&mut anims.border_color, bc_target, now);
+        entered |= seed_or_enter(&mut anims.translate, tr_target, now);
+        entered |= seed_or_enter(&mut anims.rotate, ro_target, now);
+        entered |= seed_or_enter(&mut anims.scale, sc_target, now);
+        entered |= seed_or_enter(&mut anims.padding, pd_target, now);
+        entered |= seed_or_enter(&mut anims.border_width, bw_target, now);
+
+        // An enter is under way from this frame, so there has to be another
+        // one: nothing else will ask, because no signal changed.
+        if entered {
+            request_job(id, JobRequest::Animation(RequiredJob::Paint));
+        }
     }
 
     /// Every paint: re-read the animated targets under tracking, and ask for an
@@ -268,12 +286,23 @@ impl Container {
     }
 }
 
-/// Start one animated property at the target just read for it.
+/// Start one animated property at the target just read for it, or begin the
+/// enter it declared. Returns whether an enter began, which is what needs a
+/// frame after this one.
 ///
 /// Written as a call per property rather than a loop, because each animates a
 /// different type and there is no single accessor to iterate.
-fn seed<T: crate::animation::Animatable>(slot: &mut Option<AnimationState<T>>, target: Option<T>) {
-    if let (Some(anim), Some(target)) = (slot, target) {
-        anim.set_immediate(target);
+fn seed_or_enter<T: crate::animation::Animatable>(
+    slot: &mut Option<AnimationState<T>>,
+    target: Option<T>,
+    now: impl FnOnce() -> crate::clock::FrameInstant,
+) -> bool {
+    let Some((anim, target)) = slot.as_mut().zip(target) else {
+        return false;
+    };
+    if anim.begin_enter(target, now) {
+        return true;
     }
+    anim.set_immediate(target);
+    false
 }

--- a/src/widgets/container/animations.rs
+++ b/src/widgets/container/animations.rs
@@ -75,6 +75,14 @@ pub struct AnimationState<T: Animatable> {
     initialized: bool,
     /// Previous value for change detection
     prev_value: Option<T>,
+    /// Where this property begins the one time the widget appears, until the
+    /// first layout takes it. `None` for almost every declaration — see
+    /// [`Animated::entering_from`](crate::animation::Animated::entering_from)
+    /// — and boxed for the reason `timeline` below is: this struct is held
+    /// eleven times over by every container that animates anything, and a
+    /// `Shadow` inline here would widen all eleven to carry a value almost
+    /// none of them has and none of them keeps past the first layout.
+    enter_from: Option<Box<T>>,
     /// A sequence to play on demand, and what plays it. Boxed and absent by
     /// default: most declared properties ease to a target and never carry one,
     /// so they pay a pointer rather than the struct.
@@ -104,8 +112,61 @@ impl<T: Animatable> AnimationState<T> {
             spring_state,
             initialized: false, // Not yet initialized with real content-based value
             prev_value: None,
+            enter_from: None,
             timeline: None,
         }
+    }
+
+    /// Declare where this property starts on the frame it first appears.
+    pub(crate) fn with_enter_from(mut self, from: Option<T>) -> Self {
+        self.enter_from = from.map(Box::new);
+        self
+    }
+
+    /// Begin the enter this property declared, if it declared one, and answer
+    /// whether it did.
+    ///
+    /// Every first initialisation goes through here, which is what makes an
+    /// enter reach every animatable property rather than the ones whose
+    /// initialiser remembered to ask. Taken and not read: an enter happens
+    /// once, so the first initialisation is the appearance and every one after
+    /// it is not.
+    ///
+    /// The instant is a closure because the overwhelmingly common answer is
+    /// "no enter was declared", and asking a `Tree` for the time outside a
+    /// frame is a diagnostic rather than a free read.
+    pub(crate) fn begin_enter(&mut self, target: T, now: impl FnOnce() -> FrameInstant) -> bool {
+        // A measure pass is not an appearance. It runs before the surface
+        // exists — `measure_natural_size` sizes a popup so the compositor can
+        // be told how big to make it — and it reads targets rather than
+        // in-flight values for exactly this reason. Consuming the enter there
+        // would play it against a surface that is not yet mapped, and there is
+        // no frame instant to play it against either.
+        if measuring_final() {
+            return false;
+        }
+        let Some(from) = self.enter_from.take() else {
+            return false;
+        };
+        let from = *from;
+        if from == target {
+            // Declared, but nowhere to travel from. Placing it is what every
+            // property without an enter does, and it costs no frame.
+            self.set_immediate(target);
+            return false;
+        }
+
+        self.set_immediate(from);
+        // Forward, whichever way it travels. `animate_to` would read the
+        // direction off `current`, which is now the enter value, so an enter
+        // that shrinks — a card settling down from a larger scale — would run
+        // the transition written for the value *later* decreasing, and fire
+        // its `on_complete`. In the pattern this feature exists for that
+        // callback destroys the popup, so appearing would close it.
+        self.using_reverse = false;
+        self.target = target;
+        self.begin_segment_from(from, now());
+        true
     }
 
     /// Get the currently active transition (forward or reverse).

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -3000,7 +3000,274 @@ fn a_state_override_replaces_the_whole_corner_shape() {
     assert_eq!(hovered.radii.top_left, 20.0);
 }
 
-/// Every `BackdropBlur` radius drawn by a node.
+/// A container whose background enters from transparent, and one declared the
+/// same way without an enter.
+///
+/// The pair is the assertion: on the frame after the first layout one is
+/// mid-animation and the other is already at its declared value, and some
+/// frames later they agree. Without the pair, "it is not the target yet" could
+/// be any of a dozen things.
+#[test]
+fn a_background_with_an_enter_starts_somewhere_else_and_arrives() {
+    let entering = |from: Option<Color>| {
+        let value =
+            Color::rgb(1.0, 0.0, 0.0).transition(Transition::new(100.0, TimingFunction::Linear));
+        container().width(20.0).height(20.0).background(match from {
+            Some(from) => value.entering_from(from),
+            None => value,
+        })
+    };
+
+    let t0 = std::time::Instant::now();
+
+    let mut plain = H::new(entering(None));
+    frame_at(&mut plain, t0, 100.0, 100.0);
+    assert_eq!(
+        rects(&plain.paint()).first().map(|(_, c)| *c),
+        Some(Color::rgb(1.0, 0.0, 0.0)),
+        "with no enter declared, the first frame is the declared value"
+    );
+
+    let mut entered = H::new(entering(Some(Color::rgba(1.0, 0.0, 0.0, 0.0))));
+    frame_at(&mut entered, t0, 100.0, 100.0);
+
+    // Halfway through a linear hundred milliseconds. The frame that seeds is
+    // the frame the enter begins on, so the curve is read on the next one.
+    frame_at(
+        &mut entered,
+        t0 + std::time::Duration::from_millis(50),
+        100.0,
+        100.0,
+    );
+    let midway = rects(&entered.paint())
+        .first()
+        .map(|(_, c)| *c)
+        .expect("it paints");
+    assert!(
+        midway.a > 0.0 && midway.a < 1.0,
+        "the enter is under way rather than arrived, got {midway:?}"
+    );
+
+    frame_at(
+        &mut entered,
+        t0 + std::time::Duration::from_millis(200),
+        100.0,
+        100.0,
+    );
+    assert_eq!(
+        rects(&entered.paint()).first().map(|(_, c)| *c),
+        Some(Color::rgb(1.0, 0.0, 0.0)),
+        "and it arrives at the declared value"
+    );
+}
+
+/// The same verb on a transform, which is the half the removed methods could
+/// do — and the half the one real caller uses, a menu scaling open from
+/// collapsed on its first layout.
+#[test]
+fn a_scale_with_an_enter_starts_collapsed() {
+    let t0 = std::time::Instant::now();
+    let mut h = H::new(
+        container().width(20.0).height(20.0).scale(
+            Scale::uniform(1.0)
+                .transition(Transition::new(100.0, TimingFunction::Linear))
+                .entering_from(Scale::uniform(0.0)),
+        ),
+    );
+
+    frame_at(&mut h, t0, 100.0, 100.0);
+    let first = h.paint().local_transform;
+    assert!(
+        first.a() < 1.0,
+        "the box is still opening on the frame after its first layout, got {first:?}"
+    );
+
+    frame_at(
+        &mut h,
+        t0 + std::time::Duration::from_millis(200),
+        100.0,
+        100.0,
+    );
+    assert_eq!(h.paint().local_transform.a(), 1.0, "and it finishes open");
+}
+
+/// An enter is what a widget does when it appears, so it happens once. A
+/// relayout is not an appearance.
+#[test]
+fn an_enter_is_consumed_by_the_first_layout_and_does_not_play_again() {
+    let t0 = std::time::Instant::now();
+    let mut h = H::new(
+        container().width(20.0).height(20.0).background(
+            Color::rgb(1.0, 0.0, 0.0)
+                .transition(Transition::new(100.0, TimingFunction::Linear))
+                .entering_from(Color::rgba(1.0, 0.0, 0.0, 0.0)),
+        ),
+    );
+
+    frame_at(&mut h, t0, 100.0, 100.0);
+    frame_at(
+        &mut h,
+        t0 + std::time::Duration::from_millis(200),
+        100.0,
+        100.0,
+    );
+    assert_eq!(
+        rects(&h.paint()).first().map(|(_, c)| *c),
+        Some(Color::rgb(1.0, 0.0, 0.0)),
+        "the enter has finished"
+    );
+
+    // A different viewport: layout runs again, and nothing about the widget
+    // appearing has happened.
+    frame_at(
+        &mut h,
+        t0 + std::time::Duration::from_millis(300),
+        160.0,
+        160.0,
+    );
+    assert_eq!(
+        rects(&h.paint()).first().map(|(_, c)| *c),
+        Some(Color::rgb(1.0, 0.0, 0.0)),
+        "a relayout is not an appearance, so nothing plays a second time"
+    );
+}
+
+/// The verb reaches the properties whose first value is placed somewhere other
+/// than the seed pass — a size, which `update_size_targets` initialises, and a
+/// padding, which keeps the seed it was built with and is never re-seeded.
+///
+/// These are two of the four that accepted an enter and silently dropped it
+/// while the take lived in one initialiser instead of in `AnimationState`.
+/// The padding is read through the child it moves, because a padding is only
+/// visible in where it puts things.
+#[test]
+fn an_enter_reaches_a_size_and_a_padding_too() {
+    let t0 = std::time::Instant::now();
+    let mut h = H::new(
+        container()
+            .height(60.0)
+            .width(
+                120.0f32
+                    .transition(Transition::new(100.0, TimingFunction::Linear))
+                    .entering_from(0.0),
+            )
+            .padding(
+                Padding::all(20.0)
+                    .transition(Transition::new(100.0, TimingFunction::Linear))
+                    .entering_from(Padding::all(0.0)),
+            )
+            .child(container().width(10.0).height(10.0)),
+    );
+
+    frame_at(&mut h, t0, 400.0, 400.0);
+    frame_at(
+        &mut h,
+        t0 + std::time::Duration::from_millis(50),
+        400.0,
+        400.0,
+    );
+
+    let midway = h.tree.cached_size(h.root).unwrap().width;
+    assert!(
+        midway > 0.0 && midway < 120.0,
+        "the width is opening rather than already open, got {midway}"
+    );
+    let child = h.tree.get_children(h.root)[0];
+    let inset = h.tree.get_origin(child).unwrap().0;
+    assert!(
+        inset > 0.0 && inset < 20.0,
+        "the padding is opening too, got {inset}"
+    );
+
+    frame_at(
+        &mut h,
+        t0 + std::time::Duration::from_millis(200),
+        400.0,
+        400.0,
+    );
+    assert_eq!(
+        h.tree.cached_size(h.root).unwrap().width,
+        120.0,
+        "and the width arrives"
+    );
+    assert_eq!(
+        h.tree.get_origin(h.tree.get_children(h.root)[0]).unwrap().0,
+        20.0,
+        "and so does the padding"
+    );
+}
+
+/// An appearance has no direction, so it runs the forward transition whichever
+/// way it travels.
+///
+/// `animate_to` reads the direction off the value it is leaving, and an enter
+/// has just placed that value at the start of the appearance. A card settling
+/// down from a larger scale therefore looked like a value decreasing, ran the
+/// transition written for the *later* close, and fired its `on_complete` — the
+/// callback that destroys the popup in the pattern this feature exists for.
+#[test]
+fn an_enter_that_shrinks_still_runs_the_forward_transition() {
+    let closed = std::rc::Rc::new(std::cell::Cell::new(0u32));
+    let counted = std::rc::Rc::clone(&closed);
+    let t0 = std::time::Instant::now();
+    let mut h = H::new(
+        container().width(20.0).height(20.0).scale(
+            Scale::uniform(1.0)
+                .transition(
+                    Transition::new(400.0, TimingFunction::Linear).reverse(
+                        Transition::new(20.0, TimingFunction::Linear)
+                            .on_complete(move || counted.set(counted.get() + 1)),
+                    ),
+                )
+                .entering_from(Scale::uniform(1.4)),
+        ),
+    );
+
+    frame_at(&mut h, t0, 100.0, 100.0);
+    frame_at(
+        &mut h,
+        t0 + std::time::Duration::from_millis(50),
+        100.0,
+        100.0,
+    );
+    assert_eq!(
+        closed.get(),
+        0,
+        "the reverse transition's completion belongs to the close, not the open"
+    );
+    let midway = h.paint().local_transform.a();
+    assert!(
+        midway > 1.0,
+        "and the forward curve is still running at 50ms of 400, got {midway}"
+    );
+}
+
+/// An enter is written in the vocabulary every other position takes.
+///
+/// `IntoVal` and not `Into`: the numeric widenings guido declares with
+/// `converts!(S as T)` carry no std `From`, so `Into` would accept a rotation
+/// entered from `0.0f32` and refuse the same value written `0i32` — in a
+/// setter that takes both.
+#[test]
+fn an_enter_takes_what_the_property_takes() {
+    let _ = container()
+        .rotate(45.0f32.transition(200.0).entering_from(0i32))
+        .scale(Scale::uniform(1.0).transition(200.0).entering_from(0.0f64))
+        .width(120.0f32.transition(200.0).entering_from(0u16));
+}
+
+/// A timeline already says where it starts, so an enter on one would be
+/// dropped in silence. It says so instead.
+#[test]
+#[should_panic(expected = "a timeline already says where it starts")]
+fn an_enter_on_a_timeline_refuses() {
+    let plays = create_signal(0u32);
+    let _ = 0.0f32
+        .timeline(Keyframes::new(100.0).at(1.0, 1.0), plays)
+        .entering_from(0.0);
+}
+
+/// Every `BackdropBlur` radius drawn by a node./// Every `BackdropBlur` radius drawn by a node.
 fn blur_radii(node: &RenderNode) -> Vec<f32> {
     node.commands
         .iter()

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -1552,7 +1552,7 @@ impl Widget for Container {
         }
 
         self.update_size_targets(tree, id, &lengths, content_size);
-        self.seed_animations(id);
+        self.seed_animations(tree, id);
 
         let size = self.resolve_size(&lengths, constraints, content_size);
 
@@ -1936,11 +1936,12 @@ fn sorted_axis(tree: &Tree, children: &[WidgetId]) -> Option<Axis> {
 /// never two declarations for one property to reconcile, only the one written
 /// last.
 ///
-/// The animation is seeded from the signal's value at builder time. For every
-/// property but padding and border width that seed is replaced at the first
-/// layout by `seed_animations`, which reads the signal rather than this
-/// snapshot; those two are read there only for their subscription, so their
-/// seed survives into the first advance.
+/// The animation is seeded from the signal's value at builder time, and that
+/// seed is replaced at the first layout by `seed_animations`, which reads the
+/// signal rather than this snapshot. Padding and border width used to be the
+/// exception, read there only for their subscription — which left them the two
+/// properties `is_initial()` was never false for, and so the two the drift
+/// check in `resync_animation_targets` could never speak for.
 pub(crate) fn declare<A: Default, T: Animatable, M>(
     anims: &mut Option<Box<A>>,
     value: impl IntoAnimated<T, M>,
@@ -1950,7 +1951,9 @@ pub(crate) fn declare<A: Default, T: Animatable, M>(
     let installed = motion.map(|motion| {
         let seed = signal.get_untracked();
         match *motion {
-            Motion::Ease(config) => AnimationState::new(seed, config),
+            Motion::Ease { config, enter_from } => {
+                AnimationState::new(seed, config).with_enter_from(enter_from)
+            }
             Motion::Play { keyframes, plays } => {
                 AnimationState::new(seed, instant_transition()).with_timeline(keyframes, plays)
             }
@@ -1990,9 +1993,12 @@ fn declare_size<M>(
     slot: impl FnOnce(&mut ContainerAnims) -> &mut Option<AnimationState<f32>>,
 ) -> Signal<Length> {
     let (signal, ease) = value.into_animated().into_eased();
-    let installed = ease.map(|config| {
-        let length = signal.get_untracked();
-        AnimationState::new(length.exact.or(length.min).unwrap_or(0.0), config)
+    // A size declares a `Length` and animates the `f32` inside it, so the enter
+    // is narrowed by the same formula as the seed.
+    let resolved = |length: Length| length.exact.or(length.min).unwrap_or(0.0);
+    let installed = ease.map(|(config, enter_from)| {
+        AnimationState::new(resolved(signal.get_untracked()), config)
+            .with_enter_from(enter_from.map(resolved))
     });
     write_slot(anims, slot, installed);
     signal

--- a/src/widgets/text.rs
+++ b/src/widgets/text.rs
@@ -560,6 +560,37 @@ mod tests {
         );
     }
 
+    /// A text's colour appears from somewhere else too.
+    ///
+    /// `TextAnims::retarget` is one of the four initialisers that place a
+    /// property for the first time, and it is the one furthest from the
+    /// container's seed pass. It asked for the enter only once the take moved
+    /// onto `AnimationState` itself; before that a text colour accepted an
+    /// enter and arrived at its declared value without a word.
+    #[test]
+    fn a_text_colour_can_appear_from_somewhere_else() {
+        const FROM: Color = Color::rgb(0.0, 0.0, 0.0);
+        const TO: Color = Color::rgb(1.0, 1.0, 1.0);
+
+        let mut tree = Tree::new();
+        let root = tree
+            .register(Box::new(container().child(
+                Text::new("entering").color(TO.transition(400.0).entering_from(FROM)),
+            )));
+        tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
+
+        let t0 = std::time::Instant::now();
+        all_text(&mut tree, root, t0);
+        let midway = all_text(&mut tree, root, t0 + std::time::Duration::from_millis(100))[0].0;
+        assert!(
+            midway.r > 0.01 && midway.r < 0.99,
+            "the colour is arriving rather than arrived, got {midway:?}"
+        );
+
+        let settled = all_text(&mut tree, root, t0 + std::time::Duration::from_millis(600))[0].0;
+        assert!(settled.r > 0.99, "and it gets there, got {settled:?}");
+    }
+
     /// The same for a size, which moves layout rather than paint — so the claim
     /// is what the *container* measured, not what the text drew.
     ///

--- a/src/widgets/text_style.rs
+++ b/src/widgets/text_style.rs
@@ -270,7 +270,9 @@ impl TextAnims {
         let mut wants = None;
         if let Some(a) = self.color.as_mut() {
             if a.is_initial() {
-                a.set_immediate(color);
+                if !a.begin_enter(color, || now) {
+                    a.set_immediate(color);
+                }
             } else {
                 a.animate_to(color, now);
             }
@@ -281,7 +283,9 @@ impl TextAnims {
         let mut measured = size;
         if let Some(a) = self.font_size.as_mut() {
             if a.is_initial() {
-                a.set_immediate(size);
+                if !a.begin_enter(size, || now) {
+                    a.set_immediate(size);
+                }
             } else {
                 a.animate_to(size, now);
             }


### PR DESCRIPTION
## What changed

A widget can appear mid-animation again. `Animated::entering_from(value)` says where a property begins on the one frame its widget appears, composing with the `transition` that says how it travels — the split CSS makes between `@starting-style` and `transition`. It hangs off the value rather than off three transform setters, so unlike the `animate_*_from` methods #304 removed, a card can fade in. Closes #303. Closes #349.

## What proves it

Nine tests, each named for the bullet it answers. The acceptance criterion asks for a paint-path property and a transform mid-animation on the frame after first layout and arrived some frames later, for a pair differing only in whether the value carries an enter, and for nothing playing twice: `a_background_with_an_enter_starts_somewhere_else_and_arrives`, `a_scale_with_an_enter_starts_collapsed`, `an_enter_is_consumed_by_the_first_layout_and_does_not_play_again`.

The other six came out of the readings and each fails against the version that lacks its fix, verified by mutating the line rather than by argument: `an_enter_reaches_a_size_and_a_padding_too`, `a_text_colour_can_appear_from_somewhere_else`, `an_enter_that_shrinks_still_runs_the_forward_transition`, `an_enter_takes_what_the_property_takes`, `an_enter_on_a_timeline_refuses`.

The book chapter lost its enter section in #304 and has one back that is not transform-shaped; `mdbook test` compiles both samples.

## What the review found

**Three blocking findings, all fixed.**

An enter that *shrinks* ran the reverse transition and fired its `on_complete`. `animate_to` reads direction off the value it is leaving, and an enter has just placed that value at the start of the appearance. In the very pattern this feature exists for, that callback destroys the popup — so a menu appearing from a larger scale would have closed itself. An appearance now begins forward whichever way it travels.

Two of the four initialisers were proved by nothing: deleting the padding, border-width or text-colour enter left the whole suite green. Worse, the test named for padding asserted only on width. Both are now covered by assertions that observe the thing they name.

On an auto-height popup — the one named consumer — the enter was consumed during `measure_natural_size`, which runs before the surface is mapped and outside the frame window, so it also tripped the out-of-pass clock diagnostic at a guido internal. A measure pass is not an appearance and is now skipped.

Worth answering, both acted on: `entering_from` took `impl Into<T>`, which silently misses the three widenings guido declares with `converts!(S as T)` — it now takes `IntoVal<T>`, the crate's own conversion trait, so an enter is written in the same vocabulary every other position takes. And the unreachable panic arm is an `unreachable!` with the reasoning `into_eased` already uses, while the reachable one has a `#[should_panic]` test.

Notes acted on: `docs/STYLING.md` and the widgets skill both enumerated the motion vocabulary as two verbs, and the skill is what the next agent reads.

The review agreed one commit is right here: `Motion::Ease` becoming a struct variant breaks its constructors in the same file, so no split builds.

## What was checked by hand

Nothing. Everything is reachable from the unit tests, and no golden moved because no golden carries a first frame.

## The second commit

The mutation job turned red on this branch, and it was right to. Fifty-one mutants, twenty-one caught, twenty-nine unviable, **zero survivors** — and one timeout, which is what failed the job: `TextAnims::retarget` mutated to return a font size of `-1.0` did not finish in thirty seconds.

That is not an artefact. `text("hello").font_size(-1.0)` hangs guido on `main` too, reproduced by hand with the build completed first so the wait is the run. `Metrics` built from a non-positive size does not terminate inside cosmic-text, and layout reaches it before anything can draw — no panic, no frame, nothing said. One line of ordinary application code, and a bar that hangs takes the user's panel with it.

Four places build `Metrics` from a font size, so the clamp is one door they all pass through. `a_size_that_cannot_be_shaped_still_answers` runs on a thread with a deadline, because what it guards is a hang: asserted inline, a regression would take CI down instead of failing it. Verified by removing the clamp — it fails in ten seconds rather than spinning.

This is the first time that job has found something here rather than confirming what the tests already said.

## Left undone

**#347** — padding and border width have never reported drift. Their gate is keyed on a flag only `set_immediate` sets, and nothing had ever called it for those two, so the pull half of the resync invariant has been off for them. This change is what made it visible, by adding the first seed-time call that touches them; it is present without this change and needs an acceptance criterion this change's tests cannot state.

Not opened as issues, because nobody is worse off today: the state change named in the acceptance is not separately exercised, since `take()` makes the once-only structural rather than conditional. And the ashell port needs two edits rather than one to build against current guido — its popup calls `.transform(..)` as well, which #304 also removed, and no `transform` setter exists to replace it.

https://claude.ai/code/session_01Xb5BYhQqkrE8ngiyKE6FRX