### PR TITLE
A rustdoc sample is compiled, or it says why it is not

### DIFF
--- a/guido-macros/src/lib.rs
+++ b/guido-macros/src/lib.rs
@@ -17,6 +17,10 @@ use syn::{DeriveInput, Expr, Fields, ItemFn, Meta, Type, TypeBareFn, parse_macro
 ///
 /// # Example
 /// ```ignore
+/// // not compiled: `guido-macros` is a proc-macro crate and does not depend on
+/// // `guido`, so a sample using `container()` has nothing to compile against.
+/// // `tests/forwarded_children.rs` and `examples/component_example.rs` are the
+/// // compiled versions.
 /// #[component]
 /// pub fn button(
 ///     label: String,
@@ -473,6 +477,8 @@ fn to_pascal_case(s: &str) -> String {
 /// # Example
 ///
 /// ```ignore
+/// // not compiled: see the `component` sample above — this crate has nothing to
+/// // compile a widget against.
 /// #[derive(Clone, PartialEq, SignalFields)]
 /// pub struct AppState {
 ///     pub count: i32,
@@ -492,6 +498,7 @@ fn to_pascal_case(s: &str) -> String {
 /// # Generic example
 ///
 /// ```ignore
+/// // not compiled: see the `component` sample above.
 /// #[derive(Clone, PartialEq, SignalFields)]
 /// pub struct Pair<A: Clone + PartialEq + Send + 'static, B: Clone + PartialEq + Send + 'static> {
 ///     pub first: A,

--- a/src/animation/animated.rs
+++ b/src/animation/animated.rs
@@ -8,11 +8,16 @@
 //! Two verbs, on everything a property setter already accepts — a value, a
 //! closure, a signal:
 //!
-//! ```ignore
+//! ```no_run
+//! # use guido::prelude::*;
+//! # let surface = Color::rgb(0.1, 0.1, 0.2);
+//! # let open = create_signal(false);
+//! # let rejections = create_signal(0u32);
+//! # let shake = || Keyframes::new(320.0).at(0.0, 0.0).at(0.5, 8.0).at(1.0, 0.0);
 //! container()
-//!     .background(theme.surface.transition(200.0))
+//!     .background(surface.transition(200.0))
 //!     .width((move || if open.get() { 520.0 } else { 120.0 }).transition(SpringConfig::SNAPPY))
-//!     .rotate(0.0.timeline(shake().played_by(rejections)))
+//!     .rotate(0.0.timeline(shake().played_by(rejections)));
 //! ```
 //!
 //! [`Animated`] is deliberately **not** an [`IntoSignal`]. A state layer
@@ -20,8 +25,13 @@
 //! to give — and because the two traits are separate, saying otherwise is a
 //! compile error rather than a value quietly ignored:
 //!
-//! ```ignore
-//! .when_hovered(|s| s.background(HOT.transition(900.0)))   // does not compile
+//! ```compile_fail,E0277
+//! # use guido::prelude::*;
+//! const HOT: Color = Color::rgb(0.9, 0.3, 0.2);
+//! // E0277 pinned: a bare `compile_fail` passes on any error at all, including
+//! // a typo in the sample, so it would go on passing after it stopped meaning
+//! // anything.
+//! container().when_hovered(|s| s.background(HOT.transition(900.0)));
 //! ```
 
 use crate::reactive::{IntoSignal, IntoVal, Signal};
@@ -52,15 +62,18 @@ impl<T> Animated<T> {
     /// separate questions and compose on one property, which is the split CSS
     /// makes between `transition` and `@starting-style`.
     ///
-    /// ```ignore
+    /// ```no_run
+    /// # use guido::prelude::*;
+    /// # let open = create_signal(false);
+    /// # let surface = Color::rgb(0.1, 0.1, 0.2);
     /// // a menu that scales open on its first layout
-    /// container().transform(
-    ///     (move || if open.get() { Transform::IDENTITY } else { collapsed })
-    ///         .transition(Transition::spring(SpringConfig::SNAPPY))
-    ///         .entering_from(collapsed),
-    /// )
+    /// container().scale(
+    ///     (move || if open.get() { Scale::NONE } else { Scale::uniform(0.8) })
+    ///         .transition(SpringConfig::SNAPPY)
+    ///         .entering_from(Scale::uniform(0.8)),
+    /// );
     /// // and the same verb on anything else that animates
-    /// container().background(theme.surface.transition(200.0).entering_from(Color::TRANSPARENT))
+    /// container().background(surface.transition(200.0).entering_from(Color::TRANSPARENT));
     /// ```
     ///
     /// Played once, at the first layout, and consumed there: a relayout, a
@@ -151,9 +164,12 @@ pub trait Animate<T: Clone + 'static, M>: IntoSignal<T, M> + Sized {
     /// A bare number is milliseconds; a [`Transition`](super::Transition) or a
     /// [`SpringConfig`](super::SpringConfig) says which curve.
     ///
-    /// ```ignore
-    /// container().background(theme.surface.transition(200.0))
-    /// container().width(w.transition(Transition::spring(SpringConfig::SNAPPY)))
+    /// ```no_run
+    /// # use guido::prelude::*;
+    /// # let surface = Color::rgb(0.1, 0.1, 0.2);
+    /// # let w = create_signal(120.0f32);
+    /// container().background(surface.transition(200.0));
+    /// container().width(w.transition(Transition::spring(SpringConfig::SNAPPY)));
     /// ```
     fn transition(self, transition: impl Into<TransitionConfig>) -> Animated<T> {
         Animated {
@@ -179,9 +195,14 @@ pub trait Animate<T: Clone + 'static, M>: IntoSignal<T, M> + Sized {
     /// back to it, and a sequence resting on a live signal has nowhere else to
     /// put its expression:
     ///
-    /// ```ignore
-    /// container().rotate(0.0.timeline(shake().played_by(rejections)))
-    /// container().rotate((move || spin.get() * STEP).timeline(shake().played_by(rejections)))
+    /// ```no_run
+    /// # use guido::prelude::*;
+    /// # let rejections = create_signal(0u32);
+    /// # let spin = create_signal(0.0f32);
+    /// # const STEP: f32 = 90.0;
+    /// # let shake = || Keyframes::new(320.0).at(0.0, 0.0).at(0.5, 8.0).at(1.0, 0.0);
+    /// container().rotate(0.0.timeline(shake().played_by(rejections)));
+    /// container().rotate((move || spin.get() * STEP).timeline(shake().played_by(rejections)));
     /// ```
     ///
     /// A timeline is for something that happens and is over. A change that

--- a/src/animation/keyframes.rs
+++ b/src/animation/keyframes.rs
@@ -16,7 +16,9 @@
 //! [`timeline`](crate::animation::Animate::timeline), on whatever the property
 //! rests at between plays:
 //!
-//! ```ignore
+//! ```no_run
+//! # use guido::prelude::*;
+//! # let rejections = create_signal(0u32);
 //! container().rotate(0.0.timeline(
 //!     Keyframes::new(320.0)
 //!         .at(0.0, 0.0)
@@ -25,7 +27,7 @@
 //!         .at(0.8, 0.4)
 //!         .at(1.0, 0.0)
 //!         .played_by(rejections),
-//! ))
+//! ));
 //! ```
 //!
 //! A timeline belongs to the one property it moves — a rotation for a shake, a

--- a/src/animation/spring.rs
+++ b/src/animation/spring.rs
@@ -18,14 +18,16 @@
 //!
 //! ## Usage
 //!
-//! ```ignore
-//! use guido::animation::{TimingFunction, SpringConfig};
+//! A spring is a timing, and a timing rides with the value it moves — a state
+//! layer supplies the value to move *to* and says nothing about how:
+//!
+//! ```no_run
+//! use guido::prelude::*;
+//! use guido::animation::SpringConfig;
 //!
 //! container()
-//!     .scale(1.0)
-//!     .when_hovered(|s| s
-//!         .scale(1.1)
-//!         .timing(TimingFunction::Spring(SpringConfig::BOUNCY)))
+//!     .scale(Scale::NONE.transition(SpringConfig::BOUNCY))
+//!     .when_hovered(|s| s.scale(1.1));
 //! ```
 
 /// Configuration for spring physics animation

--- a/src/animation/timing.rs
+++ b/src/animation/timing.rs
@@ -18,12 +18,16 @@
 //!
 //! ## Example
 //!
-//! ```ignore
+//! A curve rides with the value it moves, in the [`Transition`](super::Transition)
+//! the property is declared with. A state layer supplies a value and never a
+//! timing, so the curve is named once, where the property is:
+//!
+//! ```no_run
+//! # use guido::prelude::*;
+//! # let surface = Color::rgb(0.3, 0.3, 0.4);
 //! container()
-//!     .when_hovered(|s| s
-//!         .lighter(0.1)
-//!         .timing(TimingFunction::EaseOut)
-//!         .duration(Duration::from_millis(150)))
+//!     .background(surface.transition(Transition::new(150.0, TimingFunction::EaseOut)))
+//!     .when_hovered(|s| s.lighter(0.1));
 //! ```
 
 use super::spring::SpringConfig;

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -13,10 +13,11 @@
 //! keystroke behind — announcing caps lock only once you had already typed
 //! into it.
 //!
-//! ```ignore
+//! ```no_run
+//! # use guido::prelude::*;
 //! container().child(move || {
 //!     keyboard_modifiers().get().caps_lock.then(|| text("Caps lock is on"))
-//! })
+//! });
 //! ```
 
 use crate::reactive::global::GlobalSignal;

--- a/src/layout/flex_layout.rs
+++ b/src/layout/flex_layout.rs
@@ -22,10 +22,12 @@
 //!
 //! ## Usage
 //!
-//! ```ignore
+//! ```no_run
+//! # use guido::prelude::*;
+//! # let (button_a, button_b, button_c) = (text("a"), text("b"), text("c"));
 //! container()
 //!     .layout(Flex::row().spacing(8.0).main_alignment(MainAlignment::Center))
-//!     .children([button_a, button_b, button_c])
+//!     .children([button_a, button_b, button_c]);
 //! ```
 
 use super::{Axis, Constraints, CrossAlignment, Layout, MainAlignment, Size};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,8 @@ thread_local! {
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```no_run
+/// # use guido::prelude::*;
 /// set_default_font_family(FontFamily::Name("Inter".into()));
 /// ```
 pub fn set_default_font_family(family: FontFamily) {
@@ -91,6 +92,8 @@ pub fn default_font_family() -> FontFamily {
 /// # Example
 ///
 /// ```ignore
+/// // not compiled: `include_bytes!` needs a font file at the reader's own path,
+/// // and the point of the sample is that the bytes are embedded at compile time.
 /// const NERD_FONT: &[u8] = include_bytes!("../assets/MyFont.ttf");
 /// guido::load_font(NERD_FONT.to_vec());
 /// ```
@@ -209,7 +212,7 @@ pub mod prelude {
 ///
 /// The two are meant to be imported together:
 ///
-/// ```ignore
+/// ```no_run
 /// use guido::prelude::*;
 /// use guido::widget_prelude::*;
 /// ```
@@ -2099,11 +2102,15 @@ impl App {
     ///
     /// # Example
     ///
-    /// ```ignore
+    /// ```no_run
+    /// # use guido::prelude::*;
+    /// # let config = SurfaceConfig::new();
+    /// # let view = || text("hi");
     /// App::new()
     ///     .default_font_family(FontFamily::Name("Inter".into()))
-    ///     .add_surface(config, || view)
-    ///     .run();
+    ///     .run(|app| {
+    ///         app.add_surface(config, view);
+    ///     });
     /// ```
     pub fn default_font_family(self, family: FontFamily) -> Self {
         set_default_font_family(family);
@@ -2123,7 +2130,8 @@ impl App {
     ///
     /// # Example
     ///
-    /// ```ignore
+    /// ```no_run
+    /// # use guido::prelude::*;
     /// App::new().run(|app| {
     ///     let bar_id = app.add_surface(
     ///         SurfaceConfig::new()
@@ -2131,7 +2139,7 @@ impl App {
     ///             .anchor(Anchor::TOP | Anchor::LEFT | Anchor::RIGHT)
     ///             .layer(Layer::Top)
     ///             .namespace("status-bar"),
-    ///         || status_bar_widget()
+    ///         || text("bar"),
     ///     );
     /// });
     /// ```
@@ -2162,7 +2170,10 @@ impl App {
     ///
     /// # Example
     ///
-    /// ```ignore
+    /// ```no_run
+    /// # use guido::prelude::*;
+    /// # let config = SurfaceConfig::new();
+    /// # let build_ui = |c: RwSignal<i32>| text(move || c.get().to_string());
     /// App::new().run(|app| {
     ///     let count = create_signal(0);
     ///     app.add_surface(config, move || build_ui(count));

--- a/src/outputs.rs
+++ b/src/outputs.rs
@@ -4,7 +4,9 @@
 //! tracked closure (effects, dynamic children, reactive properties) and the
 //! closure re-runs when monitors are added, removed, or reconfigured.
 //!
-//! ```ignore
+//! ```no_run
+//! # use guido::prelude::*;
+//! # let bar_widget = || text("bar");
 //! // One bar per monitor, reacting to hotplug:
 //! create_effect(move || {
 //!     for info in outputs().get() {

--- a/src/pivot.rs
+++ b/src/pivot.rs
@@ -41,26 +41,27 @@ pub enum VerticalAnchor {
 /// The centre of the widget by default.
 ///
 /// # Example
-/// ```ignore
+/// ```no_run
+/// # use guido::prelude::*;
 /// // Rotate around the top-left corner
 /// container()
 ///     .rotate(45.0)
-///     .pivot(Pivot::TOP_LEFT)
+///     .pivot(Pivot::TOP_LEFT);
 ///
 /// // Scale from the bottom-right corner
 /// container()
 ///     .scale(1.5)
-///     .pivot(Pivot::BOTTOM_RIGHT)
+///     .pivot(Pivot::BOTTOM_RIGHT);
 ///
 /// // Use percentage-based origin (25% from left, 75% from top)
 /// container()
 ///     .rotate(30.0)
-///     .pivot(Pivot::percent(25.0, 75.0))
+///     .pivot(Pivot::percent(25.0, 75.0));
 ///
 /// // Use pixel-based offset (10px from left, 20px from top)
 /// container()
 ///     .scale(2.0)
-///     .pivot(Pivot::px(10.0, 20.0))
+///     .pivot(Pivot::px(10.0, 20.0));
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Pivot {
@@ -136,9 +137,10 @@ impl Pivot {
     /// A pivot from percentages (0-100 scale)
     ///
     /// # Example
-    /// ```ignore
+    /// ```no_run
+    /// # use guido::prelude::*;
     /// // 25% from left, 75% from top
-    /// Pivot::percent(25.0, 75.0)
+    /// Pivot::percent(25.0, 75.0);
     /// ```
     pub fn percent(x_percent: f32, y_percent: f32) -> Self {
         Self {
@@ -150,9 +152,10 @@ impl Pivot {
     /// A pivot from pixel offsets from the top-left corner
     ///
     /// # Example
-    /// ```ignore
+    /// ```no_run
+    /// # use guido::prelude::*;
     /// // 10px from left, 20px from top
-    /// Pivot::px(10.0, 20.0)
+    /// Pivot::px(10.0, 20.0);
     /// ```
     pub fn px(x: f32, y: f32) -> Self {
         Self {

--- a/src/reactive/callback.rs
+++ b/src/reactive/callback.rs
@@ -12,7 +12,8 @@
 //! The argument list is a tuple, and each arity gets its own `new`/`run` so
 //! both ends stay flat:
 //!
-//! ```ignore
+//! ```no_run
+//! # use guido::prelude::*;
 //! let greet = Callback::new(|name: String| println!("hi {name}"));
 //! greet.run("world".into());
 //! ```

--- a/src/reactive/diagnostics.rs
+++ b/src/reactive/diagnostics.rs
@@ -6,9 +6,11 @@
 //! for. That is the single most common way to write a UI that silently stops
 //! updating —
 //!
-//! ```ignore
-//! text(format!("{}", count.get()))          // snapshot: never updates
-//! text(move || format!("{}", count.get()))  // reactive: the closure re-runs
+//! ```no_run
+//! # use guido::prelude::*;
+//! # let count = create_signal(0);
+//! text(format!("{}", count.get()));          // snapshot: never updates
+//! text(move || format!("{}", count.get()));  // reactive: the closure re-runs
 //! ```
 //!
 //! Rust cannot express this at compile time: the two lines differ only in

--- a/src/reactive/effect.rs
+++ b/src/reactive/effect.rs
@@ -7,7 +7,9 @@ use super::runtime::{EffectId, run_effect_by_id, with_runtime};
 /// or the root one `App::run` opens — and is disposed with it. Created outside
 /// any scope it runs for the lifetime of the application.
 ///
-/// ```ignore
+/// ```no_run
+/// # use guido::prelude::*;
+/// # let count = create_signal(0);
 /// create_effect(move || println!("count is {}", count.get()));
 /// ```
 ///

--- a/src/reactive/global.rs
+++ b/src/reactive/global.rs
@@ -11,6 +11,8 @@
 //! A `GlobalSignal` says so at the declaration:
 //!
 //! ```ignore
+//! // not compiled: `GlobalSignal` is crate-internal, and a doctest compiles
+//! // against the crate from outside.
 //! static MODIFIERS: GlobalSignal<Modifiers> = GlobalSignal::new(Modifiers::default);
 //!
 //! pub fn keyboard_modifiers() -> Signal<Modifiers> {

--- a/src/reactive/invalidation.rs
+++ b/src/reactive/invalidation.rs
@@ -58,6 +58,9 @@ thread_local! {
 /// container for layout, which re-lays-out every sibling as well.
 ///
 /// ```ignore
+/// // not compiled: a fragment of a `Widget` impl, shown without the impl it
+/// // belongs to — `self` has no meaning on its own. `tests/external_widget.rs`
+/// // is where the same call is compiled.
 /// fn layout(&mut self, tree: &mut Tree, id: WidgetId, c: Constraints) -> Size {
 ///     with_signal_tracking(id, JobType::Layout, || {
 ///         let text = self.content.get();   // subscribes this widget, not its parent

--- a/src/reactive/memo.rs
+++ b/src/reactive/memo.rs
@@ -16,13 +16,14 @@ use super::signal::{RwSignal, Signal, create_signal};
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```no_run
+/// # use guido::prelude::*;
 /// let count = create_signal(0);
 /// let doubled = create_memo(move || count.get() * 2);
 ///
 /// container().background(move || {
 ///     if doubled.get() > 10 { Color::RED } else { Color::BLUE }
-/// })
+/// });
 /// ```
 pub struct Memo<T: Clone + PartialEq + Send + 'static> {
     signal: RwSignal<T>,
@@ -44,10 +45,11 @@ impl<T: Clone + PartialEq + Send + 'static> Copy for Memo<T> {}
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```no_run
+/// # use guido::prelude::*;
 /// let count = create_signal(0);
 /// let label = create_memo(move || format!("Count: {}", count.get()));
-/// text(label)  // Only repaints when the formatted string actually changes
+/// text(label);  // Only repaints when the formatted string actually changes
 /// ```
 pub fn create_memo<T, F>(f: F) -> Memo<T>
 where

--- a/src/reactive/owner.rs
+++ b/src/reactive/owner.rs
@@ -13,7 +13,9 @@
 //!
 //! # Example
 //!
-//! ```ignore
+//! ```no_run
+//! # use guido::prelude::*;
+//! # use guido::reactive::__internal::{with_owner, dispose_owner};
 //! // Create a scope with automatic cleanup
 //! let (result, owner_id) = with_owner(|| {
 //!     let signal = create_signal(42);
@@ -438,7 +440,11 @@ pub fn dispose_owner_now(id: OwnerId) {
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```no_run
+/// # use guido::prelude::*;
+/// # use guido::reactive::__internal::with_owner;
+/// # let start_timer = || 0u32;
+/// # let stop_timer = |_: u32| {};
 /// with_owner(|| {
 ///     // Start a timer
 ///     let timer_id = start_timer();

--- a/src/reactive/service.rs
+++ b/src/reactive/service.rs
@@ -5,10 +5,12 @@
 //!
 //! # Example
 //!
-//! ```ignore
+//! ```no_run
+//! # use guido::prelude::*;
+//! # enum MyCommand { DoSomething }
 //! let service = create_service(move |mut rx, ctx| async move {
 //!     while ctx.is_running() {
-//!         if let Some(cmd) = rx.recv().await {
+//!         if let Some(MyCommand::DoSomething) = rx.recv().await {
 //!             // handle command
 //!         }
 //!         // update signals
@@ -98,7 +100,9 @@ impl<Cmd: 'static> Service<Cmd> {
 ///
 /// # Example: Bidirectional Service
 ///
-/// ```ignore
+/// ```no_run
+/// # use guido::prelude::*;
+/// # use std::time::Duration;
 /// enum Cmd {
 ///     SwitchWorkspace(i32),
 /// }
@@ -176,13 +180,16 @@ where
 /// keep. It is aborted when the scope that created it is disposed, exactly as a
 /// service is.
 ///
-/// ```ignore
+/// ```no_run
+/// # use guido::prelude::*;
+/// # use std::time::Duration;
+/// # let now = || String::from("09:41");
 /// let time = create_signal(String::new());
 /// let time_w = time.writer();
 ///
 /// create_task(move |ctx| async move {
 ///     while ctx.is_running() {
-///         time_w.set(chrono::Local::now().format("%H:%M").to_string());
+///         time_w.set(now());
 ///         tokio::time::sleep(Duration::from_secs(1)).await;
 ///     }
 /// });

--- a/src/reactive/signal.rs
+++ b/src/reactive/signal.rs
@@ -375,7 +375,14 @@ impl<T: Clone + Send + Sync + 'static> RwSignal<T> {
     /// When the scope that created it is disposed the sender drops, so
     /// `changed()` returns `Err`: the task's cue that the UI is gone.
     ///
-    /// ```ignore
+    /// ```no_run
+    /// # use guido::prelude::*;
+    /// # use std::time::Duration;
+    /// # #[derive(Clone, Copy, PartialEq)] enum Menu { SystemInfo }
+    /// # #[derive(Clone, Copy)] enum Scope { All, Bar }
+    /// # let menu = create_signal(None::<Menu>);
+    /// # let interval = Duration::from_secs(1);
+    /// # let sample = |_: Scope| {};
     /// let wide = create_memo(move || menu.get() == Some(Menu::SystemInfo));
     /// let mut wide_rx = wide.watch();
     ///
@@ -425,7 +432,10 @@ impl<T: Clone + 'static> From<RwSignal<T>> for Signal<T> {
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```no_run
+/// # use guido::prelude::*;
+/// # use std::time::Duration;
+/// # let get_current_time = || String::from("09:41");
 /// let time = create_signal(get_current_time());
 /// let time_w = time.writer();
 ///
@@ -555,11 +565,12 @@ impl<T: Clone + Send + 'static> WriteSignal<T> {
 ///
 /// # Example
 ///
-/// ```ignore
-/// let count = create_signal(0);
-/// count.set(1);           // write
+/// ```no_run
+/// # use guido::prelude::*;
+/// let count = create_signal(0.0f32);
+/// count.set(1.0);         // write
 /// count.get();            // read
-/// container().padding(count) // auto-converts to Signal<T> via IntoSignal
+/// container().padding(count); // auto-converts to Signal<T> via IntoSignal
 /// ```
 pub fn create_signal<T: Clone + Send + 'static>(value: T) -> RwSignal<T> {
     let id = create_signal_value(value);
@@ -582,9 +593,10 @@ pub fn create_signal<T: Clone + Send + 'static>(value: T) -> RwSignal<T> {
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```no_run
+/// # use guido::prelude::*;
 /// let color = create_stored(Color::RED);
-/// container().background(color) // Copy, no clone needed
+/// container().background(color); // Copy, no clone needed
 /// ```
 pub fn create_stored<T: Clone + 'static>(value: T) -> Signal<T> {
     let id = create_stored_value(value);
@@ -607,10 +619,11 @@ pub fn create_stored<T: Clone + 'static>(value: T) -> Signal<T> {
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```no_run
+/// # use guido::prelude::*;
 /// let count = create_signal(0);
 /// let label = create_derived(move || format!("Count: {}", count.get()));
-/// text(label) // Copy, reactive
+/// text(label); // Copy, reactive
 /// ```
 pub fn create_derived<T: Clone + 'static>(f: impl Fn() -> T + 'static) -> Signal<T> {
     let id = allocate_signal_slot();

--- a/src/reactive/trigger.rs
+++ b/src/reactive/trigger.rs
@@ -10,10 +10,12 @@ use super::signal::{RwSignal, create_signal};
 /// "something happened" pulse through the reactive graph when there is no
 /// value to carry (external data changed, a cache was invalidated):
 ///
-/// ```ignore
+/// ```no_run
+/// # use guido::prelude::*;
 /// let refresh = create_trigger();
 ///
 /// create_effect(move || {
+/// # let rebuild_from_external_source = || {};
 ///     refresh.track();
 ///     rebuild_from_external_source();
 /// });

--- a/src/renderer/paint_context.rs
+++ b/src/renderer/paint_context.rs
@@ -25,6 +25,8 @@ use crate::widgets::{Color, Rect};
 /// # Example
 ///
 /// ```ignore
+/// // not compiled: a fragment of a `Widget` impl, shown without the impl it
+/// // belongs to. `tests/external_widget.rs` is the compiled version of this.
 /// fn paint(&self, ctx: &mut PaintContext) {
 ///     // Local bounds (0,0 origin with widget's own width/height)
 ///     let local_bounds = Rect::new(0.0, 0.0, self.bounds.width, self.bounds.height);

--- a/src/session_lock.rs
+++ b/src/session_lock.rs
@@ -6,8 +6,9 @@
 //! compositor blanks all outputs and routes input to the lock surfaces, so
 //! a `text_input` password field works out of the box.
 //!
-//! ```ignore
-//! lock_session(|output| lock_screen_widget(output));
+//! ```no_run
+//! # use guido::prelude::*;
+//! lock_session(|output: OutputInfo| text(format!("locked: {}", output.id.raw())));
 //! // …later, e.g. after password verification:
 //! unlock_session();
 //! ```

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -6,7 +6,9 @@
 //!
 //! # Static Surface Definition (at startup)
 //!
-//! ```ignore
+//! ```no_run
+//! # use guido::prelude::*;
+//! # let status_bar_widget = || text("bar");
 //! App::new().run(|app| {
 //!     app.add_surface(
 //!         SurfaceConfig::new()
@@ -21,7 +23,9 @@
 //!
 //! # Dynamic Surface Creation (at runtime)
 //!
-//! ```ignore
+//! ```no_run
+//! # use guido::prelude::*;
+//! # let popup_widget = || text("popup");
 //! // In an event handler or anywhere in widget code:
 //! let handle = spawn_surface(
 //!     SurfaceConfig::new()
@@ -71,7 +75,8 @@ impl SurfaceId {
 ///
 /// Use the builder pattern to configure surface properties:
 ///
-/// ```ignore
+/// ```no_run
+/// # use guido::prelude::*;
 /// SurfaceConfig::new()
 ///     .width(300)
 ///     .height(200)
@@ -79,7 +84,7 @@ impl SurfaceId {
 ///     .layer(Layer::Overlay)
 ///     .keyboard_interactivity(KeyboardInteractivity::Exclusive)
 ///     .namespace("my-popup")
-///     .background_color(Color::rgb(0.2, 0.2, 0.3))
+///     .background_color(Color::rgb(0.2, 0.2, 0.3));
 /// ```
 #[derive(Clone)]
 pub struct SurfaceConfig {
@@ -118,10 +123,11 @@ pub struct SurfaceConfig {
 /// because `zwlr_layer_surface_v1::set_margin` is defined in integers and a
 /// fractional margin has nothing to round to that the compositor would honour.
 ///
-/// ```ignore
-/// SurfaceConfig::new().margin(8)                   // all four edges
-/// SurfaceConfig::new().margin([0, 12])             // none top/bottom, 12 aside
-/// SurfaceConfig::new().margin([8, 12, 0, 12])      // top, right, bottom, left
+/// ```no_run
+/// # use guido::prelude::*;
+/// SurfaceConfig::new().margin(8);                   // all four edges
+/// SurfaceConfig::new().margin([0, 12]);             // none top/bottom, 12 aside
+/// SurfaceConfig::new().margin([8, 12, 0, 12]);      // top, right, bottom, left
 /// ```
 ///
 /// Negative values are allowed: layer-shell reads them as pushing the surface
@@ -209,10 +215,11 @@ impl From<[u32; 4]> for Margin {
 /// [`content()`] constructor reads like [`fill()`](crate::layout::fill)
 /// and friends:
 ///
-/// ```ignore
+/// ```no_run
+/// # use guido::prelude::*;
 /// SurfaceConfig::new()
 ///     .width(360)             // fixed
-///     .height(content())      // follows the toast stack
+///     .height(content());     // follows the toast stack
 /// ```
 ///
 /// Content semantics, designed to stay footgun-free:
@@ -425,11 +432,12 @@ pub fn content() -> SurfaceExtent {
 /// default is [`ExclusiveZone::None`] — a bar declares its reservation
 /// explicitly:
 ///
-/// ```ignore
-/// .exclusive_zone(ExclusiveZone::Auto)    // a bar reserving itself
-/// .exclusive_zone(34)                     // fixed reservation
-/// .exclusive_zone(ExclusiveZone::None)    // reserve nothing (toasts, OSD)
-/// .exclusive_zone(ExclusiveZone::Ignore)  // overlap panels too
+/// ```no_run
+/// # use guido::prelude::*;
+/// SurfaceConfig::new().exclusive_zone(ExclusiveZone::Auto);   // a bar reserving itself
+/// SurfaceConfig::new().exclusive_zone(34);                    // fixed reservation
+/// SurfaceConfig::new().exclusive_zone(ExclusiveZone::None);   // reserve nothing (toasts, OSD)
+/// SurfaceConfig::new().exclusive_zone(ExclusiveZone::Ignore); // overlap panels too
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ExclusiveZone {
@@ -656,7 +664,11 @@ pub type PopupGravity = PopupAnchor;
 /// The compositor positions the popup relative to `anchor_rect` (parent
 /// surface coordinates) and adjusts it to stay on screen (flip/slide).
 ///
-/// ```ignore
+/// ```no_run
+/// # use guido::prelude::*;
+/// # let bar_surface_id = SurfaceId::next();
+/// # let button_rect = Rect::new(0.0, 0.0, 10.0, 10.0);
+/// # let menu_widget = || text("menu");
 /// spawn_popup(
 ///     bar_surface_id,
 ///     PopupConfig::new(250)
@@ -938,7 +950,8 @@ pub(crate) fn drain_surface_commands() -> Vec<SurfaceCommand> {
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```no_run
+/// # use guido::prelude::*;
 /// let handle = spawn_surface(
 ///     SurfaceConfig::new()
 ///         .width(300)
@@ -1066,7 +1079,12 @@ pub(crate) fn reset_popups() {
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```no_run
+/// # use guido::prelude::*;
+/// # let button_ref = create_widget_ref();
+/// # let bar_id = SurfaceId::next();
+/// # let menu_open = create_signal(true);
+/// # let menu_widget = || text("menu");
 /// let button_rect = button_ref.rect().get();
 /// let popup = spawn_popup(
 ///     bar_id,
@@ -1110,7 +1128,10 @@ where
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```no_run
+/// # use guido::prelude::*;
+/// # let config = SurfaceConfig::new();
+/// # let status_bar_id = SurfaceId::next();
 /// // Store the ID when adding the surface
 /// App::new().run(|app| {
 ///     let status_bar_id = app.add_surface(config, move || {

--- a/src/widgets/children.rs
+++ b/src/widgets/children.rs
@@ -388,30 +388,34 @@ impl Drop for ChildrenSource {
 ///
 /// # Example
 ///
-/// ```ignore
-/// use guido::{create_signal, create_effect, on_cleanup};
+/// ```no_run
+/// use guido::prelude::*;
+/// # #[derive(Clone, PartialEq)] struct Item { id: u64, name: String }
+/// # let data = create_signal(Vec::<Item>::new());
 ///
-/// // Using .children() with dynamic keyed items - ownership is automatic
-/// container().children(move || {
-///     data.get().iter().map(|item| {
-///         (item.id, move || {
-///             // Signals created here are automatically cleaned up
-///             let local_state = create_signal(0);
+/// // `keyed` is how a caller reaches this: one owner per key, and ownership of
+/// // whatever the builder creates is automatic.
+/// container().children(keyed(
+///     move || data.get(),
+///     |item| item.id,
+///     |item| {
+///         // Signals created here are automatically cleaned up
+///         let local_state = create_signal(0);
 ///
-///             // Effects are automatically disposed
-///             create_effect(move || {
-///                 println!("Item {} state: {}", item.id, local_state.get());
-///             });
+///         // Effects are automatically disposed
+///         let id = item.id;
+///         create_effect(move || {
+///             println!("Item {id} state: {}", local_state.get());
+///         });
 ///
-///             // Register custom cleanup for non-reactive resources
-///             on_cleanup(|| {
-///                 println!("Item {} was removed!", item.id);
-///             });
+///         // Register custom cleanup for non-reactive resources
+///         on_cleanup(move || {
+///             println!("Item {id} was removed!");
+///         });
 ///
-///             text(move || format!("Item: {}", item.name))
-///         })
-///     })
-/// });
+///         text(move || format!("Item: {}", item.name))
+///     },
+/// ));
 /// ```
 pub struct DynItem {
     pub key: u64,
@@ -455,8 +459,10 @@ impl DynItem {
 ///
 /// # Example
 ///
-/// ```ignore
-/// use guido::{OwnedWidget, with_owner, create_signal, text};
+/// ```no_run
+/// use guido::prelude::*;
+/// # use guido::reactive::__internal::with_owner;
+/// use guido::widgets::children::OwnedWidget;
 ///
 /// // Manual ownership wrapping (usually not needed - use .children() instead)
 /// let (widget, owner_id) = with_owner(|| {

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -671,11 +671,16 @@ impl Container {
     ///
     /// # Example
     ///
-    /// ```ignore
-    /// container().background(Color::rgb(0.2, 0.2, 0.3))
-    /// container().background(Color::rgba(0.0, 0.0, 0.0, 0.5))  // 50% transparent black
-    /// container().background(theme.surface.transition(200.0))  // eased
-    /// container().background(theme.surface.timeline(flash().played_by(errors)))
+    /// ```no_run
+    /// # use guido::prelude::*;
+    /// # struct Theme { surface: Color }
+    /// # let theme = Theme { surface: Color::rgb(0.12, 0.12, 0.16) };
+    /// # let flash = || Keyframes::new(200.0).at(0.0, Color::BLACK).at(0.5, Color::WHITE).at(1.0, Color::BLACK);
+    /// # let errors = create_signal(0u32);
+    /// container().background(Color::rgb(0.2, 0.2, 0.3));
+    /// container().background(Color::rgba(0.0, 0.0, 0.0, 0.5));  // 50% transparent black
+    /// container().background(theme.surface.transition(200.0));  // eased
+    /// container().background(theme.surface.timeline(flash().played_by(errors)));
     /// ```
     pub fn background<M>(mut self, color: impl IntoAnimated<Color, M>) -> Self {
         self.background = Some(declare(&mut self.anims, color, |a| &mut a.background));
@@ -693,11 +698,12 @@ impl Container {
     /// bottom-right, bottom-left]` clockwise as CSS writes it. A constructor
     /// names another shape:
     ///
-    /// ```ignore
-    /// container().corners(8.0)
-    /// container().corners([16.0, 0.0])
-    /// container().corners(Corners::squircle(12.0))
-    /// container().corners(Corners::bevel([16.0, 0.0]))
+    /// ```no_run
+    /// # use guido::prelude::*;
+    /// container().corners(8.0);
+    /// container().corners([16.0, 0.0]);
+    /// container().corners(Corners::squircle(12.0));
+    /// container().corners(Corners::bevel([16.0, 0.0]));
     /// ```
     ///
     /// The shape reaches everything: the box, its border and shadow, the blur
@@ -721,11 +727,12 @@ impl Container {
     /// translucent. Pair it with a translucent
     /// [`background()`](Self::background) so the result shows through.
     ///
-    /// ```ignore
+    /// ```no_run
+    /// # use guido::prelude::*;
     /// container()
     ///     .corners(16.0)
     ///     .backdrop_blur(32.0)
-    ///     .background(Color::rgba(0.1, 0.1, 0.15, 0.6))
+    ///     .background(Color::rgba(0.1, 0.1, 0.15, 0.6));
     /// ```
     ///
     /// Restrict it with [`BackdropSources`](crate::backdrop::BackdropSources) when
@@ -811,16 +818,23 @@ impl Container {
     /// half-declaration to mean. Each half takes a signal of its own, so
     /// anything that has to change over time already can:
     ///
-    /// ```ignore
-    /// container().border(1.5, move || if failed.get() { theme.danger } else { theme.line })
+    /// ```no_run
+    /// # use guido::prelude::*;
+    /// # struct Theme { line: Color, danger: Color }
+    /// # let theme = Theme { line: Color::rgb(0.3, 0.3, 0.35), danger: Color::rgb(0.9, 0.3, 0.2) };
+    /// # let failed = create_signal(false);
+    /// container().border(1.5, move || if failed.get() { theme.danger } else { theme.line });
     /// ```
     ///
     /// A state layer says it the same way, and replaces the whole border:
     ///
-    /// ```ignore
+    /// ```no_run
+    /// # use guido::prelude::*;
+    /// # struct Theme { line: Color, accent: Color }
+    /// # let theme = Theme { line: Color::rgb(0.3, 0.3, 0.35), accent: Color::rgb(0.4, 0.6, 1.0) };
     /// container()
     ///     .border(1.5, theme.line)
-    ///     .when_focused(|s| s.border(1.5, theme.accent))
+    ///     .when_focused(|s| s.border(1.5, theme.accent));
     /// ```
     ///
     /// A width repeated across layers is a constant in your own code — there is
@@ -830,11 +844,13 @@ impl Container {
     /// two channels are different types and a border can spring open while its
     /// colour eases.
     ///
-    /// ```ignore
+    /// ```no_run
+    /// # use guido::prelude::*;
+    /// # let thick = create_signal(false);
     /// container().border(
     ///     (move || if thick.get() { 14.0 } else { 2.0 }).transition(SpringConfig::BOUNCY),
     ///     Color::rgb(0.40, 0.50, 0.70).transition(300.0),
-    /// )
+    /// );
     /// ```
     pub fn border<M1, M2>(
         mut self,
@@ -855,10 +871,15 @@ impl Container {
     /// a value meaning *off*, a gradient that only applies sometimes forces the
     /// caller back to branching in Rust and rebuilding the widget.
     ///
-    /// ```ignore
+    /// ```no_run
+    /// # use guido::prelude::*;
+    /// # struct Theme { surface: Color }
+    /// # let theme = Theme { surface: Color::rgb(0.12, 0.12, 0.16) };
+    /// # let expanded = create_signal(false);
+    /// # let palette = create_signal(LinearGradient::horizontal(Color::WHITE, Color::BLACK));
     /// container()
     ///     .background(theme.surface)
-    ///     .gradient(move || expanded.get().then(|| palette.get().header()))
+    ///     .gradient(move || expanded.get().then(|| palette.get()));
     /// ```
     pub fn gradient<M>(mut self, gradient: impl IntoSignal<Option<LinearGradient>, M>) -> Self {
         self.gradient = Some(gradient.into_signal());
@@ -993,7 +1014,8 @@ impl Container {
     /// `Option<Callback>` — the last being what a `#[component]` callback prop
     /// holds, so a component forwards its own prop with no ceremony:
     ///
-    /// ```ignore
+    /// ```no_run
+    /// # use guido::prelude::*;
     /// #[component]
     /// fn button(#[prop(callback)] on_click: ()) -> impl Widget {
     ///     container().on_click(on_click)
@@ -1094,11 +1116,16 @@ impl Container {
     /// so a card can spring into place while its rotation eases. Declaring one
     /// says nothing about the other two.
     ///
-    /// ```ignore
-    /// container().translate((20.0, 10.0))
-    /// container().translate(move || Translate::new(offset.get(), 0.0))
-    /// container().translate(target.transition(SpringConfig::SNAPPY))
-    /// container().translate(Translate::NONE.timeline(nod().played_by(refusals)))
+    /// ```no_run
+    /// # use guido::prelude::*;
+    /// # let offset = create_signal(0.0f32);
+    /// # let target = create_signal(Translate::NONE);
+    /// # let refusals = create_signal(0u32);
+    /// # let nod = || Keyframes::new(200.0).at(0.0, Translate::NONE).at(0.5, Translate::new(0.0, 4.0)).at(1.0, Translate::NONE);
+    /// container().translate((20.0, 10.0));
+    /// container().translate(move || Translate::new(offset.get(), 0.0));
+    /// container().translate(target.transition(SpringConfig::SNAPPY));
+    /// container().translate(Translate::NONE.timeline(nod().played_by(refusals)));
     /// ```
     pub fn translate<M>(mut self, t: impl IntoAnimated<Translate, M>) -> Self {
         let signal = declare(&mut self.anims, t, |a| &mut a.translate);
@@ -1113,10 +1140,14 @@ impl Container {
     /// [`rotate`](Self::rotate) is given is what an animation interpolates and
     /// what a read gives back.
     ///
-    /// ```ignore
-    /// container().rotate(45.0)
-    /// container().rotate(move || heading.get())
-    /// container().rotate(0.0.timeline(shake().played_by(rejections)))
+    /// ```no_run
+    /// # use guido::prelude::*;
+    /// # let heading = create_signal(0.0f32);
+    /// # let rejections = create_signal(0u32);
+    /// # let shake = || Keyframes::new(320.0).at(0.0, 0.0).at(0.5, 8.0).at(1.0, 0.0);
+    /// container().rotate(45.0);
+    /// container().rotate(move || heading.get());
+    /// container().rotate(0.0.timeline(shake().played_by(rejections)));
     /// ```
     ///
     /// An eased angle is interpolated as the number it is, so a turn to 360°
@@ -1142,11 +1173,15 @@ impl Container {
     ///
     /// A bare factor scales both axes; a pair scales them apart.
     ///
-    /// ```ignore
-    /// container().scale(1.5)
-    /// container().scale((2.0, 0.5))
-    /// container().scale(open_size.transition(SpringConfig::SNAPPY))
-    /// container().scale(Scale::NONE.timeline(pulse().played_by(beats)))
+    /// ```no_run
+    /// # use guido::prelude::*;
+    /// # let open_size = create_signal(Scale::NONE);
+    /// # let beats = create_signal(0u32);
+    /// # let pulse = || Keyframes::new(200.0).at(0.0, Scale::NONE).at(0.5, Scale::uniform(1.1)).at(1.0, Scale::NONE);
+    /// container().scale(1.5);
+    /// container().scale((2.0, 0.5));
+    /// container().scale(open_size.transition(SpringConfig::SNAPPY));
+    /// container().scale(Scale::NONE.timeline(pulse().played_by(beats)));
     /// ```
     pub fn scale<M>(mut self, factor: impl IntoAnimated<Scale, M>) -> Self {
         let signal = declare(&mut self.anims, factor, |a| &mut a.scale);
@@ -1175,10 +1210,14 @@ impl Container {
     /// whose highlight belongs to the row.
     ///
     /// # Example
-    /// ```ignore
+    /// ```no_run
+    /// # use guido::prelude::*;
+    /// # struct Theme { accent: Color }
+    /// # let theme = Theme { accent: Color::rgb(0.4, 0.6, 1.0) };
+    /// # let password = create_signal(String::new());
     /// container().control()
     ///     .child(text("Password").when_focused(|s| s.color(theme.accent)))
-    ///     .child(text_input(password))
+    ///     .child(text_input(password));
     /// ```
     pub fn control(mut self) -> Self {
         self.declared_control = true;

--- a/src/widgets/corners.rs
+++ b/src/widgets/corners.rs
@@ -7,13 +7,14 @@
 //!
 //! The constructors name the *shape*, and take the size:
 //!
-//! ```ignore
-//! container().corners(8.0)                        // rounded, uniform
-//! container().corners([16.0, 0.0])                // rounded on the top pair only
-//! container().corners(Corners::squircle(12.0))    // iOS-style continuous
-//! container().corners(Corners::bevel(12.0))       // a diagonal cut
-//! container().corners(Corners::scoop(12.0))       // concave
-//! container().corners(Corners::superellipse(12.0, 1.5))
+//! ```no_run
+//! # use guido::prelude::*;
+//! container().corners(8.0);                        // rounded, uniform
+//! container().corners([16.0, 0.0]);                // rounded on the top pair only
+//! container().corners(Corners::squircle(12.0));    // iOS-style continuous
+//! container().corners(Corners::bevel(12.0));       // a diagonal cut
+//! container().corners(Corners::scoop(12.0));       // concave
+//! container().corners(Corners::superellipse(12.0, 1.5));
 //! ```
 //!
 //! The radii take one value for all four, `[top, bottom]` for the two pairs,

--- a/src/widgets/font.rs
+++ b/src/widgets/font.rs
@@ -8,9 +8,10 @@ use cosmic_text::{Family, Weight};
 ///
 /// # Examples
 ///
-/// ```ignore
-/// text("Hello").font_family(FontFamily::Monospace)
-/// text("Hello").font_family(FontFamily::Name("Inter".into()))
+/// ```no_run
+/// # use guido::prelude::*;
+/// text("Hello").font_family(FontFamily::Monospace);
+/// text("Hello").font_family(FontFamily::Name("Inter".into()));
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
 pub enum FontFamily {
@@ -47,9 +48,10 @@ impl FontFamily {
 ///
 /// # Examples
 ///
-/// ```ignore
-/// text("Hello").font_weight(FontWeight::BOLD)
-/// text("Hello").font_weight(FontWeight(600))
+/// ```no_run
+/// # use guido::prelude::*;
+/// text("Hello").font_weight(FontWeight::BOLD);
+/// text("Hello").font_weight(FontWeight(600));
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub struct FontWeight(pub u16);

--- a/src/widgets/image.rs
+++ b/src/widgets/image.rs
@@ -98,11 +98,13 @@ pub enum ContentFit {
 /// the box itself comes from the enclosing container, like every other size in
 /// guido:
 ///
-/// ```ignore
+/// ```no_run
+/// # use guido::prelude::*;
+/// # let source = "./photo.jpg";
 /// container()
 ///     .width(fill())
 ///     .height(fill())
-///     .child(image(source).content_fit(ContentFit::Cover))
+///     .child(image(source).content_fit(ContentFit::Cover));
 /// ```
 pub struct Image {
     source: Signal<ImageSource>,
@@ -256,24 +258,24 @@ impl Widget for Image {
 ///
 /// # Examples
 ///
-/// ```ignore
+/// ```no_run
+/// # use guido::prelude::*;
+/// # let svg_data: Vec<u8> = Vec::new();
 /// // From file path (auto-detects SVG)
-/// image("./icon.png")
-/// image("./logo.svg")
+/// image("./icon.png");
+/// image("./logo.svg");
 ///
-/// // With explicit dimensions
-/// image("./icon.png")
-///     .width(32.0)
-///     .height(32.0)
+/// // Sized by the container it sits in: an image has no width of its own
+/// container().width(32.0).height(32.0).child(image("./icon.png"));
 ///
-/// // With content fit mode
-/// image("./photo.jpg")
+/// // With content fit mode, in a box that gives it its size
+/// container()
 ///     .width(200.0)
 ///     .height(150.0)
-///     .content_fit(ContentFit::Cover)
+///     .child(image("./photo.jpg").content_fit(ContentFit::Cover));
 ///
 /// // From ImageSource
-/// image(ImageSource::SvgBytes(svg_data.into()))
+/// image(ImageSource::SvgBytes(svg_data.into()));
 /// ```
 pub fn image<M>(source: impl IntoSignal<ImageSource, M>) -> Image {
     Image::new(source)

--- a/src/widgets/into_child.rs
+++ b/src/widgets/into_child.rs
@@ -2,12 +2,19 @@
 //!
 //! Children come in four forms — two static, two reactive:
 //!
-//! ```ignore
+//! ```no_run
+//! # use guido::prelude::*;
+//! # #[derive(Clone, PartialEq)] struct Item { id: u64, name: String }
+//! # let entries = create_signal(Vec::<Item>::new());
+//! # let items = create_signal(Vec::<Item>::new());
+//! # let build_menu = |_: Vec<Item>| text("menu");
+//! # let row = |item: Item| text(item.name);
+//! # let (a, b, c) = (text("a"), text("b"), text("c"));
 //! container()
 //!     .child(text("hi"))                                  // static single
 //!     .child(move || build_menu(entries.get()))           // reactive single
 //!     .children([a, b, c])                                // static list
-//!     .children(keyed(move || items.get(), |i| i.id, row)) // reactive keyed list
+//!     .children(keyed(move || items.get(), |i| i.id, row)); // reactive keyed list
 //! ```
 //!
 //! A reactive closure re-runs when a signal it read is written, and its
@@ -313,18 +320,25 @@ pub struct KeyedChildren<T, I, K, W> {
 /// Rows are indexed by the key itself, not by a hash of it, so two distinct keys
 /// are never reconciled as one:
 ///
-/// ```ignore
+/// ```no_run
+/// # use guido::prelude::*;
+/// # #[derive(Clone, PartialEq)] struct Space { id: u64 }
+/// # let workspaces = create_signal(Vec::<Space>::new());
+/// # let workspace_pill = |_: Space| text("ws");
 /// container().children(keyed(
 ///     move || workspaces.get(),
 ///     |ws| ws.id,
 ///     workspace_pill,
-/// ))
+/// ));
 ///
+/// # #[derive(Clone, PartialEq)] struct Tab { title: String }
+/// # let tabs = create_signal(Vec::<Tab>::new());
+/// # let tab_button = |_: Tab| text("tab");
 /// container().children(keyed(
 ///     move || tabs.get(),
 ///     |tab| tab.title.clone(),
 ///     tab_button,
-/// ))
+/// ));
 /// ```
 pub fn keyed<T, I, K, W>(
     data: impl Fn() -> I + 'static,

--- a/src/widgets/scroll.rs
+++ b/src/widgets/scroll.rs
@@ -98,15 +98,18 @@ fn pill() -> crate::widgets::Corners {
 /// compiled and did nothing. Reached through [`Container::scroll`], there is no
 /// way to spell the parts apart from the thing they configure.
 ///
-/// ```ignore
-/// container().scroll(Scroll::vertical())
+/// ```no_run
+/// # use guido::prelude::*;
+/// # let handle_color = Color::rgb(0.4, 0.4, 0.4);
+/// # let hot = Color::rgb(0.6, 0.6, 0.6);
+/// container().scroll(Scroll::vertical());
 ///
 /// container().scroll(
 ///     Scroll::vertical()
 ///         .width(6.0)
-///         .handle(|h| h.background(theme.handle)
-///             .when_hovered(|s| s.background(theme.hot))),
-/// )
+///         .handle(move |h| h.background(handle_color)
+///             .when_hovered(move |s| s.background(hot))),
+/// );
 /// ```
 ///
 /// The axis is structural — it decides what kind of widget this is — so it is

--- a/src/widgets/state_layer.rs
+++ b/src/widgets/state_layer.rs
@@ -6,12 +6,13 @@
 //! could not follow the theme would be a second, quieter styling system.
 //!
 //! # Example
-//! ```ignore
+//! ```no_run
+//! # use guido::prelude::*;
 //! container()
 //!     .background(Color::rgb(0.2, 0.2, 0.3))
 //!     .when_hovered(|s| s.lighter(0.1))
 //!     .when_pressed(|s| s.darker(0.1).scale(0.98))
-//!     .child(text("Interactive button"))
+//!     .child(text("Interactive button"));
 //! ```
 
 use crate::reactive::{IntoSignal, Signal, create_stored};
@@ -196,10 +197,13 @@ impl StateStyle {
     /// property somebody else owns — so a hover already eases under whatever
     /// the base declared:
     ///
-    /// ```ignore
+    /// ```no_run
+    /// # use guido::prelude::*;
+    /// # let base = Color::rgb(0.2, 0.2, 0.3);
+    /// # const HOT: Color = Color::rgb(0.9, 0.3, 0.2);
     /// container()
-    ///     .background(base.transition(200.0))    // the property eases
-    ///     .when_hovered(|s| s.background(HOT.transition(900.0)))   // the override changes the value
+    ///     .background(base.transition(200.0))   // the property eases
+    ///     .when_hovered(|s| s.background(HOT)); // the override supplies the value
     /// ```
     ///
     /// Declaring a timing here is a compile error rather than a value quietly
@@ -225,10 +229,11 @@ impl StateStyle {
     /// by blending toward white.
     ///
     /// # Example
-    /// ```ignore
+    /// ```no_run
+    /// # use guido::prelude::*;
     /// container()
     ///     .background(Color::rgb(0.2, 0.2, 0.3))
-    ///     .when_hovered(|s| s.lighter(0.1)) // 10% lighter on hover
+    ///     .when_hovered(|s| s.lighter(0.1)); // 10% lighter on hover
     /// ```
     pub fn lighter<M>(mut self, amount: impl IntoSignal<f32, M>) -> Self {
         self.background = Some(BackgroundOverride::Lighter(amount.into_signal()));
@@ -238,10 +243,11 @@ impl StateStyle {
     /// Darken the base background by amount (0.0-1.0).
     ///
     /// # Example
-    /// ```ignore
+    /// ```no_run
+    /// # use guido::prelude::*;
     /// container()
     ///     .background(Color::rgb(0.2, 0.2, 0.3))
-    ///     .when_pressed(|s| s.darker(0.1)) // 10% darker on press
+    ///     .when_pressed(|s| s.darker(0.1)); // 10% darker on press
     /// ```
     pub fn darker<M>(mut self, amount: impl IntoSignal<f32, M>) -> Self {
         self.background = Some(BackgroundOverride::Darker(amount.into_signal()));
@@ -294,8 +300,9 @@ impl StateStyle {
     ///
     /// The press effect, most of the time:
     ///
-    /// ```ignore
-    /// container().when_pressed(|s| s.scale(0.98))
+    /// ```no_run
+    /// # use guido::prelude::*;
+    /// container().when_pressed(|s| s.scale(0.98));
     /// ```
     pub fn scale<M>(mut self, factor: impl IntoSignal<Scale, M>) -> Self {
         self.scale = Some(factor.into_signal());
@@ -336,10 +343,11 @@ impl StateStyle {
     /// Useful for making semi-transparent elements more visible on hover.
     ///
     /// # Example
-    /// ```ignore
+    /// ```no_run
+    /// # use guido::prelude::*;
     /// container()
     ///     .background(Color::rgba(1.0, 0.5, 0.0, 0.4))
-    ///     .when_hovered(|s| s.lighter(0.1).alpha(0.7)) // boost alpha on hover
+    ///     .when_hovered(|s| s.lighter(0.1).alpha(0.7)); // boost alpha on hover
     /// ```
     pub fn alpha<M>(mut self, alpha: impl IntoSignal<f32, M>) -> Self {
         self.alpha = Some(alpha.into_signal());
@@ -351,10 +359,11 @@ impl StateStyle {
     /// The ripple expands from the click point and fades out when released.
     ///
     /// # Example
-    /// ```ignore
+    /// ```no_run
+    /// # use guido::prelude::*;
     /// container()
     ///     .when_pressed(|s| s.ripple())
-    ///     .child(text("Click for ripple"))
+    ///     .child(text("Click for ripple"));
     /// ```
     pub fn ripple(mut self) -> Self {
         self.ripple = Some(RippleConfig::default());
@@ -364,10 +373,11 @@ impl StateStyle {
     /// Enable ripple effect with a custom color.
     ///
     /// # Example
-    /// ```ignore
+    /// ```no_run
+    /// # use guido::prelude::*;
     /// container()
     ///     .when_pressed(|s| s.ripple_with_color(Color::rgba(1.0, 0.5, 0.0, 0.3)))
-    ///     .child(text("Orange ripple"))
+    ///     .child(text("Orange ripple"));
     /// ```
     pub fn ripple_with_color<M>(mut self, color: impl IntoSignal<Color, M>) -> Self {
         self.ripple = Some(RippleConfig::with_color(color));
@@ -405,8 +415,11 @@ pub fn resolve_background(base: Color, override_: &BackgroundOverride) -> Color 
 /// The closure receives the same partial style the widget itself is built
 /// with, because an override *is* another partial style:
 ///
-/// ```ignore
-/// text("Save").color(theme.weak).when_hovered(|s| s.color(theme.strong))
+/// ```no_run
+/// # use guido::prelude::*;
+/// # struct Theme { weak: Color, strong: Color }
+/// # let theme = Theme { weak: Color::rgb(0.6, 0.6, 0.6), strong: Color::WHITE };
+/// text("Save").color(theme.weak).when_hovered(|s| s.color(theme.strong));
 /// ```
 ///
 /// Layers resolve in reverse declaration order, per property, exactly as a

--- a/src/widgets/text.rs
+++ b/src/widgets/text.rs
@@ -32,8 +32,11 @@ pub(crate) fn decoration_overflow(stroke: Option<TextStroke>, shadow: Option<Tex
 /// the defaults:
 /// white, 14 logical pixels, the registered family, normal weight.
 ///
-/// ```ignore
-/// text("Hello").font_size(21.0).color(theme.text)
+/// ```no_run
+/// # use guido::prelude::*;
+/// # struct Theme { text: Color }
+/// # let theme = Theme { text: Color::WHITE };
+/// text("Hello").font_size(21.0).color(theme.text);
 /// ```
 ///
 /// There is no enclosing declaration to inherit from: a container draws a box
@@ -117,11 +120,12 @@ impl Text {
     /// text's own colour is the tint laid over it — which is why this is usually
     /// paired with a translucent one.
     ///
-    /// ```ignore
+    /// ```no_run
+    /// # use guido::prelude::*;
     /// text("09:41")
     ///     .font_size(76.0)
     ///     .color(Color::rgba(1.0, 1.0, 1.0, 0.35))
-    ///     .backdrop_blur(16.0)
+    ///     .backdrop_blur(16.0);
     /// ```
     ///
     /// It filters what *this surface* has already drawn — a wallpaper, a photo,
@@ -378,15 +382,19 @@ impl Widget for Text {
 /// Create a text widget
 ///
 /// Accepts static strings, closures, or signals:
-/// ```ignore
-/// text("Hello")  // static string
-/// text(move || format!("Count: {}", count.get()))  // reactive closure
-/// text(my_signal)  // reactive signal
+/// ```no_run
+/// # use guido::prelude::*;
+/// # let count = create_signal(0);
+/// # let my_signal = create_signal(String::from("hi"));
+/// text("Hello");  // static string
+/// text(move || format!("Count: {}", count.get()));  // reactive closure
+/// text(my_signal);  // reactive signal
 /// ```
 ///
 /// Styling is declared here, on the widget that draws the glyphs:
-/// ```ignore
-/// text("Hello").font_size(18.0).bold()
+/// ```no_run
+/// # use guido::prelude::*;
+/// text("Hello").font_size(18.0).bold();
 /// ```
 pub fn text<M>(content: impl IntoSignal<String, M>) -> Text {
     Text::new(content)

--- a/src/widgets/text_input.rs
+++ b/src/widgets/text_input.rs
@@ -458,10 +458,11 @@ impl TextInput {
     /// The container has the same builder; put the ref on the *input* when what
     /// you mean is "focus this field", since a container cannot take focus.
     ///
-    /// ```ignore
+    /// ```no_run
+    /// # use guido::prelude::*;
     /// let field = create_widget_ref();
     /// // ...
-    /// container().on_click(move || field.focus())
+    /// container().on_click(move || field.focus());
     /// ```
     pub fn widget_ref(mut self, widget_ref: WidgetRef) -> Self {
         self.widget_ref = Some(widget_ref);
@@ -1600,9 +1601,10 @@ impl Widget for TextInput {
 /// Create a text input widget with two-way signal binding.
 ///
 /// Changes made in the text input will be written back to the signal.
-/// ```ignore
+/// ```no_run
+/// # use guido::prelude::*;
 /// let username = create_signal(String::new());
-/// text_input(username)
+/// text_input(username);
 /// ```
 pub fn text_input(signal: RwSignal<String>) -> TextInput {
     TextInput::new(signal)

--- a/src/widgets/text_style.rs
+++ b/src/widgets/text_style.rs
@@ -5,8 +5,11 @@
 //! say how those glyphs look. A container draws a box and says nothing about
 //! what is written inside it.
 //!
-//! ```ignore
-//! text("Hello").font_size(16.0).color(theme.text).bold()
+//! ```no_run
+//! # use guido::prelude::*;
+//! # struct Theme { text: Color }
+//! # let theme = Theme { text: Color::WHITE };
+//! text("Hello").font_size(16.0).color(theme.text).bold();
 //! ```
 //!
 //! # A style is a partial record
@@ -26,9 +29,11 @@
 //! Write a function. It keeps the declaration next to the widget that draws
 //! it, costs no wrapper node, and gives the style a name:
 //!
-//! ```ignore
-//! let label = |s: &str| text(s).color(theme.weak).font_size(12.0);
-//! container().children([label("one"), label("two"), label("three")])
+//! ```no_run
+//! # use guido::prelude::*;
+//! # let weak = Color::rgb(0.6, 0.6, 0.6);
+//! let label = move |s: &str| text(s).color(weak).font_size(12.0);
+//! container().children([label("one"), label("two"), label("three")]);
 //! ```
 //!
 //! # A state that reaches the glyphs
@@ -37,9 +42,12 @@
 //! each where it happens and let [`control()`](crate::widgets::Container::control)
 //! join them: a leaf resolves its own states from the nearest control above it.
 //!
-//! ```ignore
+//! ```no_run
+//! # use guido::prelude::*;
+//! # let weak = Color::rgb(0.6, 0.6, 0.6);
+//! # let strong = Color::WHITE;
 //! container().control().when_hovered(|s| s.lighter(0.1))
-//!     .child(text("Label").color(weak).when_hovered(|s| s.color(strong)))
+//!     .child(text("Label").color(weak).when_hovered(|s| s.color(strong)));
 //! ```
 
 use smallvec::SmallVec;

--- a/src/widgets/widget.rs
+++ b/src/widgets/widget.rs
@@ -847,12 +847,15 @@ pub trait Widget {
     /// Type-erase this widget into a boxed trait object.
     ///
     /// Useful when returning different widget types from conditional branches:
-    /// ```ignore
-    /// if condition {
+    /// ```no_run
+    /// # use guido::prelude::*;
+    /// # let condition = true;
+    /// # let (widget_a, widget_b) = (text("a"), text("b"));
+    /// let _child = if condition {
     ///     widget_a.into_any()
     /// } else {
     ///     widget_b.into_any()
-    /// }
+    /// };
     /// ```
     fn into_any(self) -> AnyWidget
     where

--- a/tests/documentation_references.rs
+++ b/tests/documentation_references.rs
@@ -324,3 +324,94 @@ fn every_fence_in_the_book_says_what_it_holds() {
         wrong.join("\n")
     );
 }
+
+/// Every rustdoc sample in `src/` is compiled, or says why it is not.
+///
+/// An `ignore`d block is the one place in this repository where an API name can
+/// be written and nothing at all checks it. Prose in backticks is checked above;
+/// the book's fences are checked below and by `mdbook test`; every other rustdoc
+/// sample is compiled by rustdoc in CI. An `ignore` is exempt from all four, and
+/// it does not announce itself in the rendered page.
+///
+/// Three samples were found teaching methods the crate does not have, two of them
+/// `container().font_size(..)` and one `container().transform(..)`. The first
+/// would have been copied by a caller: it sat on `Text`'s own documentation, next
+/// to a line saying a container declares nothing about text.
+///
+/// Extending the name check above cannot catch these. `font_size` exists three
+/// times over — on `Text`, on `TextInput`, on `TextStyle` — and what made the
+/// sample false was the receiver. Only a compiler knows receivers, so the sample
+/// has to reach one.
+///
+/// The escape hatch is the block that says why, as its first line: a sample built
+/// around an `async` block, or one that would open a surface on somebody's screen,
+/// has a reason and should carry it where the next reader meets it.
+#[test]
+fn every_rustdoc_sample_is_compiled_or_says_why_not() {
+    /// What an exempt block's first line has to start with.
+    const REASON: &str = "// not compiled:";
+
+    // Both crates, as the prose test above reads both: `guido-macros` carries the
+    // `#[component]` sample, which is the first one a new caller copies.
+    let mut sources = Vec::new();
+    read_dir_files(&repo().join("src"), "rs", &mut sources);
+    read_dir_files(&repo().join("guido-macros/src"), "rs", &mut sources);
+    assert!(!sources.is_empty(), "no sources found: scanning nothing");
+
+    let mut unexplained = Vec::new();
+    let mut exempt = 0usize;
+    for file in sources {
+        let source = std::fs::read_to_string(&file).expect("unreadable source");
+        let lines: Vec<&str> = source.lines().collect();
+        for (number, line) in lines.iter().enumerate() {
+            let Some(fence) = doc_comment_body(line) else {
+                continue;
+            };
+            // Tokenised rather than compared: ```` ```rust,ignore ```` and
+            // ```` ```ignore,no_run ```` are skipped by rustdoc exactly the same,
+            // and the first is in the book's own allowlist twenty lines up — so it
+            // is the spelling an author coming from the book reaches for. Matching
+            // one spelling is how the fence-label scar above happened.
+            let Some(info) = fence.trim().strip_prefix("```") else {
+                continue;
+            };
+            if !info.split(',').any(|token| token.trim() == "ignore") {
+                continue;
+            }
+            // The first line of the block, which is where the reason goes.
+            let first = lines
+                .get(number + 1)
+                .and_then(|next| doc_comment_body(next))
+                .unwrap_or_default();
+            if first.trim_start().starts_with(REASON) {
+                exempt += 1;
+                continue;
+            }
+            let name = file.strip_prefix(repo()).unwrap_or(&file).display();
+            unexplained.push(format!("  {name}:{}", number + 1));
+        }
+    }
+
+    assert!(
+        unexplained.is_empty(),
+        "{} rustdoc sample(s) are marked `ignore`, so nothing compiles them and \
+         nothing else checks the names inside them. Either drop the `ignore` — \
+         adding whatever hidden `#` setup lines it takes, or `no_run` where the \
+         sample compiles but must not run — or state the reason on the block's \
+         first line as `{REASON} ...`.\n{}\n\n({exempt} exempt with a reason)",
+        unexplained.len(),
+        unexplained.join("\n")
+    );
+}
+
+/// What a line says after its doc-comment marker, if it is one.
+///
+/// Both markers: an inner `//!` block is documentation the same as an outer
+/// `///` one, and `src/lib.rs` carries most of its samples in the inner kind.
+fn doc_comment_body(line: &str) -> Option<&str> {
+    let trimmed = line.trim_start();
+    let body = trimmed
+        .strip_prefix("///")
+        .or_else(|| trimmed.strip_prefix("//!"))?;
+    Some(body.strip_prefix(' ').unwrap_or(body))
+}


### PR DESCRIPTION
## What changed

An `ignore`d rustdoc sample was the one place in this repository where an API name
could be written and nothing at all checked it. Prose in backticks has
`documentation_references`, the book's fences have `mdbook test` and a test on the
fence label, and every other rustdoc sample has rustdoc in CI. An `ignore` was
exempt from all four and said nothing about it in the rendered page.

`every_rustdoc_sample_is_compiled_or_says_why_not` closes that, over both crates.
87 samples are compiled now; 7 carry a stated reason on their first line. The
reason is the escape hatch on purpose: a fragment of a `Widget` impl, a
crate-internal type no doctest can reach, a proc-macro crate with no widget to
compile against. Each also says where the same thing *is* compiled.

The conversions add hidden `#` lines for the locals a sample illustrates with, so
what a reader sees is unchanged. Closes #364.

## What proves it

The test failed 91 times when it was written, which is every `ignore` block that
existed. It passes now, and the compiler holds the rest: `cargo test --doc` is 108
passing and 4 ignored.

It is proof against the next mechanical pass too. The label is tokenised rather
than compared, because ```` ```rust,ignore ```` is skipped by rustdoc exactly the
same and sits in the book's own allowlist twenty lines above — so it is the
spelling somebody reaches for next. Confirmed by planting one in
`src/widgets/corners.rs`: the test names the file and line.

**Seven claims the compiler rejected**, each a method or a shape that does not
exist. This is the substance of the change, not a side effect of it:

| sample | the claim | the truth |
| --- | --- | --- |
| `entering_from` | `container().transform(..)` | the family is `translate`, `rotate`, `scale` |
| `timing`, `spring` module headers | `StateStyle::timing`, `StateStyle::duration` | a layer supplies a value, never a timing |
| `image` ×2 | `Image::width`, `Image::height` | an image is sized by its container |
| `App::default_font_family` | `.add_surface(..).run()` chained | `add_surface` takes `&mut self` and returns an id |
| `DynItem` | `.children()` over `(key, builder)` pairs | `keyed(data, key, build)` |
| `OwnedWidget` | `use guido::{OwnedWidget, with_owner, ..}` | none of the four live there |
| three of my own | `played_by(create_trigger())` | it takes a count, not a trigger |

That last row is the argument in miniature: I wrote a false sample during this
work and the compiler caught it within the minute, which is exactly what could not
happen before.

The two rewrites that replaced a claim rather than adding setup — the `timing` and
`spring` headers — now teach what `docs/STATE_LAYER.md` already stated, that the
motion belongs to the property and a hover eases under whatever the base declared.
They did not invent a spelling to go green.

## What the review found

**Zero blocking.** Three worth answering; two acted on, one answered here.

The ratchet matched only the exact string ```` ```ignore ````, which would have let
the next mechanical pass re-open the very hole this closes. Tokenised, and the
variant is now a failing test.

It scanned `src/` only, while the prose test beside it reads both crates — leaving
three blocks in `guido-macros`, including the `#[component]` sample, which is the
first one a new caller copies. It scans both now. Those three cannot compile where
they live: the macros crate is a proc-macro crate with no dependency on `guido`, so
`container()` has nothing to compile against. They carry that reason and point at
`tests/forwarded_children.rs` and `examples/component_example.rs`, which are the
compiled versions.

**Answered rather than acted on:** every conversion went to `no_run` and none to a
plain fence, where the issue's acceptance allows a plain one for samples that can
run. `no_run` compiles, which is the whole substance here — types, receivers,
import paths, arity. Running would additionally prove no panic, and the samples
where that is safe are the ones whose bodies do nothing observable, so the return is
small against a per-sample judgement about whether running is safe in a merged
doctest binary. A sample that must not run is the common case in this crate:
`App::run`, `spawn_surface`, `lock_session`, `create_task`.

Its notes were taken: a hidden local named `hot` that was actually the base colour,
four keyframe stubs that did not move (rustdoc has a toggle for hidden lines, so a
reader does meet them), a line whose only job was type inference in a body meant for
copying, a visible `__internal` import that read as endorsed where `context.rs`
keeps the same one hidden, and a fixture struct duplicated five times with two of
four fields unused at every site.

## What was checked by hand

Nothing. The compiler is the check this change is about, and the planted
`rust,ignore` was verified through the test rather than by eye.

## Left undone

`examples/effect_cleanup_test.rs` has an `ignore` block, and cargo never doctests
an example's doc comments, so it is structurally out of this test's reach. Nobody is
worse off today — it is a comment in a test example, not documentation a caller
follows — so it is this sentence and not an issue.

https://claude.ai/code/session_01UBH3udwnC1nUZ7wv5TS7N9
