### PR TITLE
The seed runs before the measurement that consumes what it places

### DIFF
--- a/.claude/skills/widgets/SKILL.md
+++ b/.claude/skills/widgets/SKILL.md
@@ -236,8 +236,8 @@ Three rules the shape depends on, in order of how easily they are broken:
   `height` declare a `Length` and move an `f32` — so `width(w.timeline(..))`
   does not compile rather than compiling and playing nothing.
 
-A new animatable property adds its name to four lists that nothing keeps in
+A new animatable property adds its name to five lists that nothing keeps in
 step: `ContainerAnims`'s fields, `start_timeline!` and the `advance_anim!`
-block in `advance_animations`, and the drift block in
-`resync_animation_targets`. Miss one and the property silently never plays or
-never wakes.
+block in `advance_animations`, the seed block in `seed_animations`, and the
+drift block in `resync_animation_targets`. Miss one and the property silently
+never plays, never wakes, or keeps whatever value the builder happened to see.

--- a/src/widgets/container/anim_bridge.rs
+++ b/src/widgets/container/anim_bridge.rs
@@ -21,7 +21,11 @@
 //! - [`seed_animations`] is (1): at the first layout, every animated property
 //!   is read under Animation tracking so its subscription starts *now*. Widget
 //!   creation and first layout run in one synchronous block — for popups, the
-//!   measure-before-spawn — so nothing can land in between.
+//!   measure-before-spawn — so nothing can land in between. It runs *before*
+//!   the measurement, not after: padding is a property a layout reads, and one
+//!   placed after `read_box_lengths` is a value that layout never saw. On the
+//!   popup path there is no later pass to repair that — the size is a return
+//!   value.
 //! - [`resync_animation_targets`] is (2): every paint re-reads the targets
 //!   under tracking and asks for an Animation job when one has drifted, so
 //!   `advance_animations` adopts whatever the subscription missed.
@@ -147,9 +151,10 @@ impl Container {
         // Targets are computed under `&self` first: the writes below need
         // `&mut self.anims`, and the effective_* readers need `&self`.
         let (pd_target, bw_target) = with_signal_tracking(id, JobType::Animation, || {
-            // Read for the subscription, and kept: these two keep the
-            // seed they were built with rather than being re-seeded here,
-            // but an enter declared on them still has to begin somewhere.
+            // Read under tracking for the subscription, and placed below like
+            // every other property — which they have been since #348 gave them
+            // a `seed_or_enter`, and which is why the drift check can speak for
+            // them at all: it is gated on their having been placed.
             (
                 pd_init.then(|| self.effective_padding_target(id)),
                 bw_init.then(|| self.effective_border_width_target(id)),

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -2652,6 +2652,176 @@ fn a_translate_target_behind_an_untaken_branch_is_picked_up_by_the_resync() {
     );
 }
 
+/// A padding written between construction and the first layout arrives.
+///
+/// The push half, for padding. The builder seeds from `get_untracked()`, so a
+/// write in that window is one nothing has subscribed to yet; what closes it is
+/// `seed_animations` re-reading the target at the first layout and placing it
+/// before the measurement that consumes it. Seed after `read_box_lengths` and the
+/// container measures with whatever the builder happened to see, with no later
+/// pass obliged to fix it.
+#[test]
+fn a_padding_written_before_the_first_layout_arrives() {
+    let inset = create_signal(0.0f32);
+    let mut h = H::new(
+        container()
+            .width(200.0)
+            .height(200.0)
+            .padding(
+                (move || Padding::all(inset.get()))
+                    .transition(Transition::new(80.0, TimingFunction::Linear)),
+            )
+            .child(box_of(20.0, 20.0)),
+    );
+
+    // Between the builder and the first layout, as a popup's content is built
+    // one frame and laid out the next.
+    inset.set(24.0);
+
+    // One frame: the seed runs before the measurement, so the layout that places
+    // the value is the layout that uses it.
+    let x = h.frame(400.0, 400.0).node.children[0].local_transform.tx();
+    assert!(
+        (x - 24.0).abs() < 0.5,
+        "the write landed before anything was listening and has to be picked up \
+         at the seed, got {x}"
+    );
+}
+
+/// And the size that padding feeds settles on the padding that was measured.
+///
+/// The consequence with no second chance. `update_size_targets` runs after the
+/// seed and places the size target from `content + padding` — so with the seed
+/// last, it placed a size computed from the padding the builder captured, and a
+/// placement jumps: no animation is left running, and nothing asks again. The
+/// container keeps a width that is wrong for the rest of its life, not for a
+/// frame.
+///
+/// Content-driven on purpose — a width with a cap and no exact value — because a
+/// container told its width outright does not consult its padding for it.
+#[test]
+fn a_size_settles_on_the_padding_the_layout_measured() {
+    let inset = create_signal(0.0f32);
+    let mut h = H::new(
+        container()
+            .padding(
+                (move || Padding::all(inset.get()))
+                    .transition(Transition::new(80.0, TimingFunction::Linear)),
+            )
+            .width(at_most(200.0).transition(Transition::new(80.0, TimingFunction::Linear)))
+            .child(box_of(20.0, 20.0)),
+    );
+
+    inset.set(24.0);
+    settle(&mut h, 120);
+
+    let width = h.tree.cached_size(h.root).map(|s| s.width);
+    assert!(
+        width.is_some_and(|w| (w - 68.0).abs() < 0.5),
+        "the size follows the content plus the padding that was measured, \
+         20 + 24 + 24: got {width:?}"
+    );
+}
+
+/// The same for a border width, seeded from the same pass by the same call.
+#[test]
+fn a_border_width_written_before_the_first_layout_arrives() {
+    let thickness = create_signal(0.0f32);
+    let mut h = H::new(container().width(80.0).height(80.0).border(
+        (move || thickness.get()).transition(Transition::new(80.0, TimingFunction::Linear)),
+        Color::WHITE,
+    ));
+
+    thickness.set(5.0);
+    // One frame is enough: a border width is paint-only, so unlike a padding it
+    // arrived even when the seed ran last. What this kills is its own
+    // `seed_or_enter` line; the arm it has in the drift list is the other
+    // border-width test's, one screen down.
+    let frame = h.frame(200.0, 200.0);
+    let width = borders(&frame.node).first().map(|(width, _)| *width);
+    assert!(
+        width.is_some_and(|w| (w - 5.0).abs() < 0.5),
+        "the write landed before anything was listening and has to be picked up \
+         at the seed, got {width:?}"
+    );
+}
+
+/// The same for a padding, which the drift list names first.
+///
+/// Read off the child's position, because that is where a padding arrives: the
+/// container's own rect says nothing about its inside.
+#[test]
+fn a_padding_target_behind_an_untaken_branch_is_picked_up_by_the_resync() {
+    let armed = create_signal(false);
+    let inset = create_signal(0.0f32);
+    let mut h = H::new(
+        container()
+            .width(200.0)
+            .height(200.0)
+            .padding(
+                (move || {
+                    if armed.get() {
+                        Padding::all(inset.get())
+                    } else {
+                        Padding::all(0.0)
+                    }
+                })
+                .transition(Transition::new(80.0, TimingFunction::Linear)),
+            )
+            .child(box_of(20.0, 20.0)),
+    );
+    h.fit(400.0, 400.0);
+    h.paint();
+
+    // The branch flips, which the first subscription can see.
+    armed.set(true);
+    settle(&mut h, 120);
+
+    // And this is the write nothing else can see.
+    inset.set(30.0);
+    settle(&mut h, 120);
+
+    let x = h.paint().children[0].local_transform.tx();
+    assert!(
+        (x - 30.0).abs() < 0.5,
+        "a padding behind a branch nobody tracked still has to converge, got {x}"
+    );
+}
+
+/// The same for a border width, the slot beside padding's in the drift list.
+///
+/// These two are the last pair of arms in that list nothing watched: deleting
+/// either changed nothing any test could see.
+#[test]
+fn a_border_width_target_behind_an_untaken_branch_is_picked_up_by_the_resync() {
+    let armed = create_signal(false);
+    let thickness = create_signal(0.0f32);
+    let mut h = H::new(
+        container().width(80.0).height(80.0).border(
+            (move || {
+                if armed.get() { thickness.get() } else { 0.0 }
+            })
+            .transition(Transition::new(80.0, TimingFunction::Linear)),
+            Color::WHITE,
+        ),
+    );
+    h.fit(200.0, 200.0);
+    h.paint();
+
+    armed.set(true);
+    settle(&mut h, 120);
+
+    thickness.set(6.0);
+    settle(&mut h, 120);
+
+    let width = borders(&h.paint()).first().map(|(width, _)| *width);
+    assert!(
+        width.is_some_and(|w| (w - 6.0).abs() < 0.5),
+        "a border width behind a branch nobody tracked still has to converge, \
+         got {width:?}"
+    );
+}
+
 /// The same for a shadow, which reaches paint by its own slot in both the seed
 /// and the drift list.
 ///
@@ -3397,7 +3567,7 @@ fn an_enter_is_consumed_by_the_first_layout_and_does_not_play_again() {
 
 /// The verb reaches the properties whose first value is placed somewhere other
 /// than the seed pass — a size, which `update_size_targets` initialises, and a
-/// padding, which keeps the seed it was built with and is never re-seeded.
+/// padding, which reaches `seed_or_enter` last of the nine.
 ///
 /// These are two of the four that accepted an enter and silently dropped it
 /// while the take lived in one initialiser instead of in `AnimationState`.

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -1614,6 +1614,18 @@ impl Widget for Container {
         );
         tree.clear_needs_layout(id);
 
+        // Before the measurement, because the measurement consumes what this
+        // places: `read_box_lengths` reads the animated padding, and a value
+        // seeded after it is a value this layout never saw. Asking for another
+        // layout afterwards would not do — `measure_natural_size` runs a layout
+        // whose size is a *return value*, so on the popup path there is no later
+        // pass for a repair to land in.
+        //
+        // Above it rather than at the top of the function: a layout that skips
+        // must not seed, and the gate is what decides that. Below the gate the
+        // first layout never skips, because it has no cached constraints.
+        self.seed_animations(tree, id);
+
         let lengths = self.read_box_lengths(id, constraints);
         let child = self.child_layout(&lengths, constraints);
         let padding = lengths.padding;
@@ -1662,7 +1674,6 @@ impl Widget for Container {
         }
 
         self.update_size_targets(tree, id, &lengths, content_size);
-        self.seed_animations(tree, id);
 
         let size = self.resolve_size(&lengths, constraints, content_size);
 


### PR DESCRIPTION
## What changed

`seed_animations` moves above `read_box_lengths`, which is the pass that consumes
what it places. It ran at the end of `Container::layout` and `read_box_lengths`
reads the animated padding at the top, so a padding the seed placed was a value
that layout never measured with. A placement jumps, so no animation was left
running to carry it, and the drift check then compared a target against the
effective value it had just been set from and found them equal. A padding written
between the builder and the first layout — the window the whole seed exists for —
stayed at whatever `get_untracked` happened to see.

It is not one frame of wrongness. `update_size_targets` reads that same stale
padding to place a content-driven size, and that placement jumps too: a container
that should be 68 wide settles at 20 and stays there.

Closes #347 — though not by fixing what #347 describes. See below.

## What #347 actually asked, and what was left of it

The issue says padding and border width never report drift, because nothing ever
calls `set_immediate` for them so `is_initial()` stays true. **That is false on
current main.** #348 gave both a `seed_or_enter` like every other property, which
calls `set_immediate`, so the gate opens. I verified it by deleting both arms from
`resync_animation_targets`: the two new untaken-branch tests fail, so the arms are
load-bearing.

What remained was the issue's own last line — *"whichever way it is fixed, the
pull half has to be watched for these two"* — and that is now true. Writing the
acceptance test is what turned up the live defect above.

## What proves it

Five tests. The reviewer applied five mutations one at a time and each is killed
by exactly one of them, with no overlap:

| mutation | killed by |
| --- | --- |
| the seed restored to its old position | the padding-arrives test |
| `seed_or_enter` deleted for padding | the same |
| `seed_or_enter` deleted for border width | the border-arrives test |
| padding's arm deleted from the drift list | the padding untaken-branch test |
| border width's arm deleted | the border untaken-branch test |

Nothing else in the suite notices the ordering mutation, which is the point: this
window was unwatched. The size test was added after the review and is red at 20
against the old ordering, which is the permanent half of the same defect.

No golden and no snapshot moved, and none should: this is a first-frame ordering
change, not a steady-state one. The goldens were run on lavapipe anyway.

## What the review found

**Zero blocking.** One worth answering, acted on: the commit body claimed two
consequences in passing — the settled size, and an `entering_from` padding being
measured at the value it enters from — and nothing asserted either. The reviewer
verified both are real and that the first is *permanent*. It has its own test now.
For the second, the line that would break it already has a killer, so it stays a
sentence.

Its notes were taken too. A test's doc named the pass its sibling watches rather
than its own. Two comments claimed padding and border width "keep the seed they
were built with and are never re-seeded", three lines above the calls that re-seed
them — made false by #348. And the `widgets` skill still counted four lists a new
animated property joins, `seed_animations` having become a fifth in #348; it says
five now.

An earlier pair of quality passes changed the design. My first fix asked for an
`Animation(Layout)` job when the placement moved the value, which needed a
two-field struct threaded through nine call sites. The argument against it was
decisive: `measure_natural_size` runs a layout whose size is a *return value*,
consumed synchronously to spawn a popup, so a requested job arrives after the
compositor has been told the size — and that pass consumes `is_initial()`, leaving
the real first layout with nothing to repair. Ordering the two correctly removes
the question instead of answering it late, and the machinery went with it.

## What was checked by hand

Nothing. Every claim here is a layout or a paint the tests drive directly; no
surface, compositor or real frame is involved.

## Left undone

**#366** — a container whose first layout is a natural-size measure pass never
plays a declared `entering_from`, which is the popup path and so the case the
feature was built for. `begin_enter` correctly declines under `measuring_final()`
without taking the enter, `seed_or_enter` reads that as "none declared" and places
the value, and `set_immediate` then marks it initialised, so the real first layout
skips the property entirely and the enter is stranded. Verified by running it: the
padding sits at its target from the first real frame. Pre-existing, and unchanged
by this — the measure pass consumes `is_initial()` either way. It is filed rather
than fixed here because which of the two steps should give way is a decision, and
it is provable on its own.

The commit could have been two: the pull-half tests answer #347's last line and
stand alone, while the ordering fix and its three tests are a different statement.
The reviewer raised it as a nit and I left it, because the subject says what is
now true of the load-bearing half and splitting it would put the issue's own
acceptance criterion in a commit that closes nothing.

https://claude.ai/code/session_01UBH3udwnC1nUZ7wv5TS7N9
