### PR TITLE
A container declares where input reaches the surface

### DIFF
--- a/.claude/skills/widgets/SKILL.md
+++ b/.claude/skills/widgets/SKILL.md
@@ -12,7 +12,7 @@ declarations do not.**
 
 Reactive: `background`, `gradient`, `backdrop_blur`, `overflow`, `corners`,
 `border`, `translate`, `rotate`, `scale`, `pivot`, `width`, `height`,
-`padding`, `visible`, `enabled`, `shadow` — and beyond `Container`, `Text`'s `wrap`,
+`padding`, `visible`, `enabled`, `takes_input`, `shadow` — and beyond `Container`, `Text`'s `wrap`,
 `Image`'s `content_fit`, `TextInput`'s `password`, `mask_char`, `caret` and `readonly`,
 `RippleConfig`'s colour, and the direction a `Flex` is built with.
 

--- a/book/src/advanced/wayland.md
+++ b/book/src/advanced/wayland.md
@@ -548,56 +548,87 @@ most recently.
 
 ## Input Regions
 
-By default the whole surface accepts pointer and touch input. An input
-region limits input to a set of rectangles (logical surface
-coordinates) — everything outside them lets clicks pass through to the
-windows below. This is how transparent overlays avoid stealing clicks:
+By default the whole surface accepts pointer and touch input. A container can
+say otherwise, and what it says goes to the compositor: everything outside the
+region lets clicks reach the windows below.
+
+The surface declares the baseline and a container declares the exception. An
+overlay that lets everything past, with one pill that does not:
 
 ```rust,ignore
 # extern crate guido;
 # use guido::prelude::*;
 # fn main() {
-// Only the given rectangle is clickable:
 SurfaceConfig::new()
-    .background_color(Color::TRANSPARENT);
-    .input_region([Rect::new(16.0, 20.0, 200.0, 40.0)])
+    .background_color(Color::TRANSPARENT)
+    .click_through();
 
-// Fully click-through (e.g. a HUD or wallpaper widget):
-SurfaceConfig::new().click_through()
+container()
+    .takes_input(true)
+    .corners(20.0)
+    .on_click(|| {})
 # ;
 # }
 ```
 
-At runtime, use the handle — `None` restores full-surface input, an
-empty list is fully click-through:
+And the other way round, a bar that takes input with a notch the desktop gets:
 
 ```rust,ignore
 # extern crate guido;
 # use guido::prelude::*;
 # fn main() {
+container().takes_input(false).width(200.0)
+# ;
+# }
+```
+
+The region is read off the frame that was drawn, so it follows the shape on
+screen: its corners, its transform, its clip. A container that stops painting —
+hidden, culled, scrolled out of view — takes its region with it, and a frame
+that changes nothing publishes nothing. `examples/input_region.rs` is the first
+of the two, in full.
+
+**What a container declares is its own shape.** Children are covered because
+they are drawn inside it, not because the declaration reaches them. A child
+drawn *outside* its parent — `overflow` is `Visible` by default, so a transform
+or a size larger than the parent does it — is outside the region as well, and on
+a click-through surface a handler on that child never runs:
+
+```rust,ignore
+# extern crate guido;
+# use guido::prelude::*;
+# fn main() {
+# let do_thing = || {};
+container()
+    .takes_input(true)
+    .width(100.0)
+    .height(30.0)
+    // 40px below the parent, so outside the region: those clicks go to the
+    // desktop, not to this handler.
+    .child(container().translate((0.0, 40.0)).on_click(do_thing))
+# ;
+# }
+```
+
+Declare `takes_input` on the container whose shape you mean, and a nested
+declaration of the opposite kind is simply a smaller area declared later — an
+island inside a hole works with no rule of its own.
+
+`takes_input(false)` is not the same as
+[`enabled(false)`](../interactivity/disabled.md): a disabled container
+refuses input and still blocks what is behind the surface, which is what a
+disabled button should do.
+
+For a region that belongs to no widget, the surface still takes rectangles
+directly:
+
+```rust,ignore
+# extern crate guido;
+# use guido::prelude::*;
+# fn main() {
+SurfaceConfig::new().input_region([Rect::new(16.0, 20.0, 200.0, 40.0)]);
 surface_handle(id).set_input_region(Some(vec![rect]));
 surface_handle(id).set_input_region(None);
-# ;
-# }
-```
-
-The idiomatic pattern glues the region to a widget's bounds with a
-`WidgetRef`, so it follows layout changes automatically (full version
-in `examples/input_region.rs`):
-
-```rust,ignore
-# extern crate guido;
-# use guido::prelude::*;
-# fn main() {
-let pill_ref = create_widget_ref();
-// ...build the surface with .click_through() and .widget_ref(pill_ref)...
-
-create_effect(move || {
-    let rect = pill_ref.rect().get();
-    if rect.width > 0.0 {
-        surface_handle(id).set_input_region(Some(vec![rect]));
-    }
-});
 # ;
 # }
 ```

--- a/book/src/interactivity/disabled.md
+++ b/book/src/interactivity/disabled.md
@@ -20,6 +20,12 @@ container()
 click, a key, a scroll, a nested button's handler — is reached, and nothing
 below it has to know why.
 
+It still stands in the way, which is the point: a click on a disabled button is
+a click the application swallowed, not one the desktop behind the surface
+receives. Letting it through is
+[`takes_input(false)`](../advanced/wayland.md#input-regions), a different
+question asked of the compositor rather than of the widget.
+
 ## It propagates, and cannot be undone from below
 
 A container declaring `enabled(true)` inside one declaring `enabled(false)` is

--- a/examples/input_region.rs
+++ b/examples/input_region.rs
@@ -1,8 +1,9 @@
 //! Click-through overlay: only the centered pill accepts input.
 //!
-//! The surface spans the whole top edge without reserving space, but its
-//! input region is glued to the pill's bounds via a `WidgetRef` — clicks
-//! anywhere else pass through to the windows below.
+//! The surface spans the whole top edge without reserving space and lets
+//! everything through; the pill declares that input reaches it. The region the
+//! compositor is given is read off the frame, so it is the pill's rounded
+//! shape, wherever the layout put it, and it is gone the moment the pill is.
 
 use guido::prelude::*;
 
@@ -10,18 +11,16 @@ fn main() {
     env_logger::init();
 
     App::new().run(|app| {
-        let pill_ref = create_widget_ref();
         let count = create_signal(0);
 
-        let id = app.add_surface(
+        app.add_surface(
             SurfaceConfig::new()
                 .height(80)
                 .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
                 .layer(Layer::Overlay)
                 .exclusive_zone(ExclusiveZone::None)
                 .background_color(Color::TRANSPARENT)
-                // Start fully click-through; the effect below narrows the
-                // region to the pill once it has been laid out.
+                // Everything passes through, except what says otherwise.
                 .click_through(),
             move || {
                 container()
@@ -34,7 +33,7 @@ fn main() {
                     )
                     .child(
                         container()
-                            .widget_ref(pill_ref)
+                            .takes_input(true)
                             .padding([10.0, 24.0])
                             .background(Color::rgba(0.15, 0.15, 0.25, 0.95))
                             .corners(20.0)
@@ -50,14 +49,5 @@ fn main() {
                     )
             },
         );
-
-        // Keep the input region glued to the pill's bounds (re-runs whenever
-        // layout moves or resizes it).
-        create_effect(move || {
-            let rect = pill_ref.rect().get();
-            if rect.width > 0.0 {
-                surface_handle(id).set_input_region(Some(vec![rect]));
-            }
-        });
     });
 }

--- a/src/blur.rs
+++ b/src/blur.rs
@@ -4,25 +4,16 @@
 //! which emits one `DrawCommand::BackdropBlur` carrying the sources it asked
 //! for. The renderer filters the surface's own backdrop from that command; this
 //! module reads the compositor's region off the same one, after the frame has
-//! been flattened, and tessellates its rounded corners into axis-aligned rects
-//! — `wl_region` has no notion of curves.
+//! been flattened, through the tessellation in [`crate::region`] — `wl_region`
+//! has no notion of curves.
 //!
 //! Nothing is remembered between frames: see [`regions_from_commands`] for why
 //! that is the whole point. No-ops when the compositor does not support the
 //! protocol or its blur capability.
 
 use crate::backdrop::BackdropSources;
-use crate::renderer::{CornerRadii, DrawCommand, EllipticalRadii, FlattenedCommand};
-use crate::widgets::Rect;
-
-/// An axis-aligned rectangle of a blur region, in logical surface pixels.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct BlurRect {
-    pub x: i32,
-    pub y: i32,
-    pub width: i32,
-    pub height: i32,
-}
+use crate::region::{RegionRect, rounded_rect_to_rects};
+use crate::renderer::{DrawCommand, FlattenedCommand};
 
 /// The region to hand `ext-background-effect-v1`, read off the frame that was
 /// just drawn.
@@ -37,7 +28,7 @@ pub(crate) struct BlurRect {
 /// no command in it; one served from the paint cache carries its command along
 /// unchanged; a culled one is absent. Ordering stops mattering too, since the
 /// list only exists after the paint that built it.
-pub(crate) fn regions_from_commands(commands: &[FlattenedCommand]) -> Vec<BlurRect> {
+pub(crate) fn regions_from_commands(commands: &[FlattenedCommand]) -> Vec<RegionRect> {
     let mut out = Vec::new();
     for cmd in commands {
         let DrawCommand::BackdropBlur {
@@ -62,166 +53,18 @@ pub(crate) fn regions_from_commands(commands: &[FlattenedCommand]) -> Vec<BlurRe
         else {
             continue;
         };
-        out.extend(rounded_rect_to_blur_rects(world, world_radii));
+        out.extend(rounded_rect_to_rects(world, world_radii));
     }
     out.sort_unstable_by_key(|r| (r.y, r.x, r.width, r.height));
     out
 }
 
-/// Approximate a rounded rectangle as a union of axis-aligned rects that
-/// **inscribe** the shape. Zero radii or a degenerate rectangle yield the
-/// bounding box.
-///
-/// Every corner separately, and every corner an ellipse. One radius for the
-/// whole shape was the seam this used to be reached through: the caller
-/// computed four and collapsed them with `.max()` on the way in, so a card cut
-/// square on one side by a clip was still tessellated as though that side were
-/// round, and the region lost a wedge the size of the radius along the cut —
-/// which is the artefact the clipping exists to prevent.
-///
-/// `bounds` is in logical surface pixels, matching what `wl_region` expects.
-fn rounded_rect_to_blur_rects(bounds: Rect, radii: EllipticalRadii) -> Vec<BlurRect> {
-    if bounds.width <= 0.0 || bounds.height <= 0.0 {
-        return Vec::new();
-    }
-
-    let (w, h) = (bounds.width, bounds.height);
-    let (rx, ry) = clamp_radii(radii, w, h);
-
-    // How far each side is eaten into at height `y`, by whichever corner on that
-    // side reaches it. Zero between the bands, and correct where a shape short
-    // enough for its corners to meet has both reaching the same height.
-    let left = |y: f32| {
-        corner_inset(y, rx.top_left, ry.top_left).max(corner_inset(
-            h - y,
-            rx.bottom_left,
-            ry.bottom_left,
-        ))
-    };
-    let right = |y: f32| {
-        corner_inset(y, rx.top_right, ry.top_right).max(corner_inset(
-            h - y,
-            rx.bottom_right,
-            ry.bottom_right,
-        ))
-    };
-
-    let band_top = ry.top_left.max(ry.top_right);
-    let band_bottom = ry.bottom_left.max(ry.bottom_right);
-    if band_top <= 0.5 && band_bottom <= 0.5 {
-        return Vec::from_iter(to_blur_rect(bounds));
-    }
-
-    let mut out = Vec::new();
-
-    // The straight middle is one rect rather than a stack of slabs.
-    if h - band_bottom > band_top {
-        out.extend(to_blur_rect(Rect::new(
-            bounds.x,
-            bounds.y + band_top,
-            w,
-            h - band_top - band_bottom,
-        )));
-    }
-
-    let emit_band = |y_start: f32, y_end: f32, out: &mut Vec<BlurRect>| {
-        let band_h = y_end - y_start;
-        if band_h <= 0.0 {
-            return;
-        }
-        let steps = (band_h.ceil() as u32).clamp(4, 32);
-        let slab_h = band_h / steps as f32;
-        for i in 0..steps {
-            let y0 = y_start + i as f32 * slab_h;
-            let y1 = y0 + slab_h;
-            // Widest inset within the slab keeps it inside the curve.
-            let (l, r) = (left(y0).max(left(y1)), right(y0).max(right(y1)));
-            let slab_w = w - l - r;
-            if slab_w <= 0.0 {
-                continue;
-            }
-            out.extend(to_blur_rect(Rect::new(
-                bounds.x + l,
-                bounds.y + y0,
-                slab_w,
-                slab_h,
-            )));
-        }
-    };
-
-    emit_band(0.0, band_top, &mut out);
-    // Starting where the top band ended, so corners tall enough to meet in a
-    // short shape are tessellated once rather than twice.
-    emit_band((h - band_bottom).max(band_top), h, &mut out);
-
-    out
-}
-
-/// Shrink radii until no two sharing an edge can overlap, all by one factor so
-/// the shape keeps its proportions — the rule CSS `border-radius` uses.
-fn clamp_radii(radii: EllipticalRadii, w: f32, h: f32) -> (CornerRadii, CornerRadii) {
-    let non_negative = |r: CornerRadii| CornerRadii {
-        top_left: r.top_left.max(0.0),
-        top_right: r.top_right.max(0.0),
-        bottom_right: r.bottom_right.max(0.0),
-        bottom_left: r.bottom_left.max(0.0),
-    };
-    let (rx, ry) = (non_negative(radii.x), non_negative(radii.y));
-
-    let ratio = |extent: f32, sum: f32| if sum > extent { extent / sum } else { 1.0 };
-    let f = ratio(w, rx.top_left + rx.top_right)
-        .min(ratio(w, rx.bottom_left + rx.bottom_right))
-        .min(ratio(h, ry.top_left + ry.bottom_left))
-        .min(ratio(h, ry.top_right + ry.bottom_right));
-
-    (rx.scaled(f), ry.scaled(f))
-}
-
-/// How far a corner eats into its side at distance `d` from the edge it sits
-/// on, for an ellipse `rx` wide and `ry` tall. Zero once past the corner.
-fn corner_inset(d: f32, rx: f32, ry: f32) -> f32 {
-    if rx <= 0.0 || ry <= 0.0 || d >= ry {
-        return 0.0;
-    }
-    let dy = (ry - d) / ry;
-    rx - rx * (1.0 - dy * dy).max(0.0).sqrt()
-}
-
-/// Round-to-nearest on all four edges so adjacent slabs tile without gaps
-/// (inward rounding would drop sub-pixel slabs). `None` when the rounding
-/// collapses the rectangle to nothing.
-fn to_blur_rect(b: Rect) -> Option<BlurRect> {
-    let x0 = b.x.round() as i32;
-    let y0 = b.y.round() as i32;
-    let x1 = (b.x + b.width).round() as i32;
-    let y1 = (b.y + b.height).round() as i32;
-    (x1 > x0 && y1 > y0).then_some(BlurRect {
-        x: x0,
-        y: y0,
-        width: x1 - x0,
-        height: y1 - y0,
-    })
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::renderer::CornerRadii;
+    use crate::widgets::Rect;
 
-    fn covers(rects: &[BlurRect], x: i32, y: i32) -> bool {
-        rects
-            .iter()
-            .any(|r| x >= r.x && x < r.x + r.width && y >= r.y && y < r.y + r.height)
-    }
-
-    /// The same radius on every corner and both axes.
-    fn round(radius: f32) -> EllipticalRadii {
-        EllipticalRadii::circular(CornerRadii::uniform(radius))
-    }
-
-    /// The radius belongs to the blur guido runs in its own shader. The
-    /// compositor picks its own, so a region is published for a compositor
-    /// source whatever the radius says — including zero, which is the spelling
-    /// for "blur nothing yourself, let the compositor blur what is behind me".
     #[test]
     fn a_compositor_region_does_not_need_a_radius() {
         let command = FlattenedCommand {
@@ -240,198 +83,12 @@ mod tests {
         };
         assert_eq!(
             regions_from_commands(&[command]),
-            vec![BlurRect {
+            vec![RegionRect {
                 x: 0,
                 y: 0,
                 width: 100,
                 height: 50
             }]
         );
-    }
-
-    #[test]
-    fn zero_radius_is_bounding_box() {
-        let rects = rounded_rect_to_blur_rects(Rect::new(10.0, 20.0, 100.0, 50.0), round(0.0));
-        assert_eq!(
-            rects,
-            vec![BlurRect {
-                x: 10,
-                y: 20,
-                width: 100,
-                height: 50
-            }]
-        );
-    }
-
-    #[test]
-    fn degenerate_rect_is_empty() {
-        assert!(rounded_rect_to_blur_rects(Rect::new(0.0, 0.0, 0.0, 40.0), round(8.0)).is_empty());
-        assert!(rounded_rect_to_blur_rects(Rect::new(0.0, 0.0, 40.0, -1.0), round(8.0)).is_empty());
-    }
-
-    #[test]
-    fn rounded_corners_are_cut() {
-        let rects = rounded_rect_to_blur_rects(Rect::new(0.0, 0.0, 100.0, 60.0), round(20.0));
-        // Corner pixels outside the curve are not covered…
-        assert!(!covers(&rects, 0, 0));
-        assert!(!covers(&rects, 99, 0));
-        assert!(!covers(&rects, 0, 59));
-        assert!(!covers(&rects, 99, 59));
-        // …while the center and edge midpoints are.
-        assert!(covers(&rects, 50, 30));
-        assert!(covers(&rects, 0, 30));
-        assert!(covers(&rects, 99, 30));
-        assert!(covers(&rects, 50, 0));
-        assert!(covers(&rects, 50, 59));
-    }
-
-    #[test]
-    fn slabs_stay_inside_the_curve() {
-        let r = 16.0f32;
-        let rects = rounded_rect_to_blur_rects(Rect::new(0.0, 0.0, 80.0, 80.0), round(r));
-        for rect in &rects {
-            // Every rect corner must be inside (or on) the rounded shape,
-            // with half-pixel tolerance for edge rounding.
-            for (px, py) in [
-                (rect.x, rect.y),
-                (rect.x + rect.width, rect.y),
-                (rect.x, rect.y + rect.height),
-                (rect.x + rect.width, rect.y + rect.height),
-            ] {
-                let (px, py) = (px as f32, py as f32);
-                let cx = px.clamp(r, 80.0 - r);
-                let cy = py.clamp(r, 80.0 - r);
-                let dist = ((px - cx).powi(2) + (py - cy).powi(2)).sqrt();
-                assert!(
-                    dist <= r + 0.75,
-                    "corner ({px}, {py}) is {dist} from the curve center, radius {r}"
-                );
-            }
-        }
-    }
-
-    #[test]
-    fn radius_clamped_to_half_size() {
-        // Radius larger than half the shape: a circle-ish region, still non-empty
-        let rects = rounded_rect_to_blur_rects(Rect::new(0.0, 0.0, 40.0, 40.0), round(100.0));
-        assert!(!rects.is_empty());
-        assert!(covers(&rects, 20, 20));
-        assert!(!covers(&rects, 0, 0));
-    }
-
-    /// A square corner is square. This is the seam the region used to be lost
-    /// at: a clip squared off two corners, the caller collapsed the four radii
-    /// with `.max()`, and the shape arrived here as though all four were round —
-    /// so the region gave back a wedge the size of the radius along the cut,
-    /// which is the artefact the clipping exists to prevent.
-    #[test]
-    fn a_square_corner_is_not_rounded_because_another_one_is() {
-        let square_right = EllipticalRadii::circular(CornerRadii {
-            top_left: 16.0,
-            top_right: 0.0,
-            bottom_right: 0.0,
-            bottom_left: 16.0,
-        });
-        let rects = rounded_rect_to_blur_rects(Rect::new(0.0, 0.0, 40.0, 100.0), square_right);
-
-        assert!(
-            covers(&rects, 39, 0) && covers(&rects, 39, 99),
-            "the cut edge is straight, so its corners reach the edge"
-        );
-        assert!(
-            !covers(&rects, 0, 0) && !covers(&rects, 0, 99),
-            "and the round ones are still cut"
-        );
-    }
-
-    /// Only the corner that has a radius is cut. A list row rounding its top
-    /// corners and butting against the next one keeps its full bottom edge.
-    #[test]
-    fn corners_are_cut_one_by_one() {
-        let rects = rounded_rect_to_blur_rects(
-            Rect::new(0.0, 0.0, 100.0, 60.0),
-            EllipticalRadii::circular(CornerRadii::top(20.0)),
-        );
-
-        assert!(!covers(&rects, 0, 0) && !covers(&rects, 99, 0), "top cut");
-        assert!(
-            covers(&rects, 0, 59) && covers(&rects, 99, 59),
-            "bottom square"
-        );
-    }
-
-    /// An unevenly scaled corner is an ellipse: 32 wide and 16 tall reaches the
-    /// left edge 16 down, where a circle of either radius would not.
-    #[test]
-    fn an_elliptical_corner_is_cut_on_both_of_its_axes() {
-        let radii = EllipticalRadii {
-            x: CornerRadii::uniform(32.0),
-            y: CornerRadii::uniform(16.0),
-        };
-        let rects = rounded_rect_to_blur_rects(Rect::new(0.0, 0.0, 200.0, 100.0), radii);
-
-        assert!(!covers(&rects, 0, 0), "the corner itself is outside");
-        assert!(
-            covers(&rects, 0, 20),
-            "the curve is 16 tall, so the left edge is reached by 20 down"
-        );
-        assert!(
-            !covers(&rects, 5, 1),
-            "and 32 wide, so it is still outside 5 in at the top"
-        );
-    }
-
-    /// Every emitted rect stays inside the ellipse it approximates, for radii
-    /// that differ per corner and per axis — the property the whole tessellation
-    /// exists to have, checked where the shape is least uniform.
-    #[test]
-    fn slabs_stay_inside_a_shape_with_four_different_corners() {
-        let radii = EllipticalRadii {
-            x: CornerRadii {
-                top_left: 30.0,
-                top_right: 10.0,
-                bottom_right: 0.0,
-                bottom_left: 20.0,
-            },
-            y: CornerRadii {
-                top_left: 15.0,
-                top_right: 10.0,
-                bottom_right: 0.0,
-                bottom_left: 40.0,
-            },
-        };
-        let (w, h) = (120.0f32, 100.0f32);
-        let rects = rounded_rect_to_blur_rects(Rect::new(0.0, 0.0, w, h), radii);
-        assert!(!rects.is_empty());
-
-        // The centre of each corner's ellipse, and its two semi-axes.
-        let corners = [
-            (30.0f32, 15.0f32, 30.0f32, 15.0f32, true, true),
-            (w - 10.0, 10.0, 10.0, 10.0, false, true),
-            (20.0, h - 40.0, 20.0, 40.0, true, false),
-        ];
-        for rect in &rects {
-            for (px, py) in [
-                (rect.x, rect.y),
-                (rect.x + rect.width, rect.y),
-                (rect.x, rect.y + rect.height),
-                (rect.x + rect.width, rect.y + rect.height),
-            ] {
-                let (px, py) = (px as f32, py as f32);
-                for (cx, cy, rx, ry, left, top) in corners {
-                    // Only points in this corner's quadrant are governed by it.
-                    let in_x = if left { px < cx } else { px > cx };
-                    let in_y = if top { py < cy } else { py > cy };
-                    if !in_x || !in_y {
-                        continue;
-                    }
-                    let d = ((px - cx) / rx).powi(2) + ((py - cy) / ry).powi(2);
-                    assert!(
-                        d <= 1.0 + 0.1,
-                        "({px}, {py}) is outside the {rx}x{ry} corner at ({cx}, {cy}): {d}"
-                    );
-                }
-            }
-        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1773,9 +1773,9 @@ fn paint_and_present<P: Platform>(ctx: &mut FrameContext<P>, frame: &Frame, geom
     });
 
     // Flatten tree into reused buffers
-    let compositor_blur;
+    let carried;
     time_phase!(render_stats::Phase::Flatten, {
-        compositor_blur = flatten_root_into(
+        carried = flatten_root_into(
             &surface.root_node,
             &mut surface.flattened_commands,
             &mut surface.command_layers,
@@ -1797,7 +1797,7 @@ fn paint_and_present<P: Platform>(ctx: &mut FrameContext<P>, frame: &Frame, geom
     // it owes the compositor the empty region that withdraws the last one.
     if wayland_state.supports_blur_region()
         && let Some(mut handle) = wayland_state.surface(id)
-        && (compositor_blur || handle.has_published_blur())
+        && (carried.compositor_blur || handle.has_published_blur())
     {
         let blur_rects = blur::regions_from_commands(&surface.flattened_commands);
         handle.sync_blur_region(blur_rects, false);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod layout;
 pub mod outputs;
 pub mod pivot;
 pub mod reactive;
+mod region;
 pub mod render_stats;
 pub mod session_lock;
 pub mod surface;
@@ -839,7 +840,7 @@ pub(crate) trait Surface {
     }
 
     /// Publish the region to blur behind this surface.
-    fn sync_blur_region(&mut self, rects: Vec<blur::BlurRect>, commit: bool) {
+    fn sync_blur_region(&mut self, rects: Vec<region::RegionRect>, commit: bool) {
         let _ = (rects, commit);
     }
 
@@ -1313,7 +1314,7 @@ impl Surface for WaylandSurface<'_> {
         self.state.take_blur_resync(self.id)
     }
 
-    fn sync_blur_region(&mut self, rects: Vec<blur::BlurRect>, commit: bool) {
+    fn sync_blur_region(&mut self, rects: Vec<region::RegionRect>, commit: bool) {
         self.state.sync_blur_region(self.id, rects, commit)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -452,7 +452,26 @@ fn process_surface_commands<P: Platform>(
                 }
             }
             SurfaceCommand::SetInputRegion { id, rects } => {
-                with_surface(wayland_state, id, |s| s.set_input_region(rects.as_deref()));
+                // The base, not a separate opinion: a frame that publishes a
+                // declared region reads this, so what a handle says survives
+                // the next declaration instead of being overwritten by it.
+                let mut declaring = false;
+                if let Some(managed) = surface_manager.get_mut(id) {
+                    managed.input_base = rects.clone();
+                    declaring = managed.input_region.is_some();
+                }
+
+                if declaring {
+                    // The tree has already spoken, and the answer is composed
+                    // from both. Applying the base alone here would drop the
+                    // declarations for a frame, so the frame that composes them
+                    // is asked for instead.
+                    if let Some(managed) = surface_manager.get(id) {
+                        jobs::request_job(managed.widget_id, jobs::JobRequest::Paint);
+                    }
+                } else {
+                    with_surface(wayland_state, id, |s| s.set_input_region(rects.as_deref()));
+                }
             }
             SurfaceCommand::CreatePopup {
                 id,
@@ -842,6 +861,12 @@ pub(crate) trait Surface {
     /// Publish the region to blur behind this surface.
     fn sync_blur_region(&mut self, rects: Vec<region::RegionRect>, commit: bool) {
         let _ = (rects, commit);
+    }
+
+    /// Publish where input reaches this surface: the area it takes, and the
+    /// declarations the frame made about it.
+    fn sync_input_region(&mut self, request: &region::InputRegionRequest, commit: bool) {
+        let _ = (request, commit);
     }
 
     /// Ask to be told when this surface's last frame has been shown.
@@ -1316,6 +1341,10 @@ impl Surface for WaylandSurface<'_> {
 
     fn sync_blur_region(&mut self, rects: Vec<region::RegionRect>, commit: bool) {
         self.state.sync_blur_region(self.id, rects, commit)
+    }
+
+    fn sync_input_region(&mut self, request: &region::InputRegionRequest, commit: bool) {
+        self.state.sync_input_region(self.id, request, commit)
     }
 
     fn request_frame_callback(&mut self) {
@@ -1801,6 +1830,35 @@ fn paint_and_present<P: Platform>(ctx: &mut FrameContext<P>, frame: &Frame, geom
     {
         let blur_rects = blur::regions_from_commands(&surface.flattened_commands);
         handle.sync_blur_region(blur_rects, false);
+    }
+
+    // And the other region read off the same frame, on the same commit. The
+    // rule for whether to publish at all is here rather than in a platform:
+    // a surface whose tree has never declared anything about input is left
+    // alone, so what a config or a handle asked for stays; one that has
+    // declared publishes when the answer changes and not otherwise. The one
+    // frame that must be published while carrying nothing is the frame that
+    // stops declaring, which owes the compositor its base back.
+    if carried.input_region || surface.input_region.is_some() {
+        let request = region::InputRegionRequest {
+            base: region::base_rects(
+                surface.input_base.as_deref(),
+                frame.width as f32,
+                frame.height as f32,
+            ),
+            ops: region::input_ops_from_commands(&surface.flattened_commands),
+        };
+        if surface.input_region.as_ref() != Some(&request)
+            && let Some(mut handle) = wayland_state.surface(id)
+        {
+            handle.sync_input_region(&request, false);
+            // Remembered while the tree is still declaring. The frame that
+            // stops declaring publishes the base once and then forgets, so a
+            // surface whose declaration resolves to nothing this frame — fully
+            // clipped, scrolled away — does not re-send the same region on
+            // every frame after it.
+            surface.input_region = carried.input_region.then_some(request);
+        }
     }
 
     // Here, above `present`, because both of these have to ride its commit —

--- a/src/platform/backdrop.rs
+++ b/src/platform/backdrop.rs
@@ -17,7 +17,7 @@ use wayland_protocols::ext::background_effect::v1::client::{
 };
 
 use super::wayland::WaylandState;
-use crate::blur::BlurRect;
+use crate::region::RegionRect;
 use crate::surface::SurfaceId;
 
 /// The compositor's background-effect manager and what it currently offers.
@@ -91,7 +91,7 @@ impl WaylandState {
     /// an *empty* region, never NULL: NULL only withdraws our opinion and
     /// lets such a rule blur the whole surface, where an empty region says
     /// "blur exactly nothing".
-    pub(crate) fn sync_blur_region(&mut self, id: SurfaceId, rects: Vec<BlurRect>, commit: bool) {
+    pub(crate) fn sync_blur_region(&mut self, id: SurfaceId, rects: Vec<RegionRect>, commit: bool) {
         if !self.backdrop.bg_effect_supports_blur {
             return;
         }

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -512,7 +512,7 @@ impl WaylandState {
             layer_surface.set_margin(margin.top, margin.right, margin.bottom, margin.left);
         }
 
-        if let Some(rects) = &config.input_region {
+        if let Some(rects) = &declared.input_region {
             self.apply_input_region(&wl_surface, Some(rects));
         }
 

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -444,6 +444,57 @@ impl WaylandState {
         }
     }
 
+    /// Publish where input reaches a surface: the area it takes, then the
+    /// declarations the frame made, in the order they were painted.
+    ///
+    /// `wl_region` is exactly this program — add and subtract — so a rounded
+    /// hole cut out of a bar needs no complement computed anywhere.
+    ///
+    /// Not committed here by default: the request rides the buffer commit
+    /// inside the upcoming present, so the region and the frame it was read
+    /// off change together. `commit: true` is for the paths that skip
+    /// presenting.
+    pub(crate) fn sync_input_region(
+        &mut self,
+        id: SurfaceId,
+        request: &crate::region::InputRegionRequest,
+        commit: bool,
+    ) {
+        let Some(surface_state) = self.surfaces.get(&id) else {
+            return;
+        };
+        let Ok(region) = Region::new(&self.compositor_state) else {
+            log::warn!("Failed to create wl_region for input");
+            return;
+        };
+
+        for r in &request.base {
+            region.add(r.x, r.y, r.width, r.height);
+        }
+        for op in &request.ops {
+            let r = op.rect;
+            if op.takes {
+                region.add(r.x, r.y, r.width, r.height);
+            } else {
+                region.subtract(r.x, r.y, r.width, r.height);
+            }
+        }
+        surface_state
+            .wl_surface
+            .set_input_region(Some(region.wl_region()));
+
+        log::debug!(
+            "Surface {:?} input region: {} base rect(s), {} declaration(s)",
+            id,
+            request.base.len(),
+            request.ops.len()
+        );
+
+        if commit {
+            surface_state.wl_surface.commit();
+        }
+    }
+
     /// Set the input region for a surface at runtime.
     pub fn set_surface_input_region(&mut self, id: SurfaceId, rects: Option<&[Rect]>) {
         if let Some(surface_state) = self.surfaces.get(&id) {

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -42,8 +42,8 @@ use super::lock::Lock;
 use super::outputs::OutputRegistry;
 use super::popups::Popups;
 use super::selections::Selections;
-use crate::blur::BlurRect;
 use crate::outputs::{self};
+use crate::region::RegionRect;
 use crate::surface::SurfaceId;
 use crate::widgets::{Event, Rect};
 
@@ -110,7 +110,7 @@ pub struct WaylandSurfaceState {
     /// Last blur rects pushed to the compositor. `None` means nothing has
     /// been pushed yet (also reset when the blur capability changes, so the
     /// region is re-sent if it comes back).
-    pub(super) blur_region: Option<Vec<BlurRect>>,
+    pub(super) blur_region: Option<Vec<RegionRect>>,
     /// Set when the compositor's blur capability changes, so a surface that is
     /// not repainting knows it owes a region — and, the rest of the time, knows
     /// it does not. See
@@ -420,12 +420,8 @@ impl WaylandState {
         let region = Region::new(&self.compositor_state)
             .map_err(|e| log::warn!("Failed to create wl_region: {e}"))
             .ok()?;
-        for r in rects {
-            let x = r.x.floor() as i32;
-            let y = r.y.floor() as i32;
-            let width = (r.x + r.width).ceil() as i32 - x;
-            let height = (r.y + r.height).ceil() as i32 - y;
-            region.add(x, y, width, height);
+        for r in rects.iter().copied().filter_map(RegionRect::covering) {
+            region.add(r.x, r.y, r.width, r.height);
         }
         Some(region)
     }

--- a/src/region.rs
+++ b/src/region.rs
@@ -1,0 +1,374 @@
+//! The rectangles a `wl_region` is made of, and how a rounded shape becomes
+//! them.
+//!
+//! Two regions travel from a frame to the compositor: the backdrop blur's, and
+//! the surface's input region. Both are `wl_region`s, both are read off the
+//! flattened frame, and both need the same thing from a rounded container —
+//! the axis-aligned rectangles that stand in for a shape the protocol has no
+//! way to describe. That translation lives here so there is one of it.
+
+use crate::renderer::{CornerRadii, EllipticalRadii};
+use crate::widgets::Rect;
+
+/// An axis-aligned rectangle of a region, in logical surface pixels.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct RegionRect {
+    pub x: i32,
+    pub y: i32,
+    pub width: i32,
+    pub height: i32,
+}
+
+impl RegionRect {
+    /// A whole-pixel rectangle covering all of `r`.
+    ///
+    /// Outward, because a region is a claim about where something is: a
+    /// fractional bound rounded inward leaves a dead line along an edge
+    /// somebody drew. It is the rule the surface's own declared rectangles
+    /// have always taken to the compositor.
+    pub(crate) fn covering(r: Rect) -> Option<Self> {
+        let x = r.x.floor() as i32;
+        let y = r.y.floor() as i32;
+        let width = (r.x + r.width).ceil() as i32 - x;
+        let height = (r.y + r.height).ceil() as i32 - y;
+        (width > 0 && height > 0).then_some(Self {
+            x,
+            y,
+            width,
+            height,
+        })
+    }
+}
+
+/// Approximate a rounded rectangle as a union of axis-aligned rects that
+/// **inscribe** the shape. Zero radii or a degenerate rectangle yield the
+/// bounding box.
+///
+/// Every corner separately, and every corner an ellipse: a shape cut square on
+/// one side by a clip must not be tessellated as though that side were round,
+/// which loses a wedge the size of the radius along the cut.
+///
+/// `bounds` is in logical surface pixels, matching what `wl_region` expects.
+pub(crate) fn rounded_rect_to_rects(bounds: Rect, radii: EllipticalRadii) -> Vec<RegionRect> {
+    if bounds.width <= 0.0 || bounds.height <= 0.0 {
+        return Vec::new();
+    }
+
+    let (w, h) = (bounds.width, bounds.height);
+    let (rx, ry) = clamp_radii(radii, w, h);
+
+    // How far each side is eaten into at height `y`, by whichever corner on that
+    // side reaches it. Zero between the bands, and correct where a shape short
+    // enough for its corners to meet has both reaching the same height.
+    let left = |y: f32| {
+        corner_inset(y, rx.top_left, ry.top_left).max(corner_inset(
+            h - y,
+            rx.bottom_left,
+            ry.bottom_left,
+        ))
+    };
+    let right = |y: f32| {
+        corner_inset(y, rx.top_right, ry.top_right).max(corner_inset(
+            h - y,
+            rx.bottom_right,
+            ry.bottom_right,
+        ))
+    };
+
+    let band_top = ry.top_left.max(ry.top_right);
+    let band_bottom = ry.bottom_left.max(ry.bottom_right);
+    if band_top <= 0.5 && band_bottom <= 0.5 {
+        return Vec::from_iter(to_region_rect(bounds));
+    }
+
+    let mut out = Vec::new();
+
+    // The straight middle is one rect rather than a stack of slabs.
+    if h - band_bottom > band_top {
+        out.extend(to_region_rect(Rect::new(
+            bounds.x,
+            bounds.y + band_top,
+            w,
+            h - band_top - band_bottom,
+        )));
+    }
+
+    let emit_band = |y_start: f32, y_end: f32, out: &mut Vec<RegionRect>| {
+        let band_h = y_end - y_start;
+        if band_h <= 0.0 {
+            return;
+        }
+        let steps = (band_h.ceil() as u32).clamp(4, 32);
+        let slab_h = band_h / steps as f32;
+        for i in 0..steps {
+            let y0 = y_start + i as f32 * slab_h;
+            let y1 = y0 + slab_h;
+            // Widest inset within the slab keeps it inside the curve.
+            let (l, r) = (left(y0).max(left(y1)), right(y0).max(right(y1)));
+            let slab_w = w - l - r;
+            if slab_w <= 0.0 {
+                continue;
+            }
+            out.extend(to_region_rect(Rect::new(
+                bounds.x + l,
+                bounds.y + y0,
+                slab_w,
+                slab_h,
+            )));
+        }
+    };
+
+    emit_band(0.0, band_top, &mut out);
+    // Starting where the top band ended, so corners tall enough to meet in a
+    // short shape are tessellated once rather than twice.
+    emit_band((h - band_bottom).max(band_top), h, &mut out);
+
+    out
+}
+
+/// Shrink radii until no two sharing an edge can overlap, all by one factor so
+/// the shape keeps its proportions — the rule CSS `border-radius` uses.
+fn clamp_radii(radii: EllipticalRadii, w: f32, h: f32) -> (CornerRadii, CornerRadii) {
+    let non_negative = |r: CornerRadii| CornerRadii {
+        top_left: r.top_left.max(0.0),
+        top_right: r.top_right.max(0.0),
+        bottom_right: r.bottom_right.max(0.0),
+        bottom_left: r.bottom_left.max(0.0),
+    };
+    let (rx, ry) = (non_negative(radii.x), non_negative(radii.y));
+
+    let ratio = |extent: f32, sum: f32| if sum > extent { extent / sum } else { 1.0 };
+    let f = ratio(w, rx.top_left + rx.top_right)
+        .min(ratio(w, rx.bottom_left + rx.bottom_right))
+        .min(ratio(h, ry.top_left + ry.bottom_left))
+        .min(ratio(h, ry.top_right + ry.bottom_right));
+
+    (rx.scaled(f), ry.scaled(f))
+}
+
+/// How far a corner eats into its side at distance `d` from the edge it sits
+/// on, for an ellipse `rx` wide and `ry` tall. Zero once past the corner.
+fn corner_inset(d: f32, rx: f32, ry: f32) -> f32 {
+    if rx <= 0.0 || ry <= 0.0 || d >= ry {
+        return 0.0;
+    }
+    let dy = (ry - d) / ry;
+    rx - rx * (1.0 - dy * dy).max(0.0).sqrt()
+}
+
+/// Round-to-nearest on all four edges so adjacent slabs tile without gaps
+/// (inward rounding would drop sub-pixel slabs). `None` when the rounding
+/// collapses the rectangle to nothing.
+fn to_region_rect(b: Rect) -> Option<RegionRect> {
+    let x0 = b.x.round() as i32;
+    let y0 = b.y.round() as i32;
+    let x1 = (b.x + b.width).round() as i32;
+    let y1 = (b.y + b.height).round() as i32;
+    (x1 > x0 && y1 > y0).then_some(RegionRect {
+        x: x0,
+        y: y0,
+        width: x1 - x0,
+        height: y1 - y0,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn covers(rects: &[RegionRect], x: i32, y: i32) -> bool {
+        rects
+            .iter()
+            .any(|r| x >= r.x && x < r.x + r.width && y >= r.y && y < r.y + r.height)
+    }
+
+    fn round(radius: f32) -> EllipticalRadii {
+        EllipticalRadii::circular(CornerRadii::uniform(radius))
+    }
+
+    #[test]
+    fn zero_radius_is_bounding_box() {
+        let rects = rounded_rect_to_rects(Rect::new(10.0, 20.0, 100.0, 50.0), round(0.0));
+        assert_eq!(
+            rects,
+            vec![RegionRect {
+                x: 10,
+                y: 20,
+                width: 100,
+                height: 50
+            }]
+        );
+    }
+
+    #[test]
+    fn degenerate_rect_is_empty() {
+        assert!(rounded_rect_to_rects(Rect::new(0.0, 0.0, 0.0, 40.0), round(8.0)).is_empty());
+        assert!(rounded_rect_to_rects(Rect::new(0.0, 0.0, 40.0, -1.0), round(8.0)).is_empty());
+    }
+
+    #[test]
+    fn rounded_corners_are_cut() {
+        let rects = rounded_rect_to_rects(Rect::new(0.0, 0.0, 100.0, 60.0), round(20.0));
+        // Corner pixels outside the curve are not covered…
+        assert!(!covers(&rects, 0, 0));
+        assert!(!covers(&rects, 99, 0));
+        assert!(!covers(&rects, 0, 59));
+        assert!(!covers(&rects, 99, 59));
+        // …while the center and edge midpoints are.
+        assert!(covers(&rects, 50, 30));
+        assert!(covers(&rects, 0, 30));
+        assert!(covers(&rects, 99, 30));
+        assert!(covers(&rects, 50, 0));
+        assert!(covers(&rects, 50, 59));
+    }
+
+    #[test]
+    fn slabs_stay_inside_the_curve() {
+        let r = 16.0f32;
+        let rects = rounded_rect_to_rects(Rect::new(0.0, 0.0, 80.0, 80.0), round(r));
+        for rect in &rects {
+            // Every rect corner must be inside (or on) the rounded shape,
+            // with half-pixel tolerance for edge rounding.
+            for (px, py) in [
+                (rect.x, rect.y),
+                (rect.x + rect.width, rect.y),
+                (rect.x, rect.y + rect.height),
+                (rect.x + rect.width, rect.y + rect.height),
+            ] {
+                let (px, py) = (px as f32, py as f32);
+                let cx = px.clamp(r, 80.0 - r);
+                let cy = py.clamp(r, 80.0 - r);
+                let dist = ((px - cx).powi(2) + (py - cy).powi(2)).sqrt();
+                assert!(
+                    dist <= r + 0.75,
+                    "corner ({px}, {py}) is {dist} from the curve center, radius {r}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn radius_clamped_to_half_size() {
+        // Radius larger than half the shape: a circle-ish region, still non-empty
+        let rects = rounded_rect_to_rects(Rect::new(0.0, 0.0, 40.0, 40.0), round(100.0));
+        assert!(!rects.is_empty());
+        assert!(covers(&rects, 20, 20));
+        assert!(!covers(&rects, 0, 0));
+    }
+
+    /// A square corner is square. This is the seam the region used to be lost
+    /// at: a clip squared off two corners, the caller collapsed the four radii
+    /// with `.max()`, and the shape arrived here as though all four were round —
+    /// so the region gave back a wedge the size of the radius along the cut,
+    /// which is the artefact the clipping exists to prevent.
+    #[test]
+    fn a_square_corner_is_not_rounded_because_another_one_is() {
+        let square_right = EllipticalRadii::circular(CornerRadii {
+            top_left: 16.0,
+            top_right: 0.0,
+            bottom_right: 0.0,
+            bottom_left: 16.0,
+        });
+        let rects = rounded_rect_to_rects(Rect::new(0.0, 0.0, 40.0, 100.0), square_right);
+
+        assert!(
+            covers(&rects, 39, 0) && covers(&rects, 39, 99),
+            "the cut edge is straight, so its corners reach the edge"
+        );
+        assert!(
+            !covers(&rects, 0, 0) && !covers(&rects, 0, 99),
+            "and the round ones are still cut"
+        );
+    }
+
+    /// Only the corner that has a radius is cut. A list row rounding its top
+    /// corners and butting against the next one keeps its full bottom edge.
+    #[test]
+    fn corners_are_cut_one_by_one() {
+        let rects = rounded_rect_to_rects(
+            Rect::new(0.0, 0.0, 100.0, 60.0),
+            EllipticalRadii::circular(CornerRadii::top(20.0)),
+        );
+
+        assert!(!covers(&rects, 0, 0) && !covers(&rects, 99, 0), "top cut");
+        assert!(
+            covers(&rects, 0, 59) && covers(&rects, 99, 59),
+            "bottom square"
+        );
+    }
+
+    /// An unevenly scaled corner is an ellipse: 32 wide and 16 tall reaches the
+    /// left edge 16 down, where a circle of either radius would not.
+    #[test]
+    fn an_elliptical_corner_is_cut_on_both_of_its_axes() {
+        let radii = EllipticalRadii {
+            x: CornerRadii::uniform(32.0),
+            y: CornerRadii::uniform(16.0),
+        };
+        let rects = rounded_rect_to_rects(Rect::new(0.0, 0.0, 200.0, 100.0), radii);
+
+        assert!(!covers(&rects, 0, 0), "the corner itself is outside");
+        assert!(
+            covers(&rects, 0, 20),
+            "the curve is 16 tall, so the left edge is reached by 20 down"
+        );
+        assert!(
+            !covers(&rects, 5, 1),
+            "and 32 wide, so it is still outside 5 in at the top"
+        );
+    }
+
+    /// Every emitted rect stays inside the ellipse it approximates, for radii
+    /// that differ per corner and per axis — the property the whole tessellation
+    /// exists to have, checked where the shape is least uniform.
+    #[test]
+    fn slabs_stay_inside_a_shape_with_four_different_corners() {
+        let radii = EllipticalRadii {
+            x: CornerRadii {
+                top_left: 30.0,
+                top_right: 10.0,
+                bottom_right: 0.0,
+                bottom_left: 20.0,
+            },
+            y: CornerRadii {
+                top_left: 15.0,
+                top_right: 10.0,
+                bottom_right: 0.0,
+                bottom_left: 40.0,
+            },
+        };
+        let (w, h) = (120.0f32, 100.0f32);
+        let rects = rounded_rect_to_rects(Rect::new(0.0, 0.0, w, h), radii);
+        assert!(!rects.is_empty());
+
+        // The centre of each corner's ellipse, and its two semi-axes.
+        let corners = [
+            (30.0f32, 15.0f32, 30.0f32, 15.0f32, true, true),
+            (w - 10.0, 10.0, 10.0, 10.0, false, true),
+            (20.0, h - 40.0, 20.0, 40.0, true, false),
+        ];
+        for rect in &rects {
+            for (px, py) in [
+                (rect.x, rect.y),
+                (rect.x + rect.width, rect.y),
+                (rect.x, rect.y + rect.height),
+                (rect.x + rect.width, rect.y + rect.height),
+            ] {
+                let (px, py) = (px as f32, py as f32);
+                for (cx, cy, rx, ry, left, top) in corners {
+                    // Only points in this corner's quadrant are governed by it.
+                    let in_x = if left { px < cx } else { px > cx };
+                    let in_y = if top { py < cy } else { py > cy };
+                    if !in_x || !in_y {
+                        continue;
+                    }
+                    let d = ((px - cx) / rx).powi(2) + ((py - cy) / ry).powi(2);
+                    assert!(
+                        d <= 1.0 + 0.1,
+                        "({px}, {py}) is outside the {rx}x{ry} corner at ({cx}, {cy}): {d}"
+                    );
+                }
+            }
+        }
+    }
+}

--- a/src/region.rs
+++ b/src/region.rs
@@ -7,7 +7,7 @@
 //! the axis-aligned rectangles that stand in for a shape the protocol has no
 //! way to describe. That translation lives here so there is one of it.
 
-use crate::renderer::{CornerRadii, EllipticalRadii};
+use crate::renderer::{CornerRadii, DrawCommand, EllipticalRadii, FlattenedCommand};
 use crate::widgets::Rect;
 
 /// An axis-aligned rectangle of a region, in logical surface pixels.
@@ -20,6 +20,13 @@ pub(crate) struct RegionRect {
 }
 
 impl RegionRect {
+    /// Whether this rectangle holds `(x, y)`, half-open on the far edges as
+    /// [`Rect::contains`] is: the pixel a rectangle ends at belongs to the next
+    /// one.
+    pub(crate) fn contains(&self, x: i32, y: i32) -> bool {
+        x >= self.x && y >= self.y && x < self.x + self.width && y < self.y + self.height
+    }
+
     /// A whole-pixel rectangle covering all of `r`.
     ///
     /// Outward, because a region is a claim about where something is: a
@@ -172,14 +179,89 @@ fn to_region_rect(b: Rect) -> Option<RegionRect> {
     })
 }
 
+/// One declaration of where input reaches a surface, in the order it was
+/// painted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct InputRegionOp {
+    /// Whether input reaches this rectangle. `false` cuts it out of whatever
+    /// came before.
+    pub takes: bool,
+    pub rect: RegionRect,
+}
+
+/// What a surface asks the compositor about where input reaches it: the area
+/// it takes before any container has spoken, and the declarations that came
+/// out of the frame.
+///
+/// Two fields rather than one resolved list, because a rounded hole cut out of
+/// a surface is not a union of rectangles anyone should have to compute:
+/// `wl_region` subtracts, and this is that program in the order it is applied.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub(crate) struct InputRegionRequest {
+    pub base: Vec<RegionRect>,
+    pub ops: Vec<InputRegionOp>,
+}
+
+/// The input declarations of the frame that was just drawn, in paint order.
+///
+/// Read off the flattened commands for the reason
+/// [`crate::blur::regions_from_commands`] gives at length: a container that did
+/// not paint has no command here, so a hidden, culled or replaced declaration
+/// takes itself back without anyone having to remember it.
+///
+/// Not sorted, unlike a blur region: these compose, and the order they compose
+/// in is the order they were painted in.
+pub(crate) fn input_ops_from_commands(commands: &[FlattenedCommand]) -> Vec<InputRegionOp> {
+    let mut out = Vec::new();
+    for cmd in commands {
+        let DrawCommand::InputRegion {
+            rect,
+            corner_radii,
+            takes,
+        } = &*cmd.command
+        else {
+            continue;
+        };
+        let Some((world, world_radii)) = cmd.clipped_world_rounded_rect(*rect, *corner_radii)
+        else {
+            continue;
+        };
+        out.extend(
+            rounded_rect_to_rects(world, world_radii)
+                .into_iter()
+                .map(|rect| InputRegionOp {
+                    takes: *takes,
+                    rect,
+                }),
+        );
+    }
+    out
+}
+
+/// The area a surface takes input in before any container has spoken: the
+/// whole of it, or whatever the surface itself declared, at creation or since.
+///
+/// A surface that says nothing takes input everywhere, which is what the
+/// protocol's null region means. `click_through` is the same declaration with
+/// nothing in it, and a declaration cuts the base down to the rectangles it
+/// names.
+pub(crate) fn base_rects(declared: Option<&[Rect]>, width: f32, height: f32) -> Vec<RegionRect> {
+    match declared {
+        None => Vec::from_iter(RegionRect::covering(Rect::new(0.0, 0.0, width, height))),
+        Some(rects) => rects
+            .iter()
+            .copied()
+            .filter_map(RegionRect::covering)
+            .collect(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     fn covers(rects: &[RegionRect], x: i32, y: i32) -> bool {
-        rects
-            .iter()
-            .any(|r| x >= r.x && x < r.x + r.width && y >= r.y && y < r.y + r.height)
+        rects.iter().any(|r| r.contains(x, y))
     }
 
     fn round(radius: f32) -> EllipticalRadii {

--- a/src/renderer/commands.rs
+++ b/src/renderer/commands.rs
@@ -282,6 +282,22 @@ pub enum DrawCommand {
         font_weight: FontWeight,
     },
 
+    /// Where pointer and touch input reaches this surface, or stops reaching
+    /// it. Draws nothing: it rides the frame so that the region published to
+    /// the compositor is read off the same list the pixels came from, which is
+    /// what keeps a hidden, culled or cached container from leaving a stale
+    /// hole behind it.
+    InputRegion {
+        /// The area declared, in local coordinates.
+        rect: Rect,
+        /// Corner radii of that area, so the region follows the shape drawn
+        /// rather than its bounding box.
+        corner_radii: CornerRadii,
+        /// Whether input reaches this area. `false` is a hole in a surface
+        /// that otherwise takes input; `true` is an island in one that does
+        /// not.
+        takes: bool,
+    },
     /// Filter what has already been drawn beneath `rect`, in place.
     ///
     /// Ordered before the container's own background so the container paints

--- a/src/renderer/flatten.rs
+++ b/src/renderer/flatten.rs
@@ -941,6 +941,36 @@ mod tests {
         assert_eq!(groups, 2, "which is what the split is for");
     }
 
+    /// The other region a frame carries, and the same two questions: the
+    /// compositor has to be told it is there, and a command that draws nothing
+    /// must not cost a draw group. This one is stricter than the blur above —
+    /// it is declared *over* a background rather than under one, which is the
+    /// order `Container::paint` emits, and the order that would split a group
+    /// for a command with no pixels in it.
+    #[test]
+    fn an_input_declaration_is_carried_without_costing_a_group() {
+        let rect = Rect::new(0.0, 0.0, 100.0, 100.0);
+        let mut node = RenderNode::new(1);
+        node.bounds = rect;
+        node.commands
+            .push(Rc::new(DrawCommand::rounded_rect(rect, Color::WHITE, 0.0)));
+        node.commands.push(Rc::new(DrawCommand::InputRegion {
+            rect,
+            corner_radii: CornerRadii::from(0.0),
+            takes: true,
+        }));
+
+        let (mut commands, mut layers) = (Vec::new(), Vec::new());
+        let carried = flatten_root_into(&node, &mut commands, &mut layers);
+
+        assert!(
+            carried.input_region,
+            "the frame carries a declaration, and the loop is told so"
+        );
+        assert_eq!(layers.len(), 1, "and it splits nothing to say it");
+        assert_eq!(commands.len(), 2, "while still travelling with the frame");
+    }
+
     #[test]
     fn ascending_layers_stay_in_one_group() {
         // The common case: nothing is painted over a higher layer, so the

--- a/src/renderer/flatten.rs
+++ b/src/renderer/flatten.rs
@@ -237,12 +237,11 @@ impl FlattenedCommand {
 /// column of buttons stays one group; a tint over a photo gets two.
 struct LayeredCommands {
     groups: Vec<LayerBuckets>,
-    /// Whether any command asks the compositor to blur behind it.
-    ///
-    /// Counted while the commands go past, because the alternative is walking
-    /// them all again afterwards to find out — on every painted frame, for the
-    /// large majority of surfaces that never ask for it at all.
-    compositor_blur: bool,
+    /// What this frame carries for the compositor, counted while the commands
+    /// go past — because the alternative is walking them all again afterwards
+    /// to find out, on every painted frame, for the large majority of surfaces
+    /// that carry neither.
+    carried: RegionsCarried,
 }
 
 #[derive(Default)]
@@ -346,15 +345,32 @@ impl LayeredCommands {
     fn new() -> Self {
         Self {
             groups: vec![LayerBuckets::default()],
-            compositor_blur: false,
+            carried: RegionsCarried::default(),
         }
     }
 
     fn push(&mut self, cmd: FlattenedCommand) {
-        if let DrawCommand::BackdropBlur { sources, .. } = &*cmd.command
-            && sources.contains(crate::backdrop::BackdropSources::COMPOSITOR)
-        {
-            self.compositor_blur = true;
+        match &*cmd.command {
+            DrawCommand::BackdropBlur { sources, .. }
+                if sources.contains(crate::backdrop::BackdropSources::COMPOSITOR) =>
+            {
+                self.carried.compositor_blur = true;
+            }
+            DrawCommand::InputRegion { .. } => {
+                self.carried.input_region = true;
+                // No pixels, so no group. Splitting one for a command that
+                // draws nothing costs a pipeline bind per frame, and recording
+                // its bounds spends one of the tracked rectangles a real
+                // overlap test needs. Its place in the list is all the region
+                // is read for.
+                self.groups
+                    .last_mut()
+                    .expect("at least one group")
+                    .bucket_mut(cmd.layer)
+                    .push(cmd);
+                return;
+            }
+            _ => {}
         }
         let layer = cmd.layer;
         let rect = world_bounds(&cmd);
@@ -492,23 +508,33 @@ impl CommandLayer {
 ///
 /// `layers` receives the groups to draw, in order; see [`CommandLayer`].
 ///
-/// Returns whether the frame carries a backdrop blur the *compositor* is asked
-/// to apply, which is the only reason to walk the result again and build a
-/// `wl_region` from it.
+/// Returns what the frame carries that becomes a `wl_region` — a backdrop blur
+/// the *compositor* is asked to apply, and a declaration about where input
+/// reaches the surface — which is the only reason to walk the result again and
+/// build one from it.
 pub fn flatten_root_into(
     root: &RenderNode,
     commands: &mut Vec<FlattenedCommand>,
     layers: &mut Vec<CommandLayer>,
-) -> bool {
+) -> RegionsCarried {
     commands.clear();
     layers.clear();
 
     let mut layered = LayeredCommands::new();
     flatten_node(root, Transform::IDENTITY, None, None, &mut layered);
 
-    let compositor_blur = layered.compositor_blur;
+    let carried = layered.carried;
     layered.drain_into(commands, layers);
-    compositor_blur
+    carried
+}
+
+/// What a flattened frame carries for the compositor, counted on the way past.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct RegionsCarried {
+    /// A backdrop blur the compositor is asked to apply.
+    pub compositor_blur: bool,
+    /// A declaration about where input reaches the surface.
+    pub input_region: bool,
 }
 
 /// Recursively flatten a node and its children.
@@ -618,6 +644,9 @@ fn flatten_node(
             {
                 RenderLayer::Shapes
             }
+            // Draws nothing, for the same reason and by the same route: it
+            // travels with the shapes, where it produces no instance.
+            DrawCommand::InputRegion { .. } => RenderLayer::Shapes,
             DrawCommand::BackdropBlur { .. } | DrawCommand::TextBackdropBlur { .. } => {
                 RenderLayer::Backdrop
             }
@@ -738,7 +767,7 @@ fn world_bounds(cmd: &FlattenedCommand) -> Option<Rect> {
             radius * 2.0,
         ),
         DrawCommand::Image { rect, .. } => *rect,
-        DrawCommand::BackdropBlur { rect, .. } => *rect,
+        DrawCommand::BackdropBlur { rect, .. } | DrawCommand::InputRegion { rect, .. } => *rect,
         DrawCommand::Text {
             rect, font_size, ..
         }
@@ -896,7 +925,7 @@ mod tests {
             }));
 
             let (mut commands, mut layers) = (Vec::new(), Vec::new());
-            let told = flatten_root_into(&node, &mut commands, &mut layers);
+            let told = flatten_root_into(&node, &mut commands, &mut layers).compositor_blur;
             let drawn = layers.iter().any(|l| !l.backdrop.is_empty());
             (told, drawn, layers.len())
         };

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -29,7 +29,7 @@ mod tree;
 mod types;
 
 pub use commands::{Border, CornerRadii, DrawCommand, EllipticalRadii};
-pub use flatten::{CommandLayer, FlattenedCommand, flatten_root_into};
+pub use flatten::{CommandLayer, FlattenedCommand, RegionsCarried, flatten_root_into};
 #[cfg(any(test, feature = "testing"))]
 pub use gpu_context::OffscreenTarget;
 pub use gpu_context::{GpuContext, RenderTarget, SurfaceState};

--- a/src/renderer/paint_context.rs
+++ b/src/renderer/paint_context.rs
@@ -327,6 +327,21 @@ impl<'a> PaintContext<'a> {
         }));
     }
 
+    /// Declare where input reaches this surface, or stops reaching it, over
+    /// `rect`. Draws nothing; the region is read off the flattened frame.
+    pub fn declare_input_region(
+        &mut self,
+        rect: Rect,
+        corner_radii: impl Into<CornerRadii>,
+        takes: bool,
+    ) {
+        self.node.commands.push(Rc::new(DrawCommand::InputRegion {
+            rect,
+            corner_radii: corner_radii.into(),
+            takes,
+        }));
+    }
+
     /// Draw a circle in local coordinates.
     /// Blur whatever is already drawn beneath `rect`, masked to its rounded
     /// shape. Emitted before the container's own background so it paints over

--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -818,6 +818,8 @@ fn command_to_instance(cmd: &FlattenedCommand, scale: f32) -> Option<ShapeInstan
         // Filters the target rather than adding geometry; handled between
         // draw groups, not as an instance.
         DrawCommand::BackdropBlur { .. } | DrawCommand::TextBackdropBlur { .. } => None,
+        // Says where input goes, not what is drawn.
+        DrawCommand::InputRegion { .. } => None,
         // Image commands are handled separately via ImageQuadRenderer
         DrawCommand::Image { .. } => None,
     }

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -332,6 +332,11 @@ pub(crate) struct InitialDeclaration {
     pub believed: (u32, u32),
     /// The screen space to reserve, resolved against `believed`.
     pub exclusive_zone: i32,
+    /// The input region to apply, or `None` where the surface declared none
+    /// and takes input everywhere. Here rather than read from the config at
+    /// each platform, so "applied at birth only when one was declared" is one
+    /// rule rather than two copies of it.
+    pub input_region: Option<Vec<Rect>>,
 }
 
 pub(crate) fn initial_declaration(config: &SurfaceConfig) -> InitialDeclaration {
@@ -349,6 +354,7 @@ pub(crate) fn initial_declaration(config: &SurfaceConfig) -> InitialDeclaration 
             believed.0,
             believed.1,
         ),
+        input_region: config.input_region.clone(),
     }
 }
 

--- a/src/surface_manager.rs
+++ b/src/surface_manager.rs
@@ -10,7 +10,7 @@ use crate::reactive::owner::{OwnerId, dispose_owner_now};
 use crate::renderer::{CommandLayer, FlattenedCommand, GpuContext, RenderNode, RenderTarget};
 use crate::surface::{SurfaceConfig, SurfaceId};
 use crate::tree::{Tree, WidgetId};
-use crate::widgets::Widget;
+use crate::widgets::{Rect, Widget};
 use crate::{Platform, Surface};
 
 /// A surface with unified GPU lifecycle management.
@@ -36,6 +36,19 @@ pub struct ManagedSurface {
     pub flattened_commands: Vec<FlattenedCommand>,
     /// Draw groups over `flattened_commands`, in draw order.
     pub command_layers: Vec<CommandLayer>,
+    /// Where input reaches this surface before any container has spoken:
+    /// what the config declared, and what a handle has said since.
+    ///
+    /// One home for it, so a runtime `set_input_region` and a declaration in
+    /// the tree compose instead of erasing each other.
+    pub input_base: Option<Vec<Rect>>,
+    /// The region this surface last asked the compositor for, or `None` while
+    /// no container has ever declared one.
+    ///
+    /// Kept here rather than in a platform so that both of them publish on the
+    /// same rule: once, when it changes, and never for a surface whose tree has
+    /// said nothing about input.
+    pub input_region: Option<crate::region::InputRegionRequest>,
 }
 
 impl ManagedSurface {
@@ -48,6 +61,8 @@ impl ManagedSurface {
         owner_id: OwnerId,
         tree: &mut Tree,
     ) -> Self {
+        let config_input_region = config.input_region.clone();
+
         // Register root widget - tree assigns the ID
         let widget_id = tree.register(widget);
 
@@ -66,6 +81,8 @@ impl ManagedSurface {
             root_node: RenderNode::new(widget_id.as_u64()),
             flattened_commands: Vec::new(),
             command_layers: Vec::new(),
+            input_base: config_input_region,
+            input_region: None,
         }
     }
 

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -52,8 +52,13 @@ struct RecordedSurface {
     events: Vec<(Instant, Event)>,
     first_frame_presented: bool,
     exclusive_zones: Vec<i32>,
-    /// Every input region asked for, oldest first.
+    /// Every input region asked for, oldest first. Kept whole rather than
+    /// resolved, because "no region at all" and "a region holding nothing" are
+    /// opposite instructions that a list of rectangles cannot tell apart.
     input_regions: Vec<Option<Vec<Rect>>>,
+    /// Every derived region published, oldest first — the base a surface takes
+    /// input in, and what the frame declared about it.
+    input_requests: Vec<crate::region::InputRegionRequest>,
     sizes_asked: Vec<(u32, u32)>,
     frame_callbacks: u32,
 }
@@ -119,6 +124,10 @@ impl Surface for &mut RecordedSurface {
 
     fn set_input_region(&mut self, rects: Option<&[Rect]>) {
         self.input_regions.push(rects.map(<[Rect]>::to_vec));
+    }
+
+    fn sync_input_region(&mut self, request: &crate::region::InputRegionRequest, _commit: bool) {
+        self.input_requests.push(request.clone());
     }
 
     fn request_frame_callback(&mut self) {
@@ -384,6 +393,45 @@ impl Headless {
     /// all.
     pub fn input_regions_asked(&self, id: SurfaceId) -> &[Option<Vec<Rect>>] {
         &self.host.get(id).input_regions
+    }
+
+    /// Whether input reaches a point of a surface, by the reading the
+    /// compositor gives the last region it was handed: the area the surface
+    /// takes, then every declaration the frame made, in order.
+    ///
+    /// A surface whose tree has never declared anything takes input
+    /// everywhere, which is what it asked for by saying nothing.
+    pub fn input_reaches(&self, id: SurfaceId, x: f32, y: f32) -> bool {
+        let (x, y) = (x.floor() as i32, y.floor() as i32);
+        let surface = self.host.get(id);
+
+        // Before the tree has declared anything, the answer is whatever the
+        // surface itself asked for at birth or through a handle — which is
+        // "everywhere" only when it asked for nothing.
+        let Some(request) = surface.input_requests.last() else {
+            return match surface.input_regions.last() {
+                None | Some(None) => true,
+                Some(Some(rects)) => rects.iter().any(|r| r.contains(x as f32, y as f32)),
+            };
+        };
+
+        // The compositor's reading of the program it was handed: the
+        // area the surface takes, then every declaration in order.
+        // Here rather than beside the type, because nothing the library
+        // does asks this question — only a test does.
+        let mut takes = request.base.iter().any(|r| r.contains(x, y));
+        for op in &request.ops {
+            if op.rect.contains(x, y) {
+                takes = op.takes;
+            }
+        }
+        takes
+    }
+
+    /// How many times a surface has published a derived input region. A frame
+    /// that changes nothing must not add to this.
+    pub fn input_regions_published(&self, id: SurfaceId) -> usize {
+        self.host.get(id).input_requests.len()
     }
 
     /// The sizes a surface has asked for, oldest first.

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -30,7 +30,7 @@ use crate::renderer::{GpuContext, RenderTarget, Renderer};
 use crate::surface::{SurfaceConfig, SurfaceId};
 use crate::surface_manager::{ManagedSurface, SurfaceManager};
 use crate::tree::{Tree, WidgetId};
-use crate::widgets::{Event, MouseButton, Widget};
+use crate::widgets::{Event, MouseButton, Rect, Widget};
 use crate::{Frame, LoopContext, Platform, Surface, iterate};
 
 /// The compositor's half of one surface: what it has said, and what it has
@@ -52,6 +52,8 @@ struct RecordedSurface {
     events: Vec<(Instant, Event)>,
     first_frame_presented: bool,
     exclusive_zones: Vec<i32>,
+    /// Every input region asked for, oldest first.
+    input_regions: Vec<Option<Vec<Rect>>>,
     sizes_asked: Vec<(u32, u32)>,
     frame_callbacks: u32,
 }
@@ -115,6 +117,10 @@ impl Surface for &mut RecordedSurface {
         self.exclusive_zones.push(zone);
     }
 
+    fn set_input_region(&mut self, rects: Option<&[Rect]>) {
+        self.input_regions.push(rects.map(<[Rect]>::to_vec));
+    }
+
     fn request_frame_callback(&mut self) {
         self.frame_callbacks += 1;
     }
@@ -142,6 +148,7 @@ impl Platform for Recorder {
                 scale: 1.0,
                 sizes_asked: vec![declared.asked],
                 exclusive_zones: vec![declared.exclusive_zone],
+                input_regions: Vec::from_iter(declared.input_region.map(Some)),
                 ..Default::default()
             },
         );
@@ -370,6 +377,13 @@ impl Headless {
     /// and only a list can tell them apart.
     pub fn exclusive_zones_asked(&self, id: SurfaceId) -> &[i32] {
         &self.host.get(id).exclusive_zones
+    }
+
+    /// Every input region a surface has asked for, oldest first. `None` is the
+    /// whole surface, and an empty list is a surface that takes no input at
+    /// all.
+    pub fn input_regions_asked(&self, id: SurfaceId) -> &[Option<Vec<Rect>>] {
+        &self.host.get(id).input_regions
     }
 
     /// The sizes a surface has asked for, oldest first.

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -179,7 +179,7 @@ impl H {
 /// paint left registered.
 struct Frame {
     node: std::rc::Rc<RenderNode>,
-    blur: Vec<crate::blur::BlurRect>,
+    blur: Vec<crate::region::RegionRect>,
 }
 
 /// A leaf of an exactly known size.
@@ -4628,7 +4628,7 @@ fn a_transformed_blur_publishes_the_shape_it_is_drawn_as() {
         .frame(200.0, 200.0)
         .blur;
 
-    let span = |rects: &[crate::blur::BlurRect]| {
+    let span = |rects: &[crate::region::RegionRect]| {
         let left = rects.iter().map(|r| r.x).min().expect("a region");
         let right = rects.iter().map(|r| r.x + r.width).max().expect("a region");
         right - left

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -98,7 +98,8 @@ impl H {
             // The gate: nothing is dirty, so nothing repaints and the region
             // comes from the frame still on screen.
             let blur = crate::blur::regions_from_commands(&commands);
-            return Frame { node, blur };
+            let input = crate::region::input_ops_from_commands(&commands);
+            return Frame { node, blur, input };
         }
 
         let mut node = RenderNode::new(root.as_u64());
@@ -112,6 +113,7 @@ impl H {
         let mut layers = Vec::new();
         let _ = crate::renderer::flatten_root_into(&node, &mut commands, &mut layers);
         let blur = crate::blur::regions_from_commands(&commands);
+        let input = crate::region::input_ops_from_commands(&commands);
 
         // Per child of the root and then `clear_needs_paint(root)`, which is
         // what the loop does: the surface root always repaints, so it is never
@@ -123,7 +125,7 @@ impl H {
         self.tree.clear_needs_paint(root);
         self.last = Some((std::rc::Rc::clone(&node), commands));
 
-        Frame { node, blur }
+        Frame { node, blur, input }
     }
 
     fn send(&mut self, event: Event) -> EventResponse {
@@ -180,6 +182,7 @@ impl H {
 struct Frame {
     node: std::rc::Rc<RenderNode>,
     blur: Vec<crate::region::RegionRect>,
+    input: Vec<crate::region::InputRegionOp>,
 }
 
 /// A leaf of an exactly known size.
@@ -4642,6 +4645,67 @@ fn a_transformed_blur_publishes_the_shape_it_is_drawn_as() {
     assert!(
         turned > plain && turned < scaled,
         "turned on its corner it covers its diagonal, {turned} against {plain}"
+    );
+}
+
+/// The region an island declares is the shape it is drawn as, corners and all —
+/// the same thing `a_transformed_blur_publishes_the_shape_it_is_drawn_as` says
+/// about the other region read off a frame, and for the same reason: both come
+/// off the flattened commands, through one tessellation.
+#[test]
+fn an_island_declares_its_corners_and_not_its_bounding_box() {
+    let takes = |x: i32, y: i32, ops: &[crate::region::InputRegionOp]| {
+        ops.iter().any(|op| {
+            op.takes
+                && x >= op.rect.x
+                && y >= op.rect.y
+                && x < op.rect.x + op.rect.width
+                && y < op.rect.y + op.rect.height
+        })
+    };
+
+    let square = H::new(box_of(40.0, 40.0).takes_input(true))
+        .frame(200.0, 200.0)
+        .input;
+    let round = H::new(box_of(40.0, 40.0).corners(20.0).takes_input(true))
+        .frame(200.0, 200.0)
+        .input;
+
+    assert!(takes(1, 1, &square), "a square island reaches its corner");
+    assert!(
+        !takes(1, 1, &round),
+        "and a round one does not, so the click there goes where the pixel does"
+    );
+    assert!(takes(20, 20, &round), "its middle is still its own");
+}
+
+/// A declaration inside a clip is cut by it, the same way
+/// `a_clipped_blur_publishes_only_what_is_on_show` says the other region is:
+/// input reaches what is on screen, not what a layout pass measured.
+#[test]
+fn a_clipped_declaration_reaches_only_what_is_on_show() {
+    let island = || box_of(40.0, 40.0).takes_input(true);
+    let mut h = H::new(
+        container()
+            .width(40.0)
+            .height(40.0)
+            .overflow(Overflow::Hidden)
+            .layout(Flex::row())
+            .child(island())
+            .child(island()),
+    );
+
+    let widest = h
+        .frame(200.0, 200.0)
+        .input
+        .iter()
+        .map(|op| op.rect.x + op.rect.width)
+        .max()
+        .expect("the visible island still takes input");
+
+    assert!(
+        widest <= 40,
+        "the row is 80 wide inside a 40-wide clip, so nothing may take input at {widest}"
     );
 }
 

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -472,6 +472,10 @@ pub struct Container {
 
     // Backdrop blur: this surface's own content, the compositor's, or both.
     pub(super) backdrop_blur: Option<Signal<BackdropBlur>>,
+    /// Whether pointer and touch input reaches this container's area, said to
+    /// the compositor rather than to the hit test — see
+    /// [`takes_input`](Container::takes_input).
+    pub(super) takes_input: Option<Signal<bool>>,
 
     /// Declared with `control()`. A container is an interaction unit for other
     /// reasons too — see `is_control` — so this is only the explicit half.
@@ -523,6 +527,7 @@ impl Container {
             interaction: None,
             widget_ref: None,
             backdrop_blur: None,
+            takes_input: None,
             declared_control: false,
             anims: None,
             scroll_axis: ScrollAxis::None,
@@ -740,6 +745,62 @@ impl Container {
     /// one off with [`BackdropSources::empty`](crate::backdrop::BackdropSources::empty).
     pub fn backdrop_blur<M>(mut self, blur: impl IntoSignal<BackdropBlur, M>) -> Self {
         self.backdrop_blur = Some(blur.into_signal());
+        self
+    }
+
+    /// Whether pointer and touch input reaches this container's area at all.
+    ///
+    /// This is not the hit test. It is what the *compositor* is told, so
+    /// `takes_input(false)` does not merely stop this container answering: the
+    /// click goes to whatever is behind the surface, a terminal or the desktop.
+    /// A container that should refuse input without giving it away is
+    /// [`enabled(false)`](Self::enabled), which is a state and keeps blocking
+    /// what is underneath.
+    ///
+    /// The surface says the baseline and a container says the exception. A
+    /// surface takes input everywhere unless it declares
+    /// [`click_through`](crate::surface::SurfaceConfig::click_through), so:
+    ///
+    /// ```
+    /// # use guido::prelude::*;
+    /// // an island in a surface that lets everything else past
+    /// container().takes_input(true).corners(20.0);
+    ///
+    /// // a hole in a bar, where the desktop gets the click
+    /// container().takes_input(false).width(200.0);
+    /// ```
+    ///
+    /// **What is declared is this container's own shape, and nothing else.**
+    /// Children are covered because they are drawn inside it, not because the
+    /// declaration reaches them — so a child that draws *outside* it, which
+    /// `overflow(Visible)` allows, is outside the region too:
+    ///
+    /// ```
+    /// # use guido::prelude::*;
+    /// # let do_thing = || {};
+    /// container()
+    ///     .takes_input(true)
+    ///     .width(100.0)
+    ///     .height(30.0)
+    ///     // Drawn 40px below the parent, so outside what it declared: on a
+    ///     // click-through surface this handler never runs, because the
+    ///     // compositor sends that click to whatever is behind.
+    ///     .child(container().translate((0.0, 40.0)).on_click(do_thing));
+    /// ```
+    ///
+    /// It is the container's shape rather than its subtree because a region is
+    /// sent to the compositor as rectangles: one declaration is one shape, and
+    /// a declaration every descendant inherited would be a shape per painting
+    /// widget, every frame the region moves.
+    ///
+    /// A descendant declaring the opposite is a smaller area declared later, so
+    /// an island inside a hole needs no rule of its own.
+    ///
+    /// The region follows the shape on screen — its corners, its transform, its
+    /// clip — because it is read off the frame that was drawn, and it is gone
+    /// the moment the container stops painting.
+    pub fn takes_input<M>(mut self, takes: impl IntoSignal<bool, M>) -> Self {
+        self.takes_input = Some(takes.into_signal());
         self
     }
 
@@ -1730,6 +1791,7 @@ impl Widget for Container {
             border_color,
             gradient,
             backdrop_blur,
+            takes_input,
             overflow,
         ) = with_signal_tracking(id, JobType::Paint, || {
             (
@@ -1742,6 +1804,7 @@ impl Widget for Container {
                 self.animated_border_color(id),
                 self.gradient.as_ref().and_then(|g| g.get()),
                 self.backdrop_blur.as_ref().map(|b| b.get()),
+                self.takes_input.as_ref().map(|t| t.get()),
                 self.overflow.get_or(Overflow::Visible),
             )
         });
@@ -1781,6 +1844,13 @@ impl Widget for Container {
                 corner_radii,
                 corner_curvature,
             );
+        }
+
+        // Beside the blur command and for the same reason: a region the
+        // compositor is told about is read off the frame, so a container that
+        // stopped painting cannot leave one behind.
+        if let Some(takes) = takes_input {
+            ctx.declare_input_region(local_bounds, corner_radii, takes);
         }
 
         self.paint_decoration(

--- a/tests/headless_app.rs
+++ b/tests/headless_app.rs
@@ -452,3 +452,217 @@ fn a_click_outside_the_field_takes_the_keyboard_off_it() {
         "and a click on the bar behind it gives it back"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Input regions, declared on the tree and derived from the frame (#360)
+// ---------------------------------------------------------------------------
+
+/// A surface that lets everything through, with one island that does not.
+fn island(w: f32, h: f32) -> Container {
+    container()
+        .width(fill())
+        .height(fill())
+        .child(container().width(w).height(h).takes_input(true))
+}
+
+#[test]
+fn an_island_is_where_input_reaches_a_click_through_surface() {
+    let Some(mut app) = headless() else { return };
+    let surface = app.surface(fixed_bar().click_through(), || island(80.0, 20.0));
+    app.configure(surface, 200, 50, 1.0);
+    app.step();
+
+    assert!(app.input_reaches(surface, 40.0, 10.0), "inside the island");
+    assert!(
+        !app.input_reaches(surface, 150.0, 40.0),
+        "the surface around it passes clicks to whatever is below"
+    );
+}
+
+#[test]
+fn a_hole_passes_clicks_through_a_surface_that_otherwise_takes_them() {
+    let Some(mut app) = headless() else { return };
+    let surface = app.surface(fixed_bar(), || {
+        container()
+            .width(fill())
+            .height(fill())
+            .child(container().width(80.0).height(20.0).takes_input(false))
+    });
+    app.configure(surface, 200, 50, 1.0);
+    app.step();
+
+    assert!(
+        !app.input_reaches(surface, 40.0, 10.0),
+        "the hole is where the desktop gets the click"
+    );
+    assert!(app.input_reaches(surface, 150.0, 40.0), "the bar around it");
+}
+
+/// The region is the shape that was *drawn*. A `WidgetRef` reports the box a
+/// widget was laid out in, which is why the region could never follow one.
+#[test]
+fn a_transformed_island_declares_where_it_draws_not_where_it_was_laid_out() {
+    let Some(mut app) = headless() else { return };
+    let surface = app.surface(fixed_bar().click_through(), || {
+        container().width(fill()).height(fill()).child(
+            container()
+                .width(80.0)
+                .height(20.0)
+                .scale(2.0)
+                .takes_input(true),
+        )
+    });
+    app.configure(surface, 200, 50, 1.0);
+    app.step();
+
+    assert!(
+        app.input_reaches(surface, 100.0, 25.0),
+        "outside the laid-out box, inside the shape on screen"
+    );
+}
+
+/// Every way a container can stop painting is a way a registry would have gone
+/// stale. The frame is the register.
+#[test]
+fn an_island_that_stops_painting_stops_taking_input() {
+    let Some(mut app) = headless() else { return };
+    let shown = create_signal(true);
+    let surface = app.surface(fixed_bar().click_through(), move || {
+        container().width(fill()).height(fill()).child(
+            container()
+                .width(80.0)
+                .height(20.0)
+                .visible(shown)
+                .takes_input(true),
+        )
+    });
+    app.configure(surface, 200, 50, 1.0);
+    app.step();
+    assert!(app.input_reaches(surface, 40.0, 10.0));
+
+    shown.set(false);
+    app.step();
+    assert!(
+        !app.input_reaches(surface, 40.0, 10.0),
+        "a hidden island leaves no region behind it"
+    );
+}
+
+/// The same discipline `sync_blur_region` keeps: a frame that repaints for
+/// some other reason, with the region unchanged, says nothing about it.
+///
+/// A frame that does not repaint at all proves nothing here — it never reaches
+/// the comparison — so this one paints, twice, and watches the count stand
+/// still while the frames go up.
+#[test]
+fn a_frame_that_repaints_without_moving_the_region_publishes_nothing() {
+    let Some(mut app) = headless() else { return };
+    let shade = create_signal(Color::rgb(0.1, 0.1, 0.1));
+    let surface = app.surface(fixed_bar().click_through(), move || {
+        container()
+            .width(fill())
+            .height(fill())
+            .background(shade)
+            .child(container().width(80.0).height(20.0).takes_input(true))
+    });
+    app.configure(surface, 200, 50, 1.0);
+    app.step();
+
+    let (frames, published) = (
+        app.frames_presented(surface),
+        app.input_regions_published(surface),
+    );
+
+    shade.set(Color::rgb(0.2, 0.2, 0.2));
+    app.step();
+    shade.set(Color::rgb(0.3, 0.3, 0.3));
+    app.step();
+
+    assert!(
+        app.frames_presented(surface) > frames,
+        "the frames have to have run for this to be asking anything"
+    );
+    assert_eq!(
+        app.input_regions_published(surface),
+        published,
+        "and the region did not move, so the compositor was not told twice"
+    );
+}
+
+/// The rectangle the surface itself can name, for a region that belongs to no
+/// widget.
+const PILL: Rect = Rect {
+    x: 120.0,
+    y: 10.0,
+    width: 40.0,
+    height: 20.0,
+};
+
+/// The escape hatch is still there and still watched: a region the surface
+/// declares reaches the compositor when it is created, without a frame and
+/// without anything in the tree saying a word.
+#[test]
+fn a_surface_declared_with_a_region_asks_for_it_at_birth() {
+    let Some(mut app) = headless() else { return };
+    let surface = app.surface(fixed_bar().input_region([PILL]), container);
+    app.configure(surface, 200, 50, 1.0);
+    app.step();
+
+    assert_eq!(app.input_regions_asked(surface), [Some(vec![PILL])]);
+}
+
+/// The two ways of saying it compose rather than erasing each other: what a
+/// handle sets is the area the surface takes, and the declarations in the tree
+/// are applied on top of it.
+#[test]
+fn a_region_set_by_hand_is_the_base_the_tree_declares_against() {
+    let Some(mut app) = headless() else { return };
+    let surface = app.surface(fixed_bar(), || island(80.0, 20.0));
+    app.configure(surface, 200, 50, 1.0);
+    app.step();
+
+    surface_handle(surface).set_input_region(Some(vec![PILL]));
+    app.step();
+
+    assert!(
+        app.input_reaches(surface, 130.0, 15.0),
+        "the rectangle the handle named"
+    );
+    assert!(
+        app.input_reaches(surface, 40.0, 10.0),
+        "and the island the tree declared, on top of it"
+    );
+    assert!(
+        !app.input_reaches(surface, 40.0, 45.0),
+        "and nothing else, where the bar used to take everything"
+    );
+}
+
+/// A declaration inside a declaration is a smaller area declared later, which
+/// is the whole of the nesting rule: an island inside a hole takes input, the
+/// hole around it does not, and the bar around that still does.
+#[test]
+fn a_declaration_inside_a_hole_is_an_island_in_it() {
+    let Some(mut app) = headless() else { return };
+    let surface = app.surface(fixed_bar(), || {
+        container().width(fill()).height(fill()).child(
+            container()
+                .width(80.0)
+                .height(40.0)
+                .takes_input(false)
+                .child(container().width(20.0).height(10.0).takes_input(true)),
+        )
+    });
+    app.configure(surface, 200, 50, 1.0);
+    app.step();
+
+    assert!(app.input_reaches(surface, 10.0, 5.0), "the island");
+    assert!(
+        !app.input_reaches(surface, 60.0, 30.0),
+        "the hole around it"
+    );
+    assert!(
+        app.input_reaches(surface, 150.0, 40.0),
+        "the bar around that"
+    );
+}

--- a/tests/render_snapshots.rs
+++ b/tests/render_snapshots.rs
@@ -169,6 +169,21 @@ fn dump_command(cmd: &DrawCommand, depth: usize, kind: &str, out: &mut String) {
                 n(*curvature),
             ));
         }
+        DrawCommand::InputRegion {
+            rect: r,
+            corner_radii,
+            takes,
+        } => {
+            out.push_str(&format!(
+                "{pad}{kind} input-region {} takes={} corners={}/{}/{}/{}\n",
+                rect(r),
+                takes,
+                n(corner_radii.top_left),
+                n(corner_radii.top_right),
+                n(corner_radii.bottom_right),
+                n(corner_radii.bottom_left),
+            ));
+        }
         DrawCommand::RoundedRect {
             rect: r,
             color: c,

--- a/tests/render_snapshots.rs
+++ b/tests/render_snapshots.rs
@@ -681,3 +681,32 @@ fn baseline_alignment_lines_text_up() {
 
     assert_snapshot("baseline_alignment", render(view, 400.0, 160.0));
 }
+
+/// Where a declaration about input sits in the frame, which is the part the
+/// region's composition depends on: before the container's own background, and
+/// before the children whose declarations refine it.
+#[test]
+fn an_input_declaration_is_carried_in_paint_order() {
+    let view = container()
+        .padding(8.0)
+        .layout(Flex::column().spacing(8.0))
+        .child(
+            container()
+                .width(120.0)
+                .height(40.0)
+                .corners(20.0)
+                .background(Color::rgb(0.2, 0.2, 0.3))
+                .takes_input(true)
+                .child(swatch(20.0, 20.0, Color::CYAN)),
+        )
+        .child(
+            container()
+                .width(120.0)
+                .height(40.0)
+                .background(Color::rgb(0.3, 0.2, 0.2))
+                .takes_input(false)
+                .child(swatch(20.0, 20.0, Color::MAGENTA).takes_input(true)),
+        );
+
+    assert_snapshot("input_regions", render(view, 200.0, 140.0));
+}

--- a/tests/snapshots/input_regions.snap
+++ b/tests/snapshots/input_regions.snap
@@ -1,0 +1,12 @@
+node 0,0 136x104
+  node 0,0 120x40 at 8,8
+    draw input-region 0,0 120x40 takes=true corners=20/20/20/20
+    draw rect 0,0 120x40 fill=#33334dff radius=20/20/20/20
+    node 0,0 20x20
+      draw rect 0,0 20x20 fill=#00ffffff radius=0/0/0/0
+  node 0,0 120x40 at 8,56
+    draw input-region 0,0 120x40 takes=false corners=0/0/0/0
+    draw rect 0,0 120x40 fill=#4d3333ff radius=0/0/0/0
+    node 0,0 20x20
+      draw input-region 0,0 20x20 takes=true corners=0/0/0/0
+      draw rect 0,0 20x20 fill=#ff00ffff radius=0/0/0/0


### PR DESCRIPTION
## What changed

A surface's input region is declared on the widget tree and derived from the
frame, the way the compositor blur region already was. `Container::takes_input`
says whether pointer and touch reach a container's area; the region is read off
the flattened commands, so it follows the shape on screen — corners, transform,
clip — and disappears when the container stops painting. Closes #360.

Before, the documented way to keep a region on a widget was an effect over a
`WidgetRef`, and that rectangle is where the widget was laid out rather than
where it draws: a capsule that scales as it expands handed the compositor the
wrong shape. The example and the book chapter now teach the declaration, and
`examples/input_region.rs` lost the effect, the handle call and the `WidgetRef`
it existed to measure.

Four commits: the recorder learning to keep what a surface asks for, the
tessellation moving out of `blur` into a `region` module both halves share, the
carrier command that travels with a frame and draws nothing, and the
declaration itself.

## What proves it

`tests/headless_app.rs`, against the recorder, seven scenarios: an island in a
click-through surface, a hole in a bar, a *transformed* island (which fails by
construction on the old spelling, since a `WidgetRef` reports the laid-out box),
an island that stops painting, a declaration nested inside a hole, the escape
hatch at birth, and a handle-set region composing with a declaration rather than
being erased by it.

Two beside the container in `characterization.rs` — corners followed rather than
a bounding box, and a clip cutting a declaration to what is on show — and a new
render-tree snapshot, `input_regions.snap`, which pins where the carrier sits in
paint order: before the container's own background, and before the children
whose declarations refine it.

The publish-discipline test was rewritten after the review: the first version
stepped frames that never painted, so it never reached the guard and passed with
it deleted. It now repaints twice for another reason and watches the count stand
still. Confirmed by deleting the guard: three publishes instead of one.

`Platform::set_input_region` was an empty default and the recorder took it, so
before this branch no test in the tree could say a region had ever reached the
compositor.

## What the review found

**Two blocking, both answered.**

The first was the test above, which could not fail for the reason it claimed.

The second was that I had replaced the propagation this issue agreed on with
geometric containment, and recorded it only in the rustdoc. That decision is the
maintainer's, so I stopped and asked: containment stands, without the diagnostic
I had offered, because a declaration every descendant inherits is a shape per
painting widget on every frame the region moves. It is written up in the
`takes_input` rustdoc with the escaping-child case as a compiled sample, in the
Wayland chapter, and as a comment on #360 beside the bullet it changes.

Worth answering, acted on: the harness predicate answered "input reaches here"
for a click-through surface whose tree had declared nothing, because it read
only the derived path; the nesting rule had no test; and no render-tree scenario
exercised the new command.

Worth answering, not acted on, with reasons: the issue said one rounding rule
and that it would be outward, and outward is what the surface's own declared
rectangles take. The tessellated shapes keep round-to-nearest, because their
slabs have to tile — rounding each slab outward grows the shape it is
approximating, which is the opposite of what the tessellation is for.

Notes for later rather than now: the paint-cache replay path re-pushes the
carrier and nothing watches that; "culled" and "scrolled out of view" share
`clipped_world_rounded_rect` with blur, so they are thin rather than absent; and
`set_surface_input_region`, now reachable only for surfaces whose tree never
declares, still commits on every call.

`/simplify` ran before all of this and applied a dozen findings, the structural
ones being `RegionRect` gaining the containment and rounding both halves had
written out by hand, the tessellation's tests following it into `region`, the
carrier no longer splitting draw groups for something that draws nothing, and
the base of the region gaining one home instead of one per writer.

## What was checked by hand

**Nothing, and this is the row the contract says needs it.** `src/platform/`
gained `sync_input_region`, and the recorder proves what guido asks for, not
what a compositor does with it. `cargo run --example input_region` is the
declaration form and wants a person: the pill takes clicks, everything around it
passes through. The hole polarity has no example at all, and it is the half
where a wrong add/subtract order is invisible here, because the recorder reads
the program rather than sending it.

## Left undone

An example for the hole polarity, and a manual round for both. Not opened as an
issue: it is the standing gap in the last row of the contract's table, which
#209 already tracks, rather than something this change created.
