### PR TITLE
A text's declared values pass the door, and a bad override falls through

### DIFF
--- a/docs/STATE_LAYER.md
+++ b/docs/STATE_LAYER.md
@@ -180,6 +180,8 @@ container()
 
 A layer that says nothing about a property is passed over rather than ending the search, so a pressed layer that only scales still lets the hover's background through.
 
+So is a layer whose value is not a number. A property computed from a division that met a zero for one frame is passed over exactly as a layer that says nothing about it is, and what it falls through to is the value underneath: the next layer that has one, or the base. The base is resolved the same way, so whatever comes out of the walk is a number whatever the application computed. The same holds for a text's overrides — `when_hovered(|s| s.font_size(..))` on a label falls through to the `font_size` the label declares, not to the default.
+
 Note that a layer *replaces* the base value rather than ranking against it. A property that already carries a meaning of its own belongs in a layer with a condition, not in the base.
 
 ## State Style Methods

--- a/src/finite.rs
+++ b/src/finite.rs
@@ -74,6 +74,40 @@ impl<T: AllFinite + Clone + 'static> FiniteOr<T> for Option<Signal<T>> {
     }
 }
 
+/// The nearest state override that is a number, or `base` where none of them
+/// is.
+///
+/// [`FiniteOr`] answers for a property declared once. A property with state
+/// overrides is declared more than once — the override, and the declaration it
+/// supplies a value for — and then reading a bad override as if nothing had been
+/// declared is the wrong answer: what it falls through to is the declaration
+/// underneath it.
+///
+/// `base` is that declaration, already resolved through [`FiniteOr`], so it is
+/// finite and a bad one has already been reported. These are the same two steps
+/// in the same order as a container's resolution, and they carry the same rule:
+/// an override that is not a number is passed over exactly as one that says
+/// nothing about this property is, and passed over *silently*, because the
+/// diagnostic belongs to the declaration the widget is left following.
+///
+/// Nearest override first, stopping at the first that is a number. The ones
+/// beyond it are left unread on purpose and nothing is lost by it: only an
+/// override nearer than the winner can change the answer, and every one of those
+/// was read on the way in, so a frame where one of them stops being NaN is a
+/// frame this widget is woken for.
+pub(crate) fn first_finite_override<T: AllFinite + Clone + 'static>(
+    overrides: &[Signal<T>],
+    base: T,
+) -> T {
+    for signal in overrides {
+        let value = signal.get();
+        if value.all_finite() {
+            return value;
+        }
+    }
+    base
+}
+
 /// Every type a `Container` property is declared with, answered from the
 /// numbers it is made of.
 ///

--- a/src/widgets/text.rs
+++ b/src/widgets/text.rs
@@ -10,7 +10,7 @@ use super::container::get_animated_value;
 use super::control::Control;
 use super::font::{FontFamily, FontWeight};
 use super::state_layer::{StateWhen, Stateful};
-use super::text_style::{TextAnims, TextShadow, TextStroke, TextStyle};
+use super::text_style::{DEFAULT_FONT_SIZE, TextAnims, TextShadow, TextStroke, TextStyle};
 use super::widget::{Color, Event, EventResponse, Rect, Widget};
 
 /// How far a stroke and a shadow reach past the glyphs they decorate.
@@ -81,7 +81,7 @@ impl Text {
             backdrop_blur: None,
             anims: None,
             cached_text: String::new(), // Will be set during first layout
-            cached_font_size: 14.0,
+            cached_font_size: DEFAULT_FONT_SIZE,
             cached_font_family: default_family,
             cached_font_weight: FontWeight::NORMAL,
             cached_wrap: true,
@@ -201,14 +201,12 @@ impl Text {
         let overflow = with_signal_tracking(id, JobType::Layout, || {
             let style = self.resolved_style(tree, id);
             self.cached_text = self.content.get();
-            self.cached_font_size = style.font_size.get_or(14.0);
+            self.cached_font_size = style.resolved_font_size(id);
             // Only where a colour motion was declared. Reading it here
             // subscribes this text's *layout* to the colour, and a text that
             // merely paints one has no reason to re-measure when it changes —
             // paint reads it under its own scope, as it always did.
-            declared_color = self
-                .animates_text_color()
-                .then(|| style.color.get_or(Color::WHITE));
+            declared_color = self.animates_text_color().then(|| style.resolved_color(id));
             self.cached_font_family = style.font_family.get_or_else(default_font_family);
             self.cached_font_weight = style.font_weight.get_or(FontWeight::NORMAL);
             self.cached_wrap = self.wrap.get_or(true);
@@ -362,7 +360,7 @@ impl Widget for Text {
             let style = self.resolved_style(tree, id);
             (
                 get_animated_value(self.anims.as_ref().and_then(|a| a.color.as_ref()), || {
-                    style.color.get_or(Color::WHITE)
+                    style.resolved_color(id)
                 }),
                 style.stroke.map(|s| s.get()),
                 style.shadow.map(|s| s.get()),
@@ -417,7 +415,7 @@ pub fn text<M>(content: impl IntoSignal<String, M>) -> Text {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::animation::Animate;
+    use crate::animation::{Animatable, Animate};
     use crate::jobs;
     use crate::layout::Constraints;
     use crate::reactive::create_signal;
@@ -1120,6 +1118,180 @@ mod tests {
         assert!(
             commands(text("hi").text_shadow(visible)).len() > 1,
             "and a shadow that can be seen still draws"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // A signal that stops being a number
+    // -----------------------------------------------------------------------
+
+    /// A text through the frames a recovery claim needs: a bad number, then a
+    /// finite one, then long enough for any transition to have arrived.
+    ///
+    /// The pair is handed back rather than asserted on, so each property reads
+    /// its own half, and it is an `Option` because a text measured at NaN has no
+    /// bounds to paint into — the glyphs do not merely come out the wrong size,
+    /// they are gone.
+    fn after_a_bad_number(
+        widget: impl Widget + 'static,
+        poison: impl FnOnce(),
+        recover: impl FnOnce(),
+    ) -> Option<(Color, f32)> {
+        let ms = std::time::Duration::from_millis;
+        let mut tree = Tree::new();
+        let root = tree.register(Box::new(container().child(widget)));
+        tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
+
+        let t0 = std::time::Instant::now();
+        all_text(&mut tree, root, t0);
+
+        poison();
+        // Two frames, so a bad number is not merely the target but through
+        // `lerp` into the displayed value — which `begin_segment` then keeps as
+        // the start of every segment after it.
+        all_text(&mut tree, root, t0 + ms(1));
+        all_text(&mut tree, root, t0 + ms(50));
+
+        recover();
+        all_text(&mut tree, root, t0 + ms(100));
+        all_text(&mut tree, root, t0 + ms(1000)).first().copied()
+    }
+
+    /// The size a text draws with is the one its signal asks for, even after the
+    /// signal has spent a frame not being a number.
+    #[test]
+    fn a_font_size_follows_its_signal_again_once_the_signal_recovers() {
+        let size = create_signal(10.0f32);
+        let painted = after_a_bad_number(
+            Text::new("x").font_size((move || size.get()).transition(200.0)),
+            || size.set(f32::NAN),
+            || size.set(30.0),
+        )
+        .map(|(_, size)| size);
+
+        assert!(
+            painted.is_some_and(|size| (size - 30.0).abs() < 0.5),
+            "a size given one bad number never followed its signal again: the \
+             glyphs are drawn at {painted:?} rather than 30"
+        );
+    }
+
+    /// The size's neighbour, and the same defect in the same place.
+    ///
+    /// `TextAnims` holds exactly two motions, and both are pointed at a value
+    /// read out of the same resolved style — so a door on one of them is not the
+    /// rule the door exists to state.
+    #[test]
+    fn a_text_colour_follows_its_signal_again_once_the_signal_recovers() {
+        let hue = create_signal(Color::rgb(0.0, 0.0, 0.0));
+        let painted = after_a_bad_number(
+            Text::new("x").color((move || hue.get()).transition(200.0)),
+            || hue.set(Color::rgba(f32::NAN, 0.0, 0.0, 1.0)),
+            // Red, and not white: white is what the door hands out for a colour
+            // nobody declared, so recovering to it would pass whether the signal
+            // was followed or merely fallen back on.
+            || hue.set(Color::rgb(1.0, 0.0, 0.0)),
+        )
+        .map(|(color, _)| color);
+
+        assert!(
+            painted.is_some_and(|color| color.r > 0.99 && color.g < 0.01),
+            "a colour given one bad number never followed its signal again: \
+             got {painted:?}"
+        );
+    }
+
+    /// A colour with no motion is resolved at paint and nowhere else, so that
+    /// read is a second way past the door.
+    ///
+    /// Nothing downstream of it guards — the channels reach the shader as they
+    /// are — and the tests above cannot see it: each declares a transition, which
+    /// takes the animated branch of `get_animated_value` and leaves the closure
+    /// beside it unwatched.
+    #[test]
+    fn a_colour_with_no_motion_is_painted_through_the_door_too() {
+        let hue = create_signal(Color::rgba(f32::NAN, 0.0, 0.0, 1.0));
+        let mut tree = Tree::new();
+        let root = tree.register(Box::new(Text::new("x").color(hue)));
+        tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
+
+        let (painted, _) = frame(&mut tree, root);
+        assert!(
+            painted.channels().iter().all(|c| c.is_finite()),
+            "a colour nobody can compute reached the shader: {painted:?}"
+        );
+    }
+
+    /// Both animated text properties go through the door, not the one somebody
+    /// remembered.
+    ///
+    /// Asked of the resolver rather than of a symptom further down, for the
+    /// reason the container's enumeration gives: a symptom test passes for the
+    /// wrong reason all the time — the measurer already refuses a size it
+    /// cannot shape — and what the door promises is about the value it hands
+    /// out.
+    ///
+    /// *Animated*, and not every declared one, is the whole of what is claimed:
+    /// `TextStyle`'s stroke and shadow are numbers too and are read raw. They
+    /// are the category this issue's scope note put gradients and ripple colour
+    /// in — no `AnimationState` stands behind either, so a bad number is gone
+    /// from them the frame the signal recovers, and nothing keeps it.
+    #[test]
+    fn every_animated_text_property_is_resolved_to_a_finite_value() {
+        let nan = f32::NAN;
+        let style = TextStyle::default()
+            .font_size(nan)
+            .color(Color::rgba(nan, 0.0, 0.0, 1.0));
+
+        // Any id: neither resolver consults the tree, and the diagnostic only
+        // prints the number.
+        let id = WidgetId::from_u64(1);
+
+        assert!(
+            style.resolved_font_size(id).is_finite(),
+            "font_size resolved to a value that is not finite"
+        );
+        assert!(
+            style
+                .resolved_color(id)
+                .channels()
+                .iter()
+                .all(|c| c.is_finite()),
+            "color resolved to a value that is not finite"
+        );
+    }
+
+    /// And it says so, once.
+    ///
+    /// A property that quietly stops following its signal is the silence as much
+    /// as the value, so the diagnostic is the third thing the fix owes. Once per
+    /// property rather than once per frame, which is the dedupe in
+    /// `diagnostics::non_finite`.
+    ///
+    /// The signal is written every frame, and that is what makes this test about
+    /// the dedupe: `Text::layout` early-outs when nothing has dirtied it, so a
+    /// loop that only paints resolves the size once and would pass with the
+    /// dedupe deleted. NaN is equal to nothing including itself, so writing the
+    /// same bad number again is always a change.
+    #[cfg(debug_assertions)]
+    #[test]
+    fn a_font_size_that_is_not_a_number_is_reported_once() {
+        use crate::reactive::diagnostics::report_count;
+
+        let size = create_signal(f32::NAN);
+        let mut tree = Tree::new();
+        let root = tree.register(Box::new(Text::new("x").font_size(move || size.get())));
+        tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
+
+        let before = report_count();
+        for _ in 0..5 {
+            size.set(f32::NAN);
+            frame(&mut tree, root);
+        }
+        assert_eq!(
+            report_count() - before,
+            1,
+            "five resolutions, and it should have said so once"
         );
     }
 }

--- a/src/widgets/text.rs
+++ b/src/widgets/text.rs
@@ -34,8 +34,12 @@ pub(crate) fn decoration_overflow(stroke: Option<TextStroke>, shadow: Option<Tex
 ///
 /// ```ignore
 /// text("Hello").font_size(21.0).color(theme.text)
-/// container().font_size(21.0).child(text("Hello"))   // same, for a group
 /// ```
+///
+/// There is no enclosing declaration to inherit from: a container draws a box
+/// and says nothing about what is written inside it. A style shared by several
+/// labels is a function that returns one — see
+/// [`text_style`](crate::widgets::text_style).
 pub struct Text {
     content: Signal<String>,
     /// What this text declares about itself. Boxed and absent by default: a
@@ -145,30 +149,6 @@ impl Text {
         self
     }
 
-    /// This text's own declaration, with whatever an active state overrides
-    /// folded over it, nearest first.
-    ///
-    /// Called inside the caller's tracking scope, like the fold it wraps: the
-    /// signals come back unread, and reading them is what subscribes.
-    fn resolved_style(&self, tree: &Tree, id: WidgetId) -> TextStyle {
-        let mut style = TextStyle::default();
-        // Active overrides first, last declared first, so they outrank the
-        // text's own declaration — and `inherit_from` takes only what is still
-        // missing, which is what makes the whole chain resolve per property.
-        if !self.states.is_empty() {
-            let control = tree.nearest_control(id);
-            for (when, override_) in self.states.iter().rev() {
-                if self.is_state_active(id, control.as_ref(), when) {
-                    style.inherit_from(override_);
-                }
-            }
-        }
-        if let Some(own) = self.style.as_deref() {
-            style.inherit_from(own);
-        }
-        style
-    }
-
     /// Whether an override applies. Reading the answer is what subscribes the
     /// text to the control, so it is asked only for a state it declares.
     fn is_state_active(&self, id: WidgetId, control: Option<&Control>, when: &StateWhen) -> bool {
@@ -199,18 +179,18 @@ impl Text {
     fn refresh(&mut self, tree: &Tree, id: WidgetId) -> (f32, Option<Color>) {
         let mut declared_color = None;
         let overflow = with_signal_tracking(id, JobType::Layout, || {
-            let style = self.resolved_style(tree, id);
+            let style = self.resolved_text_style(tree, id);
             self.cached_text = self.content.get();
-            self.cached_font_size = style.resolved_font_size(id);
+            self.cached_font_size = style.font_size(id);
             // Only where a colour motion was declared. Reading it here
             // subscribes this text's *layout* to the colour, and a text that
             // merely paints one has no reason to re-measure when it changes —
             // paint reads it under its own scope, as it always did.
-            declared_color = self.animates_text_color().then(|| style.resolved_color(id));
-            self.cached_font_family = style.font_family.get_or_else(default_font_family);
-            self.cached_font_weight = style.font_weight.get_or(FontWeight::NORMAL);
+            declared_color = self.animates_text_color().then(|| style.color(id));
+            self.cached_font_family = style.font_family();
+            self.cached_font_weight = style.font_weight();
             self.cached_wrap = self.wrap.get_or(true);
-            decoration_overflow(style.stroke.map(|s| s.get()), style.shadow.map(|s| s.get()))
+            decoration_overflow(style.stroke(), style.shadow())
         });
         (overflow, declared_color)
     }
@@ -357,13 +337,13 @@ impl Widget for Text {
         // Read the painted properties with tracking so a change on whichever
         // ancestor supplied them repaints this text and nothing else.
         let (color, stroke, shadow, blur) = with_signal_tracking(id, JobType::Paint, || {
-            let style = self.resolved_style(tree, id);
+            let style = self.resolved_text_style(tree, id);
             (
                 get_animated_value(self.anims.as_ref().and_then(|a| a.color.as_ref()), || {
-                    style.resolved_color(id)
+                    style.color(id)
                 }),
-                style.stroke.map(|s| s.get()),
-                style.shadow.map(|s| s.get()),
+                style.stroke(),
+                style.shadow(),
                 self.backdrop_blur.map(|radius| radius.get()),
             )
         });
@@ -404,9 +384,9 @@ impl Widget for Text {
 /// text(my_signal)  // reactive signal
 /// ```
 ///
-/// Styling lives on an enclosing container:
+/// Styling is declared here, on the widget that draws the glyphs:
 /// ```ignore
-/// container().font_size(18.0).bold().child(text("Hello"))
+/// text("Hello").font_size(18.0).bold()
 /// ```
 pub fn text<M>(content: impl IntoSignal<String, M>) -> Text {
     Text::new(content)
@@ -833,6 +813,119 @@ mod tests {
         );
     }
 
+    /// An override nobody can compute is passed over, and the declaration it
+    /// displaced is what the text uses.
+    ///
+    /// `Container` answers the same question this way, at `resolve_state_value`:
+    /// a layer whose value is not finite is passed over exactly as one that says
+    /// nothing about the property is. What makes it possible here is that the
+    /// walk keeps a chain — a fold that picked a winner and put the door on
+    /// whatever it picked would have dropped this text's own 32 before the bad
+    /// override was ever looked at, and landed on 14.
+    #[test]
+    fn an_override_that_is_not_a_number_falls_through_to_the_declaration() {
+        let hot = create_signal(true);
+        let mut tree = Tree::new();
+        let root = tree.register(Box::new(
+            Text::new("x")
+                .font_size(32.0)
+                .color(Color::RED)
+                .state(hot, |s: TextStyle| {
+                    s.font_size(f32::NAN)
+                        .color(Color::rgba(f32::NAN, 0.0, 0.0, 1.0))
+                }),
+        ));
+        tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
+
+        #[cfg(debug_assertions)]
+        let before = crate::reactive::diagnostics::report_count();
+        let (color, size) = frame(&mut tree, root);
+        assert!(
+            (size - 32.0).abs() < 0.01,
+            "a bad override falls through to the size the text declares, not to \
+             the default: got {size}"
+        );
+        assert_eq!(color, Color::RED, "and to the colour it declares");
+
+        // And says nothing about it, as a container passes a layer over in
+        // silence: what the text is left following is exactly what it declared,
+        // so there is nothing to tell anybody. The diagnostic belongs to a
+        // declaration that is itself wrong — see
+        // `a_bad_declaration_is_reported_even_under_a_good_override`.
+        #[cfg(debug_assertions)]
+        assert_eq!(
+            crate::reactive::diagnostics::report_count() - before,
+            0,
+            "a passed-over override must not be reported"
+        );
+    }
+
+    /// A declaration the application got wrong is reported even when an override
+    /// is covering it.
+    ///
+    /// This is why the base is resolved apart from the overrides rather than as
+    /// the last link of one chain. An override that is not a number is passed over
+    /// in silence, because the value the widget is left following is fine — but
+    /// when the *declaration* is the broken one, silence loses the only message
+    /// this has to give. A state active from the first frame would bury it for the
+    /// life of the process, since the report dedupes per widget and property.
+    #[cfg(debug_assertions)]
+    #[test]
+    fn a_bad_declaration_is_reported_even_under_a_good_override() {
+        use crate::reactive::diagnostics::report_count;
+
+        let hot = create_signal(true);
+        let mut tree = Tree::new();
+        let root = tree.register(Box::new(
+            Text::new("x")
+                .font_size(f32::NAN)
+                .state(hot, |s: TextStyle| s.font_size(20.0)),
+        ));
+        tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
+
+        let before = report_count();
+        let (_, size) = frame(&mut tree, root);
+        assert!(
+            (size - 20.0).abs() < 0.01,
+            "the override is what the text draws with, got {size}"
+        );
+        assert_eq!(
+            report_count() - before,
+            1,
+            "and the declaration underneath it was still wrong"
+        );
+    }
+
+    /// An override's colour must not wake a layout, for the same reason a plain
+    /// one must not.
+    ///
+    /// This is the test that decides where a declaration is *read* — see
+    /// `ResolvedTextStyle`, which is where the reasoning lives. It fails against
+    /// the shorter fix, the one that tests each candidate as it walks.
+    #[test]
+    fn an_override_colour_wakes_no_layout_either() {
+        let hot = create_signal(true);
+        let hue = create_signal(Color::RED);
+        let mut tree = Tree::new();
+        let root = tree.register(Box::new(
+            Text::new("x").state(hot, move |s: TextStyle| s.color(hue)),
+        ));
+        tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
+        frame(&mut tree, root);
+        jobs::clear_pending_jobs();
+
+        hue.set(Color::BLUE);
+        let woken = jobs::queued_job_types(root);
+        assert!(
+            !woken.contains(&JobType::Layout),
+            "an override's colour must not re-measure the text: {woken:?}"
+        );
+        assert!(
+            woken.contains(&JobType::Paint),
+            "and it does have to repaint it: {woken:?}"
+        );
+    }
+
     /// Every override setter, not just the one an earlier test happened to
     /// reach.
     ///
@@ -1239,24 +1332,22 @@ mod tests {
     #[test]
     fn every_animated_text_property_is_resolved_to_a_finite_value() {
         let nan = f32::NAN;
-        let style = TextStyle::default()
+        let declared = TextStyle::default()
             .font_size(nan)
             .color(Color::rgba(nan, 0.0, 0.0, 1.0));
+        let mut style = crate::widgets::text_style::ResolvedTextStyle::default();
+        style.push_own(&declared);
 
-        // Any id: neither resolver consults the tree, and the diagnostic only
+        // Any id: the resolvers do not consult the tree, and the diagnostic only
         // prints the number.
         let id = WidgetId::from_u64(1);
 
         assert!(
-            style.resolved_font_size(id).is_finite(),
+            style.font_size(id).is_finite(),
             "font_size resolved to a value that is not finite"
         );
         assert!(
-            style
-                .resolved_color(id)
-                .channels()
-                .iter()
-                .all(|c| c.is_finite()),
+            style.color(id).channels().iter().all(|c| c.is_finite()),
             "color resolved to a value that is not finite"
         );
     }

--- a/src/widgets/text_input.rs
+++ b/src/widgets/text_input.rs
@@ -367,27 +367,6 @@ impl TextInput {
         }
     }
 
-    /// This input's own declarations, completed by the ancestors' for whatever
-    /// they leave out. Each walk is skipped when nothing is left to find.
-    fn resolved_text_style(&self, tree: &Tree, id: WidgetId) -> TextStyle {
-        let mut style = TextStyle::default();
-        // Active overrides first and last declared first, so they outrank this
-        // field's own declaration; `inherit_from` takes only what is missing,
-        // which resolves the chain per property.
-        if !self.states.is_empty() {
-            let control = tree.nearest_control(id);
-            for (when, override_) in self.states.iter().rev() {
-                if self.is_state_active(id, control.as_ref(), when) {
-                    style.inherit_from(override_);
-                }
-            }
-        }
-        if let Some(own) = self.text_style.as_deref() {
-            style.inherit_from(own);
-        }
-        style
-    }
-
     /// Give up the hover, and the cursor icon that goes with it.
     ///
     /// Two events mean the same thing — the pointer moved out of the bounds, or
@@ -683,14 +662,11 @@ impl TextInput {
 
                 (
                     self.value.get(),
-                    style.resolved_font_size(id),
-                    style.font_family.get_or_else(default_font_family),
-                    style.font_weight.get_or(FontWeight::NORMAL),
-                    crate::widgets::text::decoration_overflow(
-                        style.stroke.map(|s| s.get()),
-                        style.shadow.map(|s| s.get()),
-                    ),
-                    self.animates_text_color().then(|| style.resolved_color(id)),
+                    style.font_size(id),
+                    style.font_family(),
+                    style.font_weight(),
+                    crate::widgets::text::decoration_overflow(style.stroke(), style.shadow()),
+                    self.animates_text_color().then(|| style.color(id)),
                 )
             });
 
@@ -1390,7 +1366,7 @@ impl Widget for TextInput {
                 let input = self.resolved_input_style();
                 let text_color = crate::widgets::container::get_animated_value(
                     self.text_anims.as_ref().and_then(|a| a.color.as_ref()),
-                    || style.resolved_color(id),
+                    || style.color(id),
                 );
                 // Only when there is nothing to show instead. Read inside the
                 // tracking scope like every other paint input, so a prompt that
@@ -1415,8 +1391,8 @@ impl Widget for TextInput {
                     // The caret defaults to the text colour: an input that
                     // only sets `text_color` should not sprout a blue cursor.
                     input.cursor_color.get_or(text_color),
-                    style.stroke.map(|s| s.get()),
-                    style.shadow.map(|s| s.get()),
+                    style.stroke(),
+                    style.shadow(),
                     placeholder,
                 )
             });
@@ -2013,6 +1989,32 @@ mod tests {
             "a field given one bad colour never followed its signal again: \
              got {painted:?}"
         );
+    }
+
+    /// The field walks its own chain, so the fall-through is its own to get
+    /// right — see `an_override_that_is_not_a_number_falls_through_to_the_declaration`
+    /// for the rule and why a fold could not state it.
+    #[test]
+    fn an_override_that_is_not_a_number_falls_through_to_the_fields_declaration() {
+        let hot = create_signal(true);
+        let (mut tree, root, _id) = field_in_container(
+            text_input(create_signal("abc".to_owned()))
+                .font_size(32.0)
+                .color(Color::RED)
+                .state(hot, |s: TextStyle| {
+                    s.font_size(f32::NAN)
+                        .color(Color::rgba(f32::NAN, 0.0, 0.0, 1.0))
+                }),
+        );
+
+        let (color, size) = drawn_text(&mut tree, root, std::time::Instant::now())
+            .expect("the field draws its text");
+        assert!(
+            (size - 32.0).abs() < 0.01,
+            "a bad override falls through to the size the field declares, not to \
+             the default: got {size}"
+        );
+        assert_eq!(color, Color::RED, "and to the colour it declares");
     }
 
     /// A field switched to masked refuses the very next copy, not the one after.

--- a/src/widgets/text_input.rs
+++ b/src/widgets/text_input.rs
@@ -28,7 +28,7 @@ use crate::widget_ref::{WidgetRef, register_widget_ref};
 use super::control::Control;
 use super::font::{FontFamily, FontWeight};
 use super::state_layer::{StateWhen, Stateful};
-use super::text_style::TextStyle;
+use super::text_style::{DEFAULT_FONT_SIZE, TextStyle};
 use super::widget::{Color, Event, EventResponse, Key, MouseButton, Rect, Widget};
 
 /// The caret, selection band and placeholder colours a field declares for
@@ -337,7 +337,7 @@ impl TextInput {
             cached_text_width: 0.0,
             cached_glyph_positions: Vec::new(),
             measurements_dirty: true,
-            cached_font_size: 14.0,
+            cached_font_size: DEFAULT_FONT_SIZE,
             cached_font_family: default_family,
             cached_font_weight: FontWeight::NORMAL,
             password: None,
@@ -683,15 +683,14 @@ impl TextInput {
 
                 (
                     self.value.get(),
-                    style.font_size.get_or(14.0),
+                    style.resolved_font_size(id),
                     style.font_family.get_or_else(default_font_family),
                     style.font_weight.get_or(FontWeight::NORMAL),
                     crate::widgets::text::decoration_overflow(
                         style.stroke.map(|s| s.get()),
                         style.shadow.map(|s| s.get()),
                     ),
-                    self.animates_text_color()
-                        .then(|| style.color.get_or(Color::WHITE)),
+                    self.animates_text_color().then(|| style.resolved_color(id)),
                 )
             });
 
@@ -1391,7 +1390,7 @@ impl Widget for TextInput {
                 let input = self.resolved_input_style();
                 let text_color = crate::widgets::container::get_animated_value(
                     self.text_anims.as_ref().and_then(|a| a.color.as_ref()),
-                    || style.color.get_or(Color::WHITE),
+                    || style.resolved_color(id),
                 );
                 // Only when there is nothing to show instead. Read inside the
                 // tracking scope like every other paint input, so a prompt that
@@ -1778,6 +1777,31 @@ mod tests {
         });
     }
 
+    /// The colour and size the field drew its glyphs at, on a frame at a named
+    /// instant.
+    ///
+    /// Named because an eased value is a function of how long it has been
+    /// running, and a test that let the clock decide would assert on whatever
+    /// the machine managed between two calls.
+    fn drawn_text(tree: &mut Tree, id: WidgetId, at: std::time::Instant) -> Option<(Color, f32)> {
+        fn find(node: &crate::renderer::RenderNode) -> Option<(Color, f32)> {
+            for cmd in &node.commands {
+                if let crate::renderer::DrawCommand::Text {
+                    color, font_size, ..
+                } = &**cmd
+                {
+                    return Some((*color, *font_size));
+                }
+            }
+            node.children.iter().find_map(|child| find(child))
+        }
+        tree.set_frame_instant(Some(at));
+        relayout(tree, id);
+        let node = paint_once(tree, id);
+        tree.set_frame_instant(None);
+        find(&node)
+    }
+
     /// Every rectangle the field draws. Focused with no selection, the caret is
     /// the only one there can be, and its x is where the displayed text ends.
     fn drawn_rects(tree: &mut Tree, id: WidgetId) -> Vec<crate::widgets::Rect> {
@@ -1888,33 +1912,106 @@ mod tests {
                 .color((move || hue.get()).transition(400.0)),
         );
 
-        fn drawn(tree: &mut Tree, id: WidgetId, at: std::time::Instant) -> Option<Color> {
-            tree.set_frame_instant(Some(at));
-            relayout(tree, id);
-            let node = paint_once(tree, id);
-            tree.set_frame_instant(None);
-            fn walk(node: &crate::renderer::RenderNode) -> Option<Color> {
-                for cmd in &node.commands {
-                    if let crate::renderer::DrawCommand::Text { color, .. } = &**cmd {
-                        return Some(*color);
-                    }
-                }
-                node.children.iter().find_map(|c| walk(c))
-            }
-            walk(&node)
-        }
-
         let t0 = std::time::Instant::now();
-        drawn(&mut tree, root, t0);
+        drawn_text(&mut tree, root, t0);
 
         hue.set(Color::rgb(1.0, 1.0, 1.0));
-        drawn(&mut tree, root, t0 + std::time::Duration::from_millis(1));
-        let midway = drawn(&mut tree, root, t0 + std::time::Duration::from_millis(100))
+        drawn_text(&mut tree, root, t0 + std::time::Duration::from_millis(1));
+        let (midway, _) = drawn_text(&mut tree, root, t0 + std::time::Duration::from_millis(100))
             .expect("the field draws its text");
 
         assert!(
             midway.r > 0.01 && midway.r < 0.99,
             "an input's declared colour has to ease like a text's, got {midway:?}"
+        );
+    }
+
+    /// A field's own font size is resolved by its own `refresh`, so the door
+    /// `Text` passes through has to be on this path too.
+    ///
+    /// One more way to see the same poisoning: a bad size reaches the glyph
+    /// positions the caret is placed from as well as the measurement, so a field
+    /// that has seen one keeps the size it had and stops following its signal.
+    #[test]
+    fn a_fields_font_size_follows_its_signal_again_once_the_signal_recovers() {
+        use crate::animation::Animate;
+
+        let ms = std::time::Duration::from_millis;
+        let size = create_signal(10.0f32);
+        let (mut tree, root, _id) = field_in_container(
+            text_input(create_signal("abc".to_owned()))
+                .font_size((move || size.get()).transition(200.0)),
+        );
+
+        let t0 = std::time::Instant::now();
+        drawn_text(&mut tree, root, t0);
+
+        size.set(f32::NAN);
+        drawn_text(&mut tree, root, t0 + ms(1));
+        drawn_text(&mut tree, root, t0 + ms(50));
+
+        size.set(30.0);
+        drawn_text(&mut tree, root, t0 + ms(100));
+
+        let painted = drawn_text(&mut tree, root, t0 + ms(1000)).map(|(_, size)| size);
+        assert!(
+            painted.is_some_and(|size| (size - 30.0).abs() < 0.5),
+            "a field given one bad size never followed its signal again: the \
+             glyphs are drawn at {painted:?} rather than 30"
+        );
+    }
+
+    /// A field resolves its colour on two complementary paths, and both are the
+    /// door's.
+    ///
+    /// `refresh` reads it only where a motion was declared, and paint only where
+    /// one was not, so no single scenario reaches both — this is the second.
+    /// Nothing downstream guards: the channels go to the shader as they are.
+    #[test]
+    fn a_fields_colour_with_no_motion_is_painted_through_the_door() {
+        use crate::animation::Animatable;
+
+        let hue = create_signal(Color::rgba(f32::NAN, 0.0, 0.0, 1.0));
+        let (mut tree, root, _id) =
+            field_in_container(text_input(create_signal("abc".to_owned())).color(hue));
+
+        let (painted, _) = drawn_text(&mut tree, root, std::time::Instant::now())
+            .expect("the field draws its text");
+        assert!(
+            painted.channels().iter().all(|c| c.is_finite()),
+            "a colour nobody can compute reached the shader: {painted:?}"
+        );
+    }
+
+    /// And the path `refresh` owns: a colour with a motion, poisoned and then
+    /// finite again.
+    #[test]
+    fn a_fields_colour_follows_its_signal_again_once_the_signal_recovers() {
+        use crate::animation::Animate;
+
+        let ms = std::time::Duration::from_millis;
+        let hue = create_signal(Color::rgb(0.0, 0.0, 0.0));
+        let (mut tree, root, _id) = field_in_container(
+            text_input(create_signal("abc".to_owned()))
+                .color((move || hue.get()).transition(200.0)),
+        );
+
+        let t0 = std::time::Instant::now();
+        drawn_text(&mut tree, root, t0);
+
+        hue.set(Color::rgba(f32::NAN, 0.0, 0.0, 1.0));
+        drawn_text(&mut tree, root, t0 + ms(1));
+        drawn_text(&mut tree, root, t0 + ms(50));
+
+        // Red, not white: white is what a colour nobody declared falls back to.
+        hue.set(Color::rgb(1.0, 0.0, 0.0));
+        drawn_text(&mut tree, root, t0 + ms(100));
+
+        let painted = drawn_text(&mut tree, root, t0 + ms(1000)).map(|(color, _)| color);
+        assert!(
+            painted.is_some_and(|color| color.r > 0.99 && color.g < 0.01),
+            "a field given one bad colour never followed its signal again: \
+             got {painted:?}"
         );
     }
 

--- a/src/widgets/text_style.rs
+++ b/src/widgets/text_style.rs
@@ -18,8 +18,8 @@
 //!
 //! The partiality earns its keep on state overrides, which *are* merged:
 //! `when_hovered(|s| s.color(..))` changes the colour of a hovered label and
-//! leaves its metrics alone. `TextStyle::inherit_from` is what
-//! folds them, nearest declaration first.
+//! leaves its metrics alone. Every property resolves on its own, from the
+//! nearest declaration that says anything about it.
 //!
 //! # The same style, many times
 //!
@@ -45,9 +45,9 @@
 use smallvec::SmallVec;
 
 use crate::clock::FrameInstant;
-use crate::finite::FiniteOr;
+use crate::finite::{FiniteOr, first_finite_override};
 use crate::jobs::RequiredJob;
-use crate::reactive::{IntoSignal, Signal};
+use crate::reactive::{IntoSignal, OptionSignalExt, Signal};
 use crate::tree::WidgetId;
 use crate::widgets::container::AnimationState;
 
@@ -209,7 +209,8 @@ impl TextShadow {
 /// nobody can compute falls back to.
 pub(crate) const DEFAULT_FONT_SIZE: f32 = 14.0;
 
-/// The text style a container declares for its descendants.
+/// What a widget that draws glyphs declares about them, or what one of its state
+/// overrides supplies.
 ///
 /// Every field is optional and resolved independently: a state override that
 /// sets only `color` leaves the metrics the widget declared alone. Properties
@@ -231,37 +232,104 @@ pub struct TextStyle {
     pub shadow: Option<Signal<TextShadow>>,
 }
 
-impl TextStyle {
+/// What a widget's text declarations come to: its own, and the active state
+/// overrides that outrank it.
+///
+/// The two are kept apart rather than folded into a winner, which is what lets an
+/// override nobody can compute fall through to the declaration it displaced —
+/// a fold would have dropped that declaration before the finite check ever ran.
+/// Container resolves its own properties in these two steps, and
+/// [`first_finite_override`] carries the rule they share.
+///
+/// Only the two numeric properties have the distinction. A family and a weight
+/// cannot fail to be numbers, so the nearest declaration is the whole answer for
+/// them. A stroke and a shadow *can* — they are made of numbers — and they keep
+/// the nearest declaration anyway, because no `AllFinite` impl reaches them: that
+/// is a gap rather than a reason, and neither has an animation to poison, so a bad
+/// number is gone from them the frame the signal recovers.
+///
+/// **A value is read when its property is asked for, not while walking.** The
+/// walk runs during layout and again during paint, and a read subscribes whichever
+/// pass it lands in — so testing a candidate while walking would subscribe the
+/// *measurement* to a colour, and a theme change would then reflow every label
+/// that declares a hover colour, since `Text` is not a relayout boundary. Asking
+/// where the property is wanted puts each read in the pass that owns it: the size
+/// while measuring, the colour while painting.
+#[derive(Default)]
+pub(crate) struct ResolvedTextStyle {
+    /// Active overrides, nearest first.
+    color_overrides: SmallVec<[Signal<Color>; 3]>,
+    font_size_overrides: SmallVec<[Signal<f32>; 3]>,
+    /// The widget's own declaration, which every override falls through to and
+    /// where the door reports.
+    color: Option<Signal<Color>>,
+    font_size: Option<Signal<f32>>,
+    font_family: Option<Signal<FontFamily>>,
+    font_weight: Option<Signal<FontWeight>>,
+    stroke: Option<Signal<TextStroke>>,
+    shadow: Option<Signal<TextShadow>>,
+}
+
+impl ResolvedTextStyle {
+    /// Add an active override, further out than every one already added.
+    pub(crate) fn push_override(&mut self, style: &TextStyle) {
+        if let Some(color) = style.color {
+            self.color_overrides.push(color);
+        }
+        if let Some(font_size) = style.font_size {
+            self.font_size_overrides.push(font_size);
+        }
+        self.take_unset(style);
+    }
+
+    /// Add the widget's own declaration, which is the innermost there is.
+    pub(crate) fn push_own(&mut self, style: &TextStyle) {
+        self.color = style.color;
+        self.font_size = style.font_size;
+        self.take_unset(style);
+    }
+
+    /// The four that resolve to one declaration: nearest wins, so whatever is
+    /// already set was found first.
+    fn take_unset(&mut self, style: &TextStyle) {
+        self.font_family = self.font_family.or(style.font_family);
+        self.font_weight = self.font_weight.or(style.font_weight);
+        self.stroke = self.stroke.or(style.stroke);
+        self.shadow = self.shadow.or(style.shadow);
+    }
+
     /// The colour to draw the glyphs in.
-    ///
-    /// This and the size below are resolved here, rather than at each widget's
-    /// `refresh`, so that both pass [`FiniteOr`] on their way to
-    /// [`TextAnims::retarget`]: a value nothing can compute becomes a segment's
-    /// start, and every segment after it begins from there. See
-    /// [`crate::finite`] for why the door belongs at the resolver.
-    pub(crate) fn resolved_color(&self, id: WidgetId) -> Color {
-        self.color.get_finite_or(Color::WHITE, id, "color")
+    pub(crate) fn color(&self, id: WidgetId) -> Color {
+        let base = self.color.get_finite_or(Color::WHITE, id, "color");
+        first_finite_override(&self.color_overrides, base)
     }
 
-    /// The size to measure and draw the glyphs at, in logical pixels — see
-    /// [`resolved_color`](Self::resolved_color) for the door both pass.
-    pub(crate) fn resolved_font_size(&self, id: WidgetId) -> f32 {
-        self.font_size
-            .get_finite_or(DEFAULT_FONT_SIZE, id, "font_size")
+    /// The size to measure and draw the glyphs at, in logical pixels.
+    pub(crate) fn font_size(&self, id: WidgetId) -> f32 {
+        let base = self
+            .font_size
+            .get_finite_or(DEFAULT_FONT_SIZE, id, "font_size");
+        first_finite_override(&self.font_size_overrides, base)
     }
 
-    /// Take from `outer` every property this style does not already declare.
-    ///
-    /// Called as the fold moves outward from the most specific declaration —
-    /// an active state override, then the widget's own — so the nearer one
-    /// always wins: whatever is already set was found first.
-    pub(crate) fn inherit_from(&mut self, outer: &Self) {
-        self.color = self.color.or(outer.color);
-        self.font_size = self.font_size.or(outer.font_size);
-        self.font_family = self.font_family.or(outer.font_family);
-        self.font_weight = self.font_weight.or(outer.font_weight);
-        self.stroke = self.stroke.or(outer.stroke);
-        self.shadow = self.shadow.or(outer.shadow);
+    /// The family to shape the glyphs with.
+    pub(crate) fn font_family(&self) -> FontFamily {
+        self.font_family.get_or_else(crate::default_font_family)
+    }
+
+    /// The weight to shape them at, on the CSS 100-900 scale.
+    pub(crate) fn font_weight(&self) -> FontWeight {
+        self.font_weight.get_or(FontWeight::NORMAL)
+    }
+
+    /// The contour drawn around the glyphs, if one is declared.
+    pub(crate) fn stroke(&self) -> Option<TextStroke> {
+        self.stroke.map(|s| s.get())
+    }
+
+    /// The shadow cast by the glyphs, if one is declared.
+    pub(crate) fn shadow(&self) -> Option<TextShadow> {
+        self.shadow.map(|s| s.get())
     }
 }
 
@@ -383,6 +451,46 @@ macro_rules! declares_text_style {
         impl $widget {
             fn text_style_mut(&mut self) -> &mut $crate::widgets::text_style::TextStyle {
                 self.$style.get_or_insert_with(Default::default)
+            }
+
+            /// This widget's own declaration, and the active state overrides
+            /// that outrank it.
+            ///
+            /// Emitted for both widgets rather than written twice: the two
+            /// differ in nothing but which field holds the declaration, and a
+            /// widget that resolved its style its own way would be the place the
+            /// two drift apart. What stays per widget is
+            /// `is_state_active` — a text with no control above it answers for
+            /// its own hover, and a field for its own.
+            ///
+            /// Called inside the caller's tracking scope, and it has to be: the
+            /// walk reads no declared *value* — collecting those is all it does,
+            /// and `ResolvedTextStyle`'s accessors are what read them and so what
+            /// subscribe to them — but `is_state_active` reads the conditions, and
+            /// that is how a state change re-measures and repaints the widget it
+            /// belongs to. Hoisting this out of the pass, or keeping its answer
+            /// across passes, would cost exactly those subscriptions.
+            fn resolved_text_style(
+                &self,
+                tree: &$crate::tree::Tree,
+                id: $crate::tree::WidgetId,
+            ) -> $crate::widgets::text_style::ResolvedTextStyle {
+                let mut style = $crate::widgets::text_style::ResolvedTextStyle::default();
+                // Last declared first, so the nearest override outranks the ones
+                // before it, and this widget's own declaration outranks none of
+                // them — it is what they fall through to.
+                if !self.states.is_empty() {
+                    let control = tree.nearest_control(id);
+                    for (when, override_) in self.states.iter().rev() {
+                        if self.is_state_active(id, control.as_ref(), when) {
+                            style.push_override(override_);
+                        }
+                    }
+                }
+                if let Some(own) = self.$style.as_deref() {
+                    style.push_own(own);
+                }
+                style
             }
 
             /// Point the declared motions at the resolved style, and hand back

--- a/src/widgets/text_style.rs
+++ b/src/widgets/text_style.rs
@@ -45,8 +45,10 @@
 use smallvec::SmallVec;
 
 use crate::clock::FrameInstant;
+use crate::finite::FiniteOr;
 use crate::jobs::RequiredJob;
 use crate::reactive::{IntoSignal, Signal};
+use crate::tree::WidgetId;
 use crate::widgets::container::AnimationState;
 
 use super::font::{FontFamily, FontWeight};
@@ -201,6 +203,12 @@ impl TextShadow {
     }
 }
 
+/// The size a text draws at when nothing declares one, in logical pixels.
+///
+/// Beside the resolver that hands it out, which is also what a declaration
+/// nobody can compute falls back to.
+pub(crate) const DEFAULT_FONT_SIZE: f32 = 14.0;
+
 /// The text style a container declares for its descendants.
 ///
 /// Every field is optional and resolved independently: a state override that
@@ -224,6 +232,24 @@ pub struct TextStyle {
 }
 
 impl TextStyle {
+    /// The colour to draw the glyphs in.
+    ///
+    /// This and the size below are resolved here, rather than at each widget's
+    /// `refresh`, so that both pass [`FiniteOr`] on their way to
+    /// [`TextAnims::retarget`]: a value nothing can compute becomes a segment's
+    /// start, and every segment after it begins from there. See
+    /// [`crate::finite`] for why the door belongs at the resolver.
+    pub(crate) fn resolved_color(&self, id: WidgetId) -> Color {
+        self.color.get_finite_or(Color::WHITE, id, "color")
+    }
+
+    /// The size to measure and draw the glyphs at, in logical pixels — see
+    /// [`resolved_color`](Self::resolved_color) for the door both pass.
+    pub(crate) fn resolved_font_size(&self, id: WidgetId) -> f32 {
+        self.font_size
+            .get_finite_or(DEFAULT_FONT_SIZE, id, "font_size")
+    }
+
     /// Take from `outer` every property this style does not already declare.
     ///
     /// Called as the fold moves outward from the most specific declaration —


### PR DESCRIPTION
## What changed

`TextStyle` resolves the two properties its animation carries — `color` and
`font_size` — and both text widgets read them through it, so a declaration that
is not a number is coerced where it is resolved rather than reaching
`TextAnims::retarget`. Before, a NaN became a segment's start and `lerp` from a
NaN start is NaN at every `t`, so one frame with a zero divisor left a text
animating from nothing to nothing for the life of the process: the picture stays
correct, it is simply not the one the signal asks for. The door is the one #228
built; what the text widgets lacked was a resolver to hang it on. Closes #333.
The second commit closes #362.

`color` is in alongside `font_size`, which the issue did not ask for. The reason
is that `TextAnims` holds exactly two motions, both are pointed at a value read
out of the same resolved style, and they are resolved two lines apart — a door on
one of them would be the special case the door exists to remove. The issue's
"Not in scope" rules out other colours (a gradient, a ripple), and those are
untouched.

**Second commit, closing #362.** Keeping one rule for a bad number turned out to
need a second change, because the two widgets disagreed with `Container` about a
bad *override*. A text folded its declarations into a winner before reading any
of them, so the door ran on whatever the fold picked, and for an override that
meant the declaration underneath it had already been dropped: a hovered
`font_size(32.0)` whose override computed a NaN painted at 14, where a container
keeps its own 32.

`ResolvedTextStyle` now keeps the widget's own declaration and its active
overrides apart, which is the shape `Container` resolves in. The base goes through
the door, then the nearest override that is a number wins; one that is not is
passed over, silently, because what the widget is left following is fine. The
diagnostic stays with the base, and that placement earns its keep: the report
dedupes per widget and property, so a state active from the first frame would
otherwise bury a broken declaration for the life of the process.

Where the reads happen is the other half, and it is why this is not four lines in
the fold. The walk runs during layout and again during paint, so testing each
candidate as it walks subscribes the *measurement* to a colour, and a theme change
would then reflow every label declaring a hover colour, since `Text` is not a
relayout boundary. The accessors read instead, in the pass that wants the
property. The walk itself moved into `declares_text_style!`, which already emits
both widgets' style vocabulary and is where the two copies would have drifted.

The reading taken, where the issue's wording and `src/finite.rs`'s rule differ:
the issue says a poisoned text "keeps the size it had", and what it does is read
the bad value *as if it had not been declared*, which is #228's contract. So a
size that goes NaN for a frame transitions toward 14 and back rather than
holding. That is the rule the rest of the library already follows.

## What proves it

Eight tests, every one confirmed red on this branch with only the resolver
bodies reverted, and each for its own stated reason.

The acceptance criterion is `a_font_size_follows_its_signal_again_once_the_signal_recovers`
(`src/widgets/text.rs`): a size driven by a signal, NaN for two frames, then 30.
It paints nothing at all without the fix — a text measured at NaN has no bounds
to paint into — and 30 with it. `a_text_colour_follows_its_signal_again_...` is
the same for the colour, recovering to *red* rather than white so that falling
back to the default cannot pass for following the signal.

`every_animated_text_property_is_resolved_to_a_finite_value` asks the two
resolvers directly, which is how the container's twin is written and for the same
reason: a symptom test passes for the wrong reason all the time, since the
measurer already refuses a size it cannot shape.

`a_font_size_that_is_not_a_number_is_reported_once` watches the diagnostic and
its dedupe. It writes the bad signal each iteration, because `Text::layout`
early-outs when nothing dirtied it and a loop that only paints would resolve
once — confirmed by deleting the dedupe, which turns 1 into 5.

The colour's two read sites are complementary — paint resolves it where no
motion was declared, `refresh` where one was — so both widgets get one scenario
each side: `a_colour_with_no_motion_is_painted_through_the_door_too`,
`a_fields_colour_with_no_motion_is_painted_through_the_door`,
`a_fields_colour_follows_its_signal_again_...` and
`a_fields_font_size_follows_its_signal_again_...`. Reverting any one of the four
resolver calls now fails a test.

For #362, three more, each red against a faithful simulation of the old
behaviour. `an_override_that_is_not_a_number_falls_through_to_the_declaration` and
its field twin paint at 32 and fail at 14 without the split.
`a_bad_declaration_is_reported_even_under_a_good_override` is the diagnostic
asymmetry: the override is what the text draws with, and the declaration
underneath it is still reported once.

`an_override_colour_wakes_no_layout_either` is the one that chose the design. It
fails with `[Layout, Paint]` against the cheaper fix that tests each candidate as
it walks, which is how that fix was found out before it shipped.

No golden and no snapshot moved, and none should: for a finite declaration the
resolvers return exactly what the old read returned, and `DEFAULT_FONT_SIZE` is
the 14.0 the two literals held. The goldens were run on lavapipe anyway (10
passed). Nothing public changed — both resolvers and the constant are
`pub(crate)` — so the book and `docs/` are owed nothing, and
`tests/documentation_references.rs` is green.

## What the review found

**Zero blocking.** Four findings worth answering, all four acted on:

- The new test helper in `text_input.rs` had been inserted between `drawn_rects`'s
  doc comment and `drawn_rects`, so one function carried the other's
  documentation. Put back.
- The colour recovery test recovered to white, which is also what the door hands
  out for a colour nobody declared, so it could not tell "followed its signal"
  from "fell back". It recovers to red now.
- The report-once test did not exercise the dedupe it named, for the layout
  early-out reason above. It writes the signal each frame now, and deleting the
  dedupe fails it.
- Two of the four new call sites — the field's colour, on both paths — were
  unwatched. Two tests added.

The second commit's own review: **zero blocking**, three worth answering, all
three acted on. The macro's doc claimed the walk reads no signal, when it reads
the state conditions — load-bearing, and a reader told otherwise could hoist the
walk out of the tracking scope and lose state reactivity silently. Nothing pinned
the *silence* of a passed-over override, which is now asserted where the
fall-through is. And `docs/STATE_LAYER.md` stated half the rule; the other half is
uniform across widget families for the first time, so it is written there now.

Two of its notes were taken as well: `push_own`'s `or` was dead, and three doc
comments taught `container().font_size(..)`, which is not a method that exists. One
of the three was a sample a caller would have copied. A container draws a box and
says nothing about what is written inside it, which the module header already said
two lines away.

Its remaining notes are untouched code and stay unopened, as it reported them:
`Container`'s side of "the two agree" is asserted by a comment rather than a test,
so a change to `resolve_state_value` re-opens #362 from the other side and nothing
notices.

The second commit was read by two more quality passes before it existed. Applied from
them: the walk moved into the macro once it was duplicated, the base was split
from the overrides so a non-finite base is still reported — the first version
silently dropped that report, which is the finding that changed the design — the
override walk returns at the first usable candidate as `Container`'s does, four
accessors were added so the type stopped being half record and half resolver, two
doc comments describing the removed fold were fixed, and a rationale written twice
was collapsed to the type that owns the decision. One finding skipped: a test
helper that would collapse a six-line preamble repeated in four tests, three of
them pre-existing and unrelated to this change.

Its notes on scope and on the issue's "keeps the size it had" wording are
answered in **What changed** above. One note is outside this change and would
make an issue: the coercion rule is documented nowhere but `src/finite.rs`'s
module header, and now that it spans two widget families a reader of
`docs/STYLING.md` is worse off for its absence.

## What was checked by hand

Nothing. Every path here is a declared value resolved during layout or paint,
which the unit tests drive directly; no surface, compositor or real frame is
involved.

## Left undone

`TextStyle`'s stroke and shadow are made of numbers and do not pass the door, for
want of an `AllFinite` impl: `finite_by_channels!` cannot reach them, since
neither is `Animatable`. Nothing persists a bad number there — no
`AnimationState` stands behind either, so it is gone the frame the signal
recovers — and it does not reach geometry either, which I checked rather than
assumed: `decoration_overflow`'s final `max` returns the finite operand, so a
shadow with both offsets NaN still publishes a paint reach of 0. What a bad number
does reach is `TextShadow::samples`, which puts its copies at NaN positions for
that one frame. Nobody is worse off past it, so this is the sentence and not an
issue. The enumeration test's name and the type's own docs say which properties
pass the door, so the next field added to `TextStyle` is not quietly missed.

One divergence worth a maintainer's eye, and no work here: `Container` and the
text widgets now resolve state overrides by the same rule written twice.
`ResolvedTextStyle` is the better of the two on the thing `resolve_state_value`
complains about in its own comment — it resolves `nearest_control` once per pass
where the container rebuilds it once per property — but one mechanism for both is
a cross-cutting change for two call sites, which is yours to call rather than
mine.

https://claude.ai/code/session_01UBH3udwnC1nUZ7wv5TS7N9
