### PR TITLE
A measure pass places a value without spending the appearance

### DIFF
--- a/src/widgets/container/anim_bridge.rs
+++ b/src/widgets/container/anim_bridge.rs
@@ -91,10 +91,12 @@ impl Container {
             });
 
             if anim.is_initial() {
-                // Mark initialized at the first layout whatever the value, so
-                // later changes animate instead of snapping — unless an enter
-                // was declared, in which case this is the appearance it was
-                // waiting for and the size animates from there.
+                // Mark initialized at the first *real* layout whatever the
+                // value, so later changes animate instead of snapping — unless
+                // an enter was declared, in which case this is the appearance it
+                // was waiting for and the size animates from there. A measure
+                // pass places without marking, so the appearance is still to
+                // come: see `set_immediate`.
                 if anim.begin_enter(target, || tree.frame_instant()) {
                     retargeted = true;
                 } else {

--- a/src/widgets/container/animations.rs
+++ b/src/widgets/container/animations.rs
@@ -79,7 +79,8 @@ pub struct AnimationState<T: Animatable> {
     using_reverse: bool,
     /// Spring state (for spring timing functions)
     spring_state: Option<SpringState>,
-    /// Whether the animation has been initialized with its first real value
+    /// Whether a real layout has placed this. A measure pass writes the value
+    /// without setting it — see [`set_immediate`](Self::set_immediate).
     initialized: bool,
     /// Previous value for change detection
     prev_value: Option<T>,
@@ -547,13 +548,26 @@ impl<T: Animatable> AnimationState<T> {
         &self.target
     }
 
-    /// Set value immediately without animation (for initialization)
+    /// Set value immediately without animation, and mark it placed — unless this
+    /// is a measure pass.
+    ///
+    /// A measure pass places the value and does **not** mark it placed. It has
+    /// to place it: `measure_natural_size` sizes a popup before the surface
+    /// exists, and the number it reports is read off this animation — through
+    /// [`displayed`](Self::displayed), which answers with the target for exactly
+    /// that reason. What it must not do is spend the appearance.
+    /// `begin_enter` already declines there, saying in as many words that a
+    /// measure pass is not an appearance; marking the property placed would
+    /// contradict it one line later, because the layout that *is* the appearance
+    /// reads `is_initial()` to decide whether to look at the enter at all.
     pub fn set_immediate(&mut self, value: T) {
         self.current = value;
         self.target = value;
         self.start = value;
         self.progress = 1.0;
-        self.initialized = true;
+        if !measuring_final() {
+            self.initialized = true;
+        }
     }
 
     /// Check if animation has never been initialized (first layout)

--- a/src/widgets/container/characterization.rs
+++ b/src/widgets/container/characterization.rs
@@ -3565,6 +3565,74 @@ fn an_enter_is_consumed_by_the_first_layout_and_does_not_play_again() {
     );
 }
 
+/// A container whose width and padding both declare where they start.
+///
+/// Shared by the pair below, which differ in one thing — whether a measure pass
+/// runs first — and must not drift apart in any other.
+fn a_size_and_a_padding_entering() -> Container {
+    container()
+        .height(60.0)
+        .width(
+            120.0f32
+                .transition(Transition::new(100.0, TimingFunction::Linear))
+                .entering_from(0.0),
+        )
+        .padding(
+            Padding::all(20.0)
+                .transition(Transition::new(100.0, TimingFunction::Linear))
+                .entering_from(Padding::all(0.0)),
+        )
+        .child(container().width(10.0).height(10.0))
+}
+
+/// A measure pass does not spend the appearance.
+///
+/// `measure_natural_size` lays a popup out once, before the surface exists, to
+/// tell the compositor how big to make it. `begin_enter` declines there and says
+/// why — nothing is mapped, and there is no frame instant to play against — but
+/// it declines by returning the same `false` that means "nothing was declared",
+/// so the seed places the value and marks it placed. The real first layout then
+/// finds `is_initial()` false, never computes the target, and the enter that was
+/// never taken is never played.
+///
+/// Which makes the popup the one surface where an enter silently does nothing,
+/// and `entering_from`'s own documentation opens with a menu that scales open.
+#[test]
+fn a_measure_pass_leaves_the_appearance_for_the_first_real_layout() {
+    let t0 = std::time::Instant::now();
+    let mut h = H::new(a_size_and_a_padding_entering());
+
+    // The measure that runs before anything is mapped, capped at the output
+    // rather than asking for the size the surface is about to be told. Loose on
+    // both axes here, which is the layer-surface shape; a popup's measure pins
+    // the width and leaves only the height loose, and the root's constraints
+    // differ from the real layout's either way.
+    with_measure_final(|| {
+        h.fit(800.0, 800.0);
+    });
+
+    frame_at(&mut h, t0, 400.0, 400.0);
+    frame_at(
+        &mut h,
+        t0 + std::time::Duration::from_millis(50),
+        400.0,
+        400.0,
+    );
+
+    let midway = h.tree.cached_size(h.root).unwrap().width;
+    assert!(
+        midway > 0.0 && midway < 120.0,
+        "the width has to open from the value it enters from, as it does without \
+         the measure pass, got {midway}"
+    );
+    let child = h.tree.get_children(h.root)[0];
+    let inset = h.tree.get_origin(child).unwrap().0;
+    assert!(
+        inset > 0.0 && inset < 20.0,
+        "and so does the padding, got {inset}"
+    );
+}
+
 /// The verb reaches the properties whose first value is placed somewhere other
 /// than the seed pass — a size, which `update_size_targets` initialises, and a
 /// padding, which reaches `seed_or_enter` last of the nine.
@@ -3576,21 +3644,7 @@ fn an_enter_is_consumed_by_the_first_layout_and_does_not_play_again() {
 #[test]
 fn an_enter_reaches_a_size_and_a_padding_too() {
     let t0 = std::time::Instant::now();
-    let mut h = H::new(
-        container()
-            .height(60.0)
-            .width(
-                120.0f32
-                    .transition(Transition::new(100.0, TimingFunction::Linear))
-                    .entering_from(0.0),
-            )
-            .padding(
-                Padding::all(20.0)
-                    .transition(Transition::new(100.0, TimingFunction::Linear))
-                    .entering_from(Padding::all(0.0)),
-            )
-            .child(container().width(10.0).height(10.0)),
-    );
+    let mut h = H::new(a_size_and_a_padding_entering());
 
     frame_at(&mut h, t0, 400.0, 400.0);
     frame_at(

--- a/src/widgets/container/mod.rs
+++ b/src/widgets/container/mod.rs
@@ -2150,9 +2150,10 @@ mod tests {
     /// Regression test for the missed-write race that left popup menus
     /// permanently collapsed: the Animation subscription for an animated
     /// prop is only registered during paint, but the animation target is
-    /// initialized (set_immediate) during the first layout — possibly a
-    /// popup measure pass long before a heavy tree finishes its first
-    /// paint. A signal write landing in that window notified nobody and
+    /// placed (set_immediate) during the first layout, long before a heavy
+    /// tree finishes its first paint — and a popup is measured before that
+    /// again, which places the target without counting as the first layout.
+    /// A signal write landing in that window notified nobody and
     /// the animation sat on the stale target forever. The first paint must
     /// detect the drift and request an Animation job so
     /// advance_animations adopts the missed target.

--- a/src/widgets/text.rs
+++ b/src/widgets/text.rs
@@ -546,6 +546,20 @@ mod tests {
         );
     }
 
+    /// A text whose colour declares where it starts.
+    ///
+    /// Shared by the pair below, which differ in one thing — whether a measure
+    /// pass runs first — and must not drift apart in any other.
+    fn a_colour_entering(from: Color, to: Color) -> (Tree, WidgetId) {
+        let mut tree = Tree::new();
+        let root = tree
+            .register(Box::new(container().child(
+                Text::new("entering").color(to.transition(400.0).entering_from(from)),
+            )));
+        tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
+        (tree, root)
+    }
+
     /// A text's colour appears from somewhere else too.
     ///
     /// `TextAnims::retarget` is one of the four initialisers that place a
@@ -558,12 +572,7 @@ mod tests {
         const FROM: Color = Color::rgb(0.0, 0.0, 0.0);
         const TO: Color = Color::rgb(1.0, 1.0, 1.0);
 
-        let mut tree = Tree::new();
-        let root = tree
-            .register(Box::new(container().child(
-                Text::new("entering").color(TO.transition(400.0).entering_from(FROM)),
-            )));
-        tree.with_widget_mut(root, |w, id, t| w.register_children(t, id));
+        let (mut tree, root) = a_colour_entering(FROM, TO);
 
         let t0 = std::time::Instant::now();
         all_text(&mut tree, root, t0);
@@ -575,6 +584,39 @@ mod tests {
 
         let settled = all_text(&mut tree, root, t0 + std::time::Duration::from_millis(600))[0].0;
         assert!(settled.r > 0.99, "and it gets there, got {settled:?}");
+    }
+
+    /// And a measure pass does not spend it.
+    ///
+    /// `TextAnims::retarget` places a colour with `set_immediate` when no enter
+    /// begins, which is the same shape the container's seed has — so a label in a
+    /// popup lost its enter the same way a padding did, for the same reason and
+    /// in a different file. The guard is on `set_immediate` rather than on either
+    /// caller, which is what makes this one true without a second edit.
+    #[test]
+    fn a_measure_pass_leaves_a_text_colour_its_appearance() {
+        const FROM: Color = Color::rgb(0.0, 0.0, 0.0);
+        const TO: Color = Color::rgb(1.0, 1.0, 1.0);
+
+        let (mut tree, root) = a_colour_entering(FROM, TO);
+
+        // The popup path: a natural size before anything is mapped, and loose,
+        // where the layouts after it are tight.
+        let t0 = std::time::Instant::now();
+        tree.set_frame_instant(Some(t0));
+        crate::widgets::container::with_measure_final(|| {
+            let _ =
+                jobs::pump_and_layout(&mut tree, root, Constraints::new(0.0, 0.0, 800.0, 800.0));
+        });
+        tree.set_frame_instant(None);
+
+        all_text(&mut tree, root, t0);
+        let midway = all_text(&mut tree, root, t0 + std::time::Duration::from_millis(100))[0].0;
+        assert!(
+            midway.r > 0.01 && midway.r < 0.99,
+            "the colour has to arrive rather than be arrived, as it does without \
+             the measure pass, got {midway:?}"
+        );
     }
 
     /// The same for a size, which moves layout rather than paint — so the claim


### PR DESCRIPTION
## What changed

`measure_natural_size` lays a popup out once, before the surface exists, to tell
the compositor how big to make it. `begin_enter` declines to play a declared
`entering_from` there and says why — nothing is mapped, and there is no frame
instant to play against — but it declines by returning the same `false` that means
"nothing was declared". So the caller placed the value with `set_immediate`, which
marked it placed, and the layout that *is* the appearance then read `is_initial()`,
found it false, never computed the target, and left the enter untaken for the life
of the widget.

That made the popup the one surface where an enter silently does nothing, and
`entering_from`'s own documentation opens with a menu that scales open.

`initialized` now means "a real layout has placed this" rather than "something has
written to it". The value is still placed, because the measure needs it — the
number it reports is read off the animation through `displayed`, which answers
with the target for exactly that reason — and the flag is left alone until a
layout that counts. Closes #366.

## Why the guard is at the flag and not at the callers

#366 named two candidates and called the choice between them the design question.
This is the answer, and the reason is that the other one is only half a fix.

`seed_or_enter`, `update_size_targets` and `TextAnims::retarget` all have the same
`if !begin_enter { set_immediate }` shape, written independently, and the third is
in another file for another family of properties. A label in a popup lost its
colour's enter exactly the way a padding did. A guard at the container's callers
would have left that one standing and left the next one to be written standing
too.

`initialized` has exactly two writers — the constructor and `set_immediate` — and
the field is private, so there is no other route to it. A future call site cannot
get this wrong by omission.

`set_immediate` is public API and its behaviour now turns on a `pub(crate)` flag.
That is the shape `displayed()` in the same file already chose, for the same
reason and with the same justification in its rustdoc; and since
`with_measure_final` is `pub(crate)`, an external caller only ever sees the flag
set while its own `layout` is being run by the measure.

## What proves it

Two tests, both red without the guard and each for its own reason: a container
whose width and padding both enter is already at 120 and 20 instead of opening,
and a text whose colour enters is already arrived. The container one is the
issue's acceptance criterion, and the reviewer confirmed its two halves fail
independently.

The text one is what makes the third call site more than a claim in a commit
message. Without it, "this fixes text too" would be a sentence nothing checks.

No golden or snapshot moved, and none should: this changes a first-frame
transition that no golden scenario declares. They were run on lavapipe anyway.

## What the review found

**Zero blocking.** One worth answering, acted on: a comment in `container/mod.rs`
still said the target is initialised during the first layout, "possibly a popup
measure pass" — which is now precisely the case that does not initialise. The
diff had corrected its sibling in `anim_bridge.rs` and missed this one. The
`initialized` field's own doc carries the new meaning now too.

Its notes are here rather than dropped. The popup path seeds twice now, once in
the measure and once in the first real layout, where the second used to early-out;
subscriptions dedupe on a hash-set hit, so the cost is nine target reads per popup
spawn and no behaviour. And the text pair got the shared builder the container
pair had already been given, by the same argument.

Two earlier quality passes also ran. One of their findings was discarded as
invented — it described a scratch test that is not in the diff, which I checked
before acting.

## What was checked by hand

Nothing. Every path here is a layout the tests drive directly; no surface,
compositor or real frame is involved.

## Left undone

**#368** — a second route to the same symptom, with a different mechanism. A
measure pass leaves a layout cache, so a *descendant* whose constraints come out
the same in both passes is skipped entirely in the real layout, never seeds, and
never plays its enter. The popup root always escapes it, because its measure pins
the width and the real layout is tight, so the symptom is a panel that opens with
its contents already arrived.

I verified it rather than taking it on report: a child measured 150, already
arrived, against 75 halfway for the same tree with no measure pass. It is filed
rather than fixed here because the fix is in the layout cache rather than in the
animation, and because the two spellings — do not write the cache during a
measure, or invalidate the measured subtree after one — trade off against `Flex`'s
intra-pass reuse in a way that wants measuring.

One consequence of this change lands inside that scenario: a descendant whose
layout is skipped now stays `is_initial()`, so its enter can play late rather than
not at all. Bounded by #368, which covers it.

https://claude.ai/code/session_01UBH3udwnC1nUZ7wv5TS7N9
