### PR TITLE
A component places the children it was handed, and keeps its own

### DIFF
--- a/.claude/skills/widgets/SKILL.md
+++ b/.claude/skills/widgets/SKILL.md
@@ -134,8 +134,10 @@ write its own.
 Children: `.child()` for a static one — a widget, or an `Option` of one that
 is simply absent when `None`. `.children()` takes
 whatever `IntoChildren` fits — an iterator of widgets is static, a closure is
-dynamic and re-runs when what it read changes, and `keyed(data, key, build)`
-reconciles by key so widget state survives a reorder:
+dynamic and re-runs when what it read changes, `keyed(data, key, build)`
+reconciles by key so widget state survives a reorder, and a `ChildrenSource` is
+the set a component was handed by its caller, taking its place where the call is
+written:
 
 ```rust
 container().children(keyed(

--- a/book/src/advanced/components.md
+++ b/book/src/advanced/components.md
@@ -226,9 +226,14 @@ pub fn card(
         .corners(8.0)
         .layout(Flex::column().spacing(8.0))
         .child(container().child(text(title).font_size(18.0).color(Color::WHITE)))
-        .children_source(children)
+        .children(children)
 }
 ```
+
+`children` is the same method the caller uses, and the rows land where the call
+is written: the title above stays above them, and anything the component adds
+afterwards comes after. A component that never calls it drops what it was
+handed.
 
 Use with child/children methods:
 
@@ -347,7 +352,7 @@ pub fn card(
         .corners(8.0)
         .layout(Flex::column().spacing(8.0))
         .child(container().child(text(title).font_size(18.0).color(Color::WHITE)))
-        .children_source(children)
+        .children(children)
 }
 
 fn main() {

--- a/book/src/advanced/dynamic-children.md
+++ b/book/src/advanced/dynamic-children.md
@@ -301,7 +301,7 @@ impl Container {
     pub fn child<M>(self, child: impl IntoChild<M>) -> Self;
 
     // An iterator of widgets, a reactive closure returning one,
-    // or keyed(data, key, build)
+    // keyed(data, key, build), or the ChildrenSource a component was handed
     pub fn children<M>(self, children: impl IntoChildren<M>) -> Self;
 }
 

--- a/examples/component_example.rs
+++ b/examples/component_example.rs
@@ -31,7 +31,7 @@ pub fn card(
         .corners(8.0)
         .layout(Flex::column().spacing(8.0))
         .child(text(title).font_size(18.0).color(Color::WHITE))
-        .children_source(children)
+        .children(children)
 }
 
 fn main() {

--- a/src/widgets/children.rs
+++ b/src/widgets/children.rs
@@ -72,6 +72,42 @@ impl ChildrenSource {
         }
     }
 
+    /// Take everything `other` holds, in order, after what this source has.
+    ///
+    /// Both halves are build-time state — `pending_static` is drained at
+    /// registration and `segments` is written while the tree is being built —
+    /// so appending the two is the whole of it. Static widgets stay in
+    /// insertion order because the reconciler walks segments and takes that
+    /// many from the merged list in the order they were pushed.
+    ///
+    /// What it is for: a component forwarding the children it was handed, via
+    /// [`IntoChildren`](super::IntoChildren) for `ChildrenSource`.
+    pub(crate) fn append(&mut self, mut other: ChildrenSource) {
+        debug_assert!(
+            other.merged.is_empty() && !other.initial_reconcile_done,
+            "a source is forwarded while the tree is being built, before \
+             anything in it has reached a widget id"
+        );
+
+        // Moved out field by field, so the husk that drops at the end of this
+        // call holds nothing: `ChildrenSource` drops by asking the loop to
+        // unregister every widget it still has.
+        let mut statics = std::mem::take(&mut other.pending_static).into_iter();
+        for segment in std::mem::take(&mut other.segments) {
+            match segment {
+                // Back through `add_static`, so a static run arriving at the
+                // seam is opened or extended by the same rule as one written
+                // here directly.
+                SegmentType::Static(count) => {
+                    for widget in statics.by_ref().take(count) {
+                        self.add_static(widget);
+                    }
+                }
+                dynamic => self.segments.push(dynamic),
+            }
+        }
+    }
+
     /// Register all pending static widgets with the tree.
     ///
     /// This should be called before layout. It recursively registers the widget tree.

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -645,12 +645,6 @@ impl Container {
         self
     }
 
-    /// Transfer children from another ChildrenSource (useful for components)
-    pub fn children_source(mut self, source: ChildrenSource) -> Self {
-        self.children_source = source;
-        self
-    }
-
     /// Set padding in logical pixels.
     ///
     /// Accepts multiple formats via `From` conversions:

--- a/src/widgets/into_child.rs
+++ b/src/widgets/into_child.rs
@@ -164,6 +164,10 @@ pub struct StaticChildren;
 /// Marker type for reactive children (closure or [`keyed()`])
 pub struct DynamicChildren;
 
+/// Marker type for children forwarded from a [`ChildrenSource`] a component
+/// was handed
+pub struct ForwardedChildren;
+
 /// Trait for values that can be added as children to a container.
 ///
 /// Accepted forms:
@@ -172,8 +176,10 @@ pub struct DynamicChildren;
 ///   reads changes, replacing all rows
 /// - [`keyed(data, key, build)`](keyed) — reactive with stable identity:
 ///   preserves per-row state, rebuilds only changed rows
+/// - a [`ChildrenSource`] — the children a component was handed by its
+///   caller, taking their place where the call is written
 #[diagnostic::on_unimplemented(
-    message = "`.children()` takes an iterator of widgets, a reactive closure returning one, or `keyed(data, key, build)` — and `{Self}` is none of those",
+    message = "`.children()` takes an iterator of widgets, a reactive closure returning one, `keyed(data, key, build)`, or the `ChildrenSource` a component was handed — and `{Self}` is none of those",
     note = "`.children(move || widgets)` replaces all rows when a signal it reads changes; `keyed(data, key, build)` preserves per-row state via stable identity and rebuilds only rows whose item changed"
 )]
 pub trait IntoChildren<Marker = StaticChildren> {
@@ -191,6 +197,18 @@ where
         for widget in self {
             children_source.add_static(Box::new(widget));
         }
+    }
+}
+
+/// The children a component was handed, put where the component wants them.
+///
+/// `#[prop(children)]` gives the component a `ChildrenSource` the caller
+/// filled in, and this is how it goes back into a tree — as one item in a
+/// sequence, so a title above it and a footer below it stay where they were
+/// written.
+impl IntoChildren<ForwardedChildren> for ChildrenSource {
+    fn add_to_container(self, children_source: &mut ChildrenSource) {
+        children_source.append(self);
     }
 }
 

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -28,7 +28,8 @@ pub use font::{FontFamily, FontWeight};
 pub use image::{ContentFit, Image, ImageSource, image};
 pub use input_style::{InputStyle, InputStyled};
 pub use into_child::{
-    DynamicChildren, IntoChild, IntoChildren, IntoDynChild, KeyedChildren, StaticChildren, keyed,
+    DynamicChildren, ForwardedChildren, IntoChild, IntoChildren, IntoDynChild, KeyedChildren,
+    StaticChildren, keyed,
 };
 pub use scroll::{Scroll, ScrollbarVisibility};
 pub use state_layer::{

--- a/tests/forwarded_children.rs
+++ b/tests/forwarded_children.rs
@@ -1,0 +1,126 @@
+//! A component places the children it was handed among its own.
+//!
+//! `#[prop(children)]` gives a component a [`ChildrenSource`] the caller
+//! filled in, and the component decides where in its tree those rows belong.
+//! The card in the book's component chapter puts a title above them; #353 is
+//! that the title used to be thrown away, because forwarding *assigned* the
+//! source over whatever the container had already been given.
+
+use guido::component;
+use guido::prelude::*;
+use guido::widgets::{ChildrenSource, IntoChildren};
+
+mod common;
+use common::Harness;
+
+/// A container that paints a rect of its own, so `painted_rects` can see it.
+fn block(width: f32) -> Container {
+    container()
+        .width(width)
+        .height(10.0)
+        .background(Color::WHITE)
+}
+
+/// What `#[prop(children)]` hands a component: a source the caller filled.
+fn caller_children(widths: [f32; 2]) -> ChildrenSource {
+    let mut source = ChildrenSource::default();
+    widths.map(block).add_to_container(&mut source);
+    source
+}
+
+/// The widths of everything the tree drew, in the order it drew them.
+fn widths(h: &mut Harness) -> Vec<f32> {
+    h.painted_rects().iter().map(|r| r.width).collect()
+}
+
+#[test]
+fn a_container_keeps_its_own_children_when_it_forwards() {
+    let mut h = Harness::laid_out(
+        container()
+            .layout(Flex::column())
+            .child(block(11.0))
+            .children(caller_children([22.0, 33.0])),
+        200.0,
+        200.0,
+    );
+
+    assert_eq!(
+        widths(&mut h),
+        vec![11.0, 22.0, 33.0],
+        "the title a component puts above the children it was handed has to \
+         survive the forwarding, and come first"
+    );
+}
+
+/// The caller's rows can be a reactive list, and the component's own children
+/// sit on both sides of it. Segments are what carries that: the forwarded
+/// source arrives as its own run, and the static widgets around it keep their
+/// place in the order they were written.
+#[test]
+fn a_forwarded_reactive_list_keeps_the_component_s_own_rows_apart() {
+    let rows = create_signal(2usize);
+
+    let mut source = ChildrenSource::default();
+    (move || {
+        (0..rows.get())
+            .map(|i| block(20.0 + i as f32))
+            .collect::<Vec<_>>()
+    })
+    .add_to_container(&mut source);
+
+    let mut h = Harness::laid_out(
+        container()
+            .layout(Flex::column())
+            .child(block(11.0))
+            .children(source)
+            .child(block(99.0)),
+        200.0,
+        200.0,
+    );
+
+    assert_eq!(
+        widths(&mut h),
+        vec![11.0, 20.0, 21.0, 99.0],
+        "a header, the caller's two reactive rows, then a footer"
+    );
+}
+
+/// Forwarded rows sit where the call sits, so a component that forwards before
+/// adding anything of its own puts its row last.
+#[test]
+fn forwarded_children_come_before_a_row_written_after_them() {
+    let mut h = Harness::laid_out(
+        container()
+            .layout(Flex::column())
+            .children(caller_children([22.0, 33.0]))
+            .child(block(11.0)),
+        200.0,
+        200.0,
+    );
+
+    assert_eq!(widths(&mut h), vec![22.0, 33.0, 11.0]);
+}
+
+/// The card the book teaches, through the path a caller takes: the macro fills
+/// a source from the builder's own `child` calls, hands it to the body as
+/// `children`, and the body decides where it goes.
+#[component]
+fn card(#[prop(children)] children: ()) -> impl Widget {
+    container()
+        .layout(Flex::column())
+        .child(block(11.0))
+        .children(children)
+        .child(block(99.0))
+}
+
+#[test]
+fn a_component_keeps_its_own_rows_around_the_ones_it_was_handed() {
+    let mut h = Harness::laid_out(card().child(block(22.0)).child(block(33.0)), 200.0, 200.0);
+
+    assert_eq!(
+        widths(&mut h),
+        vec![11.0, 22.0, 33.0, 99.0],
+        "the component's header and footer keep their places around the \
+         caller's two rows"
+    );
+}


### PR DESCRIPTION
## What changed

A `ChildrenSource` is now one of the forms `children` accepts, so a component
places the children it was handed among its own instead of replacing them with
that set. `Container::children_source`, which assigned rather than added, is
gone. Closes #353.

The card in `examples/component_example.rs` and the two in the book's component
chapter were all written as title-then-forward, so all three silently drew no
title. They keep it now.

## What proves it

`tests/forwarded_children.rs`, four scenarios: a component's own row before the
forwarded set, after it, on both sides of a forwarded *reactive* list, and the
whole thing through `#[component]` with `#[prop(children)]` — the path a caller
actually takes.

Confirmed red before the change, with the same assertions spelled
`.children_source(..)`:

```
left: [22.0, 33.0]
right: [11.0, 22.0, 33.0]
```

Full suite green including the goldens on lavapipe, and `mdbook test` over the
book, which is what compiles the card at `book/src/advanced/components.md:352`
against the new spelling.

## What the review found

**Zero blocking.** Three worth answering, all acted on:

- Nothing went through `#[prop(children)]`, the macro half of the path this fix
  is about. That test now exists.
- The issue's acceptance names both orders and only one was written. The
  reverse order is now its own test.
- `book/src/advanced/dynamic-children.md` listed three accepted forms of
  `children` in its API reference. Four now.

Notes taken rather than acted on: `ChildrenSource::append` guards "this source
was never registered" with a `debug_assert!`, which is the right amount for a
state nothing in the library or the macro can reach; and the comment on the
move now says what it means.

Before that, `/simplify` applied five findings — the seam rule goes back
through `add_static` rather than being restated, the `on_unimplemented` message
lists the fourth form, a duplicated `ignore` sample came out, and two test
shapes shrank.

## What was checked by hand

Nothing. The example is the visible half of this — the card's title reappears —
but running it opens a real surface, so it is left for you rather than started
here. `clippy --all-targets` compiles it.

## Left undone

Static children live in two structures that have to stay in step:
`pending_static` holds the widgets and `SegmentType::Static(count)` counts them.
That is why `append` needs a comment at all. A `Static` segment owning its
widgets would make it `segments.extend(..)` with no parallel-vector reasoning.
Nobody is worse off today — the invariant holds, it has three call sites, and
this change routes through `add_static` rather than around it — so this is a
sentence rather than an issue.

https://claude.ai/code/session_01Xb5BYhQqkrE8ngiyKE6FRX
